### PR TITLE
Reverted secp256k1 verification to use public key from cert

### DIFF
--- a/src/tls/keypair.h
+++ b/src/tls/keypair.h
@@ -703,8 +703,6 @@ namespace tls
       const Hash& hash, const std::vector<uint8_t>& signature) const
     {
 #if CURVE_CHOICE_SECP256K1_BITCOIN
-      if (signature.size() != REC_ID_IDX + 1)
-        return false;
       return verify_secp256k_bc(
         ctx, signature.data(), signature.size(), hash.data(), &c4_pub);
 #else


### PR DESCRIPTION
Recovering the public key from the signature is extremely inefficient, so we revert to using the public key from the PEM.
The recoverable public key verification will still be tested the voting history test.