### PR TITLE
Restrict CI runs to branches that opt in, PRs, and to only files that…

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -2,7 +2,28 @@ trigger:
   batch: true
   branches:
     include:
-      - "*"
+      - "ci/*"
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+      - master
+    paths:
+      include:
+        - '*'
+      exclude:
+        - 'README.md'
+        - 'CCF-TECHNICAL-REPORT.pdf'
+        - 'Dockerfile'
+        - 'Doxyfile'
+        - 'THIRD_PARTY_NOTICES.txt'
+        - 'getting_started/'
+        - 'sphinx/'
+        - '.circleci/'
+        - '.github/'
+        - '.vsts-gh-pages.yml'
+        - 'LICENSE'
 
 jobs:
 - job: ACC_1804_SGX_build

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -3,27 +3,40 @@ trigger:
   branches:
     include:
       - "ci/*"
+  paths:
+    exclude:
+      - 'README.md'
+      - 'CCF-TECHNICAL-REPORT.pdf'
+      - 'Dockerfile'
+      - 'Doxyfile'
+      - 'THIRD_PARTY_NOTICES.txt'
+      - 'getting_started/'
+      - 'sphinx/'
+      - '.circleci/'
+      - '.github/'
+      - '.vsts-gh-pages.yml'
+      - 'LICENSE'
 
 pr:
   autoCancel: true
   branches:
     include:
       - master
-    paths:
-      include:
-        - '*'
-      exclude:
-        - 'README.md'
-        - 'CCF-TECHNICAL-REPORT.pdf'
-        - 'Dockerfile'
-        - 'Doxyfile'
-        - 'THIRD_PARTY_NOTICES.txt'
-        - 'getting_started/'
-        - 'sphinx/'
-        - '.circleci/'
-        - '.github/'
-        - '.vsts-gh-pages.yml'
-        - 'LICENSE'
+  paths:
+    include:
+      - '*'
+    exclude:
+      - 'README.md'
+      - 'CCF-TECHNICAL-REPORT.pdf'
+      - 'Dockerfile'
+      - 'Doxyfile'
+      - 'THIRD_PARTY_NOTICES.txt'
+      - 'getting_started/'
+      - 'sphinx/'
+      - '.circleci/'
+      - '.github/'
+      - '.vsts-gh-pages.yml'
+      - 'LICENSE'
 
 jobs:
 - job: ACC_1804_SGX_build


### PR DESCRIPTION
… make it into the build

Our current setup is causing too many builds, it's inefficient and it leads to unnecessarily high latency between changes and build results.