### PR TITLE
Workaround resolve race

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,19 +293,21 @@ if(BUILD_TESTS)
       --scenario ${CMAKE_SOURCE_DIR}/tests/simple_logging_scenario.json
   )
 
-  add_e2e_test(
-    NAME election_tests
-    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/election.py
-    ADDITIONAL_ARGS
-      --election-timeout 2000
-  )
+  if (NOT PBFT)
+    add_e2e_test(
+      NAME election_tests
+      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/election.py
+      ADDITIONAL_ARGS
+        --election-timeout 2000
+    )
 
-  add_e2e_test(
-    NAME recovery_tests
-    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/recovery.py
-    ADDITIONAL_ARGS
-      ${RECOVERY_ARGS}
-  )
+    add_e2e_test(
+      NAME recovery_tests
+      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/recovery.py
+      ADDITIONAL_ARGS
+        ${RECOVERY_ARGS}
+    )
+  endif()
 
   if (BUILD_SMALLBANK)
     include(${CMAKE_CURRENT_SOURCE_DIR}/samples/apps/smallbank/smallbank.cmake)

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -98,7 +98,7 @@ namespace asynchost
     bool connect(const std::string& host, const std::string& service)
     {
       assert_status(FRESH, CONNECTING_RESOLVING);
-      return resolve(host, service);
+      return resolve(host, service, true);
     }
 
     bool reconnect()
@@ -111,7 +111,7 @@ namespace asynchost
           // Try again, starting with DNS.
           LOG_DEBUG << "Reconnect from DNS" << std::endl;
           status = CONNECTING_RESOLVING;
-          return resolve(host, service);
+          return resolve(host, service, true);
         }
 
         case DISCONNECTED:

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -98,7 +98,7 @@ namespace asynchost
     bool connect(const std::string& host, const std::string& service)
     {
       assert_status(FRESH, CONNECTING_RESOLVING);
-      return resolve(host, service, true);
+      return resolve(host, service, false);
     }
 
     bool reconnect()
@@ -111,7 +111,7 @@ namespace asynchost
           // Try again, starting with DNS.
           LOG_DEBUG << "Reconnect from DNS" << std::endl;
           status = CONNECTING_RESOLVING;
-          return resolve(host, service, true);
+          return resolve(host, service, false);
         }
 
         case DISCONNECTED:


### PR DESCRIPTION
If node removal happens before an on_resolve() callback has fired, we can be trying to use a deleted object.

This was caught by the UBSan: https://circleci.com/gh/microsoft/CCF/198

```
../src/host/tcp.h:309:41: runtime error: member call on address 0x613000002a40 which does not point to an object of type 'asynchost::TCPImpl'
34: 0x613000002a40: note: object has invalid vptr
34:  27 00 80 19  29 00 00 20 00 00 00 00  40 2a 00 00 30 61 00 00  e0 37 de 16 be 7f 00 00  0c 00 00 00
34:               ^~~~~~~~~~~~~~~~~~~~~~~
34:               invalid vptr
34: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../src/host/tcp.h:309:41 in 
34: 
```

Long term it would be preferable to introduce a ref counting scheme to avoid this while retaining async resolve, but for now this fixes the functional issue with no serious performance impact in all but pathological cases.