### PR TITLE
Resize to avoid trailing data

### DIFF
--- a/src/consensus/pbft/pbft.h
+++ b/src/consensus/pbft/pbft.h
@@ -64,10 +64,7 @@ namespace pbft
 
       // TODO: Encrypt msg here
       auto space = (sizeof(PbftHeader) + msg->size());
-      if (serialized_msg.size() < space)
-      {
-        serialized_msg.resize(space);
-      }
+      serialized_msg.resize(space);
       auto data_ = serialized_msg.data();
       serialized::write<PbftHeader>(data_, space, hdr);
       serialized::write(


### PR DESCRIPTION
AFAICT, [this failure](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=4272&view=logs&j=13585137-c2dd-56f2-c63b-09854f0e18f7&t=3ce5bd4c-ff15-5db3-bb2c-95e75b76f8f8&l=213) started with #735. If we don't resize downwards, then the `serialized_msg` will still contain old data at the end, and it seems this is causing occasional test failures.