### PR TITLE
Add current state to advance log

### DIFF
--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -117,7 +117,7 @@ namespace ccf
 
     void advance(T s)
     {
-      LOG_DEBUG_FMT("Advancing to state {} (from {})", this->s.load());
+      LOG_DEBUG_FMT("Advancing to state {} (from {})", s, this->s.load());
       this->s.store(s);
     }
   };


### PR DESCRIPTION
That was somehow missing, meaning that enclave with debug on would not start. 