### PR TITLE
Fix mbedtls callback argument cast

### DIFF
--- a/src/tls/entropy.h
+++ b/src/tls/entropy.h
@@ -50,8 +50,7 @@ namespace tls
 
     static int rng(void* ctx, unsigned char* output, size_t len)
     {
-      MbedtlsEntropy* e = reinterpret_cast<MbedtlsEntropy*>(ctx);
-      return mbedtls_ctr_drbg_random(&e->drbg, output, len);
+      return mbedtls_ctr_drbg_random(ctx, output, len);
     }
 
     rng_func_t get_rng() override


### PR DESCRIPTION
We pass &drbg to mbedtls_ctr_drbg_random, while &drbg used to be == this when there was no vtable on the class, but now it is not.
The rng function on line 51 expects the callback data that was passed on line 45, which in the old case, MbedtlsEntropy == &MbedtlsEntropy::drbg, so the cast would succeed. Now it obviously can't.