### PR TITLE
Only detect components once

### DIFF
--- a/.azure-pipelines-templates/cimetrics.yml
+++ b/.azure-pipelines-templates/cimetrics.yml
@@ -1,8 +1,7 @@
-variables:
-  skipComponentGovernanceDetection: true
-
 jobs:
 - job: CIMetrics
+  variables:
+    skipComponentGovernanceDetection: true
   displayName: 'CI Metrics'
   
   ${{ insert }}: ${{ parameters.env }}

--- a/.azure-pipelines-templates/cimetrics.yml
+++ b/.azure-pipelines-templates/cimetrics.yml
@@ -1,3 +1,6 @@
+variables:
+  skipComponentGovernanceDetection: true
+
 jobs:
 - job: CIMetrics
   displayName: 'CI Metrics'

--- a/.azure-pipelines-templates/common.yml
+++ b/.azure-pipelines-templates/common.yml
@@ -1,3 +1,6 @@
+variables:
+  skipComponentGovernanceDetection: true
+
 jobs:
 - job: BuildAndTest_${{ parameters.target }}_${{ parameters.consensus }}_${{ parameters.protocol }}_${{ parameters.suffix }}
   displayName: 'Build and Test ${{ parameters.target }} ${{ parameters.consensus }} ${{ parameters.protocol }} ${{ parameters.suffix }}'

--- a/.azure-pipelines-templates/common.yml
+++ b/.azure-pipelines-templates/common.yml
@@ -1,8 +1,7 @@
-variables:
-  skipComponentGovernanceDetection: true
-
 jobs:
 - job: BuildAndTest_${{ parameters.target }}_${{ parameters.consensus }}_${{ parameters.protocol }}_${{ parameters.suffix }}
+  variables:
+    skipComponentGovernanceDetection: true
   displayName: 'Build and Test ${{ parameters.target }} ${{ parameters.consensus }} ${{ parameters.protocol }} ${{ parameters.suffix }}'
   dependsOn: ${{ parameters.depends_on }}
 


### PR DESCRIPTION
Component detection currently executes on every job and adds a minute every time. That's quite unnecessary.