### PR TITLE
Use node hostname with node port instead of rpc hostname

### DIFF
--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -327,6 +327,7 @@ int main(int argc, char** argv)
   ccf_config.signature_intervals = {sig_max_tx, sig_max_ms};
   ccf_config.node_info_network = {rpc_address.hostname,
                                   public_rpc_address.hostname,
+                                  node_address.hostname,
                                   node_address.port,
                                   rpc_address.port};
   ccf_config.domain = domain;

--- a/src/node/nodeinfonetwork.h
+++ b/src/node/nodeinfonetwork.h
@@ -12,14 +12,15 @@ namespace ccf
 {
   struct NodeInfoNetwork
   {
-    std::string host;
+    std::string rpchost;
     std::string pubhost;
+    std::string nodehost;
     std::string nodeport;
     std::string rpcport;
 
-    MSGPACK_DEFINE(host, pubhost, nodeport, rpcport);
+    MSGPACK_DEFINE(rpchost, pubhost, nodehost, nodeport, rpcport);
   };
   DECLARE_JSON_TYPE(NodeInfoNetwork);
   DECLARE_JSON_REQUIRED_FIELDS(
-    NodeInfoNetwork, host, pubhost, nodeport, rpcport);
+    NodeInfoNetwork, rpchost, pubhost, nodehost, nodeport, rpcport);
 }

--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -1096,7 +1096,7 @@ namespace ccf
       // If a domain is passed at node creation, record domain in SAN for node
       // hostname authentication over TLS. Otherwise, record IP in SAN.
       bool san_is_ip = config.domain.empty();
-      return {san_is_ip ? config.node_info_network.host : config.domain,
+      return {san_is_ip ? config.node_info_network.rpchost : config.domain,
               san_is_ip};
     }
 
@@ -1310,7 +1310,7 @@ namespace ccf
               }
               case NodeStatus::TRUSTED:
               {
-                add_node(node_id, ni.value.host, ni.value.nodeport);
+                add_node(node_id, ni.value.nodehost, ni.value.nodeport);
                 configure = true;
                 break;
               }
@@ -1420,11 +1420,11 @@ namespace ccf
           std::unordered_set<NodeId> configuration;
           for (auto& [node_id, ni] : w)
           {
-            add_node(node_id, ni.value.host, ni.value.nodeport);
+            add_node(node_id, ni.value.nodehost, ni.value.nodeport);
             consensus->add_configuration(
               version,
               configuration,
-              {node_id, ni.value.host, ni.value.nodeport});
+              {node_id, ni.value.nodehost, ni.value.nodeport});
           }
         });
 

--- a/src/node/rpc/nodefrontend.h
+++ b/src/node/rpc/nodefrontend.h
@@ -48,7 +48,8 @@ namespace ccf
                             const NodeId& nid, const NodeInfo& ni) {
         if (
           node_info_network.nodeport == ni.nodeport &&
-          node_info_network.host == ni.host && ni.status != NodeStatus::RETIRED)
+          node_info_network.nodehost == ni.nodehost &&
+          ni.status != NodeStatus::RETIRED)
         {
           duplicate_node_id = nid;
           return false;
@@ -76,7 +77,7 @@ namespace ccf
           fmt::format(
             "A node with the same node host {} and port {} already exists "
             "(node id: {})",
-            in.node_info_network.host,
+            in.node_info_network.nodehost,
             in.node_info_network.nodeport,
             conflicting_node_id.value()));
       }


### PR DESCRIPTION
Noticed that we assume that the rpc hostname and node hostname are the same and we are using the rpc hostname when we do `add_node`.

Fixed to use node hostname