### PR TITLE
Use public pools for virtual builds

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -52,7 +52,8 @@ jobs:
     - template: .vsts-ci-templates/coverage.yml
 
 - job: ACC_1804_virtual_SAN_build
-  pool: Ubuntu-1804-SGX-Azure
+  pool: 'Hosted Ubuntu 1604'
+  container: ccfciteam/ccf-ci-18.04:latest
   dependsOn: static_checks
   steps:
     - template: .vsts-ci-templates/build_and_test.yml

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -41,7 +41,8 @@ jobs:
         suite_name_suffix: ' SGX'
 
 - job: ACC_1804_virtual_coverage_build
-  pool: Ubuntu-1804-SGX-Azure
+  pool: 'ubuntu-16.04'
+  container: ccfciteam/ccf-ci-18.04:latest
   dependsOn: static_checks
   steps:
     - template: .vsts-ci-templates/build_and_test.yml

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -41,7 +41,7 @@ jobs:
         suite_name_suffix: ' SGX'
 
 - job: ACC_1804_virtual_coverage_build
-  pool: 'ubuntu-16.04'
+  pool: 'Hosted Ubuntu 1604'
   container: ccfciteam/ccf-ci-18.04:latest
   dependsOn: static_checks
   steps:


### PR DESCRIPTION
Public pools + containers are unfortunately very slow in Pipelines, but this frees up scarce SGX executor resources, so I think it's worth doing.