### PR TITLE
Adding coverage to perf summary csv

### DIFF
--- a/tests/coverage/add_perf_summary.py
+++ b/tests/coverage/add_perf_summary.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
 import time
 import json
 
@@ -8,4 +10,11 @@ with open("coverage.json", "r") as file:
     lines_valid = str(data["totals"]["lines"]["count"])
 
 with open("perf_summary.csv", "a") as f:
-    f.write(timestamp + "," + lines_valid + ",Unit_Test_Coverage,0,0,0," + lines_covered + ",0,0,0,0")
+    f.write(
+        timestamp
+        + ","
+        + lines_valid
+        + ",Unit_Test_Coverage,0,0,0,"
+        + lines_covered
+        + ",0,0,0,0"
+    )

--- a/tests/coverage/add_perf_summary.py
+++ b/tests/coverage/add_perf_summary.py
@@ -1,0 +1,11 @@
+import time
+import json
+
+with open("coverage.json", "r") as file:
+    timestamp = str(int(time.time()))
+    data = json.load(file)["data"][0]
+    lines_covered = str(data["totals"]["lines"]["covered"])
+    lines_valid = str(data["totals"]["lines"]["count"])
+
+with open("perf_summary.csv", "a") as f:
+    f.write(timestamp + "," + lines_valid + ",Unit_Test_Coverage,0,0,0," + lines_covered + ",0,0,0,0")

--- a/tests/coverage/generate_coverage.sh
+++ b/tests/coverage/generate_coverage.sh
@@ -21,3 +21,4 @@ mv cov_* coverage/
 
 python3.7 ../tests/coverage/cobertura_generator.py
 python3.7 ../tests/coverage/style_html.py
+python3.7 ../tests/coverage/add_perf_summary.py


### PR DESCRIPTION
Adds a line at the end of the perf summary csv file, so overall line coverage percentage will be displayed as a graph along with the performance graphs