### PR TITLE
Support for IPv6

### DIFF
--- a/src/host/dns.h
+++ b/src/host/dns.h
@@ -19,7 +19,7 @@ namespace asynchost
       bool async)
     {
       struct addrinfo hints;
-      hints.ai_family = PF_INET;
+      hints.ai_family = AF_UNSPEC;
       hints.ai_socktype = SOCK_STREAM;
       hints.ai_protocol = IPPROTO_TCP;
       hints.ai_flags = 0;

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
       true)
     ->required();
 
-  std::string consensus;
+  std::string consensus = "raft";
   app.add_set("-c,--consensus", consensus, {"raft", "pbft"}, "Consensus", true)
     ->required();
 


### PR DESCRIPTION
**Host-side**: DNS resolution does not specify IPv4 hint
**Enclave-side**: Support writing IPv6 as well as IPv4 to SAN in node certificate

Also provide default-value for consensus option to `cchost`.

Resolves https://github.com/microsoft/CCF/issues/587