### PR TITLE
Coverage badge is now green if coverage > 85%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@
 #   curl --data-binary @.codecov.yml https://codecov.io/validate
 
 coverage:
-  range: "70...85"
+  range: "50...85"
   round: nearest
   precision: 2
   status:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@
 #   curl --data-binary @.codecov.yml https://codecov.io/validate
 
 coverage:
-  range: "70...100"
+  range: "70...85"
   round: nearest
   precision: 2
   status:


### PR DESCRIPTION
As it will be very hard to achieve 100% code coverage (because of different types of curve, etc.), this reduces the threshold for the green code coverage badge to 85%.