### PR TITLE
Don't patch unnecessarily

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -308,7 +308,7 @@ function(sign_app_library name app_oe_conf_path enclave_sign_key_path)
       -e ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so
       -c ${app_oe_conf_path}
       -k ${enclave_sign_key_path}
-    DEPENDS ${name}
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so
       ${app_oe_conf_path}
       ${enclave_sign_key_path}
   )
@@ -344,9 +344,11 @@ endif()
 
 function(create_patched_enclave_lib name app_oe_conf_path enclave_sign_key_path)
   set(patched_name ${name}.patched)
-  add_custom_target(${patched_name}
-      COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so ${CMAKE_CURRENT_BINARY_DIR}/lib${patched_name}.so
-      COMMAND PYTHONPATH=${CCF_DIR}/tests:$ENV{PYTHONPATH} python3 patch_binary.py -p ${CMAKE_CURRENT_BINARY_DIR}/lib${patched_name}.so
+  set(patched_lib_name lib${patched_name}.so)
+  add_custom_command(
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${patched_lib_name}
+      COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so ${CMAKE_CURRENT_BINARY_DIR}/${patched_lib_name}
+      COMMAND PYTHONPATH=${CCF_DIR}/tests:$ENV{PYTHONPATH} python3 patch_binary.py -p ${CMAKE_CURRENT_BINARY_DIR}/${patched_lib_name}
       WORKING_DIRECTORY ${CCF_DIR}/tests
       DEPENDS ${name}
   )


### PR DESCRIPTION
Because the patched library was build with `add_custom_target`, we were running it every time we call ninja, even when there's no changes.

This changes to `add_custom_command`, so the patched library is only reproduced when its dependencies change.

```
$ touch ../src/apps/logging/logging.cpp
$ ninja -vvvv -d explain
ninja explain: output CMakeFiles/loggingenc.dir/src/apps/logging/logging.cpp.o older than most recent input ../src/apps/logging/logging.cpp (1562149069 vs 1562149257)
ninja explain: CMakeFiles/loggingenc.dir/src/apps/logging/logging.cpp.o is dirty
ninja explain: libloggingenc.so is dirty
ninja explain: libloggingenc.patched.so is dirty
ninja explain: libloggingenc.patched.so.signed is dirty
ninja explain: CMakeFiles/loggingenc.patched_signed is dirty
ninja explain: libloggingenc.patched.so.signed is dirty
ninja explain: libloggingenc.patched.so is dirty
ninja explain: libloggingenc.so is dirty
ninja explain: loggingenc.patched_signed is dirty
ninja explain: libloggingenc.so is dirty
ninja explain: libloggingenc.so.signed is dirty
ninja explain: CMakeFiles/loggingenc_signed is dirty
ninja explain: libloggingenc.so.signed is dirty
ninja explain: loggingenc_signed is dirty
ninja explain: output CMakeFiles/loggingenc.virtual.dir/src/apps/logging/logging.cpp.o older than most recent input ../src/apps/logging/logging.cpp (1562149069 vs 1562149257)
ninja explain: CMakeFiles/loggingenc.virtual.dir/src/apps/logging/logging.cpp.o is dirty
ninja explain: libloggingenc.virtual.so is dirty
ninja explain: libloggingenc.so is dirty
 ...
Created /data/src/CCF/build/libloggingenc.patched.so.signed
@v-edasht:/data/src/CCF/build$ ls -al *.so*
-rwxrwxr-x 1 v-edasht v-edasht 62447144 Jul  3 11:21 libloggingenc.patched.so
-rw-rw-r-- 1 v-edasht v-edasht 62447144 Jul  3 11:21 libloggingenc.patched.so.signed
-rwxrwxr-x 1 v-edasht v-edasht 62447144 Jul  3 11:21 libloggingenc.so
-rw-rw-r-- 1 v-edasht v-edasht 62447144 Jul  3 11:21 libloggingenc.so.signed
-rwxrwxr-x 1 v-edasht v-edasht 54915752 Jul  3 11:21 libloggingenc.virtual.so
-rwxrwxr-x 1 v-edasht v-edasht 62659744 Jul  3 10:34 libluagenericenc.so
-rw-rw-r-- 1 v-edasht v-edasht 62659744 Jul  3 10:34 libluagenericenc.so.signed
-rwxrwxr-x 1 v-edasht v-edasht 55195352 Jul  3 10:34 libluagenericenc.virtual.so
-rwxrwxr-x 1 v-edasht v-edasht 59345944 Jul  3 10:34 libsmallbankenc.so
-rw-rw-r-- 1 v-edasht v-edasht 59345944 Jul  3 10:34 libsmallbankenc.so.signed
-rwxrwxr-x 1 v-edasht v-edasht 51881400 Jul  3 10:34 libsmallbankenc.virtual.so
$ ninja -vvvv -d explain
ninja: no work to do.
```