### PR TITLE
Add basic batched app load test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,12 @@ if(BUILD_TESTS)
         --enforce-reqs
       )
 
+      add_e2e_test(
+        NAME lua_end_to_end_batched
+        PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_batched.py
+        ADDITIONAL_ARGS
+          --app-script ${CMAKE_SOURCE_DIR}/src/apps/batched/batched.lua)
+
       if (BUILD_SMALLBANK)
         include(${CMAKE_CURRENT_SOURCE_DIR}/samples/apps/smallbank/smallbank.cmake)
       endif()
@@ -340,12 +346,6 @@ if(BUILD_TESTS)
       ADDITIONAL_ARGS
         --app-script ${CMAKE_SOURCE_DIR}/src/apps/logging/logging.lua
     )
-
-    add_e2e_test(
-      NAME lua_end_to_end_batched
-      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_batched.py
-      ADDITIONAL_ARGS
-        --app-script ${CMAKE_SOURCE_DIR}/src/apps/batched/batched.lua)
 
     add_e2e_test(
       NAME end_to_end_scenario

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,12 @@ if(BUILD_TESTS)
     )
 
     add_e2e_test(
+      NAME lua_end_to_end_batched
+      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_batched.py
+      ADDITIONAL_ARGS
+        --app-script ${CMAKE_SOURCE_DIR}/src/apps/batched/batched.lua)
+
+    add_e2e_test(
       NAME end_to_end_scenario
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_scenarios.py
       ADDITIONAL_ARGS

--- a/src/apps/batched/batched.lua
+++ b/src/apps/batched/batched.lua
@@ -14,19 +14,21 @@ return {
 
   BATCH_submit = [[
     tables, gov_tables, args = ...
+    count = 0
     for n, e in ipairs(args.params) do
       id = e.id
       msg = e.msg
       tables.priv0:put(id, msg)
+      count = count + 1
     end
-    return env.jsucc(true)
+    return env.jsucc(count)
   ]],
 
   BATCH_fetch = [[
     tables, gov_tables, args = ...
     results = {}
     for n, id in ipairs(args.params) do
-      results[id] = tables.priv0:get(id)
+      table.insert(results, {id = id, msg = tables.priv0:get(id)})
     end
     return env.jsucc(results)
   ]]

--- a/src/apps/batched/batched.lua
+++ b/src/apps/batched/batched.lua
@@ -1,0 +1,33 @@
+-- Copyright (c) Microsoft Corporation. All rights reserved.
+-- Licensed under the Apache 2.0 License.
+
+return {
+  __environment = [[
+    function env.jsucc(result)
+      return {result = result}
+    end
+
+    function env.jerr(code, message)
+      return {error = {code = code, message = message}}
+    end
+  ]],
+
+  BATCH_submit = [[
+    tables, gov_tables, args = ...
+    for n, e in ipairs(args.params) do
+      id = e.id
+      msg = e.msg
+      tables.priv0:put(id, msg)
+    end
+    return env.jsucc(true)
+  ]],
+
+  BATCH_fetch = [[
+    tables, gov_tables, args = ...
+    results = {}
+    for n, id in ipairs(args.params) do
+      results[id] = tables.priv0:get(id)
+    end
+    return env.jsucc(results)
+  ]]
+}

--- a/src/apps/batched/oe_sign.conf
+++ b/src/apps/batched/oe_sign.conf
@@ -1,0 +1,7 @@
+# Enclave settings:
+Debug=1
+NumHeapPages=50000
+NumStackPages=1024
+NumTCS=8
+ProductID=1
+SecurityVersion=1

--- a/tests/e2e_batched.py
+++ b/tests/e2e_batched.py
@@ -62,23 +62,16 @@ def run(args):
         network = test(network, args, batch_size=100)
         network = test(network, args, batch_size=1000)
 
-        bs = 10000
-        try:
-            while bs <= 100000:
-                for _ in range(3):
-                    network = test(network, args, batch_size=bs)
-                bs += 10000
-        except Exception as e:
-            LOG.error("Looks like something broke")
-            LOG.error(e)
-            LOG.error("Press Ctrl+C to shutdown the network")
-
+        bs = 30000
+        while bs <= 100000:
             try:
-                while True:
-                    time.sleep(60)
-
-            except KeyboardInterrupt:
-                LOG.info("Stopping all CCF nodes...")
+                network = test(network, args, batch_size=bs)
+                bs += 10000
+            except Exception as e:
+                LOG.error("Looks like something broke")
+                LOG.error(e)
+                bs -= 10000
+                LOG.error(f"Backing off to batch size {bs}")
 
 
 if __name__ == "__main__":

--- a/tests/e2e_batched.py
+++ b/tests/e2e_batched.py
@@ -43,7 +43,7 @@ def test(network, args, batch_size=100):
         for n, m in enumerate(messages):
             fetched = fetch_response.result[n]
             assert m["id"] == fetched["id"]
-            assert m["msg"] == fetched["msg"].decode()
+            assert m["msg"] == fetched["msg"]
 
     return network
 

--- a/tests/e2e_batched.py
+++ b/tests/e2e_batched.py
@@ -57,21 +57,18 @@ def run(args):
         network.start_and_join(args)
 
         network = test(network, args, batch_size=1)
-        network = test(network, args, batch_size=5)
         network = test(network, args, batch_size=10)
         network = test(network, args, batch_size=100)
         network = test(network, args, batch_size=1000)
 
-        bs = 30000
-        while bs <= 100000:
-            try:
-                network = test(network, args, batch_size=bs)
-                bs += 10000
-            except Exception as e:
-                LOG.error("Looks like something broke")
-                LOG.error(e)
-                bs -= 10000
-                LOG.error(f"Backing off to batch size {bs}")
+        bs = 10000
+        step_size = 10000
+
+        # TODO: This tests fails with larger batch sizes, and with any transaction
+        # larger than ~2MB. Investigate why, then expand this test
+        while bs <= 30000:
+            network = test(network, args, batch_size=bs)
+            bs += step_size
 
 
 if __name__ == "__main__":

--- a/tests/e2e_batched.py
+++ b/tests/e2e_batched.py
@@ -61,14 +61,15 @@ def run(args):
         network = test(network, args, batch_size=100)
         network = test(network, args, batch_size=1000)
 
-        bs = 10000
-        step_size = 10000
+        # TODO: CI already takes ~25s for batch of 10k, so avoid large batches for now
+        # bs = 10000
+        # step_size = 10000
 
-        # TODO: This tests fails with larger batch sizes, and with any transaction
-        # larger than ~2MB. Investigate why, then expand this test
-        while bs <= 30000:
-            network = test(network, args, batch_size=bs)
-            bs += step_size
+        # # TODO: This tests fails with larger batch sizes, and with any transaction
+        # # larger than ~2MB. Investigate why, then expand this test
+        # while bs <= 30000:
+        #     network = test(network, args, batch_size=bs)
+        #     bs += step_size
 
 
 if __name__ == "__main__":

--- a/tests/e2e_batched.py
+++ b/tests/e2e_batched.py
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+import functools
+import infra.ccf
+import infra.proc
+import infra.jsonrpc
+import infra.notification
+import infra.net
+import suite.test_requirements as reqs
+import e2e_args
+
+from loguru import logger as LOG
+
+
+@reqs.lua_generic_app
+def test(network, args):
+    LOG.info("Running transactions against batched app")
+    primary, _ = network.find_primary()
+
+    with primary.node_client() as mc:
+        pass
+
+    return network
+
+
+def run(args):
+    hosts = ["localhost", "localhost"]
+
+    with infra.ccf.network(
+        hosts, args.build_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
+    ) as network:
+        network.start_and_join(args)
+
+        network = test(network, args)
+
+
+if __name__ == "__main__":
+    args = e2e_args.cli_args()
+    args.package = "libluagenericenc"
+    args.enforce_reqs = True
+
+    run(args)

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -18,7 +18,7 @@ import e2e_args
 from loguru import logger as LOG
 
 
-@reqs.lua_logging_app
+@reqs.lua_generic_app
 def test_update_lua(network, args):
     if args.package == "libluagenericenc":
         LOG.info("Updating Lua application")

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -111,7 +111,7 @@ def test(network, args, notifications_queue=None):
                         c.rpc("LOG_record", {"id": id, "msg": long_msg}), result=True,
                     )
                     check(c.rpc("LOG_get", {"id": id}), result={"msg": long_msg})
-                id += 1
+                    id += 1
 
     return network
 

--- a/tests/infra/jsonrpc.py
+++ b/tests/infra/jsonrpc.py
@@ -420,9 +420,10 @@ class CurlClient:
                 cmd.extend(["--cert", self.cert])
             LOG.debug(f"Running: {' '.join(cmd)}")
             rc = subprocess.run(cmd, capture_output=True)
-            LOG.debug(f"Received {rc.stdout.decode()}")
+            LOG.debug(f"Received {rc.stdout}")
             if rc.returncode != 0:
-                LOG.debug(f"ERR {rc.stderr.decode()}")
+                LOG.error(rc.stderr)
+                raise RuntimeError("Curl failed")
             self.stream.update(rc.stdout)
         return r.id
 

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -7,6 +7,7 @@ import infra.remote
 import infra.net
 import infra.path
 import infra.jsonrpc
+import time
 
 from loguru import logger as LOG
 
@@ -174,9 +175,12 @@ class Node:
         """
         for _ in range(timeout):
             with self.node_client() as mc:
-                rep = mc.do("getCommit", {})
-                if rep.error == None and rep.result is not None:
-                    return
+                try:
+                    rep = mc.do("getCommit", {})
+                    if rep.error == None and rep.result is not None:
+                        return
+                except:
+                    pass
             time.sleep(1)
         raise TimeoutError(f"Node {self.node_id} failed to join the network")
 

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -62,7 +62,7 @@ def logging_app(func):
     return wrapper
 
 
-def lua_logging_app(func):
+def lua_generic_app(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         if args[1].enforce_reqs is False:
@@ -72,7 +72,7 @@ def lua_logging_app(func):
         # Lua app is by looking at the package passed to the nodes at startup
         args_ = args[1]
         if args_.package is not "libluagenericenc":
-            raise TestRequirementsNotMet("Lua logging app not installed")
+            raise TestRequirementsNotMet("Lua generic app not installed")
 
         return func(*args, **kwargs)
 


### PR DESCRIPTION
This adds a basic batched app so we can stress test large requests (#557).

I see 3 potential issues we need to investigate:
- Large incoming transaction messages
- Expensive transaction execution (occupying our only thread for `O(raft timeout)`, causing #557)
- Large write sets

So far I've only looked at the first, and discovered that we close connections for any request larger than 2MB (verified that this also occurs with the logging app, where we currently test up to only 512KB). I don't have a fix for this yet, but submitting this test app for discussion/exploration. Some light tweaks should make this app suitable for testing all 3 cases.