### PR TITLE
Pending nodes should not be added to consensus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,8 +297,8 @@ if(BUILD_TESTS)
         )
 
         add_e2e_test(
-          NAME add_node_test
-          PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/addnode.py
+          NAME reconfiguration_test
+          PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/reconfiguration.py
         )
 
         add_e2e_test(

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -1182,15 +1182,17 @@ namespace ccf
           auto configure = false;
           std::unordered_set<NodeId> configuration;
 
-          // TODO(#important,#TR): Only TRUSTED nodes should be sent append
-          // entries, counted in election votes and allowed to establish
-          // node-to-node channels (section III-F).
           for (auto& [node_id, ni] : w)
           {
             switch (ni.value.status)
             {
-              case NodeStatus::TRUSTED:
               case NodeStatus::PENDING:
+              {
+                // Pending nodes are not added to consensus until they are
+                // trusted
+                break;
+              }
+              case NodeStatus::TRUSTED:
               {
                 add_node(node_id, ni.value.host, ni.value.nodeport);
                 configure = true;
@@ -1209,7 +1211,7 @@ namespace ccf
           if (configure)
           {
             s.foreach([&](NodeId node_id, const Nodes::VersionV& v) {
-              if (v.value.status != NodeStatus::RETIRED)
+              if (v.value.status == NodeStatus::TRUSTED)
                 configuration.insert(node_id);
               return true;
             });

--- a/src/node/nodetonode.h
+++ b/src/node/nodetonode.h
@@ -18,7 +18,7 @@ namespace ccf
     std::unique_ptr<ChannelManager> channels;
     std::unique_ptr<ringbuffer::AbstractWriter> to_host;
 
-    void established_channel(NodeId to)
+    void establish_channel(NodeId to)
     {
       // If the channel is not yet established, replace all sent messages with
       // a key exchange message. In the case of raft, this is acceptable since
@@ -56,7 +56,7 @@ namespace ccf
       auto& n2n_channel = channels->get(to);
       if (n2n_channel.get_status() != ChannelStatus::ESTABLISHED)
       {
-        established_channel(to);
+        establish_channel(to);
         return;
       }
 
@@ -87,7 +87,7 @@ namespace ccf
       auto& n2n_channel = channels->get(to);
       if (n2n_channel.get_status() != ChannelStatus::ESTABLISHED)
       {
-        established_channel(to);
+        establish_channel(to);
         return false;
       }
 

--- a/src/node/rpc/memberfrontend.h
+++ b/src/node/rpc/memberfrontend.h
@@ -64,6 +64,7 @@ namespace ccf
              throw std::logic_error(fmt::format("Node {} does not exist", id));
            info->status = NodeStatus::TRUSTED;
            nodes->put(id, *info);
+           LOG_INFO_FMT("Node {} is now {}", id, info->status);
            return true;
          }},
         // retire a node
@@ -97,6 +98,7 @@ namespace ccf
         // this function is called.
         {"accept_recovery",
          [this](Store::Tx& tx, const nlohmann::json& args) {
+           // TODO: Check type of args here
            if (node.is_part_of_public_network())
              return node.finish_recovery(tx, args);
            else

--- a/tests/addnode.py
+++ b/tests/addnode.py
@@ -12,6 +12,14 @@ import time
 from loguru import logger as LOG
 
 
+def check_can_progress(node):
+    with node.management_client() as mc:
+        check_commit = infra.ccf.Checker(mc)
+        with node.user_client() as c:
+            check_commit(c.rpc("LOG_record", {"id": 42, "msg": "Hello"}), result=True)
+
+
+# TODO: Rename this test to reconfiguration
 def run(args):
     hosts = ["localhost", "localhost"]
 
@@ -20,20 +28,24 @@ def run(args):
     ) as network:
         primary, others = network.start_and_join(args)
 
-        LOG.debug("Add a valid node")
+        # Adding as many pending nodes as initial (trusted) nodes should not
+        # change the raft consensus rules (i.e. majority)
+        number_new_nodes = len(hosts)
+        LOG.info(
+            f"Adding {number_new_nodes} pending nodes - consensus rules should not change"
+        )
+
+        for _ in range(number_new_nodes):
+            network.create_and_add_pending_node(args.package, "localhost", args)
+        check_can_progress(primary)
+
+        LOG.info("Add a valid node")
         new_node = network.create_and_trust_node(args.package, "localhost", args, True)
         assert new_node
-
-        with primary.management_client() as mc:
-            check_commit = infra.ccf.Checker(mc)
-
-            with new_node.user_client(format="json") as c:
-                check_commit(
-                    c.rpc("LOG_record", {"id": 42, "msg": "Hello world"}), result=True
-                )
+        check_can_progress(primary)
 
         if args.enclave_type == "debug":
-            LOG.debug("Add an invalid node (unknown code id)")
+            LOG.info("Add an invalid node (unknown code id)")
             assert (
                 network.create_and_trust_node(
                     "libluagenericenc", "localhost", args, True
@@ -43,10 +55,10 @@ def run(args):
         else:
             LOG.warning("Skipping unknown code id test with virtual enclave")
 
-        LOG.debug("Retire node")
+        LOG.info("Retire node")
         network.retire_node(primary, 0)
 
-        LOG.debug("Add a valid node")
+        LOG.info("Add a valid node")
         new_node = network.create_and_trust_node(args.package, "localhost", args)
         assert new_node
 

--- a/tests/e2e_logging_pbft.py
+++ b/tests/e2e_logging_pbft.py
@@ -27,7 +27,9 @@ def run(args):
 
         for i in range(1, 4):
             LOG.info(f"Adding node {i}")
-            assert network.create_and_trust_node(args.package, "localhost", args, False)
+            assert network.create_and_trust_node(
+                args.package, "localhost", args, should_wait=False
+            )
 
         network.add_users(primary, network.initial_users)
         LOG.info("Initial set of users added")

--- a/tests/election.py
+++ b/tests/election.py
@@ -76,7 +76,7 @@ def run(args):
 
             LOG.debug("Waiting for transaction to be committed by all nodes")
             wait_for_index_globally_committed(
-                commit_index, current_term, network.get_running_nodes()
+                commit_index, current_term, network.get_joined_nodes()
             )
 
             LOG.debug("Stopping primary")

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -280,7 +280,7 @@ class Network:
     ):
         exists = False
         for _ in range(timeout):
-            if self.check_node_exists(remote_node, node_id, node_status):
+            if self._check_node_exists(remote_node, node_id, node_status):
                 exists = True
                 break
             time.sleep(1)
@@ -465,7 +465,7 @@ class Network:
             member_id, remote_node, "trust_node", f"--node-id={node_id}"
         )
 
-    def check_node_exists(self, remote_node, node_id, node_status=None):
+    def _check_node_exists(self, remote_node, node_id, node_status=None):
         with remote_node.member_client() as c:
             rep = c.do("read", {"table": "ccf.nodes", "key": node_id})
 
@@ -477,14 +477,14 @@ class Network:
         return True
 
     def trust_node(self, remote_node, node_id):
-        if not self.check_node_exists(remote_node, node_id, NodeStatus.PENDING):
+        if not self._check_node_exists(remote_node, node_id, NodeStatus.PENDING):
             raise ValueError(f"Node {node_id} does not exist in state PENDING")
 
         member_id = 1
         result = self.propose_trust_node(member_id, remote_node, node_id)
         result = self.vote_using_majority(remote_node, result[1]["id"])
 
-        if not self.check_node_exists(remote_node, node_id, NodeStatus.TRUSTED):
+        if not self._check_node_exists(remote_node, node_id, NodeStatus.TRUSTED):
             raise ValueError(f"Node {node_id} does not exist in state TRUSTED")
 
     def propose_add_member(self, member_id, remote_node, new_member_cert):

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -670,12 +670,6 @@ def ccf_remote(
         remote.stop()
 
 
-class NodeStatus(Enum):
-    PENDING = 0
-    TRUSTED = 1
-    RETIRED = 2
-
-
 class StartType(Enum):
     new = 0
     join = 1

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -19,7 +19,6 @@ def check_can_progress(node):
             check_commit(c.rpc("LOG_record", {"id": 42, "msg": "Hello"}), result=True)
 
 
-# TODO: Rename this test to reconfiguration
 def run(args):
     hosts = ["localhost", "localhost"]
 

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -113,16 +113,18 @@ def run(args):
             args.perf_nodes,
             node_offset=(recovery_idx + 1) * len(hosts),
             pdb=args.pdb,
-        ) as network:
-            primary, backups = network.start_in_recovery(args, ledger, sealed_secrets)
+        ) as recovered_network:
+            primary, backups = recovered_network.start_in_recovery(
+                args, ledger, sealed_secrets
+            )
 
             with primary.management_client() as mc:
                 check_commit = infra.ccf.Checker(mc)
                 check = infra.ccf.Checker()
 
-                for node in network.nodes:
+                for node in recovered_network.nodes:
                     wait_for_state(node, b"partOfPublicNetwork")
-                network.wait_for_node_commit_sync()
+                recovered_network.wait_for_node_commit_sync()
                 LOG.success("Public CFTR started")
 
                 LOG.debug(
@@ -135,24 +137,24 @@ def run(args):
                             new_node_ids_offsets, new_node_ids_offsets + len(hosts)
                         ):
                             id = c.request(
-                                "read", {"table": "nodes", "key": new_node_id}
+                                "read", {"table": "ccf.nodes", "key": new_node_id}
                             )
                             assert (
-                                infra.remote.NodeStatus(c.response(id).result["status"])
-                                == infra.remote.NodeStatus.TRUSTED
+                                c.response(id).result["status"].decode()
+                                == infra.ccf.NodeStatus.TRUSTED.name
                             )
 
                 LOG.debug("2/3 members vote to complete the recovery")
-                rc, result = network.propose(
+                rc, result = recovered_network.propose(
                     1, primary, "accept_recovery", f"--sealed-secrets={sealed_secrets}"
                 )
                 assert rc and not result["completed"]
                 proposal_id = result["id"]
 
-                rc, result = network.vote(2, primary, proposal_id, True)
+                rc, result = recovered_network.vote(2, primary, proposal_id, True)
                 assert rc and result
 
-                for node in network.nodes:
+                for node in recovered_network.nodes:
                     wait_for_state(node, b"partOfNetwork")
                 LOG.success("All nodes part of network")
 
@@ -175,17 +177,17 @@ def run(args):
                 old_txs = Txs(args.msgs_per_recovery, recovery_idx)
 
                 for recovery_cnt in range(args.recovery):
-                    check_nodes_have_msgs(network.nodes, old_txs)
+                    check_nodes_have_msgs(recovered_network.nodes, old_txs)
                 LOG.success(
                     "Recovery #{} complete on all nodes".format(recovery_idx + 1)
                 )
-                network.check_for_service(primary)
+                recovered_network.check_for_service(primary)
 
                 new_txs = Txs(args.msgs_per_recovery, recovery_idx + 1)
 
                 rs = log_msgs(primary, new_txs)
                 check_responses(rs, True, check, check_commit)
-                network.wait_for_node_commit_sync()
+                recovered_network.wait_for_node_commit_sync()
                 check_nodes_have_msgs(backups, new_txs)
 
                 ledger = primary.remote.get_ledger()


### PR DESCRIPTION
Pending (i.e. before becoming trusted) nodes used to be added to the consensus. Now, we only add nodes to the consensus' configuration when they are marked as trusted in the KV store (either directly trusted before the network is opened, or via governance after the network has been opened).

To test this new behaviour, I've extended the reconfiguration test (previously called `addnode.py`) to add as many nodes (in pending state) as they are initially. Without this fix, the network would not be able to make progress since pending nodes (half of the total of nodes) would not be able to respond to append entries from the leader (since they do not have network secrets).  

I've also fixed a few bugs in the end-to-end tests that I have commented on inline.