### PR TITLE
Schedule morning CI earlier

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -39,7 +39,7 @@ pr:
       - 'LICENSE'
 
 schedules:
-- cron: "15 7 * * Mon-Fri"
+- cron: "0 3 * * Mon-Fri"
   displayName: Daily morning build
   branches:
     include:


### PR DESCRIPTION
The CI `cron` time is currently fixed to UTC, whereas the CI pool is restarted in London time. Scheduling it earlier means it will be queued, and should then run when the VMs start, regardless of daylight savings.