### PR TITLE
Add start_network.py

### DIFF
--- a/src/genesisgen/main.cpp
+++ b/src/genesisgen/main.cpp
@@ -37,7 +37,7 @@ tls::Cert gen_cert(const string& name)
   return {name, nullptr, cert, privk, nullb, tls::auth_required};
 }
 
-vector<vector<uint8_t>> slurp_certs(const string& path)
+vector<vector<uint8_t>> slurp_certs(const string& path, bool optional = false)
 {
   vector<vector<uint8_t>> certs;
 
@@ -47,8 +47,15 @@ vector<vector<uint8_t>> slurp_certs(const string& path)
 
   if (h == INVALID_HANDLE_VALUE)
   {
-    cerr << "Failed to search for cert pattern." << endl;
-    exit(-1);
+    if (optional)
+    {
+      return {};
+    }
+    else
+    {
+      cerr << "Failed to search for cert pattern." << endl;
+      exit(-1);
+    }
   }
 #else
   glob_t g;
@@ -56,8 +63,15 @@ vector<vector<uint8_t>> slurp_certs(const string& path)
 
   if (glob(path.c_str(), GLOB_ERR, NULL, &g) || g.gl_pathc < 1)
   {
-    cerr << "Failed to search for cert pattern." << endl;
-    exit(-1);
+    if (optional)
+    {
+      return {};
+    }
+    else
+    {
+      cerr << "Failed to search for cert pattern." << endl;
+      exit(-1);
+    }
   }
 #endif
 
@@ -144,10 +158,7 @@ int main(int argc, char** argv)
 
   string start_json = "startNetwork.json";
   tx_cmd->add_option(
-    "--start-json",
-    start_json,
-    "Start network RPC as a JSON file",
-    true);
+    "--start-json", start_json, "Start network RPC as a JSON file", true);
 
   string gov_script = "gov.lua";
   tx_cmd
@@ -177,25 +188,14 @@ int main(int argc, char** argv)
     true);
 
   string join_host;
-  join_rpc->add_option(
-    "--host",
-    join_host,
-    "Target host",
-    false);
+  join_rpc->add_option("--host", join_host, "Target host", false);
 
   string join_port;
-  join_rpc->add_option(
-    "--port",
-    join_port,
-    "Target port",
-    false);
+  join_rpc->add_option("--port", join_port, "Target port", false);
 
   string join_json = "joinNetwork.json";
   join_rpc->add_option(
-    "--join-json",
-    join_json,
-    "Join network RPC as a JSON file",
-    true);
+    "--join-json", join_json, "Join network RPC as a JSON file", true);
 
   CLI11_PARSE(app, argc, argv);
 
@@ -209,7 +209,7 @@ int main(int argc, char** argv)
     auto user_certs = slurp_certs(user_certs_file);
     auto member_certs = slurp_certs(member_certs_file);
     vector<NodeInfo> nodes = files::slurp_json(nodes_json_file);
-    auto attestation_cas = slurp_certs(attestation_cas_files);
+    auto attestation_cas = slurp_certs(attestation_cas_files, true);
 
     auto member_status =
       accepted ? MemberStatus::ACCEPTED : MemberStatus::ACTIVE;

--- a/src/genesisgen/main.cpp
+++ b/src/genesisgen/main.cpp
@@ -23,7 +23,7 @@ using namespace std;
 using namespace tls;
 using namespace ccf;
 
-tls::Cert genCert(const string& name)
+tls::Cert gen_cert(const string& name)
 {
   KeyPair k;
   auto cert = k.self_sign("CN=" + name);
@@ -37,7 +37,7 @@ tls::Cert genCert(const string& name)
   return {name, nullptr, cert, privk, nullb, tls::auth_required};
 }
 
-vector<vector<uint8_t>> slurpCerts(const string path)
+vector<vector<uint8_t>> slurp_certs(const string& path)
 {
   vector<vector<uint8_t>> certs;
 
@@ -201,15 +201,15 @@ int main(int argc, char** argv)
 
   if (*cert)
   {
-    genCert(name);
+    gen_cert(name);
     return 0;
   }
   else if (*tx_cmd)
   {
-    auto user_certs = slurpCerts(user_certs_file);
-    auto member_certs = slurpCerts(member_certs_file);
+    auto user_certs = slurp_certs(user_certs_file);
+    auto member_certs = slurp_certs(member_certs_file);
     vector<NodeInfo> nodes = files::slurp_json(nodes_json_file);
-    auto attestation_cas = slurpCerts(attestation_cas_files);
+    auto attestation_cas = slurp_certs(attestation_cas_files);
 
     auto member_status =
       accepted ? MemberStatus::ACCEPTED : MemberStatus::ACTIVE;

--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -1,0 +1,50 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+import e2e_args
+import infra.ccf
+import infra.proc
+import time
+
+from loguru import logger as LOG
+
+
+def run(args):
+    hosts = args.nodes or ["localhost", "localhost"]
+
+    with infra.ccf.network(hosts, args.build_dir, args.debug_nodes) as network:
+        primary, followers = network.start_and_join(args)
+
+        LOG.info("Network started")
+        LOG.info("Primary node is at {}:{}".format(primary.host, primary.tls_port))
+
+        LOG.info("Started network with the following nodes:")
+        LOG.info("  Primary = {}:{}".format(primary.pubhost, primary.tls_port))
+        for i, f in enumerate(followers):
+            LOG.info("  Follower[{}] = {}:{}".format(i, f.pubhost, f.tls_port))
+
+        try:
+            while True:
+                time.sleep(60)
+            
+        except KeyboardInterrupt:
+            LOG.info("Terminating")
+
+
+if __name__ == "__main__":
+
+    def add(parser):
+        parser.add_argument(
+            "-n",
+            "--nodes",
+            help="List of hostnames[,pub_hostnames:ports]. If empty, two nodes are spawned locally",
+            action="append",
+        )
+        parser.add_argument(
+            "-p",
+            "--package",
+            help="The enclave package to load (e.g., libloggingenc)",
+            required=True,
+        )
+
+    args = e2e_args.cli_args(add)
+    run(args)

--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -25,7 +25,7 @@ def run(args):
         try:
             while True:
                 time.sleep(60)
-            
+
         except KeyboardInterrupt:
             LOG.info("Terminating")
 


### PR DESCRIPTION
Add general `start_network.py`. This uses the e2e Python infrastructure to spin up a network, then leaves it alive until a KeyboardInterrupt. The following will start a 2-node network running the logging app:

```
$ python ../tests/start_network.py -p libloggingenc -q
```

GenesisGen's slurp_certs becomes optional like the slurps in `files.h` - `ra_ca.pem` is really optional, the default sample ca is copied by the other e2e tests but can be omitted.