### PR TITLE
Clarify options to cchost

### DIFF
--- a/src/ds/cli_helper.h
+++ b/src/ds/cli_helper.h
@@ -52,6 +52,7 @@ namespace cli
     };
 
     auto* option = app.add_option(option_name, fun, option_desc, true);
+    option->type_name("HOST:PORT");
 
     return option;
   }

--- a/src/ds/cli_helper.h
+++ b/src/ds/cli_helper.h
@@ -7,8 +7,8 @@ namespace cli
 {
   struct ParsedAddress
   {
-    std::string hostname;
-    std::string port;
+    std::string hostname = {};
+    std::string port = {};
   };
 
   CLI::Option* add_address_option(

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -180,7 +180,7 @@ int main(int argc, char** argv)
     ->add_option(
       "--network-cert-file",
       network_cert_file,
-      "Destination path to freshly created network certificate",
+      "Destination path where fresh network certificate will be created",
       true)
     ->check(CLI::NonexistentPath);
 
@@ -199,8 +199,9 @@ int main(int argc, char** argv)
     ->add_option(
       "--member-cert",
       member_cert_files,
-      "Consortium member certificates",
+      "Certificate files of the initial consortium members",
       true)
+    ->check(CLI::ExistingFile)
     ->required();
 
   auto join = app.add_subcommand("join", "Join existing network");

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -51,21 +51,27 @@ int main(int argc, char** argv)
 
   cli::ParsedAddress node_address;
   cli::add_address_option(
-    app, node_address, "--node-address", "Node-to-node listening address")
+    app,
+    node_address,
+    "--node-address",
+    "Address on which to listen for TLS commands coming from other nodes")
     ->required();
 
   cli::ParsedAddress rpc_address;
   cli::add_address_option(
-    app, rpc_address, "--rpc-address", "RPC over TLS listening address")
+    app,
+    rpc_address,
+    "--rpc-address",
+    "Address on which to listen for TLS commands coming from clients")
     ->required();
 
   cli::ParsedAddress public_rpc_address;
-  cli::add_address_option(
+  auto public_rpc_address_option = cli::add_address_option(
     app,
     public_rpc_address,
     "--public-rpc-address",
-    "Public RPC over TLS listening address")
-    ->required();
+    "Address to advertise publicly to clients (defaults to same as "
+    "--rpc-address)");
 
   std::string ledger_file("ccf.ledger");
   app.add_option("--ledger-file", ledger_file, "Ledger file", true);
@@ -231,6 +237,11 @@ int main(int argc, char** argv)
     ->check(CLI::NonexistentPath);
 
   CLI11_PARSE(app, argc, argv);
+
+  if (!(*public_rpc_address_option))
+  {
+    public_rpc_address = rpc_address;
+  }
 
   uint32_t oe_flags = 0;
   if (enclave_type == "debug")


### PR DESCRIPTION
Tweaked the descriptions and behaviour of some options.

#515: Each `--member-certs` arg must be an existing file.

```
$ ./cchost start --help
Start new network
Usage: ./cchost start [OPTIONS]

Options:
  -h,--help                   Print this help message and exit
  --network-cert-file PATH=networkcert.pem
                              Destination path where fresh network certificate will be created
  --gov-script FILE=gov.lua REQUIRED
                              Path to Lua file that defines the contents of the gov_scripts table
  --member-cert FILE=[] ... REQUIRED
                              Certificate files of the initial consortium members
```

#516: The address arguments show a type (`HOST:PORT`). `--public-rpc-address` is not a required argument, if not provided it will default to `--rpc-address`.

```
$ ./cchost --help
ccf
Usage: ./cchost [OPTIONS] SUBCOMMAND

Options:
  -h,--help                   Print this help message and exit
  -e,--enclave-file FILE REQUIRED
                              CCF transaction engine
  -t,--enclave-type TEXT in {debug,virtual} REQUIRED
                              Enclave type
  --node-address HOST:PORT REQUIRED
                              Address on which to listen for TLS commands coming from other nodes
  --rpc-address HOST:PORT REQUIRED
                              Address on which to listen for TLS commands coming from clients
  --public-rpc-address HOST:PORT
                              Address to advertise publicly to clients (defaults to same as --rpc-address)
```