### PR TITLE
Add new transaction object to test suite 

### DIFF
--- a/src/apps/logging/logging.cpp
+++ b/src/apps/logging/logging.cpp
@@ -65,7 +65,7 @@ namespace ccfapp
   enum class LoggerErrors : jsonrpc::ErrorBaseType
   {
     UNKNOWN_ID =
-      (jsonrpc::ErrorBaseType)jsonrpc::CCFErrorCodes::APP_ERROR_START,
+      (jsonrpc::ErrorBaseType)jsonrpc::CCFErrorCodes::APP_ERROR_START - 1,
     MESSAGE_EMPTY = UNKNOWN_ID - 1,
   };
 

--- a/tests/e2e_batched.py
+++ b/tests/e2e_batched.py
@@ -16,9 +16,10 @@ from loguru import logger as LOG
 id_gen = itertools.count()
 
 
+@reqs.description("Running batch submission of new entries")
 @reqs.supports_methods("BATCH_submit", "BATCH_fetch")
 def test(network, args, batch_size=100, write_key_divisor=1, write_size_multiplier=1):
-    LOG.info(f"Running batch submission of {batch_size} new entries")
+    LOG.info(f"Number of batched entries: {batch_size}")
     primary, _ = network.find_primary()
 
     # Set extended timeout, since some of these successful transactions will take many seconds

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1,14 +1,69 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 import infra.ccf
-import infra.jsonrpc
 import infra.notification
 import suite.test_requirements as reqs
+import infra.logging_app as app
 import e2e_args
 
 from loguru import logger as LOG
 
 
+@reqs.description("Running transactions against logging app")
+@reqs.supports_methods("LOG_record", "LOG_record_pub", "LOG_get", "LOG_get_pub")
+@reqs.at_least_n_nodes(2)
+def test(network, args, notifications_queue=None, verify=True):
+    txs = app.LoggingTxs(notifications_queue=notifications_queue)
+    txs.issue(network=network, number_txs=1)
+    txs.issue(network=network, number_txs=1, on_backup=True)
+    # TODO: Once the JS app supports both public and private tables, always verify
+    if verify:
+        txs.verify(network)
+    else:
+        LOG.warning("Skipping log messages verification")
+
+    return network
+
+
+@reqs.description("Write/Read large messages on primary")
+@reqs.supports_methods("LOG_record", "LOG_get")
+def test_large_messages(network, args):
+    primary, _ = network.find_primary()
+
+    with primary.node_client(format="json") as nc:
+        check_commit = infra.checker.Checker(nc)
+        check = infra.checker.Checker()
+
+        with primary.user_client(format="json") as c:
+            id = 44
+            for p in range(14, 20):
+                long_msg = "X" * (2 ** p)
+                check_commit(
+                    c.rpc("LOG_record", {"id": id, "msg": long_msg}), result=True,
+                )
+                check(c.rpc("LOG_get", {"id": id}), result={"msg": long_msg})
+                id += 1
+
+    return network
+
+
+@reqs.description("Testing forwarding on member and node frontends")
+@reqs.supports_methods("mkSign")
+@reqs.at_least_n_nodes(2)
+def test_forwarding_frontends(network, args):
+    primary, backup = network.find_primary_and_any_backup()
+
+    with primary.node_client(format="json") as nc:
+        check_commit = infra.checker.Checker(nc)
+        with backup.node_client(format="json") as c:
+            check_commit(c.do("mkSign", params={}), result=True)
+        with backup.member_client(format="json") as c:
+            check_commit(c.do("mkSign", params={}), result=True)
+
+    return network
+
+
+@reqs.description("Uninstalling Lua application")
 @reqs.lua_generic_app
 def test_update_lua(network, args):
     if args.package == "libluagenericenc":
@@ -23,12 +78,12 @@ def test_update_lua(network, args):
         with open(new_app_file, "w") as qfile:
             qfile.write(
                 """
-                            return {
-                            ping = [[
-                                tables, args = ...
-                                return {result = "pong"}
-                            ]],
-                            }"""
+                    return {
+                    ping = [[
+                        tables, args = ...
+                        return {result = "pong"}
+                    ]],
+                    }"""
             )
 
         network.consortium.set_lua_app(
@@ -55,56 +110,6 @@ def test_update_lua(network, args):
     return network
 
 
-@reqs.supports_methods("mkSign", "LOG_record", "LOG_get")
-@reqs.at_least_n_nodes(2)
-def test(network, args, notifications_queue=None):
-    LOG.info("Running transactions against logging app")
-    primary, backup = network.find_primary_and_any_backup()
-
-    with primary.node_client(format="json") as mc:
-        check_commit = infra.checker.Checker(mc, notifications_queue)
-        check = infra.checker.Checker()
-
-        msg = "Hello world"
-        msg2 = "Hello there"
-        backup_msg = "Msg sent to a backup"
-
-        LOG.info("Write/Read on primary")
-        with primary.user_client(format="json") as c:
-            check_commit(c.rpc("LOG_record", {"id": 42, "msg": msg}), result=True)
-            check_commit(c.rpc("LOG_record", {"id": 43, "msg": msg2}), result=True)
-            check(c.rpc("LOG_get", {"id": 42}), result={"msg": msg})
-            check(c.rpc("LOG_get", {"id": 43}), result={"msg": msg2})
-
-        LOG.info("Write on all backup frontends")
-        with backup.node_client(format="json") as c:
-            check_commit(c.do("mkSign", params={}), result=True)
-        with backup.member_client(format="json") as c:
-            check_commit(c.do("mkSign", params={}), result=True)
-
-        LOG.info("Write/Read on backup")
-
-        with backup.user_client(format="json") as c:
-            check_commit(
-                c.rpc("LOG_record", {"id": 100, "msg": backup_msg}), result=True
-            )
-            check(c.rpc("LOG_get", {"id": 100}), result={"msg": backup_msg})
-            check(c.rpc("LOG_get", {"id": 42}), result={"msg": msg})
-
-        LOG.info("Write/Read large messages on primary")
-        with primary.user_client(format="json") as c:
-            id = 44
-            for p in range(14, 20):
-                long_msg = "X" * (2 ** p)
-                check_commit(
-                    c.rpc("LOG_record", {"id": id, "msg": long_msg}), result=True,
-                )
-                check(c.rpc("LOG_get", {"id": id}), result={"msg": long_msg})
-                id += 1
-
-    return network
-
-
 def run(args):
     hosts = ["localhost", "localhost"]
 
@@ -119,7 +124,14 @@ def run(args):
             hosts, args.build_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb,
         ) as network:
             network.start_and_join(args)
-            network = test(network, args, notifications_queue)
+            network = test(
+                network,
+                args,
+                notifications_queue,
+                verify=args.package is not "libjsgenericenc",
+            )
+            network = test_large_messages(network, args)
+            network = test_forwarding_frontends(network, args)
             network = test_update_lua(network, args)
 
 

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -467,20 +467,20 @@ class Network:
 
 
 @contextmanager
-def network(
-    hosts, build_directory, dbg_nodes=[], perf_nodes=[], pdb=False,
-):
+def network(hosts, build_directory, dbg_nodes=[], perf_nodes=[], pdb=False, txs=None):
     """
     Context manager for Network class.
     :param hosts: a list of hostnames (localhost or remote hostnames)
     :param build_directory: the build directory
     :param dbg_nodes: default: []. List of node id's that will not start (user is prompted to start them manually)
     :param perf_nodes: default: []. List of node ids that will run under perf record
+    :param pdb: default: False. Debugger.
+    :param txs: default: None. Transactions committed on that network.
     :return: a Network instance that can be used to create/access nodes, handle the genesis state (add members, create
     node.json), and stop all the nodes that belong to the network
     """
     with infra.path.working_dir(build_directory):
-        net = Network(hosts=hosts, dbg_nodes=dbg_nodes, perf_nodes=perf_nodes)
+        net = Network(hosts=hosts, dbg_nodes=dbg_nodes, perf_nodes=perf_nodes, txs=txs)
         try:
             yield net
         except Exception:

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -65,10 +65,13 @@ class Network:
     # Maximum delay (seconds) for updates to propagate from the primary to backups
     replication_delay = 30
 
-    def __init__(self, hosts, dbg_nodes=None, perf_nodes=None, existing_network=None):
+    def __init__(
+        self, hosts, dbg_nodes=None, perf_nodes=None, existing_network=None, txs=None
+    ):
         if existing_network is None:
             self.consortium = []
             self.node_offset = 0
+            self.txs = txs
         else:
             self.consortium = existing_network.consortium
             # When creating a new network from an existing one (e.g. for recovery),
@@ -78,6 +81,7 @@ class Network:
             self.node_offset = (
                 len(existing_network.nodes) + existing_network.node_offset
             )
+            self.txs = existing_network.txs
 
         self.nodes = []
         self.hosts = hosts

--- a/tests/infra/logging_app.py
+++ b/tests/infra/logging_app.py
@@ -1,0 +1,64 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+import infra.ccf
+
+from loguru import logger as LOG
+
+
+
+class LoggingTxs:
+    def __init__(self, notifications_queue=None):
+        self.pub = {}
+        self.priv = {}
+        self.next_pub_index = 0
+        self.next_priv_index = 0
+        self.notifications_queue = notifications_queue
+
+    def issue(self, network, number_txs, on_backup=False):
+        LOG.success(f"Applying {number_txs} logging txs")
+        primary, backup = network.find_primary_and_any_backup()
+        remote_node = backup if on_backup else primary
+
+        with remote_node.node_client(format="json") as mc:
+            check_commit = infra.checker.Checker(mc)
+            check_commit_n = infra.checker.Checker(mc, self.notifications_queue)
+
+            with remote_node.user_client(format="json") as uc:
+                for _ in range(number_txs):
+                    priv_msg = f"Private message at index {self.next_priv_index}"
+                    pub_msg = f"Public message at index {self.next_pub_index}"
+                    rep_priv = uc.rpc(
+                        "LOG_record", {"id": self.next_priv_index, "msg": priv_msg,},
+                    )
+                    rep_pub = uc.rpc(
+                        "LOG_record_pub", {"id": self.next_pub_index, "msg": pub_msg,},
+                    )
+                    check_commit_n(rep_priv, result=True)
+                    check_commit(rep_pub, result=True)
+
+                    self.priv[self.next_priv_index] = priv_msg
+                    self.pub[self.next_pub_index] = pub_msg
+                    self.next_priv_index += 1
+                    self.next_pub_index += 1
+
+    def verify(self, network):
+        LOG.success(f"Verifying all logging txs")
+        primary, term = network.find_primary()
+
+        with primary.node_client(format="json") as mc:
+            check = infra.checker.Checker()
+
+            with primary.user_client(format="json") as uc:
+
+                for pub_tx_index in self.pub:
+                    check(
+                        uc.rpc("LOG_get_pub", {"id": pub_tx_index}),
+                        result={"msg": self.pub[pub_tx_index]},
+                    )
+
+                for priv_tx_index in self.priv:
+                    check(
+                        uc.rpc("LOG_get", {"id": priv_tx_index}),
+                        result={"msg": self.priv[priv_tx_index]},
+                    )

--- a/tests/infra/logging_app.py
+++ b/tests/infra/logging_app.py
@@ -41,6 +41,8 @@ class LoggingTxs:
                     self.next_priv_index += 1
                     self.next_pub_index += 1
 
+        network.wait_for_node_commit_sync()
+
     def verify(self, network):
         LOG.success(f"Verifying all logging txs")
         primary, term = network.find_primary()

--- a/tests/infra/logging_app.py
+++ b/tests/infra/logging_app.py
@@ -6,7 +6,6 @@ import infra.ccf
 from loguru import logger as LOG
 
 
-
 class LoggingTxs:
     def __init__(self, notifications_queue=None):
         self.pub = {}

--- a/tests/receipts.py
+++ b/tests/receipts.py
@@ -17,10 +17,10 @@ import e2e_args
 from loguru import logger as LOG
 
 
+@reqs.description("Running transactions against logging app")
 @reqs.supports_methods("getReceipt", "verifyReceipt", "LOG_get")
 @reqs.at_least_n_nodes(2)
 def test(network, args, notifications_queue=None):
-    LOG.info("Running transactions against logging app")
     primary, backup = network.find_primary_and_any_backup()
 
     with primary.node_client() as mc:

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -20,17 +20,15 @@ def check_can_progress(node):
             check_commit(c.rpc("mkSign", params={}), result=True)
 
 
-@reqs.none
+@reqs.description("Adding a valid node from primary")
 def test_add_node(network, args):
-    LOG.info("Adding a valid node from primary")
     new_node = network.create_and_trust_node(args.package, "localhost", args)
     assert new_node
     return network
 
 
-@reqs.at_least_n_nodes(2)
+@reqs.description("Adding a valid node from a backup")
 def test_add_node_from_backup(network, args):
-    LOG.info("Adding a valid node from a backup")
     backup = network.find_any_backup()
     new_node = network.create_and_trust_node(
         args.package, "localhost", args, target_node=backup
@@ -39,10 +37,9 @@ def test_add_node_from_backup(network, args):
     return network
 
 
-@reqs.none
+@reqs.description("Adding as many pending nodes as current number of nodes")
 def test_add_as_many_pending_nodes(network, args):
-    # Adding as many pending nodes as current number of nodes should not
-    # change the raft consensus rules (i.e. majority)
+    # Should not change the raft consensus rules (i.e. majority)
     number_new_nodes = len(network.nodes)
     LOG.info(
         f"Adding {number_new_nodes} pending nodes - consensus rules should not change"
@@ -54,7 +51,7 @@ def test_add_as_many_pending_nodes(network, args):
     return network
 
 
-@reqs.none
+@reqs.description("Add node with untrusted code version")
 def test_add_node_untrusted_code(network, args):
     if args.enclave_type == "debug":
         LOG.info("Adding an invalid node (unknown code id)")
@@ -68,9 +65,9 @@ def test_add_node_untrusted_code(network, args):
     return network
 
 
+@reqs.description("Retiring a backup")
 @reqs.at_least_n_nodes(2)
 def test_retire_node(network, args):
-    LOG.info("Retiring a backup")
     primary, _ = network.find_primary()
     backup_to_retire = network.find_any_backup()
     network.consortium.retire_node(primary, backup_to_retire)

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -74,10 +74,9 @@ def check_responses(responses, result, check, check_commit):
     check_commit(responses[-1], result=result)
 
 
-@reqs.none
-def test(network, args):
-    LOG.info("Starting network recovery")
-
+@reqs.description("Recovering a network")
+@reqs.recover(number_txs=2)
+def test(network, args, txs=None):
     primary, backups = network.find_nodes()
 
     ledger = primary.remote.get_ledger()

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -11,67 +11,11 @@ from random import seed
 import infra.ccf
 import infra.proc
 import infra.remote
+import infra.logging_app as app
 import json
 import suite.test_requirements as reqs
 
 from loguru import logger as LOG
-
-
-class Txs:
-    def __init__(self, nb_msgs, offset=0, since_beginning=False):
-        self.pub = {}
-        self.priv = {}
-
-        # After a recovery, check that all messages since the beginning of
-        # time have been successfully recovered
-        start_i = (offset * nb_msgs) if not since_beginning else 0
-
-        for i in range(start_i, nb_msgs + offset * nb_msgs):
-            self.pub[i] = "Public msg #{}".format(i)
-            self.priv[i] = "Private msg #{}".format(i)
-
-
-def check_nodes_have_msgs(nodes, txs):
-    """
-    Read and check values for messages at an offset. This effectively
-    makes sure nodes have recovered state.
-    """
-    for node in nodes:
-        with node.user_client(format="json") as c:
-            for n, msg in txs.priv.items():
-                c.do(
-                    "LOG_get",
-                    {"id": n},
-                    readonly_hint=None,
-                    expected_result={"msg": msg},
-                )
-            for n, msg in txs.pub.items():
-                c.do(
-                    "LOG_get_pub",
-                    {"id": n},
-                    readonly_hint=None,
-                    expected_result={"msg": msg},
-                )
-
-
-def log_msgs(primary, txs):
-    """
-    Log a new series of messages
-    """
-    LOG.debug("Applying new transactions")
-    responses = []
-    with primary.user_client(format="json") as c:
-        for n, msg in txs.priv.items():
-            responses.append(c.rpc("LOG_record", {"id": n, "msg": msg}))
-        for n, msg in txs.pub.items():
-            responses.append(c.rpc("LOG_record_pub", {"id": n, "msg": msg}))
-    return responses
-
-
-def check_responses(responses, result, check, check_commit):
-    for response in responses[:-1]:
-        check(response, result=result)
-    check_commit(responses[-1], result=result)
 
 
 @reqs.description("Recovering a network")
@@ -118,33 +62,18 @@ def test(network, args, txs=None):
 def run(args):
     hosts = ["localhost", "localhost"]
 
+    txs = app.LoggingTxs()
+
     with infra.ccf.network(
-        hosts, args.build_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
+        hosts, args.build_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb, txs=txs
     ) as network:
         network.start_and_join(args)
 
         for recovery_idx in range(args.recovery):
-            txs = Txs(args.msgs_per_recovery, recovery_idx)
-
-            primary, backups = network.find_nodes()
-
-            with primary.node_client() as mc:
-                check_commit = infra.checker.Checker(mc)
-                check = infra.checker.Checker()
-
-                rs = log_msgs(primary, txs)
-                check_responses(rs, True, check, check_commit)
-                network.wait_for_node_commit_sync()
-                check_nodes_have_msgs(backups, txs)
-
             recovered_network = test(network, args)
-
             network.stop_all_nodes()
             network = recovered_network
 
-            old_txs = Txs(args.msgs_per_recovery, recovery_idx, since_beginning=True)
-
-            check_nodes_have_msgs(recovered_network.nodes, old_txs)
             LOG.success("Recovery complete on all nodes")
 
 

--- a/tests/rekey.py
+++ b/tests/rekey.py
@@ -10,10 +10,10 @@ import time
 from loguru import logger as LOG
 
 
+@reqs.description("Rekey the ledger once")
 @reqs.supports_methods("mkSign")
 @reqs.at_least_n_nodes(1)
 def test(network, args):
-    LOG.info("Rekey ledger once")
     primary, _ = network.find_primary()
 
     # Retrieve current index version to check for sealed secrets later

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -11,12 +11,16 @@ class TestRequirementsNotMet(Exception):
     pass
 
 
-def none(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        return func(*args, **kwargs)
+def description(desc):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            LOG.success(desc)
+            return func(*args, **kwargs)
 
-    return wrapper
+        return wrapper
+
+    return decorator
 
 
 def ensure_reqs(check_reqs):
@@ -79,3 +83,20 @@ def installed_package(p):
 
 def lua_generic_app(func):
     return installed_package("libluagenericenc")(func)
+
+
+# Runs some transactions before recovering the network and guarantees that all
+# transactions are successfully recovered
+def recover(number_txs=5):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            network = args[0]
+            network.txs.issue(network=network, number_txs=number_txs)
+            new_network = func(*args, **kwargs)
+            new_network.txs.verify(network=new_network)
+            return new_network
+
+        return wrapper
+
+    return decorator

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -92,7 +92,11 @@ def recover(number_txs=5):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             network = args[0]
-            network.txs.issue(network=network, number_txs=number_txs)
+            e2e_args = vars(args[1])
+            network.txs.issue(
+                network=network,
+                number_txs=e2e_args.get("msgs_per_recovery") or number_txs,
+            )
             new_network = func(*args, **kwargs)
             new_network.txs.verify(network=new_network)
             return new_network


### PR DESCRIPTION
This is the last step to guarantee that our end-to-end test suite works correctly. 

There is now a new `txs` object that is passed to the `infra.ccf.network` and records all the transactions executed on the network during the test suite. Whenever we recover the network, the test suite will automatically issue some transactions prior to recovery and guarantee that they are correctly recovered post recovery.

This can be added to any of our tests via the `@reqs.recovery` decorator. I have refactored the `e2e_logging.py` test accordingly.