### PR TITLE
pbft mkSign to return success on emit_signature

### DIFF
--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -400,6 +400,7 @@ namespace ccf
             else if (consensus->type() == ConsensusType::Pbft)
             {
               consensus->emit_signature();
+              return jsonrpc::success(true);
             }
           }
 

--- a/tests/infra/checker.py
+++ b/tests/infra/checker.py
@@ -21,7 +21,9 @@ def wait_for_global_commit(node_client, commit_index, term, mksign=False, timeou
     # Forcing a signature accelerates this process for common operations
     # (e.g. governance proposals)
     if mksign:
-        node_client.rpc("mkSign", params={})
+        r = node_client.rpc("mkSign", params={})
+        if r.error is not None:
+            raise RuntimeError(f"mkSign returned an error: {r.error}")
 
     for i in range(timeout * 10):
         r = node_client.rpc("getCommit", {"commit": commit_index})


### PR DESCRIPTION
When running in pbft mkSign was returning an error that was not being caught by the checker

- made checker.py raise an error if we were unable to sign
- pbft return success after emit_signature