### PR TITLE
Fix forwarding status for non-forwardable RPCs

### DIFF
--- a/src/node/rpc/memberfrontend.h
+++ b/src/node/rpc/memberfrontend.h
@@ -351,7 +351,7 @@ namespace ccf
       };
       // ACK method cannot be forwarded and should be run on leader as it makes
       // explicit use of caller certificate
-      install(MemberProcs::ACK, ack, Write, false);
+      install(MemberProcs::ACK, ack, Write, Forwardable::DoNotForward);
 
       //! A member asks for a fresher nonce
       auto update_ack_nonce = [this](RequestArgs& args) {

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -111,7 +111,11 @@ public:
       return jsonrpc::success();
     };
     // Note that this a Write function that cannot be forwarded
-    install("empty_function", empty_function, Write, nullptr, nullptr, false);
+    install(
+      "empty_function",
+      empty_function,
+      Write,
+      Forwardable::DoNotForward);
   }
 };
 

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -111,11 +111,7 @@ public:
       return jsonrpc::success();
     };
     // Note that this a Write function that cannot be forwarded
-    install(
-      "empty_function",
-      empty_function,
-      Write,
-      Forwardable::DoNotForward);
+    install("empty_function", empty_function, Write, Forwardable::DoNotForward);
   }
 };
 

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -22,6 +22,45 @@ def run(args):
     os.makedirs(args.schema_dir, exist_ok=True)
 
     changed_files = []
+    methods_with_schema = []
+    methods_without_schema = []
+
+    def fetch_schema(client):
+        list_response = client.rpc("listMethods", {})
+        check(list_response)
+        methods = list_response.result["methods"]
+
+        for method in methods:
+            schema_found = False
+            schema_response = client.rpc("getSchema", {"method": method})
+            check(schema_response)
+
+            if schema_response.result is not None:
+                for schema_type in ["params", "result"]:
+                    element_name = "{}_schema".format(schema_type)
+                    element = schema_response.result[element_name]
+                    if element is not None and len(element) != 0:
+                        schema_found = True
+                        formatted_schema = json.dumps(element, indent=2)
+                        target_file = os.path.join(
+                            args.schema_dir, "{}_{}.json".format(method, schema_type)
+                        )
+                        with open(target_file, "a+") as f:
+                            f.seek(0)
+                            previous = f.read()
+                            if previous != formatted_schema:
+                                LOG.debug("Writing schema to {}".format(target_file))
+                                f.truncate(0)
+                                f.seek(0)
+                                f.write(formatted_schema)
+                                changed_files.append(target_file)
+                            else:
+                                LOG.debug("Schema matches in {}".format(target_file))
+
+            if schema_found:
+                methods_with_schema.append(method)
+            else:
+                methods_without_schema.append(method)
 
     with infra.ccf.network(
         hosts, args.build_dir, args.debug_nodes, args.perf_nodes
@@ -30,40 +69,22 @@ def run(args):
 
         check = infra.ccf.Checker()
 
-        with primary.user_client(format="json") as uc:
-            list_response = uc.rpc("listMethods", {})
-            check(list_response)
-            methods = list_response.result["methods"]
+        with primary.user_client(format="json") as user_client:
+            LOG.info("user frontend")
+            fetch_schema(user_client)
 
-            for method in methods:
-                schema_response = uc.rpc("getSchema", {"method": method})
-                check(schema_response)
+        with primary.management_client(format="json") as management_client:
+            LOG.info("management frontend")
+            fetch_schema(management_client)
 
-                if schema_response.result is not None:
-                    for schema_type in ["params", "result"]:
-                        element_name = "{}_schema".format(schema_type)
-                        element = schema_response.result[element_name]
-                        if element is not None and len(element) != 0:
-                            formatted_schema = json.dumps(element, indent=2)
-                            target_file = os.path.join(
-                                args.schema_dir,
-                                "{}_{}.json".format(method, schema_type),
-                            )
-                            with open(target_file, "a+") as f:
-                                f.seek(0)
-                                previous = f.read()
-                                if previous != formatted_schema:
-                                    LOG.debug(
-                                        "Writing schema to {}".format(target_file)
-                                    )
-                                    f.truncate(0)
-                                    f.seek(0)
-                                    f.write(formatted_schema)
-                                    changed_files.append(target_file)
-                                else:
-                                    LOG.debug(
-                                        "Schema matches in {}".format(target_file)
-                                    )
+        with primary.member_client(format="json") as member_client:
+            LOG.info("member frontend")
+            fetch_schema(member_client)
+
+    if len(methods_without_schema) > 0:
+        LOG.info("The following methods have no schema:")
+        for m in methods_without_schema:
+            LOG.info(" " + m)
 
     if len(changed_files) > 0:
         LOG.error("Made changes to the following schema files:")


### PR DESCRIPTION
Noticed a bug caused by my schema changes.

In `install(MemberProcs::ACK, ack, Write, false);`, the false is converted to `json` and used as the params schema. The fix is to use an enum rather than bool for the forwardability status. All the calls to `install` should be unambiguous now.

This also extends schema.py to fetch schemas from all frontends, though currently only the common RPCs have defined schemas.