### PR TITLE
Serialise base members and nlohmann::json with msgpack-c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,9 @@ if(BUILD_TESTS)
   target_link_libraries(encryptor_test PRIVATE
     secp256k1.host)
 
+  add_unit_test(msgpack_serialization_test
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/node/test/msgpack_serialization.cpp)
+
   add_unit_test(tls_test
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tls/test/main.cpp)
   target_link_libraries(tls_test PRIVATE

--- a/src/clients/client.cpp
+++ b/src/clients/client.cpp
@@ -253,6 +253,8 @@ int main(int argc, char** argv)
 
     nlohmann::json response;
 
+    cout << fmt::format("Sending RPC to {}:{}", host, port) << endl;
+
     if (*start_network)
     {
       cout << "Starting network:" << endl;

--- a/src/clients/memberclient.cpp
+++ b/src/clients/memberclient.cpp
@@ -246,9 +246,17 @@ void display_proposals(RpcTlsClient& tls_connection)
   auto params = query_params(read_proposals);
   Response<json> response =
     json::from_msgpack(tls_connection.call("query", params));
-  cout << "Displaying all pending proposals: " << endl;
-  cout << endl;
-  display(response.result);
+
+  if (response.result.empty())
+  {
+    cout << "There are no pending proposals" << endl;
+  }
+  else
+  {
+    cout << "Displaying all pending proposals: " << endl;
+    cout << endl;
+    display(response.result);
+  }
 }
 
 void submit_ack(

--- a/src/ds/msgpack_adaptor_nlohmann.h
+++ b/src/ds/msgpack_adaptor_nlohmann.h
@@ -11,6 +11,10 @@ namespace msgpack
   {
     namespace adaptor
     {
+      // Both pack and convert involve unnecessary copies. If this
+      // nlohmann::json issue is accepted, we can write custom input_adapter and
+      // output_adapter to read/write directly from msgpack objects.
+      // https://github.com/nlohmann/json/issues/1534
       template <>
       struct pack<nlohmann::json>
       {

--- a/src/ds/msgpack_adaptor_nlohmann.h
+++ b/src/ds/msgpack_adaptor_nlohmann.h
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include <msgpack-c/msgpack.hpp>
+#include <nlohmann/json.hpp>
+
+namespace msgpack
+{
+  MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
+  {
+    namespace adaptor
+    {
+      template <>
+      struct pack<nlohmann::json>
+      {
+        template <typename Stream>
+        msgpack::packer<Stream>& operator()(
+          msgpack::packer<Stream>& o, const nlohmann::json& j) const
+        {
+          const auto packed = nlohmann::json::to_msgpack(j);
+
+          o.pack_bin(packed.size());
+          o.pack_bin_body(
+            reinterpret_cast<const char*>(packed.data()), packed.size());
+
+          return o;
+        }
+      };
+
+      template <>
+      struct convert<nlohmann::json>
+      {
+        const msgpack::object& operator()(
+          const msgpack::object& o, nlohmann::json& j) const
+        {
+          if ((o.type) != msgpack::type::BIN)
+          {
+            throw msgpack::type_error();
+          }
+
+          std::vector<uint8_t> v(o.via.bin.ptr, o.via.bin.ptr + o.via.bin.size);
+          j = nlohmann::json::from_msgpack(v);
+
+          return o;
+        }
+      };
+    }
+  }
+}

--- a/src/node/members.h
+++ b/src/node/members.h
@@ -57,7 +57,7 @@ namespace ccf
     //! the next nonce the member is supposed to sign
     std::vector<uint8_t> next_nonce;
 
-    MSGPACK_DEFINE(next_nonce);
+    MSGPACK_DEFINE(MSGPACK_BASE(RawSignature), next_nonce);
   };
   ADD_JSON_TRANSLATORS_WITH_BASE(MemberAck, RawSignature, next_nonce)
   using MemberAcks = Store::Map<MemberId, MemberAck>;

--- a/src/node/proposals.h
+++ b/src/node/proposals.h
@@ -3,56 +3,13 @@
 #pragma once
 
 #include "ds/json.h"
+#include "ds/msgpack_adaptor_nlohmann.h"
 #include "entities.h"
 #include "script.h"
 
 #include <msgpack-c/msgpack.hpp>
 #include <unordered_map>
 #include <vector>
-
-namespace msgpack
-{
-  MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
-  {
-    namespace adaptor
-    {
-      template <>
-      struct pack<nlohmann::json>
-      {
-        template <typename Stream>
-        msgpack::packer<Stream>& operator()(
-          msgpack::packer<Stream>& o, const nlohmann::json& j) const
-        {
-          const auto packed = nlohmann::json::to_msgpack(j);
-
-          o.pack_bin(packed.size());
-          o.pack_bin_body(
-            reinterpret_cast<const char*>(packed.data()), packed.size());
-
-          return o;
-        }
-      };
-
-      template <>
-      struct convert<nlohmann::json>
-      {
-        const msgpack::object& operator()(
-          const msgpack::object& o, nlohmann::json& j) const
-        {
-          if ((o.type) != msgpack::type::BIN)
-          {
-            throw msgpack::type_error();
-          }
-
-          std::vector<uint8_t> v(o.via.bin.ptr, o.via.bin.ptr + o.via.bin.size);
-          j = nlohmann::json::from_msgpack(v);
-
-          return o;
-        }
-      };
-    }
-  }
-}
 
 namespace ccf
 {

--- a/src/node/proposals.h
+++ b/src/node/proposals.h
@@ -130,8 +130,8 @@ namespace ccf
 
     bool operator==(const OpenProposal& o) const
     {
-      return proposer == o.proposer && script.text == o.script.text &&
-        parameter == o.parameter;
+      return script == o.script && parameter == o.parameter &&
+        proposer == o.proposer && votes == o.votes;
     }
 
     MSGPACK_DEFINE(script, parameter, proposer, votes);

--- a/src/node/rawsignature.h
+++ b/src/node/rawsignature.h
@@ -10,6 +10,13 @@ namespace ccf
   struct RawSignature
   {
     std::vector<uint8_t> sig;
+
+    bool operator==(const RawSignature& o) const
+    {
+      return sig == o.sig;
+    }
+
+    MSGPACK_DEFINE(sig);
   };
   DECLARE_REQUIRED_JSON_FIELDS(RawSignature, sig)
 }

--- a/src/node/rpc/memberfrontend.h
+++ b/src/node/rpc/memberfrontend.h
@@ -283,8 +283,8 @@ namespace ccf
         const auto in = args.params.get<Proposal::In>();
         const auto proposal_id = get_next_id(
           args.tx.get_view(this->network.values), ValueIds::NEXT_PROPOSAL_ID);
-        args.tx.get_view(this->network.proposals)
-          ->put(proposal_id, {args.caller_id, in});
+        const OpenProposal proposal(in.script, in.parameter, args.caller_id);
+        args.tx.get_view(this->network.proposals)->put(proposal_id, proposal);
         const bool completed = complete_proposal(args.tx, proposal_id);
         return jsonrpc::success<Proposal::Out>({proposal_id, completed});
       };

--- a/src/node/rpc/test/membervoting_test.cpp
+++ b/src/node/rpc/test/membervoting_test.cpp
@@ -119,6 +119,26 @@ auto read_params(const T& key, const string& table_name)
   return params;
 }
 
+nlohmann::json get_proposal(
+  enclave::RPCContext& rpc_ctx,
+  RpcFrontend& frontend,
+  size_t proposal_id,
+  CallerId as_member)
+{
+  Script read_proposal(fmt::format(
+    R"xxx(
+        tables = ...
+        return tables["proposals"]:get({})
+      )xxx",
+    proposal_id));
+
+  const auto readj = create_json_req(read_proposal, "query");
+
+  Store::Tx tx;
+  ccf::SignedReq sr(readj);
+  return frontend.process_json(rpc_ctx, tx, as_member, readj, sr).value();
+}
+
 std::vector<uint8_t> get_cert_data(uint64_t member_id, tls::KeyPairPtr& kp_mem)
 {
   std::vector<uint8_t> ca_mem =
@@ -269,13 +289,14 @@ TEST_CASE("Add new members until there are 7, then reject")
   constexpr auto max_members = 8;
   GenesisGenerator network;
   StubNodeState node;
-  // add three active members
+  // add three initial active members
   // the proposer
-  network.add_member(vector<uint8_t>(member_caller), MemberStatus::ACTIVE);
-  // the voter
-  vector<uint8_t> voter = get_cert_data(1, kp);
-  network.add_member(voter, MemberStatus::ACTIVE);
-  network.add_member(get_cert_data(2, kp), MemberStatus::ACTIVE);
+  auto proposer_id =
+    network.add_member(vector<uint8_t>(member_caller), MemberStatus::ACTIVE);
+
+  // the voters
+  auto voter_a = network.add_member(get_cert_data(1, kp), MemberStatus::ACTIVE);
+  auto voter_b = network.add_member(get_cert_data(2, kp), MemberStatus::ACTIVE);
 
   set_whitelists(network);
   network.set_gov_scripts(lua::Interpreter().invoke<json>(gov_script_file));
@@ -289,6 +310,7 @@ TEST_CASE("Add new members until there are 7, then reject")
   {
     const auto proposal_id = i;
     new_member.id = initial_members + i++;
+
     // new member certificate
     auto v = tls::make_verifier(
       new_member.kp->self_sign(fmt::format("CN=new member{}", new_member.id)));
@@ -303,6 +325,7 @@ TEST_CASE("Add new members until there are 7, then reject")
       munpack(frontend.process(rpc_ctx, read_next_member_id)),
       ErrorCodes::INVALID_CALLER_ID);
 
+    // propose new member, as proposer
     Script proposal(R"xxx(
       local tables, member_cert = ...
       return Calls:call("new_member", member_cert)
@@ -315,49 +338,60 @@ TEST_CASE("Add new members until there are 7, then reject")
       Store::Tx tx;
       ccf::SignedReq sr(proposej);
       Response<Proposal::Out> r =
-        frontend.process_json(rpc_ctx, tx, 0, proposej, sr).value();
+        frontend.process_json(rpc_ctx, tx, proposer_id, proposej, sr).value();
+
       // the proposal should be accepted, but not succeed immediately
       CHECK(r.result.id == proposal_id);
       CHECK(r.result.completed == false);
     }
 
+    // read initial proposal, as second member
+    const Response<OpenProposal> initial_read =
+      get_proposal(rpc_ctx, frontend, proposal_id, voter_a);
+    CHECK(initial_read.result.proposer == proposer_id);
+    CHECK(initial_read.result.script == proposal);
+    CHECK(initial_read.result.parameter == new_member.cert);
+
+    // vote as second member
     Script vote_ballot(R"xxx(
-        local tables, calls = ...
-        local n = 0
-        tables["members"]:foreach( function(k, v) n = n + 1 end )
-        if n < 8 then
-          return true
-        else
-          return false
-        end
-        )xxx");
+      local tables, calls = ...
+      local n = 0
+      tables["members"]:foreach( function(k, v) n = n + 1 end )
+      if n < 8 then
+        return true
+      else
+        return false
+      end
+    )xxx");
 
     json votej =
       create_json_req_signed(Vote{proposal_id, vote_ballot}, "vote", kp);
 
-    // vote from second member
-    Store::Tx tx;
-    enclave::RPCContext mem_rpc_ctx(0, member_caller);
-    ccf::SignedReq sr(votej);
-    Response<bool> r =
-      frontend.process_json(mem_rpc_ctx, tx, 1, votej["req"], sr).value();
-    if (new_member.id < max_members)
     {
-      // vote should succeed
-      CHECK(r.result);
-      // check that member with the new new_member cert can make rpc's now
-      CHECK(
-        Response<int>(munpack(frontend.process(rpc_ctx, read_next_member_id)))
-          .result == new_member.id + 1);
-    }
-    else
-    {
-      // vote should not succeed
-      CHECK(!r.result);
-      // check that member with the new new_member cert can make rpc's now
-      check_error(
-        munpack(frontend.process(rpc_ctx, read_next_member_id)),
-        ErrorCodes::INVALID_CALLER_ID);
+      Store::Tx tx;
+      enclave::RPCContext mem_rpc_ctx(0, member_caller);
+      ccf::SignedReq sr(votej);
+      Response<bool> r =
+        frontend.process_json(mem_rpc_ctx, tx, voter_a, votej["req"], sr)
+          .value();
+      if (new_member.id < max_members)
+      {
+        // vote should succeed
+        CHECK(r.result);
+        // check that member with the new new_member cert can make rpc's now
+        CHECK(
+          Response<int>(munpack(frontend.process(rpc_ctx, read_next_member_id)))
+            .result == new_member.id + 1);
+      }
+      else
+      {
+        // vote should not succeed
+        CHECK(!r.result);
+        // check that member with the new new_member cert can make rpc's now
+        check_error(
+          munpack(frontend.process(rpc_ctx, read_next_member_id)),
+          ErrorCodes::INVALID_CALLER_ID);
+      }
     }
   }
 

--- a/src/node/script.h
+++ b/src/node/script.h
@@ -24,10 +24,16 @@ namespace ccf
     {
       text = std::move(script_);
     };
+
     Script(std::vector<uint8_t> script_)
     {
       bytecode = std::move(script_);
     };
+
+    bool operator==(const Script& other) const
+    {
+      return bytecode == other.bytecode && text == other.text;
+    }
 
     MSGPACK_DEFINE(bytecode, text);
   };

--- a/src/node/signatures.h
+++ b/src/node/signatures.h
@@ -17,7 +17,7 @@ namespace ccf
     ObjectId term;
     ObjectId commit;
 
-    MSGPACK_DEFINE(node, index, term, commit, sig);
+    MSGPACK_DEFINE(MSGPACK_BASE(RawSignature), node, index, term, commit);
 
     Signature() {}
 

--- a/src/node/test/msgpack_serialization.cpp
+++ b/src/node/test/msgpack_serialization.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#include "../proposals.h"
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+TEST_CASE("OpenProposal")
+{
+  using namespace ccf;
+
+  // Construct proposals
+  OpenProposal op0;
+
+  Script script0("return true");
+  nlohmann::json param0("hello world");
+  MemberId member0(0);
+  OpenProposal op1(script0, param0, member0);
+
+  // Check they're distinct
+  CHECK(!(op0 == op1));
+
+  // Serialize
+  msgpack::sbuffer sb0;
+  msgpack::pack(sb0, op0);
+
+  msgpack::sbuffer sb1;
+  msgpack::pack(sb1, op1);
+
+  // Deserialize
+  msgpack::object_handle obj0;
+  msgpack::unpack(obj0, sb0.data(), sb0.size(), 0);
+  OpenProposal _op0 = obj0->convert();
+
+  msgpack::object_handle obj1;
+  msgpack::unpack(obj1, sb1.data(), sb1.size(), 0);
+  OpenProposal _op1 = obj1->convert();
+
+  // Check deserializations are correct
+  CHECK(op0 == _op0);
+  CHECK(op1 == _op1);
+}

--- a/src/node/test/msgpack_serialization.cpp
+++ b/src/node/test/msgpack_serialization.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
+#include "../members.h"
 #include "../proposals.h"
+#include "../signatures.h"
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
@@ -99,5 +101,72 @@ TEST_CASE("OpenProposal")
     proposal.votes[4] = Script("Robert'); DROP TABLE Students;--");
     const auto converted = msgpack_roundtrip(proposal);
     CHECK(proposal == converted);
+  }
+}
+
+void fill_rand(std::vector<uint8_t>& v, size_t n)
+{
+  v.resize(n);
+  for (size_t i = 0; i < n; ++i)
+  {
+    v[i] = rand();
+  }
+}
+
+TEST_CASE("RawSignature")
+{
+  using namespace ccf;
+
+  {
+    INFO("Empty signature");
+    RawSignature rs;
+    const auto converted = msgpack_roundtrip(rs);
+    CHECK(rs == converted);
+  }
+
+  {
+    INFO("Byte signature");
+    RawSignature rs;
+    rs.sig.push_back(42);
+    const auto converted = msgpack_roundtrip(rs);
+    CHECK(rs == converted);
+  }
+
+  {
+    INFO("Large signature");
+    RawSignature rs;
+    fill_rand(rs.sig, 256);
+    const auto converted = msgpack_roundtrip(rs);
+    CHECK(rs == converted);
+  }
+}
+
+TEST_CASE("MemberAck")
+{
+  using namespace ccf;
+
+  {
+    INFO("Empty ack");
+    MemberAck ma;
+    const auto converted = msgpack_roundtrip(ma);
+    CHECK(ma == converted);
+  }
+
+  {
+    INFO("Implausible ack");
+    MemberAck ma;
+    ma.sig.push_back(42);
+    ma.next_nonce.push_back(100);
+    const auto converted = msgpack_roundtrip(ma);
+    CHECK(ma == converted);
+  }
+
+  {
+    INFO("Plausible ack");
+    MemberAck ma;
+    fill_rand(ma.sig, 256);
+    fill_rand(ma.next_nonce, 16);
+    const auto converted = msgpack_roundtrip(ma);
+    CHECK(ma == converted);
   }
 }

--- a/src/node/test/msgpack_serialization.cpp
+++ b/src/node/test/msgpack_serialization.cpp
@@ -170,3 +170,39 @@ TEST_CASE("MemberAck")
     CHECK(ma == converted);
   }
 }
+
+TEST_CASE("Signature")
+{
+  using namespace ccf;
+
+  {
+    INFO("Empty sig");
+    Signature sig;
+    const auto converted = msgpack_roundtrip(sig);
+    CHECK(sig == converted);
+  }
+
+  {
+    INFO("Simple sig");
+    Signature sig;
+    sig.sig.push_back(0);
+    sig.node = 0;
+    sig.index = 1;
+    sig.term = 2;
+    sig.commit = 3;
+    const auto converted = msgpack_roundtrip(sig);
+    CHECK(sig == converted);
+  }
+
+  {
+    INFO("Rand sig");
+    Signature sig;
+    fill_rand(sig.sig, 256);
+    sig.node = rand();
+    sig.index = rand();
+    sig.term = rand();
+    sig.commit = rand();
+    const auto converted = msgpack_roundtrip(sig);
+    CHECK(sig == converted);
+  }
+}

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
+set -ex
+
 if [ ! -f "env/bin/activate" ]
     then
         python3.7 -m venv env

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-set -ex
+set -e
 
 if [ ! -f "env/bin/activate" ]
     then


### PR DESCRIPTION
Some of our uses of `MSGPACK_DEFINE` were not serialising members inherited from the base type. In particular we were not fully serialising `OpenProposal`s, resulting in differences in the KV across replicas. This resulted in #214.

The fix is simple - adding `MSGPACK_BASE(T)` entries. In the case of `OpenProposal` I decided it was simpler to remove the inheritance (the fields it shares with `Proposal::In` are coincidental, not a logical hierarchy). To serialise the `nlohmann::json` field I needed to define msgpack-c's `pack` and `convert` structs, and using _that_ we can replace the special case handling of json objects in `msgpackserialise.h`.

I've added `msgpack_serialization_test` which roundtrips examples of all these types, but we don't have a way to enforce that new fields are correctly serialised.