### PR TITLE
Update contributing guide and OpenEnclave links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,3 +8,10 @@ https://cla.microsoft.com.
 When you submit a pull request, a CLA-bot will automatically determine whether you need
 to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the
 instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
+
+All pull requests must pass a suite of CI tests before they will be merged. The test
+commands are defined in `.vsts-ci.yml` and `.circleci/config.yml`, so you can locally
+repeat any tests which fail. You should at least run the `static_checks` job before
+creating a pull request, ensuring all of your code is correctly formatted. The test
+commands will only report misformatted files - to _reformat_ the files, pass `-f`
+to the `check-format.sh ...` command and remove `--check` from the `black ...` command.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the
 instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
 
+All pull requests must pass a suite of CI tests before they will be merged. The test
+commands are defined in `.vsts-ci.yml` and `.circleci/config.yml`, so you can locally
+repeat any tests which fail. You should at least run the `static_checks` job before
+creating a pull request, ensuring all of your code is correctly formatted. The test
+commands will only report misformatted files - to _reformat_ the files, pass `-f`
+to the `check-format.sh ...` command and remove `--check` from the `black ...` command.
+
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
 or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ transactions in highly performant and highly available fashion.
 
 ## A flexible confidentiality layer for any multi-party computation application or blockchain ledger to build upon
 
-CCF currently runs on [Intel SGX](https://software.intel.com/en-us/sgx)-enabled platforms. Because CCF uses the [OpenEnclave SDK](https://github.com/Microsoft/openenclave)
+CCF currently runs on [Intel SGX](https://software.intel.com/en-us/sgx)-enabled platforms. Because CCF uses the [OpenEnclave SDK](https://github.com/openenclave/openenclave)
 as the foundation for running in an enclave, as OpenEnclave supports new TEE technologies, CCF will be able to run on new platforms. Networks can be run on-premises,
 in one or many cloud-hosted data centers, including [Microsoft Azure](https://azure.microsoft.com/), or in any hybrid configuration.
 
@@ -59,7 +59,7 @@ to embed one of several language runtimes on top of its key-value store. Clients
  * Browse the [CCF Documentation](https://microsoft.github.io/CCF/).
  * Explore the CCF open-source GitHub repo, which also contains application examples and sample scripts for provisioning and setting up confidential computing VMs using Azure.
  * Learn more about [Azure Confidential Computing](https://azure.microsoft.com/solutions/confidential-compute/) offerings like Azure DC-series (which support Intel SGX TEE)
-   and [Open Enclave](https://github.com/Microsoft/openenclave) that CCF can run on.
+   and [Open Enclave](https://github.com/openenclave/openenclave) that CCF can run on.
 
 ## Getting Started on Azure Confidential Computing
 

--- a/getting_started/setup_vm/D-oe.yml
+++ b/getting_started/setup_vm/D-oe.yml
@@ -15,7 +15,7 @@
 
   - name: Download OpenEnclave source
     get_url:
-      url: https://github.com/Microsoft/openenclave/tarball/489404f2bdfdd3e07e0f150937151ae78392e8ed
+      url: https://github.com/openenclave/openenclave/tarball/489404f2bdfdd3e07e0f150937151ae78392e8ed
       dest: "{{ workspace }}/{{ oe_src }}"
       force: yes
     become: true

--- a/sphinx/source/getting_started.rst
+++ b/sphinx/source/getting_started.rst
@@ -129,7 +129,7 @@ Details
 - boost_ (eEVM_ transaction engine only)
 - libuv_
 
-.. _OpenEnclave: https://github.com/Microsoft/openenclave
+.. _OpenEnclave: https://github.com/openenclave/openenclave
 .. _mbedtls: https://tls.mbed.org/
 .. _boost: https://www.boost.org/
 .. _libuv: https://github.com/libuv/libuv


### PR DESCRIPTION
Added brief description of CI requirements + advice on passing static_checks to our contributing guidelines.

Update links to OE repo, which has moved to the [openenclave org](https://github.com/openenclave) on GitHub.