### PR TITLE
Fix Merkle Tree benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,13 +217,12 @@ if(BUILD_TESTS)
   target_link_libraries(tls_bench PRIVATE
     ${CMAKE_THREAD_LIBS_INIT}
     secp256k1.host)
-  #add_picobench(merkle_bench src/node/test/merkle_bench.cpp)
-  #target_link_libraries(merkle_bench PRIVATE
-  #  ${OE_ENCLAVE_CORE}
-  #  ccfcrypto.host
-  #  merkle_tree.host)
-  #target_include_directories(merkle_bench PRIVATE
-  #  ${MERKLE_TREE_INC})
+  add_picobench(merkle_bench src/node/test/merkle_bench.cpp)
+  target_link_libraries(merkle_bench PRIVATE
+    ccfcrypto.host
+    merkle_tree.host)
+  target_include_directories(merkle_bench PRIVATE
+    ${MERKLE_TREE_INC})
   add_picobench(history_bench src/node/test/history_bench.cpp)
   target_link_libraries(history_bench PRIVATE
     ccfcrypto.host

--- a/src/node/test/merkle_bench.cpp
+++ b/src/node/test/merkle_bench.cpp
@@ -36,10 +36,9 @@ static void append_retract(picobench::state& s)
     crypto::Sha256Hash h;
     for (size_t j = 0; j < crypto::Sha256Hash::SIZE; j++)
       h.h[j] = r();
-    
+
     hashes.emplace_back(h);
   }
-
 
   size_t index = 0;
   s.start_timer();
@@ -70,7 +69,7 @@ static void append_flush(picobench::state& s)
     crypto::Sha256Hash h;
     for (size_t j = 0; j < crypto::Sha256Hash::SIZE; j++)
       h.h[j] = r();
-    
+
     hashes.emplace_back(h);
   }
 

--- a/src/node/test/merkle_bench.cpp
+++ b/src/node/test/merkle_bench.cpp
@@ -25,45 +25,21 @@ inline void clobber_memory()
   asm volatile("" : : : "memory");
 }
 
-static void append(picobench::state& s)
-{
-  ccf::MerkleTreeHistory t;
-  vector<crypto::Sha256Hash> hashes;
-
-  for (size_t i = 0; i < s.iterations(); ++i)
-  {
-    crypto::Sha256Hash h;
-    vector<uint8_t> hv(crypto::Sha256Hash::SIZE, 0u);
-    generate(hv.begin(), hv.end(), rand);
-    h.mbedtls_sha256({hv}, h.h);
-    hashes.emplace_back(h);
-  }
-
-  size_t index = 0;
-  s.start_timer();
-  for (auto _ : s)
-  {
-    (void)_;
-    t.append(hashes[index++]);
-    // do_not_optimize();
-    clobber_memory();
-  }
-  s.stop_timer();
-}
-
 static void append_retract(picobench::state& s)
 {
   ccf::MerkleTreeHistory t;
   vector<crypto::Sha256Hash> hashes;
+  std::random_device r;
 
   for (size_t i = 0; i < s.iterations(); ++i)
   {
     crypto::Sha256Hash h;
-    vector<uint8_t> hv(crypto::Sha256Hash::SIZE, 0u);
-    generate(hv.begin(), hv.end(), rand);
-    h.mbedtls_sha256({hv}, h.h);
+    for (size_t j = 0; j < crypto::Sha256Hash::SIZE; j++)
+      h.h[j] = r();
+    
     hashes.emplace_back(h);
   }
+
 
   size_t index = 0;
   s.start_timer();
@@ -71,8 +47,11 @@ static void append_retract(picobench::state& s)
   {
     (void)_;
     t.append(hashes[index++]);
+
     if (index > 0 && index % 1000 == 0)
+    {
       t.retract(index - 1000);
+    }
 
     // do_not_optimize();
     clobber_memory();
@@ -84,13 +63,14 @@ static void append_flush(picobench::state& s)
 {
   ccf::MerkleTreeHistory t;
   vector<crypto::Sha256Hash> hashes;
+  std::random_device r;
 
   for (size_t i = 0; i < s.iterations(); ++i)
   {
     crypto::Sha256Hash h;
-    vector<uint8_t> hv(crypto::Sha256Hash::SIZE, 0u);
-    generate(hv.begin(), hv.end(), rand);
-    h.mbedtls_sha256({hv}, h.h);
+    for (size_t j = 0; j < crypto::Sha256Hash::SIZE; j++)
+      h.h[j] = r();
+    
     hashes.emplace_back(h);
   }
 
@@ -111,8 +91,6 @@ static void append_flush(picobench::state& s)
 
 const std::vector<int> sizes = {10000, 100000};
 
-PICOBENCH_SUITE("append");
-PICOBENCH(append).iterations(sizes).samples(10).baseline();
 PICOBENCH_SUITE("append_retract");
 PICOBENCH(append_retract).iterations(sizes).samples(10).baseline();
 PICOBENCH_SUITE("append_flush");


### PR DESCRIPTION
Segfaults were caused by linking liboecore.a, which results in rather unaligned memory being allocated when running outside an enclave it seems (not entirely sure why that's the case). This causes the aes asm implementation to fail on movdqu in turn.

As discussed @wintersteiger, it is possible that some stricter pre-conditions could be added in the merkle tree impl, in the future.