### PR TITLE
Add rekey docs and fix broken links in docs

### DIFF
--- a/sphinx/source/developers/build_app.rst
+++ b/sphinx/source/developers/build_app.rst
@@ -48,17 +48,17 @@ It is then possible to inspect the signed enclave library:
     mrenclave=3175971c02d00c1a8f9dd23ca89e64955c5caa94e24f4a3a0579dcfb2e6aebf9
     signature=...
 
-For a given application, the ``signature`` field depends on the key used to sign the enclave. See :ref:`Updating Code Version` for instructions on how members can register new application versions (``mrenclave`` field).
+For a given application, the ``signature`` field depends on the key used to sign the enclave. See :ref:`members/common_member_operations:Updating Code Version` for instructions on how members can register new application versions (``mrenclave`` field).
 
 .. note:: The `Open Enclave documentation <https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/buildandsign.md#signing-the-enclave>`_. provides further details about how to sign enclave applications using ``oesign``.
 
 Running the Application
 -----------------------
 
-:ref:`Operators should start each CCF node <Starting the First Node>` with the signed enclave application as enclave file. For example, for the ``luageneric`` application:
+:ref:`Operators should start each CCF node <operators/start_network:Starting the First Node>` with the signed enclave application as enclave file. For example, for the ``luageneric`` application:
 
 .. code-block:: bash
 
     $ cchost --enclave-file libluagenericenc.signed.so [args]
 
-.. note:: When deploying the ``luageneric`` application, members should also :ref:`register the Lua application <Registering the Lua Application>` before the network is opened to users.
+.. note:: When deploying the ``luageneric`` application, members should also :ref:`register the Lua application <members/open_network:Registering the Lua Application>` before the network is opened to users.

--- a/sphinx/source/developers/index.rst
+++ b/sphinx/source/developers/index.rst
@@ -3,9 +3,9 @@ Writing CCF Applications
 
 This section describes how CCF applications can be developed and deployed to a CCF network.
 
-Applications can be written in C++ or Lua (see :ref:`Example Application`). An application consists of a collection of endpoints that can be triggered by :term:`users` using JSON-RPC. Each endpoint can define an :ref:`API Schema` to validate user requests.
+Applications can be written in C++ or Lua (see :ref:`developers/example:Example Application`). An application consists of a collection of endpoints that can be triggered by :term:`users` using JSON-RPC. Each endpoint can define an :ref:`developers/logging_cpp:API Schema` to validate user requests.
 
-These endpoints mutate the state of a unique :ref:`Key-Value Store` that represents the internal state of the application. Applications define a set of ``Maps`` (see :ref:`Creating a Map`), mapping from a key to a value. When an application endpoint is triggered, the effects on the Store are committed atomically.
+These endpoints mutate the state of a unique :ref:`developers/kv/index:Key-Value Store` that represents the internal state of the application. Applications define a set of ``Maps`` (see :ref:`developers/kv/kv_how_to:Creating a Map`), mapping from a key to a value. When an application endpoint is triggered, the effects on the Store are committed atomically.
 
 .. warning:: Notifications to be described.
 

--- a/sphinx/source/developers/kv/kv_serialisation.rst
+++ b/sphinx/source/developers/kv/kv_serialisation.rst
@@ -10,7 +10,9 @@ Transactions on private :cpp:class:`kv::Map` are encrypted before being serialis
 Serialised Format
 -----------------
 
-The following table describes the structure of a serialised KV store transaction.
+The ledger is stored as a series of a 4 byte transaction length field followed by a transaction.
+
+The following table describes the structure of a serialised KV Store transaction.
 
 +----------+------------------------------------------+-------------------------------------------------------------------------+
 |          | Field Name                               | Description                                                             |

--- a/sphinx/source/developers/kv/kv_serialisation.rst
+++ b/sphinx/source/developers/kv/kv_serialisation.rst
@@ -7,9 +7,7 @@ Transactions on private :cpp:class:`kv::Map` are encrypted before being serialis
 
 .. note:: Transactions are serialised using MessagePack_ and to which is prepended a header for integrity protection.
 
-.. _protocol:
-
-Serialised format
+Serialised Format
 -----------------
 
 The following table describes the structure of a serialised KV store transaction.

--- a/sphinx/source/developers/ledger.rst
+++ b/sphinx/source/developers/ledger.rst
@@ -12,7 +12,7 @@ Each entry in the ledger corresponds to a transaction (or delta) committed by th
 
 When a transaction is committed, each affected ``Store::Map`` is serialised in different security domains (i.e. public or private), based on the policy set when the ``Store::Map`` was created (default is private). Public ``Store::Map`` are serialised and stored in the ledger as plaintext while private ``Store::Map`` are serialised and encrypted before being stored.
 
-Ledger entries are integrity-protected and encrypted using a symmetric key (AES256-GCM) shared by all trusted nodes. This key is kept secure inside each enclave and sealed to disk for service recovery. See :ref:`members/common_member_operations:Rekeying Ledger` for details on how members can rotate the ledger encryption key.
+Ledger entries are integrity-protected and encrypted using a symmetric key shared by all trusted nodes (see :ref:`developers/cryptography:Algorithms and Curves`). This key is kept secure inside each enclave and sealed to disk for service recovery. See :ref:`members/common_member_operations:Rekeying Ledger` for details on how members can rotate the ledger encryption key.
 
 Note that even if a transaction only affects a private ``Store::Map``, unencrypted information such as the version number is always present in the serialised entry. More information about the ledger entry format is available in the :ref:`developers/kv/kv_serialisation:Serialised Format` section.
 
@@ -71,22 +71,20 @@ The following diagram describes how deltas committed by the leader are written t
 Reading and Verifing Ledger
 ---------------------------
 
-The ledger is stored as a series of a 4 byte transaction length field followed by a transaction (as described on the :ref:`developers/kv/kv_serialisation:Serialised Format` section).
-
-A python implementation for parsing the ledger can be found on ledger.py.
+A Python implementation for parsing the ledger can be found in `ledger.py <https://github.com/microsoft/CCF/blob/master/tests/ledger.py>`_.
 
 The ``Ledger`` class is constructed using the path of the ledger. It then exposes an iterator for transaction data structures, where each transaction is composed of the following:
 
  * The GCM header (gcm_header)
  * The serialised public domain, containing operations made only on public tables (get_public_domain)
 
-.. note:: Parsing the encrypted private data (which begins immediately after the public data on the ledger, and is optional) is not supported by the ``Ledger`` class at the moment. This will be added at a later stage.
+.. note:: Parsing the encrypted private data (which begins immediately after the public data on the ledger, and is optional) is not supported by the ``Ledger`` class at the moment.
 
-An example of how to read and verify entries on the ledger can be found on ``votinghistory.py``, which verifies the voting history.
-Since every vote request is signed by the requesting member, verified by the primary and then stored on the ledger, the test performs the following (this sequence of operations is performed sequentially per transaction):
+An example of how to read and verify entries on the ledger can be found in `votinghistory.py <https://github.com/microsoft/CCF/blob/master/tests/votinghistory.py>`_, which verifies the voting history.
+Since every vote request is signed by the voting member, verified by the primary and then stored on the ledger, the test performs the following (this sequence of operations is performed sequentially per transaction):
 
  1. Read and store the member certificates
- 2. Read an entry from the ``voting_history`` table (each entry on the ``voting_history`` table contains the member id of the voting member, along with the signed request)
+ 2. Read an entry from the ``ccf.voting_history`` table (each entry in the table contains the member id of the voting member, along with the signed request)
  3. Create a public key using the certificate of the voting member (which was stored on step 1)
  4. Verify the signature using the public key and the raw request
  5. Repeat steps 2 - 4 until all voting history entries have been read

--- a/sphinx/source/developers/ledger.rst
+++ b/sphinx/source/developers/ledger.rst
@@ -5,20 +5,18 @@ The ledger is the persistent distributed append-only record of the transactions 
 
 A node writes its ledger to a file as specified by the ``--ledger-file`` command line argument.
 
-Ledger encryption
+Ledger Encryption
 -----------------
 
 Each entry in the ledger corresponds to a transaction (or delta) committed by the primary's key-value store.
 
 When a transaction is committed, each affected ``Store::Map`` is serialised in different security domains (i.e. public or private), based on the policy set when the ``Store::Map`` was created (default is private). Public ``Store::Map`` are serialised and stored in the ledger as plaintext while private ``Store::Map`` are serialised and encrypted before being stored.
 
-Note that even if a transaction only affects a private ``Store::Map``, unencrypted information such as the version number is always present in the serialised entry. More information about the ledger entry format is available in the :ref:`protocol` section.
+Ledger entries are integrity-protected and encrypted using a symmetric key (AES256-GCM) shared by all trusted nodes. This key is kept secure inside each enclave and sealed to disk for service recovery. See :ref:`members/common_member_operations:Rekeying Ledger` for details on how members can rotate the ledger encryption key.
 
-.. note:: Private ``Store::Map`` are encrypted using `GCM`_ by a key (a.k.a. network secrets) shared by all nodes in the CCF network.
+Note that even if a transaction only affects a private ``Store::Map``, unencrypted information such as the version number is always present in the serialised entry. More information about the ledger entry format is available in the :ref:`developers/kv/kv_serialisation:Serialised Format` section.
 
-.. _`GCM`: https://en.wikipedia.org/wiki/Galois/Counter_Mode
-
-Ledger replication
+Ledger Replication
 ------------------
 
 The replication process currently uses Raft as the consensus algorithm and therefore the terminology changes slightly. Instead of primary we use the term leader and instead of backup we use the term follower.
@@ -70,10 +68,10 @@ The following diagram describes how deltas committed by the leader are written t
         end
 
 
-Reading the ledger and verifying entries
-----------------------------------------
+Reading and Verifing Ledger
+---------------------------
 
-The ledger is stored as a series of a 4 byte transaction length field followed by a transaction (as described on the :ref:`protocol` section).
+The ledger is stored as a series of a 4 byte transaction length field followed by a transaction (as described on the :ref:`developers/kv/kv_serialisation:Serialised Format` section).
 
 A python implementation for parsing the ledger can be found on ledger.py.
 

--- a/sphinx/source/members/constitution.rst
+++ b/sphinx/source/members/constitution.rst
@@ -5,12 +5,12 @@ The :term:`constitution` defines the set of rules and conditions (as a Lua scrip
 
 Votes for the proposal are evaluated by the constitution's ``pass`` function. If the `pass` function returns ``true``, the vote is passed, and its consequences are applied to the KV in a transaction.
 
-Examples of constitution include (see :ref:`Models` for further details):
+Examples of constitution include (see :ref:`members/constitution:Models` for further details):
 
 - Strict majority (`simple constitution`_) that implements a "one-member, one-vote" constitution, with a majority rule. Votes on so-called sensitive tables, such as the one containing the constitution itself, require unanimity.
 - Operating member + strict majority (`operating member constitution`_) that extends the "strict majority" constitution by defining an operating member allowed to add new nodes to the network, retire existing ones and allow new versions of the code.
 
-Once the initial set of members have agreed on a constitution, the corresponding Lua file can be given to operators to create a new network (see :ref:`Starting a New Network`).
+Once the initial set of members have agreed on a constitution, the corresponding Lua file can be given to operators to create a new network (see :ref:`operators/start_network:Starting a New Network`).
 
 .. note:: The constitution can always be updated after the CCF network has been opened, subject to the existing constitution rules.
 
@@ -25,12 +25,12 @@ Non-member operators
 It is possible for a set of operators to host a CCF network without being members. These operators could:
 
 - Start the network
-- Hand it over to the members for them to Open (see :ref:`Opening a network`)
+- Hand it over to the members for them to Open (see :ref:`members/open_network:Opening a network`)
 
 In case of catastrophic failure, operators could also:
 
 - Start a network in recovery mode from the ledger
-- Hand it over to the members for them to Open (see :ref:`Accepting Recovery`)
+- Hand it over to the members for them to Open (see :ref:`members/common_member_operations:Accepting Recovery`)
 
 Finally, operators could:
 -	Propose new nodes (TR, Section IV D)

--- a/sphinx/source/members/index.rst
+++ b/sphinx/source/members/index.rst
@@ -15,7 +15,7 @@ The ``CCF/tests/keygenerator.sh`` script can be used to generate the member's ce
     Certificate generated at: member1_cert.pem (to be registered in CCF)
     Private key generated at: member1_privk.pem
 
-.. note:: See :ref:`Algorithms and Curves` for the list of supported cryptographic curves.
+.. note:: See :ref:`developers/cryptography:Algorithms and Curves` for the list of supported cryptographic curves.
 
 The member's private key (e.g. ``member1_privk.pem``) should be stored on a trusted device while the certificate (e.g. ``member1_cert.pem``) should be given to operators before starting the first node of a new CCF network.
 

--- a/sphinx/source/members/member_rpc_api.rst
+++ b/sphinx/source/members/member_rpc_api.rst
@@ -1,7 +1,7 @@
 Member RPC API
 ==============
 
-As well as the following methods, :ref:`Common Methods` also available to members.
+As well as the following methods, :ref:`users/rpc_api:Common Methods` also available to members.
 
 ack
 ---

--- a/sphinx/source/members/open_network.rst
+++ b/sphinx/source/members/open_network.rst
@@ -1,14 +1,14 @@
 Opening a Network
 =================
 
-This sections assumes that a set of nodes has already been started by :term:`operators`. See :ref:`Starting a New Network`.
+This sections assumes that a set of nodes has already been started by :term:`operators`. See :ref:`operators/start_network:Starting a New Network`.
 
 Adding Users
 ------------
 
-Once a CCF network is successfully started and an acceptable number of nodes have joined, members should vote to open the network to :term:`users`. First, :ref:`the identities of trusted users should be generated <Using CCF Applications>`.
+Once a CCF network is successfully started and an acceptable number of nodes have joined, members should vote to open the network to :term:`users`. First, :ref:`the identities of trusted users should be generated <users/index:Using CCF Applications>`.
 
-Then, the certificates of trusted users should be registered in CCF via the member governance interface. For example, the first member may decide to make a proposal to add a new user (here, ``user_cert`` is the PEM certificate of the user -- see :ref:`Cryptography` for a list of supported algorithms):
+Then, the certificates of trusted users should be registered in CCF via the member governance interface. For example, the first member may decide to make a proposal to add a new user (here, ``user_cert`` is the PEM certificate of the user -- see :ref:`developers/cryptography:Cryptography` for a list of supported algorithms):
 
 .. code-block:: bash
 
@@ -41,7 +41,7 @@ Registering the Lua Application
 
 .. note:: This section only applies when deploying Lua applications (i.e. using the ``libluagenericenc.so.signed`` enclave library). For C++ applications, this step should be skipped.
 
-Before opening the CCF network to users, members should vote to register the Lua application defining the user-specific business logic (see for example :ref:`Logging (Lua)`):
+
 
 .. code-block:: bash
 
@@ -80,4 +80,4 @@ Other members are then allowed to vote for the proposal, using the proposal id r
     $ memberclient --cert member3_cert --privk member3_privk --rpc-address rpc_ip:rpc_port --ca network_cert vote --proposal-id 2 --accept
     {"commit":19,"global_commit":18,"id":0,"jsonrpc":"2.0","result":true,"term":2}
 
-Once a quorum of members have approved the network opening (``"result":true``), the network is opened to users (see :ref:`Example Application` for a simple business logic and :term:`JSON-RPC` transactions). It is only then that users are able to execute transactions on the business logic defined by the enclave file (``--enclave-file`` option to ``cchost``).
+Once a quorum of members have approved the network opening (``"result":true``), the network is opened to users (see :ref:`developers/example:Example Application` for a simple business logic and :term:`JSON-RPC` transactions). It is only then that users are able to execute transactions on the business logic defined by the enclave file (``--enclave-file`` option to ``cchost``).

--- a/sphinx/source/members/proposals.rst
+++ b/sphinx/source/members/proposals.rst
@@ -12,7 +12,7 @@ For transparency and auditability, all governance operations (including votes) a
 Submitting a new proposal
 -------------------------
 
-Assuming that 3 members (``member1``, ``member2`` and ``member3``) are already registered in the CCF network and that the sample constitution is used, a member can submit a new proposal using the ``memberclient`` command-line utility (see :ref:`Member RPC API` for equivalent JSON-RPC API).
+Assuming that 3 members (``member1``, ``member2`` and ``member3``) are already registered in the CCF network and that the sample constitution is used, a member can submit a new proposal using the ``memberclient`` command-line utility (see :ref:`members/member_rpc_api:Member RPC API` for equivalent JSON-RPC API).
 
 For example, ``member1`` may submit a proposal to add a new member (``member4``) to the consortium:
 

--- a/sphinx/source/operators/operator_rpc_api.rst
+++ b/sphinx/source/operators/operator_rpc_api.rst
@@ -1,7 +1,7 @@
 Operator RPC API
 ================
 
-As well as the following methods, :ref:`Common Methods` also available to operators.
+As well as the following methods, :ref:`users/rpc_api:Common Methods` also available to operators.
 
 getQuotes
 ~~~~~~~~~

--- a/sphinx/source/operators/recovery.rst
+++ b/sphinx/source/operators/recovery.rst
@@ -38,7 +38,7 @@ Each node will then immediately restore the public entries of its ledger (``--le
 
 .. note:: If more than one node were started in ``recover`` mode, the node with the highest signed index (as per the response to the ``getSignedIndex`` JSON-RPC) should be preferred to start the new network. Other nodes should be shutdown and be restarted with the ``join`` option.
 
-Similarly to the normal join protocol (see :ref:`Adding a New Node to the Network`), other nodes are then able to join the network.
+Similarly to the normal join protocol (see :ref:`operators/start_network:Adding a New Node to the Network`), other nodes are then able to join the network.
 
 .. mermaid::
 
@@ -65,7 +65,7 @@ Similarly to the normal join protocol (see :ref:`Adding a New Node to the Networ
 
         Note over Node 3: Part of Public Network
 
-Once operators have established a recovered public network, the existing members of the consortium :ref:`must vote to accept the recovery of the network <Accepting Recovery>`.
+Once operators have established a recovered public network, the existing members of the consortium :ref:`must vote to accept the recovery of the network <members/common_member_operations:Accepting Recovery>`.
 
 .. warning:: After recovery, the identity of the network has changed. The new network certificate ``networkcert.pem`` must be distributed to all existing and new users.
 

--- a/sphinx/source/operators/start_network.rst
+++ b/sphinx/source/operators/start_network.rst
@@ -3,8 +3,8 @@ Starting a New Network
 
 .. note:: Before creating a new network:
 
-    - The :ref:`identity of the initial members of the consortium must be created <Member Governance>`.
-    - The :ref:`constitution should have been agreed by the initial members <Constitution>`.
+    - The :ref:`identity of the initial members of the consortium must be created <members/index:Member Governance>`.
+    - The :ref:`constitution should have been agreed by the initial members <members/constitution:Constitution>`.
 
 Starting the First Node
 -----------------------
@@ -40,7 +40,7 @@ The :term:`constitution`, as defined by the initial members, should be passed vi
 
 The network is now in its opening state and any new nodes can join the network without being trusted by members.
 
-.. note:: Once a CCF network is started, :ref:`members can add other members and users via governance <Opening a Network>`.
+.. note:: Once a CCF network is started, :ref:`members can add other members and users via governance <members/open_network:Opening a Network>`.
 
 Adding a New Node to the Network
 --------------------------------
@@ -64,24 +64,24 @@ To add a new node to an existing opening network, other nodes should be started 
 
 The joining node takes the certificate of the existing network to join via ``--network-cert-file`` and initiates an enclave-to-enclave TLS connection to an existing node of the network as specified by ``--target-rpc-address``.
 
-If the network has not yet been opened by members (see :ref:`Opening the Network`), the joining node becomes part of the network immediately [#remote_attestation]_.
+If the network has not yet been opened by members (see :ref:`members/open_network:Opening the Network`), the joining node becomes part of the network immediately [#remote_attestation]_.
 
-If the network has already been opened to users, members need to trust the joining node before it can become part of the network (see :ref:`Trusting a New Node`).
+If the network has already been opened to users, members need to trust the joining node before it can become part of the network (see :ref:`members/common_member_operations:Trusting a New Node`).
 
-.. note:: When starting up the network or when joining an existing network, the network secrets required to decrypt the ledger are sealed and written to a file so that the network can later be recovered. See :ref:`Catastrophic Recovery` for more details on how to recover a crashed network.
+.. note:: When starting up the network or when joining an existing network, the network secrets required to decrypt the ledger are sealed and written to a file so that the network can later be recovered. See :ref:`operators/recovery:Catastrophic Recovery` for more details on how to recover a crashed network.
 .. note:: CCF nodes can be started by using IP Addresses (both IPv4 and IPV6 are supported) or by specifying domain names. If domain names are to be used then ``--domain=<node domain name>`` should be passed to the node at startup. Once a DNS has been setup it will then be possible to connect to the node over TLS by using the node's domain name.
 
 Opening a Network to Users
 --------------------------
 
-Once a CCF network is successfully started and an acceptable number of nodes have joined, :ref:`members should vote to open the network <Opening a Network>` to :term:`users` via governance.
+Once a CCF network is successfully started and an acceptable number of nodes have joined, :ref:`members should vote to open the network <members/open_network:Opening a Network>` to :term:`users` via governance.
 
 Summary diagram
 ---------------
 
-Once a node is part of the network (started with either the ``start`` or ``join`` option), members are authorised to issue governance transactions and eventually open the network (see :ref:`Opening a Network`). Only then are users authorised to issue JSON-RPC transactions to CCF.
+Once a node is part of the network (started with either the ``start`` or ``join`` option), members are authorised to issue governance transactions and eventually open the network (see :ref:`members/open_network:Opening a Network`). Only then are users authorised to issue JSON-RPC transactions to CCF.
 
-.. note:: After the network is open to users, members can still issue governance transactions to CCF (for example, adding new users or additional members to the consortium or updating the Lua app, when applicable). See :ref:`Member Governance` for more information about member governance.
+.. note:: After the network is open to users, members can still issue governance transactions to CCF (for example, adding new users or additional members to the consortium or updating the Lua app, when applicable). See :ref:`members/index:Member Governance` for more information about member governance.
 
 The following diagram summarises the steps required to bootstrap a CCF network:
 

--- a/sphinx/source/quickstart/build.rst
+++ b/sphinx/source/quickstart/build.rst
@@ -1,7 +1,7 @@
 Building CCF
 ============
 
-Once you have cloned the CCF repository, setup your VM and installed all dependencies (see :ref:`Requirements`), you will be able to successfully build and run the CCF test suite that will deploy a local CCF network.
+Once you have cloned the CCF repository, setup your VM and installed all dependencies (see :ref:`quickstart/requirements:Requirements`), you will be able to successfully build and run the CCF test suite that will deploy a local CCF network.
 
 Building from Source
 --------------------

--- a/sphinx/source/quickstart/index.rst
+++ b/sphinx/source/quickstart/index.rst
@@ -1,9 +1,9 @@
 Quickstart
 ==========
 
-First, you should :ref:`setup a CCF-compatible environment <Environment Setup>`. Then, you will be able to :ref:`build CCF from source and run CCF test suite <Building CCF>`. Note that for rapid prototyping, you can run a `virtual` build of CCF that does not require Intel SGX.
+First, you should :ref:`setup a CCF-compatible environment <quickstart/requirements:Environment Setup>`. Then, you will be able to :ref:`build CCF from source and run CCF test suite <quickstart/build:Building CCF>`. Note that for rapid prototyping, you can run a `virtual` build of CCF that does not require Intel SGX.
 
-Once this is done, you can quickly spin up a CCF network and start :ref:`issuing commands to the deployed application <Issuing Commands>`:
+Once this is done, you can quickly spin up a CCF network and start :ref:`issuing commands to the deployed application <users/issue_commands:Issuing Commands>`:
 
 .. code-block:: bash
 
@@ -20,13 +20,13 @@ Once this is done, you can quickly spin up a CCF network and start :ref:`issuing
     [2019-10-29 14:48:12.138] See https://microsoft.github.io/CCF/users/issue_commands.html for more information.
     [2019-10-29 14:48:12.138] Press Ctrl+C to shutdown the network.
 
-You should also get familiar with some of :ref:`CCF concepts`. You will then be able to:
+You should also get familiar with some of :ref:`concepts:CCF concepts`. You will then be able to:
 
-1. :ref:`Create a consortium and agree on the constitution <Member Governance>`
-2. :ref:`Develop a CCF application, based on the example logging application <Example Application>`
-3. :ref:`Start a new CCF network to deploy the application <Starting a New Network>`
-4. :ref:`Let the consortium configure and open the network to users <Opening a Network>`
-5. :ref:`Have users issue business transactions to the application <Using CCF Applications>`
+1. :ref:`Create a consortium and agree on the constitution <members/index:Member Governance>`
+2. :ref:`Develop a CCF application, based on the example logging application <developers/example:Example Application>`
+3. :ref:`Start a new CCF network to deploy the application <operators/start_network:Starting a New Network>`
+4. :ref:`Let the consortium configure and open the network to users <members/open_network:Opening a Network>`
+5. :ref:`Have users issue business transactions to the application <users/index:Using CCF Applications>`
 
 .. toctree::
     :maxdepth: 2

--- a/sphinx/source/quickstart/requirements.rst
+++ b/sphinx/source/quickstart/requirements.rst
@@ -5,10 +5,10 @@ This page describes how to setup an environment to build and deploy CCF.
 
 There are two options to deploy a CCF-ready environment:
 
-- :ref:`Checkout CCF and its dependencies in a local container <Local Development without SGX (virtual)>`. This is useful for quick prototyping using CCF `virtual` mode.
-- :ref:`Create a SGX-enabled VM on Azure and install CCF dependencies <Azure Confidential Compute>`.
+- :ref:`Checkout CCF and its dependencies in a local container <quickstart/requirements:Local Development without SGX (virtual)>`. This is useful for quick prototyping using CCF `virtual` mode.
+- :ref:`Create a SGX-enabled VM on Azure and install CCF dependencies <quickstart/requirements:Azure Confidential Compute>`.
 
-Once this is done, you should look at how to :ref:`build CCF from source <Building CCF>`.
+Once this is done, you should look at how to :ref:`build CCF from source <quickstart/build:Building CCF>`.
 
 Requirements
 ------------
@@ -68,7 +68,7 @@ Then, to quickly get a VM up and running (in the East US region), you can run th
 
     $ SUBSCRIPTION=$AZURE_SUBSCRIPTION_NAME ./make_vm.sh [path_to_ssh_public_key]
 
-After signing in to your Azure account, the script will create a default ``ccf`` user on the VM, authenticated by the public key specified by ``path_to_ssh_public_key`` (defaults to ``~/.ssh/id_rsa.pub``). See :ref:`OE Engine Walkthrough` for further details about how to deploy an ACC VM.
+After signing in to your Azure account, the script will create a default ``ccf`` user on the VM, authenticated by the public key specified by ``path_to_ssh_public_key`` (defaults to ``~/.ssh/id_rsa.pub``). See :ref:`quickstart/oeengine:OE Engine Walkthrough` for further details about how to deploy an ACC VM.
 
 Then, you should ssh into your newly created vm and clone the CCF repository:
 
@@ -95,7 +95,7 @@ To quickly set up the dependencies necessary to build CCF, simply run:
     $ cd CCF/getting_started/setup_vm
     $ ./setup.sh
 
-Once this is complete, you can proceed to :ref:`Building CCF`.
+Once this is complete, you can proceed to :ref:`quickstart/build:Building CCF`.
 
 On a machine without SGX, you can instead use:
 

--- a/sphinx/source/users/client.rst
+++ b/sphinx/source/users/client.rst
@@ -32,5 +32,5 @@ Testcases will automatically switch to using the appropriate clients.
 The CCF Python infra client can be used without any modifications other than exporting the ``HTTP`` environment variable.
 By default, the Python infra uses `requests <https://realpython.com/python-requests/>`_, but exporting the ``CURL_CLIENT`` environment variable will switch to a ``curl``-based client instead.
 
-The ``start_test_network.sh`` script documented in :ref:`Quickstart` defaults to using ``curl``.
+The ``start_test_network.sh`` script documented in :ref:`quickstart/index:Quickstart` defaults to using ``curl``.
 A simple ``scurl.sh`` wrapper script is automatically generated under ``build/``, and allows sending signed requests to CCF.

--- a/sphinx/source/users/deploy_app.rst
+++ b/sphinx/source/users/deploy_app.rst
@@ -1,7 +1,7 @@
 Deploying an Application
 ========================
 
-The quickest way to deploy a CCF application is to use the `start_test_network.sh <https://github.com/microsoft/CCF/blob/master/start_test_network.sh>`_ test script, specifying the :ref:`enclave image <Writing CCF Applications>` to run.
+The quickest way to deploy a CCF application is to use the `start_test_network.sh <https://github.com/microsoft/CCF/blob/master/start_test_network.sh>`_ test script, specifying the :ref:`enclave image <developers/index:Writing CCF Applications>` to run.
 
 The script creates a new test CCF network composed of 3 nodes running locally. All the governance requests required to open the network to users are automatically issued.
 
@@ -28,5 +28,5 @@ The log files (``out`` and ``err``) and ledger (``<node_id>.ledger``) for each C
 
 .. note:: The first time the command is run, a Python virtual environment will be created. This may take a few seconds. It will not be run the next time the ``start_test_network.sh`` script is started.
 
-In a different terminal, using the local IP address and port of the CCF nodes displayed by the command (e.g. ``127.177.10.108:37765`` for node ``0``), it is then possible for users to :ref:`issue business requests <Issuing Commands>`.
+In a different terminal, using the local IP address and port of the CCF nodes displayed by the command (e.g. ``127.177.10.108:37765`` for node ``0``), it is then possible for users to :ref:`issue business requests <users/issue_commands:Issuing Commands>`.
 

--- a/sphinx/source/users/index.rst
+++ b/sphinx/source/users/index.rst
@@ -11,9 +11,9 @@ To generate the certificate and private key of trusted users should be generated
     Certificate generated at: user1_cert.pem (to be registered in CCF)
     Private key generated at: user1_privk.pem
 
-.. note:: See :ref:`Algorithms and Curves` for the list of supported cryptographic curves.
+.. note:: See :ref:`developers/cryptography:Algorithms and Curves` for the list of supported cryptographic curves.
 
-Before issuing business transactions to CCF, the certificates of trusted users need to be voted in by the consortium of members (see :ref:`Adding Users`).
+Before issuing business transactions to CCF, the certificates of trusted users need to be voted in by the consortium of members (see :ref:`members/open_network:Adding Users`).
 
 .. toctree::
     :maxdepth: 2

--- a/sphinx/source/users/issue_commands.rst
+++ b/sphinx/source/users/issue_commands.rst
@@ -3,7 +3,7 @@ Issuing Commands
 
 Clients communicate with CCF using framed :term:`JSON-RPC` over :term:`TLS`. The ``method`` must be prefixed with the name of the target frontend (``"users"`` or ``"members"``), separated from the intended ``method`` with a single ``/``.
 
-Users can issue business transactions to CCF using the ``client`` command-line utility built with CCF. For example, to record a message at a specific id with the :ref:`Example Application`:
+Users can issue business transactions to CCF using the ``client`` command-line utility built with CCF. For example, to record a message at a specific id with the :ref:`developers/example:Example Application`:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Add docs for rekeying ledger encryption key (following https://github.com/microsoft/CCF/pull/699). 

I also fixed the docs referencing issue we had by specifying the full path of each section title (half an hour well spent!). 

**This should be merged after https://github.com/microsoft/CCF/pull/699 is merged.**