### PR TITLE
RPC Client no longer needs to be synchronous

### DIFF
--- a/src/enclave/enclavetypes.h
+++ b/src/enclave/enclavetypes.h
@@ -61,13 +61,6 @@ namespace enclave
     };
     std::optional<struct forwarded> fwd = std::nullopt;
 
-    // Invalid RPCContext
-    RPCContext() :
-      client_session_id(InvalidSessionId),
-      caller_cert(nullb),
-      actor(ccf::ActorsType::unknown)
-    {}
-
     // Constructor used for non-forwarded RPC
     RPCContext(
       size_t client_session_id_,

--- a/src/enclave/rpcclient.h
+++ b/src/enclave/rpcclient.h
@@ -14,22 +14,13 @@ namespace enclave
 
   private:
     HandleDataCallback handle_data_cb;
-    AbstractRPCResponder& rpcresponder;
-
-    // Initiating RPC context in case the result of the callback should be sent
-    // to a client
-    RPCContext rpc_ctx;
 
   public:
     RPCClient(
       size_t session_id,
       ringbuffer::AbstractWriterFactory& writer_factory,
-      std::unique_ptr<tls::Context> ctx,
-      AbstractRPCResponder& rpcresponder_,
-      RPCContext& rpc_ctx_) :
-      FramedTLSEndpoint(session_id, writer_factory, move(ctx)),
-      rpcresponder(rpcresponder_),
-      rpc_ctx(rpc_ctx_)
+      std::unique_ptr<tls::Context> ctx) :
+      FramedTLSEndpoint(session_id, writer_factory, move(ctx))
     {}
 
     void connect(
@@ -45,16 +36,6 @@ namespace enclave
     bool handle_data(const std::vector<uint8_t>& data) override
     {
       auto rc = handle_data_cb(data);
-      // TODO: RPCClient no longer needs to be synchronous with an incoming RPC
-      // if (res)
-      // {
-      //   if (rpcresponder.reply_async(rpc_ctx.client_session_id, res.second))
-      //   {
-      //     LOG_DEBUG_FMT(
-      //       "RPCClient responded to session {}", rpc_ctx.client_session_id);
-      //     return true;
-      //   }
-      // }
 
       close();
       return rc;

--- a/src/enclave/rpcsessions.h
+++ b/src/enclave/rpcsessions.h
@@ -102,8 +102,7 @@ namespace enclave
       sessions.erase(id);
     }
 
-    std::shared_ptr<RPCClient> create_client(
-      RPCContext& rpc_ctx, std::shared_ptr<tls::Cert> cert)
+    std::shared_ptr<RPCClient> create_client(std::shared_ptr<tls::Cert> cert)
     {
       std::lock_guard<SpinLock> guard(lock);
       auto ctx = std::make_unique<tls::Client>(cert);
@@ -111,8 +110,8 @@ namespace enclave
 
       LOG_DEBUG_FMT("Creating a new client session inside the enclave: {}", id);
 
-      auto session = std::make_shared<RPCClient>(
-        id, writer_factory, std::move(ctx), *this, rpc_ctx);
+      auto session =
+        std::make_shared<RPCClient>(id, writer_factory, std::move(ctx));
       sessions.insert(std::make_pair(id, session));
       return session;
     }

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -317,12 +317,8 @@ namespace ccf
       auto join_client_cert = std::make_unique<tls::Cert>(
         Actors::NODES, tls_ca, node_cert, node_kp->private_key_pem(), nullb);
 
-      // TODO: The join protocol no longer needs to be synchronous
-      enclave::RPCContext rpc_ctx;
-
       // Create RPC client and connect to remote node
-      auto join_client =
-        rpcsessions.create_client(rpc_ctx, std::move(join_client_cert));
+      auto join_client = rpcsessions.create_client(std::move(join_client_cert));
 
       join_client->connect(
         args.config.joining.target_host,


### PR DESCRIPTION
https://github.com/microsoft/CCF/pull/318 removed the need for the feature introduced in https://github.com/microsoft/CCF/pull/100 since the join protocol is no longer triggered by an RPC (it happens automatically when a node starts up in `join`).

As such, I have removed this feature from the `RPCClient` class as it is no longer needed/wouldn't be tested anymore. If we need it again at some point in the future, it will be a quick job to introduce it back. 

