### PR TITLE
Remove sleep when creating a new node (test infra)

### DIFF
--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -267,9 +267,6 @@ class Network:
         try:
             if self.status is ServiceStatus.OPEN:
                 self.consortium.trust_node(1, primary, new_node.node_id)
-                if os.getenv("HTTP"):
-                    LOG.warning("Sleeping 3 seconds before continuing (HTTP)...")
-                    time.sleep(3)
             if args.consensus != "pbft":
                 new_node.wait_for_node_to_join()
         except (ValueError, TimeoutError):


### PR DESCRIPTION
We used to have to wait before issuing command to a starting node with HTTP. This is no longer the case so this PR removes the last sleep we have in our test infra.