### PR TITLE
Scheduled CI build

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -38,6 +38,14 @@ pr:
       - '.vsts-gh-pages.yml'
       - 'LICENSE'
 
+schedules:
+- cron: "15 7 * * *"
+  displayName: Daily morning build
+  branches:
+    include:
+    - master
+  always: true
+
 jobs:
 - job: ACC_1804_SGX_build
   pool: Ubuntu-1804-SGX-Azure

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -39,7 +39,7 @@ pr:
       - 'LICENSE'
 
 schedules:
-- cron: "15 7 * * *"
+- cron: "15 7 * * Mon-Fri"
   displayName: Daily morning build
   branches:
     include:


### PR DESCRIPTION
Using [yaml schedules](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#scheduled-triggers) to start CI builds every morning, Monday to Friday, shortly after the CI machines have started. This ensures we get regular perf results and early warning when external dependencies are broken.