### PR TITLE
Use unbuffer for perf tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,12 +32,6 @@ set(ENV{BETTER_EXCEPTIONS} 1)
 
 option(BUILD_TESTS "Build tests" ON)
 
-if (DEFINED ENV{BUILD_BUILDNUMBER})
-  set(PYTHON python3)
-else()
-  set(PYTHON unbuffer python3)
-endif()
-
 option(NO_COMMITTED_TX_HISTORY "Do not keep tree of hashes of committed transactions" ON)
 if(RECORD_TRACE)
   add_definitions(-DNO_COMMITTED_TX_HISTORY)

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -17,6 +17,12 @@ set(Boost_ADDITIONAL_VERSIONS "1.67" "1.67.0")
 find_package(Boost 1.60.0 REQUIRED)
 find_package(Threads REQUIRED)
 
+if (DEFINED ENV{BUILD_BUILDNUMBER})
+  set(PYTHON python3)
+else()
+  set(PYTHON unbuffer python3)
+endif()
+
 if(MSVC)
   add_compile_options(/W3 /std:c++latest)
 else()
@@ -611,7 +617,7 @@ function(add_perf_test)
 
   add_test(
     NAME ${PARSED_ARGS_NAME}
-    COMMAND python3 ${PARSED_ARGS_PYTHON_SCRIPT}
+    COMMAND ${PYTHON} ${PARSED_ARGS_PYTHON_SCRIPT}
       -b .
       -c ${PARSED_ARGS_CLIENT_BIN}
       -i ${PARSED_ARGS_ITERATIONS}


### PR DESCRIPTION
The end-to-end tests get coloured logs thanks to loguru, but through CTest they must additionally go through unbuffer. This makes that support more widely available (from common.cmake), and enables it for the small_bank perf tests.