### PR TITLE
Fix .codecov.yml as it is not currently valid

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,9 +1,6 @@
 # validate this file:
 #   curl --data-binary @.codecov.yml https://codecov.io/validate
 
-codecov:
-  comment: on
-
 coverage:
   range: "70...100"
   round: nearest
@@ -15,7 +12,7 @@ coverage:
         target: 70%
 
 comment:
-  layout: "diff, flags, files"
+  layout: "reach, diff, flags, files"
   behavior: default
   require_changes: false
   require_base: no


### PR DESCRIPTION
It turns out, the new `.codecov.yml` file was not valid (my bad!). It meant that [the default style was being used](https://docs.codecov.io/docs/codecov-yaml#section-do-i-need-a-codecov-yml-file-). 