### PR TITLE
Remove ccf.io domain

### DIFF
--- a/tests/e2e_args.py
+++ b/tests/e2e_args.py
@@ -114,7 +114,7 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
     parser.add_argument(
         "--domain",
         help="Domain name used for node certificate verification",
-        default="ccf.io",
+        default="example.com",
     )
     parser.add_argument(
         "--default-curve",


### PR DESCRIPTION
ccf.io exists and is assigned, replacing with example.com, reserved for this kind of purpose (https://tools.ietf.org/html/rfc2606)