### PR TITLE
Static checks first

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -5,41 +5,6 @@ trigger:
       - "*"
 
 jobs:
-- job: ACC_1804_SGX_build
-  pool: Ubuntu-1804-SGX-Azure
-  steps:
-    - template: .vsts-ci-templates/build_and_test.yml
-      parameters:
-        cmake_args: '-DBUILD_SMALLBANK=OFF'
-        suite_name_suffix: ' SGX'
-
-- job: ACC_1804_virtual_coverage_build
-  pool: Ubuntu-1804-SGX-Azure
-  steps:
-    - template: .vsts-ci-templates/build_and_test.yml
-      parameters:
-        cmake_args: '-DVIRTUAL_ONLY=ON -DBUILD_SMALLBANK=OFF'
-        suite_name_suffix: ' Virtual Coverage'
-    - template: .vsts-ci-templates/coverage.yml
-
-- job: ACC_1804_virtual_SAN_build
-  pool: Ubuntu-1804-SGX-Azure
-  steps:
-    - template: .vsts-ci-templates/build_and_test.yml
-      parameters:
-        cmake_args: '-DVIRTUAL_ONLY=ON -DSAN=ON -DBUILD_SMALLBANK=OFF'
-        suite_name_suffix: ' Virtual SAN'
-
-- job: ACC_1804_SGX_perf_build
-  pool: Ubuntu-1804-SGX-Azure
-  steps:
-    - template: .vsts-ci-templates/build_and_test.yml
-      parameters:
-        cmake_args: '-DBUILD_SMALLBANK=ON -DCURVE_CHOICE=secp256k1_bitcoin'
-        suite_name_suffix: ' SGX Performance'
-        ctest_filter: '-R small_bank'
-    - template: .vsts-ci-templates/push_perf_data.yml
-
 - job: static_checks
   pool: Ubuntu-1804-SGX-Azure
   steps:
@@ -65,3 +30,42 @@ jobs:
         pip install black
         black --check sphinx/ tests/ notice-check.py
       displayName: 'Check Python code format'
+
+- job: ACC_1804_SGX_build
+  pool: Ubuntu-1804-SGX-Azure
+  dependsOn: static_checks
+  steps:
+    - template: .vsts-ci-templates/build_and_test.yml
+      parameters:
+        cmake_args: '-DBUILD_SMALLBANK=OFF'
+        suite_name_suffix: ' SGX'
+
+- job: ACC_1804_virtual_coverage_build
+  pool: Ubuntu-1804-SGX-Azure
+  dependsOn: static_checks
+  steps:
+    - template: .vsts-ci-templates/build_and_test.yml
+      parameters:
+        cmake_args: '-DVIRTUAL_ONLY=ON -DBUILD_SMALLBANK=OFF'
+        suite_name_suffix: ' Virtual Coverage'
+    - template: .vsts-ci-templates/coverage.yml
+
+- job: ACC_1804_virtual_SAN_build
+  pool: Ubuntu-1804-SGX-Azure
+  dependsOn: static_checks
+  steps:
+    - template: .vsts-ci-templates/build_and_test.yml
+      parameters:
+        cmake_args: '-DVIRTUAL_ONLY=ON -DSAN=ON -DBUILD_SMALLBANK=OFF'
+        suite_name_suffix: ' Virtual SAN'
+
+- job: ACC_1804_SGX_perf_build
+  pool: Ubuntu-1804-SGX-Azure
+  dependsOn: static_checks
+  steps:
+    - template: .vsts-ci-templates/build_and_test.yml
+      parameters:
+        cmake_args: '-DBUILD_SMALLBANK=ON -DCURVE_CHOICE=secp256k1_bitcoin'
+        suite_name_suffix: ' SGX Performance'
+        ctest_filter: '-R small_bank'
+    - template: .vsts-ci-templates/push_perf_data.yml

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -81,7 +81,8 @@ if __name__ == "__main__":
     args.package = "libloggingenc"
     notify_server_host = "localhost"
     args.notify_server = (
-        notify_server_host   + ":"
+        notify_server_host
+        + ":"
         + str(infra.net.probably_free_local_port(notify_server_host))
     )
     run(args)

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -81,8 +81,7 @@ if __name__ == "__main__":
     args.package = "libloggingenc"
     notify_server_host = "localhost"
     args.notify_server = (
-        notify_server_host
-        + ":"
+        notify_server_host   + ":"
         + str(infra.net.probably_free_local_port(notify_server_host))
     )
     run(args)


### PR DESCRIPTION
If the static_checks fail, the build will fail. This change causes static_check failures to kill the build _early_, rather than after ~7 minutes when another test has failed and an agent is free.

I think this is the behaviour we want for PRs, and don't think its too strong a restriction on other builds.