### PR TITLE
TCP listens resolve synchronously

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ obj/
 tests/env/
 getting_started/create_vm/generated
 sphinx/env/
+debug/

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -138,7 +138,7 @@ namespace asynchost
     bool listen(const std::string& host, const std::string& service)
     {
       assert_status(FRESH, LISTENING_RESOLVING);
-      return resolve(host, service);
+      return resolve(host, service, false);
     }
 
     bool write(size_t len, const uint8_t* data)
@@ -282,7 +282,8 @@ namespace asynchost
       status = to;
     }
 
-    bool resolve(const std::string& host, const std::string& service)
+    bool resolve(
+      const std::string& host, const std::string& service, bool async = true)
     {
       this->host = host;
       this->service = service;
@@ -294,7 +295,7 @@ namespace asynchost
         addr_current = nullptr;
       }
 
-      if (!DNS::resolve(host, service, this, on_resolved))
+      if (!DNS::resolve(host, service, this, on_resolved, async))
       {
         status = RESOLVING_FAILED;
         return false;


### PR DESCRIPTION
Our e2e tests stopped working on some machines, as `start_network` requests were being sent before the  nodes are listening. We could add paths to check each connection's status, and only dump the cert files (indicating we're ready) inside the uv loop once we're _actually_ listening. This fix is simpler - when we `listen` for incoming TCP connections, resolve and bind synchronously rather than asynchronously, so the return code indicates the complete result.