### PR TITLE
LedgerEnclave in epbft

### DIFF
--- a/ePBFT/src/pbft/bft-simple/test/replica_test.cpp
+++ b/ePBFT/src/pbft/bft-simple/test/replica_test.cpp
@@ -379,28 +379,8 @@ int main(int argc, char** argv)
     0,
     0,
     network,
+    nullptr,
     &message_receive_base);
-
-  if (write_to_ledger)
-  {
-    std::string ledger_name("ledger_");
-    ledger_name.append(std::to_string(port));
-    ledger_name.append(".txt");
-    std::remove(ledger_name.c_str());
-
-    ringbuffer::Circuit eio(2);
-    auto wf = ringbuffer::WriterFactory(eio);
-    auto ledger = new asynchost::Ledger(ledger_name, wf);
-
-    auto append_ledger_entry_cb =
-      [](const uint8_t* data, size_t size, void* ctx) {
-        auto ledger = static_cast<asynchost::Ledger*>(ctx);
-        ledger->write_entry(data, size);
-      };
-
-    message_receive_base->register_append_ledger_entry_cb(
-      append_ledger_entry_cb, ledger);
-  }
 
   Byz_start_replica();
   service_mem = mem + used_bytes;

--- a/ePBFT/src/pbft/libbyz/LedgerReplay.cpp
+++ b/ePBFT/src/pbft/libbyz/LedgerReplay.cpp
@@ -25,7 +25,8 @@ std::vector<std::unique_ptr<Pre_prepare>> LedgerReplay::process_data(
   const std::vector<uint8_t>& data,
   Req_queue& rqueue,
   Big_req_table& brt,
-  LedgerWriter* ledger_writer)
+  LedgerWriter* ledger_writer,
+  Seqno last_executed)
 {
   auto entry_data = data.data();
   auto data_size = data.size();
@@ -34,29 +35,44 @@ std::vector<std::unique_ptr<Pre_prepare>> LedgerReplay::process_data(
 
   while (data_size > 0)
   {
-    serialized::skip(entry_data, data_size, sizeof(uint32_t));
-    // peek at header type
-    auto type = serialized::peek<Ledger_header_type>(entry_data, data_size);
+    auto ret = ledger_writer->record_entry(entry_data, data_size);
+
+    if (!ret.second)
+    {
+      // NB: This will currently never be triggered.
+      // This should only fail if there is malformed data. Truncate
+      // the log and reply false.
+      LOG_FAIL << "record entry failed, truncating to last executed: "
+               << last_executed << std::endl;
+      ledger_writer->truncate(last_executed);
+      return {};
+    }
+
+    const std::vector<uint8_t> ret_vector = ret.first;
+    auto e_data = ret_vector.data();
+    auto e_size = ret_vector.size();
+
+    auto type = serialized::peek<Ledger_header_type>(e_data, e_size);
 
     if (type == Ledger_header_type::Pre_prepare_ledger_header)
     {
       auto header =
-        serialized::overlay<Pre_prepare_ledger_header>(entry_data, data_size);
+        serialized::overlay<Pre_prepare_ledger_header>(e_data, e_size);
       latest_pre_prepare =
-        create_message<Pre_prepare>(entry_data, header.message_size);
-      serialized::skip(entry_data, data_size, header.message_size);
+        create_message<Pre_prepare>(e_data, header.message_size);
+      serialized::skip(e_data, e_size, header.message_size);
       if (latest_pre_prepare->num_big_reqs() > 0)
       {
         for (size_t i = 0; i < latest_pre_prepare->num_big_reqs(); ++i)
         {
           auto header =
             serialized::overlay<Pre_prepare_ledger_large_message_header>(
-              entry_data, data_size);
+              e_data, e_size);
 
           auto req =
-            create_message<Request>(entry_data, header.message_size).release();
+            create_message<Request>(e_data, header.message_size).release();
 
-          serialized::skip(entry_data, data_size, header.message_size);
+          serialized::skip(e_data, e_size, header.message_size);
           if (!(req->size() > Request::big_req_thresh && brt.add_request(req)))
           {
             rqueue.append(req);

--- a/ePBFT/src/pbft/libbyz/LedgerReplay.cpp
+++ b/ePBFT/src/pbft/libbyz/LedgerReplay.cpp
@@ -25,7 +25,7 @@ std::vector<std::unique_ptr<Pre_prepare>> LedgerReplay::process_data(
   const std::vector<uint8_t>& data,
   Req_queue& rqueue,
   Big_req_table& brt,
-  LedgerWriter* ledger_writer,
+  LedgerWriter& ledger_writer,
   Seqno last_executed)
 {
   auto entry_data = data.data();
@@ -35,7 +35,7 @@ std::vector<std::unique_ptr<Pre_prepare>> LedgerReplay::process_data(
 
   while (data_size > 0)
   {
-    auto ret = ledger_writer->record_entry(entry_data, data_size);
+    auto ret = ledger_writer.record_entry(entry_data, data_size);
 
     if (!ret.second)
     {
@@ -47,7 +47,7 @@ std::vector<std::unique_ptr<Pre_prepare>> LedgerReplay::process_data(
       // the log and reply false.
       LOG_FAIL << "record entry failed, truncating to last executed: "
                << last_executed << std::endl;
-      ledger_writer->truncate(last_executed);
+      ledger_writer.truncate(last_executed);
       return {};
     }
 

--- a/ePBFT/src/pbft/libbyz/LedgerReplay.cpp
+++ b/ePBFT/src/pbft/libbyz/LedgerReplay.cpp
@@ -39,6 +39,9 @@ std::vector<std::unique_ptr<Pre_prepare>> LedgerReplay::process_data(
 
     if (!ret.second)
     {
+      PBFT_ASSERT(
+        ret.second,
+        "record entry should successfully record data into the ledger");
       // NB: This will currently never be triggered.
       // This should only fail if there is malformed data. Truncate
       // the log and reply false.
@@ -48,7 +51,7 @@ std::vector<std::unique_ptr<Pre_prepare>> LedgerReplay::process_data(
       return {};
     }
 
-    const std::vector<uint8_t> ret_vector = ret.first;
+    const std::vector<uint8_t>& ret_vector = ret.first;
     auto e_data = ret_vector.data();
     auto e_size = ret_vector.size();
 

--- a/ePBFT/src/pbft/libbyz/LedgerReplay.h
+++ b/ePBFT/src/pbft/libbyz/LedgerReplay.h
@@ -25,7 +25,7 @@ public:
     const std::vector<uint8_t>& data,
     Req_queue& rqueue,
     Big_req_table& brt,
-    LedgerWriter* ledger_writed,
+    LedgerWriter& ledger_writed,
     Seqno last_executed);
   void clear_requests(Req_queue& rqueue, Big_req_table& brt);
 };

--- a/ePBFT/src/pbft/libbyz/LedgerReplay.h
+++ b/ePBFT/src/pbft/libbyz/LedgerReplay.h
@@ -25,6 +25,7 @@ public:
     const std::vector<uint8_t>& data,
     Req_queue& rqueue,
     Big_req_table& brt,
-    LedgerWriter* ledger_writed);
+    LedgerWriter* ledger_writed,
+    Seqno last_executed);
   void clear_requests(Req_queue& rqueue, Big_req_table& brt);
 };

--- a/ePBFT/src/pbft/libbyz/LedgerWriter.h
+++ b/ePBFT/src/pbft/libbyz/LedgerWriter.h
@@ -4,24 +4,22 @@
 
 #include "Prepared_cert.h"
 #include "View_change.h"
+#include "consensus/ledgerenclave.h"
 #include "ledger.h"
 #include "types.h"
 
 class LedgerWriter
 {
-public:
-  typedef void (*append_ledger_entry_cb)(
-    const uint8_t* data, size_t size, void* ctx);
-
 private:
-  // used to register a callback to write to the ledger
-  append_ledger_entry_cb ledger_entry_cb;
-  void* ledger_cb_ctx;
+  std::unique_ptr<consensus::LedgerEnclave> ledger;
 
 public:
-  LedgerWriter(append_ledger_entry_cb ledger_entry_cb_, void* ledger_cb_ctx_);
+  LedgerWriter(std::unique_ptr<consensus::LedgerEnclave> ledger_);
   virtual ~LedgerWriter() = default;
   void write_prepare(const Prepared_cert& prepared_cert, Seqno seqno);
   void write_pre_prepare(Pre_prepare* pp);
   void write_view_change(View_change* vc);
+  std::pair<std::vector<uint8_t>, bool> record_entry(
+    const uint8_t*& data, size_t& size);
+  void truncate(Seqno seqno);
 };

--- a/ePBFT/src/pbft/libbyz/Replica.cpp
+++ b/ePBFT/src/pbft/libbyz/Replica.cpp
@@ -167,7 +167,10 @@ Replica::Replica(
   non_det_choices = 0;
 
   ledger_replay = std::make_unique<LedgerReplay>();
-  ledger_writer = std::make_unique<LedgerWriter>(std::move(ledger));
+  if (ledger)
+  {
+    ledger_writer = std::make_unique<LedgerWriter>(std::move(ledger));
+  }
 }
 
 void Replica::register_exec(ExecCommand e)

--- a/ePBFT/src/pbft/libbyz/Replica.cpp
+++ b/ePBFT/src/pbft/libbyz/Replica.cpp
@@ -273,7 +273,7 @@ bool Replica::apply_ledger_data(const std::vector<uint8_t>& data)
   }
 
   auto executable_pps = ledger_replay->process_data(
-    data, rqueue, brt, ledger_writer.get(), last_executed);
+    data, rqueue, brt, *ledger_writer.get(), last_executed);
 
   for (auto& executable_pp : executable_pps)
   {

--- a/ePBFT/src/pbft/libbyz/Replica.cpp
+++ b/ePBFT/src/pbft/libbyz/Replica.cpp
@@ -70,7 +70,11 @@ void Replica::retransmit(T* m, Time cur, Time tsent, Principal* p)
 }
 
 Replica::Replica(
-  const NodeInfo& node_info, char* mem, size_t nbytes, INetwork* network) :
+  const NodeInfo& node_info,
+  char* mem,
+  size_t nbytes,
+  INetwork* network,
+  std::unique_ptr<consensus::LedgerEnclave> ledger) :
   Node(node_info),
   rqueue(),
   ro_rqueue(),
@@ -161,7 +165,9 @@ Replica::Replica(
 
   exec_command = nullptr;
   non_det_choices = 0;
+
   ledger_replay = std::make_unique<LedgerReplay>();
+  ledger_writer = std::make_unique<LedgerWriter>(std::move(ledger));
 }
 
 void Replica::register_exec(ExecCommand e)
@@ -261,8 +267,8 @@ bool Replica::apply_ledger_data(const std::vector<uint8_t>& data)
     return false;
   }
 
-  auto executable_pps =
-    ledger_replay->process_data(data, rqueue, brt, ledger_writer.get());
+  auto executable_pps = ledger_replay->process_data(
+    data, rqueue, brt, ledger_writer.get(), last_executed);
 
   for (auto& executable_pp : executable_pps)
   {
@@ -278,11 +284,6 @@ bool Replica::apply_ledger_data(const std::vector<uint8_t>& data)
       }
 
       next_pp_seqno = seqno;
-
-      if (ledger_writer)
-      {
-        ledger_writer->write_pre_prepare(executable_pp.get());
-      }
 
       if (seqno > last_prepared)
       {
@@ -304,8 +305,11 @@ bool Replica::apply_ledger_data(const std::vector<uint8_t>& data)
     else
     {
       LOG_DEBUG << "Received entries could not be processed. Received seqno: "
-                << seqno << std::endl;
+                << seqno
+                << ". Truncating ledger to last executed: " << last_executed
+                << std::endl;
       ledger_replay->clear_requests(rqueue, brt);
+      ledger_writer->truncate(last_executed);
       return false;
     }
   }
@@ -1002,12 +1006,6 @@ void Replica::register_reply_handler(reply_handler_cb cb, void* ctx)
 {
   rep_cb = cb;
   rep_cb_ctx = ctx;
-}
-
-void Replica::register_append_ledger_entry_cb(
-  LedgerWriter::append_ledger_entry_cb cb, void* ctx)
-{
-  ledger_writer = std::make_unique<LedgerWriter>(cb, ctx);
 }
 
 void Replica::register_global_commit(global_commit_handler_cb cb, void* ctx)

--- a/ePBFT/src/pbft/libbyz/Replica.cpp
+++ b/ePBFT/src/pbft/libbyz/Replica.cpp
@@ -166,9 +166,9 @@ Replica::Replica(
   exec_command = nullptr;
   non_det_choices = 0;
 
-  ledger_replay = std::make_unique<LedgerReplay>();
   if (ledger)
   {
+    ledger_replay = std::make_unique<LedgerReplay>();
     ledger_writer = std::make_unique<LedgerWriter>(std::move(ledger));
   }
 }
@@ -264,6 +264,8 @@ bool Replica::compare_execution_results(
 
 bool Replica::apply_ledger_data(const std::vector<uint8_t>& data)
 {
+  PBFT_ASSERT(ledger_replay, "ledger_replay should be initialized");
+
   if (data.empty())
   {
     LOG_FAIL << "Received empty entries" << std::endl;

--- a/ePBFT/src/pbft/libbyz/Replica.h
+++ b/ePBFT/src/pbft/libbyz/Replica.h
@@ -56,7 +56,11 @@ class Replica : public Node, public IMessageReceiveBase
 {
 public:
   Replica(
-    const NodeInfo& node_info, char* mem, size_t nbytes, INetwork* network);
+    const NodeInfo& node_info,
+    char* mem,
+    size_t nbytes,
+    INetwork* network,
+    std::unique_ptr<consensus::LedgerEnclave> ledger = nullptr);
   // Requires: "mem" is vm page aligned and nbytes is a multiple of the
   // vm page size.
   // Effects: Create a new server replica using the information in
@@ -116,10 +120,6 @@ public:
 
   void register_reply_handler(reply_handler_cb cb, void* ctx);
   // Effects: Registers a handler that takes reply messages
-
-  void register_append_ledger_entry_cb(
-    LedgerWriter::append_ledger_entry_cb cb, void* ctx);
-  // Effects: Registers a handler that writes to a ledger
 
   void register_global_commit(global_commit_handler_cb cb, void* ctx);
   // Effects:: Registers a handler that is called when a batch is committed

--- a/ePBFT/src/pbft/libbyz/keypair.h
+++ b/ePBFT/src/pbft/libbyz/keypair.h
@@ -128,9 +128,9 @@ public:
    */
   std::vector<uint8_t> sign(unsigned char* d, size_t d_size) const
   {
-    std::vector<uint8_t> sig(max_sig_size);
-    sign(d, d_size, &sig[0]);
-    return std::move(sig);
+    uint8_t sig[max_sig_size];
+    sign(d, d_size, sig);
+    return {sig, sig + signature_size};
   }
 
   /**

--- a/ePBFT/src/pbft/libbyz/keypair.h
+++ b/ePBFT/src/pbft/libbyz/keypair.h
@@ -128,9 +128,9 @@ public:
    */
   std::vector<uint8_t> sign(unsigned char* d, size_t d_size) const
   {
-    uint8_t sig[max_sig_size];
-    sign(d, d_size, sig);
-    return {sig, sig + signature_size};
+    std::vector<uint8_t> sig(max_sig_size);
+    sign(d, d_size, &sig[0]);
+    return std::move(sig);
   }
 
   /**

--- a/ePBFT/src/pbft/libbyz/libbyz.cpp
+++ b/ePBFT/src/pbft/libbyz/libbyz.cpp
@@ -113,10 +113,11 @@ int Byz_init_replica(
   void (*comp_ndet)(Seqno, Byz_buffer*),
   int ndet_max_len,
   INetwork* network,
+  std::unique_ptr<consensus::LedgerEnclave> ledger,
   IMessageReceiveBase** message_receiver)
 {
   // Initialize random number generator
-  replica = new Replica(node_info, mem, size, network);
+  replica = new Replica(node_info, mem, size, network, std::move(ledger));
   node = replica;
 
   if (message_receiver != nullptr)

--- a/ePBFT/src/pbft/libbyz/libbyz.h
+++ b/ePBFT/src/pbft/libbyz/libbyz.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "consensus/ledgerenclave.h"
 #include "nodeinfo.h"
 
 /* Because of FILE parameter */
@@ -99,6 +100,7 @@ int Byz_init_replica(
   void (*comp_ndet)(Seqno, Byz_buffer*),
   int ndet_max_len,
   INetwork* network,
+  std::unique_ptr<consensus::LedgerEnclave> ledger = nullptr,
   IMessageReceiveBase** message_receiver = nullptr);
 /* Requires: "mem" is vm page aligned and "size" is a multiple of the vm page
    size.

--- a/ePBFT/src/pbft/libbyz/receive_message_base.h
+++ b/ePBFT/src/pbft/libbyz/receive_message_base.h
@@ -19,8 +19,6 @@ public:
   typedef void (*global_commit_handler_cb)(int64_t tx_ctx, void* cb_ctx);
   virtual void register_global_commit(
     global_commit_handler_cb cb, void* ctx) = 0;
-  virtual void register_append_ledger_entry_cb(
-    LedgerWriter::append_ledger_entry_cb append_ledger_entry, void* ctx) = 0;
   virtual size_t num_correct_replicas() const = 0;
   virtual size_t f() const = 0;
   virtual void set_f(ccf::NodeId f) = 0;

--- a/ePBFT/src/pbft/libbyz/test/test_ledger_replay.cpp
+++ b/ePBFT/src/pbft/libbyz/test/test_ledger_replay.cpp
@@ -180,6 +180,9 @@ TEST_CASE("Test Ledger Replay")
           }
           break;
           default:
+            INFO(
+              "We should only encounter ledger_append or ledger_truncate "
+              "messages");
             REQUIRE(false);
         }
         ++num_msgs;
@@ -259,6 +262,9 @@ TEST_CASE("Test Ledger Replay")
             break;
           }
           default:
+            INFO(
+              "We should only encounter ledger_append or ledger_truncate "
+              "messages");
             REQUIRE(false);
         }
       });

--- a/src/consensus/pbft/pbft.h
+++ b/src/consensus/pbft/pbft.h
@@ -104,7 +104,6 @@ namespace pbft
     std::unique_ptr<AbstractPbftConfig> pbft_config;
     std::unique_ptr<ClientProxy<kv::TxHistory::RequestID, void>> client_proxy;
     std::shared_ptr<enclave::RPCSessions> rpcsessions;
-    std::unique_ptr<consensus::LedgerEnclave> ledger;
     SeqNo global_commit_seqno;
     std::unique_ptr<pbft::Store> store;
 
@@ -119,13 +118,12 @@ namespace pbft
       std::unique_ptr<pbft::Store> store_,
       std::shared_ptr<ChannelProxy> channels_,
       NodeId id,
-      std::unique_ptr<consensus::LedgerEnclave> ledger_,
+      std::unique_ptr<consensus::LedgerEnclave> ledger,
       std::shared_ptr<enclave::RPCMap> rpc_map,
       std::shared_ptr<enclave::RPCSessions> rpcsessions_) :
       Consensus(id),
       channels(channels_),
       rpcsessions(rpcsessions_),
-      ledger(std::move(ledger_)),
       global_commit_seqno(1),
       store(std::move(store_))
     {


### PR DESCRIPTION
Resolves #458 

- `LedgerWriter` will not register callbacks and a generic ctx pointer to write to the ledger 
- Replica will have the `LedgerEnclave` object passed to it during construction and it will in turn initialize `LedgerWriter` with the `LedgerEnclave` object
- `LedgerReplay` will use `LedgerWriter`'s `LedgerEnclave` to put entries into it's own ledger, same way as Raft does now. The entry will be returned to `LedgerReplay` without the frame. Then we will go on to deserializing the entry into a pre-prepare and executing it
- `test_ledger_replay` doesn't need to write to files anymore
- removed ledger initialization from `replica_test` since we don't check the ledger in e2e tests now