### PR TITLE
Remove Spectre mitigations from OE build

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
 - job: ACC_1804_SGX_build
   pool: Ubuntu-1804-DC4s
   container:
-    image: ccfciteam/ccf-ci-18.04-oe-0.6-sgx:latest
+    image: ccfciteam/ccf-ci-18.04-oe-0.6-sgx-no-mitigation:latest
     # --publish-all enables end-to-end tests to communicate over ports
     # --device /dev/sgx:/dev/sgx makes sgx available to the container
     options: --publish-all --device /dev/sgx:/dev/sgx
@@ -67,7 +67,7 @@ jobs:
 - job: ACC_1804_SGX_quick_tests
   pool: Ubuntu-1804-DC4s
   container:
-    image: ccfciteam/ccf-ci-18.04-oe-0.6-sgx:latest
+    image: ccfciteam/ccf-ci-18.04-oe-0.6-sgx-no-mitigation:latest
     # --publish-all enables end-to-end tests to communicate over ports
     # --device /dev/sgx:/dev/sgx makes sgx available to the container
     options: --publish-all --device /dev/sgx:/dev/sgx
@@ -88,7 +88,7 @@ jobs:
 - job: ACC_1804_SGX_e2e_tests_A
   pool: Ubuntu-1804-DC4s
   container:
-    image: ccfciteam/ccf-ci-18.04-oe-0.6-sgx:latest
+    image: ccfciteam/ccf-ci-18.04-oe-0.6-sgx-no-mitigation:latest
     # --publish-all enables end-to-end tests to communicate over ports
     # --device /dev/sgx:/dev/sgx makes sgx available to the container
     options: --publish-all --device /dev/sgx:/dev/sgx
@@ -109,7 +109,7 @@ jobs:
 - job: ACC_1804_SGX_e2e_tests_B
   pool: Ubuntu-1804-DC4s
   container:
-    image: ccfciteam/ccf-ci-18.04-oe-0.6-sgx:latest
+    image: ccfciteam/ccf-ci-18.04-oe-0.6-sgx-no-mitigation:latest
     # --publish-all enables end-to-end tests to communicate over ports
     # --device /dev/sgx:/dev/sgx makes sgx available to the container
     options: --publish-all --device /dev/sgx:/dev/sgx
@@ -130,7 +130,7 @@ jobs:
 - job: ACC_1804_SGX_perf_build
   pool: Ubuntu-1804-DC4s
   container:
-    image: ccfciteam/ccf-ci-18.04-oe-0.6-sgx:latest
+    image: ccfciteam/ccf-ci-18.04-oe-0.6-sgx-no-mitigation:latest
     # --publish-all enables end-to-end tests to communicate over ports
     # --device /dev/sgx:/dev/sgx makes sgx available to the container
     options: --publish-all --device /dev/sgx:/dev/sgx
@@ -148,7 +148,7 @@ jobs:
 - job: ACC_1804_SGX_perf_tests
   pool: Ubuntu-1804-DC4s
   container:
-    image: ccfciteam/ccf-ci-18.04-oe-0.6-sgx:latest
+    image: ccfciteam/ccf-ci-18.04-oe-0.6-sgx-no-mitigation:latest
     # --publish-all enables end-to-end tests to communicate over ports
     # --device /dev/sgx:/dev/sgx makes sgx available to the container
     options: --publish-all --device /dev/sgx:/dev/sgx -v /mnt/build:/__w/

--- a/docker/Dockerfile.nosgx
+++ b/docker/Dockerfile.nosgx
@@ -5,3 +5,5 @@ RUN echo "APT::Acquire::Retries \"5\";" | tee /etc/apt/apt.conf.d/80-retries
 COPY getting_started/setup_vm/ /setup_vm/
 RUN apt update && apt install -y ansible software-properties-common
 RUN cd setup_vm; ansible-playbook -i local_nosgx *.yml
+
+RUN rm -rf /tmp && apt clean

--- a/docker/Dockerfile.nosgx
+++ b/docker/Dockerfile.nosgx
@@ -6,4 +6,4 @@ COPY getting_started/setup_vm/ /setup_vm/
 RUN apt update && apt install -y ansible software-properties-common
 RUN cd setup_vm; ansible-playbook -i local_nosgx *.yml
 
-RUN rm -rf /tmp && apt clean
+RUN rm -rf /tmp/* && apt clean

--- a/docker/Dockerfile.sgx
+++ b/docker/Dockerfile.sgx
@@ -11,3 +11,5 @@ RUN cd setup_vm; ansible-playbook -i local_nodriver *.yml
 
 # Necessary to publish performance data
 RUN apt install azure-cli
+
+RUN rm -rf /tmp && apt clean

--- a/docker/Dockerfile.sgx
+++ b/docker/Dockerfile.sgx
@@ -12,4 +12,4 @@ RUN cd setup_vm; ansible-playbook -i local_nodriver *.yml
 # Necessary to publish performance data
 RUN apt install azure-cli
 
-RUN rm -rf /tmp && apt clean
+RUN rm -rf /tmp/* && apt clean

--- a/getting_started/setup_vm/D-oe.yml
+++ b/getting_started/setup_vm/D-oe.yml
@@ -41,6 +41,20 @@
       path: "{{ workspace }}/openenclave-{{ oe_ver }}/build"
       state: directory
 
+# OpenEnclave turns on the Clang speculative load hardening pass by default.
+# This is good practice for arbitrary enclaved code, as it applies a general
+# mitigation that does not depend on source code annotation. However, being
+# a general mitigation, it also carries about a 30% performance penalty when
+# measured on various CCF benchmarks. To recover this performance, CCF
+# disables the general mitigation and relies on audited code, targeting the
+# specific vulnerable loads.
+
+  - name: Disable Compiler-level Spectre mitigations
+    replace:
+      path: "{{ workspace }}/openenclave-{{ oe_ver }}/cmake/compiler_settings.cmake"
+      regexp: '-mllvm -x86-speculative-load-hardening'
+      replace: ''
+
   - name: Install OpenEnclave dependencies
     shell: |
       scripts/ansible/install-ansible.sh


### PR DESCRIPTION
This had been dropped from the 0.6 upgrade, along with the custom mbedtls build. I've also made a small change to the dockerfiles that should reduce the image size somewhat.