### PR TITLE
Generalise handling of serialisation errors

### DIFF
--- a/src/apps/batched/batched.lua
+++ b/src/apps/batched/batched.lua
@@ -15,10 +15,12 @@ return {
   BATCH_submit = [[
     tables, gov_tables, args = ...
     count = 0
-    for n, e in ipairs(args.params) do
+    for n, e in ipairs(args.params.entries) do
       id = e.id
-      msg = e.msg
-      tables.priv0:put(id, msg)
+      if id % args.params.write_key_divisor == 0 then
+        msg = string.rep(e.msg, args.params.write_size_multiplier)
+        tables.priv0:put(id, msg)
+      end
       count = count + 1
     end
     return env.jsucc(count)

--- a/src/kv/genericserialisewrapper.h
+++ b/src/kv/genericserialisewrapper.h
@@ -38,20 +38,6 @@ namespace kv
       static_cast<KotBase>(a) | static_cast<KotBase>(b));
   }
 
-  class KvSerialiserException : public std::exception
-  {
-  private:
-    std::string msg;
-
-  public:
-    KvSerialiserException(const std::string& msg_) : msg(msg_) {}
-
-    virtual const char* what() const throw()
-    {
-      return msg.c_str();
-    }
-  };
-
   template <typename K, typename V, typename Version>
   struct KeyValVersion
   {

--- a/src/kv/kvtypes.h
+++ b/src/kv/kvtypes.h
@@ -30,7 +30,8 @@ namespace kv
   {
     OK,
     CONFLICT,
-    NO_REPLICATE
+    NO_REPLICATE,
+    NO_SERIALISE
   };
 
   enum SecurityDomain

--- a/src/kv/kvtypes.h
+++ b/src/kv/kvtypes.h
@@ -30,8 +30,7 @@ namespace kv
   {
     OK,
     CONFLICT,
-    NO_REPLICATE,
-    NO_SERIALISE
+    NO_REPLICATE
   };
 
   enum SecurityDomain
@@ -75,6 +74,20 @@ namespace kv
     bool empty()
     {
       return replicated.empty() && derived.empty();
+    }
+  };
+
+  class KvSerialiserException : public std::exception
+  {
+  private:
+    std::string msg;
+
+  public:
+    KvSerialiserException(const std::string& msg_) : msg(msg_) {}
+
+    virtual const char* what() const throw()
+    {
+      return msg.c_str();
     }
   };
 

--- a/tests/e2e_batched.py
+++ b/tests/e2e_batched.py
@@ -119,4 +119,4 @@ if __name__ == "__main__":
 
     run(args)
 
-    # run_to_destruction(args)
+    run_to_destruction(args)


### PR DESCRIPTION
As discussed in #338, we currently have no way to safely recover from serialisation failures. This PR adds some more tests which will trigger serialisation failures, and ensures that they all produce a consistent response - currently aborting the executing node.

There are a few other recovery methods we could investigate here, in particular having the executing node rollback its KV, with an associated election to rollback consensus state. This may let the network recover with all nodes still alive, but needs some further thought. We hope to mitigate this risk in future with verified serialisers and increased enclave memory limits.