### PR TITLE
Disable test_TCP_with_delay

### DIFF
--- a/.azure-pipelines-no-sgx.yml
+++ b/.azure-pipelines-no-sgx.yml
@@ -142,6 +142,8 @@ jobs:
       displayName: Ninja
       workingDirectory: build
 
+    # TODO: The -E argument should be removed once this test passes consistently.
+    # Current investigation is in PR #424
     - script: |
         ./tests.sh -VV --timeout 240 --no-compress-output -T Test -E test_TCP_with_delay
       displayName: CTest

--- a/.azure-pipelines-no-sgx.yml
+++ b/.azure-pipelines-no-sgx.yml
@@ -143,9 +143,10 @@ jobs:
       workingDirectory: build
 
     - script: |
-        ./tests.sh -VV --timeout 240 --no-compress-output -T Test
+        ./tests.sh -VV --timeout 240 --no-compress-output -T Test -E test_TCP_with_delay
       displayName: CTest
       workingDirectory: build
+
     - script: 'xsltproc --stringparam suiteName "$(Agent.MachineName) SGX" ../tests/infra/ctest_to_junit.xslt Testing/*/Test.xml > JUnit.xml'
       displayName: XSLT
       workingDirectory: build


### PR DESCRIPTION
This test is still failing unpredictably, so we should disable it in the PR-gating CI until this is resolved.