### PR TITLE
Send SIGTERM to cchost if parent dies

### DIFF
--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -22,6 +22,7 @@ _libc = ctypes.CDLL("libc.so.6")
 
 
 def _term_on_pdeathsig():
+    # usr/include/linux/prctl.h: #define PR_SET_PDEATHSIG 1
     _libc.prctl(1, signal.SIGTERM)
 
 

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -11,10 +11,23 @@ from contextlib import contextmanager
 import infra.path
 import json
 import uuid
+import ctypes
+import signal
 
 from loguru import logger as LOG
 
 DBG = os.getenv("DBG", "cgdb")
+
+_libc = ctypes.CDLL("libc.so.6")
+
+
+def _term_on_pdeathsig():
+    _libc.prctl(1, signal.SIGTERM)
+
+
+def popen(*args, **kwargs):
+    kwargs["preexec_fn"] = _term_on_pdeathsig
+    return subprocess.Popen(*args, **kwargs)
 
 
 @contextmanager
@@ -356,7 +369,7 @@ class LocalRemote(CmdMixin):
         LOG.info(f"[{self.hostname}] {cmd} (env: {self.env})")
         self.stdout = open(os.path.join(self.root, "out"), "wb")
         self.stderr = open(os.path.join(self.root, "err"), "wb")
-        self.proc = subprocess.Popen(
+        self.proc = popen(
             self.cmd,
             cwd=self.root,
             stdout=self.stdout,


### PR DESCRIPTION
When builds are interrupted on DevOps, we sometimes end up with zombie cchost processes running on the executors. That seems to be caused by the Python orchestration being killed in a way that does not give it the opportunity to terminate its children.

This change configures children to set themselves a SIGTERM if their parent dies (SET_PR_PDEATHSIG), which should fix the problem. Another solution may be to run the tests (or indeed the whole job) in a container. This seems to be very slow on DevOps at the moment though.