### PR TITLE
Entropy detection during runtime

### DIFF
--- a/src/node/networksecrets.h
+++ b/src/node/networksecrets.h
@@ -118,7 +118,7 @@ namespace ccf
       auto new_secret = std::make_unique<Secret>();
       new_secret->cert = keys->self_sign(name);
       new_secret->priv_key = keys->private_key();
-      new_secret->master = tls::Entropy().random(16);
+      new_secret->master = tls::create_entropy()->random(16);
 
       add_secret(0, std::move(new_secret), force_seal);
     }

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -405,7 +405,7 @@ namespace ccf
 
       // Generate fresh key to encrypt/decrypt historical network secrets sent
       // by the leader via the kv store
-      raw_fresh_key = tls::Entropy().random(crypto::GCM_SIZE_KEY);
+      raw_fresh_key = tls::create_entropy()->random(crypto::GCM_SIZE_KEY);
 
       // Send RPC request to remote node to join the network.
       jsonrpc::ProcedureCall<JoinNetworkNodeToNode::In> join_rpc;
@@ -832,7 +832,7 @@ namespace ccf
             crypto::GcmCipher gcmcipher(serial.value().size());
 
             // Get random IV
-            auto iv = tls::Entropy().random(gcmcipher.hdr.getIv().n);
+            auto iv = tls::create_entropy()->random(gcmcipher.hdr.getIv().n);
             std::copy(iv.begin(), iv.end(), gcmcipher.hdr.iv);
 
             joiner_key.encrypt(

--- a/src/node/seal.h
+++ b/src/node/seal.h
@@ -105,7 +105,8 @@ namespace ccf
       sealed_data.key_info = seal_key_and_info->second;
 
       // Get random IV
-      auto iv = tls::Entropy().random(sealed_data.encrypted_data.hdr.getIv().n);
+      auto iv =
+        tls::create_entropy()->random(sealed_data.encrypted_data.hdr.getIv().n);
       std::copy(iv.begin(), iv.end(), sealed_data.encrypted_data.hdr.iv);
 
       // Encrypt data

--- a/src/tls/context.h
+++ b/src/tls/context.h
@@ -14,7 +14,7 @@ namespace tls
   protected:
     mbedtls_ssl_context ssl;
     mbedtls_ssl_config cfg;
-    Entropy entropy;
+    EntropyPtr entropy;
 
 #ifndef NO_STRICT_TLS_CIPHERSUITES
     const int ciphersuites[3] = {
@@ -24,11 +24,11 @@ namespace tls
 #endif
 
   public:
-    Context(bool client, bool dgram)
+    Context(bool client, bool dgram) : entropy(tls::create_entropy())
     {
       mbedtls_ssl_init(&ssl);
       mbedtls_ssl_config_init(&cfg);
-      mbedtls_ssl_conf_rng(&cfg, &Entropy::rng, &entropy);
+      mbedtls_ssl_conf_rng(&cfg, &entropy->rng, entropy->get_data());
 
       if (
         mbedtls_ssl_config_defaults(

--- a/src/tls/context.h
+++ b/src/tls/context.h
@@ -28,7 +28,7 @@ namespace tls
     {
       mbedtls_ssl_init(&ssl);
       mbedtls_ssl_config_init(&cfg);
-      mbedtls_ssl_conf_rng(&cfg, &entropy->get_rng(), entropy->get_data());
+      mbedtls_ssl_conf_rng(&cfg, entropy->get_rng(), entropy->get_data());
 
       if (
         mbedtls_ssl_config_defaults(

--- a/src/tls/context.h
+++ b/src/tls/context.h
@@ -28,7 +28,7 @@ namespace tls
     {
       mbedtls_ssl_init(&ssl);
       mbedtls_ssl_config_init(&cfg);
-      mbedtls_ssl_conf_rng(&cfg, &entropy->rng, entropy->get_data());
+      mbedtls_ssl_conf_rng(&cfg, &entropy->get_rng(), entropy->get_data());
 
       if (
         mbedtls_ssl_config_defaults(

--- a/src/tls/entropy.h
+++ b/src/tls/entropy.h
@@ -66,8 +66,10 @@ namespace tls
 
   EntropyPtr create_entropy()
   {
-    return use_drng ? std::make_unique<IntelDRNG>() :
-                      std::make_unique<MbedtlsEntropy>();
+    if (use_drng)
+      return std::make_unique<IntelDRNG>();
+
+    return std::make_unique<MbedtlsEntropy>();
   }
 
 }

--- a/src/tls/entropy.h
+++ b/src/tls/entropy.h
@@ -12,9 +12,9 @@
 namespace tls
 {
   static bool use_drng = IntelDRNG::is_drng_supported();
-  using EntropyPtr = std::unique_ptr<Entropy>;
+  using EntropyPtr = std::shared_ptr<Entropy>;
+  static EntropyPtr intel_drng_ptr;
   EntropyPtr create_entropy();
-  EntropyPtr intel_drng_ptr;
 
   class MbedtlsEntropy : public Entropy
   {
@@ -70,11 +70,11 @@ namespace tls
     if (use_drng)
     {
       if (!intel_drng_ptr)
-        intel_drng_ptr = std::make_unique<IntelDRNG>();
+        intel_drng_ptr = std::make_shared<IntelDRNG>();
       return intel_drng_ptr;
     }
 
-    return std::make_unique<MbedtlsEntropy>();
+    return std::make_shared<MbedtlsEntropy>();
   }
 
 }

--- a/src/tls/entropy.h
+++ b/src/tls/entropy.h
@@ -47,10 +47,15 @@ namespace tls
       return data;
     }
 
-    int rng(void* ctx, unsigned char* output, size_t len) const override
+    static int rng(void* ctx, unsigned char* output, size_t len)
     {
       MbedtlsEntropy* e = reinterpret_cast<MbedtlsEntropy*>(ctx);
       return mbedtls_ctr_drbg_random(&e->drbg, output, len);
+    }
+
+    rng_func_t get_rng() override
+    {
+      return &rng;
     }
 
     void* get_data() override

--- a/src/tls/entropy.h
+++ b/src/tls/entropy.h
@@ -14,6 +14,7 @@ namespace tls
   static bool use_drng = IntelDRNG::is_drng_supported();
   using EntropyPtr = std::unique_ptr<Entropy>;
   EntropyPtr create_entropy();
+  EntropyPtr intel_drng_ptr;
 
   class MbedtlsEntropy : public Entropy
   {
@@ -64,10 +65,14 @@ namespace tls
     }
   };
 
-  EntropyPtr create_entropy()
+  inline EntropyPtr create_entropy()
   {
     if (use_drng)
-      return std::make_unique<IntelDRNG>();
+    {
+      if (!intel_drng_ptr)
+        intel_drng_ptr = std::make_unique<IntelDRNG>();
+      return intel_drng_ptr;
+    }
 
     return std::make_unique<MbedtlsEntropy>();
   }

--- a/src/tls/keyexchange.h
+++ b/src/tls/keyexchange.h
@@ -46,7 +46,7 @@ namespace tls
           &len,
           own_public.data(),
           len_public,
-          &entropy->get_rng(),
+          entropy->get_rng(),
           entropy->get_data()) != 0)
       {
         throw std::logic_error("Failed to generate key exchange pair");
@@ -91,7 +91,7 @@ namespace tls
           &len,
           shared_secret.data(),
           len_shared_secret,
-          &entropy->get_rng(),
+          entropy->get_rng(),
           entropy->get_data()) != 0)
       {
         throw std::logic_error("Failed to compute shared secret");

--- a/src/tls/keyexchange.h
+++ b/src/tls/keyexchange.h
@@ -46,7 +46,7 @@ namespace tls
           &len,
           own_public.data(),
           len_public,
-          &entropy->rng,
+          &entropy->get_rng(),
           entropy->get_data()) != 0)
       {
         throw std::logic_error("Failed to generate key exchange pair");
@@ -91,7 +91,7 @@ namespace tls
           &len,
           shared_secret.data(),
           len_shared_secret,
-          &entropy->rng,
+          &entropy->get_rng(),
           entropy->get_data()) != 0)
       {
         throw std::logic_error("Failed to compute shared secret");

--- a/src/tls/keyexchange.h
+++ b/src/tls/keyexchange.h
@@ -16,7 +16,7 @@ namespace tls
   class KeyExchangeContext
   {
   private:
-    tls::Entropy entropy;
+    tls::EntropyPtr entropy;
     mbedtls_ecdh_context ctx;
     std::vector<uint8_t> own_public;
 
@@ -30,7 +30,7 @@ namespace tls
     // Size of shared secret, as per mbedtls_x25519_calc_secret
     static constexpr size_t len_shared_secret = MBEDTLS_X25519_KEY_SIZE_BYTES;
 
-    KeyExchangeContext() : own_public(len_public)
+    KeyExchangeContext() : own_public(len_public), entropy(create_entropy())
     {
       mbedtls_ecdh_init(&ctx);
       size_t len;
@@ -46,8 +46,8 @@ namespace tls
           &len,
           own_public.data(),
           len_public,
-          &tls::Entropy::rng,
-          &entropy) != 0)
+          &entropy->rng,
+          entropy->get_data()) != 0)
       {
         throw std::logic_error("Failed to generate key exchange pair");
       }
@@ -91,8 +91,8 @@ namespace tls
           &len,
           shared_secret.data(),
           len_shared_secret,
-          &tls::Entropy::rng,
-          &entropy) != 0)
+          &entropy->rng,
+          entropy->get_data()) != 0)
       {
         throw std::logic_error("Failed to compute shared secret");
       }

--- a/src/tls/keypair.h
+++ b/src/tls/keypair.h
@@ -190,12 +190,12 @@ namespace tls
 
     struct SignCsr
     {
-      Entropy entropy;
+      EntropyPtr entropy;
       mbedtls_x509_csr csr;
       mbedtls_mpi serial;
       mbedtls_x509write_cert crt;
 
-      SignCsr()
+      SignCsr() : entropy(create_entropy())
       {
         mbedtls_x509_csr_init(&csr);
         mbedtls_mpi_init(&serial);
@@ -220,7 +220,7 @@ namespace tls
      */
     KeyPair(mbedtls_ecp_group_id ec)
     {
-      Entropy entropy;
+      EntropyPtr entropy = create_entropy();
       mbedtls_pk_init(key.get());
 
       int rc = 0;
@@ -240,7 +240,7 @@ namespace tls
           }
 
           rc = mbedtls_eddsa_genkey(
-            mbedtls_pk_eddsa(*key), ec, &Entropy::rng, &entropy);
+            mbedtls_pk_eddsa(*key), ec, &entropy->rng, entropy->get_data());
           if (rc != 0)
           {
             throw std::logic_error(
@@ -260,7 +260,7 @@ namespace tls
           }
 
           rc = mbedtls_ecp_gen_key(
-            ec, mbedtls_pk_ec(*key), &Entropy::rng, &entropy);
+            ec, mbedtls_pk_ec(*key), &entropy->rng, entropy->get_data());
           if (rc != 0)
           {
             throw std::logic_error(
@@ -388,7 +388,7 @@ namespace tls
       uint8_t* sig) const
     {
       int rc = 0;
-      Entropy entropy;
+      EntropyPtr entropy = create_entropy();
 
       const auto ec = get_ec_from_context(*key);
       const auto md_type = get_md_for_ec(ec);
@@ -400,8 +400,8 @@ namespace tls
         hash_size,
         sig,
         sig_size,
-        &Entropy::rng,
-        &entropy);
+        &entropy->rng,
+        entropy->get_data());
 
       return rc;
     }
@@ -422,11 +422,11 @@ namespace tls
 
       uint8_t buf[4096];
       memset(buf, 0, sizeof(buf));
-      Entropy entropy;
+      EntropyPtr entropy = create_entropy();
 
       if (
         mbedtls_x509write_csr_pem(
-          &csr.req, buf, sizeof(buf), &Entropy::rng, &entropy) != 0)
+          &csr.req, buf, sizeof(buf), &entropy->rng, entropy->get_data()) != 0)
         return {};
 
       auto len = strlen((char*)buf) + 1;
@@ -457,7 +457,7 @@ namespace tls
 
       if (
         mbedtls_mpi_fill_random(
-          &sign.serial, 16, &Entropy::rng, &sign.entropy) != 0)
+          &sign.serial, 16, &sign.entropy->rng, sign.entropy->get_data()) != 0)
         return {};
 
       if (mbedtls_x509write_crt_set_subject_name(&sign.crt, subject) != 0)
@@ -490,7 +490,11 @@ namespace tls
 
       if (
         mbedtls_x509write_crt_pem(
-          &sign.crt, buf, sizeof(buf), &Entropy::rng, &sign.entropy) != 0)
+          &sign.crt,
+          buf,
+          sizeof(buf),
+          &sign.entropy->rng,
+          sign.entropy->get_data()) != 0)
         return {};
 
       auto len = strlen((char*)buf) + 1;

--- a/src/tls/keypair.h
+++ b/src/tls/keypair.h
@@ -242,7 +242,7 @@ namespace tls
           rc = mbedtls_eddsa_genkey(
             mbedtls_pk_eddsa(*key),
             ec,
-            &entropy->get_rng(),
+            entropy->get_rng(),
             entropy->get_data());
           if (rc != 0)
           {
@@ -263,7 +263,7 @@ namespace tls
           }
 
           rc = mbedtls_ecp_gen_key(
-            ec, mbedtls_pk_ec(*key), &entropy->get_rng(), entropy->get_data());
+            ec, mbedtls_pk_ec(*key), entropy->get_rng(), entropy->get_data());
           if (rc != 0)
           {
             throw std::logic_error(
@@ -403,7 +403,7 @@ namespace tls
         hash_size,
         sig,
         sig_size,
-        &entropy->get_rng(),
+        entropy->get_rng(),
         entropy->get_data());
 
       return rc;
@@ -432,7 +432,7 @@ namespace tls
           &csr.req,
           buf,
           sizeof(buf),
-          &entropy->get_rng(),
+          entropy->get_rng(),
           entropy->get_data()) != 0)
         return {};
 
@@ -466,7 +466,7 @@ namespace tls
         mbedtls_mpi_fill_random(
           &sign.serial,
           16,
-          &sign.entropy->get_rng(),
+          sign.entropy->get_rng(),
           sign.entropy->get_data()) != 0)
         return {};
 
@@ -503,7 +503,7 @@ namespace tls
           &sign.crt,
           buf,
           sizeof(buf),
-          &sign.entropy->get_rng(),
+          sign.entropy->get_rng(),
           sign.entropy->get_data()) != 0)
         return {};
 

--- a/src/tls/keypair.h
+++ b/src/tls/keypair.h
@@ -240,7 +240,10 @@ namespace tls
           }
 
           rc = mbedtls_eddsa_genkey(
-            mbedtls_pk_eddsa(*key), ec, &entropy->rng, entropy->get_data());
+            mbedtls_pk_eddsa(*key),
+            ec,
+            &entropy->get_rng(),
+            entropy->get_data());
           if (rc != 0)
           {
             throw std::logic_error(
@@ -260,7 +263,7 @@ namespace tls
           }
 
           rc = mbedtls_ecp_gen_key(
-            ec, mbedtls_pk_ec(*key), &entropy->rng, entropy->get_data());
+            ec, mbedtls_pk_ec(*key), &entropy->get_rng(), entropy->get_data());
           if (rc != 0)
           {
             throw std::logic_error(
@@ -400,7 +403,7 @@ namespace tls
         hash_size,
         sig,
         sig_size,
-        &entropy->rng,
+        &entropy->get_rng(),
         entropy->get_data());
 
       return rc;
@@ -426,7 +429,11 @@ namespace tls
 
       if (
         mbedtls_x509write_csr_pem(
-          &csr.req, buf, sizeof(buf), &entropy->rng, entropy->get_data()) != 0)
+          &csr.req,
+          buf,
+          sizeof(buf),
+          &entropy->get_rng(),
+          entropy->get_data()) != 0)
         return {};
 
       auto len = strlen((char*)buf) + 1;
@@ -457,7 +464,10 @@ namespace tls
 
       if (
         mbedtls_mpi_fill_random(
-          &sign.serial, 16, &sign.entropy->rng, sign.entropy->get_data()) != 0)
+          &sign.serial,
+          16,
+          &sign.entropy->get_rng(),
+          sign.entropy->get_data()) != 0)
         return {};
 
       if (mbedtls_x509write_crt_set_subject_name(&sign.crt, subject) != 0)
@@ -493,7 +503,7 @@ namespace tls
           &sign.crt,
           buf,
           sizeof(buf),
-          &sign.entropy->rng,
+          &sign.entropy->get_rng(),
           sign.entropy->get_data()) != 0)
         return {};
 


### PR DESCRIPTION
Choosing the random number generator during compilation does creates a problem running the code on hardware that is different than the one that the code was compiled on (RDRAND and RDSEED instructions must be supported).
The ideal solution is to have this behavior handled by mbedtls, therefore, this solution should be temporary.
There are now two implementation of the pure virtual Entropy class, and the correct one can be retrieved using the _tls::create_entropy_ function.
Note: _tls::create_entropy_ returns a shared_ptr since the IntelDRNG implementation (which is the commonly used one) is stateless, and there is no need to instantiate it for each call.