### PR TITLE
Add unit test for forwarder and remove NullReplicator

### DIFF
--- a/src/kv/kv.h
+++ b/src/kv/kv.h
@@ -1427,8 +1427,8 @@ namespace kv
       auto cv = current_version();
       if (cv != (v - 1))
       {
-        LOG_DEBUG << "Tried to deserialise " << v << " but current_version is "
-                  << cv << std::endl;
+        LOG_FAIL << "Tried to deserialise " << v << " but current_version is "
+                 << cv << std::endl;
         return DeserialiseSuccess::FAILED;
       }
 
@@ -1447,22 +1447,24 @@ namespace kv
         auto search = maps.find(map_name);
         if (search == maps.end())
         {
-          LOG_DEBUG << "No such map: " << map_name << std::endl;
+          LOG_FAIL << "No such map: " << map_name << " at version " << v
+                   << std::endl;
           return DeserialiseSuccess::FAILED;
         }
 
         auto view_search = views.find(map_name);
         if (view_search != views.end())
         {
-          LOG_DEBUG << "Multiple writes on " << map_name << std::endl;
+          LOG_FAIL << "Multiple writes on " << map_name << " at version " << v
+                   << std::endl;
           return DeserialiseSuccess::FAILED;
         }
 
         auto view = search->second->create_view(v);
         if (!view->deserialise(d, v))
         {
-          LOG_DEBUG << "Could not deserialise Tx for map " << map_name
-                    << std::endl;
+          LOG_FAIL << "Could not deserialise Tx for map " << map_name
+                   << " at version " << v << std::endl;
           return DeserialiseSuccess::FAILED;
         }
 
@@ -1472,14 +1474,15 @@ namespace kv
 
       if (!d.end())
       {
-        LOG_DEBUG << "Unexpected content in Tx" << std::endl;
+        LOG_FAIL << "Unexpected content in Tx at version " << v << std::endl;
         return DeserialiseSuccess::FAILED;
       }
 
       auto c = Tx::commit(views, [v]() { return v; });
       if (!c.has_value())
       {
-        LOG_DEBUG << "Failed to commit deserialised Tx" << std::endl;
+        LOG_FAIL << "Failed to commit deserialised Tx at version " << v
+                 << std::endl;
         return DeserialiseSuccess::FAILED;
       }
 

--- a/src/kv/kvtypes.h
+++ b/src/kv/kvtypes.h
@@ -12,6 +12,7 @@ namespace kv
 {
   using Version = int64_t;
   using Term = uint64_t;
+  using NodeId = uint64_t;
   static const Version NoVersion = std::numeric_limits<Version>::min();
 
   enum CommitSuccess
@@ -51,7 +52,13 @@ namespace kv
         entries) = 0;
     virtual Term get_term() = 0; // TODO(#api): this ought to have a more
                                  // abstract name than Term
+
+    virtual Term get_term(Version version) = 0;
     virtual Version get_commit_idx() = 0;
+
+    virtual NodeId leader() = 0;
+    virtual NodeId id() = 0;
+    virtual bool is_leader() = 0;
   };
 
   class TxHistory

--- a/src/kv/replicator.h
+++ b/src/kv/replicator.h
@@ -44,26 +44,25 @@ namespace kv
     {
       return 0;
     }
-  };
 
-  class NullReplicator : public Replicator
-  {
-  public:
-    bool replicate(
-      const std::vector<std::tuple<Version, std::vector<uint8_t>, bool>>&
-        entries) override
+    NodeId leader() override
+    {
+      return 1;
+    }
+
+    NodeId id() override
+    {
+      return 0;
+    }
+
+    kv::Term get_term(kv::Version version) override
+    {
+      return 2;
+    }
+
+    bool is_leader() override
     {
       return true;
-    }
-
-    kv::Term get_term() override
-    {
-      return 0;
-    }
-
-    kv::Version get_commit_idx() override
-    {
-      return 0;
     }
   };
 
@@ -97,6 +96,26 @@ namespace kv
     kv::Version get_commit_idx() override
     {
       return 0;
+    }
+
+    NodeId leader() override
+    {
+      return 1;
+    }
+
+    NodeId id() override
+    {
+      return 0;
+    }
+
+    kv::Term get_term(kv::Version version) override
+    {
+      return 2;
+    }
+
+    bool is_leader() override
+    {
+      return true;
     }
   };
 
@@ -151,6 +170,44 @@ namespace kv
     kv::Version get_commit_idx() override
     {
       return 0;
+    }
+
+    NodeId leader() override
+    {
+      return 1;
+    }
+
+    NodeId id() override
+    {
+      return 0;
+    }
+
+    kv::Term get_term(kv::Version version) override
+    {
+      return 2;
+    }
+
+    bool is_leader() override
+    {
+      return true;
+    }
+  };
+
+  class FollowerStubReplicator : public StubReplicator
+  {
+  public:
+    bool is_leader() override
+    {
+      return false;
+    }
+  };
+
+  class LeaderStubReplicator : public StubReplicator
+  {
+  public:
+    bool is_leader() override
+    {
+      return true;
     }
   };
 }

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -414,8 +414,6 @@ namespace ccf
       network.secrets = std::make_unique<NetworkSecrets>(
         "CN=The CA", std::make_unique<Seal>(writer_factory), false);
       accept_member_connections();
-      auto r = std::make_shared<kv::NullReplicator>();
-      network.tables->set_replicator(r);
       setup_store();
     }
 

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -31,7 +31,20 @@ namespace ccf
       FwdContext& fwd_ctx, const std::vector<uint8_t>& input) = 0;
   };
 
-  class Forwarder
+  class AbstractForwarder
+  {
+  public:
+    virtual ~AbstractForwarder() {}
+
+    virtual bool forward_command(
+      enclave::RpcContext& rpc_ctx,
+      NodeId from,
+      NodeId to,
+      CallerId caller_id,
+      const std::vector<uint8_t>& data) = 0;
+  };
+
+  class Forwarder : public AbstractForwarder
   {
   private:
     enclave::RPCSessions& rpcsessions;

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -96,7 +96,8 @@ public:
     auto empty_function = [this](RequestArgs& args) {
       return jsonrpc::success();
     };
-    // Note that this a Write function
+    // Note that this a Write function so that a follower executing this command
+    // will forward it to the leader
     install("empty_function", empty_function, Write);
   }
 };
@@ -499,12 +500,10 @@ TEST_CASE("Forwarding")
   TestForwardingFrontEnd frontend_follower(*network.tables);
   TestForwardingFrontEnd frontend_leader(*network2.tables);
 
-  // Set forwarder and replicator for follower frontend
   auto follower_forwarder = std::make_shared<StubForwarder>();
   auto follower_replicator = std::make_shared<kv::FollowerStubReplicator>();
   network.tables->set_replicator(follower_replicator);
 
-  // Set replicator for leader frontend
   auto leader_replicator = std::make_shared<kv::LeaderStubReplicator>();
   network2.tables->set_replicator(leader_replicator);
 

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -5,6 +5,8 @@
 #include "ds/files.h"
 #include "ds/logger.h"
 #include "enclave/appinterface.h"
+#include "kv/replicator.h"
+#include "node/entities.h"
 #include "node/networkstate.h"
 #include "node/rpc/jsonrpc.h"
 #include "node/rpc/memberfrontend.h"
@@ -86,9 +88,23 @@ public:
   }
 };
 
+class TestForwardingFrontEnd : public ccf::RpcFrontend
+{
+public:
+  TestForwardingFrontEnd(Store& tables) : RpcFrontend(tables)
+  {
+    auto empty_function = [this](RequestArgs& args) {
+      return jsonrpc::success();
+    };
+    // Note that this a Write function
+    install("empty_function", empty_function, Write);
+  }
+};
+
 // used throughout
 tls::KeyPair kp;
 ccf::NetworkState network;
+ccf::NetworkState network2;
 ccf::StubNodeState node;
 
 std::vector<uint8_t> sign_json(nlohmann::json j)
@@ -147,7 +163,7 @@ void prepare_callers()
   ccf::Certs* member_certs = &network.member_certs;
   auto user_certs_view = txs.get_view(*user_certs);
   user_certs_view->put(user_caller, 0);
-  user_certs_view->put(invalid_caller, 0);
+  user_certs_view->put(invalid_caller, 1);
   user_certs_view->put(nos_caller, 2);
   auto member_certs_view = txs.get_view(*member_certs);
   member_certs_view->put(member_caller, 0);
@@ -450,4 +466,116 @@ int main(int argc, char** argv)
   if (context.shouldExit())
     return res;
   return res;
+}
+
+class StubForwarder : public AbstractForwarder
+{
+public:
+  std::vector<std::vector<uint8_t>> forwarded_cmds;
+
+  StubForwarder() {}
+
+  bool forward_command(
+    enclave::RpcContext& rpc_ctx,
+    NodeId from,
+    NodeId to,
+    CallerId caller_id,
+    const std::vector<uint8_t>& data) override
+  {
+    forwarded_cmds.push_back(data);
+    return true;
+  }
+
+  void clear()
+  {
+    forwarded_cmds.clear();
+  }
+};
+
+TEST_CASE("Forwarding")
+{
+  prepare_callers();
+
+  TestForwardingFrontEnd frontend_follower(*network.tables);
+  TestForwardingFrontEnd frontend_leader(*network2.tables);
+
+  // Set forwarder and replicator for follower frontend
+  auto follower_forwarder = std::make_shared<StubForwarder>();
+  auto follower_replicator = std::make_shared<kv::FollowerStubReplicator>();
+  network.tables->set_replicator(follower_replicator);
+
+  // Set replicator for leader frontend
+  auto leader_replicator = std::make_shared<kv::LeaderStubReplicator>();
+  network2.tables->set_replicator(leader_replicator);
+
+  auto write_req = create_simple_json();
+  std::vector<uint8_t> serialized_call =
+    jsonrpc::pack(write_req, jsonrpc::Pack::MsgPack);
+
+  INFO("Frontend without forwarder does not forward");
+  {
+    enclave::RpcContext rpc_ctx_forwarded(
+      enclave::InvalidSessionId, user_caller);
+    REQUIRE(rpc_ctx_forwarded.is_forwarded == false);
+    REQUIRE(follower_forwarder->forwarded_cmds.empty());
+    auto serialized_response =
+      frontend_follower.process(rpc_ctx_forwarded, serialized_call);
+    REQUIRE(rpc_ctx_forwarded.is_forwarded == false);
+    REQUIRE(follower_forwarder->forwarded_cmds.size() == 0);
+
+    auto response =
+      jsonrpc::unpack(serialized_response, jsonrpc::Pack::MsgPack);
+    CHECK(
+      response[jsonrpc::ERR][jsonrpc::CODE] ==
+      static_cast<int16_t>(jsonrpc::ErrorCodes::TX_NOT_LEADER));
+  }
+
+  frontend_follower.set_cmd_forwarder(follower_forwarder);
+
+  INFO("Write command on follower is forwarded to leader");
+  {
+    enclave::RpcContext rpc_ctx_forwarded(
+      enclave::InvalidSessionId, user_caller);
+    REQUIRE(rpc_ctx_forwarded.is_forwarded == false);
+    REQUIRE(follower_forwarder->forwarded_cmds.empty());
+    frontend_follower.process(rpc_ctx_forwarded, serialized_call);
+    REQUIRE(rpc_ctx_forwarded.is_forwarded == true);
+    REQUIRE(follower_forwarder->forwarded_cmds.size() == 1);
+
+    auto forwarded_cmd = follower_forwarder->forwarded_cmds.back();
+    follower_forwarder->forwarded_cmds.pop_back();
+    FwdContext fwd_ctx(0, 0, 0);
+    auto serialized_response =
+      frontend_leader.process_forwarded(fwd_ctx, forwarded_cmd);
+
+    auto response =
+      jsonrpc::unpack(serialized_response, jsonrpc::Pack::MsgPack);
+    CHECK(response[jsonrpc::RESULT] == jsonrpc::OK);
+  }
+
+  INFO("Forwarding write command to a follower return TX_NOT_LEADER");
+  {
+    enclave::RpcContext rpc_ctx_forwarded(
+      enclave::InvalidSessionId, user_caller);
+    REQUIRE(rpc_ctx_forwarded.is_forwarded == false);
+    REQUIRE(follower_forwarder->forwarded_cmds.empty());
+    frontend_follower.process(rpc_ctx_forwarded, serialized_call);
+    REQUIRE(rpc_ctx_forwarded.is_forwarded == true);
+    REQUIRE(follower_forwarder->forwarded_cmds.size() == 1);
+
+    auto forwarded_cmd = follower_forwarder->forwarded_cmds.back();
+    follower_forwarder->forwarded_cmds.pop_back();
+    FwdContext fwd_ctx(0, 0, 0);
+
+    // Processing forwarded response by a follower frontend (here, the same
+    // frontend that the command was originally issued to)
+    auto serialized_response =
+      frontend_follower.process_forwarded(fwd_ctx, forwarded_cmd);
+    auto response =
+      jsonrpc::unpack(serialized_response, jsonrpc::Pack::MsgPack);
+
+    CHECK(
+      response[jsonrpc::ERR][jsonrpc::CODE] ==
+      static_cast<int16_t>(jsonrpc::ErrorCodes::TX_NOT_LEADER));
+  }
 }

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -47,6 +47,26 @@ public:
   {
     return 0;
   }
+
+  kv::NodeId leader() override
+  {
+    return 1;
+  }
+
+  kv::NodeId id() override
+  {
+    return 0;
+  }
+
+  kv::Term get_term(kv::Version version) override
+  {
+    return 2;
+  }
+
+  bool is_leader() override
+  {
+    return true;
+  }
 };
 
 TEST_CASE("Check signature verification")
@@ -206,6 +226,26 @@ public:
   {
     return 0;
   }
+
+  kv::NodeId leader() override
+  {
+    return 1;
+  }
+
+  kv::NodeId id() override
+  {
+    return 0;
+  }
+
+  kv::Term get_term(kv::Version version) override
+  {
+    return 2;
+  }
+
+  bool is_leader() override
+  {
+    return true;
+  }
 };
 
 TEST_CASE(
@@ -299,6 +339,26 @@ public:
   kv::Version get_commit_idx() override
   {
     return 0;
+  }
+
+  kv::NodeId leader() override
+  {
+    return 1;
+  }
+
+  kv::NodeId id() override
+  {
+    return 0;
+  }
+
+  kv::Term get_term(kv::Version version) override
+  {
+    return 2;
+  }
+
+  bool is_leader() override
+  {
+    return true;
   }
 };
 

--- a/src/node/test/history_bench.cpp
+++ b/src/node/test/history_bench.cpp
@@ -35,6 +35,26 @@ public:
   {
     return 0;
   }
+
+  NodeId leader() override
+  {
+    return 1;
+  }
+
+  NodeId id() override
+  {
+    return 0;
+  }
+
+  kv::Term get_term(kv::Version version) override
+  {
+    return 2;
+  }
+
+  bool is_leader() override
+  {
+    return true;
+  }
 };
 
 template <class A>

--- a/src/raft/raft.h
+++ b/src/raft/raft.h
@@ -158,17 +158,17 @@ namespace raft
       rand((int)(uintptr_t)this)
     {}
 
-    NodeId leader()
+    NodeId leader() override
     {
       return leader_id;
     }
 
-    NodeId id()
+    NodeId id() override
     {
       return local_id;
     }
 
-    bool is_leader()
+    bool is_leader() override
     {
       return state == Leader;
     }
@@ -273,7 +273,7 @@ namespace raft
       return current_term;
     }
 
-    Term get_term(Index idx)
+    Term get_term(Index idx) override
     {
       std::lock_guard<SpinLock> guard(lock);
       return get_term_internal(idx);

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -300,6 +300,7 @@ class Network:
         for _ in range(3):
             commits = []
             for node in self.nodes:
+                LOG.info("Talking to node {}".format(node.node_id))
                 with node.management_client() as c:
                     id = c.request("getCommit", {})
                     commits.append(c.response(id).commit)

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -300,7 +300,6 @@ class Network:
         for _ in range(3):
             commits = []
             for node in self.nodes:
-                LOG.info("Talking to node {}".format(node.node_id))
                 with node.management_client() as c:
                     id = c.request("getCommit", {})
                     commits.append(c.response(id).commit)

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -232,7 +232,7 @@ def run(args):
 if __name__ == "__main__":
 
     def add(parser):
-        parser.description = """       
+        parser.description = """
 This test executes multiple recoveries (as specified by the "--recovery" arg),
 with a fixed number of messages applied between each network crash (as
 specified by the "--msgs-per-recovery" arg). After the network is recovered


### PR DESCRIPTION
I have added some unit tests for the new frontend forwarding capability in `frontend_test.cpp`.

In the process, I had to change `raft` in `frontend.h` to be of type `kv::Replicator` which involved defining a bunch of virtual methods in all sub-classes that derive from `kv::Replicator`. We also found out an issue with the `NullReplicator` used in the very first stage of the recovery - which I have now removed as it was not used anyway. 