### PR TITLE
Raft host/port rename

### DIFF
--- a/check-format.sh
+++ b/check-format.sh
@@ -22,7 +22,11 @@ while getopts ":f:" opt; do
   esac
 done
 
-echo "Checking file format in" "$@"
+if $fix ; then
+  echo "Formatting files in" "$@"
+else
+  echo "Checking file format in" "$@"
+fi
 
 unformatted_files=""
 for file in $(find "$@" -name "*.h" -or -name "*.hpp" -or -name "*.cpp" -or -name "*.c"); do

--- a/sphinx/source/recovery.rst
+++ b/sphinx/source/recovery.rst
@@ -64,13 +64,13 @@ Once the public crash-fault tolerant network is established, members are allowed
 
 .. code-block:: bash
 
-    $ memberclient accept_recovery --sealed-secrets=/path/to/sealed/secrets/file --cert=/path/to/member1/cert --privk=/path/to/member1/private/key --server-addr=leader_rpc_ip/leader_port_ip --ca=/path/to/new/network/cert
+    $ memberclient accept_recovery --sealed-secrets=/path/to/sealed/secrets/file --cert=/path/to/member1/cert --privk=/path/to/member1/private/key --server-address=leader_rpc_ip:leader_port_ip --ca=/path/to/new/network/cert
 
 If successful, this commands returns the proposal id that can be used by other members to submit their votes:
 
 .. code-block:: bash
 
-    $ ./memberclient vote --accept --cert=/path/to/member2/cert --privk=/path/to/member2/private/key --server-addr=leader_rpc_ip/leader_rpc_port --id=proposal_id --ca=/path/to/new/network/cert
+    $ ./memberclient vote --accept --cert=/path/to/member2/cert --privk=/path/to/member2/private/key --server-address=leader_rpc_ip:leader_rpc_port --id=proposal_id --ca=/path/to/new/network/cert
 
 Once a quorum of members (defined by the constitution rules but typically, a majority of members) have agreed to recover the network, the network secrets are unsealed and the recovery of the private entries of the ledger is automatically started.
 

--- a/sphinx/source/recovery.rst
+++ b/sphinx/source/recovery.rst
@@ -22,7 +22,7 @@ To initiate the first phase of the recovery protocol, one of several nodes must 
 
 .. code-block:: bash
 
-    $ cchost --start=recover --enclave-file=/path/to/application --node-address=node_ip:node_port --rpc-address=tls_ip:tls_port
+    $ cchost --start=recover --enclave-file=/path/to/application --node-address=node_ip:node_port --rpc-address=rpc_ip:rpc_port
     --ledger-file=ledger_file --node-cert-file=/path/to/node_certificate --quote-file=/path/to/quote
 
 Each node will then immediately restore the public entries of its ledger (``--ledger-file``). Because deserialising the public entries present in the ledger may take some time, members are allowed to query the progress of the public recovery by running the ``getSignedIndex`` RPC which returns the version of the last signed recovered ledger entry. Once the public ledger is fully recovered, the ``getSignedIndex`` RPC returns ``{"state": "awaitingRecovery"}``.
@@ -64,7 +64,7 @@ Once the public crash-fault tolerant network is established, members are allowed
 
 .. code-block:: bash
 
-    $ memberclient accept_recovery --sealed-secrets=/path/to/sealed/secrets/file --cert=/path/to/member1/cert --privk=/path/to/member1/private/key --server-address=leader_rpc_ip:leader_port_ip --ca=/path/to/new/network/cert
+    $ memberclient accept_recovery --sealed-secrets=/path/to/sealed/secrets/file --cert=/path/to/member1/cert --privk=/path/to/member1/private/key --server-address=leader_rpc_ip:leader_rpc_port --ca=/path/to/new/network/cert
 
 If successful, this commands returns the proposal id that can be used by other members to submit their votes:
 

--- a/sphinx/source/recovery.rst
+++ b/sphinx/source/recovery.rst
@@ -22,9 +22,8 @@ To initiate the first phase of the recovery protocol, one of several nodes must 
 
 .. code-block:: bash
 
-    $ cchost --start=recover --enclave-file=/path/to/application --node-host=node_ip --node-port=node_port
-    --tls-host=tls_ip --tls-pubhost=tls_public_ip --tls-port=tls_port --ledger-file=ledger_file
-    --node-cert-file=/path/to/node_certificate --quote-file=/path/to/quote
+    $ cchost --start=recover --enclave-file=/path/to/application --node-address=node_ip:node_port --rpc-address=tls_ip:tls_port
+    --ledger-file=ledger_file --node-cert-file=/path/to/node_certificate --quote-file=/path/to/quote
 
 Each node will then immediately restore the public entries of its ledger (``--ledger-file``). Because deserialising the public entries present in the ledger may take some time, members are allowed to query the progress of the public recovery by running the ``getSignedIndex`` RPC which returns the version of the last signed recovered ledger entry. Once the public ledger is fully recovered, the ``getSignedIndex`` RPC returns ``{"state": "awaitingRecovery"}``.
 
@@ -65,13 +64,13 @@ Once the public crash-fault tolerant network is established, members are allowed
 
 .. code-block:: bash
 
-    $ memberclient accept_recovery --sealed-secrets=/path/to/sealed/secrets/file --cert=/path/to/member1/cert --privk=/path/to/member1/private/key --host=leader_ip --port=leader_port --ca=/path/to/new/network/cert
+    $ memberclient accept_recovery --sealed-secrets=/path/to/sealed/secrets/file --cert=/path/to/member1/cert --privk=/path/to/member1/private/key --server-addr=leader_rpc_ip/leader_port_ip --ca=/path/to/new/network/cert
 
 If successful, this commands returns the proposal id that can be used by other members to submit their votes:
 
 .. code-block:: bash
 
-    $ ./memberclient vote --accept --cert=/path/to/member2/cert --privk=/path/to/member2/private/key --host=leader_ip --port=port_ip --id=<proposal_id> --ca=/path/to/new/network/cert
+    $ ./memberclient vote --accept --cert=/path/to/member2/cert --privk=/path/to/member2/private/key --server-addr=leader_rpc_ip/leader_rpc_port --id=proposal_id --ca=/path/to/new/network/cert
 
 Once a quorum of members (defined by the constitution rules but typically, a majority of members) have agreed to recover the network, the network secrets are unsealed and the recovery of the private entries of the ledger is automatically started.
 

--- a/sphinx/source/recovery.rst
+++ b/sphinx/source/recovery.rst
@@ -22,7 +22,7 @@ To initiate the first phase of the recovery protocol, one of several nodes must 
 
 .. code-block:: bash
 
-    $ cchost --start=recover --enclave-file=/path/to/application --raft-host=raft_ip --raft-port=raft_port
+    $ cchost --start=recover --enclave-file=/path/to/application --node-host=node_ip --node-port=node_port
     --tls-host=tls_ip --tls-pubhost=tls_public_ip --tls-port=tls_port --ledger-file=ledger_file
     --node-cert-file=/path/to/node_certificate --quote-file=/path/to/quote
 

--- a/sphinx/source/rpc_api.rst
+++ b/sphinx/source/rpc_api.rst
@@ -31,7 +31,7 @@ The API can also be retrieved from a running service using the `listMethods`_ an
       "term": 2
     }
 
-    $ ./client --pretty-print --server-address 127.99.16.14:3678 --ca networkcert.pem userrpc --req @getSchema.json --cert user1_cert.pem --pk user1_privk.pem
+    $ ./client --pretty-print --server-address 127.99.16.14:36785 --ca networkcert.pem userrpc --req @getSchema.json --cert user1_cert.pem --pk user1_privk.pem
     Doing user RPC:
     {
       "commit": 4,

--- a/sphinx/source/rpc_api.rst
+++ b/sphinx/source/rpc_api.rst
@@ -7,7 +7,7 @@ The API can also be retrieved from a running service using the `listMethods`_ an
 
 .. code-block:: bash
 
-    $ ./client --pretty-print --host 127.99.16.14 --port 36785 --ca networkcert.pem userrpc --req @listMethods.json --cert user1_cert.pem --pk user1_privk.pem
+    $ ./client --pretty-print --server-address 127.99.16.14:36785 --ca networkcert.pem userrpc --req @listMethods.json --cert user1_cert.pem --pk user1_privk.pem
     Doing user RPC:
     {
       "commit": 4,
@@ -31,7 +31,7 @@ The API can also be retrieved from a running service using the `listMethods`_ an
       "term": 2
     }
 
-    $ ./client --pretty-print --host 127.99.16.14 --port 36785 --ca networkcert.pem userrpc --req @getSchema.json --cert user1_cert.pem --pk user1_privk.pem
+    $ ./client --pretty-print --server-address 127.99.16.14:3678 --ca networkcert.pem userrpc --req @getSchema.json --cert user1_cert.pem --pk user1_privk.pem
     Doing user RPC:
     {
       "commit": 4,

--- a/sphinx/source/schemas/add_node_params.json
+++ b/sphinx/source/schemas/add_node_params.json
@@ -12,6 +12,9 @@
     "host": {
       "type": "string"
     },
+    "nodeport": {
+      "type": "string"
+    },
     "pubhost": {
       "type": "string"
     },
@@ -22,9 +25,6 @@
         "type": "number"
       },
       "type": "array"
-    },
-    "raftport": {
-      "type": "string"
     },
     "status": {
       "enum": [
@@ -40,7 +40,7 @@
   "required": [
     "host",
     "pubhost",
-    "raftport",
+    "nodeport",
     "tlsport",
     "cert",
     "quote",

--- a/sphinx/source/schemas/add_node_params.json
+++ b/sphinx/source/schemas/add_node_params.json
@@ -33,7 +33,7 @@
         "RETIRED"
       ]
     },
-    "tlsport": {
+    "rpcport": {
       "type": "string"
     }
   },
@@ -41,7 +41,7 @@
     "host",
     "pubhost",
     "nodeport",
-    "tlsport",
+    "rpcport",
     "cert",
     "quote",
     "status"

--- a/sphinx/source/schemas/add_node_params.json
+++ b/sphinx/source/schemas/add_node_params.json
@@ -26,15 +26,15 @@
       },
       "type": "array"
     },
+    "rpcport": {
+      "type": "string"
+    },
     "status": {
       "enum": [
         "PENDING",
         "TRUSTED",
         "RETIRED"
       ]
-    },
-    "rpcport": {
-      "type": "string"
     }
   },
   "required": [

--- a/sphinx/source/schemas/setRecoveryNodes_params.json
+++ b/sphinx/source/schemas/setRecoveryNodes_params.json
@@ -36,7 +36,7 @@
               "RETIRED"
             ]
           },
-          "tlsport": {
+          "rpcport": {
             "type": "string"
           }
         },
@@ -44,7 +44,7 @@
           "host",
           "pubhost",
           "nodeport",
-          "tlsport",
+          "rpcport",
           "cert",
           "quote",
           "status"

--- a/sphinx/source/schemas/setRecoveryNodes_params.json
+++ b/sphinx/source/schemas/setRecoveryNodes_params.json
@@ -15,6 +15,9 @@
           "host": {
             "type": "string"
           },
+          "nodeport": {
+            "type": "string"
+          },
           "pubhost": {
             "type": "string"
           },
@@ -25,9 +28,6 @@
               "type": "number"
             },
             "type": "array"
-          },
-          "raftport": {
-            "type": "string"
           },
           "status": {
             "enum": [
@@ -43,7 +43,7 @@
         "required": [
           "host",
           "pubhost",
-          "raftport",
+          "nodeport",
           "tlsport",
           "cert",
           "quote",

--- a/sphinx/source/schemas/setRecoveryNodes_params.json
+++ b/sphinx/source/schemas/setRecoveryNodes_params.json
@@ -29,15 +29,15 @@
             },
             "type": "array"
           },
+          "rpcport": {
+            "type": "string"
+          },
           "status": {
             "enum": [
               "PENDING",
               "TRUSTED",
               "RETIRED"
             ]
-          },
-          "rpcport": {
-            "type": "string"
           }
         },
         "required": [

--- a/sphinx/source/start_network.rst
+++ b/sphinx/source/start_network.rst
@@ -8,7 +8,7 @@ To start up a network, operators should start up each node separately by running
 
 .. code-block:: bash
 
-    $ cchost --enclave-file=/path/to/application --raft-host=<raft_ip> --raft-port=<raft_port>
+    $ cchost --enclave-file=/path/to/application --node-host=<node_ip> --node-port=<node_port>
     --tls-host=<tls_ip> --tls-pubhost=<tls_public_ip> --tls-port=<tls_port> --ledger-file=/path/to/ledger
     --node-cert-file=/path/to/node_certificate --quote-file=/path/to/quote
 

--- a/sphinx/source/start_network.rst
+++ b/sphinx/source/start_network.rst
@@ -10,7 +10,6 @@ To start up a network, operators should start up each node separately by running
 
     $ cchost --enclave-file=/path/to/application --node-address=node_ip:node_port --rpc-address=rpc_ip:rpc_public_ip
     --ledger-file=/path/to/ledger --node-cert-file=/path/to/node_certificate --quote-file=/path/to/quote
-
     2019-08-06 15:04:36.951158        [info ] ../src/host/main.cpp:240             | Starting new node
     2019-08-06 15:04:39.355423        [info ] ../src/host/main.cpp:257             | Created new node
     ...

--- a/sphinx/source/start_network.rst
+++ b/sphinx/source/start_network.rst
@@ -8,7 +8,7 @@ To start up a network, operators should start up each node separately by running
 
 .. code-block:: bash
 
-    $ cchost --enclave-file=/path/to/application --node-address=node_ip:node_port --rpc-address=tls_ip:tls_public_ip
+    $ cchost --enclave-file=/path/to/application --node-address=node_ip:node_port --rpc-address=rpc_ip:rpc_public_ip
     --ledger-file=/path/to/ledger --node-cert-file=/path/to/node_certificate --quote-file=/path/to/quote
 
     2019-08-06 15:04:36.951158        [info ] ../src/host/main.cpp:240             | Starting new node
@@ -29,22 +29,22 @@ Once the initial set of nodes is running, the ``nodes.json`` file specifying the
     $ cat nodes.json
     [
         {
-            "pubhost": "tls_public_ip0",
+            "pubhost": "rpc_public_ip0",
             "cert": [<output node0 cert bytes>],
-            "host": "raft/tls_ip0",
+            "host": "raft/rpc_ip0",
             "quote": [<output quote0 bytes>],
             "status": 0,
             "nodeport": "node_port0",
-            "rpcport": "tls_port0"
+            "rpcport": "rpc_port0"
         },
         {
-            "pubhost": "tls_public_ip1",
+            "pubhost": "rpc_public_ip1",
             "cert": [<output node1 cert bytes>],
-            "host": "tls_ip1",
+            "host": "rpc_ip1",
             "quote": [<output quote1 bytes>],
             "status": 0,
             "nodeport": "node_port1",
-            "rpcport": "tls_port1"
+            "rpcport": "rpc_port1"
         }
     ]
 
@@ -71,7 +71,7 @@ Once the initial nodes are running and the initial state of the network is ready
 
 .. code-block:: bash
 
-    $ client --server-address=node0_ip:node0_tlsport startnetwork --ca=node0_cert_file --req=@startNetwork.json
+    $ client --server-address=node0_ip:node0_rpcport startnetwork --ca=node0_cert_file --req=@startNetwork.json
 
 When executing the ``startNetwork.json`` RPC request, the target node deserialises the genesis transaction and immediately becomes the Raft leader of the new single-node network. Business transactions can then be issued by users and will commit immediately.
 
@@ -82,13 +82,13 @@ Once a network has been started on one node, assuming that this node remains lea
 
 .. code-block:: bash
 
-    $ genesisgenerator joinrpc --network-cert=networkcert.pem --target-address=node0_ip:node0_tlsport --join-json=joinNetwork.json
+    $ genesisgenerator joinrpc --network-cert=networkcert.pem --target-address=node0_ip:node0_rpcport --join-json=joinNetwork.json
 
 Once done, each additional node (here, node 1) can join the existing network by running the following command:
 
 .. code-block:: bash
 
-    $ client --server-address=node1_ip:node1_tlsport --ca=node1_cert_file joinnetwork --req=@joinNetwork.json
+    $ client --server-address=node1_ip:node1_rpcport --ca=node1_cert_file joinnetwork --req=@joinNetwork.json
 
 When executing the ``joinNetwork.json`` RPC, the target node initiates an enclave-to-enclave TLS connection to the network leader to retrieve the network secrets required to decrypt the serialised replicated transactions. Once the join protocol completes, the new node becomes a follower of the Raft network and starts replicating transactions executed by the leader.
 

--- a/sphinx/source/start_network.rst
+++ b/sphinx/source/start_network.rst
@@ -30,7 +30,7 @@ Once the initial set of nodes is running, the ``nodes.json`` file specifying the
         {
             "pubhost": "rpc_public_ip0",
             "cert": [<output node0 cert bytes>],
-            "host": "raft/rpc_ip0",
+            "host": "node/rpc_ip0",
             "quote": [<output quote0 bytes>],
             "status": 0,
             "nodeport": "node_port0",
@@ -39,7 +39,7 @@ Once the initial set of nodes is running, the ``nodes.json`` file specifying the
         {
             "pubhost": "rpc_public_ip1",
             "cert": [<output node1 cert bytes>],
-            "host": "rpc_ip1",
+            "host": "node/rpc_ip1",
             "quote": [<output quote1 bytes>],
             "status": 0,
             "nodeport": "node_port1",

--- a/sphinx/source/start_network.rst
+++ b/sphinx/source/start_network.rst
@@ -31,7 +31,7 @@ Once the initial set of nodes is running, the ``nodes.json`` file specifying the
             "host": "raft/tls_ip0",
             "quote": [<output quote0 bytes>],
             "status": 0,
-            "raftport": "raft_port0",
+            "nodeport": "node_port0",
             "tlsport": "tls_port0"
         },
         {
@@ -40,7 +40,7 @@ Once the initial set of nodes is running, the ``nodes.json`` file specifying the
             "host": "tls_ip1",
             "quote": [<output quote1 bytes>],
             "status": 0,
-            "raftport": "raft_port1",
+            "nodeport": "node_port1",
             "tlsport": "tls_port1"
         }
     ]

--- a/src/clients/client.cpp
+++ b/src/clients/client.cpp
@@ -186,7 +186,7 @@ int main(int argc, char** argv)
   cli::ParsedAddress server_address;
   auto server_addr_opt =
     cli::add_address_option(
-      app, server_address, "--server-address", "Remote server")
+      app, server_address, "--server-address", "Remote node RPC server address")
       ->excludes(nodes_opt);
   app.add_option("--ca", ca_file, "Network CA", true);
 

--- a/src/clients/client.cpp
+++ b/src/clients/client.cpp
@@ -184,7 +184,10 @@ int main(int argc, char** argv)
   std::string ca_file = "networkcert.pem";
 
   cli::ParsedAddress server_address;
-  auto server_addr_opt = cli::add_address_option(app, server_address, "--server-address", "Remote server")->excludes(nodes_opt);
+  auto server_addr_opt =
+    cli::add_address_option(
+      app, server_address, "--server-address", "Remote server")
+      ->excludes(nodes_opt);
   app.add_option("--ca", ca_file, "Network CA", true);
 
   auto start_network = app.add_subcommand("startnetwork", "Start network");

--- a/src/clients/client.cpp
+++ b/src/clients/client.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
+#include "../ds/cli_helper.h"
 #include "../ds/files.h"
 #include "../node/calltypes.h"
 #include "../node/rpc/jsonrpc.h"
@@ -181,9 +182,9 @@ int main(int argc, char** argv)
 
   std::string host, port;
   std::string ca_file = "networkcert.pem";
-  auto host_opt =
-    app.add_option("--host", host, "Remote host")->excludes(nodes_opt);
-  app.add_option("--port", port, "Remote port")->needs(host_opt);
+
+  cli::ParsedAddress server_address;
+  auto server_addr_opt = cli::add_address_option(app, server_address, "--server-address", "Remote server")->excludes(nodes_opt);
   app.add_option("--ca", ca_file, "Network CA", true);
 
   auto start_network = app.add_subcommand("startnetwork", "Start network");
@@ -230,7 +231,7 @@ int main(int argc, char** argv)
   {
     // If host connection has not been set explicitly by options then load from
     // nodes file
-    if (!*host_opt)
+    if (!*server_addr_opt)
     {
       const auto j_nodes = files::slurp_json(nodes_file);
 
@@ -249,7 +250,12 @@ int main(int argc, char** argv)
       const auto& j_node = j_nodes[node_index];
 
       host = j_node["pubhost"];
-      port = j_node["tlsport"];
+      port = j_node["rpcport"];
+    }
+    else
+    {
+      host = server_address.hostname;
+      port = server_address.port;
     }
 
     nlohmann::json response;

--- a/src/clients/logging_client.cpp
+++ b/src/clients/logging_client.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
+#include "ds/cli_helper.h"
 #include "ds/files.h"
 #include "rpc_tls_client.h"
 
@@ -83,8 +84,7 @@ public:
 
 int main(int argc, char** argv)
 {
-  string host;
-  string port;
+  cli::ParsedAddress server_address;
   size_t num_messages = 1;
   size_t msg_id = 42;
   std::string msg_body = "Sample log message, for the purposes of testing";
@@ -96,8 +96,12 @@ int main(int argc, char** argv)
     CLI::App cli_app{"Logging Client"};
     cli_app.require_subcommand(0, 1);
 
-    cli_app.add_option("--host", host);
-    cli_app.add_option("--port", port);
+    cli::add_address_option(
+      cli_app,
+      server_address,
+      "--server-address",
+      "Remote node RPC server address");
+
     cli_app.add_option("--cert", cert_file)
       ->required(true)
       ->check(CLI::ExistingFile);
@@ -130,7 +134,7 @@ int main(int argc, char** argv)
   const auto cert = make_shared<tls::Cert>(
     "users", make_shared<tls::CA>(ca), raw_cert, key_pem, nullb);
 
-  LoggingClient client(host, port, cert);
+  LoggingClient client(server_address.hostname, server_address.port, cert);
 
   if (*multi_command)
   {

--- a/src/clients/memberclient.cpp
+++ b/src/clients/memberclient.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 #include "crypto/hash.h"
+#include "ds/cli_helper.h"
 #include "ds/files.h"
 #include "node/entities.h"
 #include "node/members.h"
@@ -262,10 +263,9 @@ int main(int argc, char** argv)
   CLI::App app{"Member client"};
   app.fallthrough(true);
   app.allow_extras(true);
-  string host = "localhost";
-  app.add_option("--host", host, "Remote host")->required(true);
-  string port = "5678";
-  app.add_option("--port", port, "Remote port")->required(true);
+
+  cli::ParsedAddress server_address;
+  auto server_addr_opt = cli::add_address_option(app, server_address, "--server-address", "Remote server")->required();
 
   string cert_file, privk_file, ca_file;
   app.add_option("--cert", cert_file, "Client certificate")
@@ -385,9 +385,9 @@ int main(int argc, char** argv)
     members_sni, make_shared<tls::CA>(ca), raw_cert, key_pem, nullb);
 
   unique_ptr<RpcTlsClient> tls_connection = force_unsigned ?
-    make_unique<RpcTlsClient>(host, port, members_sni, nullptr, tls_cert) :
+    make_unique<RpcTlsClient>(server_address.hostname, server_address.port, members_sni, nullptr, tls_cert) :
     make_unique<SigRpcTlsClient>(
-      key_pem, host, port, members_sni, nullptr, tls_cert);
+      key_pem, server_address.hostname, server_address.port, members_sni, nullptr, tls_cert);
 
   try
   {

--- a/src/clients/memberclient.cpp
+++ b/src/clients/memberclient.cpp
@@ -267,7 +267,7 @@ int main(int argc, char** argv)
   cli::ParsedAddress server_address;
   auto server_addr_opt =
     cli::add_address_option(
-      app, server_address, "--server-address", "Remote server")
+      app, server_address, "--server-address", "Remote node RPC server address")
       ->required();
 
   string cert_file, privk_file, ca_file;

--- a/src/clients/memberclient.cpp
+++ b/src/clients/memberclient.cpp
@@ -265,7 +265,10 @@ int main(int argc, char** argv)
   app.allow_extras(true);
 
   cli::ParsedAddress server_address;
-  auto server_addr_opt = cli::add_address_option(app, server_address, "--server-address", "Remote server")->required();
+  auto server_addr_opt =
+    cli::add_address_option(
+      app, server_address, "--server-address", "Remote server")
+      ->required();
 
   string cert_file, privk_file, ca_file;
   app.add_option("--cert", cert_file, "Client certificate")
@@ -385,9 +388,19 @@ int main(int argc, char** argv)
     members_sni, make_shared<tls::CA>(ca), raw_cert, key_pem, nullb);
 
   unique_ptr<RpcTlsClient> tls_connection = force_unsigned ?
-    make_unique<RpcTlsClient>(server_address.hostname, server_address.port, members_sni, nullptr, tls_cert) :
+    make_unique<RpcTlsClient>(
+      server_address.hostname,
+      server_address.port,
+      members_sni,
+      nullptr,
+      tls_cert) :
     make_unique<SigRpcTlsClient>(
-      key_pem, server_address.hostname, server_address.port, members_sni, nullptr, tls_cert);
+      key_pem,
+      server_address.hostname,
+      server_address.port,
+      members_sni,
+      nullptr,
+      tls_cert);
 
   try
   {

--- a/src/ds/cli_helper.h
+++ b/src/ds/cli_helper.h
@@ -5,8 +5,6 @@
 
 namespace cli
 {
-  static constexpr auto DEFAULT_ADDR = "0.0.0.0:4567";
-
   struct ParsedAddress
   {
     std::string hostname;
@@ -17,8 +15,7 @@ namespace cli
     CLI::App& app,
     ParsedAddress& parsed,
     const std::string& option_name,
-    const std::string& option_desc,
-    bool defaulted = true)
+    const std::string& option_desc)
   {
     CLI::callback_t fun = [&parsed, option_name](CLI::results_t results) {
       if (results.size() != 1)
@@ -54,11 +51,7 @@ namespace cli
       return true;
     };
 
-    auto* option = app.add_option(option_name, fun, option_desc, defaulted);
-    if (defaulted)
-    {
-      option->default_str(DEFAULT_ADDR);
-    }
+    auto* option = app.add_option(option_name, fun, option_desc, true);
 
     return option;
   }

--- a/src/ds/cli_helper.h
+++ b/src/ds/cli_helper.h
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+
+#include <CLI11/CLI11.hpp>
+
+namespace cli
+{
+  static constexpr auto DEFAULT_ADDR = "0.0.0.0:4567";
+
+  struct ParsedAddress
+  {
+    std::string hostname;
+    std::string port;
+  };
+
+  CLI::Option* add_address_option(
+    CLI::App& app,
+    ParsedAddress& parsed,
+    const std::string& option_name,
+    const std::string& option_desc,
+    bool defaulted = true)
+  {
+    CLI::callback_t fun = [&parsed, option_name](CLI::results_t results) {
+      if (results.size() != 1)
+        throw std::logic_error(
+          "Address for " + option_name + "could not be parsed");
+
+      auto addr = results[0];
+      auto found = addr.find_last_of(":");
+      if (found == std::string::npos)
+        throw std::logic_error(
+          "Address for " + option_name + " is not in format host:port");
+
+      auto hostname = addr.substr(0, found);
+      auto port = addr.substr(found + 1);
+
+      // Check if port is in valid range
+      int port_int;
+      try
+      {
+        port_int = std::stoi(port);
+      }
+      catch (const std::exception& e)
+      {
+        throw std::logic_error("Port for " + option_name + " is not a number");
+      }
+      if (port_int <= 0 || port_int > 65535)
+        throw std::logic_error(
+          "Port number is not in range 1-65535 for " + option_name);
+
+      parsed.hostname = hostname;
+      parsed.port = port;
+
+      return true;
+    };
+
+    auto* option = app.add_option(option_name, fun, option_desc, defaulted);
+    if (defaulted)
+    {
+      option->default_str(DEFAULT_ADDR);
+    }
+
+    return option;
+  }
+
+}

--- a/src/genesisgen/main.cpp
+++ b/src/genesisgen/main.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
+#include "ds/cli_helper.h"
 #include "ds/files.h"
 #include "genesisgen.h"
 #include "luainterp/luainterp.h"
@@ -183,11 +184,9 @@ int main(int argc, char** argv)
     "network",
     true);
 
-  string join_host;
-  join_rpc->add_option("--host", join_host, "Target host")->required();
-
-  string join_port;
-  join_rpc->add_option("--port", join_port, "Target port")->required();
+  cli::ParsedAddress join_target_address;
+  auto server_addr_opt = cli::add_address_option(
+    app, join_target_address, "--target-address", "Target node address");
 
   string join_json = "joinNetwork.json";
   join_rpc->add_option(
@@ -242,7 +241,11 @@ int main(int argc, char** argv)
     GenesisGenerator g;
 
     // For now, the node to contact to join the network is the first one
-    g.create_join_rpc(join_host, join_port, join_json, network_cert);
+    g.create_join_rpc(
+      join_target_address.hostname,
+      join_target_address.port,
+      join_json,
+      network_cert);
   }
 
   cout << "Done." << endl;

--- a/src/genesisgen/main.cpp
+++ b/src/genesisgen/main.cpp
@@ -240,7 +240,6 @@ int main(int argc, char** argv)
     auto network_cert = files::slurp(network_cert_file);
     GenesisGenerator g;
 
-    // For now, the node to contact to join the network is the first one
     g.create_join_rpc(
       join_target_address.hostname,
       join_target_address.port,

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
+#include "ds/cli_helper.h"
 #include "ds/files.h"
 #include "ds/logger.h"
 #include "ds/oversized.h"
@@ -19,7 +20,7 @@
 #include <string>
 #include <thread>
 
-using namespace std;
+using namespace std::string_literals;
 
 ::timespec logger::config::start{0, 0};
 
@@ -88,12 +89,23 @@ int main(int argc, char** argv)
     "Size of the internal ringbuffers, as a power of 2",
     true);
 
-  std::string node_hostname("0.0.0.0");
-  app.add_option(
-    "--node-host", node_hostname, "Node-to-node listening hostname", true);
+  cli::ParsedAddress node_address;
+  cli::add_address_option(
+    app, node_address, "--node-address", "Node-to-node listening address")
+    ->required();
 
-  std::string node_port("4568");
-  app.add_option("--node-port", node_port, "Node-to-node listening port", true);
+  cli::ParsedAddress rpc_address;
+  cli::add_address_option(
+    app, rpc_address, "--rpc-address", "RPC over TLS listening address")
+    ->required();
+
+  cli::ParsedAddress notifications_address;
+  cli::add_address_option(
+    app,
+    notifications_address,
+    "--notify-server-address",
+    "Server address to notify progress to",
+    false);
 
   std::string ledger_file("ccf.ledger");
   app.add_option("--ledger-file", ledger_file, "Ledger file", true);
@@ -114,30 +126,6 @@ int main(int argc, char** argv)
     "--node-cert-file",
     node_cert_file,
     "Path to which the node certificate will be written",
-    true);
-
-  std::string tls_hostname("0.0.0.0");
-  app.add_option("--tls-host", tls_hostname, "TLS listening hostname", true);
-
-  std::string tls_pubhostname("0.0.0.0");
-  app.add_option(
-    "--tls-pubhost", tls_pubhostname, "TLS public listening hostname", true);
-
-  std::string tls_port("4567");
-  app.add_option("--tls-port", tls_port, "TLS listening port", true);
-
-  std::string notify_server_hostname;
-  app.add_option(
-    "--notify-server-host",
-    notify_server_hostname,
-    "Server host to notify progress to",
-    true);
-
-  std::string notify_server_port;
-  app.add_option(
-    "--notify-server-port",
-    notify_server_port,
-    "Server port to notify progress to",
     true);
 
   size_t max_msg_size = 24;
@@ -188,12 +176,12 @@ int main(int argc, char** argv)
   else if (enclave_type == "virtual")
     oe_flags = ENCLAVE_FLAG_VIRTUAL;
   else
-    throw logic_error("invalid enclave type: "s + enclave_type);
+    throw std::logic_error("invalid enclave type: "s + enclave_type);
 
   // log level
   auto host_log_level = logger::config::to_level(log_level.c_str());
   if (!host_log_level)
-    throw logic_error("No such logging level: "s + log_level);
+    throw std::logic_error("No such logging level: "s + log_level);
 
   // set the host log level
   logger::config::level() = host_log_level.value();
@@ -245,13 +233,13 @@ int main(int argc, char** argv)
 
   // Initialise the enclave and create a CCF node in it
   const size_t node_size = 4096;
-  vector<uint8_t> node_cert(node_size);
-  vector<uint8_t> quote(OE_MAX_REPORT_SIZE);
+  std::vector<uint8_t> node_cert(node_size);
+  std::vector<uint8_t> quote(OE_MAX_REPORT_SIZE);
   LOG_INFO_FMT(
     "Starting new node{}", (start == "recover" ? " (recovery)" : ""));
   raft::Config raft_config{
-    chrono::milliseconds(raft_timeout),
-    chrono::milliseconds(raft_election_timeout),
+    std::chrono::milliseconds(raft_timeout),
+    std::chrono::milliseconds(raft_election_timeout),
   };
 
   EnclaveConfig config;
@@ -272,16 +260,16 @@ int main(int argc, char** argv)
   ledger.register_message_handlers(bp.get_dispatcher());
 
   asynchost::NodeConnections node(
-    ledger, writer_factory, node_hostname, node_port);
+    ledger, writer_factory, node_address.hostname, node_address.port);
   node.register_message_handlers(bp.get_dispatcher());
 
   asynchost::NotifyConnections report(
-    notify_server_hostname, notify_server_port);
+    notifications_address.hostname, notifications_address.port);
   report.register_message_handlers(bp.get_dispatcher());
 
   asynchost::RPCConnections rpc(writer_factory);
   rpc.register_message_handlers(bp.get_dispatcher());
-  rpc.listen(0, tls_hostname, tls_port);
+  rpc.listen(0, rpc_address.hostname, rpc_address.port);
 
   // Write the node cert and quote to disk. Actors can use the node cert
   // as a CA on their end of the TLS connection.

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -89,7 +89,8 @@ int main(int argc, char** argv)
     true);
 
   std::string node_hostname("0.0.0.0");
-  app.add_option("--node-host", node_hostname, "Node-to-node listening hostname", true);
+  app.add_option(
+    "--node-host", node_hostname, "Node-to-node listening hostname", true);
 
   std::string node_port("4568");
   app.add_option("--node-port", node_port, "Node-to-node listening port", true);

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -21,6 +21,7 @@
 #include <thread>
 
 using namespace std::string_literals;
+using namespace std::chrono_literals;
 
 ::timespec logger::config::start{0, 0};
 
@@ -198,7 +199,7 @@ int main(int argc, char** argv)
     auto passed = enclave.verify_quote(q, d);
     if (!passed)
     {
-      throw runtime_error("Quote verification failed");
+      throw std::runtime_error("Quote verification failed");
     }
     else
     {

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -92,13 +92,11 @@ int main(int argc, char** argv)
 
   cli::ParsedAddress node_address;
   cli::add_address_option(
-    app, node_address, "--node-address", "Node-to-node listening address")
-    ->required();
+    app, node_address, "--node-address", "Node-to-node listening address");
 
   cli::ParsedAddress rpc_address;
   cli::add_address_option(
-    app, rpc_address, "--rpc-address", "RPC over TLS listening address")
-    ->required();
+    app, rpc_address, "--rpc-address", "RPC over TLS listening address");
 
   cli::ParsedAddress notifications_address;
   cli::add_address_option(

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -103,8 +103,7 @@ int main(int argc, char** argv)
     app,
     notifications_address,
     "--notify-server-address",
-    "Server address to notify progress to",
-    false);
+    "Server address to notify progress to");
 
   std::string ledger_file("ccf.ledger");
   app.add_option("--ledger-file", ledger_file, "Ledger file", true);

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -88,11 +88,11 @@ int main(int argc, char** argv)
     "Size of the internal ringbuffers, as a power of 2",
     true);
 
-  std::string raft_hostname("0.0.0.0");
-  app.add_option("--raft-host", raft_hostname, "Raft listening hostname", true);
+  std::string node_hostname("0.0.0.0");
+  app.add_option("--node-host", node_hostname, "Node-to-node listening hostname", true);
 
-  std::string raft_port("4568");
-  app.add_option("--raft-port", raft_port, "Raft listening port", true);
+  std::string node_port("4568");
+  app.add_option("--node-port", node_port, "Node-to-node listening port", true);
 
   std::string ledger_file("ccf.ledger");
   app.add_option("--ledger-file", ledger_file, "Ledger file", true);
@@ -271,7 +271,7 @@ int main(int argc, char** argv)
   ledger.register_message_handlers(bp.get_dispatcher());
 
   asynchost::NodeConnections node(
-    ledger, writer_factory, raft_hostname, raft_port);
+    ledger, writer_factory, node_hostname, node_port);
   node.register_message_handlers(bp.get_dispatcher());
 
   asynchost::NotifyConnections report(

--- a/src/node/nodes.h
+++ b/src/node/nodes.h
@@ -32,17 +32,17 @@ namespace ccf
   {
     std::string host;
     std::string pubhost;
-    std::string raftport;
+    std::string nodeport;
     std::string tlsport;
     std::vector<uint8_t> cert;
     std::vector<uint8_t> quote;
     NodeStatus status = NodeStatus::PENDING;
 
-    MSGPACK_DEFINE(host, pubhost, raftport, tlsport, cert, quote, status);
+    MSGPACK_DEFINE(host, pubhost, nodeport, tlsport, cert, quote, status);
   };
   DECLARE_JSON_TYPE(NodeInfo);
   DECLARE_JSON_REQUIRED_FIELDS(
-    NodeInfo, host, pubhost, raftport, tlsport, cert, quote, status);
+    NodeInfo, host, pubhost, nodeport, tlsport, cert, quote, status);
 
   using Nodes = Store::Map<NodeId, NodeInfo>;
 }

--- a/src/node/nodes.h
+++ b/src/node/nodes.h
@@ -33,16 +33,16 @@ namespace ccf
     std::string host;
     std::string pubhost;
     std::string nodeport;
-    std::string tlsport;
+    std::string rpcport;
     std::vector<uint8_t> cert;
     std::vector<uint8_t> quote;
     NodeStatus status = NodeStatus::PENDING;
 
-    MSGPACK_DEFINE(host, pubhost, nodeport, tlsport, cert, quote, status);
+    MSGPACK_DEFINE(host, pubhost, nodeport, rpcport, cert, quote, status);
   };
   DECLARE_JSON_TYPE(NodeInfo);
   DECLARE_JSON_REQUIRED_FIELDS(
-    NodeInfo, host, pubhost, nodeport, tlsport, cert, quote, status);
+    NodeInfo, host, pubhost, nodeport, rpcport, cert, quote, status);
 
   using Nodes = Store::Map<NodeId, NodeInfo>;
 }

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -1115,13 +1115,13 @@ namespace ccf
         for (auto& [node_id, ni] : w)
         {
 #ifdef PBFT
-          pbft->add_configuration({node_id, ni.value.host, ni.value.raftport});
+          pbft->add_configuration({node_id, ni.value.host, ni.value.nodeport});
 #endif
           switch (ni.value.status)
           {
             case NodeStatus::PENDING:
             {
-              add_node(node_id, ni.value.host, ni.value.raftport);
+              add_node(node_id, ni.value.host, ni.value.nodeport);
               configure = true;
               break;
             }

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -166,7 +166,7 @@ namespace ccf
             return jsonrpc::error_response(
               ctx.req.seq_no,
               jsonrpc::CCFErrorCodes::TX_NOT_LEADER,
-              info->pubhost + ":" + info->tlsport);
+              info->pubhost + ":" + info->rpcport);
           }
         }
         return jsonrpc::error_response(
@@ -239,7 +239,7 @@ namespace ccf
               GetLeaderInfo::Out out;
               out.leader_id = leader_id;
               out.leader_host = info->pubhost;
-              out.leader_port = info->tlsport;
+              out.leader_port = info->rpcport;
               return jsonrpc::success(out);
             }
           }
@@ -260,7 +260,7 @@ namespace ccf
           nodes_view->foreach([&out](const NodeId& nid, const NodeInfo& ni) {
             if (ni.status == ccf::NodeStatus::TRUSTED)
             {
-              out.nodes.push_back({nid, ni.pubhost, ni.tlsport});
+              out.nodes.push_back({nid, ni.pubhost, ni.rpcport});
             }
             return true;
           });

--- a/src/node/rpc/memberfrontend.h
+++ b/src/node/rpc/memberfrontend.h
@@ -422,7 +422,7 @@ namespace ccf
         nodes_view->foreach([&new_node, &duplicate_node_id](
                               const NodeId& nid, const NodeInfo& ni) {
           if (
-            new_node.tlsport == ni.tlsport && new_node.host == ni.host &&
+            new_node.rpcport == ni.rpcport && new_node.host == ni.host &&
             ni.status != NodeStatus::RETIRED)
           {
             duplicate_node_id = nid;
@@ -437,7 +437,7 @@ namespace ccf
               "A node with the same host {} and port {} already exists (node "
               "id: {})",
               new_node.host,
-              new_node.tlsport,
+              new_node.rpcport,
               duplicate_node_id));
         const auto node_id = get_next_id(
           args.tx.get_view(this->network.values), ValueIds::NEXT_NODE_ID);

--- a/tests/e2e_scenarios.py
+++ b/tests/e2e_scenarios.py
@@ -74,9 +74,9 @@ def run(args):
 
     if args.network_only:
         LOG.info("Keeping network alive with the following nodes:")
-        LOG.info("  Primary = {}:{}".format(primary.pubhost, primary.tls_port))
+        LOG.info("  Primary = {}:{}".format(primary.pubhost, primary.rpc_port))
         for i, f in enumerate(followers):
-            LOG.info("  Follower[{}] = {}:{}".format(i, f.pubhost, f.tls_port))
+            LOG.info("  Follower[{}] = {}:{}".format(i, f.pubhost, f.rpc_port))
 
         input("Press Enter to shutdown...")
 

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -591,11 +591,11 @@ class Node:
 
     def _set_ports(self, probably_free_function):
         if self.tls_port is None:
-            self.raft_port, self.tls_port = infra.net.two_different(
+            self.node_port, self.tls_port = infra.net.two_different(
                 probably_free_function, self.host
             )
         else:
-            self.raft_port = probably_free_function(self.host)
+            self.node_port = probably_free_function(self.host)
 
     def start(
         self,
@@ -626,7 +626,7 @@ class Node:
             str(self.local_node_id),
             self.host,
             self.pubhost,
-            self.raft_port,
+            self.node_port,
             self.tls_port,
             self.remote_impl,
             enclave_type,

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -272,8 +272,7 @@ class Network:
             "./memberclient",
             f"--cert=member{member_id}_cert.pem",
             f"--privk=member{member_id}_privk.pem",
-            f"--host={remote_node.host}",
-            f"--port={remote_node.rpc_port}",
+            f"--server-address={remote_node.host}:{remote_node.rpc_port}",
             "--ca=networkcert.pem",
             *args,
         )

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -493,7 +493,7 @@ class CCFRemote(object):
         self.BIN = infra.path.build_bin_path(self.BIN, enclave_type)
         self.ledger_file = ledger_file
         self.ledger_file_name = (
-            os.path.basename(ledger_file) if ledger_file else f"{local_node_id}"
+            os.path.basename(ledger_file) if ledger_file else f"{local_node_id}.ledger"
         )
 
         cmd = [self.BIN, f"--enclave-file={lib_path}"]

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -455,7 +455,7 @@ class CCFRemote(object):
         host,
         pubhost,
         node_port,
-        tls_port,
+        rpc_port,
         remote_class,
         enclave_type,
         verify_quote,
@@ -481,7 +481,7 @@ class CCFRemote(object):
         self.host = host
         self.pubhost = pubhost
         self.node_port = node_port
-        self.tls_port = tls_port
+        self.rpc_port = rpc_port
         self.pem = "{}.pem".format(local_node_id)
         self.quote = None
         self.node_status = node_status
@@ -517,11 +517,8 @@ class CCFRemote(object):
                 self.BIN,
                 f"--enclave-file={lib_path}",
                 f"--raft-election-timeout-ms={election_timeout}",
-                f"--node-host={host}",
-                f"--node-port={node_port}",
-                f"--tls-host={host}",
-                f"--tls-pubhost={pubhost}",
-                f"--tls-port={tls_port}",
+                f"--node-address={host}:{node_port}",
+                f"--rpc-address={host}:{rpc_port}",
                 f"--ledger-file={self.ledger_file_name}",
                 f"--node-cert-file={self.pem}",
                 f"--enclave-type={enclave_type}",
@@ -547,8 +544,9 @@ class CCFRemote(object):
                         "Notification server host:port configuration is invalid"
                     )
 
-                cmd += [f"--notify-server-host={notify_server_host}"]
-                cmd += [f"--notify-server-port={notify_server_port[0]}"]
+                cmd += [
+                    f"--notify-server-address={notify_server_host}:{notify_server_port[0]}"
+                ]
 
             if self.quote:
                 cmd.append(f"--quote-file={self.quote}")
@@ -598,7 +596,7 @@ class CCFRemote(object):
             "host": self.host,
             "nodeport": str(self.node_port),
             "pubhost": self.pubhost,
-            "tlsport": str(self.tls_port),
+            "rpcport": str(self.rpc_port),
             "cert": infra.path.cert_bytes(self.pem),
             "quote": quote_bytes,
             "status": NodeStatus[self.node_status].value,
@@ -663,13 +661,13 @@ class CCFRemote(object):
 
 @contextmanager
 def ccf_remote(
-    lib_path, local_node_id, host, pubhost, node_port, tls_port, args, remote_class
+    lib_path, local_node_id, host, pubhost, node_port, rpc_port, args, remote_class
 ):
     """
     Context Manager wrapper for CCFRemote
     """
     remote = CCFRemote(
-        lib_path, local_node_id, host, pubhost, node_port, tls_port, args, remote_class
+        lib_path, local_node_id, host, pubhost, node_port, rpc_port, args, remote_class
     )
     try:
         remote.setup()

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -454,7 +454,7 @@ class CCFRemote(object):
         local_node_id,
         host,
         pubhost,
-        raft_port,
+        node_port,
         tls_port,
         remote_class,
         enclave_type,
@@ -480,7 +480,7 @@ class CCFRemote(object):
         self.local_node_id = local_node_id
         self.host = host
         self.pubhost = pubhost
-        self.raft_port = raft_port
+        self.node_port = node_port
         self.tls_port = tls_port
         self.pem = "{}.pem".format(local_node_id)
         self.quote = None
@@ -517,8 +517,8 @@ class CCFRemote(object):
                 self.BIN,
                 f"--enclave-file={lib_path}",
                 f"--raft-election-timeout-ms={election_timeout}",
-                f"--raft-host={host}",
-                f"--raft-port={raft_port}",
+                f"--node-host={host}",
+                f"--node-port={node_port}",
                 f"--tls-host={host}",
                 f"--tls-pubhost={pubhost}",
                 f"--tls-port={tls_port}",
@@ -596,7 +596,7 @@ class CCFRemote(object):
 
         return {
             "host": self.host,
-            "raftport": str(self.raft_port),
+            "nodeport": str(self.node_port),
             "pubhost": self.pubhost,
             "tlsport": str(self.tls_port),
             "cert": infra.path.cert_bytes(self.pem),
@@ -663,13 +663,13 @@ class CCFRemote(object):
 
 @contextmanager
 def ccf_remote(
-    lib_path, local_node_id, host, pubhost, raft_port, tls_port, args, remote_class
+    lib_path, local_node_id, host, pubhost, node_port, tls_port, args, remote_class
 ):
     """
     Context Manager wrapper for CCFRemote
     """
     remote = CCFRemote(
-        lib_path, local_node_id, host, pubhost, raft_port, tls_port, args, remote_class
+        lib_path, local_node_id, host, pubhost, node_port, tls_port, args, remote_class
     )
     try:
         remote.setup()

--- a/tests/infra/remote_client.py
+++ b/tests/infra/remote_client.py
@@ -55,10 +55,9 @@ class CCFRemoteClient(object):
 
         cmd = [
             self.BIN,
-            "--host={}".format(node_host),
-            "--port={}".format(node_port),
-            "--transactions={}".format(iterations),
-            "--config={}".format(os.path.basename(config)),
+            f"--server-address={node_host}:{node_port}",
+            f"--transactions={iterations}",
+            f"--config={os.path.basename(config)}",
         ] + client_command_args
 
         self.remote = remote_class(

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -79,10 +79,9 @@ def configure_remote_client(args, client_id, client_host, node, command_args):
 def run_client(args, primary, command_args):
     command = [
         args.client,
-        "--host={}".format(primary.host),
-        "--port={}".format(primary.rpc_port),
-        "--transactions={}".format(args.iterations),
-        "--config={}".format(args.config),
+        f"--server-address={primary.host}:{primary.port}",
+        f"--transactions={args.iterations}",
+        f"--config={args.config}",
     ]
     command += command_args
 

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -61,7 +61,7 @@ def configure_remote_client(args, client_id, client_host, node, command_args):
             client_host,
             args.client,
             node.host,
-            node.tls_port,
+            node.rpc_port,
             args.workspace,
             args.label,
             args.iterations,
@@ -80,7 +80,7 @@ def run_client(args, primary, command_args):
     command = [
         args.client,
         "--host={}".format(primary.host),
-        "--port={}".format(primary.tls_port),
+        "--port={}".format(primary.rpc_port),
         "--transactions={}".format(args.iterations),
         "--config={}".format(args.config),
     ]

--- a/tests/loggingclient.py
+++ b/tests/loggingclient.py
@@ -21,7 +21,7 @@ def run(args):
         infra.proc.ccall(
             "./logging_client",
             "--host={}".format(primary.host),
-            "--port={}".format(primary.tls_port),
+            "--port={}".format(primary.rpc_port),
             "--ca=networkcert.pem",
             "--cert=user1_cert.pem",
             "--privk=user1_privk.pem",

--- a/tests/loggingclient.py
+++ b/tests/loggingclient.py
@@ -20,8 +20,7 @@ def run(args):
 
         infra.proc.ccall(
             "./logging_client",
-            "--host={}".format(primary.host),
-            "--port={}".format(primary.rpc_port),
+            f"--server-address={primary.host}:{primary.rpc_port}",
             "--ca=networkcert.pem",
             "--cert=user1_cert.pem",
             "--privk=user1_privk.pem",

--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -15,12 +15,12 @@ def run(args):
         primary, followers = network.start_and_join(args)
 
         LOG.info("Network started")
-        LOG.info("Primary node is at {}:{}".format(primary.host, primary.tls_port))
+        LOG.info("Primary node is at {}:{}".format(primary.host, primary.rpc_port))
 
         LOG.info("Started network with the following nodes:")
-        LOG.info("  Primary = {}:{}".format(primary.pubhost, primary.tls_port))
+        LOG.info("  Primary = {}:{}".format(primary.pubhost, primary.rpc_port))
         for i, f in enumerate(followers):
-            LOG.info("  Follower[{}] = {}:{}".format(i, f.pubhost, f.tls_port))
+            LOG.info("  Follower[{}] = {}:{}".format(i, f.pubhost, f.rpc_port))
 
         try:
             while True:


### PR DESCRIPTION
As we now use the node-to-node connections for more than just raft (i.e. PBFT, forwarding), the CLI options and documentation are no longer raft-specific. 