### PR TITLE
Params are optional

### DIFF
--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -568,6 +568,8 @@ namespace ccf
       SignedReq signed_request;
       if (full_rpc.find(jsonrpc::SIG) != full_rpc.end())
       {
+        const auto& req = full_rpc.at(jsonrpc::REQ);
+
         // TODO(#important): Signature should only be verified for a Write
         // RPC
         if (!verify_client_signature(
@@ -579,29 +581,34 @@ namespace ccf
               signed_request))
         {
           return jsonrpc::error_response(
-            full_rpc[jsonrpc::REQ][jsonrpc::ID],
+            req.at(jsonrpc::ID),
             jsonrpc::ErrorCodes::INVALID_CLIENT_SIGNATURE,
             "Failed to verify client signature.");
         }
-        rpc_ = &full_rpc[jsonrpc::REQ];
+        rpc_ = &req;
       }
       auto& rpc = *rpc_;
 
-      if (rpc[jsonrpc::JSON_RPC] != jsonrpc::RPC_VERSION)
-        return jsonrpc::error_response(
-          rpc[jsonrpc::ID],
-          jsonrpc::ErrorCodes::INVALID_REQUEST,
-          "Wrong JSON-RPC version.");
+      std::string method = rpc.at(jsonrpc::METHOD);
+      ctx.req.seq_no = rpc.at(jsonrpc::ID);
 
-      std::string method = rpc[jsonrpc::METHOD];
-      ctx.req.seq_no = rpc[jsonrpc::ID];
-
-      const nlohmann::json& params = rpc[jsonrpc::PARAMS];
-      if (!params.is_array() && !params.is_object() && !params.is_null())
+      if (rpc.at(jsonrpc::JSON_RPC) != jsonrpc::RPC_VERSION)
         return jsonrpc::error_response(
           ctx.req.seq_no,
           jsonrpc::ErrorCodes::INVALID_REQUEST,
-          "Invalid params.");
+          "Wrong JSON-RPC version.");
+
+      const auto params_it = rpc.find(jsonrpc::PARAMS);
+      if (
+        params_it != rpc.end() &&
+        (!params_it->is_array() && !params_it->is_object()))
+        return jsonrpc::error_response(
+          ctx.req.seq_no,
+          jsonrpc::ErrorCodes::INVALID_REQUEST,
+          "If present, parameters must be an array or object");
+
+      const auto& params =
+        params_it == rpc.end() ? nlohmann::json(nullptr) : *params_it;
 
       Handler* handler = nullptr;
       auto search = handlers.find(method);

--- a/src/node/rpc/test/membervoting_test.cpp
+++ b/src/node/rpc/test/membervoting_test.cpp
@@ -82,7 +82,8 @@ json create_json_req(const json& params, const string& method_name)
   j[JSON_RPC] = RPC_VERSION;
   j[ID] = 1;
   j[METHOD] = method_name;
-  j[PARAMS] = params;
+  if (!params.is_null())
+    j[PARAMS] = params;
   return j;
 }
 
@@ -290,7 +291,7 @@ TEST_CASE("Add new members until there are 7, then reject")
 
     // check new_member id does not work before member is added
     enclave::RPCContext rpc_ctx(0, new_member.cert);
-    const Cert read_next_member_id = mpack(create_json_req(
+    const auto read_next_member_id = mpack(create_json_req(
       read_params<int>(ValueIds::NEXT_MEMBER_ID, Tables::VALUES), "read"));
     check_error(
       munpack(frontend.process(rpc_ctx, read_next_member_id)),
@@ -365,7 +366,8 @@ TEST_CASE("Add new members until there are 7, then reject")
       const Response<MemberAck> ack0 =
         munpack(frontend.process(rpc_ctx, read_nonce));
       // (2) ask for a fresher nonce
-      const auto freshen_nonce = mpack(create_json_req({}, "updateAckNonce"));
+      const auto freshen_nonce =
+        mpack(create_json_req(nullptr, "updateAckNonce"));
       check_success(munpack(frontend.process(rpc_ctx, freshen_nonce)));
       // (3) read ack entry again and check that the nonce has changed
       const Response<MemberAck> ack1 =


### PR DESCRIPTION
According to the [JSON-RPC 2.0 Spec](https://www.jsonrpc.org/specification#parameter_structures), `params` may be omitted, but if present it must be an object or list. We did not match this spec. We allowed `"params": null`, and if `params` was _missing_ we returned an error (`"[INVALID_REQUEST}: Invalid params."`).

The error was caused by a notable gotcha in `nlohmann::json`: when using `operator[]` on a const object, a missing key results in [undefined behaviour](https://github.com/nlohmann/json/blob/1126c9ca74fdea22d2ce3a065ac0fcb5792cbdaf/single_include/nlohmann/json.hpp#L15984). This is subtly different from calling on a non-const object, where this would return `null` (and modify the object).

This PR modifies `RpcFrontend::process_json()` to use method `at()` rather than `operator[]` when looking up fields in an RPC request. This will throw errors (`out_of_range.403`) if the field is missing.

This will also now reject any RPCs with `"params": null`. A non-existent `params` field is allowed, and this will show up in handlers as a null `nlohmann::json` object.