### PR TITLE
Support for WebSocket handshake

### DIFF
--- a/src/enclave/httpbuilder.h
+++ b/src/enclave/httpbuilder.h
@@ -34,17 +34,57 @@ namespace enclave
       throw std::logic_error(fmt::format("Unknown HTTP method '{}'", s));
     }
 
-    class Request
+    class Message
+    {
+    private:
+      HeaderMap headers;
+
+    protected:
+      Message() = default;
+      Message(const HeaderMap& headers_) : headers(headers_) {}
+
+      std::string get_header_string()
+      {
+        std::string header_string;
+        for (const auto& it : headers)
+        {
+          header_string += fmt::format("{}: {}\r\n", it.first, it.second);
+        }
+
+        return header_string;
+      }
+
+    public:
+      HeaderMap get_headers() const
+      {
+        return headers;
+      }
+
+      void set_header(const std::string& k, const std::string& v)
+      {
+        headers[k] = v;
+      }
+
+      void clear_headers()
+      {
+        headers.clear();
+      }
+    };
+
+    class Request : public Message
     {
     private:
       http_method method;
       std::string path = "/";
       std::map<std::string, std::string> query_params = {};
-      HeaderMap headers = default_headers();
 
     public:
-      Request(http_method m = HTTP_POST) : method(m) {}
-      Request(const char* s) : method(http_method_from_str(s)) {}
+      Request(http_method m = HTTP_POST) : method(m), Message(default_headers())
+      {}
+      Request(const char* s) :
+        method(http_method_from_str(s)),
+        Message(default_headers())
+      {}
 
       void set_path(const std::string& p)
       {
@@ -61,21 +101,6 @@ namespace enclave
       void set_query_param(const std::string& k, const std::string& v)
       {
         query_params[k] = v;
-      }
-
-      HeaderMap get_headers() const
-      {
-        return headers;
-      }
-
-      void set_header(const std::string& k, const std::string& v)
-      {
-        headers[k] = v;
-      }
-
-      void clear_headers()
-      {
-        headers.clear();
       }
 
       std::vector<uint8_t> build_request(
@@ -97,12 +122,6 @@ namespace enclave
           std::string_view() :
           std::string_view((char const*)body.data(), body.size());
 
-        std::string header_string;
-        for (const auto& it : headers)
-        {
-          header_string += fmt::format("{}: {}\r\n", it.first, it.second);
-        }
-
         const auto h = fmt::format(
           "{} {} HTTP/1.1\r\n"
           "{}"
@@ -111,11 +130,55 @@ namespace enclave
           "{}",
           http_method_str(method),
           uri,
-          header_string,
+          get_header_string(),
           body.size(),
           body_view);
 
         return std::vector<uint8_t>(h.begin(), h.end());
+      }
+    };
+
+    class Response : public Message
+    {
+    private:
+      http_status status;
+
+    public:
+      Response(http_status s = HTTP_STATUS_OK) : status(s) {}
+
+      std::vector<uint8_t> build_response_header(
+        size_t content_length = 0,
+        const std::string& content_type = "application/json")
+      {
+        std::string rep = "";
+        if (content_length > 0)
+        {
+          rep = fmt::format(
+            "HTTP/1.1 {} {}\r\n"
+            "{}"
+            "Content-Length: {}\r\n"
+            "Content-Type: {}\r\n"
+            "\r\n",
+            status,
+            http_status_str(status),
+            get_header_string(),
+            content_length,
+            content_type);
+        }
+        else
+        {
+          rep = fmt::format(
+            "HTTP/1.1 {} {}\r\n"
+            "{}"
+            "\r\n",
+            status,
+            http_status_str(status),
+            get_header_string());
+        }
+
+        LOG_FAIL_FMT("Sending HTTP response: {}", rep);
+
+        return std::vector<uint8_t>(rep.begin(), rep.end());
       }
     };
 

--- a/src/enclave/httpbuilder.h
+++ b/src/enclave/httpbuilder.h
@@ -176,8 +176,6 @@ namespace enclave
             get_header_string());
         }
 
-        LOG_FAIL_FMT("Sending HTTP response: {}", rep);
-
         return std::vector<uint8_t>(rep.begin(), rep.end());
       }
     };

--- a/src/enclave/httpendpoint.h
+++ b/src/enclave/httpendpoint.h
@@ -154,8 +154,8 @@ namespace enclave
         if (upgrade_resp.has_value())
         {
           LOG_TRACE_FMT("Upgraded to websocket");
-          send_raw(upgrade_resp.value());
           is_websocket = true;
+          send_raw(upgrade_resp.value());
           return;
         }
 

--- a/src/enclave/httpendpoint.h
+++ b/src/enclave/httpendpoint.h
@@ -65,9 +65,8 @@ namespace enclave
       }
       else
       {
-        // TODO: For now, close the connection
-        // TODO: Check if the parser can still be used once the connection has
-        // been upgraded to websocket
+        // TODO: For now, close the connection if it has been upgraded to
+        // websocket
         LOG_FAIL_FMT(
           "Receiving data after endpoint has been upgraded to websocket.");
         LOG_FAIL_FMT("Closing connection.");
@@ -148,7 +147,7 @@ namespace enclave
 
       try
       {
-        // Check if the client requested upgrade to websocket, and finish
+        // Check if the client requested upgrade to websocket, and complete
         // handshake if necessary
         auto upgrade_resp =
           http::WebSocketUpgrader::upgrade_if_necessary(headers);

--- a/src/enclave/httpendpoint.h
+++ b/src/enclave/httpendpoint.h
@@ -166,8 +166,9 @@ namespace enclave
       try
       {
         // Check if the client requested upgrade to websocket
-        auto ws_upgrader = http::WebSocketUpgrader(headers);
-        auto upgrade_resp = ws_upgrader.upgrade_if_necessary();
+        auto upgrade_resp =
+          http::WebSocketUpgrader::upgrade_if_necessary(headers);
+        // auto upgrade_resp = ws_upgrader.upgrade_if_necessary();
         if (upgrade_resp.has_value())
         {
           LOG_TRACE_FMT("Upgraded to websocket");
@@ -235,9 +236,9 @@ namespace enclave
 
         // TODO: For now, set this here as parse_rpc_context() resets
         // rpc_ctx.signed_request for a HTTP endpoint.
-        auto http_sig_v = http::HttpSignatureVerifier(
+        auto signed_req = http::HttpSignatureVerifier::parse(
           std::string(http_method_str(verb)), path, query, headers, body);
-        auto signed_req = http_sig_v.parse();
+        // auto signed_req = http_sig_v.parse();
         if (signed_req.has_value())
         {
           rpc_ctx.signed_request = signed_req;

--- a/src/enclave/httpparser.h
+++ b/src/enclave/httpparser.h
@@ -97,14 +97,6 @@ namespace enclave
         auto parsed =
           http_parser_execute(&parser, &settings, (const char*)data, size);
 
-        // TODO: Do something more clever here? Return this to the caller (i.e.
-        // HTTPEndpoint recv()) which can change the status of is_websocket
-        // accordingly?
-        if (parser.upgrade == 1)
-        {
-          LOG_FAIL_FMT("Upgraded!");
-        }
-
         LOG_TRACE_FMT("Parsed {} bytes", parsed);
 
         auto err = HTTP_PARSER_ERRNO(&parser);

--- a/src/enclave/httpparser.h
+++ b/src/enclave/httpparser.h
@@ -97,6 +97,14 @@ namespace enclave
         auto parsed =
           http_parser_execute(&parser, &settings, (const char*)data, size);
 
+        // TODO: Do something more clever here? Return this to the caller (i.e.
+        // HTTPEndpoint recv()) which can change the status of is_websocket
+        // accordingly?
+        if (parser.upgrade == 1)
+        {
+          LOG_FAIL_FMT("Upgraded!");
+        }
+
         LOG_TRACE_FMT("Parsed {} bytes", parsed);
 
         auto err = HTTP_PARSER_ERRNO(&parser);
@@ -108,7 +116,6 @@ namespace enclave
             http_errno_description(err)));
         }
 
-        // TODO: check for http->upgrade to support websockets
         return parsed;
       }
 

--- a/src/enclave/httpsig.h
+++ b/src/enclave/httpsig.h
@@ -5,11 +5,11 @@
 #include "httpparser.h"
 #include "node/clientsignatures.h"
 #include "tls/base64.h"
+#include "tls/keypair.h" // TODO: Only used for hashing
 
 #include <fmt/format_header_only.h>
 #include <optional>
 #include <string>
-#include <tls/keypair.h> // TODO: Only used for hashing
 
 namespace enclave
 {

--- a/src/enclave/httpsig.h
+++ b/src/enclave/httpsig.h
@@ -113,12 +113,6 @@ namespace enclave
     class HttpSignatureVerifier
     {
     private:
-      const std::string& verb;
-      const std::string& path;
-      const std::string& query;
-      const http::HeaderMap& headers;
-      const std::vector<uint8_t>& body;
-
       struct SignatureParams
       {
         std::string_view signature = {};
@@ -126,7 +120,7 @@ namespace enclave
         std::vector<std::string_view> signed_headers;
       };
 
-      bool parse_auth_scheme(std::string_view& auth_header_value)
+      static bool parse_auth_scheme(std::string_view& auth_header_value)
       {
         auto next_space = auth_header_value.find(" ");
         if (next_space == std::string::npos)
@@ -144,7 +138,8 @@ namespace enclave
         return true;
       }
 
-      bool verify_digest()
+      static bool verify_digest(
+        const http::HeaderMap& headers, const std::vector<uint8_t>& body)
       {
         // First, retrieve digest from header
         auto digest = headers.find(HTTP_HEADER_DIGEST);
@@ -189,7 +184,7 @@ namespace enclave
       // Parses a delimited string with no delimiter at the end
       // (e.g. "foo,bar,baz") and returns a vector parsed string views (e.g.
       // ["foo", "bar", "baz"])
-      std::vector<std::string_view> parse_delimited_string(
+      static std::vector<std::string_view> parse_delimited_string(
         std::string_view& s, const std::string& delimiter)
       {
         std::vector<std::string_view> strings;
@@ -216,7 +211,7 @@ namespace enclave
         return strings;
       }
 
-      std::optional<SignatureParams> parse_signature_params(
+      static std::optional<SignatureParams> parse_signature_params(
         std::string_view& auth_header_value)
       {
         SignatureParams sig_params = {};
@@ -283,20 +278,14 @@ namespace enclave
       }
 
     public:
-      HttpSignatureVerifier(
-        const std::string& verb_,
-        const std::string& path_,
-        const std::string& query_,
-        const http::HeaderMap& headers_,
-        const std::vector<uint8_t>& body_) :
-        verb(verb_),
-        path(path_),
-        query(query_),
-        headers(headers_),
-        body(body_)
-      {}
+      HttpSignatureVerifier() {}
 
-      std::optional<ccf::SignedReq> parse()
+      static std::optional<ccf::SignedReq> parse(
+        const std::string& verb,
+        const std::string& path,
+        const std::string& query,
+        const http::HeaderMap& headers,
+        const std::vector<uint8_t>& body)
       {
         auto auth = headers.find(HTTP_HEADER_AUTHORIZATION);
         if (auth != headers.end())
@@ -311,7 +300,7 @@ namespace enclave
               AUTH_SCHEME));
           }
 
-          if (!verify_digest())
+          if (!verify_digest(headers, body))
           {
             throw std::logic_error(fmt::format(
               "Error verifying HTTP {} header", HTTP_HEADER_DIGEST));

--- a/src/enclave/wsupgrade.h
+++ b/src/enclave/wsupgrade.h
@@ -30,11 +30,9 @@ namespace enclave
       static constexpr auto WEBSOCKET_HANDSHAKE_GUID =
         "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
-      const http::HeaderMap& headers;
-
       // Constructs base64 acccept string (as per
       // https://tools.ietf.org/html/rfc6455#section-1.3)
-      std::optional<std::string> construct_accept_string(
+      static std::optional<std::string> construct_accept_string(
         const std::string& client_key)
       {
         const auto string_to_hash =
@@ -52,9 +50,10 @@ namespace enclave
       }
 
     public:
-      WebSocketUpgrader(const http::HeaderMap& headers_) : headers(headers_) {}
+      WebSocketUpgrader() {}
 
-      std::optional<std::vector<uint8_t>> upgrade_if_necessary()
+      static std::optional<std::vector<uint8_t>> upgrade_if_necessary(
+        const http::HeaderMap& headers)
       {
         auto const upgrade_header = headers.find(HTTP_HEADER_UPGRADE);
         if (upgrade_header != headers.end())

--- a/src/enclave/wsupgrade.h
+++ b/src/enclave/wsupgrade.h
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "httpparser.h"
+#include "tls/base64.h"
+#include "tls/keypair.h"
+
+#include <optional>
+#include <string>
+
+namespace enclave
+{
+  namespace http
+  {
+    // TODO: Do we actually need a class for this? or just an inline function?
+    class WebSocketUpgrader
+    {
+    private:
+      // All HTTP headers are expected to be lowercase
+      static constexpr auto HTTP_HEADER_UPGRADE = "upgrade";
+      static constexpr auto HTTP_HEADER_CONNECTION = "connection";
+      static constexpr auto HTTP_HEADER_WEBSOCKET_KEY = "sec-websocket-key";
+      static constexpr auto HTTP_HEADER_WEBSOCKET_ACCEPT =
+        "sec-websocket-accept";
+
+      static constexpr auto UPGRADE_HEADER_WEBSOCKET = "websocket";
+      static constexpr auto CONNECTION_HEADER_UPGRADE = "Upgrade";
+
+      static constexpr auto WEBSOCKET_HANDSHAKE_GUID =
+        "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+      const http::HeaderMap& headers;
+
+      // Constructs base64 acccept string (as per
+      // https://tools.ietf.org/html/rfc6455#section-1.3)
+      std::optional<std::string> construct_accept_string(
+        const std::string& client_key)
+      {
+        const auto string_to_hash =
+          fmt::format("{}{}", client_key, WEBSOCKET_HANDSHAKE_GUID);
+
+        const auto data =
+          reinterpret_cast<const uint8_t*>(string_to_hash.data());
+        const auto size = string_to_hash.size();
+
+        tls::HashBytes accept_string_hash;
+        tls::do_hash(data, size, accept_string_hash, MBEDTLS_MD_SHA1);
+
+        return tls::b64_from_raw(
+          accept_string_hash.data(), accept_string_hash.size());
+      }
+
+    public:
+      WebSocketUpgrader(const http::HeaderMap& headers_) : headers(headers_) {}
+
+      std::optional<std::vector<uint8_t>> upgrade_if_necessary()
+      {
+        auto const upgrade_header = headers.find(HTTP_HEADER_UPGRADE);
+        if (upgrade_header != headers.end())
+        {
+          auto const header_key = headers.find(HTTP_HEADER_WEBSOCKET_KEY);
+          if (header_key == headers.end())
+          {
+            throw std::logic_error(fmt::format(
+              "{} header missing from upgrade request",
+              HTTP_HEADER_WEBSOCKET_KEY));
+          }
+
+          auto accept_string = construct_accept_string(header_key->second);
+          if (!accept_string.has_value())
+          {
+            throw std::logic_error(fmt::format(
+              "Error constructing {} header", HTTP_HEADER_WEBSOCKET_ACCEPT));
+          }
+
+          // TODO: Use response builder instead
+          auto hdr = fmt::format(
+            "HTTP/1.1 {} {}\r\n"
+            "{}: {}\r\n"
+            "{}: {}\r\n"
+            "{}: {}\r\n"
+            "\r\n",
+            HTTP_STATUS_SWITCHING_PROTOCOLS,
+            http_status_str(HTTP_STATUS_SWITCHING_PROTOCOLS),
+            HTTP_HEADER_UPGRADE,
+            UPGRADE_HEADER_WEBSOCKET,
+            HTTP_HEADER_CONNECTION,
+            CONNECTION_HEADER_UPGRADE,
+            HTTP_HEADER_WEBSOCKET_ACCEPT,
+            accept_string.value());
+
+          return std::vector<uint8_t>(hdr.begin(), hdr.end());
+        }
+        else
+        {
+          return {};
+        }
+      }
+    };
+  }
+}

--- a/src/enclave/wsupgrade.h
+++ b/src/enclave/wsupgrade.h
@@ -73,23 +73,12 @@ namespace enclave
               "Error constructing {} header", HTTP_HEADER_WEBSOCKET_ACCEPT));
           }
 
-          // TODO: Use response builder instead
-          auto hdr = fmt::format(
-            "HTTP/1.1 {} {}\r\n"
-            "{}: {}\r\n"
-            "{}: {}\r\n"
-            "{}: {}\r\n"
-            "\r\n",
-            HTTP_STATUS_SWITCHING_PROTOCOLS,
-            http_status_str(HTTP_STATUS_SWITCHING_PROTOCOLS),
-            HTTP_HEADER_UPGRADE,
-            UPGRADE_HEADER_WEBSOCKET,
-            HTTP_HEADER_CONNECTION,
-            CONNECTION_HEADER_UPGRADE,
-            HTTP_HEADER_WEBSOCKET_ACCEPT,
-            accept_string.value());
+          auto r = Response(HTTP_STATUS_SWITCHING_PROTOCOLS);
+          r.set_header(HTTP_HEADER_UPGRADE, UPGRADE_HEADER_WEBSOCKET);
+          r.set_header(HTTP_HEADER_CONNECTION, CONNECTION_HEADER_UPGRADE);
+          r.set_header(HTTP_HEADER_WEBSOCKET_ACCEPT, accept_string.value());
 
-          return std::vector<uint8_t>(hdr.begin(), hdr.end());
+          return r.build_response_header();
         }
         else
         {

--- a/src/enclave/wsupgrade.h
+++ b/src/enclave/wsupgrade.h
@@ -13,7 +13,6 @@ namespace enclave
 {
   namespace http
   {
-    // TODO: Do we actually need a class for this? or just an inline function?
     class WebSocketUpgrader
     {
     private:

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -17,6 +17,7 @@ from requests_http_signature import HTTPSignatureAuth
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import asymmetric
+from websocket import create_connection
 
 from loguru import logger as LOG
 
@@ -379,7 +380,7 @@ class RequestClient:
     def request(self, request):
         rep = requests.post(
             f"https://{self.host}:{self.port}/{request.method}",
-            json=request.to_dict(),
+            json=request.to_dict(),  # TODO: For REST queries, use data= instead
             cert=(self.cert, self.key),
             verify=self.ca,
             timeout=self.request_timeout,
@@ -391,20 +392,61 @@ class RequestClient:
         with open(self.key, "rb") as k:
             rep = requests.post(
                 f"https://{self.host}:{self.port}/{request.method}",
-                json=request.to_dict(),
+                json=request.to_dict(),  # TODO: For REST queries, use data= instead
                 cert=(self.cert, self.key),
                 verify=self.ca,
                 timeout=self.request_timeout,
                 # key_id needs to be specified but is unused
                 auth=HTTPSignatureAuth(
-                    algorithm="ecdsa-sha256",
-                    key=k.read(),
-                    key_id="tls",
-                    headers=["(request-target)", "Date"],
+                    algorithm="ecdsa-sha256", key=k.read(), key_id="tls",
                 ),
             )
             self.stream.update(rep.content)
         return request.id
+
+    def response(self, id):
+        return self.stream.response(id)
+
+    def disconnect(self):
+        pass
+
+
+class WSClient:
+    def __init__(
+        self,
+        host,
+        port,
+        cert,
+        key,
+        ca,
+        version,
+        format,
+        connection_timeout,
+        request_timeout,
+    ):
+        self.host = host
+        self.port = port
+        self.cert = cert
+        self.key = key
+        self.ca = ca
+        self.format = "json"
+        self.stream = Stream(version, "json")
+        self.request_timeout = request_timeout
+
+    def request(self, request):
+        ws = create_connection(
+            f"wss://{self.host}:{self.port}",
+            sslopt={"certfile": self.cert, "keyfile": self.key, "ca_certs": self.ca},
+        )
+        # TODO: Support sending data over websocket
+        # ws.send(request.to_json())
+        # res = ws.recv()
+        # ws.close()
+        # self.stream.update(rep.content)
+        return request.id
+
+    def signed_request(self, request):
+        raise NotImplementedError("Signed requests not implemented over WebSockets")
 
     def response(self, id):
         return self.stream.response(id)
@@ -423,6 +465,8 @@ class CCFClient:
         if os.getenv("HTTP"):
             if os.getenv("CURL_CLIENT"):
                 self.client_impl = CurlClient(*args, **kwargs)
+            elif os.getenv("WEBSOCKETS_CLIENT"):
+                self.client_impl = WSClient(*args, **kwargs)
             else:
                 self.client_impl = RequestClient(*args, **kwargs)
         else:

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -380,7 +380,7 @@ class RequestClient:
     def request(self, request):
         rep = requests.post(
             f"https://{self.host}:{self.port}/{request.method}",
-            json=request.to_dict(),  # TODO: For REST queries, use data= instead
+            json=request.to_dict(),
             cert=(self.cert, self.key),
             verify=self.ca,
             timeout=self.request_timeout,
@@ -392,13 +392,16 @@ class RequestClient:
         with open(self.key, "rb") as k:
             rep = requests.post(
                 f"https://{self.host}:{self.port}/{request.method}",
-                json=request.to_dict(),  # TODO: For REST queries, use data= instead
+                json=request.to_dict(),
                 cert=(self.cert, self.key),
                 verify=self.ca,
                 timeout=self.request_timeout,
                 # key_id needs to be specified but is unused
                 auth=HTTPSignatureAuth(
-                    algorithm="ecdsa-sha256", key=k.read(), key_id="tls",
+                    algorithm="ecdsa-sha256",
+                    key=k.read(),
+                    key_id="tls",
+                    headers=["(request-target)", "Date"],
                 ),
             )
             self.stream.update(rep.content)
@@ -446,7 +449,7 @@ class WSClient:
         return request.id
 
     def signed_request(self, request):
-        raise NotImplementedError("Signed requests not implemented over WebSockets")
+        raise NotImplementedError("Signed requests not yet implemented over WebSockets")
 
     def response(self, id):
         return self.stream.response(id)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,3 +8,4 @@ psutil
 cimetrics>=0.2.1
 requests-http-signature
 flatbuffers
+websocket-client


### PR DESCRIPTION
Resolves item 2 in https://github.com/microsoft/CCF/issues/629. 

This PR adds support for the WebSocket handshake. 

Typically, the (websocket) client sends a handshake request over HTTP, specifying the upgrade protocol and a random key, e.g.:
```
GET / HTTP/1.1
Upgrade: websocket
Connection: Upgrade
Host: 127.237.61.243:46920
Origin: http://127.237.61.243:46920
Sec-WebSocket-Key: tuCthd5nFUGth+AnhtfWCQ==
Sec-WebSocket-Version: 13
```

To complete the upgrade, the server should reply with:
```
HTTP/1.1 101 Switching Protocols
Connection: Upgrade
Sec-WebSocket-Accept: +y6XCTIDNuuThvP3OSUoiAUA+UY=
Upgrade: websocket
```

The `Sec-Websocket-Accept` string is constructed by 1) concatenating the client's key with a well-known string, 2) SHA1 it, 3) Base 64 encode the result. 

- Added a websocket client in `infra.clients.py` which only tests the handshake. 
- Added a HTTP Response builder in `httpbuilder.h` 
- Also changed the HTTP Signature parser to use static methods so that the interface is nicer.

Still to do: 
- Process the WebSockets frames once the endpoint has been upgraded. 