### PR TITLE
Decode msgpack and json consistently

### DIFF
--- a/samples/apps/txregulator/tests/txregulatorclient.py
+++ b/samples/apps/txregulator/tests/txregulatorclient.py
@@ -61,7 +61,7 @@ def run(args):
                 )
                 check(
                     c.rpc("REG_get", {"id": regulator[0]}),
-                    result=[regulator[1].encode(), regulator[2].encode()],
+                    result=[regulator[1], regulator[2]],
                 )
 
                 check(
@@ -77,7 +77,7 @@ def run(args):
                 check = infra.checker.Checker()
 
                 check(c.rpc("BK_register", {"country": bank[1]}), result=bank[0])
-                check(c.rpc("BK_get", {"id": bank[0]}), result=bank[1].encode())
+                check(c.rpc("BK_get", {"id": bank[0]}), result=bank[1])
 
                 check(
                     c.rpc("REG_register", {"country": bank[1]}),
@@ -109,31 +109,31 @@ def run(args):
                     check(
                         c.rpc("TX_get", {"tx_id": tx_id}),
                         result={
-                            "amt": amount.encode(),
+                            "amt": amount,
                             "bank_id": bank[0],
-                            "dst": transaction["dst"].encode(),
-                            "dst_country": transaction["dst_country"].encode(),
-                            "src": transaction["src"].encode(),
-                            "src_country": transaction["src_country"].encode(),
-                            "timestamp": transaction["timestamp"].encode(),
-                            "type": transaction["type"].encode(),
+                            "dst": transaction["dst"],
+                            "dst_country": transaction["dst_country"],
+                            "src": transaction["src"],
+                            "src_country": transaction["src_country"],
+                            "timestamp": transaction["timestamp"],
+                            "type": transaction["type"],
                         },
                     )
                     if float(amount) > flagged_amt:
                         check(
                             c.rpc("FLAGGED_TX_get", {"tx_id": tx_id}),
-                            result=[reg_id, False, transaction["timestamp"].encode()],
+                            result=[reg_id, False, transaction["timestamp"]],
                         )
                         flagged_tx = {
-                            "amt": amount.encode(),
+                            "amt": amount,
                             "bank_id": bank[0],
-                            "dst": transaction["dst"].encode(),
-                            "dst_country": transaction["dst_country"].encode(),
-                            "src": transaction["src"].encode(),
-                            "src_country": transaction["src_country"].encode(),
-                            "timestamp": transaction["timestamp"].encode(),
+                            "dst": transaction["dst"],
+                            "dst_country": transaction["dst_country"],
+                            "src": transaction["src"],
+                            "src_country": transaction["src_country"],
+                            "timestamp": transaction["timestamp"],
                             "tx_id": tx_id,
-                            "type": transaction["type"].encode(),
+                            "type": transaction["type"],
                         }
                         flagged_ids.append(tx_id)
                         flagged_txs[tx_id] = flagged_tx

--- a/sphinx/source/schemas/getQuotes_result.json
+++ b/sphinx/source/schemas/getQuotes_result.json
@@ -16,7 +16,12 @@
             "type": "number"
           },
           "raw": {
-            "type": "string"
+            "items": {
+              "maximum": 255,
+              "minimum": 0,
+              "type": "number"
+            },
+            "type": "array"
           }
         },
         "required": [

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -1073,7 +1073,7 @@ namespace ccf
         {
           GetQuotes::Quote quote;
           quote.node_id = nid;
-          quote.raw = std::string(ni.quote.begin(), ni.quote.end());
+          quote.raw = ni.quote;
 
 #ifdef GET_QUOTE
           oe_report_t parsed_quote = {0};

--- a/src/node/rpc/nodecalltypes.h
+++ b/src/node/rpc/nodecalltypes.h
@@ -35,10 +35,10 @@ namespace ccf
     struct Quote
     {
       NodeId node_id = {};
-      std::string raw = {};
+      std::vector<uint8_t> raw = {};
 
       std::string error = {};
-      std::string mrenclave = {};
+      std::string mrenclave = {}; // < Hex-encoded
     };
 
     struct Out

--- a/tests/governance.py
+++ b/tests/governance.py
@@ -36,7 +36,7 @@ def run(args):
             assert len(quotes) == len(hosts)
             primary_quote = quotes[0]
             assert primary_quote["node_id"] == 0
-            mrenclave = primary_quote["mrenclave"].decode()
+            mrenclave = primary_quote["mrenclave"]
 
             oed = subprocess.run(
                 [args.oesign, "dump", "-e", f"{args.package}.so.signed"],

--- a/tests/infra/jsonrpc.py
+++ b/tests/infra/jsonrpc.py
@@ -108,27 +108,14 @@ class Response:
         return d
 
     def _from_parsed(self, parsed):
-        def decode(sl, is_key=False):
-            if is_key and hasattr(sl, "decode"):
-                return sl.decode()
-            if hasattr(sl, "items"):
-                return {decode(k, is_key=True): decode(v) for k, v in sl.items()}
-            elif isinstance(sl, list):
-                return [decode(e) for e in sl]
-            else:
-                return sl
-
-        parsed_s = {
-            decode(attr, is_key=True): decode(value) for attr, value in parsed.items()
-        }
-        unexpected = parsed_s.keys() - self._attrs
+        unexpected = parsed.keys() - self._attrs
         if unexpected:
             raise ValueError("Unexpected keys in response: {}".format(unexpected))
-        for attr, value in parsed_s.items():
+        for attr, value in parsed.items():
             setattr(self, attr, value)
 
     def from_msgpack(self, data):
-        parsed = msgpack.unpackb(data)
+        parsed = msgpack.unpackb(data, raw=False)
         self._from_parsed(parsed)
 
     def from_json(self, data):


### PR DESCRIPTION
Our partially recursive failed to decode strings in lists and key-values, causing inconsistent behaviour depending on whether the `format` chosen was `"json"` or `"msgpack"`.

```
>>> o
{'abc': 'def', 'ghi': {'jkl': ['a', 'b', 'c'], 'mno': {}}}
>>> json.loads(json.dumps(o))
{'abc': 'def', 'ghi': {'jkl': ['a', 'b', 'c'], 'mno': {}}}
>>> msgpack.unpackb(msgpack.packb(o))
{b'abc': b'def', b'ghi': {b'jkl': [b'a', b'b', b'c'], b'mno': {}}}
```

Ideally they would be identical, and they are if we call `msgpack.unpackb(..., raw=False)`.

As an associated change, the raw quote is passed as a byte-vector rather than a string. This does mean it appears as a long int list when looking at the raw JSON/Python, so its a prime candidate to be hex-encoded (#278).