### PR TITLE
ePBFT - smallbank and other things

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,6 +388,10 @@ if(BUILD_TESTS)
   else()
     message(STATUS "Using PBFT as consensus")
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/pbft.cmake)
+
+    if (BUILD_SMALLBANK)
+      include(${CMAKE_CURRENT_SOURCE_DIR}/samples/apps/smallbank/smallbank.cmake)
+    endif()
   endif()
 
   if (EXTENSIVE_TESTS)

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -660,6 +660,12 @@ function(add_perf_test)
     unset(VERIFICATION_ARG)
   endif()
 
+  if(PBFT)
+    set(PBFT_ARG "--pbft")
+  else()
+    unset(PBFT_ARG)
+  endif()
+
   add_test(
     NAME ${PARSED_ARGS_NAME}
     COMMAND ${PYTHON} ${PARSED_ARGS_PYTHON_SCRIPT}
@@ -670,6 +676,7 @@ function(add_perf_test)
       ${PARSED_ARGS_ADDITIONAL_ARGS}
       --write-tx-times
       ${VERIFICATION_ARG}
+      ${PBFT_ARG}
   )
 
   ## Make python test client framework importable

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -607,6 +607,12 @@ function(add_e2e_test)
   )
 
   if (BUILD_END_TO_END_TESTS)
+    if(PBFT)
+      set(PBFT_ARG "--pbft")
+    else()
+      unset(PBFT_ARG)
+    endif()
+
     add_test(
       NAME ${PARSED_ARGS_NAME}
       COMMAND ${PYTHON} ${PARSED_ARGS_PYTHON_SCRIPT}
@@ -614,6 +620,7 @@ function(add_e2e_test)
         --label ${PARSED_ARGS_NAME}
         ${CCF_NETWORK_TEST_ARGS}
         ${PARSED_ARGS_ADDITIONAL_ARGS}
+        ${PBFT_ARG}
     )
 
     ## Make python test client framework importable

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -557,11 +557,18 @@ add_enclave_library_c(http_parser.host "${HTTP_PARSER_SOURCES}")
 set_property(TARGET http_parser.host PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # Common test args for Python scripts starting up CCF networks
+if(PBFT)
+  set(PBFT_ARG "--pbft")
+else()
+  unset(PBFT_ARG)
+endif()
+
 set(CCF_NETWORK_TEST_ARGS
   ${TEST_IGNORE_QUOTE}
   ${TEST_ENCLAVE_TYPE}
   -l ${TEST_HOST_LOGGING_LEVEL}
   -g ${CCF_DIR}/src/runtime_config/gov.lua
+  ${PBFT_ARG}
 )
 
 # Lua generic app
@@ -607,12 +614,6 @@ function(add_e2e_test)
   )
 
   if (BUILD_END_TO_END_TESTS)
-    if(PBFT)
-      set(PBFT_ARG "--pbft")
-    else()
-      unset(PBFT_ARG)
-    endif()
-
     add_test(
       NAME ${PARSED_ARGS_NAME}
       COMMAND ${PYTHON} ${PARSED_ARGS_PYTHON_SCRIPT}
@@ -620,7 +621,6 @@ function(add_e2e_test)
         --label ${PARSED_ARGS_NAME}
         ${CCF_NETWORK_TEST_ARGS}
         ${PARSED_ARGS_ADDITIONAL_ARGS}
-        ${PBFT_ARG}
     )
 
     ## Make python test client framework importable
@@ -667,12 +667,6 @@ function(add_perf_test)
     unset(VERIFICATION_ARG)
   endif()
 
-  if(PBFT)
-    set(PBFT_ARG "--pbft")
-  else()
-    unset(PBFT_ARG)
-  endif()
-
   add_test(
     NAME ${PARSED_ARGS_NAME}
     COMMAND ${PYTHON} ${PARSED_ARGS_PYTHON_SCRIPT}
@@ -683,7 +677,6 @@ function(add_perf_test)
       ${PARSED_ARGS_ADDITIONAL_ARGS}
       --write-tx-times
       ${VERIFICATION_ARG}
-      ${PBFT_ARG}
   )
 
   ## Make python test client framework importable

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -34,33 +34,35 @@ if(BUILD_TESTS)
     set(SMALL_BANK_SIGNED_ITERATIONS 2000)
   endif ()
 
-  add_perf_test(
-    NAME small_bank_sigs_client_test
-    PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/small_bank_client.py
-    CLIENT_BIN ./small_bank_client
-    VERIFICATION_FILE ${SMALL_BANK_SIGNED_VERIFICATION_FILE}
-    ITERATIONS ${SMALL_BANK_SIGNED_ITERATIONS}
-    ADDITIONAL_ARGS
-      --label Small_Bank_Client_Sigs
-      --max-writes-ahead 1000
-      --sign
-      --metrics-file small_bank_sigs_metrics.json
-  )
+  if(NOT PBFT)
+    add_perf_test(
+      NAME small_bank_sigs_client_test
+      PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/small_bank_client.py
+      CLIENT_BIN ./small_bank_client
+      VERIFICATION_FILE ${SMALL_BANK_SIGNED_VERIFICATION_FILE}
+      ITERATIONS ${SMALL_BANK_SIGNED_ITERATIONS}
+      ADDITIONAL_ARGS
+        --label Small_Bank_Client_Sigs
+        --max-writes-ahead 1000
+        --sign
+        --metrics-file small_bank_sigs_metrics.json
+    )
 
-  # It is better to run performance tests with forwarding on different machines
-  # (i.e. nodes and clients)
-  add_perf_test(
-    NAME small_bank_sigs_forwarding
-    PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/small_bank_client.py
-    CLIENT_BIN ./small_bank_client
-    ITERATIONS ${SMALL_BANK_SIGNED_ITERATIONS}
-    ADDITIONAL_ARGS
-      --label Small_Bank_ClientSigs_Forwarding
-      --max-writes-ahead 1000
-      --metrics-file small_bank_fwd_metrics.json
-      -n localhost -n localhost
-      -cn localhost
-      --send-tx-to backups
-      --sign
-  )
+    # It is better to run performance tests with forwarding on different machines
+    # (i.e. nodes and clients)
+    add_perf_test(
+      NAME small_bank_sigs_forwarding
+      PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/small_bank_client.py
+      CLIENT_BIN ./small_bank_client
+      ITERATIONS ${SMALL_BANK_SIGNED_ITERATIONS}
+      ADDITIONAL_ARGS
+        --label Small_Bank_ClientSigs_Forwarding
+        --max-writes-ahead 1000
+        --metrics-file small_bank_fwd_metrics.json
+        -n localhost -n localhost
+        -cn localhost
+        --send-tx-to backups
+        --sign
+    )
+  endif()
 endif()

--- a/src/consensus/pbft/libbyz/Big_req_table.cpp
+++ b/src/consensus/pbft/libbyz/Big_req_table.cpp
@@ -216,6 +216,9 @@ bool Big_req_table::add_unmatched(Request* r, Request*& old_req)
 
   if (centry.num_requests >= Max_unmatched_requests_per_client)
   {
+    LOG_FAIL << "Too many unbuffered requests for client_id:" << r->client_id()
+             << " max_unmatched_requests_per_client:"
+             << Max_unmatched_requests_per_client << std::endl;
     old_req = centry.requests.back();
     centry.requests.pop_back();
   }

--- a/src/consensus/pbft/libbyz/Big_req_table.cpp
+++ b/src/consensus/pbft/libbyz/Big_req_table.cpp
@@ -216,7 +216,8 @@ bool Big_req_table::add_unmatched(Request* r, Request*& old_req)
 
   if (centry.num_requests >= Max_unmatched_requests_per_client)
   {
-    LOG_FAIL << "Too many unbuffered requests for client_id:" << r->client_id() << std::endl;
+    LOG_FAIL << "Too many unbuffered requests for client_id:" << r->client_id()
+             << std::endl;
     old_req = centry.requests.back();
     centry.requests.pop_back();
   }

--- a/src/consensus/pbft/libbyz/Big_req_table.cpp
+++ b/src/consensus/pbft/libbyz/Big_req_table.cpp
@@ -216,9 +216,7 @@ bool Big_req_table::add_unmatched(Request* r, Request*& old_req)
 
   if (centry.num_requests >= Max_unmatched_requests_per_client)
   {
-    LOG_FAIL << "Too many unbuffered requests for client_id:" << r->client_id()
-             << " max_unmatched_requests_per_client:"
-             << Max_unmatched_requests_per_client << std::endl;
+    LOG_FAIL << "Too many unbuffered requests for client_id:" << r->client_id() << std::endl;
     old_req = centry.requests.back();
     centry.requests.pop_back();
   }

--- a/src/consensus/pbft/libbyz/Big_req_table.h
+++ b/src/consensus/pbft/libbyz/Big_req_table.h
@@ -78,7 +78,7 @@ public:
   void dump_state(std::ostream& os);
   // Effects: logs state for debugging
 
-  static const int Max_unmatched_requests_per_client = 1000 * 1000;
+  static const int Max_unmatched_requests_per_client = 1024;
 
 private:
   bool check_pcerts(BR_entry* bre);

--- a/src/consensus/pbft/libbyz/Big_req_table.h
+++ b/src/consensus/pbft/libbyz/Big_req_table.h
@@ -79,6 +79,8 @@ public:
   // Effects: logs state for debugging
 
   static const int Max_unmatched_requests_per_client = 1024;
+  // Effect: The maximum number of requests we will store per client.
+  // This functions as a LRU cache.
 
 private:
   bool check_pcerts(BR_entry* bre);

--- a/src/consensus/pbft/libbyz/Big_req_table.h
+++ b/src/consensus/pbft/libbyz/Big_req_table.h
@@ -78,7 +78,7 @@ public:
   void dump_state(std::ostream& os);
   // Effects: logs state for debugging
 
-  static const int Max_unmatched_requests_per_client = 10 * 1000;
+  static const int Max_unmatched_requests_per_client = 1000 * 1000;
 
 private:
   bool check_pcerts(BR_entry* bre);

--- a/src/consensus/pbft/libbyz/Big_req_table.h
+++ b/src/consensus/pbft/libbyz/Big_req_table.h
@@ -78,7 +78,7 @@ public:
   void dump_state(std::ostream& os);
   // Effects: logs state for debugging
 
-  static const int Max_unmatched_requests_per_client = 8;
+  static const int Max_unmatched_requests_per_client = 10 * 1000;
 
 private:
   bool check_pcerts(BR_entry* bre);

--- a/src/consensus/pbft/libbyz/Client_proxy.h
+++ b/src/consensus/pbft/libbyz/Client_proxy.h
@@ -146,9 +146,9 @@ bool ClientProxy<T, C>::send_request(
   bool is_read_only)
 {
   if (out_reqs.size() >= Max_outstanding)
-  {	
+  {
     LOG_FAIL << "Too many outstanding requests, rejecting!" << std::endl;
-    return false;	
+    return false;
   }
 
   Request_id rid = request_id_generator.next_rid();

--- a/src/consensus/pbft/libbyz/Client_proxy.h
+++ b/src/consensus/pbft/libbyz/Client_proxy.h
@@ -88,7 +88,7 @@ private:
     RequestContext* prev;
   };
   std::unordered_map<Request_id, std::unique_ptr<RequestContext>> out_reqs;
-  static const int Max_outstanding = 128;
+  static const int Max_outstanding = 1024;
 
   // list of outstanding requests used for retransmissions
   // (we only retransmit the request at the head of the queue)
@@ -145,10 +145,6 @@ bool ClientProxy<T, C>::send_request(
   C* owner,
   bool is_read_only)
 {
-  if (out_reqs.size() >= Max_outstanding)
-  {
-    return false;
-  }
 
   Request_id rid = request_id_generator.next_rid();
   auto req = std::make_unique<Request>(rid);

--- a/src/consensus/pbft/libbyz/Client_proxy.h
+++ b/src/consensus/pbft/libbyz/Client_proxy.h
@@ -88,7 +88,7 @@ private:
     RequestContext* prev;
   };
   std::unordered_map<Request_id, std::unique_ptr<RequestContext>> out_reqs;
-  static const int Max_outstanding = 1024;
+  static const int Max_outstanding = 1000 * 100;
 
   // list of outstanding requests used for retransmissions
   // (we only retransmit the request at the head of the queue)
@@ -145,6 +145,11 @@ bool ClientProxy<T, C>::send_request(
   C* owner,
   bool is_read_only)
 {
+  if (out_reqs.size() >= Max_outstanding)
+  {	
+    LOG_FAIL << "Too many outstanding requests, rejecting!" << std::endl;
+    return false;	
+  }
 
   Request_id rid = request_id_generator.next_rid();
   auto req = std::make_unique<Request>(rid);

--- a/src/consensus/pbft/libbyz/Log_allocator.h
+++ b/src/consensus/pbft/libbyz/Log_allocator.h
@@ -34,7 +34,7 @@
 #  define DEBUG_ALLOC 1
 #endif
 
-//#define USE_STD_MALLOC
+#define USE_STD_MALLOC
 
 class Log_allocator
 {

--- a/src/consensus/pbft/libbyz/Message.cpp
+++ b/src/consensus/pbft/libbyz/Message.cpp
@@ -93,7 +93,8 @@ void Message::trim()
 void Message::set_size(int size)
 {
   PBFT_ASSERT(msg && ALIGNED(msg), "Invalid state");
-  if (!(max_size < 0 || ALIGNED_SIZE(size) <= max_size)){
+  if (!(max_size < 0 || ALIGNED_SIZE(size) <= max_size))
+  {
     LOG_INFO << "Error - size:" << size
              << ", aligned_size:" << ALIGNED_SIZE(size)
              << ", max_size:" << max_size << std::endl;

--- a/src/consensus/pbft/libbyz/Message.cpp
+++ b/src/consensus/pbft/libbyz/Message.cpp
@@ -93,6 +93,11 @@ void Message::trim()
 void Message::set_size(int size)
 {
   PBFT_ASSERT(msg && ALIGNED(msg), "Invalid state");
+  if (!(max_size < 0 || ALIGNED_SIZE(size) <= max_size)){
+    LOG_INFO << "Error - size:" << size
+             << ", aligned_size:" << ALIGNED_SIZE(size)
+             << ", max_size:" << max_size << std::endl;
+  }
   PBFT_ASSERT(max_size < 0 || ALIGNED_SIZE(size) <= max_size, "Invalid state");
   int aligned = ALIGNED_SIZE(size);
   for (int i = size; i < aligned; i++)

--- a/src/consensus/pbft/libbyz/Pre_prepare.cpp
+++ b/src/consensus/pbft/libbyz/Pre_prepare.cpp
@@ -110,6 +110,8 @@ Pre_prepare::Pre_prepare(
   INCR_CNT(sum_batch_size, requests_in_batch);
   INCR_OP(batch_size_histogram[requests_in_batch]);
 
+  LOG_TRACE << "request in batch:" << requests_in_batch << std::endl;
+
   // Compute authenticator and update size.
   int old_size = sizeof(Pre_prepare_rep) + rep().rset_size +
     rep().n_big_reqs * sizeof(Digest) + rep().non_det_size;

--- a/src/consensus/pbft/libbyz/Replica.cpp
+++ b/src/consensus/pbft/libbyz/Replica.cpp
@@ -1916,10 +1916,11 @@ bool Replica::execute_tentative(Pre_prepare* pp, ByzInfo& info)
       // Finish constructing the reply.
       LOG_DEBUG << "Executed from tentative exec: " << pp->seqno()
                 << " from client: " << client_id
-                << " rid: " << request.request_id() << " commit_id: " << info.ctx
-                << std::endl;
+                << " rid: " << request.request_id()
+                << " commit_id: " << info.ctx << std::endl;
 
-      if (info.ctx > max_local_commit_value) {
+      if (info.ctx > max_local_commit_value)
+      {
         max_local_commit_value = info.ctx;
       }
 
@@ -1932,8 +1933,8 @@ bool Replica::execute_tentative(Pre_prepare* pp, ByzInfo& info)
 #endif
     }
     LOG_DEBUG << "Executed from tentative exec: " << pp->seqno()
-             << " rid: " << request.request_id() << " commit_id: " << info.ctx
-             << std::endl;
+              << " rid: " << request.request_id() << " commit_id: " << info.ctx
+              << std::endl;
 
     if (last_tentative_execute % checkpoint_interval == 0)
     {

--- a/src/consensus/pbft/libbyz/Replica.cpp
+++ b/src/consensus/pbft/libbyz/Replica.cpp
@@ -1836,6 +1836,7 @@ void Replica::execute_prepared(bool committed)
 
     if (global_commit_cb != nullptr)
     {
+      LOG_TRACE << "Global_commit:" << pp->get_ctx() << std::endl;
       global_commit_cb(pp->get_ctx(), global_commit_ctx);
     }
   }
@@ -1857,6 +1858,7 @@ bool Replica::execute_tentative(Pre_prepare* pp, ByzInfo& info)
     // each of them.
     Pre_prepare::Requests_iter iter(pp);
     Request request;
+    int64_t max_local_commit_value = INT64_MIN;
 
     while (iter.get(request))
     {
@@ -1914,9 +1916,14 @@ bool Replica::execute_tentative(Pre_prepare* pp, ByzInfo& info)
       // Finish constructing the reply.
       LOG_DEBUG << "Executed from tentative exec: " << pp->seqno()
                 << " from client: " << client_id
-                << " rid: " << request.request_id() << " ctx: " << info.ctx
+                << " rid: " << request.request_id() << " commit_id: " << info.ctx
                 << std::endl;
 
+      if (info.ctx > max_local_commit_value) {
+        max_local_commit_value = info.ctx;
+      }
+
+      info.ctx = max_local_commit_value;
 #ifdef ENFORCE_EXACTLY_ONCE
       replies.end_reply(client_id, request.request_id(), outb.size);
 #else
@@ -1924,6 +1931,9 @@ bool Replica::execute_tentative(Pre_prepare* pp, ByzInfo& info)
         client_id, request.request_id(), last_tentative_execute, outb.size);
 #endif
     }
+    LOG_DEBUG << "Executed from tentative exec: " << pp->seqno()
+             << " rid: " << request.request_id() << " commit_id: " << info.ctx
+             << std::endl;
 
     if (last_tentative_execute % checkpoint_interval == 0)
     {

--- a/src/consensus/pbft/libbyz/test/replica_test.cpp
+++ b/src/consensus/pbft/libbyz/test/replica_test.cpp
@@ -128,7 +128,8 @@ void setup_client_proxy()
   auto req_timer_cb = [](void* ctx) {
     auto cp = (ClientProxy<uint64_t, void>*)ctx;
 
-    while (request_count - reply_count < 7)
+    static const uint32_t max_pending_requests = 7;
+    while (request_count - reply_count < max_pending_requests)
     {
       uint8_t request_buffer[8];
       auto request = new (request_buffer) test_req;

--- a/src/consensus/pbft/libbyz/test/replica_test.cpp
+++ b/src/consensus/pbft/libbyz/test/replica_test.cpp
@@ -128,8 +128,7 @@ void setup_client_proxy()
   auto req_timer_cb = [](void* ctx) {
     auto cp = (ClientProxy<uint64_t, void>*)ctx;
 
-    while (request_count - reply_count <
-           Big_req_table::Max_unmatched_requests_per_client - 1)
+    while (request_count - reply_count < 7)
     {
       uint8_t request_buffer[8];
       auto request = new (request_buffer) test_req;

--- a/tests/e2e_args.py
+++ b/tests/e2e_args.py
@@ -101,9 +101,7 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         "--label", help="Unique identifier for the test", default=default_label
     )
     parser.add_argument(
-        "--pbft",
-        help="Use the PBFT consensus",
-        action="store_true",
+        "--pbft", help="Use the PBFT consensus", action="store_true",
     )
     add(parser)
 

--- a/tests/e2e_args.py
+++ b/tests/e2e_args.py
@@ -101,7 +101,7 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         "--label", help="Unique identifier for the test", default=default_label
     )
     parser.add_argument(
-        "--pbft", help="Use the PBFT consensus", action="store_true",
+        "--pbft", help="Opens network the PBFT way", action="store_true",
     )
     add(parser)
 

--- a/tests/e2e_args.py
+++ b/tests/e2e_args.py
@@ -100,6 +100,11 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
     parser.add_argument(
         "--label", help="Unique identifier for the test", default=default_label
     )
+    parser.add_argument(
+        "--pbft",
+        help="Use the PBFT consensus",
+        action="store_true",
+    )
     add(parser)
 
     if accept_unknown:

--- a/tests/e2e_logging_pbft.py
+++ b/tests/e2e_logging_pbft.py
@@ -18,27 +18,12 @@ from loguru import logger as LOG
 
 
 def run(args):
-    hosts = ["localhost"]
+    hosts = ["localhost"] * 4
 
     with infra.ccf.network(
         hosts, args.build_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        primary, _ = network.start_and_join(args, open_network=False)
-
-        for i in range(1, 4):
-            LOG.info(f"Adding node {i}")
-            assert network.create_and_trust_node(
-                args.package, "localhost", args, target_node=None, should_wait=False
-            )
-
-        network.add_users(primary, network.initial_users)
-        LOG.info("Initial set of users added")
-
-        # network.open_network(primary)
-        script = None
-        result = network.propose(1, primary, script, None, "open_network")
-        network.vote_using_majority(primary, result[1]["id"], False)
-        LOG.info("***** Network is now open *****")
+        primary, _ = network.start_and_join(args)
 
         with primary.node_client() as mc:
             check_commit = infra.ccf.Checker(mc)

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -331,12 +331,16 @@ class Network:
         try:
             if self.status is ServiceStatus.OPEN:
                 self.trust_node(primary, new_node.node_id)
+            if not args.pbft:
+                new_node.wait_for_node_to_join()
         except (ValueError, TimeoutError):
             LOG.error(f"New trusted node {new_node.node_id} failed to join the network")
             new_node.stop()
             return None
 
         new_node.network_state = NodeNetworkState.joined
+        if not args.pbft:
+            self.wait_for_all_nodes_to_catch_up(primary)
 
         return new_node
 

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -189,6 +189,7 @@ class Network:
 
         primary, _ = self.find_primary()
         self.check_for_service(primary, status=ServiceStatus.OPENING)
+
         return primary
 
     def start_and_join(self, args):

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -322,7 +322,6 @@ class Network:
 
         return new_node
 
-    # TODO: should_wait should disappear once nodes can join a network and catch up in PBFT
     def create_and_trust_node(
         self, lib_name, host, args, target_node=None, should_wait=True
     ):

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -209,18 +209,14 @@ class Network:
             infra.proc.ccall("cp", args.gov_script, args.build_dir).check_returncode()
         LOG.info("Lua scripts copied")
 
-        LOG.error("111111")
         primary = self._start_all_nodes(args)
-        LOG.error("222222")
 
         if not open_network:
             LOG.warning("Network still needs to be opened")
             return primary, self.nodes[1:]
 
-        LOG.error("AAAAAA")
         if not args.pbft:
             self.wait_for_all_nodes_to_catch_up(primary)
-        LOG.error("BBBBBB")
         LOG.success("All nodes joined network")
 
         if args.app_script:

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -560,8 +560,8 @@ class Network:
             """
         result = self.propose(1, node, script, None, "open_network")
         self.vote_using_majority(node, result[1]["id"], not args.pbft)
-        if not args.pbft:
-            self.check_for_service(node)
+
+        self.check_for_service(node)
         self.status = ServiceStatus.OPEN
 
     def add_users(self, node, users):

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -191,7 +191,7 @@ class Network:
         self.check_for_service(primary, status=ServiceStatus.OPENING)
         return primary
 
-    def start_and_join(self, args, open_network=True):
+    def start_and_join(self, args):
         """
         Starts a CCF network.
         :param args: command line arguments to configure the CCF nodes.
@@ -210,10 +210,6 @@ class Network:
         LOG.info("Lua scripts copied")
 
         primary = self._start_all_nodes(args)
-
-        if not open_network:
-            LOG.warning("Network still needs to be opened")
-            return primary, self.nodes[1:]
 
         if not args.pbft:
             self.wait_for_all_nodes_to_catch_up(primary)

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -293,9 +293,7 @@ class Network:
                 + getattr(node_status, f" with status {node_status.name}", "")
             )
 
-    def create_and_add_pending_node(
-        self, lib_name, host, args, target_node=None
-    ):
+    def create_and_add_pending_node(self, lib_name, host, args, target_node=None):
         """
         Create a new node and add it to the network. Note that the new node
         still needs to be trusted by members to complete the join protocol.
@@ -323,16 +321,12 @@ class Network:
 
         return new_node
 
-    def create_and_trust_node(
-        self, lib_name, host, args, target_node=None
-    ):
+    def create_and_trust_node(self, lib_name, host, args, target_node=None):
         """
         Create a new node, add it to the network and let members vote to trust
         it so that it becomes part of the consensus protocol.
         """
-        new_node = self.create_and_add_pending_node(
-            lib_name, host, args, target_node
-        )
+        new_node = self.create_and_add_pending_node(lib_name, host, args, target_node)
         if new_node is None:
             return None
 

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -27,9 +27,7 @@ def number_of_local_nodes(args):
     Not 3, because the client is typically running two threads.
     """
     if args.pbft:
-        LOG.error("foobar = true")
         return 4
-    LOG.error("foobar = false")
 
     if multiprocessing.cpu_count() > 2:
         return 2
@@ -111,21 +109,6 @@ def run(build_directory, get_command, args):
     ) as network:
         primary, backups = network.start_and_join(args)
 
-        #for i in range(1, 4):
-        #    LOG.info(f"Adding node {i}")
-        #    assert network.create_and_trust_node(
-        #        args.package, "localhost", args, target_node=None, should_wait=False
-        #    )
-
-        #network.add_users(primary, network.initial_users)
-        #LOG.info("Initial set of users added")
-
-        # network.open_network(primary)
-        #script = None
-        #result = network.propose(1, primary, script, None, "open_network")
-        #network.vote_using_majority(primary, result[1]["id"], False)
-        #LOG.info("***** Network is now open *****")
-
         command_args = get_command_args(args, get_command)
 
         if args.network_only:
@@ -161,13 +144,14 @@ def run(build_directory, get_command, args):
                                 break
                         time.sleep(1)
 
-                    #tx_rates.get_metrics()
-                    #for remote_client in clients:
-                    #    remote_client.print_and_upload_result(args.label, metrics)
-                    #    remote_client.stop()
+                    if not args.pbft:
+                        tx_rates.get_metrics()
+                        for remote_client in clients:
+                            remote_client.print_and_upload_result(args.label, metrics)
+                            remote_client.stop()
 
-                    #LOG.info(f"Rates:\n{tx_rates}")
-                    #tx_rates.save_results(args.metrics_file)
+                        LOG.info(f"Rates:\n{tx_rates}")
+                        tx_rates.save_results(args.metrics_file)
 
             except Exception:
                 for remote_client in clients:

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -21,11 +21,16 @@ logging.getLogger("matplotlib").setLevel(logging.WARNING)
 logging.getLogger("paramiko").setLevel(logging.WARNING)
 
 
-def number_of_local_nodes():
+def number_of_local_nodes(args):
     """
     On 2-core VMs, we start only one node, but on 4 core, we want to start 2.
     Not 3, because the client is typically running two threads.
     """
+    if args.pbft:
+        LOG.error("foobar = true")
+        return 4
+    LOG.error("foobar = false")
+
     if multiprocessing.cpu_count() > 2:
         return 2
     else:
@@ -97,29 +102,29 @@ def run(build_directory, get_command, args):
 
     hosts = args.nodes
     if not hosts:
-        hosts = ["localhost"] * number_of_local_nodes()
+        hosts = ["localhost"] * number_of_local_nodes(args)
 
     LOG.info("Starting nodes on {}".format(hosts))
 
     with infra.ccf.network(
         hosts, args.build_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        primary, backups = network.start_and_join(args, open_network=False)
+        primary, backups = network.start_and_join(args)
 
-        for i in range(1, 4):
-            LOG.info(f"Adding node {i}")
-            assert network.create_and_trust_node(
-                args.package, "localhost", args, target_node=None, should_wait=False
-            )
+        #for i in range(1, 4):
+        #    LOG.info(f"Adding node {i}")
+        #    assert network.create_and_trust_node(
+        #        args.package, "localhost", args, target_node=None, should_wait=False
+        #    )
 
-        network.add_users(primary, network.initial_users)
-        LOG.info("Initial set of users added")
+        #network.add_users(primary, network.initial_users)
+        #LOG.info("Initial set of users added")
 
         # network.open_network(primary)
-        script = None
-        result = network.propose(1, primary, script, None, "open_network")
-        network.vote_using_majority(primary, result[1]["id"], False)
-        LOG.info("***** Network is now open *****")
+        #script = None
+        #result = network.propose(1, primary, script, None, "open_network")
+        #network.vote_using_majority(primary, result[1]["id"], False)
+        #LOG.info("***** Network is now open *****")
 
         command_args = get_command_args(args, get_command)
 

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -23,7 +23,8 @@ logging.getLogger("paramiko").setLevel(logging.WARNING)
 
 def number_of_local_nodes(args):
     """
-    On 2-core VMs, we start only one node, but on 4 core, we want to start 2.
+    If we are using pbft then we need to have 4 nodes. Otherwise with CFT
+    on 2-core VMs, we start only one node, but on 4 core, we want to start 2.
     Not 3, because the client is typically running two threads.
     """
     if args.pbft:
@@ -144,6 +145,9 @@ def run(build_directory, get_command, args):
                                 break
                         time.sleep(1)
 
+                    # For now we will not collect metrics with PBFT as the messages that
+                    # can be created when collecting the metrics is too large.
+                    # https://github.com/microsoft/CCF/issues/534
                     if not args.pbft:
                         tx_rates.get_metrics()
                         for remote_client in clients:

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -104,7 +104,23 @@ def run(build_directory, get_command, args):
     with infra.ccf.network(
         hosts, args.build_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        primary, backups = network.start_and_join(args)
+        primary, backups = network.start_and_join(args, open_network=False)
+
+        for i in range(1, 4):
+            LOG.info(f"Adding node {i}")
+            assert network.create_and_trust_node(
+                args.package, "localhost", args, target_node=None, should_wait=False
+            )
+
+        network.add_users(primary, network.initial_users)
+        LOG.info("Initial set of users added")
+
+        # network.open_network(primary)
+        script = None
+        result = network.propose(1, primary, script, None, "open_network")
+        network.vote_using_majority(primary, result[1]["id"], False)
+        LOG.info("***** Network is now open *****")
+        LOG.error("AAAA")
 
         command_args = get_command_args(args, get_command)
 
@@ -141,13 +157,13 @@ def run(build_directory, get_command, args):
                                 break
                         time.sleep(1)
 
-                    tx_rates.get_metrics()
-                    for remote_client in clients:
-                        remote_client.print_and_upload_result(args.label, metrics)
-                        remote_client.stop()
+                    #tx_rates.get_metrics()
+                    #for remote_client in clients:
+                    #    remote_client.print_and_upload_result(args.label, metrics)
+                    #    remote_client.stop()
 
-                    LOG.info(f"Rates:\n{tx_rates}")
-                    tx_rates.save_results(args.metrics_file)
+                    #LOG.info(f"Rates:\n{tx_rates}")
+                    #tx_rates.save_results(args.metrics_file)
 
             except Exception:
                 for remote_client in clients:

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -120,7 +120,6 @@ def run(build_directory, get_command, args):
         result = network.propose(1, primary, script, None, "open_network")
         network.vote_using_majority(primary, result[1]["id"], False)
         LOG.info("***** Network is now open *****")
-        LOG.error("AAAA")
 
         command_args = get_command_args(args, get_command)
 


### PR DESCRIPTION
- Get smallbank to work with the pbft backend
- Create a python pbft flag and then use that to make  network.start_and_join work for both raft and pbft
- bug fix where we do not return the KV version properly
- change to use the standard allocator for pbft message allocations 