### PR TITLE
Increase tx count for performance test with signature

### DIFF
--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -31,7 +31,7 @@ if(BUILD_TESTS)
     PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/small_bank_client.py
     CLIENT_BIN ./small_bank_client
     VERIFICATION_FILE ${CMAKE_CURRENT_LIST_DIR}/tests/verify_small_bank_short.json
-    ITERATIONS 100000
+    ITERATIONS 50000
     ADDITIONAL_ARGS
       --label Small_Bank_Client_Sigs
       --max-writes-ahead 1000 --sign
@@ -55,6 +55,7 @@ if(BUILD_TESTS)
     NAME small_bank_sigs_forwarding
     PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/small_bank_client.py
     CLIENT_BIN ./small_bank_client
+    ITERATIONS 50000
     ADDITIONAL_ARGS
       --label Small_Bank_ClientSigs_Forwarding
       --max-writes-ahead 1000

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -31,7 +31,7 @@ if(BUILD_TESTS)
     PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/small_bank_client.py
     CLIENT_BIN ./small_bank_client
     VERIFICATION_FILE ${CMAKE_CURRENT_LIST_DIR}/tests/verify_small_bank_short.json
-    ITERATIONS 2000
+    ITERATIONS 100000
     ADDITIONAL_ARGS
       --label Small_Bank_Client_Sigs
       --max-writes-ahead 1000 --sign

--- a/samples/apps/smallbank/tests/verify_small_bank_short.json
+++ b/samples/apps/smallbank/tests/verify_small_bank_short.json
@@ -1,7 +1,7 @@
 {
     "params": {
         "seed": 42,
-        "transactions": 2000,
+        "transactions": 50000,
         "accounts": 10
     },
     "initial": [
@@ -49,43 +49,43 @@
     "final": [
         {
             "account": 0,
-            "balance": 52
+            "balance": 49
         },
         {
             "account": 1,
-            "balance": 32
+            "balance": 43
         },
         {
             "account": 2,
-            "balance": 0
+            "balance": 1764
         },
         {
             "account": 3,
-            "balance": 41951
+            "balance": 43
         },
         {
             "account": 4,
-            "balance": 0
+            "balance": 244
         },
         {
             "account": 5,
-            "balance": 5
+            "balance": -38
         },
         {
             "account": 6,
-            "balance": 94
+            "balance": -42
         },
         {
             "account": 7,
-            "balance": 737
+            "balance": 248231
         },
         {
             "account": 8,
-            "balance": 493
+            "balance": 0
         },
         {
             "account": 9,
-            "balance": 0
+            "balance": -8
         }
     ]
 }


### PR DESCRIPTION
The iterations count with performance test with signature used to be very low for historical reasons. I have bumped this up to `50000` so that we get more accurate performance results. 