### PR TITLE
Fix jsonrpc.py format

### DIFF
--- a/tests/infra/jsonrpc.py
+++ b/tests/infra/jsonrpc.py
@@ -176,7 +176,7 @@ class FramedTLSClient:
         self.conn.sendall(frame)
 
     def _read(self):
-        size, = struct.unpack("<I", self.conn.recv(4))
+        (size,) = struct.unpack("<I", self.conn.recv(4))
         data = self.conn.recv(size)
         while len(data) < size:
             data += self.conn.recv(size - len(data))


### PR DESCRIPTION
Looks like the latest version of `black` (`black-19.10b0`), that has automatically been picked up by the latest `master` build, does not like this.