### PR TITLE
Compact the right history where recovering private ledger

### DIFF
--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -535,9 +535,8 @@ namespace ccf
         return;
       }
 
-      // If the final recovery version has been reached, end recovery
       if (result == kv::DeserialiseSuccess::PASS_SIGNATURE)
-        network.tables->compact(ledger_idx);
+        recovery_store->compact(ledger_idx);
 
       if (recovery_store->current_version() == recovery_v)
       {


### PR DESCRIPTION
Follow-up on this is #226. Part of that is making the max tree size customistable (probably a cli argument), so we can make sure we've done at least one in each recovery.