### PR TITLE
Ignore failures when decoding logs

### DIFF
--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -63,7 +63,7 @@ def log_errors(out_path, err_path):
     try:
         errors = 0
         tail_lines = deque(maxlen=10)
-        with open(out_path, "r", errors='replace') as lines:
+        with open(out_path, "r", errors="replace") as lines:
             for line in lines:
                 stripped_line = line.rstrip()
                 tail_lines.append(stripped_line)

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -63,7 +63,7 @@ def log_errors(out_path, err_path):
     try:
         errors = 0
         tail_lines = deque(maxlen=10)
-        with open(out_path, "r", errors='ignore') as lines:
+        with open(out_path, "r", errors='replace') as lines:
             for line in lines:
                 stripped_line = line.rstrip()
                 tail_lines.append(stripped_line)

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -63,7 +63,7 @@ def log_errors(out_path, err_path):
     try:
         errors = 0
         tail_lines = deque(maxlen=10)
-        with open(out_path, "r") as lines:
+        with open(out_path, "r", errors='ignore') as lines:
             for line in lines:
                 stripped_line = line.rstrip()
                 tail_lines.append(stripped_line)


### PR DESCRIPTION
If we run the end-to-end tests with `TRACE` logging level, then OE gives us its `verbose` logs. These include [direct dumps of the CRL data in DER format](https://github.com/openenclave/openenclave/blob/3a25e82565493522eeb8a103354bcf1f5f51ec55/host/sgx/sgxquoteprovider.c#L125) - this is non-printable non-UTF8 binary. When our Python infra scans the output for errors it fails to decode these lines, and previously this raised an exception and crashed the test.

Now we just ignore these decode errors, replacing unparseable bytes with a placeholder character.