### PR TITLE
Avoid unnecessary copies of lambda capture - universal forwarding

### DIFF
--- a/src/ds/champmap.h
+++ b/src/ds/champmap.h
@@ -133,7 +133,7 @@ namespace champ
     }
 
     template <class F>
-    void foreach(F f) const
+    void foreach(F&& f) const
     {
       for (const auto& bin : bins)
       {
@@ -274,7 +274,7 @@ namespace champ
     }
 
     template <class F>
-    void foreach(SmallIndex depth, F f) const
+    void foreach(SmallIndex depth, F&& f) const
     {
       const auto entries = data_map.pop();
       for (SmallIndex i = 0; i < entries; ++i)
@@ -285,9 +285,9 @@ namespace champ
       for (size_t i = entries; i < nodes.size(); ++i)
       {
         if (depth == (collision_depth - 1))
-          node_as<Collisions<K, V, H>>(i)->foreach(f);
+          node_as<Collisions<K, V, H>>(i)->foreach(std::forward<F>(f));
         else
-          node_as<SubNodes<K, V, H>>(i)->foreach(depth + 1, f);
+          node_as<SubNodes<K, V, H>>(i)->foreach(depth + 1, std::forward<F>(f));
       }
     }
 
@@ -340,9 +340,9 @@ namespace champ
     }
 
     template <class F>
-    void foreach(F f) const
+    void foreach(F&& f) const
     {
-      root->foreach(0, f);
+      root->foreach(0, std::forward<F>(f));
     }
   };
 }

--- a/src/ds/rbmap.h
+++ b/src/ds/rbmap.h
@@ -78,13 +78,13 @@ public:
   }
 
   template <class F>
-  void foreach(F f) const
+  void foreach(F&& f) const
   {
     if (!empty())
     {
-      left().foreach(f);
+      left().foreach(std::forward<F>(f));
       f(rootKey(), rootValue());
-      right().foreach(f);
+      right().foreach(std::forward<F>(f));
     }
   }
 

--- a/src/ds/test/map_bench.cpp
+++ b/src/ds/test/map_bench.cpp
@@ -65,6 +65,22 @@ static void benchmark_get(picobench::state& s)
   s.stop_timer();
 }
 
+template <class M>
+static void benchmark_foreach(picobench::state& s)
+{
+  size_t size = s.iterations();
+  auto map = gen_map<M>(size);
+  V v{};
+  s.start_timer();
+  for (auto _ : s)
+  {
+    (void)_;
+    map.foreach([&v](const auto& key, const auto& value) { v += value; });
+    clobber_memory();
+  }
+  s.stop_timer();
+}
+
 const std::vector<int> sizes = {32, 32 << 2, 32 << 4, 32 << 6, 32 << 8};
 
 PICOBENCH_SUITE("put");
@@ -78,3 +94,11 @@ auto bench_rb_map_get = benchmark_get<RBMap<K, V>>;
 PICOBENCH(bench_rb_map_get).iterations(sizes).samples(10).baseline();
 auto bench_champ_map_get = benchmark_get<champ::Map<K, V>>;
 PICOBENCH(bench_champ_map_get).iterations(sizes).samples(10);
+
+const std::vector<int> for_sizes = {32 << 4, 32 << 5, 32 << 6};
+
+PICOBENCH_SUITE("foreach");
+auto bench_rb_map_foreach = benchmark_foreach<RBMap<K, V>>;
+PICOBENCH(bench_rb_map_foreach).iterations(for_sizes).samples(10).baseline();
+auto bench_champ_map_foreach = benchmark_foreach<champ::Map<K, V>>;
+PICOBENCH(bench_champ_map_foreach).iterations(for_sizes).samples(10);

--- a/src/ds/test/map_bench.cpp
+++ b/src/ds/test/map_bench.cpp
@@ -75,7 +75,8 @@ static void benchmark_foreach(picobench::state& s)
   for (auto _ : s)
   {
     (void)_;
-    map.foreach([&v](const auto& key, const auto& value) { v += value; });
+    map.foreach(
+      [&v, s, map](const auto& key, const auto& value) { v += value; });
     clobber_memory();
   }
   s.stop_timer();

--- a/src/kv/kv.h
+++ b/src/kv/kv.h
@@ -433,7 +433,7 @@ namespace kv
        * @param F functor, taking a key and a value, return value is ignored
        */
       template <class F>
-      void foreach(F f)
+      void foreach(F&& f)
       {
         if (commit_version != NoVersion)
           return;


### PR DESCRIPTION
I noticed our kv map foreach implementations were taking copies of the functor, with potentially expensive copy of the captured args. I've changed these to use universal forwarding, and added a benchmark of foreach.

Sample of new benchmark before:
```
foreach:
===============================================================================
   Name (baseline is *)   |   Dim   |  Total ms |  ns/op  |Baseline| Ops/second
===============================================================================
   bench_rb_map_foreach * |     512 |     9.366 |   18292 |      - |    54667.0
  bench_champ_map_foreach |     512 |     0.328 |     641 |  0.035 |  1559074.3
   bench_rb_map_foreach * |    1024 |    37.663 |   36780 |      - |    27188.6
  bench_champ_map_foreach |    1024 |     1.007 |     983 |  0.027 |  1016579.0
   bench_rb_map_foreach * |    2048 |   153.956 |   75173 |      - |    13302.5
  bench_champ_map_foreach |    2048 |    34.681 |   16934 |  0.225 |    59052.0
===============================================================================
```

And after:
```
foreach:
===============================================================================
   Name (baseline is *)   |   Dim   |  Total ms |  ns/op  |Baseline| Ops/second
===============================================================================
   bench_rb_map_foreach * |     512 |     3.642 |    7113 |      - |   140570.6
  bench_champ_map_foreach |     512 |     0.240 |     467 |  0.066 |  2136894.8
   bench_rb_map_foreach * |    1024 |    14.707 |   14361 |      - |    69628.2
  bench_champ_map_foreach |    1024 |     0.854 |     834 |  0.058 |  1198922.8
   bench_rb_map_foreach * |    2048 |    60.134 |   29362 |      - |    34057.2
  bench_champ_map_foreach |    2048 |    17.928 |    8754 |  0.298 |   114231.6
===============================================================================
```