### PR TITLE
Allowing to break KV foreach loops

### DIFF
--- a/src/ds/test/map_bench.cpp
+++ b/src/ds/test/map_bench.cpp
@@ -75,8 +75,10 @@ static void benchmark_foreach(picobench::state& s)
   for (auto _ : s)
   {
     (void)_;
-    map.foreach(
-      [&v, s, map](const auto& key, const auto& value) { v += value; });
+    map.foreach([&v, s, map](const auto& key, const auto& value) {
+      v += value;
+      return true;
+    });
     clobber_memory();
   }
   s.stop_timer();

--- a/src/ds/test/map_test.cpp
+++ b/src/ds/test/map_test.cpp
@@ -114,6 +114,7 @@ TEST_CASE("persistent map operations")
         auto p = rb_new.get(k);
         REQUIRE(p.has_value());
         REQUIRE(p.value() == v);
+        return true;
       });
       REQUIRE(n == champ_new.size());
     }
@@ -126,6 +127,7 @@ TEST_CASE("persistent map operations")
         auto p = rb.get(k);
         REQUIRE(p.has_value());
         REQUIRE(p.value() == v);
+        return true;
       });
       REQUIRE(n == champ.size());
     }

--- a/src/genesisgen/genesisgen.h
+++ b/src/genesisgen/genesisgen.h
@@ -80,8 +80,8 @@ public:
 
     nodes_view->foreach(
       [&start_node](const ccf::NodeId& id, const ccf::NodeInfo& v) {
-        if (start_node == ccf::INVALID_ID)
-          start_node = id;
+        start_node = id;
+        return false;
       });
 
     rpc.params.id = start_node;

--- a/src/kv/kv.h
+++ b/src/kv/kv.h
@@ -195,36 +195,36 @@ namespace kv
         return false;
 
       size_t count = 0;
-      state2.state.foreach(
-        [&count](const K& k, const VersionV& v) {
-          count++;
-          return true;
-        });
-
-      size_t i = 0;
-      bool ok = state1.state.foreach([&state2, &ok, &i](const K& k, const VersionV& v) {
-        auto search = state2.state.get(k);
-
-        if (search.has_value())
-        {
-          auto& found = search.value();
-          if (found.version != v.version)
-          {
-            return false;
-          }
-          else if (Check::ne(found.value, v.value))
-          {
-            return false;
-          }
-        }
-        else
-        {
-          return false;
-        }
-
-        i++;
+      state2.state.foreach([&count](const K& k, const VersionV& v) {
+        count++;
         return true;
       });
+
+      size_t i = 0;
+      bool ok =
+        state1.state.foreach([&state2, &ok, &i](const K& k, const VersionV& v) {
+          auto search = state2.state.get(k);
+
+          if (search.has_value())
+          {
+            auto& found = search.value();
+            if (found.version != v.version)
+            {
+              return false;
+            }
+            else if (Check::ne(found.value, v.value))
+            {
+              return false;
+            }
+          }
+          else
+          {
+            return false;
+          }
+
+          i++;
+          return true;
+        });
 
       if (i != count)
         ok = false;

--- a/src/kv/kv.h
+++ b/src/kv/kv.h
@@ -202,7 +202,7 @@ namespace kv
 
       size_t i = 0;
       bool ok =
-        state1.state.foreach([&state2, &ok, &i](const K& k, const VersionV& v) {
+        state1.state.foreach([&state2, &i](const K& k, const VersionV& v) {
           auto search = state2.state.get(k);
 
           if (search.has_value())
@@ -432,7 +432,8 @@ namespace kv
 
       /** Iterate over all entries in the map
        *
-       * @param F functor, taking a key and a value, return value is ignored
+       * @param F functor, taking a key and a value, return value determines
+       * whether the iteration should continue (true) or stop (false)
        */
       template <class F>
       bool foreach(F&& f)

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -182,6 +182,20 @@ TEST_CASE("Reads/writes and deletions")
     auto vc = view3->get(k);
     REQUIRE(!vc.has_value());
   }
+
+  INFO("Test early temination of KV foreach");
+  {
+    Store::Tx tx;
+    auto view = tx.get_view(map);
+    view->put("key1", "value1");
+    view->put("key2", "value2");
+    size_t ctr = 0;
+    view->foreach([&ctr](const auto& key, const auto& value) {
+      ++ctr;
+      return false;
+    });
+    REQUIRE(ctr == 1);
+  }
 }
 
 TEST_CASE("Rollback and compact")

--- a/src/luainterp/luakv.h
+++ b/src/luainterp/luakv.h
@@ -141,6 +141,7 @@ namespace ccf
 
           // Call the lua functor. This pops the args and functor-copy
           lua_pcall(l, ifunc, 0, 0);
+          return true;
         });
 
         return 0;

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -634,8 +634,8 @@ namespace ccf
           }
 #endif
           result.quotes.push_back(quote);
-          return true;
         }
+        return true;
       });
     };
 

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -634,6 +634,7 @@ namespace ccf
           }
 #endif
           result.quotes.push_back(quote);
+          return true;
         }
       });
     };
@@ -655,6 +656,7 @@ namespace ccf
           // Only retire nodes that have not already been retired
           if (ni.status != ccf::NodeStatus::RETIRED)
             nodes_to_delete[nid] = ni;
+          return true;
         });
       for (auto [nid, ni] : nodes_to_delete)
       {
@@ -666,6 +668,7 @@ namespace ccf
       certs_view->foreach(
         [&certs_to_delete](const Cert& cstr, const NodeId& _) {
           certs_to_delete.push_back(cstr);
+          return true;
         });
       for (Cert& cstr : certs_to_delete)
       {
@@ -796,6 +799,7 @@ namespace ccf
         [&new_followers, this](const NodeId& nid, const NodeInfo& ni) {
           if (ni.status != ccf::NodeStatus::RETIRED && nid != self)
             new_followers[nid] = ni;
+          return true;
         });
 
       // For all nodes in the new network, write all past network secrets to the
@@ -1108,6 +1112,7 @@ namespace ccf
           s.foreach([&](NodeId node_id, const Nodes::VersionV& v) {
             if (v.value.status != NodeStatus::RETIRED)
               configuration.insert(node_id);
+            return true;
           });
           raft->add_configuration(version, move(configuration));
         }

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -262,6 +262,7 @@ namespace ccf
             {
               out.nodes.push_back({nid, ni.pubhost, ni.tlsport});
             }
+            return true;
           });
 
           return jsonrpc::success(out);

--- a/src/node/rpc/memberfrontend.h
+++ b/src/node/rpc/memberfrontend.h
@@ -397,14 +397,14 @@ namespace ccf
 #endif
         auto nodes_view = args.tx.get_view(this->network.nodes);
         NodeId duplicate_node_id = NoNode;
-        // TODO(#api): foreach should check the callback's value and be able to
-        // stop once the returned value is false
         nodes_view->foreach([&new_node, &duplicate_node_id](
                               const NodeId& nid, const NodeInfo& ni) {
-          if (
-            duplicate_node_id == NoNode &&
-            (new_node.tlsport == ni.tlsport && new_node.host == ni.host))
+          if (new_node.tlsport == ni.tlsport && new_node.host == ni.host)
+          {
             duplicate_node_id = nid;
+            return false;
+          }
+          return true;
         });
         if (duplicate_node_id != NoNode)
           return jsonrpc::error(


### PR DESCRIPTION
KV foreach callback functions can now control whether to continue iterating by returning true (continue) or false (stop).