### PR TITLE
Friendly HTTP signatures with curl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,6 +352,7 @@ if(BUILD_TESTS)
     add_e2e_test(
       NAME end_to_end_logging
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py
+      CURL_CLIENT TRUE
     )
 
     add_e2e_test(

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -631,7 +631,7 @@ endfunction()
 function(add_e2e_test)
   cmake_parse_arguments(PARSE_ARGV 0 PARSED_ARGS
     ""
-    "NAME;PYTHON_SCRIPT;IS_SUITE"
+    "NAME;PYTHON_SCRIPT;IS_SUITE;CURL_CLIENT"
     "ADDITIONAL_ARGS"
   )
 
@@ -674,6 +674,14 @@ function(add_e2e_test)
         PROPERTY
           ENVIRONMENT "HTTP=ON"
       )
+      if (${PARSED_ARGS_CURL_CLIENT})
+        set_property(
+          TEST ${PARSED_ARGS_NAME}
+          APPEND
+          PROPERTY
+            ENVIRONMENT "CURL_CLIENT=ON"
+        )
+      endif()
     endif()
   endif()
 endfunction()

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -157,9 +157,11 @@ add_custom_command(
     COMMENT "Generating code from EDL, and renaming to .cpp"
 )
 
-# Copy all utilities from tests directory
-file(GLOB TEST_UTILITIES ${CCF_DIR}/tests/*.sh)
-file(COPY ${TEST_UTILITIES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+# Copy utilities from tests directory
+set(CCF_UTILITIES tests.sh keygenerator.sh cimetrics_env.sh upload_pico_metrics.py scurl.sh)
+foreach(UTILITY ${CCF_UTILITIES})
+  configure_file(${CCF_DIR}/tests/${UTILITY} ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
+endforeach()
 
 if("sgx" IN_LIST TARGET)
   # If OE was built with LINK_SGX=1, then we also need to link SGX

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -157,10 +157,9 @@ add_custom_command(
     COMMENT "Generating code from EDL, and renaming to .cpp"
 )
 
-configure_file(${CCF_DIR}/tests/tests.sh ${CMAKE_CURRENT_BINARY_DIR}/tests.sh COPYONLY)
-configure_file(${CCF_DIR}/tests/keygenerator.sh ${CMAKE_CURRENT_BINARY_DIR}/keygenerator.sh COPYONLY)
-configure_file(${CCF_DIR}/tests/cimetrics_env.sh ${CMAKE_CURRENT_BINARY_DIR}/cimetrics_env.sh COPYONLY)
-configure_file(${CCF_DIR}/tests/upload_pico_metrics.py ${CMAKE_CURRENT_BINARY_DIR}/upload_pico_metrics.py COPYONLY)
+# Copy all utilities from tests directory
+file(GLOB TEST_UTILITIES ${CCF_DIR}/tests/*.sh)
+file(COPY ${TEST_UTILITIES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 if("sgx" IN_LIST TARGET)
   # If OE was built with LINK_SGX=1, then we also need to link SGX

--- a/src/enclave/httpendpoint.h
+++ b/src/enclave/httpendpoint.h
@@ -52,7 +52,7 @@ namespace enclave
             return;
           }
         }
-        catch(const std::exception& e)
+        catch (const std::exception& e)
         {
           LOG_FAIL_FMT("Error parsing request: {}", e.what());
           return;

--- a/src/enclave/httpendpoint.h
+++ b/src/enclave/httpendpoint.h
@@ -44,10 +44,17 @@ namespace enclave
           buf.size(),
           std::string(buf.begin(), buf.end()));
 
-        // TODO: This should return an error to the client if this fails
-        if (p.execute(buf.data(), buf.size()) == 0)
+        try
         {
-          LOG_FAIL_FMT("Failed to parse request");
+          if (p.execute(buf.data(), buf.size()) == 0)
+          {
+            LOG_FAIL_FMT("Failed to parse request");
+            return;
+          }
+        }
+        catch(const std::exception& e)
+        {
+          LOG_FAIL_FMT("Error parsing request: {}", e.what());
           return;
         }
       }

--- a/src/enclave/httpsig.h
+++ b/src/enclave/httpsig.h
@@ -182,6 +182,13 @@ namespace enclave
           {
             auto parsed_signed_headers =
               parse_delimited_string(v, SIGN_PARAMS_HEADERS_DELIMITER);
+
+            if (parsed_signed_headers.size() == 0)
+            {
+              LOG_FAIL_FMT("No headers specified in {} field", SIGN_PARAMS_HEADERS);
+              return {};
+            }
+
             for (const auto& h : parsed_signed_headers)
             {
               sig_params.signed_headers.emplace_back(h);

--- a/src/enclave/httpsig.h
+++ b/src/enclave/httpsig.h
@@ -185,7 +185,8 @@ namespace enclave
 
             if (parsed_signed_headers.size() == 0)
             {
-              LOG_FAIL_FMT("No headers specified in {} field", SIGN_PARAMS_HEADERS);
+              LOG_FAIL_FMT(
+                "No headers specified in {} field", SIGN_PARAMS_HEADERS);
               return {};
             }
 

--- a/start_test_network.sh
+++ b/start_test_network.sh
@@ -18,5 +18,4 @@ source env/bin/activate
 pip install -q -U -r ../tests/requirements.txt
 echo "Python environment successfully setup"
 
-# TODO: https://github.com/microsoft/CCF/issues/612
-python ../tests/start_network.py --package "$1" --label test_network
+CURL_CLIENT=ON python ../tests/start_network.py --package "$1" --label test_network

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -91,7 +91,7 @@ class Response:
     def _from_parsed(self, parsed):
         unexpected = parsed.keys() - self._attrs
         if unexpected:
-            raise ValueError("Unexpected keys in response: {}".format(unexpected))
+            raise ValueError(f"Unexpected keys in response: {unexpected}")
         for attr, value in parsed.items():
             setattr(self, attr, value)
 
@@ -189,7 +189,7 @@ class Stream:
 
     def update(self, msg):
         r = Response(0)
-        getattr(r, "from_{}".format(self.format))(msg)
+        getattr(r, f"from_{self.format}")(msg)
         self.pending[r.id] = r
 
 
@@ -274,7 +274,7 @@ class FramedTLSJSONRPCClient:
         return self.client.disconnect()
 
     def request(self, request):
-        self.client.send(getattr(request, "to_{}".format(self.format))())
+        self.client.send(getattr(request, "to_{self.format}")())
         return request.id
 
     def tick(self):
@@ -295,23 +295,29 @@ class CurlClient:
         self.cert = cert
         self.key = key
         self.ca = ca
-        self.format = format
-        self.stream = Stream(version, self.format)
+        self.format = "json"
+        self.stream = Stream(version, "json")
 
-    def request(self, request):
+    def _request(self, request, is_signed=False):
         with tempfile.NamedTemporaryFile() as nf:
-            msg = getattr(request, "to_{}".format(self.format))()
-            LOG.debug("Going to send {}".format(msg))
+            msg = getattr(request, f"to_{self.format}")()
+            LOG.debug(f"Going to send {msg}")
             nf.write(msg)
             nf.flush()
-            cmd = [
-                "curl",
+            if is_signed:
+                cmd = ["./scurl.sh"]
+            else:
+                cmd = ["curl"]
+
+            cmd += [
                 f"https://{self.host}:{self.port}/{request.method}",
                 "-H",
                 "Content-Type: application/json",
                 "--data-binary",
                 f"@{nf.name}",
+                "-w \\n%{http_code}",
             ]
+
             if self.ca:
                 cmd.extend(["--cacert", self.ca])
             if self.key:
@@ -320,42 +326,26 @@ class CurlClient:
                 cmd.extend(["--cert", self.cert])
             LOG.debug(f"Running: {' '.join(cmd)}")
             rc = subprocess.run(cmd, capture_output=True)
-            LOG.debug(f"Received {rc.stdout}")
+
             if rc.returncode != 0:
                 LOG.error(rc.stderr)
-                raise RuntimeError("Curl failed")
-            self.stream.update(rc.stdout)
+                raise RuntimeError(f"Curl failed with return code {rc.returncode}")
+
+            # The response status code is displayed on the last line of
+            # the output (via -w option)
+            rep, status_code = rc.stdout.decode().rsplit("\n", 1)
+            if int(status_code) != 200:
+                LOG.error(rep)
+                raise RuntimeError(f"Curl failed with status code {status_code}")
+
+            self.stream.update(rep.encode())
         return request.id
+
+    def request(self, request):
+        return self._request(request, is_signed=False)
 
     def signed_request(self, request):
-        with tempfile.NamedTemporaryFile() as nf:
-            msg = getattr(request, "to_{}".format(self.format))()
-            LOG.debug("Going to send {}".format(msg))
-            nf.write(msg)
-            nf.flush()
-            cmd = [
-                "./scurl.sh",
-                "--fail",
-                f"https://{self.host}:{self.port}/{request.method}",
-                "-H",
-                "Content-Type: application/json",
-                "--data-binary",
-                f"@{nf.name}",
-            ]
-            if self.ca:
-                cmd.extend(["--cacert", self.ca])
-            if self.key:
-                cmd.extend(["--key", self.key])
-            if self.cert:
-                cmd.extend(["--cert", self.cert])
-            LOG.debug(f"Running: {' '.join(cmd)}")
-            rc = subprocess.run(cmd, capture_output=True)
-            if rc.returncode != 0:
-                LOG.debug(f"ERR {rc.stderr.decode()}")
-                raise RuntimeError("Signed Curl failed")
-
-            self.stream.update(rc.stdout)
-        return request.id
+        return self._request(request, is_signed=True)
 
     def response(self, id):
         return self.stream.response(id)
@@ -382,6 +372,7 @@ class RequestClient:
         self.cert = cert
         self.key = key
         self.ca = ca
+        self.format = "json"
         self.stream = Stream(version, "json")
         self.request_timeout = request_timeout
 
@@ -442,7 +433,7 @@ class CCFClient:
             f"{self.prefix}/{method}", params, *args, **kwargs
         )
         if self.description:
-            description = " ({})".format(self.description)
+            description = f" ({self.description})"
         for logger in self.rpc_loggers:
             logger.log_request(r, self.name, description)
 
@@ -454,7 +445,7 @@ class CCFClient:
             f"{self.prefix}/{method}", params, *args, **kwargs
         )
         if self.description:
-            description = " ({}) [signed]".format(self.description)
+            description = f" ({self.description}) [signed]"
         for logger in self.rpc_loggers:
             logger.log_request(r, self.name, description)
 

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -274,7 +274,7 @@ class FramedTLSJSONRPCClient:
         return self.client.disconnect()
 
     def request(self, request):
-        self.client.send(getattr(request, "to_{self.format}")())
+        self.client.send(getattr(request, f"to_{self.format}")())
         return request.id
 
     def tick(self):

--- a/tests/keygenerator.sh
+++ b/tests/keygenerator.sh
@@ -36,7 +36,7 @@ fi
 
 if [ "$curve" == "$DEFAULT_CURVE" ]; then
     digest="$DIGEST_SHA384"
-elif [ "$curve" ==  "$EDWARDS_CURVE" ]; then
+elif [ "$curve" == "$EDWARDS_CURVE" ]; then
     digest="$DIGEST_SHA512"
 else
     digest="$DIGEST_SHA256"

--- a/tests/scurl.sh
+++ b/tests/scurl.sh
@@ -4,39 +4,52 @@
 
 set -e
 
-# Loop through all arguments and find request data
+# Loop through all arguments and find request data and private key
 next_is_data=false
+next_is_privk=false
 for item in "$@" ; do
     if [ "$next_is_data" == true ]; then
         request=$item
         next_is_data=false
     fi
-    if [ "$item" == "-d" ] || [ "$items" == "--data-binary" ]; then
+    if [ "$next_is_privk" == true ]; then
+        privk=$item
+        next_is_privk=false
+    fi
+    if [ "$item" == "-d" ] || [ "$item" == "--data-binary" ]; then
         next_is_data=true
+    fi
+    if [ "$item" == "--key" ]; then
+        next_is_privk=true
     fi
 done
 
 if [ -z "$request" ]; then
-    echo "No request found in arguments"
+    echo "No request found in arguments (-d or --data-binary)"
     exit 1
 fi
 
-if [ $(echo "$request" | cut -c1) == "@" ]; then
+if [ -z "$privk" ]; then
+    echo "No private key found in arguments (--key)"
+    exit 1
+fi
+
+# If the first letter of the request is @, consider it a filename
+if [ "$(echo "$request" | cut -c1)" == "@" ]; then
     request="${request:1}"
     request=$(cat "$request")
 fi
 
-# Get date
 date=$(date "+%a, %d %b %Y %H:%M:%S %Z")
 
-req_digest=$(echo -n $request | openssl dgst -sha256 -binary | openssl base64)
+req_digest=$(echo -n "$request" | openssl dgst -sha256 -binary | openssl base64)
 
 # Construct string to sign
 string_to_sign="date: $date
 digest: SHA-256=$req_digest"
 
 # Compute signature
-signed_raw=$(echo -n "$string_to_sign" | openssl dgst -sha256 -sign member1_privk.pem | openssl base64 -A)
+signed_raw=$(echo -n "$string_to_sign" | openssl dgst -sha256 -sign "$privk" | openssl base64 -A)
 
 curl \
 -H "Date: $date" \

--- a/tests/scurl.sh
+++ b/tests/scurl.sh
@@ -56,5 +56,3 @@ curl \
 -H "Digest: SHA-256=$req_digest" \
 -H "Authorization: Signature keyId=\"tls\",algorithm=\"ecdsa-sha256\",headers=\"date digest\",signature=\"$signed_raw\"" \
 "$@"
-
-echo ""

--- a/tests/scurl.sh
+++ b/tests/scurl.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+set -e
+
+# TODO:
+# - Support for inline string input
+
+req=$1
+
+# Args:
+# - private key
+# - headers to sign
+# - host and port
+# - Passthrough to curl: URI, --cacert, --key, --cert, -data-binary
+
+# Get date
+date=$(date "+%a, %d %b %Y %H:%M:%S %Z")
+echo "$date"
+
+# Compute digest
+req_digest=$(echo -n $(cat $req) | openssl dgst -sha256 -binary | openssl base64)
+echo $req_digest
+
+# Construct string to sign
+string_to_sign="date: $date
+digest: SHA-256=$req_digest"
+echo -n $string_to_sign > string_to_sign
+echo "$string_to_sign"
+
+echo ""
+echo ""
+echo ""
+echo ""
+
+# Create signature
+signed_raw=$(echo -n "$string_to_sign" | openssl dgst -sha256 -sign member1_privk.pem | openssl base64 -A)
+echo $signed_raw
+
+curl \
+-H "Date: $date" \
+-H "Digest: SHA-256=$req_digest" \
+-H "Authorization: Signature keyId=\"lala\",algorithm=\"ecdsa-sha256\",headers=\"date digest\",signature=\"$signed_raw\"" \
+-H "Content-Type: application/json" \
+-d @$req \
+--key member1_privk.pem \
+--cert member1_cert.pem \
+--cacert networkcert.pem \
+https://127.47.192.242:42503/members/vote


### PR DESCRIPTION
Resolves https://github.com/microsoft/CCF/issues/612 

Introduces the friendly `scurl.sh` script that can be used just like `curl` (arguments are forwarded to curl) and will automagically sign HTTP requests with the private key passed to `curl` to authenticate the client over the TLS connection (via `--key`). 

The signed header fields are very much hard-coded for now but I will address that in a further PR.