### PR TITLE
"Virtual only" build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ if(BUILD_TESTS)
     ${CMAKE_CURRENT_SOURCE_DIR}/src/kv/test/kv_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/kv/test/kv_contention.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/kv/test/kv_serialisation.cpp)
-  use_oe_mbedtls(kv_test)
+  use_client_mbedtls(kv_test)
   target_link_libraries(kv_test PRIVATE
     ${CMAKE_THREAD_LIBS_INIT}
     secp256k1.host)
@@ -98,8 +98,6 @@ if(BUILD_TESTS)
 
   add_unit_test(raft_test
     ${CMAKE_CURRENT_SOURCE_DIR}/src/raft/test/main.cpp)
-  target_include_directories(raft_test PRIVATE
-    ${OE_INCLUDE_DIR})
   target_link_libraries(raft_test PRIVATE
     ${CRYPTO_LIBRARY})
 
@@ -123,7 +121,6 @@ if(BUILD_TESTS)
    add_unit_test(history_test
      ${CMAKE_CURRENT_SOURCE_DIR}/src/node/test/history.cpp)
    target_include_directories(history_test PRIVATE
-     ${OE_INCLUDE_DIR}
      ${MERKLE_TREE_INC})
    target_link_libraries(history_test PRIVATE
      ${CRYPTO_LIBRARY}
@@ -133,7 +130,7 @@ if(BUILD_TESTS)
   add_unit_test(encryptor_test
     ${CMAKE_CURRENT_SOURCE_DIR}/src/node/test/encryptor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/crypto/symmkey.cpp)
-  use_oe_mbedtls(encryptor_test)
+  use_client_mbedtls(encryptor_test)
   target_link_libraries(encryptor_test PRIVATE
     secp256k1.host)
 
@@ -145,11 +142,11 @@ if(BUILD_TESTS)
 
   add_unit_test(keyexchange_test
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tls/test/keyexchange.cpp)
-  use_oe_mbedtls(keyexchange_test)
+  use_client_mbedtls(keyexchange_test)
 
   add_unit_test(channels_test
     ${CMAKE_CURRENT_SOURCE_DIR}/src/node/test/channels.cpp)
-  use_oe_mbedtls(channels_test)
+  use_client_mbedtls(channels_test)
   target_link_libraries(channels_test PRIVATE secp256k1.host)
 
   add_unit_test(frontend_test
@@ -176,7 +173,6 @@ if(BUILD_TESTS)
     ${CMAKE_CURRENT_SOURCE_DIR}/src/luainterp/test/lua_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/luainterp/test/luakv.cpp)
   target_include_directories(lua_test PRIVATE
-    ${OE_INCLUDE_DIR}
     ${LUA_DIR})
   target_link_libraries(lua_test PRIVATE
     lua.host)
@@ -185,7 +181,6 @@ if(BUILD_TESTS)
     ${CMAKE_CURRENT_SOURCE_DIR}/src/apps/luageneric/luageneric_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/apps/luageneric/luageneric.cpp)
   target_include_directories(luageneric_test PRIVATE
-    ${OE_INCLUDE_DIR}
     ${LUA_DIR})
   target_link_libraries(luageneric_test PRIVATE
     lua.host
@@ -247,7 +242,7 @@ if(BUILD_TESTS)
   # Raft driver and scenario test
   add_executable(raft_driver
     ${CMAKE_CURRENT_SOURCE_DIR}/src/raft/test/driver.cpp)
-  use_oe_mbedtls(raft_driver)
+  use_client_mbedtls(raft_driver)
   target_include_directories(raft_driver PRIVATE
     src/raft)
   add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,6 @@ if(BUILD_TESTS)
   add_test(
     NAME member_client_test
     COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/tests/memberclient.py -b . -p libloggingenc ${CCF_NETWORK_TEST_ARGS})
-  add_virtual_only(member_client_test)
 
   ## Logging client end to end test
   add_test(
@@ -263,7 +262,6 @@ if(BUILD_TESTS)
     COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/tests/loggingclient.py
       -b .
       ${CCF_NETWORK_TEST_ARGS})
-  add_virtual_only(logging_client_test)
 
   ## Lua Logging client end to end test
   add_test(
@@ -272,7 +270,6 @@ if(BUILD_TESTS)
       -b .
       --app-script ${CMAKE_SOURCE_DIR}/src/apps/logging/logging.lua
       ${CCF_NETWORK_TEST_ARGS})
-  add_virtual_only(lua_logging_client_test)
 
   if(QUOTES_ENABLED)
     ## Tests generation and verification of quotes
@@ -290,7 +287,6 @@ if(BUILD_TESTS)
       ${TEST_FORWARD_TO_LEADER}
       ${CCF_NETWORK_TEST_ARGS}
   )
-  add_virtual_only(end_to_end_logging)
 
   add_test(
     NAME end_to_end_scenario
@@ -300,7 +296,6 @@ if(BUILD_TESTS)
       ${CCF_NETWORK_TEST_ARGS}
       --scenario ${CMAKE_SOURCE_DIR}/tests/simple_logging_scenario.json
   )
-  add_virtual_only(end_to_end_scenario)
 
   add_test(
     NAME election_tests
@@ -311,7 +306,6 @@ if(BUILD_TESTS)
       ${TEST_FORWARD_TO_LEADER}
       ${CCF_NETWORK_TEST_ARGS}
   )
-  add_virtual_only(election_tests)
 
   add_test(
     NAME recovery_tests
@@ -321,7 +315,6 @@ if(BUILD_TESTS)
       ${CCF_NETWORK_TEST_ARGS}
       ${RECOVERY_ARGS}
   )
-  add_virtual_only(recovery_tests)
 
   if(BUILD_SMALLBANK)
     include(${CMAKE_CURRENT_SOURCE_DIR}/samples/apps/smallbank/smallbank.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,7 @@ if(BUILD_TESTS)
   add_test(
     NAME member_client_test
     COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/tests/memberclient.py -b . -p libloggingenc ${CCF_NETWORK_TEST_ARGS})
+  add_virtual_only(member_client_test)
 
   ## Logging client end to end test
   add_test(
@@ -262,6 +263,7 @@ if(BUILD_TESTS)
     COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/tests/loggingclient.py
       -b .
       ${CCF_NETWORK_TEST_ARGS})
+  add_virtual_only(logging_client_test)
 
   ## Lua Logging client end to end test
   add_test(
@@ -270,6 +272,7 @@ if(BUILD_TESTS)
       -b .
       --app-script ${CMAKE_SOURCE_DIR}/src/apps/logging/logging.lua
       ${CCF_NETWORK_TEST_ARGS})
+  add_virtual_only(lua_logging_client_test)
 
   if(QUOTES_ENABLED)
     ## Tests generation and verification of quotes
@@ -287,6 +290,7 @@ if(BUILD_TESTS)
       ${TEST_FORWARD_TO_LEADER}
       ${CCF_NETWORK_TEST_ARGS}
   )
+  add_virtual_only(end_to_end_logging)
 
   add_test(
     NAME end_to_end_scenario
@@ -296,6 +300,7 @@ if(BUILD_TESTS)
       ${CCF_NETWORK_TEST_ARGS}
       --scenario ${CMAKE_SOURCE_DIR}/tests/simple_logging_scenario.json
   )
+  add_virtual_only(end_to_end_scenario)
 
   add_test(
     NAME election_tests
@@ -306,6 +311,7 @@ if(BUILD_TESTS)
       ${TEST_FORWARD_TO_LEADER}
       ${CCF_NETWORK_TEST_ARGS}
   )
+  add_virtual_only(election_tests)
 
   add_test(
     NAME recovery_tests
@@ -315,6 +321,7 @@ if(BUILD_TESTS)
       ${CCF_NETWORK_TEST_ARGS}
       ${RECOVERY_ARGS}
   )
+  add_virtual_only(recovery_tests)
 
   if(BUILD_SMALLBANK)
     include(${CMAKE_CURRENT_SOURCE_DIR}/samples/apps/smallbank/smallbank.cmake)

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -236,7 +236,7 @@ set(ENCLAVE_FILES
 )
 
 function(enable_quote_code name)
-  if (OE AND NOT OE_NO_SGX AND NOT DISABLE_QUOTE_VERIFICATION)
+  if (QUOTES_ENABLED)
     target_compile_definitions(${name} PRIVATE -DGET_QUOTE)
   endif()
 endfunction()

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -565,6 +565,17 @@ function(add_client_exe name)
 
 endfunction()
 
+function(add_virtual_only name)
+  if(VIRTUAL_ONLY)
+    set_property(
+      TEST ${name}
+      APPEND
+      PROPERTY
+        ENVIRONMENT "TEST_ENCLAVE=virtual"
+    )
+  endif()
+endfunction()
+
 ## Helper for building end-to-end perf tests using the python infrastucture
 function(add_perf_test)
 
@@ -608,8 +619,11 @@ function(add_perf_test)
   ## Make python test client framework importable
   set_property(
     TEST ${PARSED_ARGS_NAME}
+    APPEND
     PROPERTY
       ENVIRONMENT "PYTHONPATH=${CCF_DIR}/tests:$ENV{PYTHONPATH}"
   )
+
+  add_virtual_only(${PARSED_ARGS_NAME})
 
 endfunction()

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -155,6 +155,9 @@ if(NOT VIRTUAL_ONLY)
       set(TEST_EXPECT_QUOTE "-q")
     endif()
   endif()
+else()
+  set(TEST_ENCLAVE_TYPE
+    -e virtual)
 endif()
 
 # Test-only option to enable extensive tests
@@ -526,6 +529,7 @@ set_property(TARGET lua.host PROPERTY POSITION_INDEPENDENT_CODE ON)
 # Common test args for Python scripts starting up CCF networks
 set(CCF_NETWORK_TEST_ARGS
   ${TEST_EXPECT_QUOTE}
+  ${TEST_ENCLAVE_TYPE}
   -l ${TEST_HOST_LOGGING_LEVEL}
   -g ${CCF_DIR}/src/runtime_config/gov.lua
 )
@@ -563,17 +567,6 @@ function(add_client_exe name)
 
   use_client_mbedtls(${name})
 
-endfunction()
-
-function(add_virtual_only name)
-  if(VIRTUAL_ONLY)
-    set_property(
-      TEST ${name}
-      APPEND
-      PROPERTY
-        ENVIRONMENT "TEST_ENCLAVE=virtual"
-    )
-  endif()
 endfunction()
 
 ## Helper for building end-to-end perf tests using the python infrastucture
@@ -623,7 +616,4 @@ function(add_perf_test)
     PROPERTY
       ENVIRONMENT "PYTHONPATH=${CCF_DIR}/tests:$ENV{PYTHONPATH}"
   )
-
-  add_virtual_only(${PARSED_ARGS_NAME})
-
 endfunction()

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -20,8 +20,6 @@ find_package(Threads REQUIRED)
 if(MSVC)
   add_compile_options(/W3 /std:c++latest)
 else()
-  #add_compile_options(-mcx16 -march=native -Wall -Werror -g -gsplit-dwarf)
-
   # GCC requires libatomic as well as libpthread.
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(${CMAKE_THREAD_LIBS_INIT} "$CMAKE_THREAD_LIBS_INIT} atomic")
@@ -106,6 +104,7 @@ include_directories(
 )
 
 
+option(VIRTUAL_ONLY "Build only virtual enclaves" OFF)
 set(OE_PREFIX "/opt/openenclave" CACHE PATH "Path to Open Enclave install")
 message(STATUS "Open Enclave prefix set to ${OE_PREFIX}")
 
@@ -126,6 +125,7 @@ set(OE_LIBCXX_INCLUDE_DIR "${OE_INCLUDE_DIR}/openenclave/3rdparty/libcxx")
 set(OESIGN "${OE_BIN_DIR}/oesign")
 set(OEGEN "${OE_BIN_DIR}/oeedger8r")
 
+
 add_custom_command(
     COMMAND ${OEGEN} ${CCF_DIR}/src/edl/ccf.edl --trusted --trusted-dir ${CMAKE_CURRENT_BINARY_DIR} --untrusted --untrusted-dir ${CMAKE_CURRENT_BINARY_DIR}
     COMMAND mv ${CMAKE_CURRENT_BINARY_DIR}/ccf_t.c ${CMAKE_CURRENT_BINARY_DIR}/ccf_t.cpp
@@ -135,23 +135,25 @@ add_custom_command(
     COMMENT "Generating code from EDL, and renaming to .cpp"
 )
 
-# If OE was built with LINK_SGX=1, then we also need to link SGX
-execute_process(COMMAND "ldd" ${OESIGN}
-                COMMAND "grep" "-c" "sgx"
-                OUTPUT_QUIET
-               RESULT_VARIABLE OE_NO_SGX)
+if(NOT VIRTUAL_ONLY)
+  # If OE was built with LINK_SGX=1, then we also need to link SGX
+  execute_process(COMMAND "ldd" ${OESIGN}
+                  COMMAND "grep" "-c" "sgx"
+                  OUTPUT_QUIET
+                RESULT_VARIABLE OE_NO_SGX)
 
-if(NOT OE_NO_SGX)
-  message(STATUS "Linking SGX")
-  set(SGX_LIBS
-    sgx_enclave_common
-    sgx_dcap_ql
-    sgx_urts
-  )
+  if(NOT OE_NO_SGX)
+    message(STATUS "Linking SGX")
+    set(SGX_LIBS
+      sgx_enclave_common
+      sgx_dcap_ql
+      sgx_urts
+    )
 
-  if (NOT DISABLE_QUOTE_VERIFICATION)
-    set(QUOTES_ENABLED ON)
-    set(TEST_EXPECT_QUOTE "-q")
+    if (NOT DISABLE_QUOTE_VERIFICATION)
+      set(QUOTES_ENABLED ON)
+      set(TEST_EXPECT_QUOTE "-q")
+    endif()
   endif()
 endif()
 
@@ -234,7 +236,7 @@ set(ENCLAVE_FILES
 )
 
 function(enable_quote_code name)
-  if (NOT OE_NO_SGX AND NOT DISABLE_QUOTE_VERIFICATION)
+  if (OE AND NOT OE_NO_SGX AND NOT DISABLE_QUOTE_VERIFICATION)
     target_compile_definitions(${name} PRIVATE -DGET_QUOTE)
   endif()
 endfunction()
@@ -325,55 +327,57 @@ function(add_enclave_lib name app_oe_conf_path enclave_sign_key_path)
     "SRCS;INCLUDE_DIRS;LINK_LIBS"
   )
 
-  add_library(${name} SHARED
-    ${ENCLAVE_FILES}
-    ${PARSED_ARGS_SRCS}
-    ${CMAKE_CURRENT_BINARY_DIR}/ccf_t.cpp
-  )
+  if(NOT VIRTUAL_ONLY)
+    add_library(${name} SHARED
+      ${ENCLAVE_FILES}
+      ${PARSED_ARGS_SRCS}
+      ${CMAKE_CURRENT_BINARY_DIR}/ccf_t.cpp
+    )
 
-  target_compile_definitions(${name} PRIVATE
-    INSIDE_ENCLAVE
-    _LIBCPP_HAS_THREAD_API_PTHREAD
-  )
-  # Not setting -nostdinc in order to pick up compiler specific xmmintrin.h.
-  target_compile_options(${name} PRIVATE
-    -nostdinc++
-    -U__linux__
-  )
-  target_include_directories(${name} SYSTEM PRIVATE
-    ${OE_INCLUDE_DIR}
-    ${OE_LIBCXX_INCLUDE_DIR}
-    ${OE_LIBC_INCLUDE_DIR}
-    ${OE_TP_INCLUDE_DIR}
-    ${PARSED_ARGS_INCLUDE_DIRS}
-    ${MERKLE_TREE_INC}
-    ${CMAKE_CURRENT_BINARY_DIR}
-  )
-  if (PBFT)
+    target_compile_definitions(${name} PRIVATE
+      INSIDE_ENCLAVE
+      _LIBCPP_HAS_THREAD_API_PTHREAD
+    )
+    # Not setting -nostdinc in order to pick up compiler specific xmmintrin.h.
+    target_compile_options(${name} PRIVATE
+      -nostdinc++
+      -U__linux__
+    )
     target_include_directories(${name} SYSTEM PRIVATE
-      ${CCF_DIR}/pbft/src/pbft/
+      ${OE_INCLUDE_DIR}
+      ${OE_LIBCXX_INCLUDE_DIR}
+      ${OE_LIBC_INCLUDE_DIR}
+      ${OE_TP_INCLUDE_DIR}
+      ${PARSED_ARGS_INCLUDE_DIRS}
+      ${MERKLE_TREE_INC}
+      ${CMAKE_CURRENT_BINARY_DIR}
     )
-  endif()
-  target_link_libraries(${name} PRIVATE
-    -nostdlib -nodefaultlibs -nostartfiles
-    -Wl,--no-undefined
-    -Wl,-Bstatic,-Bsymbolic,--export-dynamic,-pie
-    ${ENCLAVE_LIBS}
-    -lgcc
-    ${PARSED_ARGS_LINK_LIBS}
-    ccfcrypto.enclave
-    merkle_tree.enclave
-    secp256k1.enclave
-  )
-  if (PBFT)
+    if (PBFT)
+      target_include_directories(${name} SYSTEM PRIVATE
+        ${CCF_DIR}/pbft/src/pbft/
+      )
+    endif()
     target_link_libraries(${name} PRIVATE
-      -Wl,--allow-multiple-definition #TODO(#important): This is unfortunate
-      libbyz.enclave
+      -nostdlib -nodefaultlibs -nostartfiles
+      -Wl,--no-undefined
+      -Wl,-Bstatic,-Bsymbolic,--export-dynamic,-pie
+      ${ENCLAVE_LIBS}
+      -lgcc
+      ${PARSED_ARGS_LINK_LIBS}
+      ccfcrypto.enclave
+      merkle_tree.enclave
+      secp256k1.enclave
     )
+    if (PBFT)
+      target_link_libraries(${name} PRIVATE
+        -Wl,--allow-multiple-definition #TODO(#important): This is unfortunate
+        libbyz.enclave
+      )
+    endif()
+    set_property(TARGET ${name} PROPERTY POSITION_INDEPENDENT_CODE ON)
+    sign_app_library(${name} ${app_oe_conf_path} ${enclave_sign_key_path})
+    enable_quote_code(${name})
   endif()
-  set_property(TARGET ${name} PROPERTY POSITION_INDEPENDENT_CODE ON)
-  sign_app_library(${name} ${app_oe_conf_path} ${enclave_sign_key_path})
-  enable_quote_code(${name})
 
   ## Build a virtual enclave, loaded as a shared library without OE
   set(virt_name ${name}.virtual)
@@ -456,28 +460,30 @@ target_link_libraries(genesisgenerator PRIVATE
   secp256k1.host
 )
 
-# Host Executable
-add_executable(cchost
-  ${CCF_DIR}/src/host/main.cpp
-  ${CMAKE_CURRENT_BINARY_DIR}/ccf_u.cpp)
-use_client_mbedtls(cchost)
-target_include_directories(cchost PRIVATE
-  ${OE_INCLUDE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-add_san(cchost)
+if(NOT VIRTUAL_ONLY)
+  # Host Executable
+  add_executable(cchost
+    ${CCF_DIR}/src/host/main.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/ccf_u.cpp)
+  use_client_mbedtls(cchost)
+  target_include_directories(cchost PRIVATE
+    ${OE_INCLUDE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
+  )
+  add_san(cchost)
 
-target_link_libraries(cchost PRIVATE
-  uv
-  ${OE_HOST_LIBRARY}
-  ${SGX_LIBS}
-  ${CRYPTO_LIBRARY}
-  ${CMAKE_DL_LIBS}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ccfcrypto.host
-  merkle_tree.host
-)
-enable_quote_code(cchost)
+  target_link_libraries(cchost PRIVATE
+    uv
+    ${OE_HOST_LIBRARY}
+    ${SGX_LIBS}
+    ${CRYPTO_LIBRARY}
+    ${CMAKE_DL_LIBS}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ccfcrypto.host
+    merkle_tree.host
+  )
+  enable_quote_code(cchost)
+endif()
 
 # Virtual Host Executable
 add_executable(cchost.virtual

--- a/cmake/crypto.cmake
+++ b/cmake/crypto.cmake
@@ -20,13 +20,15 @@ list(REMOVE_ITEM EVERCRYPT_SRC ${EVERCRYPT_SRC_EXCEPT})
 
 # We need two versions of EverCrypt, because it depends on libc
 
-add_library(evercrypt.enclave STATIC ${EVERCRYPT_SRC})
-target_compile_options(evercrypt.enclave PRIVATE -nostdinc -U__linux__ -Wno-everything)
-# TODO(#important|#pbft): Find out why kremlin needs this only when PBFT is on (KRML_HOST_PRINTF)
-target_compile_definitions(evercrypt.enclave PRIVATE INSIDE_ENCLAVE KRML_HOST_PRINTF=oe_printf)
-target_include_directories(evercrypt.enclave SYSTEM PRIVATE ${OE_LIBC_INCLUDE_DIR})
-set_property(TARGET evercrypt.enclave PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_include_directories(evercrypt.enclave PRIVATE ${EVERCRYPT_INC})
+if(NOT VIRTUAL_ONLY)
+  add_library(evercrypt.enclave STATIC ${EVERCRYPT_SRC})
+  target_compile_options(evercrypt.enclave PRIVATE -nostdinc -U__linux__ -Wno-everything)
+  # TODO(#important|#pbft): Find out why kremlin needs this only when PBFT is on (KRML_HOST_PRINTF)
+  target_compile_definitions(evercrypt.enclave PRIVATE INSIDE_ENCLAVE KRML_HOST_PRINTF=oe_printf)
+  target_include_directories(evercrypt.enclave SYSTEM PRIVATE ${OE_LIBC_INCLUDE_DIR})
+  set_property(TARGET evercrypt.enclave PROPERTY POSITION_INDEPENDENT_CODE ON)
+  target_include_directories(evercrypt.enclave PRIVATE ${EVERCRYPT_INC})
+endif()
 
 add_library(evercrypt.host STATIC ${EVERCRYPT_SRC})
 target_compile_options(evercrypt.host PRIVATE -Wno-everything)
@@ -39,14 +41,16 @@ target_include_directories(evercrypt.host PRIVATE ${EVERCRYPT_INC})
 set(MERKLE_TREE_PREFIX ${CCF_DIR}/3rdparty/merkle_tree)
 file(GLOB MERKLE_TREE_SRC "${MERKLE_TREE_PREFIX}/*.[c]")
 
-add_library(merkle_tree.enclave ${MERKLE_TREE_SRC})
-target_compile_options(merkle_tree.enclave PRIVATE -nostdinc -U__linux__ -Wno-everything)
-target_compile_definitions(merkle_tree.enclave PRIVATE INSIDE_ENCLAVE)
-target_include_directories(merkle_tree.enclave PRIVATE ${EVERCRYPT_INC})
-target_include_directories(merkle_tree.enclave SYSTEM PRIVATE ${OE_LIBC_INCLUDE_DIR})
-target_link_libraries(merkle_tree.enclave PRIVATE evercrypt.enclave)
-set_property(TARGET merkle_tree.enclave PROPERTY POSITION_INDEPENDENT_CODE ON)
-set(MERKLE_TREE_INC ${MERKLE_TREE_PREFIX} ${EVERCRYPT_INC})
+if(NOT VIRTUAL_ONLY)
+  add_library(merkle_tree.enclave ${MERKLE_TREE_SRC})
+  target_compile_options(merkle_tree.enclave PRIVATE -nostdinc -U__linux__ -Wno-everything)
+  target_compile_definitions(merkle_tree.enclave PRIVATE INSIDE_ENCLAVE)
+  target_include_directories(merkle_tree.enclave PRIVATE ${EVERCRYPT_INC})
+  target_include_directories(merkle_tree.enclave SYSTEM PRIVATE ${OE_LIBC_INCLUDE_DIR})
+  target_link_libraries(merkle_tree.enclave PRIVATE evercrypt.enclave)
+  set_property(TARGET merkle_tree.enclave PROPERTY POSITION_INDEPENDENT_CODE ON)
+  set(MERKLE_TREE_INC ${MERKLE_TREE_PREFIX} ${EVERCRYPT_INC})
+endif()
 
 add_library(merkle_tree.host ${MERKLE_TREE_SRC})
 target_compile_options(merkle_tree.host PRIVATE -Wno-everything)
@@ -65,27 +69,29 @@ set(CCFCRYPTO_SRC
 
 set(CCFCRYPTO_INC ${CCF_DIR}/src/crypto/ ${EVERCRYPT_INC})
 
-add_library(ccfcrypto.enclave STATIC ${CCFCRYPTO_SRC})
-target_compile_definitions(ccfcrypto.enclave PRIVATE
-  INSIDE_ENCLAVE
-  _LIBCPP_HAS_THREAD_API_PTHREAD
-)
-target_compile_options(ccfcrypto.enclave PRIVATE -nostdinc++ -U__linux__)
-target_include_directories(ccfcrypto.enclave PRIVATE
-  ${OE_LIBCXX_INCLUDE_DIR}
-  ${OE_LIBC_INCLUDE_DIR}
-  ${OE_TP_INCLUDE_DIR}
-  ${EVERCRYPT_INC}
-)
-target_link_libraries(ccfcrypto.enclave PRIVATE
-  -nostdlib -nodefaultlibs -nostartfiles
-  -Wl,--no-undefined
-  -Wl,-Bstatic,-Bsymbolic,--export-dynamic,-pie
-  -lgcc
-  evercrypt.enclave
-)
-use_oe_mbedtls(ccfcrypto.enclave)
-set_property(TARGET ccfcrypto.enclave PROPERTY POSITION_INDEPENDENT_CODE ON)
+if(NOT VIRTUAL_ONLY)
+  add_library(ccfcrypto.enclave STATIC ${CCFCRYPTO_SRC})
+  target_compile_definitions(ccfcrypto.enclave PRIVATE
+    INSIDE_ENCLAVE
+    _LIBCPP_HAS_THREAD_API_PTHREAD
+  )
+  target_compile_options(ccfcrypto.enclave PRIVATE -nostdinc++ -U__linux__)
+  target_include_directories(ccfcrypto.enclave PRIVATE
+    ${OE_LIBCXX_INCLUDE_DIR}
+    ${OE_LIBC_INCLUDE_DIR}
+    ${OE_TP_INCLUDE_DIR}
+    ${EVERCRYPT_INC}
+  )
+  target_link_libraries(ccfcrypto.enclave PRIVATE
+    -nostdlib -nodefaultlibs -nostartfiles
+    -Wl,--no-undefined
+    -Wl,-Bstatic,-Bsymbolic,--export-dynamic,-pie
+    -lgcc
+    evercrypt.enclave
+  )
+  use_oe_mbedtls(ccfcrypto.enclave)
+  set_property(TARGET ccfcrypto.enclave PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
 
 add_library(ccfcrypto.host STATIC
   ${CCFCRYPTO_SRC})

--- a/cmake/secp256k1.cmake
+++ b/cmake/secp256k1.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-if (OE)
+if(NOT VIRTUAL_ONLY)
     add_library(secp256k1.enclave STATIC ${CCF_DIR}/3rdparty/secp256k1/src/secp256k1.c)
     target_include_directories(secp256k1.enclave PUBLIC ${CCF_DIR}/3rdparty/secp256k1)
     target_compile_options(secp256k1.enclave PRIVATE -fvisibility=hidden -nostdinc -U__linux__ -Wno-everything)

--- a/cmake/secp256k1.cmake
+++ b/cmake/secp256k1.cmake
@@ -1,11 +1,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
-add_library(secp256k1.enclave STATIC ${CCF_DIR}/3rdparty/secp256k1/src/secp256k1.c)
-target_include_directories(secp256k1.enclave PUBLIC ${CCF_DIR}/3rdparty/secp256k1)
-target_compile_options(secp256k1.enclave PRIVATE -fvisibility=hidden -nostdinc -U__linux__ -Wno-everything)
-target_compile_definitions(secp256k1.enclave PRIVATE HAVE_CONFIG_H SECP256K1_BUILD)
-target_include_directories(secp256k1.enclave SYSTEM PRIVATE ${OE_LIBC_INCLUDE_DIR})
-set_property(TARGET secp256k1.enclave PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+if (OE)
+    add_library(secp256k1.enclave STATIC ${CCF_DIR}/3rdparty/secp256k1/src/secp256k1.c)
+    target_include_directories(secp256k1.enclave PUBLIC ${CCF_DIR}/3rdparty/secp256k1)
+    target_compile_options(secp256k1.enclave PRIVATE -fvisibility=hidden -nostdinc -U__linux__ -Wno-everything)
+    target_compile_definitions(secp256k1.enclave PRIVATE HAVE_CONFIG_H SECP256K1_BUILD)
+    target_include_directories(secp256k1.enclave SYSTEM PRIVATE ${OE_LIBC_INCLUDE_DIR})
+    set_property(TARGET secp256k1.enclave PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
 
 add_library(secp256k1.host STATIC ${CCF_DIR}/3rdparty/secp256k1/src/secp256k1.c)
 target_include_directories(secp256k1.host PUBLIC ${CCF_DIR}/3rdparty/secp256k1)

--- a/src/raft/test/driver.h
+++ b/src/raft/test/driver.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "../../ds/logger.h"
-#include "../host.h"
 #include "../raft.h"
 
 #include <chrono>


### PR DESCRIPTION
This adds a VIRTUAL_ONLY flag to cmake, to allow building virtual enclaves only and running only the corresponding tests. The ulterior motive for this change is to have a fully public CI, which can run on public executors.

Note that this does not allow for a completely OpenEnclave-free build, because we still require the oeedger8r, the files it produces from the EDL and some OpenEnclave headers. What is does allow though, importantly, is builds against the binary release of OpenEnclave (.deb packages), on a machine without SGX.