### PR TITLE
Log end of output when nodes crash

### DIFF
--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -14,6 +14,7 @@ import uuid
 import ctypes
 import signal
 import re
+from collections import deque
 
 from loguru import logger as LOG
 
@@ -60,15 +61,22 @@ def log_errors(out_path, err_path):
     error_filter = ["fail", "fatal"]
     try:
         errors = 0
+        tail_lines = deque(maxlen=15)
         with open(out_path, "r") as lines:
             for line in lines:
-                if any(x in line for x in error_filter):
-                    LOG.error("{}: {}".format(out_path, line.rstrip()))
+                stripped_line = line.rstrip()
+                tail_lines.append(stripped_line)
+                if any(x in stripped_line for x in error_filter):
+                    LOG.error("{}: {}".format(out_path, stripped_line))
                     errors += 1
+        if errors:
+            LOG.info("{} errors found, printing end of output for context:", errors)
+            for line in tail_lines:
+                LOG.info(line)
         if errors:
             try:
                 with open(err_path, "r") as lines:
-                    LOG.error("{} contents:".format(err_path))
+                    LOG.error("contents of {}:".format(err_path))
                     LOG.error(lines.read())
             except IOError:
                 LOG.exception("Could not read err output {}".format(err_path))

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -73,7 +73,6 @@ def log_errors(out_path, err_path):
             LOG.info("{} errors found, printing end of output for context:", errors)
             for line in tail_lines:
                 LOG.info(line)
-        if errors:
             try:
                 with open(err_path, "r") as lines:
                     LOG.error("contents of {}:".format(err_path))


### PR DESCRIPTION
This completes #303.

For example, if a node comes under the influence of supernatural forces, we should see something like this:

```
42: 2019-08-19 14:44:23.615 | INFO     | infra.jsonrpc:log_request:216 - [127.45.115.244:53293] #1 getSchema {'method': 'LOG_get'} (node 0 (user))
42: 2019-08-19 14:44:24.725 | INFO     | infra.remote:stop:408 - [127.45.115.244] closing
42: 2019-08-19 14:44:24.732 | ERROR    | infra.remote:log_errors:70 - /data/src/CCF/build/workspace/schema_tests_0/out: 2019-08-19 14:44:23.538558        [fail ] ../src/host/rpcconnections.h:179     | Cannot close id 4: does not exist
42: 2019-08-19 14:44:24.733 | ERROR    | infra.remote:log_errors:70 - /data/src/CCF/build/workspace/schema_tests_0/out: 2019-08-19 14:44:23.625556        [fatal] ../src/host/enclave.h:120            | Failed to call in enclave_run: OE_ENCLAVE_ABORTING
42: 2019-08-19 14:44:24.733 | ERROR    | infra.remote:log_errors:70 - /data/src/CCF/build/workspace/schema_tests_0/out: 2019-08-19 14:44:23.625620        [fail ] ../src/host/main.cpp:294             | Exception in enclave::run: Fatal: [fatal] ../src/host/enclave.h:120            | Failed to call in enclave_run: OE_ENCLAVE_ABORTING
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:73 - 3 errors found, printing end of output for context:
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:75 - 2019-08-19 14:44:23.622166 -0.091 [info ] ../src/node/rpc/frontend.h:307       |  All work and no play
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:75 - 2019-08-19 14:44:23.622168 -0.091 [info ] ../src/node/rpc/frontend.h:307       |  All work and no play
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:75 - 2019-08-19 14:44:23.622170 -0.091 [info ] ../src/node/rpc/frontend.h:307       |  All work and no play
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:75 - 2019-08-19 14:44:23.622172 -0.091 [info ] ../src/node/rpc/frontend.h:307       |    All work and no play
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:75 - 2019-08-19 14:44:23.622174 -0.091 [info ] ../src/node/rpc/frontend.h:307       |   All work and no play
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:75 - 2019-08-19 14:44:23.622175 -0.091 [info ] ../src/node/rpc/frontend.h:307       |   All work and no play
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:75 - 2019-08-19 14:44:23.622177 -0.091 [info ] ../src/node/rpc/frontend.h:307       |   All work and no play
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:75 - 2019-08-19 14:44:23.622179 -0.091 [info ] ../src/node/rpc/frontend.h:307       |  All work and no play
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:75 - 2019-08-19 14:44:23.622181 -0.091 [info ] ../src/node/rpc/frontend.h:307       |  All work and no play
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:75 - 2019-08-19 14:44:23.622183 -0.091 [info ] ../src/node/rpc/frontend.h:307       |        All work and no play
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:75 - 2019-08-19 14:44:23.622185 -0.091 [info ] ../src/node/rpc/frontend.h:307       |  All work and no play
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:75 - 13:44:23:619541 tid(0x7fa9039ff700) (H)[ERROR]:OE_ENCLAVE_ABORTING[../host/sgx/calls.c oe_call_enclave_function_by_table_id:857]
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:75 - 2019-08-19 14:44:23.625556        [fatal] ../srchost/enclave.h:120            | Failed to call in enclave_run: OE_ENCLAVE_ABORTING
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:75 - 2019-08-19 14:44:23.625620        [fail ] ../src/host/main.cpp:294             | Exception in enclave::run: Fatal: [fatal] ../src/host/enclave.h:120            | Failed to call in enclave_run: OE_ENCLAVE_ABORTING
42: 2019-08-19 14:44:24.734 | INFO     | infra.remote:log_errors:75 -
42: 2019-08-19 14:44:24.734 | ERROR    | infra.remote:log_errors:79 - contents of /data/src/CCF/build/workspace/schema_tests_0/err:
42: 2019-08-19 14:44:24.734 | ERROR    | infra.remote:log_errors:80 - terminate called after throwing an instance of 'std::logic_error'
42:   what():  Fatal: [fatal] ../src/host/enclave.h:120            | Failed to call in enclave_run: OE_ENCLAVE_ABORTING42:
42:
42: 2019-08-19 14:44:24.735 | INFO     | infra.remote:stop:408 - [127.97.109.12] closing
42: 2019-08-19 14:44:24.773 | INFO     | infra.ccf:stop_all_nodes:358 - All remotes stopped...
```