### PR TITLE
Support for forwarding for all frontends

### DIFF
--- a/src/enclave/rpchandler.h
+++ b/src/enclave/rpchandler.h
@@ -17,10 +17,13 @@ namespace enclave
     const size_t session_id;
     const CBuffer caller;
     bool is_forwarded = false;
+    const ccf::ActorsType actor;
 
-    RpcContext(size_t session_id_, CBuffer caller_) :
+    RpcContext(
+      size_t session_id_, CBuffer caller_, ccf::ActorsType actor_) :
       session_id(session_id_),
-      caller(caller_)
+      caller(caller_),
+      actor(actor_)
     {}
   };
 

--- a/src/enclave/rpchandler.h
+++ b/src/enclave/rpchandler.h
@@ -20,7 +20,9 @@ namespace enclave
     const ccf::ActorsType actor;
 
     RpcContext(
-      size_t session_id_, CBuffer caller_, ccf::ActorsType actor_) :
+      size_t session_id_,
+      CBuffer caller_,
+      ccf::ActorsType actor_ = ccf::ActorsType::unknown) :
       session_id(session_id_),
       caller(caller_),
       actor(actor_)

--- a/src/enclave/rpcmap.h
+++ b/src/enclave/rpcmap.h
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "node/entities.h"
+#include "rpchandler.h"
+
+namespace enclave
+{
+  class RpcMap
+  {
+  private:
+    std::unordered_map<uint8_t, std::shared_ptr<RpcHandler>> map;
+    std::map<std::string, ccf::ActorsType> actors_map;
+
+  public:
+    RpcMap() = default;
+
+    template <ccf::ActorsType T>
+    void register_frontend(
+      std::string name, std::shared_ptr<RpcHandler> handler_)
+    {
+      actors_map.emplace(name, T);
+      map.emplace(T, handler_);
+    }
+
+    ccf::ActorsType resolve(std::string& name)
+    {
+      auto search = actors_map.find(name);
+      if (search == actors_map.end())
+        return ccf::ActorsType::unknown;
+
+      return search->second;
+    }
+
+    std::optional<std::shared_ptr<RpcHandler>> find(ccf::ActorsType index)
+    {
+      auto search = map.find(index);
+      if (search == map.end())
+        return {};
+
+      return search->second;
+    }
+
+    auto& get_map()
+    {
+      return map;
+    }
+  };
+
+#define REGISTER_FRONTEND(rpc_map, name, fe) \
+  rpc_map->register_frontend<ccf::ActorsType::name>(#name, fe)
+
+}

--- a/src/enclave/tlsendpoint.h
+++ b/src/enclave/tlsendpoint.h
@@ -5,9 +5,9 @@
 #include "ds/logger.h"
 #include "ds/messaging.h"
 #include "ds/ringbuffer.h"
+#include "endpoint.h"
 #include "tls/context.h"
 #include "tls/msg_types.h"
-#include "endpoint.h"
 
 namespace enclave
 {

--- a/src/enclave/tlsendpoint.h
+++ b/src/enclave/tlsendpoint.h
@@ -2,11 +2,11 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
-#include "../ds/logger.h"
-#include "../ds/messaging.h"
-#include "../ds/ringbuffer.h"
-#include "../tls/context.h"
-#include "../tls/msg_types.h"
+#include "ds/logger.h"
+#include "ds/messaging.h"
+#include "ds/ringbuffer.h"
+#include "tls/context.h"
+#include "tls/msg_types.h"
 #include "endpoint.h"
 
 namespace enclave
@@ -67,7 +67,7 @@ namespace enclave
 
     std::vector<uint8_t> read(size_t up_to, bool exact = false)
     {
-      LOG_DEBUG << "Requesting " << up_to << " bytes" << std::endl;
+      LOG_TRACE << "Requesting " << up_to << " bytes" << std::endl;
       // This will return en empty vector if the connection isn't
       // ready, but it will not block on the handshake.
       do_handshake();
@@ -85,7 +85,7 @@ namespace enclave
 
       if (read_buffer.size() > 0)
       {
-        LOG_DEBUG << "read_buffer is of size: " << read_buffer.size()
+        LOG_TRACE << "read_buffer is of size: " << read_buffer.size()
                   << std::endl;
         offset = std::min(up_to, read_buffer.size());
         ::memcpy(data.data(), read_buffer.data(), offset);
@@ -100,7 +100,7 @@ namespace enclave
       }
 
       auto r = ctx->read(data.data() + offset, up_to - offset);
-      LOG_DEBUG << "ctx->read returned: " << r << std::endl;
+      LOG_TRACE << "ctx->read returned: " << r << std::endl;
 
       switch (r)
       {
@@ -108,7 +108,7 @@ namespace enclave
         case MBEDTLS_ERR_NET_CONN_RESET:
         case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY:
         {
-          LOG_DEBUG << "TLS " << session_id << " on read: " << strerror(r)
+          LOG_TRACE << "TLS " << session_id << " on read: " << strerror(r)
                     << std::endl;
 
           stop(closed);
@@ -140,7 +140,7 @@ namespace enclave
 
       if (r < 0)
       {
-        LOG_DEBUG << "TLS " << session_id << " on read: " << strerror(r)
+        LOG_TRACE << "TLS " << session_id << " on read: " << strerror(r)
                   << std::endl;
         stop(error);
         return {};
@@ -153,7 +153,7 @@ namespace enclave
       // MBEDTLS_ERR_SSL_WANT_READ. Probably hit a size limit - try again
       if (exact && (total < up_to))
       {
-        LOG_DEBUG << "Asked for exactly " << up_to << ", received " << total
+        LOG_TRACE << "Asked for exactly " << up_to << ", received " << total
                   << ", retrying" << std::endl;
         read_buffer = move(data);
         return read(up_to, exact);
@@ -225,7 +225,7 @@ namespace enclave
         }
         else
         {
-          LOG_DEBUG << "TLS " << session_id << " on flush: " << strerror(r)
+          LOG_TRACE << "TLS " << session_id << " on flush: " << strerror(r)
                     << std::endl;
           stop(error);
         }
@@ -238,7 +238,7 @@ namespace enclave
       {
         case handshake:
         {
-          LOG_DEBUG << "TLS " << session_id << " closed during handshake"
+          LOG_TRACE << "TLS " << session_id << " closed during handshake"
                     << std::endl;
           stop(closed);
           break;
@@ -257,14 +257,14 @@ namespace enclave
               // mbedtls may return 0 when a close notify has not been
               // sent. This can't be disambiguated from a successful
               // close notify, so treat them the same.
-              LOG_DEBUG << "TLS " << session_id << " closed" << std::endl;
+              LOG_TRACE << "TLS " << session_id << " closed" << std::endl;
               stop(closed);
               break;
             }
 
             default:
             {
-              LOG_DEBUG << "TLS " << session_id << " on close: " << strerror(r)
+              LOG_TRACE << "TLS " << session_id << " on close: " << strerror(r)
                         << std::endl;
               stop(error);
               break;
@@ -303,7 +303,7 @@ namespace enclave
         case MBEDTLS_ERR_SSL_NO_CLIENT_CERTIFICATE:
         case MBEDTLS_ERR_SSL_PEER_VERIFY_FAILED:
         {
-          LOG_DEBUG << "TLS " << session_id << " on handshake: " << strerror(rc)
+          LOG_TRACE << "TLS " << session_id << " on handshake: " << strerror(rc)
                     << std::endl;
           stop(authfail);
           break;
@@ -311,7 +311,7 @@ namespace enclave
 
         case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY:
         {
-          LOG_DEBUG << "TLS " << session_id << " on handshake: " << strerror(rc)
+          LOG_TRACE << "TLS " << session_id << " on handshake: " << strerror(rc)
                     << std::endl;
           stop(closed);
           break;
@@ -329,10 +329,10 @@ namespace enclave
           if (r > 0)
           {
             buf.resize(r);
-            LOG_FAIL << std::string(buf.data(), buf.size()) << std::endl;
+            LOG_TRACE << std::string(buf.data(), buf.size()) << std::endl;
           }
 
-          LOG_DEBUG << "TLS " << session_id << " on handshake: " << strerror(rc)
+          LOG_TRACE << "TLS " << session_id << " on handshake: " << strerror(rc)
                     << std::endl;
           stop(authfail);
           return;
@@ -340,7 +340,7 @@ namespace enclave
 
         default:
         {
-          LOG_DEBUG << "TLS " << session_id << " on handshake: " << strerror(rc)
+          LOG_TRACE << "TLS " << session_id << " on handshake: " << strerror(rc)
                     << std::endl;
           stop(error);
           break;

--- a/src/enclave/tlsframedendpoint.h
+++ b/src/enclave/tlsframedendpoint.h
@@ -38,7 +38,7 @@ namespace enclave
           const uint8_t* data = len.data();
           size_t size = len.size();
           msg_size = serialized::read<uint32_t>(data, size);
-          LOG_DEBUG << "msg size is: " << msg_size << std::endl;
+          LOG_TRACE << "msg size is: " << msg_size << std::endl;
         }
 
         // Arbitrary limit on RPC size to stop a client from requesting

--- a/src/node/entities.h
+++ b/src/node/entities.h
@@ -5,6 +5,7 @@
 #include "kv/kvserialiser.h"
 
 #include <limits>
+#include <map>
 #include <stdint.h>
 #include <vector>
 
@@ -30,6 +31,16 @@ namespace ccf
     static constexpr auto USERS = "users";
     static constexpr auto NODES = "nodes";
     static constexpr auto MANAGEMENT = "management";
+  };
+
+  enum ActorsType
+  {
+    members = 0,
+    users,
+    nodes,
+    management,
+    // not to be used
+    unknown
   };
 
   struct Tables

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -20,7 +20,7 @@ namespace ccf
       size_t session_id_,
       NodeId forwarder_id_,
       CallerId caller_id_,
-      ccf::ActorsType actor_) :
+      ccf::ActorsType actor_ = ccf::ActorsType::unknown) :
       session_id(session_id_),
       forwarder_id(forwarder_id_),
       caller_id(caller_id_),

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -12,13 +12,19 @@ namespace ccf
     const size_t session_id;
     const NodeId forwarder_id;
     const CallerId caller_id;
+    const ccf::ActorsType actor;
 
     NodeId leader_id;
 
-    FwdContext(size_t session_id_, NodeId forwarder_id_, CallerId caller_id_) :
+    FwdContext(
+      size_t session_id_,
+      NodeId forwarder_id_,
+      CallerId caller_id_,
+      ccf::ActorsType actor_) :
       session_id(session_id_),
       forwarder_id(forwarder_id_),
-      caller_id(caller_id_)
+      caller_id(caller_id_),
+      actor(actor_)
     {}
   };
 
@@ -72,11 +78,13 @@ namespace ccf
       const std::vector<uint8_t>& data)
     {
       std::vector<uint8_t> plain(
-        sizeof(caller_id) + sizeof(rpc_ctx.session_id) + data.size());
+        sizeof(caller_id) + sizeof(rpc_ctx.session_id) + sizeof(rpc_ctx.actor) +
+        data.size());
       auto data_ = plain.data();
       auto size_ = plain.size();
       serialized::write(data_, size_, caller_id);
       serialized::write(data_, size_, rpc_ctx.session_id);
+      serialized::write(data_, size_, rpc_ctx.actor);
       serialized::write(data_, size_, data.data(), data.size());
 
       ForwardedHeader msg = {ForwardedMsg::forwarded_cmd, from};
@@ -110,10 +118,12 @@ namespace ccf
       auto size_ = plain_.size();
       auto caller_id = serialized::read<CallerId>(data_, size_);
       auto session_id = serialized::read<size_t>(data_, size_);
+      auto actor = serialized::read<ccf::ActorsType>(data_, size_);
       std::vector<uint8_t> rpc = serialized::read(data_, size_, size_);
 
       return std::make_pair(
-        FwdContext(session_id, msg.from_node, caller_id), std::move(rpc));
+        FwdContext(session_id, msg.from_node, caller_id, actor),
+        std::move(rpc));
     }
 
     bool send_forwarded_response(
@@ -173,14 +183,20 @@ namespace ccf
         {
           if (rpc_map)
           {
-            LOG_DEBUG << "Forwarded RPC: " << ccf::Actors::USERS << std::endl;
-
             auto fwd = recv_forwarded_command(data, size);
             if (!fwd.has_value())
               return;
 
-            auto fwd_handler = dynamic_cast<ccf::ForwardedRpcHandler*>(
-              rpc_map->at(std::string(ccf::Actors::USERS)).get());
+            auto handler = rpc_map->find(fwd->first.actor);
+            if (!handler.has_value())
+              return;
+
+            auto fwd_handler =
+              dynamic_cast<ccf::ForwardedRpcHandler*>(handler.value().get());
+            if (!fwd_handler)
+              return;
+
+            LOG_DEBUG << "Forwarded RPC: " << fwd->first.actor << std::endl;
 
             auto rep = fwd_handler->process_forwarded(fwd->first, fwd->second);
 

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -407,18 +407,6 @@ namespace ccf
       update_raft();
       fwd_ctx.leader_id = raft->id();
 
-      // If the RPC was forwarded, assume that the caller has already been
-      // verified
-      if (fwd_ctx.caller_id == INVALID_ID)
-      {
-        return jsonrpc::pack(
-          jsonrpc::error_response(
-            0,
-            jsonrpc::ErrorCodes::INVALID_CALLER_ID,
-            "No corresponding caller entry exists (forwarded)."),
-          jsonrpc::Pack::Text);
-      }
-
       auto pack = detect_pack(input);
       if (!pack.has_value())
         return jsonrpc::pack(
@@ -427,6 +415,18 @@ namespace ccf
             jsonrpc::ErrorCodes::INVALID_REQUEST,
             "Empty forwarded request."),
           jsonrpc::Pack::Text);
+
+      // If the RPC was forwarded, assume that the caller has already been
+      // verified
+      if (certs && fwd_ctx.caller_id == INVALID_ID)
+      {
+        return jsonrpc::pack(
+          jsonrpc::error_response(
+            0,
+            jsonrpc::ErrorCodes::INVALID_CALLER_ID,
+            "No corresponding caller entry exists (forwarded)."),
+          pack.value());
+      }
 
       auto rpc = unpack_json(input, pack.value());
       if (!rpc.first)

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -47,6 +47,12 @@ def run(args):
                     check(c.rpc("LOG_get", {"id": 42}), result=msg)
                     check(c.rpc("LOG_get", {"id": 43}), result=msg2)
 
+                LOG.debug("Write on all follower frontends")
+                with follower.management_client(format="json") as c:
+                    check_commit(c.do("mkSign", params={}), result="OK")
+                with follower.member_client(format="json") as c:
+                    check_commit(c.do("mkSign", params={}), result="OK")
+
                 LOG.debug("Write/Read on follower")
                 with follower.user_client(format="json") as c:
                     check_commit(
@@ -54,7 +60,6 @@ def run(args):
                         result="OK",
                     )
                     check(c.rpc("LOG_get", {"id": 100}), result=follower_msg)
-
                     check(c.rpc("LOG_get", {"id": 42}), result=msg)
 
                 LOG.debug("Write/Read large messages on leader")


### PR DESCRIPTION
Only the `USERS` frontend used to be forwarded. This PR adds support for forwarding all frontends (i.e. `MEMBERS`, `MANAGEMENT` and `NODES`) by passing a new `ActorsType` enum (indicating which frontend to forward to) to the forwarded command.

I've added a new `RpcMap` class that handles the conversion between a string (`host` in `rpcendpoint.h`) and the `ActorsType` enum that uniquely identifies each frontend. Please let me know if there's a better way to do this.

**Also:**
- Changed some logs to `LOG_TRACE` as they are too verbose for a debug build.
- Simplified some things in `nodefrontend.h` as 1) we don't need to check whether we are leader (it is handled at the generic `frontend.h` level) and 2) the joining node's id is already passed in the `args` to the handler.