### PR TITLE
End to end coverage

### DIFF
--- a/.vsts-ci-templates/build_and_test.yml
+++ b/.vsts-ci-templates/build_and_test.yml
@@ -6,7 +6,7 @@ steps:
 - task: CMake@1
   displayName: CMake
   inputs:
-    cmakeArgs: '-GNinja ..'
+    cmakeArgs: '-GNinja -DEND_TO_END_COVERAGE=ON ..'
 
 - script: ninja
   displayName: Ninja
@@ -38,10 +38,3 @@ steps:
     CODECOV_TOKEN=$(codecov) ../tests/coverage/generate_coverage.sh
   displayName: CoverageGeneration
   workingDirectory: build
-
-- task: PublishCodeCoverageResults@1
-  inputs:
-    codeCoverageTool: Cobertura
-    summaryFileLocation: '$(System.DefaultWorkingDirectory)/build/coverage.xml'
-    reportDirectory: '$(System.DefaultWorkingDirectory)/build/coverage'
-  condition: succeededOrFailed()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,17 @@ if(BUILD_TESTS)
       ${CCF_NETWORK_TEST_ARGS}
   )
 
+  if(END_TO_END_COVERAGE)
+    add_test(
+      NAME end_to_end_logging_coverage
+      COMMAND
+        ${PYTHON} ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py
+        -b .
+        ${TEST_FORWARD_TO_LEADER}
+        ${CCF_NETWORK_TEST_COV_ARGS}
+    )
+  endif()
+
   add_test(
     NAME end_to_end_scenario
     COMMAND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ endif()
 
 option(BUILD_SMALLBANK "Build SmallBank sample app and clients" ON)
 
+option(END_TO_END_COVERAGE "Run additional tests in virtual enclaves to generate coverage for end to end tests" OFF)
+
 # MemberClient executable
 add_executable(memberclient src/clients/memberclient.cpp)
 use_client_mbedtls(memberclient)
@@ -282,17 +284,6 @@ if(BUILD_TESTS)
       ${CCF_NETWORK_TEST_ARGS}
   )
 
-  if(END_TO_END_COVERAGE)
-    add_test(
-      NAME end_to_end_logging_coverage
-      COMMAND
-        ${PYTHON} ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py
-        -b .
-        ${TEST_FORWARD_TO_LEADER}
-        ${CCF_NETWORK_TEST_COV_ARGS}
-    )
-  endif()
-
   add_test(
     NAME end_to_end_scenario
     COMMAND
@@ -337,4 +328,16 @@ if(BUILD_TESTS)
   if (EXTENSIVE_TESTS)
     set_tests_properties(recovery_tests PROPERTIES TIMEOUT 2000)
   endif()
+
+  if(END_TO_END_COVERAGE)
+    add_test(
+      NAME end_to_end_logging_coverage
+      COMMAND
+        ${PYTHON} ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py
+        -b .
+        ${TEST_FORWARD_TO_LEADER}
+        ${CCF_NETWORK_TEST_COV_ARGS}
+    )
+  endif()
+
 endif()

--- a/tests/coverage/generate_coverage.sh
+++ b/tests/coverage/generate_coverage.sh
@@ -25,6 +25,6 @@ for e2e in *.virtual.so; do
     if [ -f "$e2e".profraw  ]; then
         llvm-profdata-7 merge -sparse "$e2e".profraw -o "$e2e".profdata
         llvm-cov-7 show -instr-profile "$e2e".profdata -object cchost.virtual -object "$e2e" -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)" > "$e2e".txt
-        bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" -f "$e2e".txt -F "$e2e"
+        bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" -f "$e2e".txt -F end_to_end
     fi
 done

--- a/tests/coverage/generate_coverage.sh
+++ b/tests/coverage/generate_coverage.sh
@@ -22,9 +22,9 @@ llvm-cov-7 show -instr-profile coverage.profdata "${objects[@]}" -ignore-filenam
 bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" -f codecov.txt -F unit
 
 for e2e in *.virtual.so; do
-    if [ -f "$e2e".profraw  ]; then
-        llvm-profdata-7 merge -sparse *_"$e2e".profraw -o "$e2e".profdata
+    if [ -f 0_"$e2e".profraw  ]; then
+        llvm-profdata-7 merge -sparse ./*_"$e2e".profraw -o "$e2e".profdata
         llvm-cov-7 show -instr-profile "$e2e".profdata -object cchost.virtual -object "$e2e" -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)" > "$e2e".txt
-        bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" -f "$e2e".txt -F $(echo $"e2e" | cut -d. -f1)
+        bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" -f "$e2e".txt -F "$(echo $"e2e" | cut -d. -f1)"
     fi
 done

--- a/tests/coverage/generate_coverage.sh
+++ b/tests/coverage/generate_coverage.sh
@@ -24,7 +24,7 @@ bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" -f codecov.txt -F 
 for e2e in *.virtual.so; do
     if [ -f "$e2e".profraw  ]; then
         llvm-profdata-7 merge -sparse "$e2e".profraw -o "$e2e".profdata
-        llvm-cov-7 show -instr-profile "$e2e".profdata -object ccfhost.virtual -object "$e2e" -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)" > "$e2e".txt
+        llvm-cov-7 show -instr-profile "$e2e".profdata -object cchost.virtual -object "$e2e" -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)" > "$e2e".txt
         bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" -f "$e2e".txt -F "$e2e"
     fi
 done

--- a/tests/coverage/generate_coverage.sh
+++ b/tests/coverage/generate_coverage.sh
@@ -27,7 +27,7 @@ llvm-cov-7 show -instr-profile coverage.profdata "${objects[@]}" -ignore-filenam
 bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" -f codecov.txt -F unit
 
 for e2e in *.virtual.so; do
-    if [ -f "$e2e".profraw  ]; do
+    if [ -f "$e2e".profraw  ]; then
         llvm-profdata-7 merge -sparse "$e2e".profraw -o "$e2e".profdata
         llvm-cov-7 show -instr-profile "$e2e".profdata -object ccfhost.virtual -object "$e2e" -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)" > "$e2e".txt
         bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" -f "$e2e".txt -F "$e2e"

--- a/tests/coverage/generate_coverage.sh
+++ b/tests/coverage/generate_coverage.sh
@@ -2,17 +2,12 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-set -e
+set -ex
 
-for f in *_test.profraw; do
-    echo "$f" >> prof_files
-done
-
-# Generate html coverage report for individual unit test
 objects=()
 for f in *_test; do
     objects+=( -object "$f")
-    llvm-cov-7 show -instr-profile "$f".profdata -output-dir=cov_"$f" -format=html "$f" -Xdemangler c++filt -Xdemangler -n -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)"
+    echo "$f".profraw >> prof_files
 done
 
 # Merge coverage report for all unit tests
@@ -33,11 +28,3 @@ for e2e in *.virtual.so; do
         bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" -f "$e2e".txt -F "$e2e"
     fi
 done
-
-# Generate html for Azure Devops
-mv cov_* coverage/
-python3.7 ../tests/coverage/cobertura_generator.py
-python3.7 ../tests/coverage/style_html.py
-
-# Add coverage results to perf summary file
-python3.7 ../tests/coverage/add_perf_summary.py

--- a/tests/coverage/generate_coverage.sh
+++ b/tests/coverage/generate_coverage.sh
@@ -23,8 +23,8 @@ bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" -f codecov.txt -F 
 
 for e2e in *.virtual.so; do
     if [ -f "$e2e".profraw  ]; then
-        llvm-profdata-7 merge -sparse "$e2e".profraw -o "$e2e".profdata
+        llvm-profdata-7 merge -sparse *_"$e2e".profraw -o "$e2e".profdata
         llvm-cov-7 show -instr-profile "$e2e".profdata -object cchost.virtual -object "$e2e" -ignore-filename-regex="(boost|openenclave|3rdparty|/test/)" > "$e2e".txt
-        bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" -f "$e2e".txt -F end_to_end
+        bash <(curl -s https://codecov.io/bash) -t "${CODECOV_TOKEN}" -f "$e2e".txt -F $(echo $"e2e" | cut -d. -f1)
     fi
 done

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -453,8 +453,11 @@ class CCFRemote(object):
         if self.quote is not None:
             cmd.append("--quote-file={}".format(self.quote))
 
-        self.profraw = f"{os.path.basename(lib_path)}.profraw"
-        env = {"LLVM_PROFILE_FILE": self.profraw}
+        env = {}
+        if enclave_type == "virtual":
+            self.profraw = f"{os.path.basename(lib_path)}.profraw"
+            env["LLVM_PROFILE_FILE"] = self.profraw
+
         oe_log_level = CCF_TO_OE_LOG_LEVEL.get(log_level)
         if oe_log_level:
             env["OE_LOG_LEVEL"] = oe_log_level
@@ -509,10 +512,11 @@ class CCFRemote(object):
             self.remote.stop()
         except Exception:
             LOG.exception("Failed to shut down {} cleanly".format(self.node_id))
-        try:
-            self.remote.get(self.profraw, timeout=0)
-        except Exception:
-            LOG.info(f"Could not retrieve {self.profraw}")
+        if self.profraw:
+            try:
+                self.remote.get(self.profraw)
+            except Exception:
+                LOG.info(f"Could not retrieve {self.profraw}")
 
     def wait_for_stdout_line(self, line, timeout=5):
         return self.remote.wait_for_stdout_line(line, timeout)

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -456,7 +456,7 @@ class CCFRemote(object):
         env = {}
         self.profraw = None
         if enclave_type == "virtual":
-            self.profraw = f"{os.path.basename(lib_path)}.profraw"
+            self.profraw = f"{node_id}_{os.path.basename(lib_path)}.profraw"
             env["LLVM_PROFILE_FILE"] = self.profraw
 
         oe_log_level = CCF_TO_OE_LOG_LEVEL.get(log_level)

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -510,7 +510,7 @@ class CCFRemote(object):
         except Exception:
             LOG.exception("Failed to shut down {} cleanly".format(self.node_id))
         try:
-            self.remote.get(self.profraw)
+            self.remote.get(self.profraw, tiemout=0)
         except Exception:
             LOG.info(f"Could not retrieve {self.profraw}")
 

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -454,6 +454,7 @@ class CCFRemote(object):
             cmd.append("--quote-file={}".format(self.quote))
 
         env = {}
+        self.profraw = None
         if enclave_type == "virtual":
             self.profraw = f"{os.path.basename(lib_path)}.profraw"
             env["LLVM_PROFILE_FILE"] = self.profraw

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -453,7 +453,8 @@ class CCFRemote(object):
         if self.quote is not None:
             cmd.append("--quote-file={}".format(self.quote))
 
-        env = {}
+        self.profraw = f"{os.path.basename(lib_path)}.profraw"
+        env = {'LLVM_PROFILE_FILE': self.profraw}
         oe_log_level = CCF_TO_OE_LOG_LEVEL.get(log_level)
         if oe_log_level:
             env["OE_LOG_LEVEL"] = oe_log_level
@@ -508,6 +509,10 @@ class CCFRemote(object):
             self.remote.stop()
         except Exception:
             LOG.exception("Failed to shut down {} cleanly".format(self.node_id))
+        try:
+            self.remote.get(self.profraw)
+        except Exception:
+            LOG.info(f"Could not retrieve {self.profraw}")
 
     def wait_for_stdout_line(self, line, timeout=5):
         return self.remote.wait_for_stdout_line(line, timeout)

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -454,7 +454,7 @@ class CCFRemote(object):
             cmd.append("--quote-file={}".format(self.quote))
 
         self.profraw = f"{os.path.basename(lib_path)}.profraw"
-        env = {'LLVM_PROFILE_FILE': self.profraw}
+        env = {"LLVM_PROFILE_FILE": self.profraw}
         oe_log_level = CCF_TO_OE_LOG_LEVEL.get(log_level)
         if oe_log_level:
             env["OE_LOG_LEVEL"] = oe_log_level

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -510,7 +510,7 @@ class CCFRemote(object):
         except Exception:
             LOG.exception("Failed to shut down {} cleanly".format(self.node_id))
         try:
-            self.remote.get(self.profraw, tiemout=0)
+            self.remote.get(self.profraw, timeout=0)
         except Exception:
             LOG.info(f"Could not retrieve {self.profraw}")
 


### PR DESCRIPTION
Code coverage from end to end tests, tagged accordingly (so we can display only unit coverage or only end to end coverage). This should help us find any dead code we may have.

At the moment, this is only for one end to end test, a bit more file mangling is necessary to aggregate the rest of them (recovery and election mainly).