### PR TITLE
Two merkle trees

### DIFF
--- a/src/consensus/pbft/libbyz/Pre_prepare.cpp
+++ b/src/consensus/pbft/libbyz/Pre_prepare.cpp
@@ -20,6 +20,7 @@ Pre_prepare::Pre_prepare(
   rep().view = v;
   rep().seqno = s;
   rep().merkle_root.fill(0);
+  rep().r_merkle_root.fill(0);
 
   START_CC(pp_digest_cycles);
   INCR_OP(pp_digest);
@@ -232,6 +233,10 @@ bool Pre_prepare::calculate_digest(Digest& d)
     d.update_last(context, (char*)&(rep().seqno), sizeof(Seqno));
     d.update_last(
       context, (const char*)rep().merkle_root.data(), rep().merkle_root.size());
+    d.update_last(
+      context,
+      (const char*)rep().r_merkle_root.data(),
+      rep().r_merkle_root.size());
     d.update_last(context, (char*)&rep().ctx, sizeof(rep().ctx));
 
     Request req;
@@ -389,13 +394,19 @@ bool Pre_prepare::convert(Message* m1, Pre_prepare*& m2)
   return true;
 }
 
-void Pre_prepare::set_merkle_root_and_ctx(
-  const std::array<uint8_t, MERKLE_ROOT_SIZE>& merkle_root, int64_t ctx)
+void Pre_prepare::set_merkle_roots_and_ctx(
+  const std::array<uint8_t, MERKLE_ROOT_SIZE>& merkle_root,
+  const std::array<uint8_t, MERKLE_ROOT_SIZE>& r_merkle_root,
+  int64_t ctx)
 {
   std::copy(
     std::begin(merkle_root),
     std::end(merkle_root),
     std::begin(rep().merkle_root));
+  std::copy(
+    std::begin(r_merkle_root),
+    std::end(r_merkle_root),
+    std::begin(rep().r_merkle_root));
   rep().ctx = ctx;
 }
 
@@ -403,6 +414,12 @@ const std::array<uint8_t, MERKLE_ROOT_SIZE>& Pre_prepare::get_merkle_root()
   const
 {
   return rep().merkle_root;
+}
+
+const std::array<uint8_t, MERKLE_ROOT_SIZE>& Pre_prepare::get_r_merkle_root()
+  const
+{
+  return rep().r_merkle_root;
 }
 
 int64_t Pre_prepare::get_ctx() const

--- a/src/consensus/pbft/libbyz/Pre_prepare.cpp
+++ b/src/consensus/pbft/libbyz/Pre_prepare.cpp
@@ -19,8 +19,8 @@ Pre_prepare::Pre_prepare(
 {
   rep().view = v;
   rep().seqno = s;
-  rep().merkle_root.fill(0);
-  rep().r_merkle_root.fill(0);
+  rep().full_state_merkle_root.fill(0);
+  rep().replicated_state_merkle_root.fill(0);
 
   START_CC(pp_digest_cycles);
   INCR_OP(pp_digest);
@@ -232,11 +232,13 @@ bool Pre_prepare::calculate_digest(Digest& d)
     d.update_last(context, (char*)&(rep().view), sizeof(View));
     d.update_last(context, (char*)&(rep().seqno), sizeof(Seqno));
     d.update_last(
-      context, (const char*)rep().merkle_root.data(), rep().merkle_root.size());
+      context,
+      (const char*)rep().full_state_merkle_root.data(),
+      rep().full_state_merkle_root.size());
     d.update_last(
       context,
-      (const char*)rep().r_merkle_root.data(),
-      rep().r_merkle_root.size());
+      (const char*)rep().replicated_state_merkle_root.data(),
+      rep().replicated_state_merkle_root.size());
     d.update_last(context, (char*)&rep().ctx, sizeof(rep().ctx));
 
     Request req;
@@ -395,31 +397,31 @@ bool Pre_prepare::convert(Message* m1, Pre_prepare*& m2)
 }
 
 void Pre_prepare::set_merkle_roots_and_ctx(
-  const std::array<uint8_t, MERKLE_ROOT_SIZE>& merkle_root,
-  const std::array<uint8_t, MERKLE_ROOT_SIZE>& r_merkle_root,
+  const std::array<uint8_t, MERKLE_ROOT_SIZE>& full_state_merkle_root,
+  const std::array<uint8_t, MERKLE_ROOT_SIZE>& replicated_state_merkle_root,
   int64_t ctx)
 {
   std::copy(
-    std::begin(merkle_root),
-    std::end(merkle_root),
-    std::begin(rep().merkle_root));
+    std::begin(full_state_merkle_root),
+    std::end(full_state_merkle_root),
+    std::begin(rep().full_state_merkle_root));
   std::copy(
-    std::begin(r_merkle_root),
-    std::end(r_merkle_root),
-    std::begin(rep().r_merkle_root));
+    std::begin(replicated_state_merkle_root),
+    std::end(replicated_state_merkle_root),
+    std::begin(rep().replicated_state_merkle_root));
   rep().ctx = ctx;
 }
 
-const std::array<uint8_t, MERKLE_ROOT_SIZE>& Pre_prepare::get_merkle_root()
-  const
+const std::array<uint8_t, MERKLE_ROOT_SIZE>& Pre_prepare::
+  get_full_state_merkle_root() const
 {
-  return rep().merkle_root;
+  return rep().full_state_merkle_root;
 }
 
-const std::array<uint8_t, MERKLE_ROOT_SIZE>& Pre_prepare::get_r_merkle_root()
-  const
+const std::array<uint8_t, MERKLE_ROOT_SIZE>& Pre_prepare::
+  get_replicated_state_merkle_root() const
 {
-  return rep().r_merkle_root;
+  return rep().replicated_state_merkle_root;
 }
 
 int64_t Pre_prepare::get_ctx() const

--- a/src/consensus/pbft/libbyz/Pre_prepare.h
+++ b/src/consensus/pbft/libbyz/Pre_prepare.h
@@ -24,8 +24,8 @@ struct Pre_prepare_rep : public Message_rep
 {
   View view;
   Seqno seqno;
-  std::array<uint8_t, MERKLE_ROOT_SIZE> merkle_root;
-  std::array<uint8_t, MERKLE_ROOT_SIZE> r_merkle_root;
+  std::array<uint8_t, MERKLE_ROOT_SIZE> full_state_merkle_root;
+  std::array<uint8_t, MERKLE_ROOT_SIZE> replicated_state_merkle_root;
   int64_t ctx; // a context provided when a the batch is executed
                // the contents are opaque
   Digest digest; // digest of request set concatenated with
@@ -94,12 +94,14 @@ public:
   // Effects: Fetches the digest from the message.
 
   void set_merkle_roots_and_ctx(
-    const std::array<uint8_t, MERKLE_ROOT_SIZE>& merkle_root,
-    const std::array<uint8_t, MERKLE_ROOT_SIZE>& r_merkle_root,
+    const std::array<uint8_t, MERKLE_ROOT_SIZE>& full_state_merkle_root,
+    const std::array<uint8_t, MERKLE_ROOT_SIZE>& replicated_state_merkle_root,
     int64_t ctx);
 
-  const std::array<uint8_t, MERKLE_ROOT_SIZE>& get_merkle_root() const;
-  const std::array<uint8_t, MERKLE_ROOT_SIZE>& get_r_merkle_root() const;
+  const std::array<uint8_t, MERKLE_ROOT_SIZE>& get_full_state_merkle_root()
+    const;
+  const std::array<uint8_t, MERKLE_ROOT_SIZE>&
+  get_replicated_state_merkle_root() const;
 
   int64_t get_ctx() const;
 

--- a/src/consensus/pbft/libbyz/Pre_prepare.h
+++ b/src/consensus/pbft/libbyz/Pre_prepare.h
@@ -25,6 +25,7 @@ struct Pre_prepare_rep : public Message_rep
   View view;
   Seqno seqno;
   std::array<uint8_t, MERKLE_ROOT_SIZE> merkle_root;
+  std::array<uint8_t, MERKLE_ROOT_SIZE> r_merkle_root;
   int64_t ctx; // a context provided when a the batch is executed
                // the contents are opaque
   Digest digest; // digest of request set concatenated with
@@ -92,10 +93,13 @@ public:
   Digest& digest() const;
   // Effects: Fetches the digest from the message.
 
-  void set_merkle_root_and_ctx(
-    const std::array<uint8_t, MERKLE_ROOT_SIZE>& merkle_root, int64_t ctx);
+  void set_merkle_roots_and_ctx(
+    const std::array<uint8_t, MERKLE_ROOT_SIZE>& merkle_root,
+    const std::array<uint8_t, MERKLE_ROOT_SIZE>& r_merkle_root,
+    int64_t ctx);
 
   const std::array<uint8_t, MERKLE_ROOT_SIZE>& get_merkle_root() const;
+  const std::array<uint8_t, MERKLE_ROOT_SIZE>& get_r_merkle_root() const;
 
   int64_t get_ctx() const;
 

--- a/src/consensus/pbft/libbyz/Replica.cpp
+++ b/src/consensus/pbft/libbyz/Replica.cpp
@@ -241,8 +241,8 @@ bool Replica::compare_execution_results(
         std::end(pp_root),
         std::begin(info.full_state_merkle_root)))
   {
-    LOG_FAIL << "Merkle root between execution and the pre_prepare message "
-                "does not match, seqno:"
+    LOG_FAIL << "Full state merkle root between execution and the pre_prepare "
+                "message does not match, seqno:"
              << pre_prepare->seqno() << std::endl;
     return false;
   }
@@ -252,9 +252,8 @@ bool Replica::compare_execution_results(
         std::end(r_pp_root),
         std::begin(info.replicated_state_merkle_root)))
   {
-    LOG_FAIL << "Merkle root for replicated data between execution and the "
-                "pre_prepare message "
-                "does not match, seqno:"
+    LOG_FAIL << "Replicated state merkle root between execution and the "
+                "pre_prepare message does not match, seqno:"
              << pre_prepare->seqno() << std::endl;
     return false;
   }

--- a/src/consensus/pbft/libbyz/test/replica_main.cpp
+++ b/src/consensus/pbft/libbyz/test/replica_main.cpp
@@ -66,10 +66,10 @@ ExecCommand exec_command = [](
   Byz_modify(&counter, sizeof(counter));
   counter++;
 
-  info.merkle_root.fill(0);
-  ((Long*)(info.merkle_root.data()))[0] = counter;
-  info.r_merkle_root.fill(0);
-  ((Long*)(info.r_merkle_root.data()))[0] = counter;
+  info.full_state_merkle_root.fill(0);
+  ((Long*)(info.full_state_merkle_root.data()))[0] = counter;
+  info.replicated_state_merkle_root.fill(0);
+  ((Long*)(info.replicated_state_merkle_root.data()))[0] = counter;
 
   if (!ro & is_test)
   {

--- a/src/consensus/pbft/libbyz/test/replica_main.cpp
+++ b/src/consensus/pbft/libbyz/test/replica_main.cpp
@@ -68,6 +68,8 @@ ExecCommand exec_command = [](
 
   info.merkle_root.fill(0);
   ((Long*)(info.merkle_root.data()))[0] = counter;
+  info.r_merkle_root.fill(0);
+  ((Long*)(info.r_merkle_root.data()))[0] = counter;
 
   if (!ro & is_test)
   {

--- a/src/consensus/pbft/libbyz/test/replica_test.cpp
+++ b/src/consensus/pbft/libbyz/test/replica_test.cpp
@@ -197,6 +197,8 @@ ExecCommand exec_command = [](
 
   info.merkle_root.fill(0);
   ((Long*)(info.merkle_root.data()))[0] = counter;
+  info.r_merkle_root.fill(0);
+  ((Long*)(info.r_merkle_root.data()))[0] = counter;
   info.ctx = counter;
 
   if (total_requests_executed != counter)

--- a/src/consensus/pbft/libbyz/test/replica_test.cpp
+++ b/src/consensus/pbft/libbyz/test/replica_test.cpp
@@ -195,10 +195,10 @@ ExecCommand exec_command = [](
   counter++;
   have_executed_request = true;
 
-  info.merkle_root.fill(0);
-  ((Long*)(info.merkle_root.data()))[0] = counter;
-  info.r_merkle_root.fill(0);
-  ((Long*)(info.r_merkle_root.data()))[0] = counter;
+  info.full_state_merkle_root.fill(0);
+  ((Long*)(info.full_state_merkle_root.data()))[0] = counter;
+  info.replicated_state_merkle_root.fill(0);
+  ((Long*)(info.replicated_state_merkle_root.data()))[0] = counter;
   info.ctx = counter;
 
   if (total_requests_executed != counter)

--- a/src/consensus/pbft/libbyz/test/test_ledger_replay.cpp
+++ b/src/consensus/pbft/libbyz/test/test_ledger_replay.cpp
@@ -43,10 +43,10 @@ public:
                                ByzInfo& info) {
     auto request = reinterpret_cast<fake_req*>(inb->contents);
     info.ctx = request->ctx;
-    info.merkle_root.fill(0);
-    info.r_merkle_root.fill(0);
-    info.merkle_root.data()[0] = request->rt;
-    info.r_merkle_root.data()[0] = request->rt;
+    info.full_state_merkle_root.fill(0);
+    info.replicated_state_merkle_root.fill(0);
+    info.full_state_merkle_root.data()[0] = request->rt;
+    info.replicated_state_merkle_root.data()[0] = request->rt;
     return 0;
   };
 };
@@ -145,13 +145,15 @@ TEST_CASE("Test Ledger Replay")
       // imitate exec command
       ByzInfo info;
       info.ctx = fr->ctx;
-      info.merkle_root.fill(0);
-      info.r_merkle_root.fill(0);
-      info.merkle_root.data()[0] = fr->rt;
-      info.r_merkle_root.data()[0] = fr->rt;
+      info.full_state_merkle_root.fill(0);
+      info.replicated_state_merkle_root.fill(0);
+      info.full_state_merkle_root.data()[0] = fr->rt;
+      info.replicated_state_merkle_root.data()[0] = fr->rt;
 
       pp->set_merkle_roots_and_ctx(
-        info.merkle_root, info.r_merkle_root, info.ctx);
+        info.full_state_merkle_root,
+        info.replicated_state_merkle_root,
+        info.ctx);
 
       ledger_writer.write_pre_prepare(pp.get());
     }

--- a/src/consensus/pbft/libbyz/test/test_ledger_replay.cpp
+++ b/src/consensus/pbft/libbyz/test/test_ledger_replay.cpp
@@ -44,7 +44,9 @@ public:
     auto request = reinterpret_cast<fake_req*>(inb->contents);
     info.ctx = request->ctx;
     info.merkle_root.fill(0);
+    info.r_merkle_root.fill(0);
     info.merkle_root.data()[0] = request->rt;
+    info.r_merkle_root.data()[0] = request->rt;
     return 0;
   };
 };
@@ -144,9 +146,12 @@ TEST_CASE("Test Ledger Replay")
       ByzInfo info;
       info.ctx = fr->ctx;
       info.merkle_root.fill(0);
+      info.r_merkle_root.fill(0);
       info.merkle_root.data()[0] = fr->rt;
+      info.r_merkle_root.data()[0] = fr->rt;
 
-      pp->set_merkle_root_and_ctx(info.merkle_root, info.ctx);
+      pp->set_merkle_roots_and_ctx(
+        info.merkle_root, info.r_merkle_root, info.ctx);
 
       ledger_writer.write_pre_prepare(pp.get());
     }

--- a/src/consensus/pbft/libbyz/types.h
+++ b/src/consensus/pbft/libbyz/types.h
@@ -45,8 +45,8 @@ typedef struct _Byz_buffer Byz_rep;
 static const uint32_t MERKLE_ROOT_SIZE = 32;
 struct ByzInfo
 {
-  std::array<uint8_t, MERKLE_ROOT_SIZE> merkle_root;
-  std::array<uint8_t, MERKLE_ROOT_SIZE> r_merkle_root;
+  std::array<uint8_t, MERKLE_ROOT_SIZE> full_state_merkle_root;
+  std::array<uint8_t, MERKLE_ROOT_SIZE> replicated_state_merkle_root;
   int64_t ctx;
 };
 

--- a/src/consensus/pbft/libbyz/types.h
+++ b/src/consensus/pbft/libbyz/types.h
@@ -46,6 +46,7 @@ static const uint32_t MERKLE_ROOT_SIZE = 32;
 struct ByzInfo
 {
   std::array<uint8_t, MERKLE_ROOT_SIZE> merkle_root;
+  std::array<uint8_t, MERKLE_ROOT_SIZE> r_merkle_root;
   int64_t ctx;
 };
 

--- a/src/consensus/pbft/pbftconfig.h
+++ b/src/consensus/pbft/pbftconfig.h
@@ -126,10 +126,15 @@ namespace pbft
       auto rep = frontend->process_pbft(ctx);
 
       static_assert(sizeof(info.merkle_root) == sizeof(crypto::Sha256Hash));
+      static_assert(sizeof(info.r_merkle_root) == sizeof(crypto::Sha256Hash));
       std::copy(
         std::begin(rep.merkle_root.h),
         std::end(rep.merkle_root.h),
         std::begin(info.merkle_root));
+      std::copy(
+        std::begin(rep.r_merkle_root.h),
+        std::end(rep.r_merkle_root.h),
+        std::begin(info.r_merkle_root));
       info.ctx = rep.version;
 
       outb->size = rep.result.size();

--- a/src/consensus/pbft/pbftconfig.h
+++ b/src/consensus/pbft/pbftconfig.h
@@ -125,16 +125,19 @@ namespace pbft
 
       auto rep = frontend->process_pbft(ctx);
 
-      static_assert(sizeof(info.merkle_root) == sizeof(crypto::Sha256Hash));
-      static_assert(sizeof(info.r_merkle_root) == sizeof(crypto::Sha256Hash));
+      static_assert(
+        sizeof(info.full_state_merkle_root) == sizeof(crypto::Sha256Hash));
+      static_assert(
+        sizeof(info.replicated_state_merkle_root) ==
+        sizeof(crypto::Sha256Hash));
       std::copy(
-        std::begin(rep.merkle_root.h),
-        std::end(rep.merkle_root.h),
-        std::begin(info.merkle_root));
+        std::begin(rep.full_state_merkle_root.h),
+        std::end(rep.full_state_merkle_root.h),
+        std::begin(info.full_state_merkle_root));
       std::copy(
-        std::begin(rep.r_merkle_root.h),
-        std::end(rep.r_merkle_root.h),
-        std::begin(info.r_merkle_root));
+        std::begin(rep.replicated_state_merkle_root.h),
+        std::end(rep.replicated_state_merkle_root.h),
+        std::begin(info.replicated_state_merkle_root));
       info.ctx = rep.version;
 
       outb->size = rep.result.size();

--- a/src/enclave/rpchandler.h
+++ b/src/enclave/rpchandler.h
@@ -32,8 +32,8 @@ namespace enclave
     struct ProcessPbftResp
     {
       std::vector<uint8_t> result;
-      crypto::Sha256Hash merkle_root;
-      crypto::Sha256Hash r_merkle_root;
+      crypto::Sha256Hash full_state_merkle_root;
+      crypto::Sha256Hash replicated_state_merkle_root;
       kv::Version version;
     };
 

--- a/src/enclave/rpchandler.h
+++ b/src/enclave/rpchandler.h
@@ -33,6 +33,7 @@ namespace enclave
     {
       std::vector<uint8_t> result;
       crypto::Sha256Hash merkle_root;
+      crypto::Sha256Hash r_merkle_root;
       kv::Version version;
     };
 

--- a/src/kv/kv.h
+++ b/src/kv/kv.h
@@ -1655,7 +1655,8 @@ namespace kv
           }
           success = DeserialiseSuccess::PASS_SIGNATURE;
         }
-        h->append(data);
+        auto rep = frame::replicated(data.data());
+        h->append(rep.p, rep.n, data.data(), data.size());
       }
 
       return success;

--- a/src/kv/kvtypes.h
+++ b/src/kv/kvtypes.h
@@ -102,6 +102,7 @@ namespace kv
       RequestID rid;
       Version version;
       crypto::Sha256Hash merkle_root;
+      crypto::Sha256Hash r_merkle_root;
     };
 
     struct ResponseCallbackArgs
@@ -114,8 +115,14 @@ namespace kv
     using ResponseCallbackHandler = std::function<bool(ResponseCallbackArgs)>;
 
     virtual ~TxHistory() {}
-    virtual void append(const std::vector<uint8_t>& data) = 0;
-    virtual void append(const uint8_t* data, size_t size) = 0;
+    virtual void append(
+      const std::vector<uint8_t>& replicated,
+      const std::vector<uint8_t>& all_data) = 0;
+    virtual void append(
+      const uint8_t* replicated,
+      size_t replicated_size,
+      const uint8_t* all_data,
+      size_t all_data_size) = 0;
     virtual bool verify(Term* term = nullptr) = 0;
     virtual void rollback(Version v) = 0;
     virtual void compact(Version v) = 0;
@@ -146,6 +153,7 @@ namespace kv
     virtual void clear_on_result() = 0;
     virtual void clear_on_response() = 0;
     virtual crypto::Sha256Hash get_root() = 0;
+    virtual crypto::Sha256Hash get_r_root() = 0;
     virtual std::vector<uint8_t> get_receipt(Version v) = 0;
     virtual bool verify_receipt(const std::vector<uint8_t>& receipt) = 0;
   };

--- a/src/kv/kvtypes.h
+++ b/src/kv/kvtypes.h
@@ -101,8 +101,8 @@ namespace kv
     {
       RequestID rid;
       Version version;
-      crypto::Sha256Hash merkle_root;
-      crypto::Sha256Hash r_merkle_root;
+      crypto::Sha256Hash full_state_merkle_root;
+      crypto::Sha256Hash replicated_state_merkle_root;
     };
 
     struct ResponseCallbackArgs
@@ -152,8 +152,8 @@ namespace kv
     virtual void register_on_response(ResponseCallbackHandler func) = 0;
     virtual void clear_on_result() = 0;
     virtual void clear_on_response() = 0;
-    virtual crypto::Sha256Hash get_root() = 0;
-    virtual crypto::Sha256Hash get_r_root() = 0;
+    virtual crypto::Sha256Hash get_full_state_root() = 0;
+    virtual crypto::Sha256Hash get_replicated_state_root() = 0;
     virtual std::vector<uint8_t> get_receipt(Version v) = 0;
     virtual bool verify_receipt(const std::vector<uint8_t>& receipt) = 0;
   };

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -101,7 +101,11 @@ namespace kv
 
     ConsensusType type() override
     {
+#ifdef PBFT
+      return ConsensusType::Pbft;
+#else
       return ConsensusType::Raft;
+#endif
     }
   };
 

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -717,7 +717,7 @@ namespace ccf
       // When reaching the end of the private ledger, make sure the same
       // ledger has been read and swap in private state
       auto h = dynamic_cast<MerkleTxHistory*>(recovery_history.get());
-      if (h->get_root() != recovery_root)
+      if (h->get_full_state_root() != recovery_root)
       {
         LOG_FATAL_FMT(
           "Root of public store does not match root of private store");
@@ -807,7 +807,7 @@ namespace ccf
       // Record real store version and root
       recovery_v = network.tables->current_version();
       auto h = dynamic_cast<MerkleTxHistory*>(history.get());
-      recovery_root = h->get_root();
+      recovery_root = h->get_full_state_root();
 
       LOG_DEBUG_FMT("Recovery store successfully setup: {}", recovery_v);
     }

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -400,6 +400,7 @@ namespace ccf
             else if (consensus->type() == ConsensusType::Pbft)
             {
               consensus->emit_signature();
+              return jsonrpc::success(true);
             }
           }
 

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -217,16 +217,16 @@ TEST_CASE("Check signing works across rollback")
 
   INFO("Check merkle roots are updating");
   {
-    auto primary_root = primary_history->get_root();
+    auto primary_root = primary_history->get_full_state_root();
     auto pr_str = fmt::format("{}", primary_root);
-    auto backup_root = backup_history->get_root();
+    auto backup_root = backup_history->get_full_state_root();
     auto bk_str = fmt::format("{}", backup_root);
 
     REQUIRE(pr_str == bk_str);
 
-    auto r_primary_root = primary_history->get_r_root();
+    auto r_primary_root = primary_history->get_replicated_state_root();
     auto r_pr_str = fmt::format("{}", r_primary_root);
-    auto r_backup_root = backup_history->get_r_root();
+    auto r_backup_root = backup_history->get_replicated_state_root();
     auto r_bk_str = fmt::format("{}", r_backup_root);
 
     REQUIRE(r_pr_str == r_bk_str);

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -236,7 +236,7 @@ TEST_CASE("Check signing works across rollback")
 
     if (consensus->type() == ConsensusType::Raft)
     {
-      // check that the replicated tree is not beign updated
+      // check that the replicated tree is not being updated
       REQUIRE(r_pr_str == empty_hash_str);
     }
     else

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -197,11 +197,52 @@ TEST_CASE("Check signing works across rollback")
   }
 
   primary_store.rollback(1);
+  if (consensus->type() == ConsensusType::Pbft)
+  {
+    backup_store.rollback(1);
+  }
 
   INFO("Issue signature, and verify successfully on backup");
   {
     primary_history->emit_signature();
-    REQUIRE(backup_store.current_version() == 2);
+    if (consensus->type() == ConsensusType::Pbft)
+    {
+      REQUIRE(backup_store.current_version() == 1);
+    }
+    else
+    {
+      REQUIRE(backup_store.current_version() == 2);
+    }
+  }
+
+  INFO("Check merkle roots are updating");
+  {
+    auto primary_root = primary_history->get_root();
+    auto pr_str = fmt::format("{}", primary_root);
+    auto backup_root = backup_history->get_root();
+    auto bk_str = fmt::format("{}", backup_root);
+
+    REQUIRE(pr_str == bk_str);
+
+    auto r_primary_root = primary_history->get_r_root();
+    auto r_pr_str = fmt::format("{}", r_primary_root);
+    auto r_backup_root = backup_history->get_r_root();
+    auto r_bk_str = fmt::format("{}", r_backup_root);
+
+    REQUIRE(r_pr_str == r_bk_str);
+
+    auto empty_hash = crypto::Sha256Hash();
+    auto empty_hash_str = fmt::format("{}", empty_hash);
+
+    if (consensus->type() == ConsensusType::Raft)
+    {
+      // check that the replicated tree is not beign updated
+      REQUIRE(r_pr_str == empty_hash_str);
+    }
+    else
+    {
+      REQUIRE(r_pr_str != empty_hash_str);
+    }
   }
 }
 

--- a/src/node/test/history_bench.cpp
+++ b/src/node/test/history_bench.cpp
@@ -156,7 +156,7 @@ static void append(picobench::state& s)
   for (auto _ : s)
   {
     (void)_;
-    history->append(txs[idx++]);
+    history->append({}, txs[idx++]);
     clobber_memory();
   }
   s.stop_timer();
@@ -196,7 +196,7 @@ static void append_compact(picobench::state& s)
   for (auto _ : s)
   {
     (void)_;
-    history->append(txs[idx++]);
+    history->append({}, txs[idx++]);
     if (idx % 1000)
       history->compact(idx);
     clobber_memory();

--- a/tests/infra/checker.py
+++ b/tests/infra/checker.py
@@ -21,7 +21,9 @@ def wait_for_global_commit(node_client, commit_index, term, mksign=False, timeou
     # Forcing a signature accelerates this process for common operations
     # (e.g. governance proposals)
     if mksign:
-        node_client.rpc("mkSign", params={})
+        r = node_client.rpc("mkSign", params={})
+        if r.error is not None:
+            raise RuntimeError(f"mkSign returned an error: {r.error}")
 
     for i in range(timeout * 10):
         r = node_client.rpc("getCommit", {"commit": commit_index})


### PR DESCRIPTION
Regarding #539 (item 4, 5c, 5d)

- added second merkle tree to be updated when we are running in pbft and have replicated data (replicated tables). The original merkle tree continues to be updated due to all of the maps on both of the consensuses
- second merkle tree root (r_merkle_root) is added to the pre-prepare
- history will append, rollback, and compact the replicated merkle tree only when the consensus is pbft, otherwise it ignores it

We only use the replicated merkle tree root in the pre-prepare. Everything else still relies only on the all-data merkle tree (but can be updated when/if needed to use the `r_root()` too):
 
- `receipts` are issued and verified over the all-data merkle tree
- `history->emit_signature()` is done over the all-data merkle tree root
- `history->verify()` is done over the all-data merkle tree root
- recovery uses the all-data merkle tree root
- `history->add_result()` stores the root of the all-data merkle tree in the `results` map