### PR TITLE
Harden Lua handler API

### DIFF
--- a/sphinx/source/logging_lua.rst
+++ b/sphinx/source/logging_lua.rst
@@ -32,13 +32,15 @@ The interface between Lua RPC handlers and the rest of CCF is simple. A fixed se
 
 * ``gov_tables``: the set of governance tables the application can read. For example, ``gov_tables.membercerts`` holds the certificates of CCF members.
 
-* ``caller_id``: the caller's id.
+* ``args``: a table containing the arguments parsed from this RPC. Attempting to access any missing keys will result in an error rather than ``nil``. The valid keys are:
 
-* ``method``: the method name.
+    * ``caller_id``: the caller's id.
 
-* ``params``: the RPC's parameters indexed by name. All JSON is translated to Lua tables.
+    * ``method``: the method name.
 
-The Lua table returned by an RPC handler is translated to JSON and returned to the client.
+    * ``params``: the RPC's ``params``, converted from JSON to a Lua table. If the JSON params were an object, this will be an object-like table with named string keys. If the JSON params were an array, this will be an array-like table with consecutive numbered keys.
+
+The Lua value returned by an RPC handler is translated to JSON and returned to the client. To indicate an error, return a table with a key named ``error``. The value at this key will be used as JSON error object in the response. 
 
 Accessing Tables
 ~~~~~~~~~~~~~~~~

--- a/sphinx/source/logging_lua.rst
+++ b/sphinx/source/logging_lua.rst
@@ -40,7 +40,7 @@ The interface between Lua RPC handlers and the rest of CCF is simple. A fixed se
 
     * ``params``: the RPC's ``params``, converted from JSON to a Lua table. If the JSON params were an object, this will be an object-like table with named string keys. If the JSON params were an array, this will be an array-like table with consecutive numbered keys.
 
-The Lua value returned by an RPC handler is translated to JSON and returned to the client. To indicate an error, return a table with a key named ``error``. The value at this key will be used as JSON error object in the response. 
+The Lua value returned by an RPC handler is translated to JSON and returned to the client. To indicate an error, return a table with a key named ``error``. The value at this key will be used as the JSON error object in the response. 
 
 Accessing Tables
 ~~~~~~~~~~~~~~~~

--- a/sphinx/source/logging_lua.rst
+++ b/sphinx/source/logging_lua.rst
@@ -6,7 +6,7 @@ Overview
 
 CCF comes with a generic application for running Lua scripts called *luageneric*, implemented in [CCF]/src/apps/luageneric/luageneric.cpp. At runtime, *luageneric* dispatches incoming RPCs to Lua scripts stored in the table *APP_SCRIPTS*. The initial contents of the table (i.e., at "genesis") are set by a Lua script passed to the *genesisgenerator* via the ``--app-script`` parameter. 
 
-If the key ``__default`` exists in *APP_SCRIPTS*, then *luageneric* forwards all RPCs to the corresponding script. Otherwise, it uses an RPC's method name to lookup a handler script from *APP_SCRIPTS*. The script at key ``__environment`` is also special. If set, the corresponding script is invoked before any actual handler script to initialize the Lua environment. 
+The *luageneric* uses an RPC's method name to lookup a handler script from *APP_SCRIPTS*. The script at key ``__environment`` is also special. If set, the corresponding script is invoked before any actual handler script to initialize the Lua environment. 
 
 RPC Handler
 ```````````

--- a/src/apps/logging/logging.lua
+++ b/src/apps/logging/logging.lua
@@ -3,62 +3,63 @@
 
 return {
   __environment = [[
-  env = {
-    error_codes = {
-      PARSE_ERROR = -32700,
-      INVALID_REQUEST = -32600,
-      METHOD_NOT_FOUND = -32601,
-      INVALID_PARAMS = -32602,
-      INTERNAL_ERROR = -32603,
-      INVALID_CLIENT_SIGNATURE = -32605,
-      INVALID_CALLER_ID = -32606,
-      
-      INSUFFICIENT_RIGHTS = -32006,
-      DENIED = -32007
+    env = {
+      error_codes = {
+        PARSE_ERROR = -32700,
+        INVALID_REQUEST = -32600,
+        METHOD_NOT_FOUND = -32601,
+        INVALID_PARAMS = -32602,
+        INTERNAL_ERROR = -32603,
+        INVALID_CLIENT_SIGNATURE = -32605,
+        INVALID_CALLER_ID = -32606,
+        
+        INSUFFICIENT_RIGHTS = -32006,
+        DENIED = -32007
+      }
     }
-  }
-  function env.jsucc (result)
-    return {result = result}
-  end
 
-  function env.jerr (code, message)
-    return {error = {code = code, message = message}}
-  end
-
-  -- custom functions for logging
-  function env.get(table)
-    msg = table:get(args.params.id)
-    if not msg then
-      return env.jerr(env.error_codes.INVALID_PARAMS, "No such record") 
+    function env.jsucc (result)
+      return {result = result}
     end
-    return env.jsucc(msg)
-  end
-  
-  function env.record(table)
-    table:put(args.params.id, args.params.msg)
-    return env.jsucc(true)
-  end
+
+    function env.jerr (code, message)
+      return {error = {code = code, message = message}}
+    end
+
+    -- custom functions for logging
+    function env.get(table)
+      msg = table:get(args.params.id)
+      if not msg then
+        return env.jerr(env.error_codes.INVALID_PARAMS, "No such record") 
+      end
+      return env.jsucc(msg)
+    end
+    
+    function env.record(table)
+      table:put(args.params.id, args.params.msg)
+      return env.jsucc(true)
+    end
   ]],
   
   LOG_get = [[
-  -- SNIPPET_START: lua_params
-  tables, gov_tables, args = ...
-  -- SNIPPET_END: lua_params
-  return env.get(tables.priv0)
+    -- SNIPPET_START: lua_params
+    tables, gov_tables, args = ...
+    -- SNIPPET_END: lua_params
+    return env.get(tables.priv0)
   ]],
 
   LOG_get_pub = [[
-  tables, gov_tables, args = ...
-  return env.get(tables.pub0)
+    tables, gov_tables, args = ...
+    return env.get(tables.pub0)
   ]],
 
   LOG_record = [[
-  tables, gov_tables, args = ...
-  return env.record(tables.priv0)
+    tables, gov_tables, args = ...
+    return env.record(tables.priv0)
   ]],
 
   LOG_record_pub = [[
-  tables, gov_tables, args = ...
-  return env.record(tables.pub0)
+    tables, gov_tables, args = ...
+    return env.record(tables.pub0)
   ]]
 }

--- a/src/apps/logging/logging.lua
+++ b/src/apps/logging/logging.lua
@@ -18,11 +18,11 @@ return {
       }
     }
 
-    function env.jsucc (result)
+    function env.jsucc(result)
       return {result = result}
     end
 
-    function env.jerr (code, message)
+    function env.jerr(code, message)
       return {error = {code = code, message = message}}
     end
 

--- a/src/apps/logging/logging.lua
+++ b/src/apps/logging/logging.lua
@@ -27,7 +27,7 @@ return {
 
   -- custom functions for logging
   function env.get(table)
-    msg = table:get(params.id)
+    msg = table:get(args.params.id)
     if not msg then
       return env.jerr(env.error_codes.INVALID_PARAMS, "No such record") 
     end
@@ -35,30 +35,30 @@ return {
   end
   
   function env.record(table)
-    table:put(params.id, params.msg)
+    table:put(args.params.id, args.params.msg)
     return env.jsucc(true)
   end
   ]],
   
   LOG_get = [[
   -- SNIPPET_START: lua_params
-  tables, gov_tables, caller_id, method, params = ...
+  tables, gov_tables, args = ...
   -- SNIPPET_END: lua_params
   return env.get(tables.priv0)
   ]],
 
   LOG_get_pub = [[
-  tables, gov_tables, caller_id, method, params = ...
+  tables, gov_tables, args = ...
   return env.get(tables.pub0)
   ]],
 
   LOG_record = [[
-  tables, gov_tables, caller_id, method, params = ...
+  tables, gov_tables, args = ...
   return env.record(tables.priv0)
   ]],
 
   LOG_record_pub = [[
-  tables, gov_tables, caller_id, method, params = ...
+  tables, gov_tables, args = ...
   return env.record(tables.pub0)
   ]]
 }

--- a/src/apps/logging/logging.lua
+++ b/src/apps/logging/logging.lua
@@ -40,7 +40,7 @@ return {
       return env.jsucc(true)
     end
   ]],
-  
+
   LOG_get = [[
     -- SNIPPET_START: lua_params
     tables, gov_tables, args = ...

--- a/src/apps/luageneric/luageneric.cpp
+++ b/src/apps/luageneric/luageneric.cpp
@@ -64,22 +64,19 @@ namespace ccfapp
       tsr = std::make_unique<AppTsr>(network, app_tables);
 
       auto default_handler = [this](RequestArgs& args) {
-        const auto scripts = args.tx.get_view(this->network.app_scripts);
-        auto handler_script = scripts->get(UserScriptIds::DEFAULT_HANDLER);
-        if (!handler_script)
-        {
-          if (args.method == UserScriptIds::ENV_HANDLER)
-            return jsonrpc::error(
-              jsonrpc::ErrorCodes::METHOD_NOT_FOUND,
-              "Cannot call environment script ('" + args.method + "')");
+        if (args.method == UserScriptIds::ENV_HANDLER)
+          return jsonrpc::error(
+            jsonrpc::ErrorCodes::METHOD_NOT_FOUND,
+            "Cannot call environment script ('" + args.method + "')");
 
-          // try find specific script for method
-          handler_script = scripts->get(args.method);
-          if (!handler_script)
-            return jsonrpc::error(
-              jsonrpc::ErrorCodes::METHOD_NOT_FOUND,
-              "No handler script found for method '" + args.method + "'");
-        }
+        const auto scripts = args.tx.get_view(this->network.app_scripts);
+
+        // try find script for method
+        auto handler_script = scripts->get(args.method);
+        if (!handler_script)
+          return jsonrpc::error(
+            jsonrpc::ErrorCodes::METHOD_NOT_FOUND,
+            "No handler script found for method '" + args.method + "'");
 
         const auto result = tsr->run<nlohmann::json>(
           args.tx,

--- a/src/apps/luageneric/luageneric.cpp
+++ b/src/apps/luageneric/luageneric.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 #include "enclave/appinterface.h"
+#include "luainterp/luaargs.h"
 #include "luainterp/luainterp.h"
 #include "luainterp/luakv.h"
 #include "luainterp/txscriptrunner.h"
@@ -85,9 +86,7 @@ namespace ccfapp
            WlIds::USER_APP_CAN_READ_ONLY,
            scripts->get(UserScriptIds::ENV_HANDLER)},
           // vvv arguments to the script vvv
-          args.caller_id,
-          args.method,
-          args.params);
+          args);
 
         if (result.find(jsonrpc::ERR) == result.end())
         {

--- a/src/apps/luageneric/luageneric_test.cpp
+++ b/src/apps/luageneric/luageneric_test.cpp
@@ -108,7 +108,7 @@ void set_handler(NetworkTables& network, const string& method, const Script& h)
 
 using Params = map<string, json>;
 
-auto make_pc(string method, Params params)
+auto make_pc(const string& method, const Params& params)
 {
   return json::to_msgpack(ProcedureCall<Params>{method, 0, params});
 }
@@ -251,7 +251,8 @@ TEST_CASE("simple bank")
     local acc = params.account
     local amt = tables.priv0:get(acc)
     if not amt then
-      return env.jerr(env.error_codes.INVALID_PARAMS, "account " .. acc .. " does not exist")
+      return env.jerr(
+        env.error_codes.INVALID_PARAMS, "account " .. acc .. " does not exist")
     end
 
     return env.jsucc(amt)
@@ -265,12 +266,14 @@ TEST_CASE("simple bank")
     local dst = params.dst
     local src_n = tables.priv0:get(src)
     if not src_n then
-      return env.jerr(env.error_codes.INVALID_PARAMS, "source account does not exist")
+      return env.jerr(
+        env.error_codes.INVALID_PARAMS, "source account does not exist")
     end
 
     local dst_n = tables.priv0:get(dst)
     if not dst_n then
-      return env.jerr(env.error_codes.INVALID_PARAMS, "destination account does not exist")
+      return env.jerr(
+        env.error_codes.INVALID_PARAMS, "destination account does not exist")
     end
 
     local amt = params.amt

--- a/src/apps/luageneric/luageneric_test.cpp
+++ b/src/apps/luageneric/luageneric_test.cpp
@@ -65,30 +65,33 @@ auto init_frontend(
   set_whitelists(network);
 
   const auto env_script = R"xxx(
-  return {
-  __environment = [[
-    env = {
-      error_codes = {
-        PARSE_ERROR = -32700,
-        INVALID_REQUEST = -32600,
-        METHOD_NOT_FOUND = -32601,
-        INVALID_PARAMS = -32602,
-        INTERNAL_ERROR = -32603,
-        INVALID_CLIENT_SIGNATURE = -32605,
-        INVALID_CALLER_ID = -32606,
+    return {
+      __environment = [[
+        env = {
+          error_codes = {
+            PARSE_ERROR = -32700,
+            INVALID_REQUEST = -32600,
+            METHOD_NOT_FOUND = -32601,
+            INVALID_PARAMS = -32602,
+            INTERNAL_ERROR = -32603,
+            INVALID_CLIENT_SIGNATURE = -32605,
+            INVALID_CALLER_ID = -32606,
 
-        INSUFFICIENT_RIGHTS = -32006,
-        DENIED = -32007
-      }
+            INSUFFICIENT_RIGHTS = -32006,
+            DENIED = -32007
+          }
+        }
+
+        function env.jsucc (result)
+          return {result = result}
+        end
+
+        function env.jerr (code, message)
+          return {error = {code = code, message = message}}
+        end
+      ]]
     }
-    function env.jsucc (result)
-      return {result = result}
-    end
-
-    function env.jerr (code, message)
-      return {error = {code = code, message = message}}
-    end
-  ]]})xxx";
+  )xxx";
 
   network.set_app_scripts(
     lua::Interpreter().invoke<nlohmann::json>(env_script));
@@ -145,9 +148,8 @@ TEST_CASE("simple lua apps")
   SUBCASE("echo")
   {
     constexpr auto app = R"xxx(
-    tables, gov_tables, caller_id, method, params = ...
-
-    return env.jsucc(params.verb)
+      tables, gov_tables, caller_id, method, params = ...
+      return env.jsucc(params.verb)
     )xxx";
     add_handler(network, "echo", {app});
 
@@ -159,26 +161,22 @@ TEST_CASE("simple lua apps")
 
   SUBCASE("store/load different types in generic table")
   {
-    constexpr auto app = R"xxx(
-    tables, gov_tables, caller_id, method, params = ...
-
-    handlers = {}
-    function handlers.store()
+    constexpr auto store = R"xxx(
+      tables, gov_tables, caller_id, method, params = ...
       local r = tables.priv0:put(params.k, params.v)
       return env.jsucc(r)
-    end
+    )xxx";
+    add_handler(network, "store", {store});
 
-    function handlers.load()
+    constexpr auto load = R"xxx(
+      tables, gov_tables, caller_id, method, params = ...
       local v = tables.priv0:get(params.k)
       if not v then
         return env.jerr(env.error_codes.INVALID_PARAMS, "key does not exist")
       end
       return env.jsucc(v)
-    end
-
-    return handlers[method]()
     )xxx";
-    set_default_handler(network, {app});
+    add_handler(network, "load", {load});
 
     // (1) store/load vector -> vector
     check_store_load(
@@ -201,26 +199,22 @@ TEST_CASE("simple lua apps")
 
   SUBCASE("access gov tables")
   {
-    constexpr auto app = R"xxx(
-    tables, gov_tables, caller_id, method, params = ...
-
-    handlers = {}
-    -- allowed
-    function handlers.get_members()
+    constexpr auto get_members = R"xxx(
+      tables, gov_tables, caller_id, method, params = ...
       local members = {}
       gov_tables.members:foreach(
-        function(k, v) members[tostring(k)] = v end )
+        function(k, v) members[tostring(k)] = v end
+      )
       return env.jsucc(members)
-    end
-
-    -- not allowed
-    function handlers.put_member()
-      return env.jsucc(gov_tables.members:put(params.k, params.v))
-    end
-
-    return handlers[method]()
     )xxx";
-    set_default_handler(network, {app});
+    add_handler(network, "get_members", {get_members});
+
+    // Not allowed
+    constexpr auto put_member = R"xxx(
+      tables, gov_tables, caller_id, method, params = ...
+      return env.jsucc(gov_tables.members:put(params.k, params.v))
+    )xxx";
+    add_handler(network, "put_member", {put_member});
 
     // (1) read out members table
     const auto pc = make_pc("get_members", {});
@@ -246,87 +240,89 @@ TEST_CASE("simple bank")
   const Cert u0 = {0};
   enclave::RPCContext rpc_ctx(0, u0);
 
-  constexpr auto app = R"xxx(
-  tables, gov_tables, caller_id, method, params = ...
-  handlers = {}
-  function handlers.SB_create()
-      local dst = params.dst
-      if tables.priv0:get(dst) then
-        return env.jerr(env.error_codes.INVALID_PARAMS, "account already exists")
-      end
+  constexpr auto create_method = "SB_create";
+  constexpr auto create = R"xxx(
+    tables, gov_tables, caller_id, method, params = ...
+    local dst = params.dst
+    if tables.priv0:get(dst) then
+      return env.jerr(env.error_codes.INVALID_PARAMS, "account already exists")
+    end
 
-      tables.priv0:put(dst, params.amt)
-      return env.jsucc(true)
-  end
-
-  function handlers.SB_read()
-      local acc = params.account
-      local amt = tables.priv0:get(acc)
-      if not amt then
-        return env.jerr(env.error_codes.INVALID_PARAMS, "account " .. acc .. " does not exist")
-      end
-
-      return env.jsucc(amt)
-  end
-
-  function handlers.SB_transfer()
-      local src = params.src
-      local dst = params.dst
-      local src_n = tables.priv0:get(src)
-      if not src_n then
-        return env.jerr(env.error_codes.INVALID_PARAMS, "source account does not exist")
-      end
-
-      local dst_n = tables.priv0:get(dst)
-      if not dst_n then
-        return env.jerr(env.error_codes.INVALID_PARAMS, "destination account does not exist")
-      end
-
-      local amt = params.amt
-      if src_n < amt then
-        return env.jerr(env.error_codes.INVALID_PARAMS, "insufficient funds")
-      end
-
-      tables.priv0:put(src, src_n - amt)
-      tables.priv0:put(dst, dst_n + amt)
-
-      return env.jsucc(true)
-  end
-
-  return handlers[method]()
+    tables.priv0:put(dst, params.amt)
+    return env.jsucc(true)
   )xxx";
-  set_default_handler(network, {app});
+  add_handler(network, create_method, {create});
+
+  constexpr auto read_method = "SB_read";
+  constexpr auto read = R"xxx(
+    tables, gov_tables, caller_id, method, params = ...
+    local acc = params.account
+    local amt = tables.priv0:get(acc)
+    if not amt then
+      return env.jerr(env.error_codes.INVALID_PARAMS, "account " .. acc .. " does not exist")
+    end
+
+    return env.jsucc(amt)
+  )xxx";
+  add_handler(network, read_method, {read});
+
+  constexpr auto transfer_method = "SB_transfer";
+  constexpr auto transfer = R"xxx(
+    tables, gov_tables, caller_id, method, params = ...
+    local src = params.src
+    local dst = params.dst
+    local src_n = tables.priv0:get(src)
+    if not src_n then
+      return env.jerr(env.error_codes.INVALID_PARAMS, "source account does not exist")
+    end
+
+    local dst_n = tables.priv0:get(dst)
+    if not dst_n then
+      return env.jerr(env.error_codes.INVALID_PARAMS, "destination account does not exist")
+    end
+
+    local amt = params.amt
+    if src_n < amt then
+      return env.jerr(env.error_codes.INVALID_PARAMS, "insufficient funds")
+    end
+
+    tables.priv0:put(src, src_n - amt)
+    tables.priv0:put(dst, dst_n + amt)
+
+    return env.jsucc(true)
+  )xxx";
+  add_handler(network, transfer_method, {transfer});
 
   {
-    const auto pc = make_pc("SB_create", {{"dst", 1}, {"amt", 123}});
+    const auto pc = make_pc(create_method, {{"dst", 1}, {"amt", 123}});
     check_success<bool>(frontend->process(rpc_ctx, pc), true);
 
-    const auto pc1 = make_pc("SB_read", {{"account", 1}});
+    const auto pc1 = make_pc(read_method, {{"account", 1}});
     check_success(frontend->process(rpc_ctx, pc1), 123);
   }
 
   {
-    const auto pc = make_pc("SB_create", {{"dst", 2}, {"amt", 999}});
+    const auto pc = make_pc(create_method, {{"dst", 2}, {"amt", 999}});
     check_success<bool>(frontend->process(rpc_ctx, pc), true);
 
-    const auto pc1 = make_pc("SB_read", {{"account", 2}});
+    const auto pc1 = make_pc(read_method, {{"account", 2}});
     check_success(frontend->process(rpc_ctx, pc1), 999);
   }
 
   {
-    const auto pc = make_pc("SB_read", {{"account", 3}});
+    const auto pc = make_pc(read_method, {{"account", 3}});
     check_error(frontend->process(rpc_ctx, pc), ErrorCodes::INVALID_PARAMS);
   }
 
   {
     const auto pc =
-      make_pc("SB_transfer", {{"src", 1}, {"dst", 2}, {"amt", 5}});
+      make_pc(transfer_method, {{"src", 1}, {"dst", 2}, {"amt", 5}});
     check_success<bool>(frontend->process(rpc_ctx, pc), true);
 
-    const auto pc1 = make_pc("SB_read", {{"account", 1}});
+    const auto pc1 = make_pc(read_method, {{"account", 1}});
     check_success(frontend->process(rpc_ctx, pc1), 123 - 5);
 
-    const auto pc2 = make_pc("SB_read", {{"account", 2}});
+    const auto pc2 = make_pc(read_method, {{"account", 2}});
     check_success(frontend->process(rpc_ctx, pc2), 999 + 5);
   }
 }

--- a/src/apps/luageneric/luageneric_test.cpp
+++ b/src/apps/luageneric/luageneric_test.cpp
@@ -155,17 +155,17 @@ TEST_CASE("simple lua apps")
 
     // call "missing"
     const auto pc = make_pc("missing", {});
-    const auto err =
+    const auto response =
       check_error(frontend->process(rpc_ctx, pc), ErrorCodes::SCRIPT_ERROR);
-    const auto error_msg = err[MESSAGE].get<string>();
+    const auto error_msg = response[ERR][MESSAGE].get<string>();
     CHECK(error_msg.find("THIS_KEY_DOESNT_EXIST") != string::npos);
   }
 
   SUBCASE("echo")
   {
     constexpr auto app = R"xxx(
-      tables, gov_tables, caller_id, method, params = ...
-      return env.jsucc(params.verb)
+      tables, gov_tables, args = ...
+      return env.jsucc(args.params.verb)
     )xxx";
     set_handler(network, "echo", {app});
 
@@ -178,15 +178,15 @@ TEST_CASE("simple lua apps")
   SUBCASE("store/load different types in generic table")
   {
     constexpr auto store = R"xxx(
-      tables, gov_tables, caller_id, method, params = ...
-      local r = tables.priv0:put(params.k, params.v)
+      tables, gov_tables, args = ...
+      local r = tables.priv0:put(args.params.k, args.params.v)
       return env.jsucc(r)
     )xxx";
     set_handler(network, "store", {store});
 
     constexpr auto load = R"xxx(
-      tables, gov_tables, caller_id, method, params = ...
-      local v = tables.priv0:get(params.k)
+      tables, gov_tables, args = ...
+      local v = tables.priv0:get(args.params.k)
       if not v then
         return env.jerr(env.error_codes.INVALID_PARAMS, "key does not exist")
       end
@@ -216,7 +216,7 @@ TEST_CASE("simple lua apps")
   SUBCASE("access gov tables")
   {
     constexpr auto get_members = R"xxx(
-      tables, gov_tables, caller_id, method, params = ...
+      tables, gov_tables, args = ...
       local members = {}
       gov_tables.members:foreach(
         function(k, v) members[tostring(k)] = v end
@@ -227,8 +227,8 @@ TEST_CASE("simple lua apps")
 
     // Not allowed
     constexpr auto put_member = R"xxx(
-      tables, gov_tables, caller_id, method, params = ...
-      return env.jsucc(gov_tables.members:put(params.k, params.v))
+      tables, gov_tables, args = ...
+      return env.jsucc(gov_tables.members:put(args.params.k, args.params.v))
     )xxx";
     set_handler(network, "put_member", {put_member});
 
@@ -258,21 +258,21 @@ TEST_CASE("simple bank")
 
   constexpr auto create_method = "SB_create";
   constexpr auto create = R"xxx(
-    tables, gov_tables, caller_id, method, params = ...
-    local dst = params.dst
+    tables, gov_tables, args = ...
+    local dst = args.params.dst
     if tables.priv0:get(dst) then
       return env.jerr(env.error_codes.INVALID_PARAMS, "account already exists")
     end
 
-    tables.priv0:put(dst, params.amt)
+    tables.priv0:put(dst, args.params.amt)
     return env.jsucc(true)
   )xxx";
   set_handler(network, create_method, {create});
 
   constexpr auto read_method = "SB_read";
   constexpr auto read = R"xxx(
-    tables, gov_tables, caller_id, method, params = ...
-    local acc = params.account
+    tables, gov_tables, args = ...
+    local acc = args.params.account
     local amt = tables.priv0:get(acc)
     if not amt then
       return env.jerr(
@@ -285,9 +285,9 @@ TEST_CASE("simple bank")
 
   constexpr auto transfer_method = "SB_transfer";
   constexpr auto transfer = R"xxx(
-    tables, gov_tables, caller_id, method, params = ...
-    local src = params.src
-    local dst = params.dst
+    tables, gov_tables, args = ...
+    local src = args.params.src
+    local dst = args.params.dst
     local src_n = tables.priv0:get(src)
     if not src_n then
       return env.jerr(
@@ -300,7 +300,7 @@ TEST_CASE("simple bank")
         env.error_codes.INVALID_PARAMS, "destination account does not exist")
     end
 
-    local amt = params.amt
+    local amt = args.params.amt
     if src_n < amt then
       return env.jerr(env.error_codes.INVALID_PARAMS, "insufficient funds")
     end

--- a/src/apps/luageneric/luageneric_test.cpp
+++ b/src/apps/luageneric/luageneric_test.cpp
@@ -103,6 +103,14 @@ void set_default_handler(GenesisGenerator& network, Script dh)
   REQUIRE(tx.commit() == kv::CommitSuccess::OK);
 }
 
+void add_handler(
+  GenesisGenerator& network, const std::string& method, const Script& h)
+{
+  Store::Tx tx;
+  tx.get_view(network.app_scripts)->put(method, h);
+  REQUIRE(tx.commit() == kv::CommitSuccess::OK);
+}
+
 using Params = map<string, json>;
 
 auto make_pc(string method, Params params)
@@ -139,15 +147,9 @@ TEST_CASE("simple lua apps")
     constexpr auto app = R"xxx(
     tables, gov_tables, caller_id, method, params = ...
 
-    -- define handlers
-    handlers = {}
-    function handlers.echo()
-      return env.jsucc(params.verb)
-    end
-    -- call handler
-    return handlers[method]()
+    return env.jsucc(params.verb)
     )xxx";
-    set_default_handler(network, {app});
+    add_handler(network, "echo", {app});
 
     // call "echo" function with "hello"
     const string verb = "hello";

--- a/src/clients/logging_client.cpp
+++ b/src/clients/logging_client.cpp
@@ -130,46 +130,33 @@ int main(int argc, char** argv)
 
   LoggingClient client(host, port, cert);
 
-  try
+  if (*multi_command)
   {
-    if (*multi_command)
+    const size_t final_msg_id = msg_id + num_messages - 1;
+    for (auto id = msg_id; id <= final_msg_id; ++id)
     {
-      const size_t final_msg_id = msg_id + num_messages - 1;
-      for (auto id = msg_id; id <= final_msg_id; ++id)
-      {
-        // Only print response and retrieve log for first and last messages
-        bool const print_status = id == msg_id || id == final_msg_id;
+      // Only print response and retrieve log for first and last messages
+      bool const print_status = id == msg_id || id == final_msg_id;
 
-        const auto record_msg = client.make_timestamped_message(msg_body);
-
-        client.record_log_message(id, record_msg, print_status);
-
-        if (print_status)
-        {
-          client.get_log_message(id);
-        }
-      }
-    }
-    else
-    {
       const auto record_msg = client.make_timestamped_message(msg_body);
 
-      // First transaction - record a log message
-      client.record_log_message(msg_id, record_msg);
+      client.record_log_message(id, record_msg, print_status);
 
-      // Second transaction - get a log message
-      client.get_log_message(msg_id);
+      if (print_status)
+      {
+        client.get_log_message(id);
+      }
     }
   }
-  catch (const char* e)
+  else
   {
-    cout << "Error: " << e << endl;
-    return 1;
-  }
-  catch (exception& e)
-  {
-    cout << "Exception: " << e.what() << endl;
-    return 1;
+    const auto record_msg = client.make_timestamped_message(msg_body);
+
+    // First transaction - record a log message
+    client.record_log_message(msg_id, record_msg);
+
+    // Second transaction - get a log message
+    client.get_log_message(msg_id);
   }
 
   return 0;

--- a/src/luainterp/luaargs.h
+++ b/src/luainterp/luaargs.h
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "luautil.h"
+#include "node/rpc/frontend.h"
+
+/**
+ * @file luarpcargs.h
+ * @brief Convert from RpcFrontend::RequestArgs to a lua table, giving named
+ * access to RPC args and explicit errors on attempts to access missing keys.
+ */
+namespace ccf
+{
+  namespace lua
+  {
+    /**
+     * Push a RequestArgs onto the lua stack
+     *
+     * Leaves a single new value, but may use additional stack space during
+     * construction. The pushed value is a table with named keys for the members
+     * which should be accessible to lua RPC handlers.
+     */
+    template <>
+    inline void push_raw(lua_State* l, const RpcFrontend::RequestArgs& args)
+    {}
+
+    // To get RequestArgs as a return value from lua execution, implement this
+    // template <>
+    // inline nlohmann::json check_get(lua_State* l, int arg)
+    // {}
+  } // namespace lua
+} // namespace ccf

--- a/src/luainterp/luainterp.h
+++ b/src/luainterp/luainterp.h
@@ -152,7 +152,7 @@ namespace ccf
       void push(T&& o)
       {
         prepare_push();
-        lua::push_raw(l, o);
+        lua::push_raw(l, std::forward<T>(o));
       }
 
       /**

--- a/src/luainterp/luajson.h
+++ b/src/luainterp/luajson.h
@@ -94,7 +94,10 @@ namespace ccf
       switch (lua_type(l, arg))
       {
         case LUA_TNIL:
+        {
+          j = nullptr;
           break;
+        }
         case LUA_TNUMBER:
         {
           if (lua_isinteger(l, arg))

--- a/src/luainterp/luajson.h
+++ b/src/luainterp/luajson.h
@@ -22,7 +22,7 @@ namespace ccf
      * (starting from 1) respectively.
      */
     template <>
-    inline void push_raw(lua_State* l, nlohmann::json j)
+    inline void push_raw(lua_State* l, const nlohmann::json& j)
     {
       switch (j.type())
       {

--- a/src/luainterp/luauserdata.h
+++ b/src/luainterp/luauserdata.h
@@ -162,7 +162,7 @@ namespace ccf
     };
 
     template <typename T, typename X>
-    void push_raw(lua_State* l, UserDataExt<T, X> udx)
+    void push_raw(lua_State* l, const UserDataExt<T, X>& udx)
     {
       UserData<T, UserDataExt<T, X>>::push_boxed(l, udx.p);
     }

--- a/src/luainterp/luautil.h
+++ b/src/luainterp/luautil.h
@@ -54,11 +54,41 @@ namespace ccf
       return idx < 0 ? stack_size + 1 + idx : idx;
     }
 
+    inline void push_raw(lua_State* l, const char* s)
+    {
+      lua_pushstring(l, s);
+    }
+
+    inline void push_raw(lua_State* l, int i)
+    {
+      lua_pushinteger(l, i);
+    }
+
+    inline void push_raw(lua_State* l, uint64_t i)
+    {
+      lua_pushinteger(l, (lua_Integer)i);
+    }
+
+    inline void push_raw(lua_State* l, double d)
+    {
+      lua_pushnumber(l, d);
+    }
+
+    inline void push_raw(lua_State* l, bool b)
+    {
+      lua_pushboolean(l, b);
+    }
+
+    inline void push_raw(lua_State* l, std::nullptr_t)
+    {
+      lua_pushnil(l);
+    }
+
     /** The base push case. Specialize this to push other types onto the lua
      * stack.
      */
     template <typename T>
-    void push_raw(lua_State* l, T o)
+    void push_raw(lua_State* l, const T& o)
     {
       static_assert(
         std::is_empty<T>::value,
@@ -66,45 +96,9 @@ namespace ccf
     }
 
     template <>
-    inline void push_raw(lua_State* l, const char* s)
-    {
-      lua_pushstring(l, s);
-    }
-
-    template <>
-    inline void push_raw(lua_State* l, std::string s)
+    inline void push_raw(lua_State* l, const std::string& s)
     {
       lua_pushstring(l, s.c_str());
-    }
-
-    template <>
-    inline void push_raw(lua_State* l, int i)
-    {
-      lua_pushinteger(l, i);
-    }
-
-    template <>
-    inline void push_raw(lua_State* l, uint64_t i)
-    {
-      lua_pushinteger(l, (lua_Integer)i);
-    }
-
-    template <>
-    inline void push_raw(lua_State* l, double d)
-    {
-      lua_pushnumber(l, d);
-    }
-
-    template <>
-    inline void push_raw(lua_State* l, bool b)
-    {
-      lua_pushboolean(l, b);
-    }
-
-    template <>
-    inline void push_raw(lua_State* l, std::nullptr_t)
-    {
-      lua_pushnil(l);
     }
 
     template <typename F0, typename F1>

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -40,9 +40,6 @@ namespace ccf
       DoNotForward
     };
 
-  protected:
-    Store& tables;
-
     struct RequestArgs
     {
       enclave::RPCContext& rpc_ctx;
@@ -52,6 +49,9 @@ namespace ccf
       const nlohmann::json& params;
       const SignedReq& signed_request;
     };
+
+  protected:
+    Store& tables;
 
   private:
     using HandleFunction =

--- a/src/node/scripts.h
+++ b/src/node/scripts.h
@@ -21,8 +21,6 @@ namespace ccf
 
   struct UserScriptIds
   {
-    //! default script for handling rpc
-    static auto constexpr DEFAULT_HANDLER = "__default";
     //! script that sets the environment for rpc handler scripts
     static auto constexpr ENV_HANDLER = "__environment";
   };

--- a/tests/loggingclient.py
+++ b/tests/loggingclient.py
@@ -25,7 +25,7 @@ def run(args):
             "--ca=networkcert.pem",
             "--cert=user1_cert.pem",
             "--privk=user1_privk.pem",
-        )
+        ).check_returncode()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously if we changed the arguments passed to Lua method handlers then existing apps would likely return obscure errors. Either they'd try to access a `nil` parameter, or try to use a parameter of the wrong type.

This change mitigates that. Lua arguments are passed in a named table, and looking up any missing keys in that table will result in a readable error.

For example if we changed the arguments from `(int a, string b)` to `(string c)`, under the old scheme:

```
tables, gov_tables, a, b = …
x = a + 5 // ERROR: attempt to perform arithmetic on a string value
s = b + "_foo" // ERROR: attempt to perform arithmetic on a nil value
```

Under the new
```
tables, gov_tables, args = …
x = args.a + 5 // ERROR: 'a' is not a lua argument
s = args.b + "_foo" // ERROR: 'b' is not a lua argument
```

Hopefully these errors make it more obvious that the API has changed, and app writers can easily find the relevant notes in the changelist.

TODO: Check if we can roll tables and gov_tables into this as well.