### PR TITLE
Small bank balance as a Read handler

### DIFF
--- a/samples/apps/smallbank/app/smallbank.cpp
+++ b/samples/apps/smallbank/app/smallbank.cpp
@@ -331,7 +331,7 @@ namespace ccfapp
 
       install(Procs::SMALL_BANKING_CREATE, create, Write);
       install(Procs::SMALL_BANKING_CREATE_BATCH, create_batch, Write);
-      install(Procs::SMALL_BANKING_BALANCE, balance, Write);
+      install(Procs::SMALL_BANKING_BALANCE, balance, Read);
       install(Procs::SMALL_BANKING_TRANSACT_SAVINGS, transact_savings, Write);
       install(Procs::SMALL_BANKING_DEPOSIT_CHECKING, deposit_checking, Write);
       install(Procs::SMALL_BANKING_AMALGAMATE, amalgamate, Write);

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -88,6 +88,13 @@ namespace kv
     {
       return false;
     }
+
+    bool replicate(
+      const std::vector<std::tuple<SeqNo, std::vector<uint8_t>, bool>>& entries)
+      override
+    {
+      return false;
+    }
   };
 
   class PrimaryStubConsensus : public StubConsensus

--- a/src/node/clientsignatures.h
+++ b/src/node/clientsignatures.h
@@ -12,10 +12,16 @@ namespace ccf
 {
   struct SignedReq
   {
-    // the encoded json-rpc signed by the clients private key
+    // the signature of the msgpack-encoded json-rpc (via the client's private
+    // key)
     std::vector<uint8_t> sig = {};
     // the encoded json-rpc sent by the client
     std::vector<uint8_t> req = {};
+
+    bool operator==(const SignedReq& other) const
+    {
+      return (sig == other.sig) && (req == other.req);
+    }
 
     MSGPACK_DEFINE(sig, req);
   };

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -499,6 +499,7 @@ namespace ccf
         return jsonrpc::pack(rpc.second, ctx.pack.value());
       }
 
+      update_consensus();
       auto rpc_ = &rpc.second;
       SignedReq signed_request(rpc.second);
       if (rpc_->find(jsonrpc::SIG) != rpc_->end())
@@ -805,7 +806,6 @@ namespace ccf
           method);
       }
 
-      update_consensus();
       update_history();
 
       bool is_primary = (consensus == nullptr) || consensus->is_primary();

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -260,55 +260,6 @@ TEST_CASE("SignedReq to and from json")
   REQUIRE(sr.req.empty());
 }
 
-TEST_CASE("Verify signature on Member Frontend")
-{
-  prepare_callers();
-  TestMemberFrontend frontend(*network.tables, network, node);
-  CallerId caller_id(0);
-  CallerId inval_caller_id(1);
-  Store::Tx tx;
-
-  SUBCASE("with signature")
-  {
-    auto signed_call = create_signed_json();
-    SignedReq signed_request(signed_call);
-    CHECK(frontend.verify_client_signature(
-      member_caller, caller_id, signed_call, signed_request));
-  }
-
-  SUBCASE("signature not verified")
-  {
-    auto signed_call = create_signed_json();
-    SignedReq signed_request(signed_call);
-    CHECK(!frontend.verify_client_signature(
-      invalid_caller, inval_caller_id, signed_call, signed_request));
-  }
-}
-
-TEST_CASE("Verify signature")
-{
-  prepare_callers();
-  TestUserFrontend frontend(*network.tables);
-  CallerId caller_id(0);
-  CallerId inval_caller_id(1);
-
-  SUBCASE("with signature")
-  {
-    auto signed_call = create_signed_json();
-    SignedReq signed_request(signed_call);
-    CHECK(frontend.verify_client_signature(
-      user_caller, caller_id, signed_call, signed_request));
-  }
-
-  SUBCASE("signature not verified")
-  {
-    auto signed_call = create_signed_json();
-    SignedReq signed_request(signed_call);
-    CHECK(!frontend.verify_client_signature(
-      invalid_caller, inval_caller_id, signed_call, signed_request));
-  }
-}
-
 TEST_CASE("get_signed_req")
 {
   prepare_callers();

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -264,18 +264,18 @@ TEST_CASE("Verify signature on Member Frontend")
 
   SUBCASE("with signature")
   {
-    SignedReq signed_request;
     auto signed_call = create_signed_json();
+    SignedReq signed_request(signed_call);
     CHECK(frontend.verify_client_signature(
-      member_caller, caller_id, signed_call, false, signed_request));
+      member_caller, caller_id, signed_call, signed_request));
   }
 
   SUBCASE("signature not verified")
   {
-    SignedReq signed_request;
     auto signed_call = create_signed_json();
+    SignedReq signed_request(signed_call);
     CHECK(!frontend.verify_client_signature(
-      invalid_caller, inval_caller_id, signed_call, false, signed_request));
+      invalid_caller, inval_caller_id, signed_call, signed_request));
   }
 }
 
@@ -288,18 +288,18 @@ TEST_CASE("Verify signature")
 
   SUBCASE("with signature")
   {
-    SignedReq signed_request;
     auto signed_call = create_signed_json();
+    SignedReq signed_request(signed_call);
     CHECK(frontend.verify_client_signature(
-      user_caller, caller_id, signed_call, false, signed_request));
+      user_caller, caller_id, signed_call, signed_request));
   }
 
   SUBCASE("signature not verified")
   {
-    SignedReq signed_request;
     auto signed_call = create_signed_json();
+    SignedReq signed_request(signed_call);
     CHECK(!frontend.verify_client_signature(
-      invalid_caller, inval_caller_id, signed_call, false, signed_request));
+      invalid_caller, inval_caller_id, signed_call, signed_request));
   }
 }
 

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -257,16 +257,23 @@ TEST_CASE("Verify signature on Member Frontend")
 
   SUBCASE("with signature")
   {
+    SignedReq signed_request;
     auto signed_call = create_signed_json();
     CHECK(frontend.verify_client_signature(
-      txs, member_caller, caller_id, signed_call, false));
+      txs, member_caller, caller_id, signed_call, false, signed_request));
   }
 
   SUBCASE("signature not verified")
   {
+    SignedReq signed_request;
     auto signed_call = create_signed_json();
     CHECK(!frontend.verify_client_signature(
-      txs, invalid_caller, inval_caller_id, signed_call, false));
+      txs,
+      invalid_caller,
+      inval_caller_id,
+      signed_call,
+      false,
+      signed_request));
   }
 }
 
@@ -280,16 +287,23 @@ TEST_CASE("Verify signature")
 
   SUBCASE("with signature")
   {
+    SignedReq signed_request;
     auto signed_call = create_signed_json();
     CHECK(frontend.verify_client_signature(
-      txs, user_caller, caller_id, signed_call, false));
+      txs, user_caller, caller_id, signed_call, false, signed_request));
   }
 
   SUBCASE("signature not verified")
   {
+    SignedReq signed_request;
     auto signed_call = create_signed_json();
     CHECK(!frontend.verify_client_signature(
-      txs, invalid_caller, inval_caller_id, signed_call, false));
+      txs,
+      invalid_caller,
+      inval_caller_id,
+      signed_call,
+      false,
+      signed_request));
   }
 }
 

--- a/tests/infra/rates.py
+++ b/tests/infra/rates.py
@@ -7,7 +7,7 @@ from statistics import mean, harmonic_mean, median, pstdev
 
 from loguru import logger as LOG
 
-COMMIT_COUNT_CUTOFF = 10
+COMMIT_COUNT_CUTOFF = 15
 
 
 class TxRates:


### PR DESCRIPTION
Resolves https://github.com/microsoft/CCF/issues/417.

These changes result from switching the `balance` endpoint of our small bank app from `Write` to `Read`:
- The primary (and only the primary) now stores the signed client request.
- For a forwarded command, the primary stores the signed client request without validating it, trusting that the forwarder backup has verified it.

I added the corresponding unit tests in `frontend_test.cpp`. 

Plus some minor changes:
- Moved some functions from `public:` to `private:` in `frontend.h`.
- Added curly braces under if/else statements in `frontend.h`. 
