### PR TITLE
Check cpp format

### DIFF
--- a/check-format.sh
+++ b/check-format.sh
@@ -5,7 +5,7 @@
 set -u
 
 unformatted_files=""
-for f in $(find src -name "*.h" -o -name "*.hpp" -o -name "*.cpp" -name "*.c"); do
+for f in $(find src -name "*.h" -or -name "*.hpp" -or -name "*.cpp" -or -name "*.c"); do
   # Workaround for https://bugs.llvm.org/show_bug.cgi?id=39216
   d=$(cat "$f" | clang-format-7 -style=file --assume-filename "$f".cpp | diff "$f" -)
   if [ "$d" != "" ]; then

--- a/check-format.sh
+++ b/check-format.sh
@@ -7,7 +7,7 @@ set -u
 unformatted_files=""
 for f in $(find src -name "*.h" -or -name "*.hpp" -or -name "*.cpp" -or -name "*.c"); do
   # Workaround for https://bugs.llvm.org/show_bug.cgi?id=39216
-  d=$(cat "$f" | clang-format-7 -style=file --assume-filename "$f".cpp | diff "$f" -)
+  d=$(cat "$f" | clang-format-7 -style=file --assume-filename "${f%.*}".cpp | diff "$f" -)
   if [ "$d" != "" ]; then
     if [ "$unformatted_files" != "" ]; then
       unformatted_files+=$'\n'

--- a/src/apps/logging/logging.cpp
+++ b/src/apps/logging/logging.cpp
@@ -85,9 +85,9 @@ namespace ccfapp
       install(Procs::LOG_GET_PUBLIC, get_public, Read);
 
       nwt.signatures.set_global_hook([this, &notifier](
-                                           kv::Version version,
-                                           const Signatures::State& s,
-                                           const Signatures::Write& w) {
+                                       kv::Version version,
+                                       const Signatures::State& s,
+                                       const Signatures::Write& w) {
         if (w.size() > 0)
         {
           nlohmann::json notify_j;

--- a/src/clients/logging_client.cpp
+++ b/src/clients/logging_client.cpp
@@ -87,9 +87,15 @@ int main(int argc, char** argv)
     CLI::App cli_app{"Logging Client"};
     cli_app.add_option("--host", host);
     cli_app.add_option("--port", port);
-    cli_app.add_option("--cert", cert_file)->required(true)->check(CLI::ExistingFile);
-    cli_app.add_option("--privk", key_file)->required(true)->check(CLI::ExistingFile);
-    cli_app.add_option("--ca", ca_file)->required(true)->check(CLI::ExistingFile);
+    cli_app.add_option("--cert", cert_file)
+      ->required(true)
+      ->check(CLI::ExistingFile);
+    cli_app.add_option("--privk", key_file)
+      ->required(true)
+      ->check(CLI::ExistingFile);
+    cli_app.add_option("--ca", ca_file)
+      ->required(true)
+      ->check(CLI::ExistingFile);
     CLI11_PARSE(cli_app, argc, argv);
   }
 

--- a/src/crypto/hash.cpp
+++ b/src/crypto/hash.cpp
@@ -1,17 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
-#include <stdexcept>
 #include "hash.h"
 
 #include <mbedtls/sha256.h>
+#include <stdexcept>
 
-extern "C" {
+extern "C"
+{
 #include <evercrypt/EverCrypt_Hash.h>
 }
 
 using namespace std;
 
-void crypto::Sha256Hash::mbedtls_sha256(initializer_list<CBuffer> il, uint8_t *h)
+void crypto::Sha256Hash::mbedtls_sha256(
+  initializer_list<CBuffer> il, uint8_t* h)
 {
   mbedtls_sha256_context ctx;
   mbedtls_sha256_starts_ret(&ctx, 0);
@@ -23,24 +25,28 @@ void crypto::Sha256Hash::mbedtls_sha256(initializer_list<CBuffer> il, uint8_t *h
   mbedtls_sha256_free(&ctx);
 }
 
-void crypto::Sha256Hash::evercrypt_sha256(initializer_list<CBuffer> il, uint8_t *h)
+void crypto::Sha256Hash::evercrypt_sha256(
+  initializer_list<CBuffer> il, uint8_t* h)
 {
-  EverCrypt_Hash_state_s *state = EverCrypt_Hash_create(Spec_Hash_Definitions_SHA2_256);
+  EverCrypt_Hash_state_s* state =
+    EverCrypt_Hash_create(Spec_Hash_Definitions_SHA2_256);
   EverCrypt_Hash_init(state);
 
   for (auto data : il)
   {
-    EverCrypt_Hash_update_multi(state, const_cast<uint8_t*>(data.p), data.rawSize());
-    EverCrypt_Hash_update_last(state, const_cast<uint8_t*>(data.p), data.rawSize());
+    EverCrypt_Hash_update_multi(
+      state, const_cast<uint8_t*>(data.p), data.rawSize());
+    EverCrypt_Hash_update_last(
+      state, const_cast<uint8_t*>(data.p), data.rawSize());
   }
 
   EverCrypt_Hash_finish(state, h);
   EverCrypt_Hash_free(state);
 }
 
-void crypto::Sha256Hash::hacl_sha256(initializer_list<CBuffer> il, uint8_t *h)
+void crypto::Sha256Hash::hacl_sha256(initializer_list<CBuffer> il, uint8_t* h)
 {
-  uint32_t ctx[137U] = { 0U };
+  uint32_t ctx[137U] = {0U};
   Hacl_Hash_Core_SHA2_init_256(ctx);
 
   for (auto data : il)
@@ -48,9 +54,9 @@ void crypto::Sha256Hash::hacl_sha256(initializer_list<CBuffer> il, uint8_t *h)
     uint64_t input_len = data.rawSize();
     uint32_t blocks_n = input_len / (uint32_t)64U;
     uint32_t blocks_len = blocks_n * (uint32_t)64U;
-    uint8_t *blocks = const_cast<uint8_t*>(data.p);
+    uint8_t* blocks = const_cast<uint8_t*>(data.p);
     uint32_t rest_len = input_len - blocks_len;
-    uint8_t *rest = blocks + blocks_len;
+    uint8_t* rest = blocks + blocks_len;
     Hacl_Hash_SHA2_update_multi_256(ctx, blocks, blocks_n);
     Hacl_Hash_SHA2_update_last_256(ctx, blocks_len, rest, rest_len);
   }
@@ -58,9 +64,7 @@ void crypto::Sha256Hash::hacl_sha256(initializer_list<CBuffer> il, uint8_t *h)
   Hacl_Hash_Core_SHA2_finish_256(ctx, h);
 }
 
-crypto::Sha256Hash::Sha256Hash() : h{0}
-{
-}
+crypto::Sha256Hash::Sha256Hash() : h{0} {}
 
 crypto::Sha256Hash::Sha256Hash(initializer_list<CBuffer> il) : h{0}
 {

--- a/src/crypto/symmkey.cpp
+++ b/src/crypto/symmkey.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 #include "symmkey.h"
+
 #include "error.h"
 
 #include <mbedtls/aes.h>

--- a/src/host/test/ledger.cpp
+++ b/src/host/test/ledger.cpp
@@ -49,11 +49,13 @@ TEST_CASE("Entry sizes")
   REQUIRE(l.entry_size(3) == 0);
 
   REQUIRE(l.framed_entries_size(1, 1) == (e1.size() + sizeof(uint32_t)));
-  REQUIRE(l.framed_entries_size(1, 2) == (e1.size() + sizeof(uint32_t) + e2.size() + sizeof(uint32_t)));
+  REQUIRE(
+    l.framed_entries_size(1, 2) ==
+    (e1.size() + sizeof(uint32_t) + e2.size() + sizeof(uint32_t)));
 
-/*
-  auto e = l.read_framed_entries(1, 1);
-  for (auto c : e)
-    std::cout << std::hex << (int)c;
-  std::cout << std::endl;*/
+  /*
+    auto e = l.read_framed_entries(1, 1);
+    for (auto c : e)
+      std::cout << std::hex << (int)c;
+    std::cout << std::endl;*/
 }

--- a/src/kv/test/kv_bench.cpp
+++ b/src/kv/test/kv_bench.cpp
@@ -89,7 +89,8 @@ static void deserialise(picobench::state& s)
   s.start_timer();
   auto rc = kv_store2.deserialise(serial.first);
   if (rc != kv::DeserialiseSuccess::PASS)
-    throw std::logic_error("Transaction deserialisation failed: " + std::to_string(rc));
+    throw std::logic_error(
+      "Transaction deserialisation failed: " + std::to_string(rc));
   s.stop_timer();
 }
 

--- a/src/kv/test/kv_contention.cpp
+++ b/src/kv/test/kv_contention.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
-#include "../kvserialiser.h"
 #include "../kv.h"
+#include "../kvserialiser.h"
 
 #include <atomic>
 #include <chrono>

--- a/src/kv/test/kv_serialisation.cpp
+++ b/src/kv/test/kv_serialisation.cpp
@@ -3,8 +3,8 @@
 #include "../../ds/logger.h"
 #include "../../enclave/appinterface.h"
 #include "../../node/encryptor.h"
-#include "../kvserialiser.h"
 #include "../kv.h"
+#include "../kvserialiser.h"
 #include "../replicator.h"
 
 #include <doctest/doctest.h>

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -4,8 +4,8 @@
 #include "../../ds/logger.h"
 #include "../../enclave/appinterface.h"
 #include "../../node/encryptor.h"
-#include "../kvserialiser.h"
 #include "../kv.h"
+#include "../kvserialiser.h"
 #include "../node/history.h"
 #include "../replicator.h"
 
@@ -560,11 +560,13 @@ TEST_CASE("map swap between stores")
 {
   Store s1;
   auto& d1 = s1.create<size_t, size_t>("data", kv::SecurityDomain::PRIVATE);
-  auto& pd1 = s1.create<size_t, size_t>("public_data", kv::SecurityDomain::PUBLIC);
+  auto& pd1 =
+    s1.create<size_t, size_t>("public_data", kv::SecurityDomain::PUBLIC);
 
   Store s2;
   auto& d2 = s2.create<size_t, size_t>("data", kv::SecurityDomain::PRIVATE);
-  auto& pd2 = s2.create<size_t, size_t>("public_data", kv::SecurityDomain::PUBLIC);
+  auto& pd2 =
+    s2.create<size_t, size_t>("public_data", kv::SecurityDomain::PUBLIC);
 
   {
     Store::Tx tx;
@@ -632,7 +634,9 @@ TEST_CASE("invalid map swaps")
     s2.create<size_t, size_t>("one");
     s2.create<size_t, size_t>("two");
 
-    REQUIRE_THROWS_WITH(s2.swap_private_maps(s1), "Private map list mismatch during swap, missing at least two");
+    REQUIRE_THROWS_WITH(
+      s2.swap_private_maps(s1),
+      "Private map list mismatch during swap, missing at least two");
   }
 
   {
@@ -643,20 +647,25 @@ TEST_CASE("invalid map swaps")
     Store s2;
     s2.create<size_t, size_t>("one");
 
-    REQUIRE_THROWS_WITH(s2.swap_private_maps(s1), "Private map list mismatch during swap, two not found");
+    REQUIRE_THROWS_WITH(
+      s2.swap_private_maps(s1),
+      "Private map list mismatch during swap, two not found");
   }
 }
 
 TEST_CASE("private recovery map swap")
 {
   Store s1;
-  auto& priv1 = s1.create<size_t, size_t>("private", kv::SecurityDomain::PRIVATE);
-  auto& pub1 = s1.create<size_t, std::string>("public", kv::SecurityDomain::PUBLIC);
+  auto& priv1 =
+    s1.create<size_t, size_t>("private", kv::SecurityDomain::PRIVATE);
+  auto& pub1 =
+    s1.create<size_t, std::string>("public", kv::SecurityDomain::PUBLIC);
 
   Store s2;
-  auto& priv2 = s2.create<size_t, size_t>("private", kv::SecurityDomain::PRIVATE);
-  auto& pub2 = s2.create<size_t, std::string>("public", kv::SecurityDomain::PUBLIC);
-
+  auto& priv2 =
+    s2.create<size_t, size_t>("private", kv::SecurityDomain::PRIVATE);
+  auto& pub2 =
+    s2.create<size_t, std::string>("public", kv::SecurityDomain::PUBLIC);
 
   INFO("Populate s1 with public entries");
   // We compact twice, deliberately. A public KV during recovery

--- a/src/luainterp/test/luakv.cpp
+++ b/src/luainterp/test/luakv.cpp
@@ -160,7 +160,8 @@ namespace ccf
           const auto next_k = k + 1;
           REQUIRE(next_tx->put(next_k, s1));
           REQUIRE(
-            li.invoke<nullptr_t>(get_globally_committed, next_tx, next_k) == nullptr);
+            li.invoke<nullptr_t>(get_globally_committed, next_tx, next_k) ==
+            nullptr);
         }
 
         REQUIRE(next_txs.commit() == kv::CommitSuccess::OK);

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -12,7 +12,8 @@
 
 #include <doctest/doctest.h>
 
-extern "C" {
+extern "C"
+{
 #include <evercrypt/EverCrypt_AutoConfig2.h>
 }
 

--- a/src/node/test/history_bench.cpp
+++ b/src/node/test/history_bench.cpp
@@ -7,7 +7,8 @@
 #include <ctime>
 #include <picobench/picobench.hpp>
 
-extern "C" {
+extern "C"
+{
 #include <evercrypt/EverCrypt_AutoConfig2.h>
 }
 
@@ -77,18 +78,18 @@ static void hash_only(picobench::state& s)
   s.stop_timer();
 }
 
-template<size_t S>
+template <size_t S>
 static void hash_mbedtls_sha256(picobench::state& s)
 {
   ::srand(42);
 
   std::vector<std::vector<uint8_t>> txs;
-  for (size_t i=0; i<s.iterations(); i++)
+  for (size_t i = 0; i < s.iterations(); i++)
   {
     std::vector<uint8_t> tx;
-    for (size_t j=0; j<S; j++)
+    for (size_t j = 0; j < S; j++)
     {
-        tx.push_back(::rand() % 256);
+      tx.push_back(::rand() % 256);
     }
     txs.push_back(tx);
   }
@@ -153,8 +154,7 @@ static void append(picobench::state& s)
   store.set_replicator(replicator);
 
   std::shared_ptr<kv::TxHistory> history =
-    std::make_shared<ccf::MerkleTxHistory>(
-      store, 0, kp, signatures, nodes);
+    std::make_shared<ccf::MerkleTxHistory>(store, 0, kp, signatures, nodes);
   store.set_history(history);
 
   std::vector<std::vector<uint8_t>> txs;
@@ -195,8 +195,7 @@ static void append_compact(picobench::state& s)
   store.set_replicator(replicator);
 
   std::shared_ptr<kv::TxHistory> history =
-    std::make_shared<ccf::MerkleTxHistory>(
-      store, 0, kp, signatures, nodes);
+    std::make_shared<ccf::MerkleTxHistory>(store, 0, kp, signatures, nodes);
   store.set_history(history);
 
   std::vector<std::vector<uint8_t>> txs;

--- a/src/node/test/merkle_bench.cpp
+++ b/src/node/test/merkle_bench.cpp
@@ -7,7 +7,8 @@
 #include <picobench/picobench.hpp>
 #include <random>
 
-extern "C" {
+extern "C"
+{
 #include <evercrypt/EverCrypt_AutoConfig2.h>
 }
 

--- a/src/tls/test/bench.cpp
+++ b/src/tls/test/bench.cpp
@@ -2,21 +2,22 @@
 // Licensed under the Apache 2.0 License.
 #define PICOBENCH_IMPLEMENT_WITH_MAIN
 #include "../keypair.h"
+
 #include <picobench/picobench.hpp>
 
 using namespace std;
 
 static constexpr size_t SHA256_BYTES = 256 / 8;
-static const string contents_ = 
-                       "Lorem ipsum dolor sit amet, consectetur adipiscing "
-                       "elit, sed do eiusmod tempor incididunt ut labore et"
-                       " dolore magna aliqua. Ut enim ad minim veniam, quis"
-                       " nostrud exercitation ullamco laboris nisi ut "
-                       "aliquip ex ea commodo consequat. Duis aute irure "
-                       "dolor in reprehenderit in voluptate velit esse "
-                       "cillum dolore eu fugiat nulla pariatur. Excepteur "
-                       "sint occaecat cupidatat non proident, sunt in culpa "
-                       "qui officia deserunt mollit anim id est laborum.";
+static const string contents_ =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing "
+  "elit, sed do eiusmod tempor incididunt ut labore et"
+  " dolore magna aliqua. Ut enim ad minim veniam, quis"
+  " nostrud exercitation ullamco laboris nisi ut "
+  "aliquip ex ea commodo consequat. Duis aute irure "
+  "dolor in reprehenderit in voluptate velit esse "
+  "cillum dolore eu fugiat nulla pariatur. Excepteur "
+  "sint occaecat cupidatat non proident, sunt in culpa "
+  "qui officia deserunt mollit anim id est laborum.";
 
 template <class A>
 inline void do_not_optimize(A const& value)
@@ -34,9 +35,9 @@ static void benchmark_sign(picobench::state& s)
 {
   tls::KeyPair kp;
   vector<uint8_t> contents(contents_.size() * C);
-  for(decltype(C) i = 0; i < C; i++)
+  for (decltype(C) i = 0; i < C; i++)
   {
-      copy(contents_.begin(), contents_.end(), back_inserter(contents));
+    copy(contents_.begin(), contents_.end(), back_inserter(contents));
   }
 
   s.start_timer();
@@ -55,9 +56,9 @@ static void benchmark_verify(picobench::state& s)
 {
   tls::KeyPair kp;
   vector<uint8_t> contents(contents_.size() * C);
-  for(decltype(C) i = 0; i < C; i++)
+  for (decltype(C) i = 0; i < C; i++)
   {
-      copy(contents_.begin(), contents_.end(), back_inserter(contents));
+    copy(contents_.begin(), contents_.end(), back_inserter(contents));
   }
   auto signature = kp.sign(contents);
   auto public_key = kp.public_key();
@@ -79,9 +80,9 @@ static void benchmark_hash(picobench::state& s)
 {
   tls::KeyPair kp;
   vector<uint8_t> contents(contents_.size() * C);
-  for(decltype(C) i = 0; i < C; i++)
+  for (decltype(C) i = 0; i < C; i++)
   {
-      copy(contents_.begin(), contents_.end(), back_inserter(contents));
+    copy(contents_.begin(), contents_.end(), back_inserter(contents));
   }
 
   s.start_timer();

--- a/src/tls/test/main.cpp
+++ b/src/tls/test/main.cpp
@@ -3,22 +3,22 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "../keypair.h"
 
-#include <doctest/doctest.h>
 #include <chrono>
+#include <doctest/doctest.h>
 #include <string>
 
 using namespace std;
 
-static const string contents_ = 
-                       "Lorem ipsum dolor sit amet, consectetur adipiscing "
-                       "elit, sed do eiusmod tempor incididunt ut labore et"
-                       " dolore magna aliqua. Ut enim ad minim veniam, quis"
-                       " nostrud exercitation ullamco laboris nisi ut "
-                       "aliquip ex ea commodo consequat. Duis aute irure "
-                       "dolor in reprehenderit in voluptate velit esse "
-                       "cillum dolore eu fugiat nulla pariatur. Excepteur "
-                       "sint occaecat cupidatat non proident, sunt in culpa "
-                       "qui officia deserunt mollit anim id est laborum.";
+static const string contents_ =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing "
+  "elit, sed do eiusmod tempor incididunt ut labore et"
+  " dolore magna aliqua. Ut enim ad minim veniam, quis"
+  " nostrud exercitation ullamco laboris nisi ut "
+  "aliquip ex ea commodo consequat. Duis aute irure "
+  "dolor in reprehenderit in voluptate velit esse "
+  "cillum dolore eu fugiat nulla pariatur. Excepteur "
+  "sint occaecat cupidatat non proident, sunt in culpa "
+  "qui officia deserunt mollit anim id est laborum.";
 
 void corrupt(std::vector<uint8_t>& buf)
 {
@@ -27,60 +27,62 @@ void corrupt(std::vector<uint8_t>& buf)
 
 TEST_CASE("Sign, verify, with PublicKey")
 {
-    tls::KeyPair kp;
-    vector<uint8_t> contents(contents_.begin(), contents_.end());
-    const vector<uint8_t> signature = kp.sign(contents);
+  tls::KeyPair kp;
+  vector<uint8_t> contents(contents_.begin(), contents_.end());
+  const vector<uint8_t> signature = kp.sign(contents);
 
-    vector<uint8_t> public_key = kp.public_key();
-    tls::PublicKey pubk(public_key);
-    REQUIRE(pubk.verify(contents.data(), contents.size(), signature.data(), signature.size()));
+  vector<uint8_t> public_key = kp.public_key();
+  tls::PublicKey pubk(public_key);
+  REQUIRE(pubk.verify(
+    contents.data(), contents.size(), signature.data(), signature.size()));
 }
 
 TEST_CASE("Sign, fail to verify with bad signature")
 {
-    tls::KeyPair kp;
-    vector<uint8_t> contents(contents_.begin(), contents_.end());
-    vector<uint8_t> signature = kp.sign(contents);
+  tls::KeyPair kp;
+  vector<uint8_t> contents(contents_.begin(), contents_.end());
+  vector<uint8_t> signature = kp.sign(contents);
 
-    vector<uint8_t> public_key = kp.public_key();
-    tls::PublicKey pubk(public_key);
-    corrupt(signature);
-    REQUIRE_FALSE(pubk.verify(contents.data(), contents.size(), signature.data(), signature.size()));
+  vector<uint8_t> public_key = kp.public_key();
+  tls::PublicKey pubk(public_key);
+  corrupt(signature);
+  REQUIRE_FALSE(pubk.verify(
+    contents.data(), contents.size(), signature.data(), signature.size()));
 }
 
 TEST_CASE("Sign, fail to verify with bad contents")
 {
-    tls::KeyPair kp;
-    vector<uint8_t> contents(contents_.begin(), contents_.end());
-    vector<uint8_t> signature = kp.sign(contents);
+  tls::KeyPair kp;
+  vector<uint8_t> contents(contents_.begin(), contents_.end());
+  vector<uint8_t> signature = kp.sign(contents);
 
-    vector<uint8_t> public_key = kp.public_key();
-    tls::PublicKey pubk(public_key);
-    corrupt(contents);
-    REQUIRE_FALSE(pubk.verify(contents.data(), contents.size(), signature.data(), signature.size()));
+  vector<uint8_t> public_key = kp.public_key();
+  tls::PublicKey pubk(public_key);
+  corrupt(contents);
+  REQUIRE_FALSE(pubk.verify(
+    contents.data(), contents.size(), signature.data(), signature.size()));
 }
 
 TEST_CASE("Sign, verify with certificate")
 {
-    tls::KeyPair kp;
-    vector<uint8_t> contents(contents_.begin(), contents_.end());
-    const vector<uint8_t> signature = kp.sign(contents);
+  tls::KeyPair kp;
+  vector<uint8_t> contents(contents_.begin(), contents_.end());
+  const vector<uint8_t> signature = kp.sign(contents);
 
-    auto cert = kp.self_sign("CN=name");
-    tls::Verifier verifier(cert);
-    REQUIRE(verifier.verify(contents, signature));
+  auto cert = kp.self_sign("CN=name");
+  tls::Verifier verifier(cert);
+  REQUIRE(verifier.verify(contents, signature));
 }
-
 
 TEST_CASE("Sign, verify. Fail to verify with bad contents")
 {
-    tls::KeyPair kp;
-    vector<uint8_t> contents(contents_.begin(), contents_.end());
-    const vector<uint8_t> signature = kp.sign(contents);
+  tls::KeyPair kp;
+  vector<uint8_t> contents(contents_.begin(), contents_.end());
+  const vector<uint8_t> signature = kp.sign(contents);
 
-    auto cert = kp.self_sign("CN=name");
-    tls::Verifier verifier(cert);
-    REQUIRE(verifier.verify(contents, signature));
-    corrupt(contents);
-    REQUIRE_FALSE(verifier.verify(contents, signature));
+  auto cert = kp.self_sign("CN=name");
+  tls::Verifier verifier(cert);
+  REQUIRE(verifier.verify(contents, signature));
+  corrupt(contents);
+  REQUIRE_FALSE(verifier.verify(contents, signature));
 }


### PR DESCRIPTION
Our check_format script wasn't actually running on .cpp files (due to the missing `-or` before the `"*.c"` arg). Now it is.

Also needed to remove the suffix for `--assume-filename`. Formatting `kv.h.cpp` seems to be fine, but `symmkey.cpp.cpp` isn't (`symmkey.h` is no longer recognised as the special header that gets its own line).