### PR TITLE
Allow RPC body to be given on command line

### DIFF
--- a/.vsts-gh-pages.yml
+++ b/.vsts-gh-pages.yml
@@ -15,6 +15,7 @@ jobs:
     - script: |
         python3.7 -m venv env
         source env/bin/activate
+        pip install wheel
         pip install -U -r requirements.txt
         make html
       displayName: Sphinx

--- a/sphinx/source/rpc_api.rst
+++ b/sphinx/source/rpc_api.rst
@@ -7,7 +7,7 @@ The API can also be retrieved from a running service using the `listMethods`_ an
 
 .. code-block:: bash
 
-    $ ./client --pretty-print --host 127.99.16.14 --port 36785 --ca networkcert.pem userrpc --req listMethods.json --cert user1_cert.pem --pk user1_privk.pem
+    $ ./client --pretty-print --host 127.99.16.14 --port 36785 --ca networkcert.pem userrpc --req @listMethods.json --cert user1_cert.pem --pk user1_privk.pem
     Doing user RPC:
     {
       "commit": 4,
@@ -31,7 +31,7 @@ The API can also be retrieved from a running service using the `listMethods`_ an
       "term": 2
     }
 
-    $ ./client --pretty-print --host 127.99.16.14 --port 36785 --ca networkcert.pem userrpc --req getSchema.json --cert user1_cert.pem --pk user1_privk.pem
+    $ ./client --pretty-print --host 127.99.16.14 --port 36785 --ca networkcert.pem userrpc --req @getSchema.json --cert user1_cert.pem --pk user1_privk.pem
     Doing user RPC:
     {
       "commit": 4,

--- a/sphinx/source/start_network.rst
+++ b/sphinx/source/start_network.rst
@@ -68,7 +68,7 @@ Once the initial nodes are running and the initial state of the network is ready
 
 .. code-block:: bash
 
-    $ client --host=<node0_ip> --port=<node0_tlsport> startnetwork --ca=<node0_cert> --req=startNetwork.json
+    $ client --host=<node0_ip> --port=<node0_tlsport> startnetwork --ca=<node0_cert> --req=@startNetwork.json
 
 When executing the ``startNetwork.json`` RPC request, the target node deserialises the genesis transaction and immediately becomes the Raft leader of the new single-node network. Business transactions can then be issued by users and will commit immediately.
 
@@ -85,7 +85,7 @@ Once done, each additional node (here, node 1) can join the existing network by 
 
 .. code-block:: bash
 
-    $ client --host=<node1_ip> --port=<node1_tlsport> joinnetwork --ca=<node1_cert> --req=joinNetwork.json
+    $ client --host=<node1_ip> --port=<node1_tlsport> joinnetwork --ca=<node1_cert> --req=@joinNetwork.json
 
 When executing the ``joinNetwork.json`` RPC, the target node initiates an enclave-to-enclave TLS connection to the network leader to retrieve the network secrets required to decrypt the serialised replicated transactions. Once the join protocol completes, the new node becomes a follower of the Raft network and starts replicating transactions executed by the leader.
 

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -557,6 +557,7 @@ class Node:
             "--port={}".format(self.tls_port),
             "--ca={}".format(self.remote.pem),
             "startnetwork",
+            "--req=@startnetwork.json"
         ).check_returncode()
         LOG.info("Started Network")
 
@@ -580,7 +581,7 @@ class Node:
             "--port={}".format(self.tls_port),
             "--ca={}".format(self.remote.pem),
             "joinnetwork",
-            "--req=joinNetwork.json",
+            "--req=@joinNetwork.json",
         ).check_returncode()
         self.complete_join_network()
 

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -557,7 +557,7 @@ class Node:
             "--port={}".format(self.tls_port),
             "--ca={}".format(self.remote.pem),
             "startnetwork",
-            "--req=@startnetwork.json",
+            "--req=@startNetwork.json",
         ).check_returncode()
         LOG.info("Started Network")
 

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -557,7 +557,7 @@ class Node:
             "--port={}".format(self.tls_port),
             "--ca={}".format(self.remote.pem),
             "startnetwork",
-            "--req=@startnetwork.json"
+            "--req=@startnetwork.json",
         ).check_returncode()
         LOG.info("Started Network")
 


### PR DESCRIPTION
Update `--req` options to the client binary with curl-style syntax, allowing load-from-file or specify-on-command-line.

So you can write:
```
$ ./client --pretty-print userrpc --req @listMethods.json
```
or
```
$ ./client --pretty-print userrpc --req '{"id": 1, "jsonrpc": "2.0", "method": "listMethods"}'
```
