### PR TITLE
Truncate long filenames in logger

### DIFF
--- a/src/ds/logger.h
+++ b/src/ds/logger.h
@@ -135,14 +135,14 @@ namespace logger
       const std::optional<::timespec>& enclave_ts = std::nullopt) override
     {
       auto file_line = fmt::format("{}:{}", file_name, line_number);
-      auto data = file_line.data();
+      auto file_line_data = file_line.data();
 
       // Truncate to final characters - if too long, advance char*
       constexpr auto max_len = 36u;
 
       const auto len = file_line.size();
       if (len > max_len)
-        data += len - max_len;
+        file_line_data += len - max_len;
 
       if (enclave_ts.has_value())
       {
@@ -155,7 +155,7 @@ namespace logger
           enclave_ts.value().tv_sec,
           enclave_ts.value().tv_nsec / 1000000,
           log_level,
-          file_line,
+          file_line_data,
           msg);
       }
       else
@@ -166,7 +166,7 @@ namespace logger
           "{}        [{:<5}] {:<36} | {}",
           get_timestamp(host_tm, host_ts),
           log_level,
-          file_line,
+          file_line_data,
           msg);
       }
     }


### PR DESCRIPTION
Minor feature that was lost in a previous refactor. Lines up the actual log messages (from the `|`), regardless of the length of the path+linenumber.

Before:

```
2019-11-01T16:39:47.328568Z        [info ] ../src/host/main.cpp:323             | Creating new node: new network (with 3 initial member(s))
2019-11-01T16:39:47.339420Z        [info ] ../src/consensus/pbft/libbyz/Node.cpp:85 |  max faulty (f): 0 num replicas: 1
2019-11-01T16:39:47.339465Z        [info ] ../src/consensus/pbft/libbyz/Node.cpp:127 | Adding principal with id:0
2019-11-01T16:39:47.339490Z        [info ] ../src/consensus/pbft/libbyz/Node.cpp:157 | Added principal with id:0
2019-11-01T16:39:47.339496Z        [info ] ../src/consensus/pbft/libbyz/Node.cpp:101 | My id is 0
```

After:
```
2019-11-01T16:48:57.282875Z        [info ] ../src/host/main.cpp:317             | Creating new node: new network (with 3 initial member(s))
2019-11-01T16:48:58.145720Z -0.731 [info ] rc/consensus/pbft/libbyz/Node.cpp:84 |  max faulty (f): 0 num replicas: 1
2019-11-01T16:48:58.145910Z -0.731 [info ] c/consensus/pbft/libbyz/Node.cpp:117 | Adding principal with id:0
2019-11-01T16:48:58.145940Z -0.731 [info ] c/consensus/pbft/libbyz/Node.cpp:147 | Added principal with id:0
2019-11-01T16:48:58.145980Z -0.731 [info ] c/consensus/pbft/libbyz/Node.cpp:100 | My id is 0
```