### PR TITLE
No quotes with virtual

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -502,7 +502,6 @@ target_link_libraries(cchost.virtual PRIVATE
   ccfcrypto.host
   merkle_tree.host
 )
-enable_quote_code(cchost.virtual)
 
 # Client executable
 add_executable(client ${CCF_DIR}/src/clients/client.cpp)

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -61,8 +61,9 @@ int main(int argc, char** argv)
   std::string quote_file("quote.bin");
   app.add_option("-q,--quote-file", quote_file, "SGX quote file", true);
 
-  std::string quote_cert("nodecert.pem");
-  app.add_option("-c,--quote-cert", quote_cert, "SGX quote certificate", true);
+  std::string quoted_data("nodecert.pem");
+  app.add_option(
+    "-c,--quoted-data", quoted_data, "SGX quoted certificate", true);
 
   size_t sig_max_tx = 1000;
   app.add_option(
@@ -201,7 +202,7 @@ int main(int argc, char** argv)
   if (start == "verify")
   {
     auto q = files::slurp(quote_file);
-    auto d = files::slurp(quote_cert);
+    auto d = files::slurp(quoted_data);
 
     auto passed = enclave.verify_quote(q, d);
     if (!passed)

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -262,18 +262,15 @@ int main(int argc, char** argv)
 
   LOG_INFO << "Created new node." << std::endl;
 
-#ifdef GET_QUOTE
-  auto enclave_ok = enclave.verify_quote(quote, node_cert);
-  if (!enclave_ok)
-    LOG_FATAL << "Verification of local node quote failed" << std::endl;
-#endif
-
   // Write the node cert and quote to disk. Actors can use the node cert
   // as a CA on their end of the TLS connection.
   files::dump(node_cert, node_cert_file);
 
 #ifdef GET_QUOTE
   files::dump(quote, quote_file);
+
+  if (!enclave.verify_quote(quote, node_cert))
+    LOG_FATAL << "Verification of local node quote failed" << std::endl;
 #endif
 
   // ledger

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -378,9 +378,11 @@ class CCFRemote(object):
         self.raft_port = raft_port
         self.tls_port = tls_port
         self.pem = "{}.pem".format(node_id)
-        self.quote = expect_quote
+        self.quote = None
         self.node_status = node_status
-        if expect_quote:
+        # Only expect a quote if the enclave is not virtual and quotes have
+        # not been explictly disabled
+        if enclave_type != "virtual" and expect_quote:
             self.quote = "quote{}.bin".format(node_id)
         self.BIN = infra.path.build_bin_path(self.BIN, enclave_type)
         self.ledger_file = ledger_file
@@ -427,8 +429,9 @@ class CCFRemote(object):
             cmd += ["--notify-server-host={}".format(notify_server_host)]
             cmd += ["--notify-server-port={}".format(notify_server_port[0])]
 
-        if expect_quote:
+        if self.quote is not None:
             cmd.append("--quote-file={}".format(self.quote))
+
         self.remote = remote_class(
             node_id,
             host,

--- a/tests/quote_verification.py
+++ b/tests/quote_verification.py
@@ -57,7 +57,7 @@ def create_node(lib_path, node_id, quote_path, cert_path):
         proc.wait()
 
 
-def verify_quote(lib_path, quote_path, cert_path, should_fail=False):
+def verify_quote(lib_path, quote_path, quoted_path, should_fail=False):
     # As per OE 0.4.0, oe_verify_report() on the host leaks memory.
     # Turn ASAN leak check off for now until OE fixes it.
     asan_env_disable_leak = {"ASAN_OPTIONS": "detect_leaks=0"}
@@ -66,7 +66,7 @@ def verify_quote(lib_path, quote_path, cert_path, should_fail=False):
         "--enclave-file={}".format(lib_path),
         "--start=verify",
         "--quote-file={}".format(quote_path),
-        "--quote-cert={}".format(cert_path),
+        "--quoted-data={}".format(quoted_path),
     ]
     print(">> {} &".format(" ".join(cmd)))
     proc = Popen(


### PR DESCRIPTION
While investigating the issue with large hanging RPCs (fixed in https://github.com/microsoft/CCF/pull/41), I've noticed that very large (10kB) all-zero quotes were dumped to disk by the virtual host (`cchost.virtual`) and passed around in the genesis transaction, etc. This PR removes quotes altogether when using virtual enclaves.

I've also moved the quote file dump before the quote verification so that we can hopefully debug what is wrong with the quote (e.g. `OE_MISSING_CERTIFICATE_CHAIN`) if the verification fails.