### PR TITLE
Do not call get_full_state_root() when it is not needed

### DIFF
--- a/src/node/history.h
+++ b/src/node/history.h
@@ -607,9 +607,9 @@ namespace ccf
       size_t all_data_size) override
     {
       append(replicated, replicated_size, all_data, all_data_size);
+#ifdef PBFT
       auto root = get_full_state_root();
       LOG_DEBUG_FMT("HISTORY: add_result {0} {1} {2}", id, version, root);
-#ifdef PBFT
       results[id] = {version, root};
       if (on_result.has_value())
         on_result.value()({id, version, root});
@@ -618,9 +618,9 @@ namespace ccf
 
     void add_result(kv::TxHistory::RequestID id, kv::Version version) override
     {
+#ifdef PBFT
       auto root = get_full_state_root();
       LOG_DEBUG_FMT("HISTORY: add_result {0} {1} {2}", id, version, root);
-#ifdef PBFT
       results[id] = {version, root};
       if (on_result.has_value())
         on_result.value()({id, version, root});


### PR DESCRIPTION
Resolve #724 

This removes 2 calls to get_full_state_root() that are not needed in the Raft case.

  | before | after
-- | -- | --
  | 54957.4 | 61590.5
  | 55383.4 | 59255.6
  | 55322.7 | 61837.1
  | 54537.9 | 61819.2
  | 54345.3 | 61231.4
  |   |  
average | 54909.34 | 61146.76
  |   |  
  |   |  
Improvement | 10.20% |  


"python3" "/home/alexsha/CCF/samples/apps/smallbank/tests/small_bank_client.py" "-b" "." "-c" "./small_bank_client" "--ignore-quote" "-l" "info" "-g" "/home/alexsha/CCF/src/runtime_config/gov.lua" "--consensus" "raft" "--worker_threads" "0" "--default-curve" "secp384r1" "--write-tx-times" "--label" "SB_^" "--transactions" "200000" "--max-writes-ahead" "5000" "--metrics-file" "small_bank_metrics.json" -n 10.190.228.230 -n 10.190.228.232 -n 10.190.228.234 --sig-max-tx 5000

Run on the upstairs cluster