### PR TITLE
Fix debug e2e test issue

### DIFF
--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -451,7 +451,7 @@ class Network:
                         and resp.result["term"] == term_leader
                     ):
                         joined_nodes += 1
-            if joined_nodes == self.get_running_nodes():
+            if joined_nodes == len(self.get_running_nodes()):
                 break
             time.sleep(1)
         assert joined_nodes == len(
@@ -696,6 +696,7 @@ class Node:
             if self.perf:
                 self.remote.set_perf()
             self.remote.start()
+        self.remote.get_startup_files()
 
     def stop(self):
         if self.remote:

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -605,6 +605,8 @@ class CCFRemote(object):
 
     def start(self):
         self.remote.start()
+
+    def get_startup_files(self):
         self.remote.get(self.pem)
         if self.start_type in {StartType.new, StartType.recover}:
             self.remote.get("networkcert.pem")


### PR DESCRIPTION
When manually spinning up CCF nodes via our e2e python infra, the files created at node startup (node certificate, network certificate) were only copied over to the local directory for clients to use when using non-debug nodes. This PR fixes the behaviour so that the files are also copied over when manually spinning up debug nodes (i.e. `-d <node_id>`).