### PR TITLE
Support large messages over HTTP

### DIFF
--- a/src/enclave/http.h
+++ b/src/enclave/http.h
@@ -176,19 +176,15 @@ namespace enclave
     HTTPEndpoint(
       size_t session_id,
       ringbuffer::AbstractWriterFactory& writer_factory,
-      std::unique_ptr<tls::Context> ctx)
-    {
-      LOG_FAIL_FMT("FAIL");
-      assert(false);
-    }
+      std::unique_ptr<tls::Context> ctx) = delete;
 
     void recv(const uint8_t* data, size_t size)
     {
       recv_buffered(data, size);
 
       LOG_TRACE_FMT("recv called with {} bytes", size);
-      auto buf = read(4096, false); // TODO: retry if more was pending
-      LOG_TRACE_FMT("read got {}", buf.size());
+
+      auto buf = read_all_available();
 
       if (buf.size() == 0)
         return;

--- a/src/enclave/tlsendpoint.h
+++ b/src/enclave/tlsendpoint.h
@@ -195,7 +195,7 @@ namespace enclave
 
     std::vector<uint8_t> read_all_available()
     {
-      constexpr auto read_size = 1024;
+      constexpr auto read_size = 4096;
       auto buf = read(read_size, false);
 
       if (buf.size() == read_size)

--- a/src/enclave/tlsendpoint.h
+++ b/src/enclave/tlsendpoint.h
@@ -193,6 +193,30 @@ namespace enclave
       return data;
     }
 
+    std::vector<uint8_t> read_all_available()
+    {
+      constexpr auto read_size = 1024;
+      auto buf = read(read_size, false);
+
+      if (buf.size() == read_size)
+      {
+        while (true)
+        {
+          const auto more = read(read_size, false);
+
+          buf.insert(buf.end(), more.begin(), more.end());
+
+          if (more.size() != read_size)
+          {
+            break;
+          }
+        }
+      }
+
+      LOG_TRACE_FMT("read_all_available returning {} bytes", buf.size());
+      return buf;
+    }
+
     void recv(const uint8_t* data, size_t size)
     {
       pending_read.insert(pending_read.end(), data, data + size);

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -100,18 +100,16 @@ def test(network, args, notifications_queue=None):
             check(c.rpc("LOG_get", {"id": 100}), result={"msg": backup_msg})
             check(c.rpc("LOG_get", {"id": 42}), result={"msg": msg})
 
-        # TODO: Remove when HTTP supports large messages
-        if not os.getenv("HTTP"):
-            LOG.info("Write/Read large messages on primary")
-            with primary.user_client(format="json") as c:
-                id = 44
-                for p in range(14, 20):
-                    long_msg = "X" * (2 ** p)
-                    check_commit(
-                        c.rpc("LOG_record", {"id": id, "msg": long_msg}), result=True,
-                    )
-                    check(c.rpc("LOG_get", {"id": id}), result={"msg": long_msg})
-                    id += 1
+        LOG.info("Write/Read large messages on primary")
+        with primary.user_client(format="json") as c:
+            id = 44
+            for p in range(14, 20):
+                long_msg = "X" * (2 ** p)
+                check_commit(
+                    c.rpc("LOG_record", {"id": id, "msg": long_msg}), result=True,
+                )
+                check(c.rpc("LOG_get", {"id": id}), result={"msg": long_msg})
+                id += 1
 
     return network
 


### PR DESCRIPTION
`HTTPEndpoint` now reads all available data from TLS connection before trying to parse. We could do this more efficiently by converting `read(size...)` to `read_into(vector, size...)`, but I don't think its necessary at the moment (and `read()` is already pretty complicated).

I actually need this to run any e2e HTTP tests on my VM, as the quote pushes the join request over the previous 4k limit.

Resolves #548.