### PR TITLE
Add docker file for public CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM oeciteam/oetools-full-18.04
+
+COPY getting_started/setup_vm/ /setup_vm/
+RUN apt install -y ansible software-properties-common
+RUN cd setup_vm; ansible-playbook -i local_skip_dependencies *.yml

--- a/getting_started/setup_vm/D-oe.yml
+++ b/getting_started/setup_vm/D-oe.yml
@@ -138,6 +138,7 @@
     become: true
     async: 600
     poll: 5
+    when: skip_dependencies is undefined
 
   - name: Install ninja
     apt:

--- a/getting_started/setup_vm/local_skip_dependencies
+++ b/getting_started/setup_vm/local_skip_dependencies
@@ -1,0 +1,7 @@
+[local]
+localhost ansible_connection=local
+
+[local:vars]
+oe_playbook=scripts/ansible/oe-contributors-acc-setup.yml
+oe_build_opts=''
+skip_dependencies=true


### PR DESCRIPTION
This is for #101, and also to hopefully dispatch some of the jobs in the private CI to public executors and relieve our overloaded VMs.

https://hub.docker.com/r/ccfciteam/ccf-ci-18.04/tags