### PR TITLE
Friendlier formatting of log messages

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,3 +8,10 @@ https://cla.microsoft.com.
 When you submit a pull request, a CLA-bot will automatically determine whether you need
 to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the
 instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
+
+All pull requests must pass a suite of CI tests before they will be merged. The test
+commands are defined in `.vsts-ci.yml` and `.circleci/config.yml`, so you can locally
+repeat any tests which fail. You should at least run the `static_checks` job before
+creating a pull request, ensuring all of your code is correctly formatted. The test
+commands will only report misformatted files - to _reformat_ the files, pass `-f`
+to the `check-format.sh ...` command and remove `--check` from the `black ...` command.

--- a/3rdparty/fmt/format_header_only.h
+++ b/3rdparty/fmt/format_header_only.h
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+
+// To avoid repeating this macro everywhere CCF wants to include, we do it once
+// here
+
+#define FMT_HEADER_ONLY
+#include "format.h"

--- a/3rdparty/fmt/format_header_only.h
+++ b/3rdparty/fmt/format_header_only.h
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 
-// To avoid repeating this macro everywhere CCF wants to include, we do it once
-// here
-
+// To avoid repeating this macro everywhere CCF wants to use libfmt, we do
+// it once here
 #define FMT_HEADER_ONLY
 #include "format.h"
+
+// This allows types which have operator<< defined to be used in format calls
 #include "ostream.h"

--- a/3rdparty/fmt/format_header_only.h
+++ b/3rdparty/fmt/format_header_only.h
@@ -6,3 +6,4 @@
 
 #define FMT_HEADER_ONLY
 #include "format.h"
+#include "ostream.h"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ transactions in highly performant and highly available fashion.
 
 ## A flexible confidentiality layer for any multi-party computation application or blockchain ledger to build upon
 
-CCF currently runs on [Intel SGX](https://software.intel.com/en-us/sgx)-enabled platforms. Because CCF uses the [OpenEnclave SDK](https://github.com/Microsoft/openenclave)
+CCF currently runs on [Intel SGX](https://software.intel.com/en-us/sgx)-enabled platforms. Because CCF uses the [OpenEnclave SDK](https://github.com/openenclave/openenclave)
 as the foundation for running in an enclave, as OpenEnclave supports new TEE technologies, CCF will be able to run on new platforms. Networks can be run on-premises,
 in one or many cloud-hosted data centers, including [Microsoft Azure](https://azure.microsoft.com/), or in any hybrid configuration.
 
@@ -59,7 +59,7 @@ to embed one of several language runtimes on top of its key-value store. Clients
  * Browse the [CCF Documentation](https://microsoft.github.io/CCF/).
  * Explore the CCF open-source GitHub repo, which also contains application examples and sample scripts for provisioning and setting up confidential computing VMs using Azure.
  * Learn more about [Azure Confidential Computing](https://azure.microsoft.com/solutions/confidential-compute/) offerings like Azure DC-series (which support Intel SGX TEE)
-   and [Open Enclave](https://github.com/Microsoft/openenclave) that CCF can run on.
+   and [Open Enclave](https://github.com/openenclave/openenclave) that CCF can run on.
 
 ## Getting Started on Azure Confidential Computing
 
@@ -99,6 +99,13 @@ https://cla.microsoft.com.
 When you submit a pull request, a CLA-bot will automatically determine whether you need
 to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the
 instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
+
+All pull requests must pass a suite of CI tests before they will be merged. The test
+commands are defined in `.vsts-ci.yml` and `.circleci/config.yml`, so you can locally
+repeat any tests which fail. You should at least run the `static_checks` job before
+creating a pull request, ensuring all of your code is correctly formatted. The test
+commands will only report misformatted files - to _reformat_ the files, pass `-f`
+to the `check-format.sh ...` command and remove `--check` from the `black ...` command.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)

--- a/getting_started/setup_vm/D-oe.yml
+++ b/getting_started/setup_vm/D-oe.yml
@@ -15,7 +15,7 @@
 
   - name: Download OpenEnclave source
     get_url:
-      url: https://github.com/Microsoft/openenclave/tarball/489404f2bdfdd3e07e0f150937151ae78392e8ed
+      url: https://github.com/openenclave/openenclave/tarball/489404f2bdfdd3e07e0f150937151ae78392e8ed
       dest: "{{ workspace }}/{{ oe_src }}"
       force: yes
     become: true

--- a/sphinx/source/getting_started.rst
+++ b/sphinx/source/getting_started.rst
@@ -129,7 +129,7 @@ Details
 - boost_ (eEVM_ transaction engine only)
 - libuv_
 
-.. _OpenEnclave: https://github.com/Microsoft/openenclave
+.. _OpenEnclave: https://github.com/openenclave/openenclave
 .. _mbedtls: https://tls.mbed.org/
 .. _boost: https://www.boost.org/
 .. _libuv: https://github.com/libuv/libuv

--- a/src/apps/logging/logging.cpp
+++ b/src/apps/logging/logging.cpp
@@ -6,8 +6,7 @@
 #include "node/rpc/nodeinterface.h"
 #include "node/rpc/userfrontend.h"
 
-#define FMT_HEADER_ONLY
-#include <fmt/format.h>
+#include <fmt/format_header_only.h>
 #include <valijson/adapters/nlohmann_json_adapter.hpp>
 #include <valijson/schema.hpp>
 #include <valijson/schema_parser.hpp>

--- a/src/ds/json.h
+++ b/src/ds/json.h
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 #pragma once
-#define FMT_HEADER_ONLY
-#include <fmt/format.h>
+#include <fmt/format_header_only.h>
 #include <nlohmann/json.hpp>
 #include <sstream>
 

--- a/src/ds/logger.h
+++ b/src/ds/logger.h
@@ -5,6 +5,7 @@
 #include "ringbuffer.h"
 
 #include <cstring>
+#include <fmt/format_header_only.h>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -89,8 +90,7 @@ namespace logger
     LogLine(Level ll, const char* file_name, int line_number) : log_level(ll)
     {
       ss << "[" << config::to_string(ll) << "]" << file_name << ":"
-         << line_number << " - "
-         << " - ";
+         << line_number << " - ";
     }
 
     template <typename T>

--- a/src/ds/logger.h
+++ b/src/ds/logger.h
@@ -146,20 +146,25 @@ namespace logger
 #define LOG_TRACE \
   logger::config::ok(logger::TRACE) && \
     logger::Out() == logger::LogLine(logger::TRACE, __FILE__, __LINE__)
+#define LOG_TRACE_FMT(...) LOG_TRACE << fmt::format(__VA_ARGS__) << std::endl
 
 #define LOG_DEBUG \
   logger::config::ok(logger::DBG) && \
     logger::Out() == logger::LogLine(logger::DBG, __FILE__, __LINE__)
+#define LOG_DEBUG_FMT(...) LOG_DEBUG << fmt::format(__VA_ARGS__) << std::endl
 
 #define LOG_INFO \
   logger::config::ok(logger::INFO) && \
     logger::Out() == logger::LogLine(logger::INFO, __FILE__, __LINE__)
+#define LOG_INFO_FMT(...) LOG_INFO << fmt::format(__VA_ARGS__) << std::endl
 
 #define LOG_FAIL \
   logger::config::ok(logger::FAIL) && \
     logger::Out() == logger::LogLine(logger::FAIL, __FILE__, __LINE__)
+#define LOG_FAIL_FMT(...) LOG_FAIL << fmt::format(__VA_ARGS__) << std::endl
 
 #define LOG_FATAL \
   logger::config::ok(logger::FATAL) && \
     logger::Out() == logger::LogLine(logger::FATAL, __FILE__, __LINE__)
+#define LOG_FATAL_FMT(...) LOG_FATAL << fmt::format(__VA_ARGS__) << std::endl
 }

--- a/src/ds/messaging.h
+++ b/src/ds/messaging.h
@@ -85,8 +85,7 @@ namespace messaging
           ", cannot set handler for " + build_message_name(m, message_label));
       }
 
-      LOG_DEBUG << "Setting handler for " << message_label << " (" << m << ")"
-                << std::endl;
+      LOG_DEBUG_FMT("Setting handler for {} ({})", message_label, m);
       handlers.insert(it, {m, h});
 
       if (message_label != nullptr)

--- a/src/ds/test/logger_bench.cpp
+++ b/src/ds/test/logger_bench.cpp
@@ -21,6 +21,22 @@ static void log_accepted(picobench::state& s)
   std::cout.clear();
 }
 
+static void log_accepted_fmt(picobench::state& s)
+{
+  // Swallow the output instead of printing to stdout.
+  std::cout.setstate(std::ios_base::badbit);
+
+  logger::config::level() = logger::DBG;
+  picobench::scope scope(s);
+
+  for (size_t i = 0; i < s.iterations(); ++i)
+  {
+    LOG_DEBUG_FMT("test");
+  }
+
+  std::cout.clear();
+}
+
 static void log_rejected(picobench::state& s)
 {
   logger::config::level() = logger::FAIL;
@@ -32,8 +48,21 @@ static void log_rejected(picobench::state& s)
   }
 }
 
+static void log_rejected_fmt(picobench::state& s)
+{
+  logger::config::level() = logger::FAIL;
+  picobench::scope scope(s);
+
+  for (size_t i = 0; i < s.iterations(); ++i)
+  {
+    LOG_DEBUG_FMT("test");
+  }
+}
+
 const std::vector<int> sizes = {100000};
 
 PICOBENCH_SUITE("logger");
 PICOBENCH(log_accepted).iterations(sizes).samples(10);
+PICOBENCH(log_accepted_fmt).iterations(sizes).samples(10);
 PICOBENCH(log_rejected).iterations(sizes).samples(10);
+PICOBENCH(log_rejected_fmt).iterations(sizes).samples(10);

--- a/src/enclave/ccf_v.h
+++ b/src/enclave/ccf_v.h
@@ -28,8 +28,7 @@ T get_enclave_exported_function(const char* func_name)
   void* sym = dlsym(virtual_enclave_handle, func_name);
   if (sym == nullptr)
   {
-    LOG_FATAL << "Failed to find symbol: " << func_name << std::endl
-              << "  " << dlerror() << std::endl;
+    LOG_FATAL_FMT("Failed to find symbol: {}\n  {}", func_name, dlerror());
   }
   return (T)sym;
 }
@@ -62,14 +61,14 @@ extern "C"
   {
     if (virtual_enclave_handle)
     {
-      LOG_FATAL << "Current implementation is limited to a single virtual "
-                   "enclave per process"
-                << std::endl;
+      LOG_FATAL_FMT(
+        "Current implementation is limited to a single virtual "
+        "enclave per process");
     }
     virtual_enclave_handle = dlopen(path, RTLD_LAZY);
     if (virtual_enclave_handle == nullptr)
     {
-      LOG_FATAL << "Could not load virtual enclave: " << dlerror() << std::endl;
+      LOG_FATAL_FMT("Could not load virtual enclave: {}", dlerror());
     }
   }
 

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -172,8 +172,7 @@ namespace enclave
               else if (node.is_reading_private_ledger())
                 node.recover_private_ledger_entry(body);
               else
-                LOG_FAIL << "Cannot recover ledger entry: Unexpected state"
-                         << std::endl;
+                LOG_FAIL_FMT("Cannot recover ledger entry: Unexpected state");
             });
 
           DISPATCHER_SET_MESSAGE_HANDLER(

--- a/src/enclave/rpcclient.h
+++ b/src/enclave/rpcclient.h
@@ -49,7 +49,7 @@ namespace enclave
       if (res.first)
       {
         LOG_DEBUG_FMT(
-          "RPCClient: responding to session {}", rpc_ctx.client_session_is);
+          "RPCClient: responding to session {}", rpc_ctx.client_session_id);
         rpcresponder.reply_async(rpc_ctx.client_session_id, res.second);
       }
 

--- a/src/enclave/rpcclient.h
+++ b/src/enclave/rpcclient.h
@@ -48,8 +48,8 @@ namespace enclave
       auto res = handle_data_cb(data);
       if (res.first)
       {
-        LOG_DEBUG << "RPCClient: responding to session "
-                  << rpc_ctx.client_session_id << std::endl;
+        LOG_DEBUG_FMT(
+          "RPCClient: responding to session {}", rpc_ctx.client_session_is);
         rpcresponder.reply_async(rpc_ctx.client_session_id, res.second);
       }
 

--- a/src/enclave/rpcendpoint.h
+++ b/src/enclave/rpcendpoint.h
@@ -43,7 +43,7 @@ namespace enclave
           return false;
 
         // If there is a client cert, pass it to the rpc handler.
-        LOG_DEBUG << "RPC endpoint " << session_id << ": " << host << std::endl;
+        LOG_DEBUG_FMT("RPC endpoint {}: {}", session_id, host);
         handler = search.value();
         caller = peer_cert();
       }

--- a/src/enclave/rpcsessions.h
+++ b/src/enclave/rpcsessions.h
@@ -70,8 +70,7 @@ namespace enclave
         throw std::logic_error(
           "Duplicate conn ID received inside enclave: " + std::to_string(id));
 
-      LOG_DEBUG << "Accepting a session inside the enclave: " << id
-                << std::endl;
+      LOG_DEBUG_FMT("Accepting a session inside the enclave: {}", id);
       auto ctx = std::make_unique<tls::Server>(certs);
 
       auto session = std::make_shared<RPCEndpoint>(
@@ -96,7 +95,7 @@ namespace enclave
     void remove_session(size_t id)
     {
       std::lock_guard<SpinLock> guard(lock);
-      LOG_DEBUG << "Stopping a session inside the enclave: " << id << std::endl;
+      LOG_DEBUG_FMT("Stopping a session inside the enclave: {}", id);
       sessions.erase(id);
     }
 
@@ -107,8 +106,7 @@ namespace enclave
       auto ctx = std::make_unique<tls::Client>(cert);
       auto id = ++next_client_session_id;
 
-      LOG_DEBUG << "Creating a new client session inside the enclave: " << id
-                << std::endl;
+      LOG_DEBUG_FMT("Creating a new client session inside the enclave: {}", id);
 
       auto session = std::make_shared<RPCClient>(
         id, writer_factory, std::move(ctx), *this, rpc_ctx);

--- a/src/enclave/tlsendpoint.h
+++ b/src/enclave/tlsendpoint.h
@@ -441,7 +441,7 @@ namespace enclave
       void* ctx, int level, const char* file, int line, const char* str)
     {
       (void)level;
-      LOG_DEBUG << file << ":" << line << ": " << str << std::endl;
+      LOG_DEBUG_FMT("{}:{}: {}", file, line, str);
     }
 
     std::string strerror(int err)

--- a/src/enclave/tlsendpoint.h
+++ b/src/enclave/tlsendpoint.h
@@ -67,7 +67,7 @@ namespace enclave
 
     std::vector<uint8_t> read(size_t up_to, bool exact = false)
     {
-      LOG_TRACE << "Requesting " << up_to << " bytes" << std::endl;
+      LOG_TRACE_FMT("Requesting {} bytes", up_to);
       // This will return en empty vector if the connection isn't
       // ready, but it will not block on the handshake.
       do_handshake();
@@ -85,8 +85,7 @@ namespace enclave
 
       if (read_buffer.size() > 0)
       {
-        LOG_TRACE << "read_buffer is of size: " << read_buffer.size()
-                  << std::endl;
+        LOG_TRACE_FMT("read_buffer is of size: {}", read_buffer.size());
         offset = std::min(up_to, read_buffer.size());
         ::memcpy(data.data(), read_buffer.data(), offset);
 
@@ -100,7 +99,7 @@ namespace enclave
       }
 
       auto r = ctx->read(data.data() + offset, up_to - offset);
-      LOG_TRACE << "ctx->read returned: " << r << std::endl;
+      LOG_TRACE_FMT("ctx->read returned: {}", r);
 
       switch (r)
       {
@@ -108,8 +107,7 @@ namespace enclave
         case MBEDTLS_ERR_NET_CONN_RESET:
         case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY:
         {
-          LOG_TRACE << "TLS " << session_id << " on read: " << strerror(r)
-                    << std::endl;
+          LOG_TRACE_FMT("TLS {} on read: {}", session_id, strerror(r));
 
           stop(closed);
 
@@ -140,8 +138,7 @@ namespace enclave
 
       if (r < 0)
       {
-        LOG_TRACE << "TLS " << session_id << " on read: " << strerror(r)
-                  << std::endl;
+        LOG_TRACE_FMT("TLS {} on read: {}", session_id, strerror(r));
         stop(error);
         return {};
       }
@@ -153,8 +150,8 @@ namespace enclave
       // MBEDTLS_ERR_SSL_WANT_READ. Probably hit a size limit - try again
       if (exact && (total < up_to))
       {
-        LOG_TRACE << "Asked for exactly " << up_to << ", received " << total
-                  << ", retrying" << std::endl;
+        LOG_TRACE_FMT(
+          "Asked for exactly {}, received {}, retrying", up_to, total);
         read_buffer = move(data);
         return read(up_to, exact);
       }
@@ -225,8 +222,7 @@ namespace enclave
         }
         else
         {
-          LOG_TRACE << "TLS " << session_id << " on flush: " << strerror(r)
-                    << std::endl;
+          LOG_TRACE_FMT("TLS {} on flush: {}", session_id, strerror(r));
           stop(error);
         }
       }
@@ -238,8 +234,7 @@ namespace enclave
       {
         case handshake:
         {
-          LOG_TRACE << "TLS " << session_id << " closed during handshake"
-                    << std::endl;
+          LOG_TRACE_FMT("TLS {} closed during handshake", session_id);
           stop(closed);
           break;
         }
@@ -257,15 +252,14 @@ namespace enclave
               // mbedtls may return 0 when a close notify has not been
               // sent. This can't be disambiguated from a successful
               // close notify, so treat them the same.
-              LOG_TRACE << "TLS " << session_id << " closed" << std::endl;
+              LOG_TRACE_FMT("TLS {} closed ({})", session_id, r);
               stop(closed);
               break;
             }
 
             default:
             {
-              LOG_TRACE << "TLS " << session_id << " on close: " << strerror(r)
-                        << std::endl;
+              LOG_TRACE_FMT("TLS {} on_close: {}", session_id, strerror(r));
               stop(error);
               break;
             }
@@ -303,16 +297,14 @@ namespace enclave
         case MBEDTLS_ERR_SSL_NO_CLIENT_CERTIFICATE:
         case MBEDTLS_ERR_SSL_PEER_VERIFY_FAILED:
         {
-          LOG_TRACE << "TLS " << session_id << " on handshake: " << strerror(rc)
-                    << std::endl;
+          LOG_TRACE_FMT("TLS {} on handshake: {}", session_id, strerror(rc));
           stop(authfail);
           break;
         }
 
         case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY:
         {
-          LOG_TRACE << "TLS " << session_id << " on handshake: " << strerror(rc)
-                    << std::endl;
+          LOG_TRACE_FMT("TLS {} on handshake: {}", session_id, strerror(rc));
           stop(closed);
           break;
         }
@@ -329,19 +321,17 @@ namespace enclave
           if (r > 0)
           {
             buf.resize(r);
-            LOG_TRACE << std::string(buf.data(), buf.size()) << std::endl;
+            LOG_TRACE_FMT(std::string(buf.data(), buf.size()));
           }
 
-          LOG_TRACE << "TLS " << session_id << " on handshake: " << strerror(rc)
-                    << std::endl;
+          LOG_TRACE_FMT("TLS {} on handshake: {}", session_id, strerror(rc));
           stop(authfail);
           return;
         }
 
         default:
         {
-          LOG_TRACE << "TLS " << session_id << " on handshake: " << strerror(rc)
-                    << std::endl;
+          LOG_TRACE_FMT("TLS {} on handshake: {}", session_id, strerror(rc));
           stop(error);
           break;
         }

--- a/src/enclave/tlsframedendpoint.h
+++ b/src/enclave/tlsframedendpoint.h
@@ -38,7 +38,7 @@ namespace enclave
           const uint8_t* data = len.data();
           size_t size = len.size();
           msg_size = serialized::read<uint32_t>(data, size);
-          LOG_TRACE << "msg size is: " << msg_size << std::endl;
+          LOG_TRACE_FMT("msg size is: {}", msg_size);
         }
 
         // Arbitrary limit on RPC size to stop a client from requesting

--- a/src/host/beforeio.h
+++ b/src/host/beforeio.h
@@ -20,7 +20,7 @@ namespace asynchost
 
       if ((rc = uv_prepare_init(uv_default_loop(), &uv_handle)) < 0)
       {
-        LOG_FAIL << "uv_prepare_init failed: " << uv_strerror(rc) << std::endl;
+        LOG_FAIL_FMT("uv_prepare_init failed: {}", uv_strerror(rc));
         throw std::logic_error("uv_prepare_init failed");
       }
 
@@ -28,7 +28,7 @@ namespace asynchost
 
       if ((rc = uv_prepare_start(&uv_handle, on_prepare)) < 0)
       {
-        LOG_FAIL << "uv_prepare_start failed: " << uv_strerror(rc) << std::endl;
+        LOG_FAIL_FMT("uv_prepare_start failed: {}", uv_strerror(rc));
         throw std::logic_error("uv_prepare_start failed");
       }
     }

--- a/src/host/dns.h
+++ b/src/host/dns.h
@@ -40,7 +40,7 @@ namespace asynchost
              service.c_str(),
              &hints)) < 0)
         {
-          LOG_FAIL << "uv_getaddrinfo failed: " << uv_strerror(rc) << std::endl;
+          LOG_FAIL_FMT("uv_getaddrinfo failed (async): {}", uv_strerror(rc));
           delete resolver;
           return false;
         }
@@ -56,7 +56,7 @@ namespace asynchost
              service.c_str(),
              &hints)) < 0)
         {
-          LOG_FAIL << "uv_getaddrinfo failed: " << uv_strerror(rc) << std::endl;
+          LOG_FAIL_FMT("uv_getaddrinfo failed: {}", uv_strerror(rc));
           delete resolver;
           return false;
         }

--- a/src/host/enclave.h
+++ b/src/host/enclave.h
@@ -70,8 +70,7 @@ namespace host
 
         if (err != OE_OK)
         {
-          LOG_FATAL << "Could not create enclave: " << oe_result_str(err)
-                    << std::endl;
+          LOG_FATAL_FMT("Could not create enclave: {}", oe_result_str(err));
         }
       }
     }
@@ -100,8 +99,8 @@ namespace host
 
       if (err != OE_OK)
       {
-        LOG_FATAL << "Failed to call in enclave_create_node: "
-                  << oe_result_str(err) << std::endl;
+        LOG_FATAL_FMT(
+          "Failed to call in enclave_create_node: {}", oe_result_str(err));
       }
 
       node_cert.resize(node_cert_len);
@@ -119,8 +118,7 @@ namespace host
 
       if (err != OE_OK)
       {
-        LOG_FATAL << "Failed to call in enclave_run: " << oe_result_str(err)
-                  << std::endl;
+        LOG_FATAL_FMT("Failed to call in enclave_run: {}", oe_result_str(err));
       }
 
       return ret;

--- a/src/host/enclave.h
+++ b/src/host/enclave.h
@@ -172,7 +172,7 @@ namespace host
         LOG_FAIL << "Quote does not contain expected data" << std::endl;
         return false;
       }
-      LOG_INFO << "Quote verified." << std::endl;
+      LOG_INFO_FMT("Quote verified");
 #else
       throw std::logic_error("Quote verification is not implemented");
 #endif

--- a/src/host/enclave.h
+++ b/src/host/enclave.h
@@ -149,8 +149,7 @@ namespace host
         oe_verify_report(e, quote_raw.data(), quote_raw.size(), &parsed);
       if (result != OE_OK)
       {
-        LOG_FAIL << "Quote could not be verified: " << oe_result_str(result)
-                 << std::endl;
+        LOG_FAIL_FMT("Quote could not be verified: {}", oe_result_str(result));
         return false;
       }
 
@@ -159,15 +158,17 @@ namespace host
       constexpr auto size = crypto::Sha256Hash::SIZE;
       if (parsed.report_data_size < size)
       {
-        LOG_FAIL << "Quote data length is too small. Expected: " << size
-                 << ", Actual: " << parsed.report_data_size << std::endl;
+        LOG_FAIL_FMT(
+          "Quote data length is too small. Expected: {}, Actual: {}",
+          size,
+          parsed.report_data_size);
         return false;
       }
 
       crypto::Sha256Hash hash{expected_contents};
       if (0 != memcmp(hash.h, parsed.report_data, size))
       {
-        LOG_FAIL << "Quote does not contain expected data" << std::endl;
+        LOG_FAIL_FMT("Quote does not contain expected data");
         return false;
       }
       LOG_INFO_FMT("Quote verified");

--- a/src/host/everyio.h
+++ b/src/host/everyio.h
@@ -22,7 +22,7 @@ namespace asynchost
 
       if ((rc = uv_idle_init(uv_default_loop(), &uv_handle)) < 0)
       {
-        LOG_FAIL << "uv_idle_init failed: " << uv_strerror(rc) << std::endl;
+        LOG_FAIL_FMT("uv_idle_init failed: {}", uv_strerror(rc));
         throw std::logic_error("uv_idle_init failed");
       }
 
@@ -30,7 +30,7 @@ namespace asynchost
 
       if ((rc = uv_idle_start(&uv_handle, on_every)) < 0)
       {
-        LOG_FAIL << "uv_idle_start failed: " << uv_strerror(rc) << std::endl;
+        LOG_FAIL_FMT("uv_idle_start failed: {}", uv_strerror(rc));
         throw std::logic_error("uv_idle_start failed");
       }
     }

--- a/src/host/handle_ringbuffer.h
+++ b/src/host/handle_ringbuffer.h
@@ -102,7 +102,7 @@ namespace asynchost
       // This flushes the enclave to host ringbuffer on each libuv loop
       // iteration.
       while (bp.read_n(max_messages, r) > 0)
-        ;
+        continue;
     }
   };
 

--- a/src/host/handle_ringbuffer.h
+++ b/src/host/handle_ringbuffer.h
@@ -79,12 +79,15 @@ namespace asynchost
             sealed_secrets_json.find(std::to_string(version)) !=
             sealed_secrets_json.end())
           {
-            LOG_FATAL << "Could not seal secrets at version " << version
-                      << " because they already exist" << std::endl;
+            LOG_FATAL_FMT(
+              "Could not seal secrets at version {} because they already exist",
+              version);
           }
 
-          LOG_DEBUG << "Writing sealed secrets for version " << version
-                    << " to " << sealed_secrets_file << std::endl;
+          LOG_DEBUG_FMT(
+            "Writing sealed secrets for version {} to {}",
+            version,
+            sealed_secrets_file);
 
           sealed_secrets_json[std::to_string(version)] = sealed_secrets_;
 

--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -152,8 +152,7 @@ namespace asynchost
       fseeko(file, total_len, SEEK_SET);
       positions.push_back(total_len);
 
-      LOG_DEBUG << "Ledger write " << positions.size() << ": " << size
-                << " bytes" << std::endl;
+      LOG_DEBUG_FMT("Ledger write {}: {} bytes", positions.size(), size);
 
       total_len += (size + frame_header_size);
 
@@ -168,8 +167,7 @@ namespace asynchost
 
     void truncate(size_t last_idx)
     {
-      LOG_DEBUG << "Ledger truncate: " << last_idx << "/" << positions.size()
-                << std::endl;
+      LOG_DEBUG_FMT("Ledger truncate: {}/{}", last_idx, positions.size());
 
       // positions[last_idx - 1] is the position of the specified
       // final index. Truncate the ledger at position[last_idx].

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -286,7 +286,7 @@ int main(int argc, char** argv)
   files::dump(quote, quote_file);
 
   if (!enclave.verify_quote(quote, node_cert))
-    LOG_FATAL << "Verification of local node quote failed" << std::endl;
+    LOG_FATAL_FMT("Verification of local node quote failed");
 #endif
 
   // Start a thread which will ECall and process messages inside the enclave
@@ -300,7 +300,7 @@ int main(int argc, char** argv)
 #ifndef VIRTUAL_ENCLAVE
     catch (const std::exception& e)
     {
-      LOG_FAIL << "Exception in enclave::run: " << e.what() << std::endl;
+      LOG_FAIL_FMT("Exception in enclave::run: {}", e.what());
 
       // This exception should be rethrown, probably aborting the process, but
       // we sleep briefly to allow more outbound messages to be processed. If

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -211,7 +211,7 @@ int main(int argc, char** argv)
     }
     else
     {
-      LOG_INFO << "Quote verified" << std::endl;
+      LOG_INFO_FMT("Quote verified");
       return 0;
     }
   }
@@ -242,8 +242,8 @@ int main(int argc, char** argv)
   const size_t node_size = 4096;
   vector<uint8_t> node_cert(node_size);
   vector<uint8_t> quote(OE_MAX_REPORT_SIZE);
-  LOG_INFO << "Starting new node" << (start == "recover" ? " (recovery)." : ".")
-           << std::endl;
+  LOG_INFO_FMT(
+    "Starting new node{}", (start == "recover" ? " (recovery)" : ""));
   raft::Config raft_config{
     chrono::milliseconds(raft_timeout),
     chrono::milliseconds(raft_election_timeout),
@@ -260,7 +260,7 @@ int main(int argc, char** argv)
 
   enclave.create_node(config, node_cert, quote, start == "recover");
 
-  LOG_INFO << "Created new node." << std::endl;
+  LOG_INFO_FMT("Created new node");
 
   // ledger
   asynchost::Ledger ledger(ledger_file, writer_factory);

--- a/src/host/nodeconnections.h
+++ b/src/host/nodeconnections.h
@@ -158,7 +158,7 @@ namespace asynchost
         peer->set_behaviour(std::make_unique<IncomingBehaviour>(parent, id));
         parent.incoming.emplace(id, peer);
 
-        LOG_DEBUG_FMT("node accept {}", node);
+        LOG_DEBUG_FMT("node accept {}", id);
       }
     };
 

--- a/src/host/nodeconnections.h
+++ b/src/host/nodeconnections.h
@@ -29,7 +29,7 @@ namespace asynchost
 
       void on_read(size_t len, uint8_t*& incoming)
       {
-        LOG_DEBUG << "node " << node << " received " << len << std::endl;
+        LOG_DEBUG_FMT("node {} received {}", node, len);
 
         pending.insert(pending.end(), incoming, incoming + len);
 
@@ -50,8 +50,7 @@ namespace asynchost
 
           if (size < msg_size)
           {
-            LOG_DEBUG << "node " << node << " have " << size << "/" << msg_size
-                      << std::endl;
+            LOG_DEBUG_FMT("node {} has {}/{}", node, size, msg_size);
             break;
           }
 
@@ -63,8 +62,8 @@ namespace asynchost
           if (node == ccf::NoNode)
             associate(header.from_node);
 
-          LOG_DEBUG << "node in: node " << node << ", size " << msg_size
-                    << ", type " << msg_type << std::endl;
+          LOG_DEBUG_FMT(
+            "node in: node {}, size {}, type {}", node, msg_size, msg_type);
 
           RINGBUFFER_WRITE_MESSAGE(
             ccf::node_inbound,
@@ -96,8 +95,7 @@ namespace asynchost
 
       void on_disconnect()
       {
-        LOG_DEBUG << "node incoming disconnect " << id << ", " << node
-                  << std::endl;
+        LOG_DEBUG_FMT("node incoming disconnect {}, {}", id, node);
 
         parent.incoming.erase(id);
 
@@ -109,8 +107,7 @@ namespace asynchost
       {
         node = n;
         parent.associated.emplace(node, parent.incoming.at(id));
-        LOG_DEBUG << "node incoming " << id << " associated with " << node
-                  << std::endl;
+        LOG_DEBUG_FMT("node incoming {} associated with {}", id, node);
       }
     };
 
@@ -123,19 +120,19 @@ namespace asynchost
 
       void on_resolve_failed()
       {
-        LOG_DEBUG << "node resolve failed " << node << std::endl;
+        LOG_DEBUG_FMT("node resolve failed {}", node);
         reconnect();
       }
 
       void on_connect_failed()
       {
-        LOG_DEBUG << "node connect failed " << node << std::endl;
+        LOG_DEBUG_FMT("node connect failed {}", node);
         reconnect();
       }
 
       void on_disconnect()
       {
-        LOG_DEBUG << "node disconnect " << node << std::endl;
+        LOG_DEBUG_FMT("node disconnect failed {}", node);
         reconnect();
       }
 
@@ -161,7 +158,7 @@ namespace asynchost
         peer->set_behaviour(std::make_unique<IncomingBehaviour>(parent, id));
         parent.incoming.emplace(id, peer);
 
-        LOG_DEBUG << "node accept " << id << std::endl;
+        LOG_DEBUG_FMT("node accept {}", node);
       }
     };
 
@@ -232,8 +229,12 @@ namespace asynchost
               size_to_send +
               ledger.framed_entries_size(ae.prev_idx + 1, ae.idx));
 
-            LOG_DEBUG << "raft send AE to " << to << " [" << frame
-                      << "]: " << ae.idx << ", " << ae.prev_idx << std::endl;
+            LOG_DEBUG_FMT(
+              "raft send AE to {} [{}]: {}, {}",
+              to,
+              frame,
+              ae.idx,
+              ae.prev_idx);
 
             // TODO(#performance): writev
             node.value()->write(sizeof(uint32_t), (uint8_t*)&frame);
@@ -249,8 +250,7 @@ namespace asynchost
             // Write as framed data to the recipient.
             uint32_t frame = (uint32_t)size_to_send;
 
-            LOG_DEBUG << "node send to " << to << " [" << frame << "]"
-                      << std::endl;
+            LOG_DEBUG_FMT("node send to {} [{}]", to, frame);
 
             node.value()->write(sizeof(uint32_t), (uint8_t*)&frame);
             node.value()->write(size_to_send, data_to_send);
@@ -264,20 +264,18 @@ namespace asynchost
     {
       if (outgoing.find(node) != outgoing.end())
       {
-        LOG_FAIL << "Cannot add node " << node << ": already in use"
-                 << std::endl;
+        LOG_FAIL_FMT("Cannot add node {}: already in use", node);
         return false;
       }
 
-      LOG_DEBUG << "Adding node " << node << " " << host << ":" << service
-                << std::endl;
+      LOG_DEBUG_FMT("Adding node {} {}:{}", node, host, service);
 
       TCP s;
       s->set_behaviour(std::make_unique<OutgoingBehaviour>(*this, node));
 
       if (!s->connect(host, service))
       {
-        LOG_DEBUG << "Node failed initial connect " << node << std::endl;
+        LOG_DEBUG_FMT("Node failed initial connect {}", node);
         return false;
       }
 
@@ -300,18 +298,17 @@ namespace asynchost
           return s->second;
       }
 
-      LOG_FAIL << "Unknown node " << node << std::endl;
+      LOG_FAIL_FMT("Unknown node {}", node);
       return {};
     }
 
     bool remove_node(ccf::NodeId node)
     {
-      LOG_DEBUG << "removing node " << node << std::endl;
+      LOG_DEBUG_FMT("removing node {}", node);
 
       if (outgoing.erase(node) < 1)
       {
-        LOG_FAIL << "Cannot remove node " << node << ": does not exist"
-                 << std::endl;
+        LOG_FAIL_FMT("Cannot remove node {}: does not exist", node);
         return false;
       }
 

--- a/src/host/notifyconnections.h
+++ b/src/host/notifyconnections.h
@@ -23,19 +23,19 @@ namespace asynchost
 
       void on_resolve_failed()
       {
-        LOG_DEBUG << "notify client resolve failed " << std::endl;
+        LOG_DEBUG_FMT("notify client resolve failed");
         reconnect();
       }
 
       void on_connect_failed()
       {
-        LOG_DEBUG << "notify client connect failed " << std::endl;
+        LOG_DEBUG_FMT("notify client connect failed");
         reconnect();
       }
 
       void on_disconnect()
       {
-        LOG_DEBUG << "notify client disconnect " << std::endl;
+        LOG_DEBUG_FMT("notify client disconnect");
         reconnect();
       }
 

--- a/src/host/notifyconnections.h
+++ b/src/host/notifyconnections.h
@@ -50,14 +50,13 @@ namespace asynchost
     {
       if (!host.empty())
       {
-        LOG_INFO << "Notifications client connecting to: " << host << ":"
-                 << service << std::endl;
+        LOG_INFO_FMT(
+          "Notifications client connecting to: {}:{}", host, service);
 
         notify_client->set_behaviour(std::make_unique<ClientBehaviour>(*this));
         if (!notify_client->connect(host, service))
         {
-          LOG_FATAL << "Notifications client failed initial connect"
-                    << std::endl;
+          LOG_FATAL_FMT("Notifications client failed initial connect");
         }
         is_setup = true;
       }

--- a/src/host/rpcconnections.h
+++ b/src/host/rpcconnections.h
@@ -25,19 +25,19 @@ namespace asynchost
 
       void on_resolve_failed()
       {
-        LOG_DEBUG << "rpc resolve failed " << id << std::endl;
+        LOG_DEBUG_FMT("rpc resolve failed {}", id);
         cleanup();
       }
 
       void on_connect_failed()
       {
-        LOG_DEBUG << "rpc connect failed " << id << std::endl;
+        LOG_DEBUG_FMT("rpc connect failed {}", id);
         cleanup();
       }
 
       void on_read(size_t len, uint8_t*& data)
       {
-        LOG_DEBUG << "rpc read " << id << ": " << len << std::endl;
+        LOG_DEBUG_FMT("rpc read {}: {}", id, len);
 
         RINGBUFFER_WRITE_MESSAGE(
           tls::tls_inbound,
@@ -48,7 +48,7 @@ namespace asynchost
 
       void on_disconnect()
       {
-        LOG_DEBUG << "rpc disconnect " << id << std::endl;
+        LOG_DEBUG_FMT("rpc disconnect {}", id);
         cleanup();
       }
 
@@ -72,13 +72,13 @@ namespace asynchost
 
       void on_resolve_failed()
       {
-        LOG_DEBUG << "rpc resolve failed " << id << std::endl;
+        LOG_DEBUG_FMT("rpc resolve failed {}", id);
         cleanup();
       }
 
       void on_listen_failed()
       {
-        LOG_DEBUG << "rpc connect failed " << id << std::endl;
+        LOG_DEBUG_FMT("rpc connect failed {}", id);
         cleanup();
       }
 
@@ -90,7 +90,7 @@ namespace asynchost
 
         parent.sockets.emplace(client_id, peer);
 
-        LOG_DEBUG << "rpc accept " << client_id << std::endl;
+        LOG_DEBUG_FMT("rpc accept {}", client_id);
 
         RINGBUFFER_WRITE_MESSAGE(
           tls::tls_start, parent.to_enclave, (size_t)client_id);
@@ -119,8 +119,7 @@ namespace asynchost
 
       if (sockets.find(id) != sockets.end())
       {
-        LOG_FAIL << "Cannot listen on id " << id << ": already in use"
-                 << std::endl;
+        LOG_FAIL_FMT("Cannot listen on id {}: already in use", id);
         return false;
       }
 
@@ -142,8 +141,7 @@ namespace asynchost
 
       if (sockets.find(id) != sockets.end())
       {
-        LOG_FAIL << "Cannot connect on id " << id << ": already in use"
-                 << std::endl;
+        LOG_FAIL_FMT("Cannot connect on id {}: already in use", id);
         return false;
       }
 
@@ -163,9 +161,11 @@ namespace asynchost
 
       if (s == sockets.end())
       {
-        LOG_FAIL << "Received an outbound message for id (" << id
-                 << ") which is not a known connection. Ignoring message of "
-                 << len << " bytes" << std::endl;
+        LOG_FAIL_FMT(
+          "Received an outbound message for id {} which is not a known "
+          "connection. Ignoring message of {} bytes",
+          id,
+          len);
         return false;
       }
 
@@ -176,7 +176,7 @@ namespace asynchost
     {
       if (sockets.erase(id) < 1)
       {
-        LOG_FAIL << "Cannot close id " << id << ": does not exist" << std::endl;
+        LOG_FAIL_FMT("Cannot close id {}: does not exist", id);
         return false;
       }
 
@@ -192,8 +192,7 @@ namespace asynchost
             ringbuffer::read_message<tls::tls_outbound>(data, size);
 
           int64_t connect_id = (int64_t)id;
-          LOG_DEBUG << "rpc write from enclave " << connect_id << ": "
-                    << body.size << std::endl;
+          LOG_DEBUG_FMT("rpc write from enclave {}: {}", connect_id, body.size);
 
           write(connect_id, body.size, body.data);
         });
@@ -204,8 +203,7 @@ namespace asynchost
             ringbuffer::read_message<tls::tls_connect>(data, size);
 
           int64_t connect_id = (int64_t)id;
-          LOG_DEBUG << "rpc connect request from enclave " << connect_id
-                    << std::endl;
+          LOG_DEBUG_FMT("rpc connect request from enclave {}", connect_id);
 
           if (check_enclave_side_id(connect_id))
             connect(connect_id, host, service);
@@ -215,7 +213,7 @@ namespace asynchost
         disp, tls::tls_closed, [this](const uint8_t* data, size_t size) {
           auto [id] = ringbuffer::read_message<tls::tls_closed>(data, size);
 
-          LOG_DEBUG << "rpc closed from enclave " << id << std::endl;
+          LOG_DEBUG_FMT("rpc closed from enclave {}", id);
           close(id);
         });
 
@@ -223,7 +221,7 @@ namespace asynchost
         disp, tls::tls_error, [this](const uint8_t* data, size_t size) {
           auto [id] = ringbuffer::read_message<tls::tls_error>(data, size);
 
-          LOG_DEBUG << "rpc error from enclave " << id << std::endl;
+          LOG_DEBUG_FMT("rpc error from enclave {}", id);
           close(id);
         });
     }
@@ -253,8 +251,7 @@ namespace asynchost
 
       if (!ok)
       {
-        LOG_FAIL << "rpc id is not in dedicated range (" << id << " )"
-                 << std::endl;
+        LOG_FAIL_FMT("rpc id is not in dedicated range ({})", id);
       }
 
       return ok;

--- a/src/host/signal.h
+++ b/src/host/signal.h
@@ -22,7 +22,7 @@ namespace asynchost
 
       if ((rc = uv_signal_init(uv_default_loop(), &uv_handle)) < 0)
       {
-        LOG_FAIL << "uv_signal_init failed: " << uv_strerror(rc) << std::endl;
+        LOG_FAIL_FMT("uv_signal_init failed: {}", uv_strerror(rc));
         throw std::logic_error("uv_signal_init failed");
       }
 
@@ -30,7 +30,7 @@ namespace asynchost
 
       if ((rc = uv_signal_start(&uv_handle, on_signal, signum)) < 0)
       {
-        LOG_FAIL << "uv_signal_start failed: " << uv_strerror(rc) << std::endl;
+        LOG_FAIL_FMT("uv_signal_start failed: {}", uv_strerror(rc));
         throw std::logic_error("uv_signal_start failed");
       }
     }

--- a/src/host/sigterm.h
+++ b/src/host/sigterm.h
@@ -21,7 +21,7 @@ namespace asynchost
 
     void on_signal()
     {
-      LOG_INFO << "SIGTERM: Shutting down enclave gracefully..." << std::endl;
+      LOG_INFO_FMT("SIGTERM: Shutting down enclave gracefully...");
       RINGBUFFER_WRITE_MESSAGE(AdminMessage::stop, to_enclave);
       uv_stop(uv_default_loop());
     }

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -109,7 +109,7 @@ namespace asynchost
         case CONNECTING_FAILED:
         {
           // Try again, starting with DNS.
-          LOG_DEBUG << "Reconnect from DNS" << std::endl;
+          LOG_DEBUG_FMT("Reconnect from DNS");
           status = CONNECTING_RESOLVING;
           return resolve(host, service, false);
         }
@@ -118,7 +118,7 @@ namespace asynchost
         {
           // Close and reset the uv_handle before trying again with the same
           // addr_current that succeeded previously.
-          LOG_DEBUG << "Reconnect from resolved address" << std::endl;
+          LOG_DEBUG_FMT("Reconnect from resolved address");
           status = RECONNECTING;
           uv_close((uv_handle_t*)&uv_handle, on_reconnect);
           return true;
@@ -180,7 +180,7 @@ namespace asynchost
 
       if ((rc = uv_tcp_init(uv_default_loop(), &uv_handle)) < 0)
       {
-        LOG_FAIL << "uv_tcp_init failed: " << uv_strerror(rc) << std::endl;
+        LOG_FAIL_FMT("uv_tcp_init failed: {}", uv_strerror(rc));
         return false;
       }
 
@@ -201,7 +201,7 @@ namespace asynchost
       if ((rc = uv_write(req, (uv_stream_t*)&uv_handle, &buf, 1, on_write)) < 0)
       {
         free_write(req);
-        LOG_FAIL << "uv_write failed: " << uv_strerror(rc) << std::endl;
+        LOG_FAIL_FMT("uv_write failed: {}", uv_strerror(rc));
         assert_status(CONNECTED, DISCONNECTED);
         behaviour->on_disconnect();
         return false;
@@ -233,8 +233,7 @@ namespace asynchost
       }
 
       assert_status(LISTENING_RESOLVING, LISTENING_FAILED);
-      LOG_FAIL << "uv_tcp_bind or uv_listen failed: " << uv_strerror(rc)
-               << std::endl;
+      LOG_FAIL_FMT("uv_tcp_bind or uv_listen failed: {}", uv_strerror(rc));
       behaviour->on_listen_failed();
     }
 
@@ -249,7 +248,7 @@ namespace asynchost
           (rc = uv_tcp_connect(
              req, &uv_handle, addr_current->ai_addr, on_connect)) < 0)
         {
-          LOG_DEBUG << "uv_tcp_connect retry: " << uv_strerror(rc) << std::endl;
+          LOG_DEBUG_FMT("uv_tcp_connect retry: {}", uv_strerror(rc));
           addr_current = addr_current->ai_next;
           continue;
         }
@@ -261,8 +260,10 @@ namespace asynchost
       assert_status(CONNECTING_RESOLVING, CONNECTING_FAILED);
       delete req;
 
-      LOG_DEBUG << "unable to connect: all resolved addresses failed: " << host
-                << ":" << service << std::endl;
+      LOG_DEBUG_FMT(
+        "unable to connect: all resolved addresses failed: {}:{}",
+        host,
+        service);
 
       behaviour->on_connect_failed();
       return false;
@@ -326,7 +327,7 @@ namespace asynchost
       if (rc < 0)
       {
         status = RESOLVING_FAILED;
-        LOG_TRACE << "TCP resolve failed: " << uv_strerror(rc) << std::endl;
+        LOG_TRACE_FMT("TCP resolve failed: {}", uv_strerror(rc));
         behaviour->on_resolve_failed();
       }
       else
@@ -368,7 +369,7 @@ namespace asynchost
     {
       if (rc < 0)
       {
-        LOG_DEBUG << "on_accept failed: " << uv_strerror(rc) << std::endl;
+        LOG_DEBUG_FMT("on_accept failed: {}", uv_strerror(rc));
         return;
       }
 
@@ -378,7 +379,7 @@ namespace asynchost
         (rc = uv_accept(
            (uv_stream_t*)&uv_handle, (uv_stream_t*)&peer->uv_handle)) < 0)
       {
-        LOG_DEBUG << "uv_accept failed: " << uv_strerror(rc) << std::endl;
+        LOG_DEBUG_FMT("uv_accept failed: {}", uv_strerror(rc));
         return;
       }
 
@@ -402,8 +403,7 @@ namespace asynchost
       if (rc < 0)
       {
         // Try again on the next address.
-        LOG_DEBUG << "uv_tcp_connect async retry: " << uv_strerror(rc)
-                  << std::endl;
+        LOG_DEBUG_FMT("uv_tcp_connect async retry: {}", uv_strerror(rc));
         addr_current = addr_current->ai_next;
         assert_status(CONNECTING, CONNECTING_RESOLVING);
         connect_resolved();
@@ -433,7 +433,7 @@ namespace asynchost
       if ((rc = uv_read_start((uv_stream_t*)&uv_handle, on_alloc, on_read)) < 0)
       {
         assert_status(CONNECTED, DISCONNECTED);
-        LOG_FAIL << "uv_read_start failed: " << uv_strerror(rc) << std::endl;
+        LOG_FAIL_FMT("uv_read_start failed: {}", uv_strerror(rc));
 
         if (behaviour)
           behaviour->on_disconnect();
@@ -480,7 +480,7 @@ namespace asynchost
         on_free(buf);
         uv_read_stop((uv_stream_t*)&uv_handle);
 
-        LOG_DEBUG << "TCP on_read: " << uv_strerror(sz) << std::endl;
+        LOG_DEBUG_FMT("TCP on_read: {}", uv_strerror(sz));
         behaviour->on_disconnect();
         return;
       }

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -126,8 +126,7 @@ namespace asynchost
 
         default:
         {
-          LOG_FATAL << "Unexpected status during reconnect: " << status
-                    << std::endl;
+          LOG_FATAL_FMT("Unexpected status during reconnect: {}", status);
           abort();
         }
       }
@@ -165,8 +164,7 @@ namespace asynchost
 
         default:
         {
-          LOG_FATAL << "Unexpected status during write: " << status
-                    << std::endl;
+          LOG_FATAL_FMT("Unexpected status during write: {}", status);
           abort();
         }
       }
@@ -274,8 +272,11 @@ namespace asynchost
     {
       if (status != from)
       {
-        LOG_FATAL << "Trying to transition from " << from << " to " << to
-                  << " but current is status " << status << std::endl;
+        LOG_FATAL_FMT(
+          "Trying to transition from {} to {} but current status is {}",
+          from,
+          to,
+          status);
         abort();
       }
 
@@ -349,8 +350,7 @@ namespace asynchost
 
           default:
           {
-            LOG_FATAL << "Unexpected status during on_resolved: " << status
-                      << std::endl;
+            LOG_FATAL_FMT("Unexpected status during on_resolved: {}", status);
             abort();
           }
         }

--- a/src/host/timer.h
+++ b/src/host/timer.h
@@ -23,7 +23,7 @@ namespace asynchost
 
       if ((rc = uv_timer_init(uv_default_loop(), &uv_handle)) < 0)
       {
-        LOG_FAIL << "uv_timer_init failed: " << uv_strerror(rc) << std::endl;
+        LOG_FAIL_FMT("uv_timer_init failed: {}", uv_strerror(rc));
         throw std::logic_error("uv_timer_init failed");
       }
 
@@ -31,7 +31,7 @@ namespace asynchost
 
       if ((rc = uv_timer_start(&uv_handle, on_timer, 0, repeat_ms)) < 0)
       {
-        LOG_FAIL << "uv_timer_start failed: " << uv_strerror(rc) << std::endl;
+        LOG_FAIL_FMT("uv_timer_start failed: {}", uv_strerror(rc));
         throw std::logic_error("uv_timer_start failed");
       }
     }

--- a/src/kv/test/kv_serialisation.cpp
+++ b/src/kv/test/kv_serialisation.cpp
@@ -247,7 +247,7 @@ bool corrupt_serialised_tx(
       if (match_buffer.size() == value_to_corrupt.size())
       {
         i = 'X';
-        LOG_DEBUG << "Corrupting serialised public data" << std::endl;
+        LOG_DEBUG_FMT("Corrupting serialised public data");
         return true;
       }
     }

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -193,8 +193,7 @@ namespace ccf
       // Channel can be established
       channel.establish();
 
-      LOG_DEBUG << "node2node channel with " << peer_id << " is now established"
-                << std::endl;
+      LOG_DEBUG_FMT("node2node channel with {} is now established", peer_id);
 
       return true;
     }

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -178,8 +178,8 @@ namespace ccf
             peer_signed_public.data() + Channel::len_public,
             peer_signed_public.size() - Channel::len_public))
       {
-        LOG_FAIL << "node2node peer signature verification failed " << peer_id
-                 << std::endl;
+        LOG_FAIL_FMT(
+          "node2node peer signature verification failed {}", peer_id);
         return false;
       }
 

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -227,7 +227,7 @@ namespace ccf
       auto sig = sig_tv->get(0);
       if (!sig.has_value())
       {
-        LOG_FAIL << "No signature found in signatures map" << std::endl;
+        LOG_FAIL_FMT("No signature found in signatures map");
         return false;
       }
       auto sig_value = sig.value();
@@ -237,8 +237,8 @@ namespace ccf
       auto ni = ni_tv->get(sig_value.node);
       if (!ni.has_value())
       {
-        LOG_FAIL << "No node info, and therefore no cert for node "
-                 << sig_value.node << std::endl;
+        LOG_FAIL_FMT(
+          "No node info, and therefore no cert for node {}", sig_value.node);
         return false;
       }
       tls::Verifier from_cert(ni.value().cert);

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -69,7 +69,7 @@ namespace ccf
 
   static void log_hash(const crypto::Sha256Hash& h, HashOp flag)
   {
-    LOG_DEBUG << "History [" << flag << "] " << h << std::endl;
+    LOG_DEBUG_FMT("History [{}] {}", flag, h);
   }
 
   class NullTxHistory : public kv::TxHistory

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -104,7 +104,7 @@ namespace ccf
     void emit_signature() override
     {
       auto version = store.next_version();
-      LOG_INFO << "Issuing signature at " << version << std::endl;
+      LOG_INFO_FMT("Issuing signature at {}", version);
       store.commit(
         version,
         [version, this]() {
@@ -269,9 +269,8 @@ namespace ccf
       auto version = store.next_version();
       auto term = replicator->get_term();
       auto commit = replicator->get_commit_idx();
-      LOG_INFO << "Issuing signature at " << version << std::endl;
-      LOG_DEBUG << "Signed at " << version << " term: " << term
-                << " commit: " << commit << std::endl;
+      LOG_INFO_FMT("Issuing signature at {}", version);
+      LOG_DEBUG_FMT("Signed at {} term: {} commit: {}", version, term, commit);
       store.commit(
         version,
         [version, term, commit, this]() {

--- a/src/node/networksecrets.h
+++ b/src/node/networksecrets.h
@@ -175,8 +175,7 @@ namespace ccf
           throw std::logic_error(
             "Secrets could not be unsealed : " + std::to_string(v));
 
-        LOG_DEBUG << "Secrets successfully unsealed at version " << it.key()
-                  << std::endl;
+        LOG_DEBUG_FMT("Secrets successfully unsealed at version {}", it.key());
 
         // Deserialise network secrets
         auto new_secret = std::make_unique<Secret>();
@@ -215,8 +214,7 @@ namespace ccf
 
       current_version = new_v;
 
-      LOG_DEBUG << "Secrets used at " << old_v << " are now valid from "
-                << new_v << std::endl;
+      LOG_DEBUG_FMT("Secrets used at {} are now valid from {}", old_v, new_v);
       return true;
     }
 

--- a/src/node/networksecrets.h
+++ b/src/node/networksecrets.h
@@ -143,7 +143,7 @@ namespace ccf
       auto search = secrets_map.find(v);
       if (search != secrets_map.end())
       {
-        LOG_FAIL << "set_secret(): secrets already exist " << v << std::endl;
+        LOG_FAIL_FMT("set_secret(): secrets already exist {}", v);
         return false;
       }
 
@@ -198,14 +198,14 @@ namespace ccf
       auto search = secrets_map.find(new_v);
       if (search != secrets_map.end())
       {
-        LOG_FAIL << "promote_secrets(): secrets already exist" << std::endl;
+        LOG_FAIL_FMT("promote_secrets(): secrets already exist");
         return false;
       }
 
       search = secrets_map.find(old_v);
       if (search == secrets_map.end())
       {
-        LOG_FAIL << "promote_secrets(): no secrets to promote" << std::endl;
+        LOG_FAIL_FMT("promote_secrets(): no secrets to promote");
         return false;
       }
 
@@ -248,8 +248,7 @@ namespace ccf
       auto search = secrets_map.find(v);
       if (search == secrets_map.end())
       {
-        LOG_FAIL << "get_serialised_secret() " << v << "does not exist"
-                 << std::endl;
+        LOG_FAIL_FMT("get_serialised_secret() {} does not exist", v);
         return {};
       }
 

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -84,7 +84,7 @@ namespace ccf
     template <typename T>
     static Result<T> Fail(const char* s)
     {
-      LOG_DEBUG_FMT("{}", s);
+      LOG_DEBUG_FMT(s);
       return {{}, false};
     }
 

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -214,7 +214,7 @@ namespace ccf
 
       if (res != OE_OK)
       {
-        LOG_FAIL_FMT("Failed to get quote: {}", oe_result_str(res);
+        LOG_FAIL_FMT("Failed to get quote: {}", oe_result_str(res));
         return Fail<CreateNew::Out>("oe_get_report failed");
       }
       quote.resize(quote_len);
@@ -224,7 +224,7 @@ namespace ccf
       res = oe_parse_report(quote.data(), quote.size(), &parsed_quote);
       if (res != OE_OK)
       {
-        LOG_FAIL_FMT("Failed to parse quote: {}", oe_result_str(res);
+        LOG_FAIL_FMT("Failed to parse quote: {}", oe_result_str(res));
         return Fail<CreateNew::Out>("oe_parse_report failed");
       }
 

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -26,8 +26,8 @@
 
 #include <atomic>
 #include <chrono>
-#include <nlohmann/json.hpp>
 #include <fmt/format_header_only.h>
+#include <nlohmann/json.hpp>
 #include <stdexcept>
 #include <unordered_set>
 #include <vector>
@@ -372,7 +372,7 @@ namespace ccf
             // If the joining node was started in recovery, truncate the ledger
             // and reset the store as we will receive the entirety of the ledger
             // from the leader
-            LOG_INFO << "Truncating entire ledger" << std::endl;
+            LOG_INFO_FMT("Truncating entire ledger");
             log_truncate(0);
             network.tables->clear();
           }
@@ -389,9 +389,10 @@ namespace ccf
           else
             sm.advance(State::partOfNetwork);
 
-          LOG_INFO << "Node has now joined the network as node " << self << ": "
-                   << (public_only ? "public only" : "all domains")
-                   << std::endl;
+          LOG_INFO_FMT(
+            "Node has now joined the network as node {}: {}",
+            self,
+            (public_only ? "public only" : "all domains"));
 
           jsonrpc::Response<JoinNetwork::Out> join_rpc_resp;
           join_rpc_resp.id = rpc_ctx.req.seq_no;
@@ -437,7 +438,7 @@ namespace ccf
     {
       std::lock_guard<SpinLock> guard(lock);
       sm.expect(State::readingPublicLedger);
-      LOG_INFO << "Start public recovery" << std::endl;
+      LOG_INFO_FMT("Start public recovery");
       read_ledger_idx(++ledger_idx);
     }
 
@@ -446,14 +447,14 @@ namespace ccf
       std::lock_guard<SpinLock> guard(lock);
       sm.expect(State::readingPublicLedger);
 
-      LOG_INFO << "Deserialising public ledger entry (" << ledger_entry.size()
-               << ")" << std::endl;
+      LOG_INFO_FMT(
+        "Deserialising public ledger entry ({})", ledger_entry.size());
 
       // When reading the public ledger, deserialise in the real store
       auto result = network.tables->deserialise(ledger_entry, true);
       if (result == kv::DeserialiseSuccess::FAILED)
       {
-        LOG_FAIL << "Failed to deserialise entry in public ledger" << std::endl;
+        LOG_FAIL_FMT("Failed to deserialise entry in public ledger");
         network.tables->rollback(ledger_idx - 1);
         recover_public_ledger_end_unsafe();
         return;
@@ -496,8 +497,7 @@ namespace ccf
       auto ls_idx = last_signed_index(tx);
       network.tables->rollback(ls_idx);
       log_truncate(ls_idx);
-      LOG_INFO << "Truncating ledger to last signed index: " << ls_idx
-               << std::endl;
+      LOG_INFO_FMT("Truncating ledger to last signed index: {}", ls_idx);
 
       network.secrets->promote_secrets(0, ls_idx + 1);
       sm.advance(State::awaitingRecoveryTx);
@@ -523,15 +523,14 @@ namespace ccf
       std::lock_guard<SpinLock> guard(lock);
       sm.expect(State::readingPrivateLedger);
 
-      LOG_INFO << "Deserialising private ledger entry (" << ledger_entry.size()
-               << ")" << std::endl;
+      LOG_INFO_FMT(
+        "Deserialising private ledger entry ({})", ledger_entry.size());
 
       // When reading the private ledger, deserialise in the recovery store
       auto result = recovery_store->deserialise(ledger_entry);
       if (result == kv::DeserialiseSuccess::FAILED)
       {
-        LOG_FAIL << "Failed to deserialise entry in private ledger"
-                 << std::endl;
+        LOG_FAIL_FMT("Failed to deserialise entry in private ledger");
         recovery_store->rollback(ledger_idx - 1);
         recover_private_ledger_end_unsafe();
         return;
@@ -543,8 +542,7 @@ namespace ccf
 
       if (recovery_store->current_version() == recovery_v)
       {
-        LOG_INFO << "Reached recovery final version at " << recovery_v
-                 << std::endl;
+        LOG_INFO_FMT("Reached recovery final version at {}", recovery_v);
         recover_private_ledger_end_unsafe();
       }
       else
@@ -562,8 +560,8 @@ namespace ccf
       auto h = dynamic_cast<MerkleTxHistory*>(recovery_history.get());
       if (h->get_root() != recovery_root)
       {
-        LOG_FATAL << "Root of public store does not match root of private store"
-                  << std::endl;
+        LOG_FATAL_FMT(
+          "Root of public store does not match root of private store");
       }
 
       network.tables->swap_private_maps(*recovery_store.get());
@@ -583,7 +581,7 @@ namespace ccf
       if (raft->is_follower())
         accept_node_connections();
 
-      LOG_INFO << "Now part of network" << std::endl;
+      LOG_INFO_FMT("Now part of network");
       sm.advance(State::partOfNetwork);
     }
 
@@ -627,9 +625,8 @@ namespace ccf
             oe_parse_report(ni.quote.data(), ni.quote.size(), &parsed_quote);
           if (res != OE_OK)
           {
-            std::stringstream ss;
-            ss << "Failed to parse quote: " << oe_result_str(res);
-            quote.error = ss.str();
+            quote.error =
+              fmt::format("Failed to parse quote: {}", oe_result_str(res));
           }
           else
           {
@@ -679,12 +676,12 @@ namespace ccf
       for (const auto& ni : new_nodes)
       {
         auto nid = get_next_id(values_view, ccf::ValueIds::NEXT_NODE_ID);
-        LOG_INFO << "Adding node " << nid << std::endl;
+        LOG_INFO_FMT("Adding node ", nid);
         nodes_view->put(nid, ni);
         if (node_cert == ni.cert)
         {
           self = nid;
-          LOG_INFO << "Setting self to " << self << std::endl;
+          LOG_INFO_FMT("Setting self to ", self);
         }
         tls::Verifier verifier(ni.cert);
         certs_view->put(
@@ -693,7 +690,7 @@ namespace ccf
           nid);
       }
 
-      LOG_INFO << "Replaced nodes" << std::endl;
+      LOG_INFO_FMT("Replaced nodes");
 
       kv::Version index = 0;
       kv::Term term = 0;
@@ -711,8 +708,11 @@ namespace ccf
       if (h)
         h->set_node_id(self);
       setup_raft(true);
-      LOG_DEBUG << "Restarting Raft at index: " << index << " term: " << term
-                << " commit_idx: " << global_commit << std::endl;
+      LOG_DEBUG_FMT(
+        "Restarting Raft at index: {} term: {} commit_idx {}",
+        index,
+        term,
+        global_commit);
       raft->force_become_leader(index, term, term_history, index);
 
       // Sets itself as trusted
@@ -727,7 +727,7 @@ namespace ccf
 
       accept_node_connections();
 
-      LOG_INFO << "Restarted network" << std::endl;
+      LOG_INFO_FMT("Restarted network");
 
       sm.advance(State::partOfPublicNetwork);
 
@@ -771,8 +771,7 @@ namespace ccf
       auto h = dynamic_cast<MerkleTxHistory*>(history.get());
       recovery_root = h->get_root();
 
-      LOG_DEBUG << "Recovery store successfully setup: " << recovery_v
-                << std::endl;
+      LOG_DEBUG_FMT("Recovery store successfully setup: {}", recovery_v);
     }
 
     bool finish_recovery(
@@ -781,7 +780,7 @@ namespace ccf
       std::lock_guard<SpinLock> guard(lock);
       sm.expect(State::partOfPublicNetwork);
 
-      LOG_INFO << "Initiating end of recovery (leader)" << std::endl;
+      LOG_INFO_FMT("Initiating end of recovery (leader)");
 
       // Unseal past network secrets
       auto past_secrets_idx = network.secrets->restore(sealed_secrets);
@@ -813,9 +812,12 @@ namespace ccf
           auto serial = network.secrets->get_serialised_secret(ns_idx);
           if (serial.has_value())
           {
-            LOG_DEBUG << "Writing network secret " << ns_idx << " of size "
-                      << serial.value().size() << " to follower " << nid
-                      << " in secrets table." << std::endl;
+            LOG_DEBUG_FMT(
+              "Writing network secret {} of size {} to follower {} in secrets "
+              "table",
+              ns_idx,
+              serial.value().size(),
+              nid);
 
             // Encrypt network secrets with joiner's fresh key
             auto search = joiners_fresh_keys.find(nid);
@@ -846,8 +848,7 @@ namespace ccf
           }
           else
           {
-            LOG_FAIL << "Network secrets have not been restored: " << ns_idx
-                     << std::endl;
+            LOG_FAIL_FMT("Network secrets have not been restored: {}", ns_idx);
             return false;
           }
         }
@@ -958,7 +959,7 @@ namespace ccf
     void set_joiner_key(
       NodeId joiner_id, const std::vector<uint8_t>& raw_key) override
     {
-      LOG_DEBUG << "Setting fresh key for joiner " << joiner_id << std::endl;
+      LOG_DEBUG_FMT("Setting fresh key for joiner {}", joiner_id);
       joiners_fresh_keys.emplace(joiner_id, raw_key);
     }
 
@@ -1033,7 +1034,7 @@ namespace ccf
 
       sm.expect(State::partOfPublicNetwork);
 
-      LOG_INFO << "Initiating end of recovery (follower)" << std::endl;
+      LOG_INFO_FMT("Initiating end of recovery (follower)");
 
       // Setup new temporary store and record current version/root
       setup_private_recovery_store();

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -27,8 +27,7 @@
 #include <atomic>
 #include <chrono>
 #include <nlohmann/json.hpp>
-#define FMT_HEADER_ONLY
-#include <fmt/format.h>
+#include <fmt/format_header_only.h>
 #include <stdexcept>
 #include <unordered_set>
 #include <vector>

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -84,7 +84,7 @@ namespace ccf
     template <typename T>
     static Result<T> Fail(const char* s)
     {
-      LOG_DEBUG << s << std::endl;
+      LOG_DEBUG_FMT("{}", s);
       return {{}, false};
     }
 
@@ -214,7 +214,7 @@ namespace ccf
 
       if (res != OE_OK)
       {
-        LOG_FAIL << "Failed to get quote: " << oe_result_str(res) << std::endl;
+        LOG_FAIL_FMT("Failed to get quote: {}", oe_result_str(res);
         return Fail<CreateNew::Out>("oe_get_report failed");
       }
       quote.resize(quote_len);
@@ -224,8 +224,7 @@ namespace ccf
       res = oe_parse_report(quote.data(), quote.size(), &parsed_quote);
       if (res != OE_OK)
       {
-        LOG_FAIL << "Failed to parse quote: " << oe_result_str(res)
-                 << std::endl;
+        LOG_FAIL_FMT("Failed to parse quote: {}", oe_result_str(res);
         return Fail<CreateNew::Out>("oe_parse_report failed");
       }
 
@@ -470,8 +469,8 @@ namespace ccf
         if (sig.has_value())
         {
           auto sig_value = sig.value();
-          LOG_DEBUG << "Read signature at " << ledger_idx << " for term "
-                    << sig_value.term << std::endl;
+          LOG_DEBUG_FMT(
+            "Read signature at {} for term {}", ledger_idx, sig_value.term);
           for (auto i = term_history.size(); i <= sig_value.term; ++i)
           {
             term_history.push_back(last_recovered_commit_idx + 1);
@@ -823,8 +822,7 @@ namespace ccf
             auto search = joiners_fresh_keys.find(nid);
             if (search == joiners_fresh_keys.end())
             {
-              LOG_FAIL << "No fresh key for joiner " + std::to_string(nid)
-                       << std::endl;
+              LOG_FAIL_FMT("No fresh key for joiner {}", nid);
               continue;
             }
 

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -675,12 +675,12 @@ namespace ccf
       for (const auto& ni : new_nodes)
       {
         auto nid = get_next_id(values_view, ccf::ValueIds::NEXT_NODE_ID);
-        LOG_INFO_FMT("Adding node ", nid);
+        LOG_INFO_FMT("Adding node {}", nid);
         nodes_view->put(nid, ni);
         if (node_cert == ni.cert)
         {
           self = nid;
-          LOG_INFO_FMT("Setting self to ", self);
+          LOG_INFO_FMT("Setting self to {}", self);
         }
         tls::Verifier verifier(ni.cert);
         certs_view->put(

--- a/src/node/nodetonode.h
+++ b/src/node/nodetonode.h
@@ -27,7 +27,7 @@ namespace ccf
       if (!signed_public.has_value())
         return;
 
-      LOG_DEBUG << "node2node channel with " << to << " initiated" << std::endl;
+      LOG_DEBUG_FMT("node2node channel with {} initiated", to);
 
       ChannelHeader msg = {ChannelMsg::key_exchange, self};
       to_host->write(

--- a/src/node/quoteverification.h
+++ b/src/node/quoteverification.h
@@ -73,8 +73,7 @@ namespace ccf
 
       if (result != OE_OK)
       {
-        LOG_FAIL << "Quote could not be verified " << oe_result_str(result)
-                 << std::endl;
+        LOG_FAIL_FMT("Quote could not be verified: {}", oe_result_str(result));
         return false;
       }
       return true;

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -78,7 +78,7 @@ namespace ccf
       const auto& msg = serialized::overlay<ForwardedHeader>(data, size);
       if (msg.msg != ForwardedMsg::forwarded_cmd)
       {
-        LOG_FAIL << "Invalid forwarded message" << std::endl;
+        LOG_FAIL_FMT("Invalid forwarded message");
         return {};
       }
 
@@ -89,7 +89,7 @@ namespace ccf
       }
       catch (const std::logic_error& err)
       {
-        LOG_FAIL << "Invalid forwarded command: " << err.what() << std::endl;
+        LOG_FAIL_FMT("Invalid forwarded command: {}", err.what());
         return {};
       }
 
@@ -128,7 +128,7 @@ namespace ccf
       const auto& msg = serialized::overlay<ForwardedHeader>(data, size);
       if (msg.msg != ForwardedMsg::forwarded_response)
       {
-        LOG_FAIL << "Invalid forwarded response message" << std::endl;
+        LOG_FAIL_FMT("Invalid forwarded response message");
         return {};
       }
 
@@ -139,7 +139,7 @@ namespace ccf
       }
       catch (const std::logic_error& err)
       {
-        LOG_FAIL << "Invalid forwarded response: " << err.what() << std::endl;
+        LOG_FAIL_FMT("Invalid forwarded response: {}", err.what());
         return {};
       }
 
@@ -177,18 +177,18 @@ namespace ccf
             if (!fwd_handler)
               return;
 
-            LOG_DEBUG << "Forwarded RPC: " << r->first.actor << std::endl;
+            LOG_DEBUG_FMT("Forwarded RPC: {}", r->first.actor);
 
             auto rep = fwd_handler->process_forwarded(r->first, r->second);
 
             if (!send_forwarded_response(r->first, rep))
             {
-              LOG_FAIL << "Could not send forwarded response to "
-                       << r->first.fwd->from << std::endl;
+              LOG_FAIL_FMT(
+                "Could not send forwarded response to {}", r->first.fwd->from);
             }
 
-            LOG_DEBUG << "Sending forwarded response to " << r->first.fwd->from
-                      << std::endl;
+            LOG_DEBUG_FMT(
+              "Sending forwarded response to {}", r->first.fwd->from);
           }
           break;
         }
@@ -199,8 +199,8 @@ namespace ccf
           if (!rep.has_value())
             return;
 
-          LOG_DEBUG << "Sending forwarded response to RPC endpoint "
-                    << rep->first << std::endl;
+          LOG_DEBUG_FMT(
+            "Sending forwarded response to RPC endpoint {}", rep->first);
 
           try
           {
@@ -208,7 +208,7 @@ namespace ccf
           }
           catch (const std::logic_error& err)
           {
-            LOG_FAIL << err.what() << std::endl;
+            LOG_FAIL_FMT(err.what());
             return;
           }
 
@@ -217,8 +217,7 @@ namespace ccf
 
         default:
         {
-          LOG_FAIL << "Unknown frontend msg type: " << forwarded_msg
-                   << std::endl;
+          LOG_FAIL_FMT("Unknown frontend msg type: {}", forwarded_msg);
           break;
         }
       }

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -17,8 +17,7 @@
 #include "rpcexception.h"
 #include "serialization.h"
 
-#define FMT_HEADER_ONLY
-#include <fmt/format.h>
+#include <fmt/format_header_only.h>
 #include <utility>
 #include <vector>
 

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -472,7 +472,7 @@ namespace ccf
               ctx, local_id, leader_id, caller_id.value(), input))
           {
             // Indicate that the RPC has been forwarded to leader
-            LOG_DEBUG << "RPC forwarded to leader " << leader_id << std::endl;
+            LOG_DEBUG_FMT("RPC forwarded to leader {}", leader_id);
             ctx.is_pending = true;
             return {};
           }

--- a/src/node/rpc/nodefrontend.h
+++ b/src/node/rpc/nodefrontend.h
@@ -27,7 +27,7 @@ namespace ccf
         if (verify_result != QuoteVerificationResult::VERIFIED)
           return QuoteVerifier::quote_verification_error_to_json(verify_result);
 #else
-        LOG_INFO << "Skipped joining node quote verification." << std::endl;
+        LOG_INFO_FMT("Skipped joining node quote verification");
 #endif
 
         // TODO(#important,#TR): In addition to verifying the quote, we should
@@ -36,8 +36,8 @@ namespace ccf
         joining_nodeinfo.status = NodeStatus::TRUSTED;
         nodes_view->put(args.caller_id, joining_nodeinfo);
 
-        LOG_INFO << "Accepting a new node to the network as node "
-                 << args.caller_id << std::endl;
+        LOG_INFO_FMT(
+          "Accepting a new node to the network as node {}", args.caller_id);
 
         // Set joiner's fresh key for encrypting past network secrets
         node.set_joiner_key(args.caller_id, args.params["raw_fresh_key"]);

--- a/src/node/seal.h
+++ b/src/node/seal.h
@@ -154,7 +154,7 @@ namespace ccf
             CBuffer(),
             plain.data()))
       {
-        LOG_FAIL << "Decryption of sealed data failed" << std::endl;
+        LOG_FAIL_FMT("Decryption of sealed data failed");
         return {};
       }
 
@@ -181,8 +181,8 @@ namespace ccf
         oe_get_seal_key_by_policy(policy, temp_buf, &seal_key_size, NULL, NULL);
       if (result != OE_BUFFER_TOO_SMALL)
       {
-        LOG_FAIL << "oe_get_seal_key_by_policy (1) failed: "
-                 << oe_result_str(result) << std::endl;
+        LOG_FAIL_FMT(
+          "oe_get_seal_key_by_policy (1) failed: {}", oe_result_str(result));
         return {};
       }
       raw_seal_key.resize(seal_key_size);
@@ -192,8 +192,8 @@ namespace ccf
         policy, raw_seal_key.data(), &seal_key_size, temp_buf, &key_info_size);
       if (result != OE_BUFFER_TOO_SMALL)
       {
-        LOG_FAIL << "oe_get_seal_key_by_policy (2) failed: "
-                 << oe_result_str(result) << std::endl;
+        LOG_FAIL_FMT(
+          "oe_get_seal_key_by_policy (2) failed: {}", oe_result_str(result));
         return {};
       }
       key_info.resize(key_info_size);
@@ -207,8 +207,8 @@ namespace ccf
         &key_info_size);
       if (result != OE_OK)
       {
-        LOG_FAIL << "oe_get_seal_key_by_policy (3) failed: "
-                 << oe_result_str(result) << std::endl;
+        LOG_FAIL_FMT(
+          "oe_get_seal_key_by_policy (3) failed: {}", oe_result_str(result));
         return {};
       }
       return std::make_pair(raw_seal_key, key_info);
@@ -231,8 +231,7 @@ namespace ccf
         key_info.data(), key_info.size(), temp_buf, &seal_key_size);
       if (result != OE_BUFFER_TOO_SMALL)
       {
-        LOG_FAIL << "oe_get_seal_key (1) failed: " << oe_result_str(result)
-                 << std::endl;
+        LOG_FAIL_FMT("oe_get_seal_key (1) failed: {}", oe_result_str(result));
         return {};
       }
       raw_seal_key.resize(seal_key_size);
@@ -242,8 +241,7 @@ namespace ccf
         key_info.data(), key_info.size(), raw_seal_key.data(), &seal_key_size);
       if (result != OE_OK)
       {
-        LOG_FAIL << "oe_get_seal_key (2) failed: " << oe_result_str(result)
-                 << std::endl;
+        LOG_FAIL_FMT("oe_get_seal_key (2) failed: {}", oe_result_str(result));
         return {};
       }
       return std::move(raw_seal_key);

--- a/src/node/seal.h
+++ b/src/node/seal.h
@@ -97,7 +97,7 @@ namespace ccf
       if (!seal_key_and_info.has_value())
         return false;
 
-      LOG_DEBUG << "Seal key successfully retrieved" << std::endl;
+      LOG_DEBUG_FMT("Seal key successfully retrieved");
 
       crypto::KeyAesGcm seal_key(CBuffer(
         seal_key_and_info->first.data(), seal_key_and_info->first.size()));
@@ -138,7 +138,7 @@ namespace ccf
       if (!raw_seal_key.has_value())
         return {};
 
-      LOG_DEBUG << "Seal key successfully retrieved from key info" << std::endl;
+      LOG_DEBUG_FMT("Seal key successfully retrieved from key info");
 
       // Decrypt serialised
       crypto::KeyAesGcm seal_key(

--- a/src/node/test/merkle_mem.cpp
+++ b/src/node/test/merkle_mem.cpp
@@ -62,9 +62,9 @@ static int append_flush_and_retract()
       }
     }
     if (index % (appends / 10) == 0)
-      LOG_INFO << "MAX RSS: " << get_maxrss() << "Kb" << std::endl;
+      LOG_INFO_FMT("MAX RSS: {}Kb", get_maxrss());
   }
-  LOG_INFO << "MAX RSS: " << get_maxrss() << "Kb" << std::endl;
+  LOG_INFO_FMT("MAX RSS: {}Kb", get_maxrss());
 
   return get_maxrss() < max_expected_rss ? 0 : 1;
 }

--- a/src/node/test/merkle_mem.cpp
+++ b/src/node/test/merkle_mem.cpp
@@ -53,12 +53,12 @@ static int append_flush_and_retract()
       if (index % (flushes_without_retract * max_tree_size) == 0)
       {
         t.retract(index - max_tree_size);
-        LOG_DEBUG << "retract() " << index - max_tree_size << std::endl;
+        LOG_DEBUG_FMT("retract() {}", index - max_tree_size);
       }
       else
       {
         t.flush(index - max_tree_size);
-        LOG_DEBUG << "flush() " << index - max_tree_size << std::endl;
+        LOG_DEBUG_FMT("flush() {}", index - max_tree_size);
       }
     }
     if (index % (appends / 10) == 0)

--- a/src/pbft/pbft.h
+++ b/src/pbft/pbft.h
@@ -91,8 +91,8 @@ namespace pbft
       local_id(id),
       channels(channels_)
     {
-      LOG_INFO << "Setting up pbft replica for node with id: " << local_id
-               << std::endl;
+      LOG_INFO_FMT("Setting up PBFT replica for node with id: {}", local_id);
+
       // configure replica
       GeneralInfo general_info;
       general_info.num_replicas = 2;
@@ -121,7 +121,7 @@ namespace pbft
       my_info.pubk_enc = pubk_enc;
       my_info.host_name = "machineB";
       my_info.is_replica = true;
-      LOG_INFO << "PBFT Setup for self with id:" << local_id << std::endl;
+      LOG_INFO_FMT("PBFT setup for self with id: {}", local_id);
 
       ::NodeInfo node_info = {my_info, privk, general_info};
 
@@ -203,9 +203,9 @@ namespace pbft
       info.pubk_enc = pubk_enc;
       info.host_name = node_conf.host_name;
       info.is_replica = true;
-      LOG_INFO << "PBFT - adding node, id:" << info.id << std::endl;
+      LOG_INFO_FMT("PBFT - adding node, id: {}", info.id);
       Byz_add_principal(info);
-      LOG_INFO << "PBFT - added node, id: " << info.id << std::endl;
+      LOG_INFO_FMT("PBFT - added node, id: {}", info.id);
     }
 
     bool replicate(

--- a/src/raft/raft.h
+++ b/src/raft/raft.h
@@ -31,8 +31,7 @@ namespace raft
 
     void update(Index idx, Term term)
     {
-      LOG_DEBUG << "Updating term to: " << term << " at index: " << idx
-                << std::endl;
+      LOG_DEBUG_FMT("Updating term to: {} at index: {}", term, idx);
       for (auto i = terms.size(); i <= term; ++i)
         terms.push_back(idx);
     }
@@ -192,7 +191,7 @@ namespace raft
       // Suspend replication of append entries up to a specific version
       // Note that this should only be called when the raft lock is taken (e.g.
       // from a commit hook on a follower)
-      LOG_INFO << "Suspending replication for idx > " << idx << std::endl;
+      LOG_INFO_FMT("Suspending replication for idx > {}", idx);
       recovery_max_index = idx;
     }
 
@@ -202,7 +201,7 @@ namespace raft
       // Note that this should be called when the raft lock is not taken (e.g.
       // after the ledger has been read)
       std::lock_guard<SpinLock> guard(lock);
-      LOG_INFO << "Resuming replication" << std::endl;
+      LOG_INFO_FMT("Resuming replication");
       recovery_max_index.reset();
     }
 
@@ -295,21 +294,24 @@ namespace raft
 
       if (state != Leader)
       {
-        LOG_FAIL << "Failed to replicate " << entries.size()
-                 << " items: not leader" << std::endl;
+        LOG_FAIL_FMT(
+          "Failed to replicate {} items: not leader", entries.size());
         rollback(last_idx);
         return false;
       }
 
-      LOG_DEBUG << "Replicating " << entries.size() << " entries" << std::endl;
+      LOG_DEBUG_FMT("Replicating {} entries", entries.size());
 
       for (auto&& [index, data, globally_committable] : entries)
       {
         if (index != last_idx + 1)
           return false;
 
-        LOG_DEBUG << "Replicated on leader " << local_id << ": " << index
-                  << (globally_committable ? " committable" : "") << std::endl;
+        LOG_DEBUG_FMT(
+          "Replicated on leader {}: {}{}",
+          local_id,
+          index,
+          (globally_committable ? " committable" : ""));
 
         if (globally_committable)
           committable_indices.push_back(index);
@@ -328,8 +330,7 @@ namespace raft
           entry_size_not_limited = 0;
           for (const auto& it : nodes)
           {
-            LOG_DEBUG << "Sending updates to follower " << it.first
-                      << std::endl;
+            LOG_DEBUG_FMT("Sending updates to follower {}", it.first);
             send_append_entries(it.first, it.second.sent_idx + 1);
           }
         }
@@ -384,7 +385,7 @@ namespace raft
       {
         if (timeout_elapsed >= request_timeout)
         {
-          LOG_DEBUG << "Sending periodic updates to followers." << std::endl;
+          LOG_DEBUG_FMT("Sending periodic updates to followers");
           using namespace std::chrono_literals;
           timeout_elapsed = 0ms;
 
@@ -455,9 +456,13 @@ namespace raft
       const auto prev_term = get_term_internal(prev_idx);
       const auto term_of_idx = get_term_internal(end_idx);
 
-      LOG_DEBUG << "Send append entries from " << local_id << " to " << to
-                << ": " << start_idx << " to " << end_idx << " (" << commit_idx
-                << ")" << std::endl;
+      LOG_DEBUG_FMT(
+        "Send append entries from {} to {}: {} to {} ({})",
+        local_id,
+        to,
+        start_idx,
+        end_idx,
+        commit_idx);
 
       AppendEntries ae = {raft_append_entries,
                           local_id,
@@ -490,24 +495,31 @@ namespace raft
       }
       catch (const std::logic_error& err)
       {
-        LOG_FAIL << err.what() << std::endl;
+        LOG_FAIL_FMT("{}", err.what());
         return;
       }
-      LOG_DEBUG << "Received pt: " << r.prev_term << " pi: " << r.prev_idx
-                << " t: " << r.term << " i: " << r.idx << std::endl;
+      LOG_DEBUG_FMT(
+        "Received pt: {} pi: {} t: {} i: {}",
+        r.prev_term,
+        r.prev_idx,
+        r.term,
+        r.idx);
 
       const auto prev_term = get_term_internal(r.prev_idx);
-      LOG_DEBUG << "Previous term for " << r.prev_idx << " should be "
-                << prev_term << std::endl;
+      LOG_DEBUG_FMT("Previous term for {} should be {}", r.prev_idx, prev_term);
 
       // Don't check that the sender node ID is valid. Accept anything that
       // passes the integrity check. This way, entries containing dynamic
       // topology changes that include adding this new leader can be accepted.
       if (r.prev_idx < commit_idx)
       {
-        LOG_DEBUG << "Recv append entries to " << local_id << " from "
-                  << r.from_node << " but prev_idx (" << r.prev_idx
-                  << ") < commit_idx (" << commit_idx << ")" << std::endl;
+        LOG_DEBUG_FMT(
+          "Recv append entries to {} from {} but prev_idex ({}) < commit_idx "
+          "({})",
+          local_id,
+          r.from_node,
+          r.prev_idx,
+          commit_idx);
         return;
       }
 
@@ -526,8 +538,10 @@ namespace raft
       else if (current_term > r.term)
       {
         // Reply false, since our term is later than the received term.
-        LOG_DEBUG << "Recv append entries to " << local_id << " from "
-                  << r.from_node << " but our term is later" << std::endl;
+        LOG_DEBUG_FMT(
+          "Recv append entries to {} from {} but our term is later",
+          local_id,
+          r.from_node);
         send_append_entries_response(r.from_node, false);
         return;
       }
@@ -538,24 +552,34 @@ namespace raft
         // whose term is r.prev_term.
         if (prev_term == 0)
         {
-          LOG_DEBUG << "Recv append entries to " << local_id << " from "
-                    << r.from_node << " but our log does not yet contain index "
-                    << r.prev_idx << std::endl;
+          LOG_DEBUG_FMT(
+            "Recv append entries to {} from {} but our log does not yet "
+            "contain index {}",
+            local_id,
+            r.from_node,
+            r.prev_idx);
         }
         else
         {
-          LOG_DEBUG << "Recv append entries to " << local_id << " from "
-                    << r.from_node << " but our log at " << r.prev_idx
-                    << " has the wrong term (ours: " << prev_term
-                    << ", theirs: " << r.prev_term << ")" << std::endl;
+          LOG_DEBUG_FMT(
+            "Recv append entries to {} from {} but our log at {} has the wrong "
+            "term (ours: {}, theirs: {})",
+            local_id,
+            r.from_node,
+            r.prev_idx,
+            prev_term,
+            r.prev_term);
         }
         send_append_entries_response(r.from_node, false);
         return;
       }
 
-      LOG_DEBUG << "Recv append entries to " << local_id << " from "
-                << r.from_node << " for index " << r.idx
-                << " and previous index " << r.prev_idx << std::endl;
+      LOG_DEBUG_FMT(
+        "Recv append entries to {} from {} for index {} and previous index {}",
+        local_id,
+        r.from_node,
+        r.idx,
+        r.prev_idx);
 
       for (Index i = r.prev_idx + 1; i <= r.idx; i++)
       {
@@ -567,8 +591,7 @@ namespace raft
           continue;
         }
 
-        LOG_DEBUG << "Replicating on follower " << local_id << ": " << i
-                  << std::endl;
+        LOG_DEBUG_FMT("Replicating on follower {}: {}", local_id, i);
 
         // If replication is suspended during recovery, only accept entries if
         // their index is less than the max recovery index
@@ -578,8 +601,8 @@ namespace raft
           {
             // If no entry was replicated in the batch, abort replication of the
             // whole batch
-            LOG_INFO << "Replication suspended: " << i << " > "
-                     << recovery_max_index.value() << std::endl;
+            LOG_INFO_FMT(
+              "Replication suspended: {} > {}", i, recovery_max_index.value());
             send_append_entries_response(r.from_node, false);
             return;
           }
@@ -587,9 +610,10 @@ namespace raft
           {
             // If an entry was successfully replicated in the batch, deserialise
             // up to that entry
-            LOG_INFO << "Replication suspended up to "
-                     << recovery_max_index.value() << " but deserialised up to "
-                     << i - 1 << std::endl;
+            LOG_INFO_FMT(
+              "Replication suspended up to {} but deserialised up to {}",
+              recovery_max_index.value(),
+              i - 1);
             send_append_entries_response(r.from_node, true);
             return;
           }
@@ -604,8 +628,10 @@ namespace raft
           // NB: This will currently never be triggered.
           // This should only fail if there is malformed data. Truncate
           // the log and reply false.
-          LOG_FAIL << "Recv append entries to " << local_id << " from "
-                   << r.from_node << " but the data is malformed" << std::endl;
+          LOG_FAIL_FMT(
+            "Recv append entries to {} from {} but the data is malformed",
+            local_id,
+            r.from_node);
 
           last_idx = r.prev_idx;
           ledger->truncate(r.prev_idx);
@@ -625,7 +651,7 @@ namespace raft
             break;
 
           case kv::DeserialiseSuccess::PASS_SIGNATURE:
-            LOG_INFO << "Deserialising signature at " << i << std::endl;
+            LOG_INFO_FMT("Deserialising signature at {}", i);
             committable_indices.push_back(i);
             if (sig_term)
               term_history.update(commit_idx + 1, sig_term);
@@ -640,8 +666,7 @@ namespace raft
       if (leader_id != r.from_node)
       {
         leader_id = r.from_node;
-        LOG_DEBUG << "Node " << local_id << " thinks leader is " << leader_id
-                  << std::endl;
+        LOG_DEBUG_FMT("Node {} thinks leader is {}", local_id, leader_id);
       }
 
       send_append_entries_response(r.from_node, true);
@@ -652,9 +677,12 @@ namespace raft
 
     void send_append_entries_response(NodeId to, bool answer)
     {
-      LOG_DEBUG << "Send append entries response from " << local_id << " to "
-                << to << " for index " << last_idx << ": " << answer
-                << std::endl;
+      LOG_DEBUG_FMT(
+        "Send append entries response from {} to {} for index {}: {}",
+        local_id,
+        to,
+        last_idx,
+        answer);
 
       AppendEntriesResponse response = {
         raft_append_entries_response, local_id, current_term, last_idx, answer};
@@ -676,15 +704,19 @@ namespace raft
       if (node == nodes.end())
       {
         // Ignore if we don't recognise the node.
-        LOG_FAIL << "Recv append entries response to " << local_id
-                 << " from unknown node " << r.from_node << std::endl;
+        LOG_FAIL_FMT(
+          "Recv append entries response to {} from {}: unknown node",
+          local_id,
+          r.from_node);
         return;
       }
       else if (current_term < r.term)
       {
         // We are behind, convert to a follower.
-        LOG_DEBUG << "Recv append entries response to " << local_id << " from "
-                  << r.from_node << ": more recent term" << std::endl;
+        LOG_DEBUG_FMT(
+          "Recv append entries response to {} from {}: more recent term",
+          local_id,
+          r.from_node);
         become_follower(r.term);
         return;
       }
@@ -692,8 +724,10 @@ namespace raft
       {
         // Stale response, discard if success.
         // Otherwise reset sent_idx and try again.
-        LOG_DEBUG << "Recv append entries response to " << local_id << " from "
-                  << r.from_node << ": stale term" << std::endl;
+        LOG_DEBUG_FMT(
+          "Recv append entries response to {} from {}: stale term",
+          local_id,
+          r.from_node);
         if (r.success)
           return;
       }
@@ -701,8 +735,10 @@ namespace raft
       {
         // Stale response, discard if success.
         // Otherwise reset sent_idx and try again.
-        LOG_DEBUG << "Recv append entries response to " << local_id << " from "
-                  << r.from_node << ": stale idx" << std::endl;
+        LOG_DEBUG_FMT(
+          "Recv append entries response to {} from {}: stale idx",
+          local_id,
+          r.from_node);
         if (r.success)
           return;
       }
@@ -713,22 +749,25 @@ namespace raft
       if (!r.success)
       {
         // Failed due to log inconsistency. Reset sent_idx and try again.
-        LOG_DEBUG << "Recv append entries response to " << local_id << " from "
-                  << r.from_node << ": failed" << std::endl;
+        LOG_DEBUG_FMT(
+          "Recv append entries response to {} from {}: failed",
+          local_id,
+          r.from_node);
         send_append_entries(r.from_node, node->second.match_idx + 1);
         return;
       }
 
-      LOG_DEBUG << "Recv append entries response to " << local_id << " from "
-                << r.from_node << " for index " << r.last_log_idx << ": success"
-                << std::endl;
+      LOG_DEBUG_FMT(
+        "Recv append entries response to {} from {} for index {}: success",
+        local_id,
+        r.from_node,
+        r.last_log_idx);
       update_commit();
     }
 
     void send_request_vote(NodeId to)
     {
-      LOG_INFO << "Send request vote from " << local_id << " to " << to
-               << std::endl;
+      LOG_INFO_FMT("Send request vote from {} to {}", local_id, to);
 
       RequestVote rv = {raft_request_vote,
                         local_id,
@@ -748,33 +787,45 @@ namespace raft
       auto node = nodes.find(r.from_node);
       if (node == nodes.end())
       {
-        LOG_FAIL << "Recv request vote to " << local_id << " from unknown node "
-                 << r.from_node << std::endl;
+        LOG_FAIL_FMT(
+          "Recv request vote to {} from {}: unknown node",
+          local_id,
+          r.from_node);
         return;
       }
 
       if (current_term > r.term)
       {
         // Reply false, since our term is later than the received term.
-        LOG_DEBUG << "Recv request vote to " << local_id << " from "
-                  << r.from_node << " but our term is later" << std::endl;
+        LOG_DEBUG_FMT(
+          "Recv request vote to {} from {}: our term is later ({} > {})",
+          local_id,
+          r.from_node,
+          current_term,
+          r.term);
         send_request_vote_response(r.from_node, false);
         return;
       }
       else if (current_term < r.term)
       {
         // Become a follower in the new term.
-        LOG_DEBUG << "Recv request vote to " << local_id << " from "
-                  << r.from_node << ": their term is more recent" << std::endl;
+        LOG_DEBUG_FMT(
+          "Recv request vote to {} from {}: their term is later ({} < {})",
+          local_id,
+          r.from_node,
+          current_term,
+          r.term);
         become_follower(r.term);
       }
 
       if ((voted_for != NoNode) && (voted_for != r.from_node))
       {
         // Reply false, since we already voted for someone else.
-        LOG_DEBUG << "Recv request vote to " << local_id << " from "
-                  << r.from_node << ": we already voted for " << voted_for
-                  << std::endl;
+        LOG_DEBUG_FMT(
+          "Recv request vote to {} from {}: alredy voted for {}",
+          local_id,
+          r.from_node,
+          voted_for);
         send_request_vote_response(r.from_node, false);
         return;
       }
@@ -799,8 +850,8 @@ namespace raft
 
     void send_request_vote_response(NodeId to, bool answer)
     {
-      LOG_INFO << "Send request vote response from " << local_id << " to " << to
-               << ": " << answer << std::endl;
+      LOG_INFO_FMT(
+        "Send request vote response from {} to {}: {}", local_id, to, answer);
 
       RequestVoteResponse response = {
         raft_request_vote_response, local_id, current_term, answer};

--- a/src/raft/raft.h
+++ b/src/raft/raft.h
@@ -495,7 +495,7 @@ namespace raft
       }
       catch (const std::logic_error& err)
       {
-        LOG_FAIL_FMT("{}", err.what());
+        LOG_FAIL_FMT(err.what());
         return;
       }
       LOG_DEBUG_FMT(

--- a/src/tls/keypair.h
+++ b/src/tls/keypair.h
@@ -245,8 +245,7 @@ namespace tls
         ctx, &sig_, hash.data(), c4_priv, nullptr, nullptr);
       if (rc != 1)
       {
-        LOG_FAIL << "secp256k1_ecdsa_sign_recoverable failed with " << rc
-                 << std::endl;
+        LOG_FAIL_FMT("secp256k1_ecdsa_sign_recoverable failed with {}", rc);
         return {};
       }
       int rcode = 0;
@@ -254,9 +253,10 @@ namespace tls
         ctx, sig, &rcode, &sig_);
       if (rc != 1)
       {
-        LOG_FAIL << "secp256k1_ecdsa_recoverable_signature_serialize_compact "
-                    "failed with "
-                 << rc << std::endl;
+        LOG_FAIL_FMT(
+          "secp256k1_ecdsa_recoverable_signature_serialize_compact failed with "
+          "{}",
+          rc);
         return {};
       }
       written = 64;
@@ -346,8 +346,7 @@ namespace tls
         ctx, &sig_, hash.h, c4_priv, nullptr, nullptr);
       if (rc != 1)
       {
-        LOG_FAIL << "secp256k1_ecdsa_sign_recoverable failed with " << rc
-                 << std::endl;
+        LOG_FAIL_FMT("secp256k1_ecdsa_sign_recoverable failed with {}", rc);
         return {};
       }
       int rcode = 0;
@@ -355,9 +354,10 @@ namespace tls
         ctx, sig, &rcode, &sig_);
       if (rc != 1)
       {
-        LOG_FAIL << "secp256k1_ecdsa_recoverable_signature_serialize_compact "
-                    "failed with "
-                 << rc << std::endl;
+        LOG_FAIL_FMT(
+          "secp256k1_ecdsa_recoverable_signature_serialize_compact failed with "
+          "{}",
+          rc);
         return {};
       }
       written = 64;
@@ -550,7 +550,7 @@ namespace tls
         signature.size());
 
       if (rc)
-        LOG_DEBUG << "Failed to verify signature: " << rc << std::endl;
+        LOG_DEBUG_FMT("Failed to verify signature: {}", rc);
 
       return rc;
 #endif
@@ -678,7 +678,7 @@ namespace tls
         signature.size());
 
       if (rc)
-        LOG_DEBUG << "Failed to verify signature: " << rc << std::endl;
+        LOG_DEBUG_FMT("Failed to verify signature: {}", rc);
 
       return rc == 0;
 #endif
@@ -713,7 +713,7 @@ namespace tls
         signature.size());
 
       if (rc)
-        LOG_DEBUG << "Failed to verify signature: " << rc << std::endl;
+        LOG_DEBUG_FMT("Failed to verify signature: {}", rc);
 
       return rc == 0;
 #endif


### PR DESCRIPTION
I added nicer logging macros, which let us use the `fmtlib` formatting syntax and automatically add newlines.

Rather than keeping both methods around and gradually phasing out the older macros, I decided to do a full replacement pass now. This is a very large change, but minor errors in it are probably acceptable.

While I was rewriting these logging lines, I made some more consistent (removing terminating full stops, repeated format for similar messages), so the conversions aren't all precisely one-to-one.

I don't expect anyone to read this entire thing in fine detail, but please spend a while looking for any misconversions (missing "{}"s, missing arguments, misordered arguments, typos, copy-paste errors). If we get a few approvals, we've probably got reasonable coverage of the changes.

Resolves #176.