### PR TITLE
A simple test wrapper for ctest

### DIFF
--- a/.vsts-ci-templates/build_and_test.yml
+++ b/.vsts-ci-templates/build_and_test.yml
@@ -13,10 +13,7 @@ steps:
   workingDirectory: build
 
 - script: |
-    python3.7 -m venv env
-    source env/bin/activate
-    pip install -U -r ../tests/requirements.txt
-    ctest -VV --timeout 240 --no-compress-output -T Test
+    ./tests.sh -VV --timeout 240 --no-compress-output -T Test
   displayName: CTest
   workingDirectory: build
 

--- a/.vsts-ci-templates/build_and_test_with_san.yml
+++ b/.vsts-ci-templates/build_and_test_with_san.yml
@@ -13,10 +13,7 @@ steps:
   workingDirectory: build
 
 - script: |
-    python3.7 -m venv env
-    source env/bin/activate
-    pip install -U -r ../tests/requirements.txt
-    ctest -VV --timeout 240 --no-compress-output -T Test
+    ./tests.sh -VV --timeout 240 --no-compress-output -T Test
   displayName: CTest
   workingDirectory: build
 
@@ -26,8 +23,7 @@ steps:
   condition: succeededOrFailed()
 
 - script: |
-    source env/bin/activate
-    TEST_ENCLAVE=virtual ctest -VV -R client_test --timeout 240 --no-compress-output -T Test
+    TEST_ENCLAVE=virtual ./tests.sh -VV -R client_test --timeout 240 --no-compress-output -T Test
   displayName: CTest
   workingDirectory: build
 

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -20,7 +20,7 @@ jobs:
     - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
       displayName: 'Component Detection'
 
-    - script: find . -regex ".*\.sh$" | xargs shellcheck -s bash -e SC2044,SC2002
+    - script: find . -regex ".*\.sh$" | xargs shellcheck -s bash -e SC2044,SC2002,SC1091
       displayName: 'Shell Check'
 
     - script: python3.7 notice-check.py

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -135,6 +135,8 @@ add_custom_command(
     COMMENT "Generating code from EDL, and renaming to .cpp"
 )
 
+configure_file(${CCF_DIR}/tests/tests.sh ${CMAKE_CURRENT_BINARY_DIR}/tests.sh COPYONLY)
+
 if(NOT VIRTUAL_ONLY)
   # If OE was built with LINK_SGX=1, then we also need to link SGX
   execute_process(COMMAND "ldd" ${OESIGN}

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -262,17 +262,6 @@ int main(int argc, char** argv)
 
   LOG_INFO << "Created new node." << std::endl;
 
-  // Write the node cert and quote to disk. Actors can use the node cert
-  // as a CA on their end of the TLS connection.
-  files::dump(node_cert, node_cert_file);
-
-#ifdef GET_QUOTE
-  files::dump(quote, quote_file);
-
-  if (!enclave.verify_quote(quote, node_cert))
-    LOG_FATAL << "Verification of local node quote failed" << std::endl;
-#endif
-
   // ledger
   asynchost::Ledger ledger(ledger_file, writer_factory);
   ledger.register_message_handlers(bp.get_dispatcher());
@@ -288,6 +277,17 @@ int main(int argc, char** argv)
   asynchost::RPCConnections rpc(writer_factory);
   rpc.register_message_handlers(bp.get_dispatcher());
   rpc.listen(0, tls_hostname, tls_port);
+
+  // Write the node cert and quote to disk. Actors can use the node cert
+  // as a CA on their end of the TLS connection.
+  files::dump(node_cert, node_cert_file);
+
+#ifdef GET_QUOTE
+  files::dump(quote, quote_file);
+
+  if (!enclave.verify_quote(quote, node_cert))
+    LOG_FATAL << "Verification of local node quote failed" << std::endl;
+#endif
 
   // Start a thread which will ECall and process messages inside the enclave
   auto enclave_thread = std::thread([&]() {

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -8,6 +8,6 @@ if [ ! -f "env/bin/activate" ]
 fi
 
 source env/bin/activate
-pip install -q -r ../tests/requirements.txt
+pip install -q -U -r ../tests/requirements.txt
 
 ctest "$@"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+if [ ! -f "env/bin/activate" ]
+    then
+        python3.7 -m venv env
+fi
+
+source env/bin/activate
+pip install -q -r ../tests/requirements.txt
+
+ctest "$@"


### PR DESCRIPTION
Allows replacing:

```
python -m venv env
source env/bin/activate
pip install -r ../tests/requirements.txt
ctest ARGS
```

with

```
./tests.sh ARGS
```