### PR TITLE
Fix e2e ePBFT test

### DIFF
--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -1049,13 +1049,10 @@ namespace ccf
                                         kv::Version version,
                                         const Service::State& s,
                                         const Service::Write& w) {
-        if (w.size() > 0)
+        if (w.at(0).value.status == ServiceStatus::OPEN)
         {
-          if (w.at(0).value.status == ServiceStatus::OPEN)
-          {
-            accept_user_connections();
-            LOG_INFO_FMT("Now accepting user transactions");
-          }
+          accept_user_connections();
+          LOG_INFO_FMT("Now accepting user transactions");
         }
       });
 
@@ -1244,6 +1241,11 @@ namespace ccf
     void setup_pbft()
     {
       setup_n2n_channels();
+
+      // Since global hooks are not yet called when running CCF with ePBFT,
+      // opening the network to users is hardcoded here for now. See
+      // https://github.com/microsoft/CCF/issues/373
+      accept_user_connections();
 
       consensus = std::make_shared<PbftConsensusType>(
         n2n_channels,

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -611,10 +611,9 @@ namespace ccf
       if (!rpc.first)
         return {jsonrpc::pack(rpc.second, pack.value()), merkle_root};
 
-      SignedReq signed_request;
-
       // Strip signature
       auto rpc_ = &rpc.second;
+      SignedReq signed_request(rpc.second);
       if (rpc_->find(jsonrpc::SIG) != rpc_->end())
       {
         auto& req = rpc_->at(jsonrpc::REQ);


### PR DESCRIPTION
The changes brought by the light-genesis mean that 1) the user connections are only opened once the service table changes from `OPENING` to `OPEN` are globally committed and 2) we now use the member frontend (requiring signed requests) to open the network. 

We actually do not use global hooks in PBFT yet (see https://github.com/microsoft/CCF/issues/373) so for now, we hard code the opening of the user frontend in `setup_pbft()`. 