### PR TITLE
Query network for current leader before sending joinNetwork

### DIFF
--- a/tests/addnode.py
+++ b/tests/addnode.py
@@ -60,7 +60,7 @@ def run(args):
             infra.jsonrpc.ErrorCode.CODE_ID_NOT_FOUND,
         )
 
-        new_node.join_network()
+        new_node.join_network(network)
         network.wait_for_node_commit_sync()
 
         # retire a node

--- a/tests/code_update.py
+++ b/tests/code_update.py
@@ -97,7 +97,8 @@ def run(args):
         }
 
         res, new_node = network.create_and_add_node(args.package, args, True)
-        new_node.join_network()
+        assert res
+        new_node.join_network(network)
 
         new_code_id = get_code_id(f"{args.patched_file_name}.so.signed")
 
@@ -109,9 +110,6 @@ def run(args):
 
         add_new_code(primary, new_code_id)
 
-        with open("networkcert.pem", mode="rb") as file:
-            net_cert = list(file.read())
-
         new_nodes = set()
         old_nodes_count = len(network.nodes)
         # add nodes using the same code id that failed earlier
@@ -119,7 +117,7 @@ def run(args):
             LOG.debug(f"Adding node using new code")
             res, new_node = network.create_and_add_node(args.patched_file_name, args)
             assert res
-            new_node.join_network()
+            new_node.join_network(network)
             new_nodes.add(new_node)
 
         network.wait_for_node_commit_sync()
@@ -139,7 +137,8 @@ def run(args):
         new_leader = network.find_leader()[0]
         LOG.debug(f"Waiting, new_leader is {new_leader.node_id}")
         res, new_node = network.create_and_add_node(args.patched_file_name, args)
-        new_node.join_network_custom(new_leader.host, new_leader.tls_port, net_cert)
+        assert res
+        new_node.join_network(network)
         network.wait_for_node_commit_sync()
 
 

--- a/tests/code_update.py
+++ b/tests/code_update.py
@@ -135,7 +135,7 @@ def run(args):
         time.sleep(args.election_timeout * 6 / 1000)
 
         new_leader = network.find_leader()[0]
-        LOG.debug(f"Waiting, new_leader is {new_leader.node_id}")
+        LOG.debug(f"Waited, new_leader is {new_leader.node_id}")
         res, new_node = network.create_and_add_node(args.patched_file_name, args)
         assert res
         new_node.join_network(network)

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -138,9 +138,8 @@ def run(args):
                 wait_for_state(primary, b"awaitingRecovery")
                 set_recovery_nodes(primary, followers)
 
-                network.generate_join_rpc(primary)
                 for node in followers:
-                    node.join_network()
+                    node.join_network(network)
 
                 LOG.success("Public CFTR started")
                 network.wait_for_node_commit_sync()

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -83,7 +83,7 @@ def wait_for_state(node, state):
         raise TimeoutError("Timed out waiting for public ledger to be read")
 
 
-def set_recovery_nodes(primary, followers):
+def set_recovery_nodes(network, primary, followers):
     """
     Create and send recovery transaction, with new network definition.
     """
@@ -92,6 +92,7 @@ def set_recovery_nodes(primary, followers):
     with primary.management_client() as c:
         id = c.request("setRecoveryNodes", recovery_rpc)
         r = c.response(id).result
+        network.net_cert = list(r)
         with open("networkcert.pem", "w") as nc:
             nc.write(r.decode())
 
@@ -136,7 +137,7 @@ def run(args):
                 check = infra.ccf.Checker()
 
                 wait_for_state(primary, b"awaitingRecovery")
-                set_recovery_nodes(primary, followers)
+                set_recovery_nodes(network, primary, followers)
 
                 for node in followers:
                     node.join_network(network)


### PR DESCRIPTION
We previously used the C++ client app for most `joinNetwork` requests, relying on the `joinNetwork.json` file written during genesis. If we have any additional elections during the test then these joins will fail. This replaces the use of `joinNetwork.json` with a direct RPC from the Python client, retrieving the current leader just before sending a freshly populated join request.

`networkcert.pem` is read once when the network is created, then stored on the Python `Network` instance. If we called `startNetwork` in the same way (directly from Python) we could simplify this even further and store the contents from the RPC response, but we probably still want to dump the resulting cert to file and need to re-examine how we generate the initial node's ID.

This fixes #256.