### PR TITLE
Restore perf data by copying CSVs from remote clients

### DIFF
--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -285,7 +285,7 @@ class LocalRemote(CmdMixin):
             self.cmd[0] = "./{}".format(self.cmd[0])
         assert self._rc("chmod +x {}".format(os.path.join(self.root, executable))) == 0
 
-    def get(self, filename, timeout=60):
+    def get(self, filename, timeout=60, targetname=None):
         path = os.path.join(self.root, filename)
         for _ in range(timeout):
             if os.path.exists(path):
@@ -293,7 +293,9 @@ class LocalRemote(CmdMixin):
             time.sleep(1)
         else:
             raise ValueError(path)
-        assert self._rc("cp {} {}".format(path, filename)) == 0
+        if targetname is None:
+            targetname = filename
+        assert self._rc("cp {} {}".format(path, targetname)) == 0
 
     def list_files(self):
         return os.listdir(self.root)

--- a/tests/infra/remote_client.py
+++ b/tests/infra/remote_client.py
@@ -75,9 +75,22 @@ class CCFRemoteClient(object):
     def debug_node_cmd(self):
         return self.remote._dbg()
 
-    def stop(self):
+    def stop(self, retrieve_csvs=False):
         try:
             self.remote.stop()
+            if retrieve_csvs:
+                remote_files = self.remote.list_files()
+                remote_csvs = [f for f in remote_files if f.endswith(".csv")]
+                for csv in remote_csvs:
+                    if csv == "perf_summary.csv":
+                        remote_perf = "{}_perf_summary.csv".format(self.name)
+                        self.remote.get(csv, 1, remote_perf)
+                        with open("perf_summary.csv", "a") as l:
+                            with open(remote_perf, "r") as r:
+                                for line in r.readlines():
+                                    l.write(line)
+                    else:
+                        self.remote.get(csv, 1)
         except Exception:
             LOG.exception("Failed to shut down {} cleanly".format(self.name))
 

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -129,9 +129,9 @@ def run(build_directory, get_command, args):
                     continue_processing = tx_rates.process_next()
                     time.sleep(1)
                     if not continue_processing:
-                        for remote in clients:
+                        for i, remote in enumerate(clients):
                             remote.wait()
-                            remote.stop()
+                            remote.stop(i == 0)
                         break
 
                 LOG.info(f"Rates: {tx_rates}")


### PR DESCRIPTION
Since running the perf clients in `/tmp/…` rather `build` we stopped getting perf data results, as the performance result CSVs are in the wrong folder. This copies the `.csv`s from the _first_ client back to the build directory, appending entries from `perf_summary.csv`. Eventually we'll want some way to tag, store, and display the results from _all_ clients - this is a quick fix to restore the old behaviour.