### PR TITLE
Use libcurl on the host to send HTTP notifications

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -320,6 +320,8 @@ endfunction()
 include(${CCF_DIR}/cmake/crypto.cmake)
 include(${CCF_DIR}/cmake/secp256k1.cmake)
 
+find_package(CURL REQUIRED)
+
 ## Build PBFT if used as consensus
 if (PBFT)
   message(STATUS "Using PBFT as consensus")
@@ -524,7 +526,7 @@ if(NOT ${TARGET} STREQUAL "virtual")
     ${CMAKE_THREAD_LIBS_INIT}
     ccfcrypto.host
     evercrypt.host
-    curl
+    CURL::libcurl
   )
   enable_quote_code(cchost)
 endif()
@@ -552,7 +554,7 @@ if(${TARGET} STREQUAL "virtual" OR ${TARGET} STREQUAL "all")
     -stdlib=libc++
     ccfcrypto.host
     evercrypt.host
-    curl
+    CURL::libcurl
   )
 endif()
 

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -524,6 +524,7 @@ if(NOT ${TARGET} STREQUAL "virtual")
     ${CMAKE_THREAD_LIBS_INIT}
     ccfcrypto.host
     evercrypt.host
+    curl
   )
   enable_quote_code(cchost)
 endif()
@@ -551,6 +552,7 @@ if(${TARGET} STREQUAL "virtual" OR ${TARGET} STREQUAL "all")
     -stdlib=libc++
     ccfcrypto.host
     evercrypt.host
+    curl
   )
 endif()
 

--- a/getting_started/setup_vm/roles/ccf_dependencies/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_dependencies/vars/common.yml
@@ -11,6 +11,7 @@ debs:
   - expect
   - xsltproc
   - git
+  - curl
 mbedtls_ver: "2.16.2"
 mbedtls_dir: "mbedtls-{{ mbedtls_ver }}"
 mbedtls_src: "{{ mbedtls_dir }}.tar.gz"

--- a/getting_started/setup_vm/roles/ccf_dependencies/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_dependencies/vars/common.yml
@@ -11,7 +11,7 @@ debs:
   - expect
   - xsltproc
   - git
-  - curl
+  - libcurl4-openssl-dev
 mbedtls_ver: "2.16.2"
 mbedtls_dir: "mbedtls-{{ mbedtls_ver }}"
 mbedtls_src: "{{ mbedtls_dir }}.tar.gz"

--- a/sphinx/source/getting_started.rst
+++ b/sphinx/source/getting_started.rst
@@ -145,11 +145,12 @@ Details
 - OpenEnclave_
 - mbedtls_
 - libuv_
+- libcurl_
 
 .. _OpenEnclave: https://github.com/openenclave/openenclave
 .. _mbedtls: https://tls.mbed.org/
 .. _libuv: https://github.com/libuv/libuv
-.. _eEvm: https://github.com/Microsoft/eEVM
+.. _libcurl: https://curl.haxx.se/libcurl/
 
 Building CCF
 -------------

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -352,8 +352,9 @@ int main(int argc, char** argv)
   node.register_message_handlers(bp.get_dispatcher());
 
   asynchost::NotifyConnections report(
-    notifications_address.hostname, notifications_address.port);
-  report.register_message_handlers(bp.get_dispatcher());
+    bp.get_dispatcher(),
+    notifications_address.hostname,
+    notifications_address.port);
 
   asynchost::RPCConnections rpc(writer_factory);
   rpc.register_message_handlers(bp.get_dispatcher());

--- a/src/host/notifyconnections.h
+++ b/src/host/notifyconnections.h
@@ -81,9 +81,10 @@ namespace asynchost
           CURLcode res;
           if (curl)
           {
+            std::string s((char const*)data, size);
             curl_easy_setopt(curl, CURLOPT_URL, "0.0.0.0:4242");
             curl_easy_setopt(curl, CURLOPT_POST, 1L);
-            curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data);
+            curl_easy_setopt(curl, CURLOPT_POSTFIELDS, s.c_str());
 
             res = curl_easy_perform(curl);
             /* Check for errors */

--- a/src/host/notifyconnections.h
+++ b/src/host/notifyconnections.h
@@ -58,6 +58,8 @@ namespace asynchost
         notify_destination = fmt::format("{}:{}", host, service);
 
         multi_handle = curl_multi_init();
+
+        headers = curl_slist_append(headers, "Content-Type: application/json");
       }
 
       register_message_handlers(disp);

--- a/src/host/notifyconnections.h
+++ b/src/host/notifyconnections.h
@@ -5,6 +5,8 @@
 #include "ds/messaging.h"
 #include "tcp.h"
 
+#include <curl/curl.h>
+
 namespace asynchost
 {
   class NotifyConnections
@@ -74,6 +76,24 @@ namespace asynchost
 
           if (is_setup)
             notify_client->write(msg.size(), msg.data());
+
+          CURL* curl = curl_easy_init();
+          CURLcode res;
+          if (curl)
+          {
+            curl_easy_setopt(curl, CURLOPT_URL, "0.0.0.0:4242");
+            curl_easy_setopt(curl, CURLOPT_POST, 1L);
+            curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data);
+
+            res = curl_easy_perform(curl);
+            /* Check for errors */
+            if (res != CURLE_OK)
+              LOG_FAIL_FMT(
+                "curl_easy_perform() failed: {}", curl_easy_strerror(res));
+
+            /* always cleanup */
+            curl_easy_cleanup(curl);
+          }
         });
     }
   };

--- a/src/host/notifyconnections.h
+++ b/src/host/notifyconnections.h
@@ -12,55 +12,14 @@ namespace asynchost
   class NotifyConnections
   {
   private:
-    TCP notify_client;
-    bool is_setup = false;
-
-    class ClientBehaviour : public TCPBehaviour
-    {
-    private:
-      NotifyConnections& parent;
-
-    public:
-      ClientBehaviour(NotifyConnections& parent) : parent(parent) {}
-
-      void on_resolve_failed()
-      {
-        LOG_DEBUG_FMT("notify client resolve failed");
-        reconnect();
-      }
-
-      void on_connect_failed()
-      {
-        LOG_DEBUG_FMT("notify client connect failed");
-        reconnect();
-      }
-
-      void on_disconnect()
-      {
-        LOG_DEBUG_FMT("notify client disconnect");
-        reconnect();
-      }
-
-      void reconnect()
-      {
-        parent.notify_client->reconnect();
-      }
-    };
+    std::string listen_address;
 
   public:
     NotifyConnections(const std::string& host, const std::string& service)
     {
       if (!host.empty())
       {
-        LOG_INFO_FMT(
-          "Notifications client connecting to: {}:{}", host, service);
-
-        notify_client->set_behaviour(std::make_unique<ClientBehaviour>(*this));
-        if (!notify_client->connect(host, service))
-        {
-          LOG_FATAL_FMT("Notifications client failed initial connect");
-        }
-        is_setup = true;
+        listen_address = fmt::format("{}:{}", host, service);
       }
     }
 
@@ -74,26 +33,29 @@ namespace asynchost
           auto [msg] =
             ringbuffer::read_message<AdminMessage::notification>(data, size);
 
-          if (is_setup)
-            notify_client->write(msg.size(), msg.data());
-
           CURL* curl = curl_easy_init();
           CURLcode res;
           if (curl)
           {
             std::string s((char const*)data, size);
-            curl_easy_setopt(curl, CURLOPT_URL, "0.0.0.0:4242");
+            curl_easy_setopt(curl, CURLOPT_URL, listen_address.c_str());
             curl_easy_setopt(curl, CURLOPT_POST, 1L);
             curl_easy_setopt(curl, CURLOPT_POSTFIELDS, s.c_str());
 
             res = curl_easy_perform(curl);
             /* Check for errors */
             if (res != CURLE_OK)
+            {
               LOG_FAIL_FMT(
                 "curl_easy_perform() failed: {}", curl_easy_strerror(res));
+            }
 
             /* always cleanup */
             curl_easy_cleanup(curl);
+          }
+          else
+          {
+            LOG_FAIL_FMT("curl_easy_init failed");
           }
         });
     }

--- a/src/host/notifyconnections.h
+++ b/src/host/notifyconnections.h
@@ -18,13 +18,15 @@ namespace asynchost
 
     std::string notify_destination = {};
 
+    // To ensure we cleanup all open handles, keep track of them locally
+    std::set<CURL*> easy_handles;
+
     void send_notification(const std::vector<uint8_t>& body)
     {
       if (multi_handle)
       {
         CURL* curl = curl_easy_init();
-
-        curl_multi_add_handle(multi_handle, curl);
+        easy_handles.insert(curl);
 
         curl_easy_setopt(curl, CURLOPT_URL, notify_destination.c_str());
         curl_easy_setopt(curl, CURLOPT_POST, 1L);
@@ -32,6 +34,8 @@ namespace asynchost
         curl_easy_setopt(curl, CURLOPT_COPYPOSTFIELDS, body.data());
 
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+
+        curl_multi_add_handle(multi_handle, curl);
       }
     };
 
@@ -41,6 +45,14 @@ namespace asynchost
       const std::string& host,
       const std::string& service)
     {
+      auto init_res = curl_global_init(CURL_GLOBAL_ALL);
+      if (init_res != 0)
+      {
+        LOG_FATAL_FMT(
+          "libcurl global initialisation failed: {}",
+          curl_easy_strerror(init_res));
+      }
+
       if (!host.empty())
       {
         notify_destination = fmt::format("{}:{}", host, service);
@@ -53,8 +65,14 @@ namespace asynchost
 
     ~NotifyConnectionsImpl()
     {
-      // TODO: Remove and cleanup all remaining handles,
+      // TODO: Remove and cleanup all remaining handles
+      for (auto easy_handle : easy_handles)
+      {
+        curl_multi_remove_handle(multi_handle, easy_handle);
+        curl_easy_cleanup(easy_handle);
+      }
       curl_multi_cleanup(multi_handle);
+      easy_handles.clear();
     }
 
     void every()
@@ -62,7 +80,54 @@ namespace asynchost
       int still_running = 0;
       curl_multi_perform(multi_handle, &still_running);
 
-      // TODO: Get info on remaining handles, remove those which are done
+      CURLMsg* message;
+      int pending;
+      while ((message = curl_multi_info_read(multi_handle, &pending)))
+      {
+        switch (message->msg)
+        {
+          case CURLMSG_DONE:
+          {
+            CURL* easy_handle = message->easy_handle;
+
+            long response_code;
+            auto res = curl_easy_getinfo(
+              easy_handle, CURLINFO_RESPONSE_CODE, &response_code);
+            if (res == CURLE_OK)
+            {
+              LOG_DEBUG_FMT(
+                "Notification completed with response code {}", response_code);
+            }
+            else
+            {
+              LOG_FAIL_FMT(
+                "Unable to retrieve response code for completed notification: "
+                "{}",
+                curl_easy_strerror(res));
+            }
+
+            // Cleanup completed handles - NB: message contents are invalidated!
+            auto mres = curl_multi_remove_handle(multi_handle, easy_handle);
+            if (mres != CURLM_OK)
+            {
+              LOG_FAIL_FMT(
+                "Failed to remove curl handle from multi-handle: {}",
+                curl_multi_strerror(mres));
+            }
+
+            curl_easy_cleanup(easy_handle);
+            easy_handles.erase(easy_handle);
+            break;
+          }
+          default:
+          {
+            LOG_FAIL_FMT(
+              "Unhandled case while processing curl info message: {}",
+              message->msg);
+            break;
+          }
+        }
+      }
     }
 
     void register_message_handlers(

--- a/src/host/notifyconnections.h
+++ b/src/host/notifyconnections.h
@@ -58,6 +58,10 @@ namespace asynchost
         notify_destination = fmt::format("{}:{}", host, service);
 
         multi_handle = curl_multi_init();
+        if (multi_handle == nullptr)
+        {
+          LOG_FAIL_FMT("Failed to initialised curl multi handle");
+        }
 
         headers = curl_slist_append(headers, "Content-Type: application/json");
       }
@@ -67,7 +71,6 @@ namespace asynchost
 
     ~NotifyConnectionsImpl()
     {
-      // TODO: Remove and cleanup all remaining handles
       for (auto easy_handle : easy_handles)
       {
         curl_multi_remove_handle(multi_handle, easy_handle);

--- a/src/host/notifyconnections.h
+++ b/src/host/notifyconnections.h
@@ -42,6 +42,11 @@ namespace asynchost
             curl_easy_setopt(curl, CURLOPT_POST, 1L);
             curl_easy_setopt(curl, CURLOPT_POSTFIELDS, s.c_str());
 
+            curl_slist* headers = nullptr;
+            headers =
+              curl_slist_append(headers, "Content-Type: application/json");
+            curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+
             res = curl_easy_perform(curl);
             /* Check for errors */
             if (res != CURLE_OK)

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -30,9 +30,7 @@ def run(args):
             with primary.management_client() as mc:
                 check_commit = infra.ccf.Checker(mc)
                 check = infra.ccf.Checker()
-                # TODO: Notifications are disabled until
-                # https://github.com/microsoft/CCF/issues/272 is implemented
-                # check_notification = infra.ccf.Checker(None, notifications.get_queue())
+                check_notification = infra.ccf.Checker(None, notifications.get_queue())
 
                 msg = "Hello world"
                 msg2 = "Hello there"
@@ -43,11 +41,11 @@ def run(args):
                     check_commit(
                         c.rpc("LOG_record", {"id": 42, "msg": msg}), result=True
                     )
-                    # check_notification(
-                    #     c.rpc("LOG_record", {"id": 43, "msg": msg2}), result=True
-                    # )
+                    check_notification(
+                        c.rpc("LOG_record", {"id": 43, "msg": msg2}), result=True
+                    )
                     check(c.rpc("LOG_get", {"id": 42}), result={"msg": msg})
-                    # check(c.rpc("LOG_get", {"id": 43}), result={"msg": msg2})
+                    check(c.rpc("LOG_get", {"id": 43}), result={"msg": msg2})
 
                 LOG.debug("Write on all backup frontends")
                 with backup.management_client(format="json") as c:


### PR DESCRIPTION
In cchost, when sending notifications, we now send them as individual HTTP POST requests rather than raw over TCP. This uses libcurl. We create a single multi-handle, create individual easy-handles for each request, add those to the multi-handle, and then perform/pump/advance the multi-handle once each uv loop.

There's probably some improvements still to be made here:
- fiddling with `CURLOPT`s to limit the amount of work done in each `curl_multi_perform`
- adding more appropriate headers to the notifications

And relatedly, possible extensions to the notification system:
- app dictating target address, per-notification
- handling HTTP response to our notifications, with retries or informing the app or at least detailed logging

The Python changes to run a simple HTTP server are surprisingly small. Good job Python.

Resolves #272.