### PR TITLE
CCF + PBFT in real enclave

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,12 +255,6 @@ if(BUILD_TESTS)
       ADDITIONAL_ARGS
         --oesign ${OESIGN}
     )
-
-    ## Add node test
-    add_e2e_test(
-      NAME add_node_test
-      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/addnode.py
-    )
   endif()
 
   add_e2e_test(
@@ -275,6 +269,8 @@ if(BUILD_TESTS)
       --scenario ${CMAKE_SOURCE_DIR}/tests/simple_logging_scenario.json
   )
 
+  # TODO: These tests make use of dynamic node configuration that is not
+  # yet supported by PBFT
   if (NOT PBFT)
     add_e2e_test(
       NAME election_tests
@@ -289,6 +285,13 @@ if(BUILD_TESTS)
       ADDITIONAL_ARGS
         ${RECOVERY_ARGS}
     )
+
+    if(QUOTES_ENABLED)
+      add_e2e_test(
+        NAME add_node_test
+        PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/addnode.py
+      )
+    endif()
   endif()
 
   add_e2e_test(

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -389,11 +389,11 @@ function(add_enclave_lib name app_oe_conf_path enclave_sign_key_path)
       -nostdlib -nodefaultlibs -nostartfiles
       -Wl,--no-undefined
       -Wl,-Bstatic,-Bsymbolic,--export-dynamic,-pie
-      ${ENCLAVE_LIBS}
       -lgcc
       ${PARSED_ARGS_LINK_LIBS}
       ccfcrypto.enclave
       evercrypt.enclave
+      ${ENCLAVE_LIBS}
       secp256k1.enclave
     )
     set_property(TARGET ${name} PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
This PR adds support for PBFT with real enclave (it was previously only supporting virtual enclaves). 

The changes are:
- Change in the linking order for real enclaves. Otherwise, PBFT will try to use Open Enclave's mbedtls for its underlying crypto function (which we don't want, as we need the functions in `evercrypt.enclave`).
- Move the new `addnode` end-to-end test so that it is only built when PBFT is disabled (as it makes use of dynamic configuration).