### PR TITLE
Adding support for Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,9 +2,7 @@
 #   curl --data-binary @.codecov.yml https://codecov.io/validate
 
 codecov:
-  # comment: on
-  branch: codecov
-
+  comment: on
 
 coverage:
   range: "70...100"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,23 @@
+# validate this file:
+#   curl --data-binary @.codecov.yml https://codecov.io/validate
+
+codecov:
+  comment: on
+  branch: codecov
+
+
+coverage:
+  range: "25...50"
+  round: down
+  precision: 2
+  status:
+    project: off
+    patch: off
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: no
+  require_head: yes
+  branches: null
+

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,22 +2,24 @@
 #   curl --data-binary @.codecov.yml https://codecov.io/validate
 
 codecov:
-  comment: on
+  # comment: on
   branch: codecov
 
 
 coverage:
-  range: "25...50"
-  round: down
+  range: "70...100"
+  round: nearest
   precision: 2
   status:
-    project: off
-    patch: off
+    project:
+      default: false
+      ccf:
+        target: 70%
+
 comment:
-  layout: "reach, diff, flags, files"
+  layout: "diff, flags, files"
   behavior: default
   require_changes: false
   require_base: no
   require_head: yes
-  branches: null
 

--- a/.vsts-ci-templates/build_and_test.yml
+++ b/.vsts-ci-templates/build_and_test.yml
@@ -35,7 +35,7 @@ steps:
   workingDirectory: build
 
 - script: |
-    ../tests/coverage/generate_coverage.sh
+    CODECOV_TOKEN=$(codecov) ../tests/coverage/generate_coverage.sh
   displayName: CoverageGeneration
   workingDirectory: build
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://msr-gryffindor.visualstudio.com/COCO/_apis/build/status/CCF%20Github%20CI?branchName=master)](https://msr-gryffindor.visualstudio.com/COCO/_build/latest?definitionId=82&branchName=master)
+[![codecov](https://codecov.io/gh/microsoft/CCF/branch/master/graph/badge.svg)](https://codecov.io/gh/microsoft/CCF)
 
 # The Confidential Consortium Framework
 
@@ -15,7 +16,7 @@ CCF enables enterprise-ready computation or blockchain networks that deliver:
    effectively verify the entire network. This simplifies consensus and thus improves transaction speed and latency — all without compromising security or assuming trust.
 
  * **Richer, more flexible confidentiality models.** Beyond safeguarding data access with encryption-in-use via TEEs, we use industry standards (TLS and remote attestation)
-   to ensure secure node communication. Transactions can be processed in the clear or revealed only to authorized parties, without requiring complicated confidentiality schemes. 
+   to ensure secure node communication. Transactions can be processed in the clear or revealed only to authorized parties, without requiring complicated confidentiality schemes.
 
  * **Network and service policy management through non-centralized governance.** The framework provides a network and service configuration to express and manage consortium
    and multi-party policies. Governance actions, such as adding members to the governing consortium or initiating catastrophic recovery, can be managed and recorded through
@@ -28,11 +29,11 @@ CCF enables enterprise-ready computation or blockchain networks that deliver:
 
 In a public blockchain network, anyone can transact on the network, actors on the network are pseudo-anonymous and untrusted, and anyone can add nodes to the network
 — with full access to the ledger and with the ability to participate in consensus. Similarly, other distributed data technologies (such as distributed databases)
-can have challenges in multi-party scenarios when it comes to deciding what party operates it and whether that party could choose or could be compelled to act maliciously. 
- 
+can have challenges in multi-party scenarios when it comes to deciding what party operates it and whether that party could choose or could be compelled to act maliciously.
+
 In contrast, in a consortium or multi-party network backed by TEEs, such as CCF, consortium member identities and node identities are known and controlled.
 A trusted network of enclaves running on physical nodes is established without requiring the actors that control those nodes to trust one another
-—  what code is run is controlled and correctness of its output can be guaranteed, simplifying the consensus methods and reducing duplicative validation of data. 
+—  what code is run is controlled and correctness of its output can be guaranteed, simplifying the consensus methods and reducing duplicative validation of data.
 
 ![diagram](https://microsoft.github.io/CCF/_images/ccf.svg)
 

--- a/tests/coverage/generate_coverage.sh
+++ b/tests/coverage/generate_coverage.sh
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-CODECOV_TOKEN=cabeafff-d9e7-47cb-96b0-cb545e4b3ad9
 for f in *profraw; do
     echo "$f" >> prof_files
 done
@@ -15,14 +14,14 @@ for f in *_test; do
     llvm-cov-7 show -instr-profile "$f".profdata -output-dir=cov_"$f" -format=html "$f" -Xdemangler c++filt -Xdemangler -n -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)"
 done
 
-llvm-cov-7 show -instr-profile coverage.profdata -output-dir=coverage -format=html ds_test "${objects[@]}" -Xdemangler c++filt -Xdemangler -n -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)"
-llvm-cov-7 export -instr-profile coverage.profdata -format=text ds_test "${objects[@]}" -Xdemangler c++filt -Xdemangler -n -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)" -summary-only > coverage.json
+llvm-cov-7 show -instr-profile coverage.profdata -output-dir=coverage -format=html "${objects[@]}" -Xdemangler c++filt -Xdemangler -n -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)"
+llvm-cov-7 export -instr-profile coverage.profdata -format=text "${objects[@]}" -Xdemangler c++filt -Xdemangler -n -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)" -summary-only > coverage.json
 
-llvm-cov-7 show -instr-profile coverage.profdata -object channels_test -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)" > coverage2.txt
+llvm-cov-7 show -instr-profile coverage.profdata "${objects[@]}" -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)" > coverage2.txt
 
 bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -f coverage2.txt || echo "Codecov did not collect coverage reports"
 
-# mv cov_* coverage/
+mv cov_* coverage/
 
 python3.7 ../tests/coverage/cobertura_generator.py
 python3.7 ../tests/coverage/style_html.py

--- a/tests/coverage/generate_coverage.sh
+++ b/tests/coverage/generate_coverage.sh
@@ -2,27 +2,34 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
+set -e
+
 for f in *profraw; do
     echo "$f" >> prof_files
 done
 
-llvm-profdata-7 merge -sparse -f prof_files -o coverage.profdata
-
+# Generate html coverage report for individual unit test
 objects=()
 for f in *_test; do
     objects+=( -object "$f")
     llvm-cov-7 show -instr-profile "$f".profdata -output-dir=cov_"$f" -format=html "$f" -Xdemangler c++filt -Xdemangler -n -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)"
 done
 
+# Merge coverage report for all unit tests
+llvm-profdata-7 merge -sparse -f prof_files -o coverage.profdata
+
+# Generate combined coverage report
 llvm-cov-7 show -instr-profile coverage.profdata -output-dir=coverage -format=html "${objects[@]}" -Xdemangler c++filt -Xdemangler -n -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)"
 llvm-cov-7 export -instr-profile coverage.profdata -format=text "${objects[@]}" -Xdemangler c++filt -Xdemangler -n -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)" -summary-only > coverage.json
 
-llvm-cov-7 show -instr-profile coverage.profdata "${objects[@]}" -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)" > coverage2.txt
+# Generate and upload combined coverage report for Codecov
+llvm-cov-7 show -instr-profile coverage.profdata "${objects[@]}" -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)" > codecov.txt
+bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" -f codecov.txt
 
-bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -f coverage2.txt || echo "Codecov did not collect coverage reports"
-
+# Generate html for Azure Devops
 mv cov_* coverage/
-
 python3.7 ../tests/coverage/cobertura_generator.py
 python3.7 ../tests/coverage/style_html.py
+
+# Add coverage results to perf summary file
 python3.7 ../tests/coverage/add_perf_summary.py

--- a/tests/coverage/generate_coverage.sh
+++ b/tests/coverage/generate_coverage.sh
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
+CODECOV_TOKEN=cabeafff-d9e7-47cb-96b0-cb545e4b3ad9
 for f in *profraw; do
     echo "$f" >> prof_files
 done
@@ -17,7 +18,11 @@ done
 llvm-cov-7 show -instr-profile coverage.profdata -output-dir=coverage -format=html ds_test "${objects[@]}" -Xdemangler c++filt -Xdemangler -n -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)"
 llvm-cov-7 export -instr-profile coverage.profdata -format=text ds_test "${objects[@]}" -Xdemangler c++filt -Xdemangler -n -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)" -summary-only > coverage.json
 
-mv cov_* coverage/
+llvm-cov-7 show -instr-profile coverage.profdata -object channels_test -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)" > coverage2.txt
+
+bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN} -f coverage2.txt || echo "Codecov did not collect coverage reports"
+
+# mv cov_* coverage/
 
 python3.7 ../tests/coverage/cobertura_generator.py
 python3.7 ../tests/coverage/style_html.py


### PR DESCRIPTION
This PR adds support for Codecov as a code coverage tool, which has a nice integration with GitHub. 

For each PR, there should be a code coverage report automatically published as a comment on GitHub. I've also added a badge at the top of `README.md`.