### PR TITLE
Clear new rollback counter in store clear()

### DIFF
--- a/src/kv/kv.h
+++ b/src/kv/kv.h
@@ -1678,6 +1678,7 @@ namespace kv
       compacted = 0;
       last_replicated = 0;
       last_committable = 0;
+      rollback_count = 0;
       pending_txs.clear();
     }
 


### PR DESCRIPTION
Small tweak to clear the KV store's rollback counter when `clear()` is called on the whole store.