### PR TITLE
Automatically populate error codes in Lua

### DIFF
--- a/sphinx/source/logging_lua.rst
+++ b/sphinx/source/logging_lua.rst
@@ -6,7 +6,14 @@ Overview
 
 CCF comes with a generic application for running Lua scripts called *luageneric*, implemented in [CCF]/src/apps/luageneric/luageneric.cpp. At runtime, *luageneric* dispatches incoming RPCs to Lua scripts stored in the table *APP_SCRIPTS*. The RPC method name is used as the key, and if a script exists at this key it is called with the RPC arguments. The initial contents of the table (i.e., at "genesis") are set by a Lua script passed to the *genesisgenerator* via the ``--app-script`` parameter. 
 
-The script at key ``__environment`` is special. If set, the corresponding script is invoked before any actual handler script to initialize the Lua environment. 
+The script at key ``__environment`` is special. If set, the corresponding script is invoked before any actual handler script to initialize the Lua environment.
+
+Some global values are pre-populated in the Lua environment, to be used by both ``__environment`` and the handler scripts:
+
+* Loggers: the functions ``LOG_TRACE``, ``LOG_DEBUG``, ``LOG_INFO``, ``LOG_FAIL``, and ``LOG_FATAL`` will call CCF's equivalent logging macros, allowing Lua apps to write to stdout.
+
+* ``env`` table: common constants/functions should be set on this table rather than as additional global fields. This will contain a table named ``error_codes`` listing JSON RPC error codes defined by CCF (e.g., ``env.error_codes.INVALID_PARAMS`` can be used rather than ``-32603``). App-specific error codes may be added to this table with values between ``APP_ERROR_START`` and ``SERVER_ERROR_END``.
+
 
 RPC Handler
 ```````````
@@ -16,7 +23,7 @@ The following shows an implementation of the Logging application, where each RPC
 .. literalinclude:: ../../src/apps/logging/logging.lua
     :language: lua
 
-Here, functionality shared between the handlers (e.g., ``env.jsucc()``) is defined in the ``__environment`` script.
+Here, functionality shared between the handlers (e.g., ``env.jsucc()``) and app-specific error codes (e.g., ``MESSAGE_EMPTY``) are defined in the ``__environment`` script.
 
 Interface
 `````````

--- a/src/apps/logging/logging.lua
+++ b/src/apps/logging/logging.lua
@@ -3,30 +3,6 @@
 
 return {
   __environment = [[
-    env.error_codes = {
-      PARSE_ERROR = -32700,
-      INVALID_REQUEST = -32600,
-      METHOD_NOT_FOUND = -32601,
-      INVALID_PARAMS = -32602,
-      INTERNAL_ERROR = -32603,
-
-      TX_NOT_LEADER = -32001,
-      TX_FAILED_TO_REPLICATE = -32002,
-      SCRIPT_ERROR = -32003,
-      INSUFFICIENT_RIGHTS = -32004,
-      TX_LEADER_UNKNOWN = -32005,
-      RPC_NOT_SIGNED = -32006,
-      INVALID_CLIENT_SIGNATURE = -32007,
-      INVALID_CALLER_ID = -32008,
-      CODE_ID_NOT_FOUND = -32009,
-      CODE_ID_RETIRED = -32010,
-      RPC_NOT_FORWARDED = -32011,
-      QUOTE_NOT_VERIFIED = -32012,
-
-      UNKNOWN_ID = -32050,
-      MESSAGE_EMPTY = -32051,
-    }
-
     function env.jsucc(result)
       return {result = result}
     end
@@ -73,9 +49,5 @@ return {
   LOG_record_pub = [[
     tables, gov_tables, args = ...
     return env.record(tables.pub0)
-  ]],
-
-  write_test = [[
-    env.LOG_INFO("Hello world from lua")
   ]]
 }

--- a/src/apps/logging/logging.lua
+++ b/src/apps/logging/logging.lua
@@ -3,30 +3,28 @@
 
 return {
   __environment = [[
-    env = {
-      error_codes = {
-        PARSE_ERROR = -32700,
-        INVALID_REQUEST = -32600,
-        METHOD_NOT_FOUND = -32601,
-        INVALID_PARAMS = -32602,
-        INTERNAL_ERROR = -32603,
+    env.error_codes = {
+      PARSE_ERROR = -32700,
+      INVALID_REQUEST = -32600,
+      METHOD_NOT_FOUND = -32601,
+      INVALID_PARAMS = -32602,
+      INTERNAL_ERROR = -32603,
 
-        TX_NOT_LEADER = -32001,
-        TX_FAILED_TO_REPLICATE = -32002,
-        SCRIPT_ERROR = -32003,
-        INSUFFICIENT_RIGHTS = -32004,
-        TX_LEADER_UNKNOWN = -32005,
-        RPC_NOT_SIGNED = -32006,
-        INVALID_CLIENT_SIGNATURE = -32007,
-        INVALID_CALLER_ID = -32008,
-        CODE_ID_NOT_FOUND = -32009,
-        CODE_ID_RETIRED = -32010,
-        RPC_NOT_FORWARDED = -32011,
-        QUOTE_NOT_VERIFIED = -32012,
+      TX_NOT_LEADER = -32001,
+      TX_FAILED_TO_REPLICATE = -32002,
+      SCRIPT_ERROR = -32003,
+      INSUFFICIENT_RIGHTS = -32004,
+      TX_LEADER_UNKNOWN = -32005,
+      RPC_NOT_SIGNED = -32006,
+      INVALID_CLIENT_SIGNATURE = -32007,
+      INVALID_CALLER_ID = -32008,
+      CODE_ID_NOT_FOUND = -32009,
+      CODE_ID_RETIRED = -32010,
+      RPC_NOT_FORWARDED = -32011,
+      QUOTE_NOT_VERIFIED = -32012,
 
-        UNKNOWN_ID = -32050,
-        MESSAGE_EMPTY = -32051,
-      }
+      UNKNOWN_ID = -32050,
+      MESSAGE_EMPTY = -32051,
     }
 
     function env.jsucc(result)
@@ -75,5 +73,9 @@ return {
   LOG_record_pub = [[
     tables, gov_tables, args = ...
     return env.record(tables.pub0)
+  ]],
+
+  write_test = [[
+    env.LOG_INFO("Hello world from lua")
   ]]
 }

--- a/src/apps/logging/logging.lua
+++ b/src/apps/logging/logging.lua
@@ -3,6 +3,9 @@
 
 return {
   __environment = [[
+    env.error_codes.UNKNOWN_ID = env.error_codes.APP_ERROR_START
+    env.error_codes.MESSAGE_EMPTY = env.error_codes.UNKNOWN_ID - 1
+
     function env.jsucc(result)
       return {result = result}
     end

--- a/src/apps/luageneric/luageneric.cpp
+++ b/src/apps/luageneric/luageneric.cpp
@@ -24,8 +24,49 @@ namespace ccfapp
   class AppTsr : public TxScriptRunner
   {
   private:
-    // TODO: once the kv store allows for dynamic table creation, we can derive
-    // this list dynamically based on an apps requirements.
+    void add_error_codes(
+      lua_State* l, char const* table_name = "error_codes") const
+    {
+      // Get env table on top of stack
+      lua_getglobal(l, env_table_name);
+      if (lua_isnil(l, -1))
+      {
+        LOG_INFO_FMT(
+          "There is no env table '{}', skipping creation of error codes table "
+          "'{}'",
+          env_table_name,
+          table_name);
+      }
+
+      // Create error_codes table
+      lua_newtable(l);
+
+#define XX(Name, Value) \
+  lua_pushinteger(l, Value); \
+  lua_setfield(l, -2, #Name);
+
+      XX_STANDARD_ERROR_CODES;
+      XX_CCF_ERROR_CODES;
+
+#undef XX
+
+      lua_setfield(l, -2, table_name);
+
+      // Remove env table from stack
+      lua_pop(l, 1);
+    }
+
+    void setup_environment(
+      lua::Interpreter& li,
+      const std::optional<Script>& env_script) const override
+    {
+      TxScriptRunner::setup_environment(li, env_script);
+
+      add_error_codes(li.get_state());
+    }
+
+    // TODO: once the kv store allows for dynamic table creation, we can
+    // derive this list dynamically based on an apps requirements.
     const std::vector<GenericTable*> app_tables;
     void add_custom_tables(
       lua::Interpreter& li,

--- a/src/apps/luageneric/luageneric.cpp
+++ b/src/apps/luageneric/luageneric.cpp
@@ -60,9 +60,22 @@ namespace ccfapp
       lua::Interpreter& li,
       const std::optional<Script>& env_script) const override
     {
-      TxScriptRunner::setup_environment(li, env_script);
+      auto l = li.get_state();
+
+      // Create env table
+      lua_newtable(l);
+      lua_setglobal(l, env_table_name);
+
+      // Register global logging functions
+      lua_register(l, "LOG_TRACE", lua_log_trace);
+      lua_register(l, "LOG_DEBUG", lua_log_debug);
+      lua_register(l, "LOG_INFO", lua_log_info);
+      lua_register(l, "LOG_FAIL", lua_log_fail);
+      lua_register(l, "LOG_FATAL", lua_log_fatal);
 
       add_error_codes(li.get_state());
+
+      TxScriptRunner::setup_environment(li, env_script);
     }
 
     // TODO: once the kv store allows for dynamic table creation, we can

--- a/src/apps/luageneric/luageneric.cpp
+++ b/src/apps/luageneric/luageneric.cpp
@@ -31,7 +31,7 @@ namespace ccfapp
       lua_getglobal(l, env_table_name);
       if (lua_isnil(l, -1))
       {
-        LOG_INFO_FMT(
+        LOG_FAIL_FMT(
           "There is no env table '{}', skipping creation of error codes table "
           "'{}'",
           env_table_name,

--- a/src/apps/luageneric/luageneric_test.cpp
+++ b/src/apps/luageneric/luageneric_test.cpp
@@ -335,3 +335,144 @@ TEST_CASE("simple bank")
     check_success(frontend->process(rpc_ctx, pc2), 999 + 5);
   }
 }
+
+TEST_CASE("pre-populated environment")
+{
+  GenesisGenerator network;
+  StubNotifier notifier;
+  // create network with 1 user and 3 active members
+  auto frontend = init_frontend(network, notifier, 1, 3);
+  const Cert u0 = {0};
+  enclave::RPCContext rpc_ctx(0, u0);
+
+  {
+    constexpr auto log_trace_method = "log_trace";
+    constexpr auto log_trace = R"xxx(
+      LOG_TRACE("Logging trace message from Lua")
+      LOG_TRACE("Concatenating ", 3, " args")
+      return env.jsucc(true)
+    )xxx";
+    set_handler(network, log_trace_method, {log_trace});
+
+    {
+      const auto pc = make_pc(log_trace_method, {});
+      check_success(frontend->process(rpc_ctx, pc), true);
+    }
+
+    constexpr auto log_debug_method = "log_debug";
+    constexpr auto log_debug = R"xxx(
+      LOG_DEBUG("Logging debug message from Lua")
+      LOG_DEBUG("Concatenating ", 3, " args")
+      return env.jsucc(true)
+    )xxx";
+    set_handler(network, log_debug_method, {log_debug});
+
+    {
+      const auto pc = make_pc(log_debug_method, {});
+      check_success(frontend->process(rpc_ctx, pc), true);
+    }
+
+    constexpr auto log_info_method = "log_info";
+    constexpr auto log_info = R"xxx(
+      LOG_INFO("Logging state message from Lua")
+      LOG_INFO("Concatenating ", 3, " args")
+      return env.jsucc(true)
+    )xxx";
+    set_handler(network, log_info_method, {log_info});
+
+    {
+      const auto pc = make_pc(log_info_method, {});
+      check_success(frontend->process(rpc_ctx, pc), true);
+    }
+
+    constexpr auto log_fail_method = "log_fail";
+    constexpr auto log_fail = R"xxx(
+      LOG_FAIL("Logging failures from Lua")
+      LOG_FAIL("Concatenating ", 3, " args")
+      return env.jsucc(true)
+    )xxx";
+    set_handler(network, log_fail_method, {log_fail});
+
+    {
+      const auto pc = make_pc(log_fail_method, {});
+      check_success(frontend->process(rpc_ctx, pc), true);
+    }
+
+    constexpr auto log_fatal_method = "log_fatal";
+    constexpr auto log_fatal = R"xxx(
+      LOG_FATAL("Logging a fatal error, raising an error")
+      return env.jsucc(true)
+    )xxx";
+    set_handler(network, log_fatal_method, {log_fatal});
+
+    {
+      const auto pc = make_pc(log_fatal_method, {});
+      check_error(
+        frontend->process(rpc_ctx, pc),
+        jsonrpc::StandardErrorCodes::INTERNAL_ERROR);
+    }
+  }
+
+  {
+    // Test Lua sees the correct error codes by returning them from RPC
+    constexpr auto invalid_params_method = "invalid_params";
+    constexpr auto invalid_params = R"xxx(
+      return env.jsucc(
+        {
+          env.error_codes.PARSE_ERROR,
+          env.error_codes.INVALID_REQUEST,
+          env.error_codes.METHOD_NOT_FOUND,
+          env.error_codes.INVALID_PARAMS,
+          env.error_codes.INTERNAL_ERROR,
+          env.error_codes.METHOD_NOT_FOUND,
+
+          env.error_codes.TX_NOT_LEADER,
+          env.error_codes.TX_FAILED_TO_REPLICATE,
+          env.error_codes.SCRIPT_ERROR,
+          env.error_codes.INSUFFICIENT_RIGHTS,
+          env.error_codes.TX_LEADER_UNKNOWN,
+          env.error_codes.RPC_NOT_SIGNED,
+          env.error_codes.INVALID_CLIENT_SIGNATURE,
+          env.error_codes.INVALID_CALLER_ID,
+          env.error_codes.CODE_ID_NOT_FOUND,
+          env.error_codes.CODE_ID_RETIRED,
+          env.error_codes.RPC_NOT_FORWARDED,
+          env.error_codes.QUOTE_NOT_VERIFIED
+        }
+      )
+    )xxx";
+    set_handler(network, invalid_params_method, {invalid_params});
+
+    {
+      using EBT = jsonrpc::ErrorBaseType;
+      using StdEC = jsonrpc::StandardErrorCodes;
+      using CCFEC = jsonrpc::CCFErrorCodes;
+      const auto pc = make_pc(invalid_params_method, {});
+      const Response<std::vector<EBT>> r =
+        json::from_msgpack(frontend->process(rpc_ctx, pc));
+
+      std::vector<EBT> expected;
+      expected.push_back(EBT(StdEC::PARSE_ERROR));
+      expected.push_back(EBT(StdEC::INVALID_REQUEST));
+      expected.push_back(EBT(StdEC::METHOD_NOT_FOUND));
+      expected.push_back(EBT(StdEC::INVALID_PARAMS));
+      expected.push_back(EBT(StdEC::INTERNAL_ERROR));
+      expected.push_back(EBT(StdEC::METHOD_NOT_FOUND));
+
+      expected.push_back(EBT(CCFEC::TX_NOT_LEADER));
+      expected.push_back(EBT(CCFEC::TX_FAILED_TO_REPLICATE));
+      expected.push_back(EBT(CCFEC::SCRIPT_ERROR));
+      expected.push_back(EBT(CCFEC::INSUFFICIENT_RIGHTS));
+      expected.push_back(EBT(CCFEC::TX_LEADER_UNKNOWN));
+      expected.push_back(EBT(CCFEC::RPC_NOT_SIGNED));
+      expected.push_back(EBT(CCFEC::INVALID_CLIENT_SIGNATURE));
+      expected.push_back(EBT(CCFEC::INVALID_CALLER_ID));
+      expected.push_back(EBT(CCFEC::CODE_ID_NOT_FOUND));
+      expected.push_back(EBT(CCFEC::CODE_ID_RETIRED));
+      expected.push_back(EBT(CCFEC::RPC_NOT_FORWARDED));
+      expected.push_back(EBT(CCFEC::QUOTE_NOT_VERIFIED));
+
+      CHECK(r.result == expected);
+    }
+  }
+}

--- a/src/apps/luageneric/luageneric_test.cpp
+++ b/src/apps/luageneric/luageneric_test.cpp
@@ -71,20 +71,6 @@ auto init_frontend(
   const auto env_script = R"xxx(
     return {
       __environment = [[
-        env = {
-          error_codes = {
-            PARSE_ERROR = -32700,
-            INVALID_REQUEST = -32600,
-            METHOD_NOT_FOUND = -32601,
-            INVALID_PARAMS = -32602,
-            INTERNAL_ERROR = -32603,
-            INVALID_CLIENT_SIGNATURE = -32605,
-            INVALID_CALLER_ID = -32606,
-
-            INSUFFICIENT_RIGHTS = -32006,
-          }
-        }
-
         function env.jsucc (result)
           return {result = result}
         end

--- a/src/luainterp/txscriptrunner.h
+++ b/src/luainterp/txscriptrunner.h
@@ -201,17 +201,6 @@ namespace ccf
       {
         auto l = li.get_state();
 
-        // Create env table
-        lua_newtable(l);
-        lua_setglobal(l, env_table_name);
-
-        // Register global logging functions
-        lua_register(l, "LOG_TRACE", lua_log_trace);
-        lua_register(l, "LOG_DEBUG", lua_log_debug);
-        lua_register(l, "LOG_INFO", lua_log_info);
-        lua_register(l, "LOG_FAIL", lua_log_fail);
-        lua_register(l, "LOG_FATAL", lua_log_fatal);
-
         if (env_script)
         {
           load(li, *env_script);

--- a/src/luainterp/txscriptrunner.h
+++ b/src/luainterp/txscriptrunner.h
@@ -153,27 +153,38 @@ namespace ccf
           ss.str(), static_cast<int>(jsonrpc::CCFErrorCodes::SCRIPT_ERROR));
       }
 
+      static std::string get_var_string_from_args(lua_State* l)
+      {
+        size_t args = lua_gettop(l);
+        std::stringstream ss;
+        for (size_t i = 1; i <= args; ++i)
+        {
+          ss << lua_tostring(l, i);
+        }
+        return ss.str();
+      }
+
       static int lua_log_debug(lua_State* l)
       {
-        LOG_DEBUG_FMT(lua_tostring(l, 1));
+        LOG_DEBUG_FMT(get_var_string_from_args(l));
         return 0;
       }
 
       static int lua_log_info(lua_State* l)
       {
-        LOG_INFO_FMT(lua_tostring(l, 1));
+        LOG_INFO_FMT(get_var_string_from_args(l));
         return 0;
       }
 
       static int lua_log_fail(lua_State* l)
       {
-        LOG_FAIL_FMT(lua_tostring(l, 1));
+        LOG_FAIL_FMT(get_var_string_from_args(l));
         return 0;
       }
 
       static int lua_log_fatal(lua_State* l)
       {
-        LOG_FATAL_FMT(lua_tostring(l, 1));
+        LOG_FATAL_FMT(get_var_string_from_args(l));
         return 0;
       }
 
@@ -182,6 +193,8 @@ namespace ccf
       {
         auto state = li.get_state();
         lua_newtable(state);
+        lua_pushinteger(state, 5);
+        lua_setfield(state, -2, "foo");
         lua_setglobal(state, "env");
         lua_register(state, "LOG_DEBUG", lua_log_debug);
         lua_register(state, "LOG_INFO", lua_log_info);

--- a/src/luainterp/txscriptrunner.h
+++ b/src/luainterp/txscriptrunner.h
@@ -31,6 +31,8 @@ namespace ccf
     class TxScriptRunner
     {
     protected:
+      static constexpr auto env_table_name = "env";
+
       /** Dummy type to distinguish writable from read-only tables at compile
        * time. Used to instantiate lua::UserDataExt for writable tables.
        */
@@ -188,18 +190,20 @@ namespace ccf
         return 0;
       }
 
-      virtual void run_environment_script(
+      virtual void setup_environment(
         lua::Interpreter& li, const std::optional<Script>& env_script) const
       {
-        auto state = li.get_state();
-        lua_newtable(state);
-        lua_pushinteger(state, 5);
-        lua_setfield(state, -2, "foo");
-        lua_setglobal(state, "env");
-        lua_register(state, "LOG_DEBUG", lua_log_debug);
-        lua_register(state, "LOG_INFO", lua_log_info);
-        lua_register(state, "LOG_FAIL", lua_log_fail);
-        lua_register(state, "LOG_FATAL", lua_log_fatal);
+        auto l = li.get_state();
+
+        // Create env table
+        lua_newtable(l);
+        lua_setglobal(l, env_table_name);
+
+        // Register global logging functions
+        lua_register(l, "LOG_DEBUG", lua_log_debug);
+        lua_register(l, "LOG_INFO", lua_log_info);
+        lua_register(l, "LOG_FAIL", lua_log_fail);
+        lua_register(l, "LOG_FATAL", lua_log_fatal);
 
         if (env_script)
         {
@@ -242,7 +246,7 @@ namespace ccf
         lua::Interpreter li;
 
         // run an optional environment script
-        run_environment_script(li, txs.env_script);
+        setup_environment(li, txs.env_script);
 
         load(li, txs.script);
 

--- a/src/luainterp/txscriptrunner.h
+++ b/src/luainterp/txscriptrunner.h
@@ -166,6 +166,12 @@ namespace ccf
         return ss.str();
       }
 
+      static int lua_log_trace(lua_State* l)
+      {
+        LOG_TRACE_FMT(get_var_string_from_args(l));
+        return 0;
+      }
+
       static int lua_log_debug(lua_State* l)
       {
         LOG_DEBUG_FMT(get_var_string_from_args(l));
@@ -200,6 +206,7 @@ namespace ccf
         lua_setglobal(l, env_table_name);
 
         // Register global logging functions
+        lua_register(l, "LOG_TRACE", lua_log_trace);
         lua_register(l, "LOG_DEBUG", lua_log_debug);
         lua_register(l, "LOG_INFO", lua_log_info);
         lua_register(l, "LOG_FAIL", lua_log_fail);

--- a/src/luainterp/txscriptrunner.h
+++ b/src/luainterp/txscriptrunner.h
@@ -153,11 +153,40 @@ namespace ccf
           ss.str(), static_cast<int>(jsonrpc::CCFErrorCodes::SCRIPT_ERROR));
       }
 
+      static int lua_log_debug(lua_State* l)
+      {
+        LOG_DEBUG_FMT(lua_tostring(l, 1));
+        return 0;
+      }
+
+      static int lua_log_info(lua_State* l)
+      {
+        LOG_INFO_FMT(lua_tostring(l, 1));
+        return 0;
+      }
+
+      static int lua_log_fail(lua_State* l)
+      {
+        LOG_FAIL_FMT(lua_tostring(l, 1));
+        return 0;
+      }
+
+      static int lua_log_fatal(lua_State* l)
+      {
+        LOG_FATAL_FMT(lua_tostring(l, 1));
+        return 0;
+      }
+
       virtual void run_environment_script(
         lua::Interpreter& li, const std::optional<Script>& env_script) const
       {
-        lua_newtable(li.get_state());
-        lua_setglobal(li.get_state(), "env");
+        auto state = li.get_state();
+        lua_newtable(state);
+        lua_setglobal(state, "env");
+        lua_register(state, "LOG_DEBUG", lua_log_debug);
+        lua_register(state, "LOG_INFO", lua_log_info);
+        lua_register(state, "LOG_FAIL", lua_log_fail);
+        lua_register(state, "LOG_FATAL", lua_log_fatal);
 
         if (env_script)
         {


### PR DESCRIPTION
Rather than manually repeating the possible RPC errors in every lua app, and trying to keep these up-to-date, we automatically fill in the `env.error_codes` field from `luageneric`. This also means the `env` table is created from C++, and should not be created by apps.

While doing this I added access to the logging macros in Lua, with the same names they have in C++.

Resolves #265, though ignores the similar duplication in Python.