### PR TITLE
Add generic JSON-scenario perf client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -429,7 +429,7 @@ if(BUILD_TESTS)
       LABEL logging_scenario_perf_test
       ADDITIONAL_ARGS
         --package libloggingenc
-        --scenario-file ${CMAKE_CURRENT_LIST_DIR}/tests
+        --scenario-file ${CMAKE_CURRENT_LIST_DIR}/tests/perf_logging_scenario_100txs.json
         --repetitions 1000
     )
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,13 @@ target_link_libraries(logging_client PRIVATE
   ${CMAKE_THREAD_LIBS_INIT}
 )
 
-add_enclave_lib(loggingenc ${CMAKE_CURRENT_SOURCE_DIR}/src/apps/logging/oe_sign.conf ${CMAKE_CURRENT_SOURCE_DIR}/src/apps/sample_key.pem SRCS src/apps/logging/logging.cpp src/apps/logging/stub_for_code_signing.cpp)
+add_enclave_lib(loggingenc
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/apps/logging/oe_sign.conf
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/apps/sample_key.pem
+  SRCS
+    src/apps/logging/logging.cpp
+    src/apps/logging/stub_for_code_signing.cpp
+)
 
 if(BUILD_TESTS)
   # Tests
@@ -413,6 +419,18 @@ if(BUILD_TESTS)
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/election.py
       ADDITIONAL_ARGS
         --election-timeout 2000
+    )
+
+    # Logging scenario perf test
+    add_perf_test(
+      NAME logging_scenario_perf_test
+      PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/perfclient.py
+      CLIENT_BIN ./scenario_perf_client
+      LABEL logging_scenario_perf_test
+      ADDITIONAL_ARGS
+        --package libloggingenc
+        --scenario-file ${CMAKE_CURRENT_LIST_DIR}/tests
+        --repetitions 1000
     )
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,19 +421,20 @@ if(BUILD_TESTS)
         --election-timeout 2000
     )
 
-    # Logging scenario perf test
-    add_perf_test(
-      NAME logging_scenario_perf_test
-      PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/perfclient.py
-      CLIENT_BIN ./scenario_perf_client
-      LABEL logging_scenario_perf_test
-      ADDITIONAL_ARGS
-        --package libloggingenc
-        --scenario-file ${CMAKE_CURRENT_LIST_DIR}/tests/perf_logging_scenario_100txs.json
-        --repetitions 1000
-    )
+    if (NOT PBFT)
+      # Logging scenario perf test
+      add_perf_test(
+        NAME logging_scenario_perf_test
+        PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/perfclient.py
+        CLIENT_BIN ./scenario_perf_client
+        LABEL logging_scenario_perf_test
+        ADDITIONAL_ARGS
+          --package libloggingenc
+          --scenario-file ${CMAKE_CURRENT_LIST_DIR}/tests/perf_logging_scenario_100txs.json
+          --repetitions 1000
+      )
+    endif()
   endif()
-
 
   if (EXTENSIVE_TESTS)
     set_tests_properties(recovery_tests PROPERTIES TIMEOUT 2000)

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -555,6 +555,16 @@ target_link_libraries(client PRIVATE
 )
 add_dependencies(client flatbuffers)
 
+# Perf scenario executable
+add_executable(scenario_perf_client
+  ${CCF_DIR}/samples/perf_client/scenario_perf_client.cpp
+)
+use_client_mbedtls(scenario_perf_client)
+target_link_libraries(scenario_perf_client PRIVATE
+  ${CMAKE_THREAD_LIBS_INIT}
+  secp256k1.host
+)
+
 # Lua for host and enclave
 add_enclave_library_c(lua.enclave "${LUA_SOURCES}")
 target_compile_definitions(lua.enclave PRIVATE NO_IO)

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -599,9 +599,6 @@ add_enclave_lib(luagenericenc ${CCF_DIR}/src/apps/luageneric/oe_sign.conf ${CCF_
 
 # Samples
 
-# Common options
-set(TEST_ITERATIONS 200000)
-
 ## Helper for building clients inheriting from perf_client
 function(add_client_exe name)
 
@@ -685,14 +682,9 @@ function(add_perf_test)
 
   cmake_parse_arguments(PARSE_ARGV 0 PARSED_ARGS
     ""
-    "NAME;PYTHON_SCRIPT;CLIENT_BIN;ITERATIONS;VERIFICATION_FILE;LABEL"
+    "NAME;PYTHON_SCRIPT;CLIENT_BIN;VERIFICATION_FILE;LABEL"
     "ADDITIONAL_ARGS"
   )
-
-  ## Use default value if undefined
-  if(NOT PARSED_ARGS_ITERATIONS)
-    set(PARSED_ARGS_ITERATIONS ${TEST_ITERATIONS})
-  endif()
 
   if(PARSED_ARGS_VERIFICATION_FILE)
     set(VERIFICATION_ARG "--verify ${PARSED_ARGS_VERIFICATION_FILE}")
@@ -715,12 +707,11 @@ function(add_perf_test)
     COMMAND ${PYTHON} ${PARSED_ARGS_PYTHON_SCRIPT}
       -b .
       -c ${PARSED_ARGS_CLIENT_BIN}
-      -i ${PARSED_ARGS_ITERATIONS}
       ${CCF_NETWORK_TEST_ARGS}
-      ${PARSED_ARGS_ADDITIONAL_ARGS}
       --write-tx-times
       ${VERIFICATION_ARG}
       ${LABEL_ARG}
+      ${PARSED_ARGS_ADDITIONAL_ARGS}
   )
 
   ## Make python test client framework importable

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -27,9 +27,9 @@ if(BUILD_TESTS)
     PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/small_bank_client.py
     CLIENT_BIN ./small_bank_client
     VERIFICATION_FILE ${SMALL_BANK_VERIFICATION_FILE}
-    ITERATIONS ${SMALL_BANK_ITERATIONS}
     LABEL Small_Bank_ClientCpp
     ADDITIONAL_ARGS
+      --transactions ${SMALL_BANK_ITERATIONS}
       --max-writes-ahead 1000
       --metrics-file small_bank_metrics.json
   )
@@ -51,9 +51,9 @@ if(BUILD_TESTS)
       PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/small_bank_client.py
       CLIENT_BIN ./small_bank_client
       VERIFICATION_FILE ${SMALL_BANK_SIGNED_VERIFICATION_FILE}
-      ITERATIONS ${SMALL_BANK_SIGNED_ITERATIONS}
       LABEL Small_Bank_Client_Sigs
       ADDITIONAL_ARGS
+        --transactions ${SMALL_BANK_SIGNED_ITERATIONS}
         --max-writes-ahead 1000
         --sign
         --metrics-file small_bank_sigs_metrics.json
@@ -65,9 +65,9 @@ if(BUILD_TESTS)
       NAME small_bank_sigs_forwarding
       PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/small_bank_client.py
       CLIENT_BIN ./small_bank_client
-      ITERATIONS ${SMALL_BANK_SIGNED_ITERATIONS}
       LABEL Small_Bank_ClientSigs_Forwarding
       ADDITIONAL_ARGS
+        --transactions ${SMALL_BANK_SIGNED_ITERATIONS}
         --max-writes-ahead 1000
         --metrics-file small_bank_fwd_metrics.json
         -n localhost -n localhost

--- a/samples/perf_client/scenario_perf_client.cpp
+++ b/samples/perf_client/scenario_perf_client.cpp
@@ -29,7 +29,7 @@ private:
     }
 
     // Reserve space for transactions
-    prepared_txs.resize(transactions.size() * repetitions);
+    prepared_txs.reserve(transactions.size() * repetitions);
 
     for (size_t r = 0; r < repetitions; ++r)
     {
@@ -38,10 +38,7 @@ private:
         const auto& transaction = transactions[i];
 
         add_prepared_tx(
-          transaction["method"],
-          transaction["params"],
-          true,
-          r * repetitions + i);
+          transaction["method"], transaction["params"], true, std::nullopt);
       }
     }
   }

--- a/samples/perf_client/scenario_perf_client.cpp
+++ b/samples/perf_client/scenario_perf_client.cpp
@@ -17,7 +17,7 @@ private:
 
   void prepare_transactions() override
   {
-    constexpr transactions_element_name = "transactions";
+    constexpr auto transactions_element_name = "transactions";
 
     const auto transactions = scenario_json[transactions_element_name];
     if (!transactions.is_array())

--- a/samples/perf_client/scenario_perf_client.cpp
+++ b/samples/perf_client/scenario_perf_client.cpp
@@ -29,13 +29,20 @@ private:
     }
 
     // Reserve space for transactions
-    prepared_txs.resize(transactions.size());
+    prepared_txs.resize(transactions.size() * repetitions);
 
-    for (size_t i = 0; i < transactions.size(); ++i)
+    for (size_t r = 0; r < repetitions; ++r)
     {
-      const auto& transaction = transactions[i];
+      for (size_t i = 0; i < transactions.size(); ++i)
+      {
+        const auto& transaction = transactions[i];
 
-      add_prepared_tx(transaction["method"], transaction["params"], true, i);
+        add_prepared_tx(
+          transaction["method"],
+          transaction["params"],
+          true,
+          r * repetitions + i);
+      }
     }
   }
 

--- a/samples/perf_client/scenario_perf_client.h
+++ b/samples/perf_client/scenario_perf_client.h
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#include "ds/files.h"
+#include "perf_client.h"
+
+#include <nlohmann/json.hpp>
+#include <string>
+
+using Base = client::PerfBase;
+
+class ScenarioPerfClient : public Base
+{
+private:
+  size_t repetitions = 1;
+  std::string scenario_file;
+  nlohmann::json scenario_json;
+
+  void prepare_transactions() override
+  {
+    constexpr transactions_element_name = "transactions";
+
+    const auto transactions = scenario_json[transactions_element_name];
+    if (!transactions.is_array())
+    {
+      throw std::runtime_error(fmt::format(
+        "Expected scenario to contain a '{}' field containing an array of "
+        "transaction objects",
+        transactions_element_name));
+    }
+
+    // Reserve space for transactions
+    prepared_txs.resize(transactions.size());
+
+    for (size_t i = 0; i < transactions.size(); ++i)
+    {
+      const auto& transaction = transactions[i];
+
+      add_prepared_tx(transaction["method"], transaction["params"], true, i);
+    }
+  }
+
+  void pre_creation_hook() override
+  {
+    scenario_json = files::slurp_json(scenario_file);
+  }
+
+public:
+  ScenarioPerfClient() : Base("scenario_perf") {}
+
+  void setup_parser(CLI::App& app) override
+  {
+    Base::setup_parser(app);
+
+    app.add_option("--repetitions", repetitions);
+    app.add_option("--scenario-file", scenario_file)
+      ->required(true)
+      ->check(CLI::ExistingFile);
+  }
+};
+
+int main(int argc, char** argv)
+{
+  ScenarioPerfClient client;
+  CLI::App cli_app{"Scenario Perf Client"};
+  client.setup_parser(cli_app);
+  CLI11_PARSE(cli_app, argc, argv);
+
+  client.run();
+
+  return 0;
+}

--- a/tests/infra/remote_client.py
+++ b/tests/infra/remote_client.py
@@ -28,7 +28,6 @@ class CCFRemoteClient(object):
         node_port,
         workspace,
         label,
-        iterations,
         config,
         command_args,
         remote_class,
@@ -56,7 +55,6 @@ class CCFRemoteClient(object):
         cmd = [
             self.BIN,
             f"--rpc-address={node_host}:{node_port}",
-            f"--transactions={iterations}",
             f"--config={os.path.basename(config)}",
         ] + client_command_args
 

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -39,8 +39,6 @@ def get_command_args(args, get_command):
     command_args = []
     if args.label:
         command_args.append("--label={}".format(args.label))
-    if args.sign:
-        command_args.append("--sign")
     return get_command(*command_args)
 
 
@@ -68,7 +66,6 @@ def configure_remote_client(args, client_id, client_host, node, command_args):
             node.rpc_port,
             args.workspace,
             args.label,
-            args.iterations,
             args.config,
             command_args,
             remote_impl,

--- a/tests/perf_logging_scenario_100txs.json
+++ b/tests/perf_logging_scenario_100txs.json
@@ -1,0 +1,704 @@
+{
+  "transactions": [
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 0,
+        "msg": "Unique message: d41d8cd98f00b204e9800998ecf8427e"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 1,
+        "msg": "Unique message: 93b885adfe0da089cdf634904fd59f71"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 2,
+        "msg": "Unique message: c4103f122d27677c9db144cae1394a66"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 3,
+        "msg": "Unique message: 693e9af84d3dfcc71e640e005bdc5e2e"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 4,
+        "msg": "Unique message: f1d3ff8443297732862df21dc4e57262"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 5,
+        "msg": "Unique message: ca9c491ac66b2c62500882e93f3719a8"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 6,
+        "msg": "Unique message: 7319468847d7b1aee40dbf5dd963c999"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 7,
+        "msg": "Unique message: d310a40483f9399dd7ed1712e0fdd702"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 8,
+        "msg": "Unique message: 7dea362b3fac8e00956a4952a3d4f474"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 9,
+        "msg": "Unique message: 3f2829b2ffe8434d67f98a2a98968652"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 10,
+        "msg": "Unique message: a63c90cc3684ad8b0a2176a6a8fe9005"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 11,
+        "msg": "Unique message: 74da4121dc1c0ed2a8e5b0741f824034"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 12,
+        "msg": "Unique message: 8dd6bb7329a71449b0a1b292b5999164"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 13,
+        "msg": "Unique message: 0b867e53c1d233ce9fe49d54549a2323"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 14,
+        "msg": "Unique message: 36df9540a5ef4996a9737657e4a8929c"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 15,
+        "msg": "Unique message: 3449c9e5e332f1dbb81505cd739fbf3f"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 16,
+        "msg": "Unique message: 4ae71336e44bf9bf79d2752e234818a5"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 17,
+        "msg": "Unique message: f3c8bdb6b9df478f227af2ce61c8a5a1"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 18,
+        "msg": "Unique message: ff035bff2dcf972ee7dfd023455997ef"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 19,
+        "msg": "Unique message: 0e6bce6899fae841f79024afbdf7db1d"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 20,
+        "msg": "Unique message: 441018525208457705bf09a8ee3c1093"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 21,
+        "msg": "Unique message: 2319ac34f4848755a639fd524038dfd3"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 22,
+        "msg": "Unique message: db46e81649d6863b16bd99ab139c865b"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 23,
+        "msg": "Unique message: 6b43b583e2b662724b6fbb5189f6ab28"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 24,
+        "msg": "Unique message: 1681ffc6e046c7af98c9e6c232a3fe0a"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 25,
+        "msg": "Unique message: d28c293e10139d5d8f6e4592aeaffc1b"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 26,
+        "msg": "Unique message: a396c59a96af3b36d364448c7b687fb1"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 27,
+        "msg": "Unique message: 65435a5d117aa6b052a5f737d9946a7b"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 28,
+        "msg": "Unique message: 1c9e99e48a495fe81d388fdb4900e59f"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 29,
+        "msg": "Unique message: 4aa476a72347ba44c9bd20c974d0f181"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 30,
+        "msg": "Unique message: 862dec5c27142824a394bc6464928f48"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 31,
+        "msg": "Unique message: 3861facee9efc127e340387f1936b8fb"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 32,
+        "msg": "Unique message: 70bc8f4b72a86921468bf8e8441dce51"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 33,
+        "msg": "Unique message: 099a150e83972a433492a59c2fbe98e0"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 34,
+        "msg": "Unique message: 0b91f1d54f932dc6382dc69f197900cf"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 35,
+        "msg": "Unique message: c54104d7894a1941ca710981da437f9f"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 36,
+        "msg": "Unique message: 81684c2e68ade2cd4bf9f2e8a67dd4fe"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 37,
+        "msg": "Unique message: 21e2e8fe686ed0003b67d698b1273481"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 38,
+        "msg": "Unique message: f3a534d52e3fe0c7a85b30ca00ca7424"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 39,
+        "msg": "Unique message: 002d5910de023eddce8358edf169c07f"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 40,
+        "msg": "Unique message: fd4b38e94292e00251b9f39c47ee5710"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 41,
+        "msg": "Unique message: f5cfd73023c1eedb6b9569736073f1dd"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 42,
+        "msg": "Unique message: c183857770364b05c2011bdebb914ed3"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 43,
+        "msg": "Unique message: aea2fa668453e23c431649801e5ea548"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 44,
+        "msg": "Unique message: 3e5ceb07f51a70d9d431714f04c0272f"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 45,
+        "msg": "Unique message: 7622214b8536afe7b89b1c6606069b0d"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 46,
+        "msg": "Unique message: d898504a722bff1524134c6ab6a5eaa5"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 47,
+        "msg": "Unique message: 0d7db7ff842f89a36b58fa2541de2a6c"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 48,
+        "msg": "Unique message: b203621a65475445e6fcdca717c667b5"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 49,
+        "msg": "Unique message: 884bb48a55da67b4812805cb8905277d"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 50,
+        "msg": "Unique message: 871bdd96b159c14d15c8d97d9111e9c8"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 51,
+        "msg": "Unique message: e2365bc6a6fbd41287fae648437296fa"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 52,
+        "msg": "Unique message: 469aa816010c9c8639a9176f625189af"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 53,
+        "msg": "Unique message: eca0470178275ac94e5de381969ed232"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 54,
+        "msg": "Unique message: 8910e6fc12f07a52b796eb55fbf3edda"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 55,
+        "msg": "Unique message: c9ea3314b91c9fd4e38f9432064fd1f2"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 56,
+        "msg": "Unique message: e3c4dd21a9171fd39d208efa09bf7883"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 57,
+        "msg": "Unique message: ab9d8ef2ffa9145d6c325cefa41d5d4e"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 58,
+        "msg": "Unique message: 2c1cf4f76fa1cecc0c4737cfd8d95118"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 59,
+        "msg": "Unique message: 22031453e4c3a1a0d47b0b97d83d8984"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 60,
+        "msg": "Unique message: a302a771ee0e3127b8950f0a67d17e49"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 61,
+        "msg": "Unique message: e2a482a3896964675811dba0bfde2f0b"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 62,
+        "msg": "Unique message: 8d7d1020185f9b09cc22e789887be328"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 63,
+        "msg": "Unique message: 65cecfb980d72fde57d175d6ec1c3f64"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 64,
+        "msg": "Unique message: 3b5d3c7d207e37dceeedd301e35e2e58"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 65,
+        "msg": "Unique message: 1ef5e829303a139ce967440e0cdca10c"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 66,
+        "msg": "Unique message: 402535c9f22ff836ea91dd12e8b8847b"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 67,
+        "msg": "Unique message: 53553242d57214aaa5726a09b05fe7bc"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 68,
+        "msg": "Unique message: 7c909b3e2820c8b47ed418753698a6da"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 69,
+        "msg": "Unique message: 3b8151acfb469ae41d3f0449058076e1"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 70,
+        "msg": "Unique message: 3287282fa1a1523a294fb018e3679872"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 71,
+        "msg": "Unique message: 2f0f98115f17f2869c1f59ba804af077"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 72,
+        "msg": "Unique message: ac3b5a19643ee5816a1df17f2fadaae3"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 73,
+        "msg": "Unique message: fa67ab9184f8d574cef7cd8e0b2f1a78"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 74,
+        "msg": "Unique message: aa6672fe9e8426f8dd570c81095e1476"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 75,
+        "msg": "Unique message: 6e36ba0fe61f7c6334305d61299c04cf"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 76,
+        "msg": "Unique message: e6b62b76fb2eb2a0e0adde0c067da680"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 77,
+        "msg": "Unique message: 2b62a30906a2b8bf3b68abd2ef9d105b"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 78,
+        "msg": "Unique message: b79abf5c5f2244956c7246e9112595ce"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 79,
+        "msg": "Unique message: 55712f2f2f21a8321b9ee45d40b89091"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 80,
+        "msg": "Unique message: bbf7c6077962a7c28114dbd10be947cd"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 81,
+        "msg": "Unique message: 9546c10433c45bfb9947449dd8d304de"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 82,
+        "msg": "Unique message: 516c0567e329930b320357809a0c9149"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 83,
+        "msg": "Unique message: 0efce63cf4c085888a2772125dfe7aaa"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 84,
+        "msg": "Unique message: 3561c0dffdb90248fa1fc2d4fb86f08a"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 85,
+        "msg": "Unique message: eeb20c9bc165677800b6dc7621a50cc9"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 86,
+        "msg": "Unique message: bb1ef3ddda35b590d4aa204d0493e921"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 87,
+        "msg": "Unique message: eecae68e4f9ee6f037742aac8f36cc1b"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 88,
+        "msg": "Unique message: f2331152449c622545360f18dfdf0e2d"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 89,
+        "msg": "Unique message: 335a7c8e767a2dd0ecf3460eaabb0bbd"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 90,
+        "msg": "Unique message: 3277ca99dfe4a704df82c63ac9e876fd"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 91,
+        "msg": "Unique message: 67130d31b6048171a64ed87d36022a6e"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 92,
+        "msg": "Unique message: 534d78034b774b6266f2189576f8c6e3"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 93,
+        "msg": "Unique message: 90c805bcb9fa376aacfb38d598ec7bb6"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 94,
+        "msg": "Unique message: 363c2e67f9e853fbc532d0b6404db30a"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 95,
+        "msg": "Unique message: 0a1dfc18c8c8381f05f8ad9d2b4509b5"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 96,
+        "msg": "Unique message: aceb486e7e4b2d2f1c5f2328b503502b"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 97,
+        "msg": "Unique message: 9e0573ecb4a0800788a3aa64ad731bbc"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 98,
+        "msg": "Unique message: 33aa8cb471ba9dee750c069bca801127"
+      }
+    },
+    {
+      "method": "LOG_record",
+      "params": {
+        "id": 99,
+        "msg": "Unique message: fa8715078d45101200a6e2bf7321aa04"
+      }
+    }
+  ]
+}

--- a/tests/perfclient.py
+++ b/tests/perfclient.py
@@ -80,9 +80,11 @@ if __name__ == "__main__":
             required=True,
         )
 
-    def get_command(host_arg, port_arg):
-        return ["host:", host_arg, "port:", port_arg]
+    args, unknown_args = cli_args(add, accept_unknown=True)
 
-    args = cli_args(add)
+    unknown_args = [term for arg in unknown_args for term in arg.split(" ")]
 
-    infra.runner.run(args.build_dir, args.package, get_command, args)
+    def get_command(*args):
+        return [*args] + unknown_args
+
+    infra.runner.run(args.build_dir, get_command, args)

--- a/tests/perfclient.py
+++ b/tests/perfclient.py
@@ -36,7 +36,6 @@ def cli_args(add=lambda x: None, accept_unknown=False):
         default="metrics.json",
         help="Path to json file where the transaction rate metrics will be saved to",
     )
-    parser.add_argument("-t", "--threads", help="Number of client threads", default=1)
     parser.add_argument(
         "-f",
         "--fixed-seed",
@@ -51,13 +50,6 @@ def cli_args(add=lambda x: None, accept_unknown=False):
     )
     parser.add_argument(
         "--config", help="Path to config for client binary", default=default_config_path
-    )
-
-    parser.add_argument(
-        "-i", "--iterations", help="Number of transactions", required=True, type=int
-    )
-    parser.add_argument(
-        "--sign", help="Sign all client transactions", action="store_true"
     )
 
     return e2e_args.cli_args(add=add, parser=parser, accept_unknown=accept_unknown)


### PR DESCRIPTION
We have a user-extensible perf client, but it requires transactions to be generated in C++. Since we expect to support systems where no client code is written in C++ this isn't always appropriate. This PR adds a new perf client which, instead of generating transactions at run-time, simply loads a set of static transactions (another 'scenario') from file.

There's a new test using this client with a simple scenario for the logging app. We don't actually care about the performance result from this, its simply to ensure the new `scenario_perf_client` is regularly built and run.