### PR TITLE
Implement listMethods for lua generic app

### DIFF
--- a/src/apps/luageneric/luageneric.cpp
+++ b/src/apps/luageneric/luageneric.cpp
@@ -166,6 +166,22 @@ namespace ccfapp
       // TODO: https://github.com/microsoft/CCF/issues/409
       set_default(default_handler, Write);
     }
+
+    // Since we do our own dispatch within the default handler, report the
+    // supported methods here
+    void list_methods(Store::Tx& tx, ListMethods::Out& out) override
+    {
+      ccf::UserRpcFrontend::list_methods(tx, out);
+
+      auto scripts = tx.get_view(this->network.app_scripts);
+      scripts->foreach([&out](const auto& key, const auto&) {
+        if (key != UserScriptIds::ENV_HANDLER)
+        {
+          out.methods.push_back(key);
+        }
+        return true;
+      });
+    }
   };
 
   std::shared_ptr<enclave::RpcHandler> get_rpc_handler(

--- a/tests/e2e_batched.py
+++ b/tests/e2e_batched.py
@@ -17,7 +17,7 @@ from loguru import logger as LOG
 id_gen = itertools.count()
 
 
-@reqs.lua_generic_app
+@reqs.supports_methods("BATCH_submit", "BATCH_fetch")
 def test(network, args, batch_size=100):
     LOG.info(f"Running batch submission of {batch_size} new entries")
     primary, _ = network.find_primary()

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -64,7 +64,7 @@ def test_update_lua(network, args):
     return network
 
 
-@reqs.logging_app
+@reqs.supports_methods("mkSign", "LOG_record", "LOG_get")
 @reqs.at_least_2_nodes
 def test(network, args, notifications_queue=None):
     LOG.info("Running transactions against logging app")

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -18,7 +18,7 @@ import e2e_args
 from loguru import logger as LOG
 
 
-@reqs.lua_logging_app
+@reqs.installed_package("libluagenericenc")
 def test_update_lua(network, args):
     if args.package == "libluagenericenc":
         LOG.info("Updating Lua application")
@@ -65,8 +65,10 @@ def test_update_lua(network, args):
 
 
 @reqs.supports_methods("mkSign", "LOG_record", "LOG_get")
-@reqs.at_least_2_nodes
+@reqs.at_least_n_nodes(2)
 def test(network, args, notifications_queue=None):
+    """This is the docstring for the test function"""
+
     LOG.info("Running transactions against logging app")
     primary, backup = network.find_primary_and_any_backup()
 
@@ -130,8 +132,8 @@ def run(args):
             hosts, args.build_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
         ) as network:
             network.start_and_join(args)
-            test(network, args, notifications_queue)
-            test_update_lua(network, args)
+            network = test(network, args, notifications_queue)
+            network = test_update_lua(network, args)
 
 
 if __name__ == "__main__":

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -67,8 +67,6 @@ def test_update_lua(network, args):
 @reqs.supports_methods("mkSign", "LOG_record", "LOG_get")
 @reqs.at_least_n_nodes(2)
 def test(network, args, notifications_queue=None):
-    """This is the docstring for the test function"""
-
     LOG.info("Running transactions against logging app")
     primary, backup = network.find_primary_and_any_backup()
 

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -28,7 +28,7 @@ def test_add_node(network, args):
     return network
 
 
-@reqs.at_least_2_nodes
+@reqs.at_least_n_nodes(2)
 def test_add_node_from_backup(network, args):
     LOG.info("Adding a valid node from a backup")
     backup = network.find_any_backup()
@@ -66,7 +66,7 @@ def test_add_node_untrusted_code(network, args):
     return network
 
 
-@reqs.at_least_2_nodes
+@reqs.at_least_n_nodes(2)
 def test_retire_node(network, args):
     LOG.info("Retiring a backup")
     primary, _ = network.find_primary()

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -34,7 +34,7 @@ def ensure_reqs(check_reqs, func):
                     f"Could not check if test requirements were met: {e}"
                 )
 
-        func(network, args, *nargs, **kwargs)
+        return func(network, args, *nargs, **kwargs)
 
     return wrapper
 

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -84,3 +84,7 @@ def installed_package(p):
         return ensure_reqs(check, func)
 
     return decorator
+
+
+def lua_generic_app(func):
+    return installed_package("libluagenericenc")(func)

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -19,62 +19,22 @@ def none(func):
     return wrapper
 
 
-# TODO: Parameterise this decorator once we add a test that requires a
-# different number of nodes
-def at_least_2_nodes(func):
+def ensure_reqs(check_reqs, func):
     @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        if args[1].enforce_reqs is False:
-            return func(*args, **kwargs)
+    def wrapper(network, args, *nargs, **kwargs):
+        if args.enforce_reqs:
+            try:
+                # This should throw TestRequirementsNotMet if any checks fail.
+                # Return code is ignored
+                check_reqs(network, args, *nargs, **kwargs)
+            except TestRequirementsNotMet:
+                raise
+            except Exception as e:
+                raise TestRequirementsNotMet(
+                    f"Could not check if test requirements were met: {e}"
+                )
 
-        network = args[0]
-        running_nodes = len(network.get_joined_nodes())
-        if running_nodes < 2:
-            raise TestRequirementsNotMet(
-                f"Too few nodes. Only have {running_nodes}, requires 2"
-            )
-
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
-def logging_app(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        if args[1].enforce_reqs is False:
-            return func(*args, **kwargs)
-
-        network = args[0]
-        try:
-            primary, term = network.find_primary()
-            with primary.user_client(format="json") as c:
-                resp = c.rpc("listMethods", {})
-                if "LOG_record" not in resp.result["methods"]:
-                    raise TestRequirementsNotMet("Logging app not installed")
-        except TestRequirementsNotMet:
-            raise
-        except Exception as e:
-            raise TestRequirementsNotMet("Could not check if constraints were met")
-
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
-def lua_logging_app(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        if args[1].enforce_reqs is False:
-            return func(*args, **kwargs)
-
-        # For now, the only way to find out whether the network is running a
-        # Lua app is by looking at the package passed to the nodes at startup
-        args_ = args[1]
-        if args_.package is not "libluagenericenc":
-            raise TestRequirementsNotMet("Lua logging app not installed")
-
-        return func(*args, **kwargs)
+        func(network, args, *nargs, **kwargs)
 
     return wrapper
 
@@ -82,28 +42,45 @@ def lua_logging_app(func):
 def supports_methods(*methods):
     def decorator(func):
         @functools.wraps(func)
-        def wrapper(network, args, *nargs, **kwargs):
-            if args.enforce_reqs:
-                try:
-                    primary, term = network.find_primary()
-                    with primary.user_client() as c:
-                        response = c.rpc("listMethods", {})
-                        supported_methods = response.result["methods"]
-                        missing = {*methods}.difference(supported_methods)
-                        if missing:
-                            concat = ", ".join(missing)
-                            raise TestRequirementsNotMet(
-                                f"Missing required methods: {concat}"
-                            )
-                except TestRequirementsNotMet:
-                    raise
-                except Exception as e:
-                    raise TestRequirementsNotMet(
-                        f"Could not check if constraints were met: {e}"
-                    )
+        def check(network, args, *nargs, **kwargs):
+            primary, term = network.find_primary()
+            with primary.user_client() as c:
+                response = c.rpc("listMethods", {})
+                supported_methods = response.result["methods"]
+                missing = {*methods}.difference(supported_methods)
+                if missing:
+                    concat = ", ".join(missing)
+                    raise TestRequirementsNotMet(f"Missing required methods: {concat}")
 
-            return func(network, args, *nargs, **kwargs)
+        return ensure_reqs(check, func)
 
-        return wrapper
+    return decorator
+
+
+def at_least_n_nodes(n):
+    def decorator(func):
+        @functools.wraps(func)
+        def check(network, args, *nargs, **kwargs):
+            running_nodes = len(network.get_joined_nodes())
+            if running_nodes < n:
+                raise TestRequirementsNotMet(
+                    f"Too few nodes. Only have {running_nodes}, requires at least {n}"
+                )
+
+        return ensure_reqs(check, func)
+
+    return decorator
+
+
+def installed_package(p):
+    def decorator(func):
+        @functools.wraps(func)
+        def check(network, args, *nargs, **kwargs):
+            if args.package != p:
+                raise TestRequirementsNotMet(
+                    f"Incorrect app. Requires '{p}', not '{args.package}'"
+                )
+
+        return ensure_reqs(check, func)
 
     return decorator

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -19,71 +19,62 @@ def none(func):
     return wrapper
 
 
-def ensure_reqs(check_reqs, func):
-    @functools.wraps(func)
-    def wrapper(network, args, *nargs, **kwargs):
-        if args.enforce_reqs:
-            try:
-                # This should throw TestRequirementsNotMet if any checks fail.
-                # Return code is ignored
-                check_reqs(network, args, *nargs, **kwargs)
-            except TestRequirementsNotMet:
-                raise
-            except Exception as e:
-                raise TestRequirementsNotMet(
-                    f"Could not check if test requirements were met: {e}"
-                )
+def ensure_reqs(check_reqs):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(network, args, *nargs, **kwargs):
+            if args.enforce_reqs:
+                try:
+                    # This should throw TestRequirementsNotMet if any checks fail.
+                    # Return code is ignored
+                    check_reqs(network, args, *nargs, **kwargs)
+                except TestRequirementsNotMet:
+                    raise
+                except Exception as e:
+                    raise TestRequirementsNotMet(
+                        f"Could not check if test requirements were met: {e}"
+                    )
 
-        return func(network, args, *nargs, **kwargs)
+            return func(network, args, *nargs, **kwargs)
 
-    return wrapper
+        return wrapper
+
+    return decorator
 
 
 def supports_methods(*methods):
-    def decorator(func):
-        @functools.wraps(func)
-        def check(network, args, *nargs, **kwargs):
-            primary, term = network.find_primary()
-            with primary.user_client() as c:
-                response = c.rpc("listMethods", {})
-                supported_methods = response.result["methods"]
-                missing = {*methods}.difference(supported_methods)
-                if missing:
-                    concat = ", ".join(missing)
-                    raise TestRequirementsNotMet(f"Missing required methods: {concat}")
+    def check(network, args, *nargs, **kwargs):
+        primary, term = network.find_primary()
+        with primary.user_client() as c:
+            response = c.rpc("listMethods", {})
+            supported_methods = response.result["methods"]
+            missing = {*methods}.difference(supported_methods)
+            if missing:
+                concat = ", ".join(missing)
+                raise TestRequirementsNotMet(f"Missing required methods: {concat}")
 
-        return ensure_reqs(check, func)
-
-    return decorator
+    return ensure_reqs(check)
 
 
 def at_least_n_nodes(n):
-    def decorator(func):
-        @functools.wraps(func)
-        def check(network, args, *nargs, **kwargs):
-            running_nodes = len(network.get_joined_nodes())
-            if running_nodes < n:
-                raise TestRequirementsNotMet(
-                    f"Too few nodes. Only have {running_nodes}, requires at least {n}"
-                )
+    def check(network, args, *nargs, **kwargs):
+        running_nodes = len(network.get_joined_nodes())
+        if running_nodes < n:
+            raise TestRequirementsNotMet(
+                f"Too few nodes. Only have {running_nodes}, requires at least {n}"
+            )
 
-        return ensure_reqs(check, func)
-
-    return decorator
+    return ensure_reqs(check)
 
 
 def installed_package(p):
-    def decorator(func):
-        @functools.wraps(func)
-        def check(network, args, *nargs, **kwargs):
-            if args.package != p:
-                raise TestRequirementsNotMet(
-                    f"Incorrect app. Requires '{p}', not '{args.package}'"
-                )
+    def check(network, args, *nargs, **kwargs):
+        if args.package != p:
+            raise TestRequirementsNotMet(
+                f"Incorrect app. Requires '{p}', not '{args.package}'"
+            )
 
-        return ensure_reqs(check, func)
-
-    return decorator
+    return ensure_reqs(check)
 
 
 def lua_generic_app(func):


### PR DESCRIPTION
Our `listMethods` RPC previously just returned the names of all registered handlers. Since the generic lua app (and presumably future similar generic interpreters) use the _default_ endpoint, they don't actually report the supported methods (ie - they don't include `LOG_record` for the lua logging app). This fixes that.

While doing this I also fiddled with the `test_requirements` to generate parameterised variants, so we can easily say "this test requires exactly these methods", rather than looking for a specific app. I also added the `ensure_reqs` meta-decorator to remove some of the boilerplate (ie - to consistently skip if `enforce_reqs` is False). I'm sure there's some way to reduce the boilerplate even further, but I don't see it straight away.