### PR TITLE
Disable quote for non-sgx machines with real enclaves

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -170,6 +170,8 @@ if(NOT VIRTUAL_ONLY)
     else()
       set(TEST_IGNORE_QUOTE "--ignore-quote")
     endif()
+  else()
+    set(TEST_IGNORE_QUOTE "--ignore-quote")
   endif()
 else()
   set(TEST_ENCLAVE_TYPE


### PR DESCRIPTION
Follow up from https://github.com/microsoft/CCF/pull/152: we also need to tell python to ignore quotes for real enclaves when OE was not build with SGX.