### PR TITLE
Remove special lua __default script

### DIFF
--- a/sphinx/source/logging_lua.rst
+++ b/sphinx/source/logging_lua.rst
@@ -4,9 +4,9 @@ Logging (Lua)
 Overview
 ````````
 
-CCF comes with a generic application for running Lua scripts called *luageneric*, implemented in [CCF]/src/apps/luageneric/luageneric.cpp. At runtime, *luageneric* dispatches incoming RPCs to Lua scripts stored in the table *APP_SCRIPTS*. The initial contents of the table (i.e., at "genesis") are set by a Lua script passed to the *genesisgenerator* via the ``--app-script`` parameter. 
+CCF comes with a generic application for running Lua scripts called *luageneric*, implemented in [CCF]/src/apps/luageneric/luageneric.cpp. At runtime, *luageneric* dispatches incoming RPCs to Lua scripts stored in the table *APP_SCRIPTS*. The RPC method name is used as the key, and if a script exists at this key it is called with the RPC arguments. The initial contents of the table (i.e., at "genesis") are set by a Lua script passed to the *genesisgenerator* via the ``--app-script`` parameter. 
 
-The *luageneric* uses an RPC's method name to lookup a handler script from *APP_SCRIPTS*. The script at key ``__environment`` is also special. If set, the corresponding script is invoked before any actual handler script to initialize the Lua environment. 
+The script at key ``__environment`` is special. If set, the corresponding script is invoked before any actual handler script to initialize the Lua environment. 
 
 RPC Handler
 ```````````

--- a/sphinx/source/logging_lua.rst
+++ b/sphinx/source/logging_lua.rst
@@ -6,7 +6,7 @@ Overview
 
 CCF comes with a generic application for running Lua scripts called *luageneric*, implemented in [CCF]/src/apps/luageneric/luageneric.cpp. At runtime, *luageneric* dispatches incoming RPCs to Lua scripts stored in the table *APP_SCRIPTS*. The initial contents of the table (i.e., at "genesis") are set by a Lua script passed to the *genesisgenerator* via the ``--app-script`` parameter. 
 
-If the key ``__default`` exists in *APP_SCRIPTS*, then *luageneric* forwards all RPCs to the corresponding script. Otherwise, it uses an RPC's method name to lookup a handler script from *APP_SCRIPTS*. The script at key ``__environment`` is also special. If set, the corresponding script is invoked before any actual handler script to initialize the Lua environment. 
+The *luageneric* uses an RPC's method name to lookup a handler script from *APP_SCRIPTS*. The script at key ``__environment`` is also special. If set, the corresponding script is invoked before any actual handler script to initialize the Lua environment. 
 
 RPC Handler
 ```````````

--- a/src/apps/luageneric/luageneric.cpp
+++ b/src/apps/luageneric/luageneric.cpp
@@ -64,22 +64,19 @@ namespace ccfapp
       tsr = std::make_unique<AppTsr>(network, app_tables);
 
       auto default_handler = [this](RequestArgs& args) {
-        const auto scripts = args.tx.get_view(this->network.app_scripts);
-        auto handler_script = scripts->get(UserScriptIds::DEFAULT_HANDLER);
-        if (!handler_script)
-        {
-          if (args.method == UserScriptIds::ENV_HANDLER)
-            return jsonrpc::error(
-              jsonrpc::ErrorCodes::METHOD_NOT_FOUND,
-              "Cannot call environment script ('" + args.method + "')");
+        if (args.method == UserScriptIds::ENV_HANDLER)
+          return jsonrpc::error(
+            jsonrpc::ErrorCodes::METHOD_NOT_FOUND,
+            "Cannot call environment script ('" + args.method + "')");
 
-          // try find specific script for method
-          handler_script = scripts->get(args.method);
-          if (!handler_script)
-            return jsonrpc::error(
-              jsonrpc::ErrorCodes::METHOD_NOT_FOUND,
-              "No handler script found for method '" + args.method + "'");
-        }
+        const auto scripts = args.tx.get_view(this->network.app_scripts);
+
+        // try find script for method
+        auto handler_script = scripts->get(args.method);
+        if (!handler_script)
+          return jsonrpc::error(
+            jsonrpc::ErrorCodes::METHOD_NOT_FOUND,
+            "No handler script found for method '" + args.method + "'");
 
         const auto result = tsr->run<nlohmann::json>(
           args.tx,

--- a/src/apps/luageneric/luageneric_test.cpp
+++ b/src/apps/luageneric/luageneric_test.cpp
@@ -108,7 +108,7 @@ void set_handler(NetworkTables& network, const string& method, const Script& h)
 
 using Params = map<string, json>;
 
-auto make_pc(string method, Params params)
+auto make_pc(const string& method, const Params& params)
 {
   return json::to_msgpack(ProcedureCall<Params>{method, 0, params});
 }
@@ -251,7 +251,8 @@ TEST_CASE("simple bank")
     local acc = params.account
     local amt = tables.priv0:get(acc)
     if not amt then
-      return env.jerr(env.error_codes.INVALID_PARAMS, "account " .. acc .. " does not exist")
+      return env.jerr(
+        env.error_codes.INVALID_PARAMS, "account " .. acc .. " does not exist")
     end
 
     return env.jsucc(amt)
@@ -265,12 +266,14 @@ TEST_CASE("simple bank")
     local dst = params.dst
     local src_n = tables.priv0:get(src)
     if not src_n then
-      return env.jerr(env.error_codes.INVALID_PARAMS, "source account does not exist")
+      return env.jerr(
+        env.error_codes.INVALID_PARAMS, "source account does not exist")
     end
 
     local dst_n = tables.priv0:get(dst)
     if not dst_n then
-      return env.jerr(env.error_codes.INVALID_PARAMS, "destination account does not exist")
+      return env.jerr(
+        env.error_codes.INVALID_PARAMS, "destination account does not exist")
     end
 
     local amt = params.amt

--- a/src/apps/luageneric/luageneric_test.cpp
+++ b/src/apps/luageneric/luageneric_test.cpp
@@ -65,30 +65,33 @@ auto init_frontend(
   set_whitelists(network);
 
   const auto env_script = R"xxx(
-  return {
-  __environment = [[
-    env = {
-      error_codes = {
-        PARSE_ERROR = -32700,
-        INVALID_REQUEST = -32600,
-        METHOD_NOT_FOUND = -32601,
-        INVALID_PARAMS = -32602,
-        INTERNAL_ERROR = -32603,
-        INVALID_CLIENT_SIGNATURE = -32605,
-        INVALID_CALLER_ID = -32606,
+    return {
+      __environment = [[
+        env = {
+          error_codes = {
+            PARSE_ERROR = -32700,
+            INVALID_REQUEST = -32600,
+            METHOD_NOT_FOUND = -32601,
+            INVALID_PARAMS = -32602,
+            INTERNAL_ERROR = -32603,
+            INVALID_CLIENT_SIGNATURE = -32605,
+            INVALID_CALLER_ID = -32606,
 
-        INSUFFICIENT_RIGHTS = -32006,
-        DENIED = -32007
-      }
+            INSUFFICIENT_RIGHTS = -32006,
+            DENIED = -32007
+          }
+        }
+
+        function env.jsucc (result)
+          return {result = result}
+        end
+
+        function env.jerr (code, message)
+          return {error = {code = code, message = message}}
+        end
+      ]]
     }
-    function env.jsucc (result)
-      return {result = result}
-    end
-
-    function env.jerr (code, message)
-      return {error = {code = code, message = message}}
-    end
-  ]]})xxx";
+  )xxx";
 
   network.set_app_scripts(
     lua::Interpreter().invoke<nlohmann::json>(env_script));
@@ -145,9 +148,8 @@ TEST_CASE("simple lua apps")
   SUBCASE("echo")
   {
     constexpr auto app = R"xxx(
-    tables, gov_tables, caller_id, method, params = ...
-
-    return env.jsucc(params.verb)
+      tables, gov_tables, caller_id, method, params = ...
+      return env.jsucc(params.verb)
     )xxx";
     add_handler(network, "echo", {app});
 
@@ -159,26 +161,22 @@ TEST_CASE("simple lua apps")
 
   SUBCASE("store/load different types in generic table")
   {
-    constexpr auto app = R"xxx(
-    tables, gov_tables, caller_id, method, params = ...
-
-    handlers = {}
-    function handlers.store()
+    constexpr auto store = R"xxx(
+      tables, gov_tables, caller_id, method, params = ...
       local r = tables.priv0:put(params.k, params.v)
       return env.jsucc(r)
-    end
+    )xxx";
+    add_handler(network, "store", {store});
 
-    function handlers.load()
+    constexpr auto load = R"xxx(
+      tables, gov_tables, caller_id, method, params = ...
       local v = tables.priv0:get(params.k)
       if not v then
         return env.jerr(env.error_codes.INVALID_PARAMS, "key does not exist")
       end
       return env.jsucc(v)
-    end
-
-    return handlers[method]()
     )xxx";
-    set_default_handler(network, {app});
+    add_handler(network, "load", {load});
 
     // (1) store/load vector -> vector
     check_store_load(
@@ -201,26 +199,22 @@ TEST_CASE("simple lua apps")
 
   SUBCASE("access gov tables")
   {
-    constexpr auto app = R"xxx(
-    tables, gov_tables, caller_id, method, params = ...
-
-    handlers = {}
-    -- allowed
-    function handlers.get_members()
+    constexpr auto get_members = R"xxx(
+      tables, gov_tables, caller_id, method, params = ...
       local members = {}
       gov_tables.members:foreach(
-        function(k, v) members[tostring(k)] = v end )
+        function(k, v) members[tostring(k)] = v end
+      )
       return env.jsucc(members)
-    end
-
-    -- not allowed
-    function handlers.put_member()
-      return env.jsucc(gov_tables.members:put(params.k, params.v))
-    end
-
-    return handlers[method]()
     )xxx";
-    set_default_handler(network, {app});
+    add_handler(network, "get_members", {get_members});
+
+    // Not allowed
+    constexpr auto put_member = R"xxx(
+      tables, gov_tables, caller_id, method, params = ...
+      return env.jsucc(gov_tables.members:put(params.k, params.v))
+    )xxx";
+    add_handler(network, "put_member", {put_member});
 
     // (1) read out members table
     const auto pc = make_pc("get_members", {});
@@ -246,87 +240,89 @@ TEST_CASE("simple bank")
   const Cert u0 = {0};
   enclave::RPCContext rpc_ctx(0, u0);
 
-  constexpr auto app = R"xxx(
-  tables, gov_tables, caller_id, method, params = ...
-  handlers = {}
-  function handlers.SB_create()
-      local dst = params.dst
-      if tables.priv0:get(dst) then
-        return env.jerr(env.error_codes.INVALID_PARAMS, "account already exists")
-      end
+  constexpr auto create_method = "SB_create";
+  constexpr auto create = R"xxx(
+    tables, gov_tables, caller_id, method, params = ...
+    local dst = params.dst
+    if tables.priv0:get(dst) then
+      return env.jerr(env.error_codes.INVALID_PARAMS, "account already exists")
+    end
 
-      tables.priv0:put(dst, params.amt)
-      return env.jsucc(true)
-  end
-
-  function handlers.SB_read()
-      local acc = params.account
-      local amt = tables.priv0:get(acc)
-      if not amt then
-        return env.jerr(env.error_codes.INVALID_PARAMS, "account " .. acc .. " does not exist")
-      end
-
-      return env.jsucc(amt)
-  end
-
-  function handlers.SB_transfer()
-      local src = params.src
-      local dst = params.dst
-      local src_n = tables.priv0:get(src)
-      if not src_n then
-        return env.jerr(env.error_codes.INVALID_PARAMS, "source account does not exist")
-      end
-
-      local dst_n = tables.priv0:get(dst)
-      if not dst_n then
-        return env.jerr(env.error_codes.INVALID_PARAMS, "destination account does not exist")
-      end
-
-      local amt = params.amt
-      if src_n < amt then
-        return env.jerr(env.error_codes.INVALID_PARAMS, "insufficient funds")
-      end
-
-      tables.priv0:put(src, src_n - amt)
-      tables.priv0:put(dst, dst_n + amt)
-
-      return env.jsucc(true)
-  end
-
-  return handlers[method]()
+    tables.priv0:put(dst, params.amt)
+    return env.jsucc(true)
   )xxx";
-  set_default_handler(network, {app});
+  add_handler(network, create_method, {create});
+
+  constexpr auto read_method = "SB_read";
+  constexpr auto read = R"xxx(
+    tables, gov_tables, caller_id, method, params = ...
+    local acc = params.account
+    local amt = tables.priv0:get(acc)
+    if not amt then
+      return env.jerr(env.error_codes.INVALID_PARAMS, "account " .. acc .. " does not exist")
+    end
+
+    return env.jsucc(amt)
+  )xxx";
+  add_handler(network, read_method, {read});
+
+  constexpr auto transfer_method = "SB_transfer";
+  constexpr auto transfer = R"xxx(
+    tables, gov_tables, caller_id, method, params = ...
+    local src = params.src
+    local dst = params.dst
+    local src_n = tables.priv0:get(src)
+    if not src_n then
+      return env.jerr(env.error_codes.INVALID_PARAMS, "source account does not exist")
+    end
+
+    local dst_n = tables.priv0:get(dst)
+    if not dst_n then
+      return env.jerr(env.error_codes.INVALID_PARAMS, "destination account does not exist")
+    end
+
+    local amt = params.amt
+    if src_n < amt then
+      return env.jerr(env.error_codes.INVALID_PARAMS, "insufficient funds")
+    end
+
+    tables.priv0:put(src, src_n - amt)
+    tables.priv0:put(dst, dst_n + amt)
+
+    return env.jsucc(true)
+  )xxx";
+  add_handler(network, transfer_method, {transfer});
 
   {
-    const auto pc = make_pc("SB_create", {{"dst", 1}, {"amt", 123}});
+    const auto pc = make_pc(create_method, {{"dst", 1}, {"amt", 123}});
     check_success<bool>(frontend->process(rpc_ctx, pc), true);
 
-    const auto pc1 = make_pc("SB_read", {{"account", 1}});
+    const auto pc1 = make_pc(read_method, {{"account", 1}});
     check_success(frontend->process(rpc_ctx, pc1), 123);
   }
 
   {
-    const auto pc = make_pc("SB_create", {{"dst", 2}, {"amt", 999}});
+    const auto pc = make_pc(create_method, {{"dst", 2}, {"amt", 999}});
     check_success<bool>(frontend->process(rpc_ctx, pc), true);
 
-    const auto pc1 = make_pc("SB_read", {{"account", 2}});
+    const auto pc1 = make_pc(read_method, {{"account", 2}});
     check_success(frontend->process(rpc_ctx, pc1), 999);
   }
 
   {
-    const auto pc = make_pc("SB_read", {{"account", 3}});
+    const auto pc = make_pc(read_method, {{"account", 3}});
     check_error(frontend->process(rpc_ctx, pc), ErrorCodes::INVALID_PARAMS);
   }
 
   {
     const auto pc =
-      make_pc("SB_transfer", {{"src", 1}, {"dst", 2}, {"amt", 5}});
+      make_pc(transfer_method, {{"src", 1}, {"dst", 2}, {"amt", 5}});
     check_success<bool>(frontend->process(rpc_ctx, pc), true);
 
-    const auto pc1 = make_pc("SB_read", {{"account", 1}});
+    const auto pc1 = make_pc(read_method, {{"account", 1}});
     check_success(frontend->process(rpc_ctx, pc1), 123 - 5);
 
-    const auto pc2 = make_pc("SB_read", {{"account", 2}});
+    const auto pc2 = make_pc(read_method, {{"account", 2}});
     check_success(frontend->process(rpc_ctx, pc2), 999 + 5);
   }
 }

--- a/src/apps/luageneric/luageneric_test.cpp
+++ b/src/apps/luageneric/luageneric_test.cpp
@@ -103,6 +103,14 @@ void set_default_handler(GenesisGenerator& network, Script dh)
   REQUIRE(tx.commit() == kv::CommitSuccess::OK);
 }
 
+void add_handler(
+  GenesisGenerator& network, const std::string& method, const Script& h)
+{
+  Store::Tx tx;
+  tx.get_view(network.app_scripts)->put(method, h);
+  REQUIRE(tx.commit() == kv::CommitSuccess::OK);
+}
+
 using Params = map<string, json>;
 
 auto make_pc(string method, Params params)
@@ -139,15 +147,9 @@ TEST_CASE("simple lua apps")
     constexpr auto app = R"xxx(
     tables, gov_tables, caller_id, method, params = ...
 
-    -- define handlers
-    handlers = {}
-    function handlers.echo()
-      return env.jsucc(params.verb)
-    end
-    -- call handler
-    return handlers[method]()
+    return env.jsucc(params.verb)
     )xxx";
-    set_default_handler(network, {app});
+    add_handler(network, "echo", {app});
 
     // call "echo" function with "hello"
     const string verb = "hello";

--- a/src/node/scripts.h
+++ b/src/node/scripts.h
@@ -21,8 +21,6 @@ namespace ccf
 
   struct UserScriptIds
   {
-    //! default script for handling rpc
-    static auto constexpr DEFAULT_HANDLER = "__default";
     //! script that sets the environment for rpc handler scripts
     static auto constexpr ENV_HANDLER = "__environment";
   };


### PR DESCRIPTION
Previously we supported 2 ways of implementing lua handlers for the luageneric app. This simplifies things by removing the older method.

We no longer support a special script at key `__default` which handles all RPCs, instead we require entries in the `APP_SCRIPTS` table for each supported method.

As a concrete example, if we previously had an app with `get` and `set` RPCs like this:

```
return {
  __default = [[
  tables, gov_tables, caller_id, method, params = ...
 
  env = {
    error_codes = {
      INVALID_PARAMS = -32602
    }
  }
  function env.jsucc (result)
    return {result = result}
  end
 
  function env.jerr (code, message)
    return {error = {code = code, message = message}}
  end
 
  handler = {}
  
  function handler.get()
    msg = tables.pub0:get(params.id)
    if not msg then
      return env.jerr(env.error_codes.INVALID_PARAMS, "No such record") 
    end
    return env.jsucc(msg)
  end
  
  function handler.set()
    tables.pub0:put(params.id, params.msg)
    return env.jsucc(true)
  end
 
  return handler[method]()
  ]]
}
```

this should be rewritten as:
```
return {
  __environment = [[
  env = {
    error_codes = {
      INVALID_PARAMS = -32602
    }
  }
  function env.jsucc (result)
    return {result = result}
  end

  function env.jerr (code, message)
    return {error = {code = code, message = message}}
  end
  ]],
  
  get = [[
    tables, gov_tables, caller_id, method, params = ...
    msg = tables.pub0:get(params.id)
    if not msg then
      return env.jerr(env.error_codes.INVALID_PARAMS, "No such record") 
    end
    return env.jsucc(msg)
  ]],

  set = [[
    tables, gov_tables, caller_id, method, params = ...
    tables.pub0:put(params.id, params.msg)
    return env.jsucc(true)
  ]],
}
```

Rather than a single script at key `__default`, this app contains 3 scripts at keys `__environment`, `get`, and `set`. The script at `__environment` is called for every RPC, to make some standard functions/constants available.

Resolves #168. Additional changes to the lua interface will resolve #163.