### PR TITLE
start_test_network.sh accepts full enclave package path

### DIFF
--- a/sphinx/source/quickstart/index.rst
+++ b/sphinx/source/quickstart/index.rst
@@ -8,7 +8,7 @@ Once this is done, you can quickly spin up a CCF network and start :ref:`issuing
 .. code-block:: bash
 
     $ cd CCF/build
-    $ ../start_test_network.sh libloggingenc.so.signed
+    $ ../start_test_network.sh ./libloggingenc.so.signed
     Setting up Python environment...
     Python environment successfully setup
     [2019-10-29 14:47:41.562] Starting 3 CCF nodes...
@@ -16,7 +16,7 @@ Once this is done, you can quickly spin up a CCF network and start :ref:`issuing
     [2019-10-29 14:48:12.138]   Node [ 0] = 127.177.10.108:37765
     [2019-10-29 14:48:12.138]   Node [ 1] = 127.169.74.37:58343
     [2019-10-29 14:48:12.138]   Node [ 2] = 127.131.108.179:50532
-    [2019-10-29 14:48:12.138] You can now issue business transactions to the libloggingenc application.
+    [2019-10-29 14:48:12.138] You can now issue business transactions to the ./libloggingenc.so.signed application.
     [2019-10-29 14:48:12.138] See https://microsoft.github.io/CCF/users/issue_commands.html for more information.
     [2019-10-29 14:48:12.138] Press Ctrl+C to shutdown the network.
 

--- a/sphinx/source/users/deploy_app.rst
+++ b/sphinx/source/users/deploy_app.rst
@@ -1,5 +1,5 @@
-Deploy an Application
-=====================
+Deploying an Application
+========================
 
 The quickest way to deploy a CCF application is to use the `start_test_network.sh <https://github.com/microsoft/CCF/blob/master/start_test_network.sh>`_ test script, specifying the :ref:`enclave image <Writing CCF Applications>` to run.
 
@@ -10,7 +10,7 @@ For example, deploying the ``libloggingenc`` example application:
 .. code-block:: bash
 
     $ cd CCF/build
-    $ ../start_test_network.sh libloggingenc.so.signed
+    $ ../start_test_network.sh ./libloggingenc.so.signed
     Setting up Python environment...
     Python environment successfully setup
     [2019-10-29 14:47:41.562] Starting 3 CCF nodes...
@@ -18,11 +18,11 @@ For example, deploying the ``libloggingenc`` example application:
     [2019-10-29 14:48:12.138]   Node [ 0] = 127.177.10.108:37765
     [2019-10-29 14:48:12.138]   Node [ 1] = 127.169.74.37:58343
     [2019-10-29 14:48:12.138]   Node [ 2] = 127.131.108.179:50532
-    [2019-10-29 14:48:12.138] You can now issue business transactions to the libloggingenc application.
+    [2019-10-29 14:48:12.138] You can now issue business transactions to the ./libloggingenc.so.signed application.
     [2019-10-29 14:48:12.138] See https://microsoft.github.io/CCF/users/issue_commands.html for more information.
     [2019-10-29 14:48:12.138] Press Ctrl+C to shutdown the network.
 
-.. note:: To use CCF `virtual` mode, the same command can be run with ``TEST_ENCLAVE=virtual`` set as environment variable and the virtual version of the enclave application passed to the script. For example ``$ TEST_ENCLAVE=virtual ../start_test_network.sh libloggingenc.virtual.so``.
+.. note:: To use CCF `virtual` mode, the same command can be run with ``TEST_ENCLAVE=virtual`` set as environment variable and the virtual version of the enclave application passed to the script. For example ``$ TEST_ENCLAVE=virtual ../start_test_network.sh ./libloggingenc.virtual.so``.
 
 The log files (``out`` and ``err``) and ledger (``<node_id>.ledger``) for each CCF node can be found under ``CCF/build/workspace/test_network_<node_id>``.
 

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -368,6 +368,20 @@ class Network:
         for u in users:
             infra.proc.ccall("./keygenerator", "--name={}".format(u)).check_returncode()
 
+    def wait_for_state(self, node, state, timeout=3):
+        for _ in range(timeout):
+            try:
+                with node.node_client(format="json") as c:
+                    id = c.request("getSignedIndex", {})
+                    r = c.response(id).result
+                    if r["state"] == state:
+                        break
+            except ConnectionRefusedError:
+                pass
+            time.sleep(1)
+        else:
+            raise TimeoutError("Timed out waiting for public ledger to be read")
+
     # TODO: The following governance functions should be moved to their own class
     # See https://github.com/microsoft/CCF/issues/364
     def check_for_service(self, node, status=ServiceStatus.OPEN):

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -380,7 +380,9 @@ class Network:
                 pass
             time.sleep(1)
         else:
-            raise TimeoutError("Timed out waiting for public ledger to be read")
+            raise TimeoutError(
+                f"Timed out waiting for public ledger to be read on node {node.node_id}"
+            )
 
     # TODO: The following governance functions should be moved to their own class
     # See https://github.com/microsoft/CCF/issues/364

--- a/tests/infra/path.py
+++ b/tests/infra/path.py
@@ -27,7 +27,7 @@ def build_lib_path(lib_name, enclave_type="debug"):
             raise ValueError(f"Virtual mode requires {VIRTUAL_EXT} enclave image")
         elif enclave_type == "debug" and SIGNED_EXT not in lib_name:
             raise ValueError(f"Real enclave requires {SIGNED_EXT} enclave image")
-        return f"./{lib_name}"
+        return lib_name
     else:
         if enclave_type == "virtual":
             return f"./{lib_name}{VIRTUAL_EXT}"

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -517,7 +517,7 @@ class CCFRemote(object):
 
         cmd = [
             self.BIN,
-            f"--enclave-file={lib_path}",
+            f"--enclave-file=./{os.path.basename(lib_path)}",
             f"--enclave-type={enclave_type}",
             f"--node-address={host}:{node_port}",
             f"--rpc-address={host}:{rpc_port}",


### PR DESCRIPTION
So that you can run, from the `build` directory: `$ ../start_test_network.sh ./libloggingenc.so.signed`.

Also moved `wait_for_state` from `recovery.py` to `ccf.py` as it is a general feature of CCF and not test-specific.