### PR TITLE
Not allowing adding nodes with a host:port combination that already exists

### DIFF
--- a/src/node/rpc/memberfrontend.h
+++ b/src/node/rpc/memberfrontend.h
@@ -395,10 +395,25 @@ namespace ccf
         if (verify_result != QuoteVerificationResult::VERIFIED)
           return QuoteVerifier::quote_verification_error_to_json(verify_result);
 #endif
+        auto nodes_view = args.tx.get_view(this->network.nodes);
+        bool is_duplicate = false;
+        // TODO(#api): foreach should check the callback's value and be able to
+        // stop once the returned value is false
+        nodes_view->foreach(
+          [&new_node, &is_duplicate](const NodeId& nid, const NodeInfo& ni) {
+            if (
+              !is_duplicate &&
+              (new_node.tlsport == ni.tlsport && new_node.host == ni.host))
+              is_duplicate = true;
+          });
+        if (is_duplicate)
+          return jsonrpc::error(
+            jsonrpc::ErrorCodes::INVALID_PARAMS,
+            "A node with the same host and port already exists");
         const auto node_id = get_next_id(
           args.tx.get_view(this->network.values), ValueIds::NEXT_NODE_ID);
         new_node.status = NodeStatus::PENDING;
-        args.tx.get_view(this->network.nodes)->put(node_id, new_node);
+        nodes_view->put(node_id, new_node);
         tls::Verifier verifier(new_node.cert);
         args.tx.get_view(this->network.node_certs)
           ->put(verifier.raw_cert_data(), node_id);

--- a/tests/addnode.py
+++ b/tests/addnode.py
@@ -25,6 +25,13 @@ def run(args):
         assert res[0] == True
         new_node = res[1]
 
+        # attempt to add a node having the host and port fields
+        # similar to a the ones of an existing node
+        assert (
+            network.add_node(new_node.remote.info()).error["code"]
+            == infra.jsonrpc.ErrorCode.INVALID_PARAMS
+        )
+
         # add an invalid node
         assert network.create_and_add_node("libluagenericenc", args, False) == (
             False,

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -213,6 +213,15 @@ class Network:
     def remove_node(self):
         last_node = self.nodes.pop()
 
+    def add_node(self, new_node_info, already_exists=False):
+        with self.find_leader()[0].member_client(format="json") as member_client:
+            j_result = member_client.rpc("add_node", new_node_info)
+
+        if j_result.error is None and not already_exists:
+            self.create_node(Node(j_result.result["id"], new_node_info["host"]))
+
+        return j_result
+
     def create_and_add_node(self, lib_name, args, should_succeed=True, node_id=None):
         forwarded_args = {
             arg: getattr(args, arg) for arg in infra.ccf.Network.node_args_to_forward
@@ -230,8 +239,7 @@ class Network:
         )
         new_node_info = new_node.remote.info()
 
-        with self.find_leader()[0].member_client(format="json") as member_client:
-            j_result = member_client.rpc("add_node", new_node_info)
+        j_result = self.add_node(new_node_info, True)
 
         if not should_succeed:
             self.remove_node()

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -213,12 +213,9 @@ class Network:
     def remove_node(self):
         last_node = self.nodes.pop()
 
-    def add_node(self, new_node_info, already_exists=False):
+    def add_node(self, new_node_info):
         with self.find_leader()[0].member_client(format="json") as member_client:
             j_result = member_client.rpc("add_node", new_node_info)
-
-        if j_result.error is None and not already_exists:
-            self.create_node(Node(j_result.result["id"], new_node_info["host"]))
 
         return j_result
 
@@ -239,7 +236,7 @@ class Network:
         )
         new_node_info = new_node.remote.info()
 
-        j_result = self.add_node(new_node_info, True)
+        j_result = self.add_node(new_node_info)
 
         if not should_succeed:
             self.remove_node()


### PR DESCRIPTION
#208 We prevent adding nodes with a host:port combination that already exists.
