### PR TITLE
Build SGX and non-SGX for every commit on master

### DIFF
--- a/.vsts-ci-no-sgx.yml
+++ b/.vsts-ci-no-sgx.yml
@@ -2,6 +2,7 @@ trigger:
   batch: true
   branches:
     include:
+      - "master"
       - "ci/*"
   paths:
     exclude:
@@ -88,7 +89,7 @@ jobs:
     - script: ../tests/coverage/generate_coverage.sh
       displayName: 'Push coverage'
       workingDirectory: build
-      env: 
+      env:
         CODECOV_TOKEN: $(codecov.token)
 
 - job: SAN
@@ -102,7 +103,7 @@ jobs:
     - checkout: self
       clean: true
       submodules: true
-      
+
     - template: .vsts-ci-templates/build.yml
       parameters:
         cmake_args: '-DTARGET=virtual -DBUILD_SMALLBANK=OFF -DSAN=ON'

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -2,6 +2,7 @@ trigger:
   batch: true
   branches:
     include:
+      - "master"
       - "ci/*"
   paths:
     exclude:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,4 +2,4 @@ paramiko
 msgpack
 loguru
 coincurve
-cimetrics>=0.1.5
+cimetrics>=0.1.6


### PR DESCRIPTION
It seems that our builds (except for the GitHub pages) were not triggered for commits on `master`. I guess there was something manually configured on the old jobs that made it build on `master`? 

This should also be the first PR since the performance tests on `master` have run. Let's see how `cimetrics` display the report below! :point_down: 