### PR TITLE
Improve error reporting on oversized messages

### DIFF
--- a/src/enclave/rpcendpoint.h
+++ b/src/enclave/rpcendpoint.h
@@ -47,7 +47,7 @@ namespace enclave
       return std::make_pair(actor, method);
     }
 
-    bool handle_data(const std::vector<uint8_t>& data)
+    bool handle_data(const std::vector<uint8_t>& data) override
     {
       LOG_DEBUG_FMT(
         "Entered handle_data, session {} with {} bytes",
@@ -128,6 +128,21 @@ namespace enclave
       }
 
       return true;
+    }
+
+    std::vector<uint8_t> oversized_message_error(
+      size_t msg_size, size_t max_msg_size) override
+    {
+      return jsonrpc::pack(
+        jsonrpc::error_response(
+          0,
+          jsonrpc::StandardErrorCodes::PARSE_ERROR,
+          fmt::format(
+            "Requested message ({} bytes) is too large. Maximum allowed is {} "
+            "bytes. Closing connection.",
+            msg_size,
+            max_msg_size)),
+        jsonrpc::Pack::Text);
     }
   };
 }

--- a/src/enclave/tlsendpoint.h
+++ b/src/enclave/tlsendpoint.h
@@ -17,7 +17,6 @@ namespace enclave
     std::unique_ptr<ringbuffer::AbstractWriter> to_host;
     size_t session_id;
 
-  private:
     enum Status
     {
       handshake,
@@ -27,6 +26,24 @@ namespace enclave
       error
     };
 
+    Status get_status() const
+    {
+      return status;
+    }
+
+    virtual std::vector<uint8_t> oversized_message_error(
+      size_t msg_size, size_t max_msg_size)
+    {
+      const auto s = fmt::format(
+        "Requested message ({} bytes) is too large. Maximum allowed is {} "
+        "bytes. Closing connection.",
+        msg_size,
+        max_msg_size);
+      const auto data = (const uint8_t*)s.data();
+      return std::vector<uint8_t>(data, data + s.size());
+    }
+
+  private:
     std::vector<uint8_t> pending_write;
     std::vector<uint8_t> pending_read;
     // Decrypted data, read through mbedtls

--- a/src/enclave/tlsframedendpoint.h
+++ b/src/enclave/tlsframedendpoint.h
@@ -12,6 +12,8 @@ namespace enclave
     uint32_t msg_size;
     size_t count;
 
+    static constexpr size_t max_msg_size = 1 * 1024 * 1024;
+
   public:
     FramedTLSEndpoint(
       size_t session_id,
@@ -24,6 +26,16 @@ namespace enclave
 
     void recv(const uint8_t* data, size_t size)
     {
+      const auto status = get_status();
+      if (status >= closed)
+      {
+        LOG_INFO_FMT(
+          "Received additional data for {}, ignoring due to status {}",
+          session_id,
+          status);
+        return;
+      }
+
       recv_buffered(data, size);
 
       while (true)
@@ -43,8 +55,14 @@ namespace enclave
 
         // Arbitrary limit on RPC size to stop a client from requesting
         // a very large allocation.
-        if (msg_size > 1 << 21)
+        if (msg_size > max_msg_size)
         {
+          LOG_FAIL_FMT(
+            "Received oversized message request ({} bytes) - closing session "
+            "{}",
+            msg_size,
+            session_id);
+          send(oversized_message_error(msg_size, max_msg_size));
           close();
           return;
         }

--- a/src/enclave/tlsframedendpoint.h
+++ b/src/enclave/tlsframedendpoint.h
@@ -12,7 +12,7 @@ namespace enclave
     uint32_t msg_size;
     size_t count;
 
-    static constexpr size_t max_msg_size = 1 * 1024 * 1024;
+    static constexpr size_t max_msg_size = 2 * 1024 * 1024;
 
   public:
     FramedTLSEndpoint(


### PR DESCRIPTION
`tlsframedendpoint` imposes a maximum message size of 2MB, but previously did so by closing connections with no logging. I've tried to improve this by logging a failure when we close these connections, logging more clearly when we're ignoring messages for closed connections, and trying to send a reasonable message back over the connection before we close it.

I made the `e2e_logging` tests deliberately increase message sizes until it hit this error, but have removed as this didn't work - the error is reported for seqno 0 so we need to fetch from the stream manually, and still we sometimes get a closed session without any preceding error message.