### PR TITLE
Updating sphinx docs

### DIFF
--- a/sphinx/source/concepts.rst
+++ b/sphinx/source/concepts.rst
@@ -17,7 +17,7 @@ Nodes are run and maintained by :term:`operators`. However, nodes must be truste
 Application
 -----------
 
-Each node runs the same application (a.k.a. transaction engine). An application is a collection of endpoints that can be triggered by trusted :term:`users`' :term:`JSON-RPC` requests over :term:`TLS`.
+Each node runs the same application (a.k.a. transaction engine). An application is a collection of endpoints that can be triggered by trusted :term:`users`' commands over :term:`TLS`.
 
 Each endpoint mutates an in-enclave-memory Key-Value Store that is replicated across all nodes in the network. Changes to the Key-Value Store must be agreed by a variable number of nodes, depending on the consensus algorithm selected (either Raft or PBFT), before being applied.
 

--- a/sphinx/source/developers/api.rst
+++ b/sphinx/source/developers/api.rst
@@ -10,6 +10,12 @@ Application Entry Point
 Application Handler
 -------------------
 
-.. doxygenclass:: ccf::RpcFrontend
+.. doxygenclass:: ccf::UserRpcFrontend
    :project: CCF
    :members:
+   :undoc-members:
+
+.. doxygenclass:: ccf::HandlerRegistry
+   :project: CCF
+   :members:
+   :undoc-members:

--- a/sphinx/source/developers/index.rst
+++ b/sphinx/source/developers/index.rst
@@ -3,7 +3,7 @@ Writing CCF Applications
 
 This section describes how CCF applications can be developed and deployed to a CCF network.
 
-Applications can be written in C++ or Lua (see :ref:`developers/example:Example Application`). An application consists of a collection of endpoints that can be triggered by :term:`users` using JSON-RPC. Each endpoint can define an :ref:`developers/logging_cpp:API Schema` to validate user requests.
+Applications can be written in C++ or Lua (see :ref:`developers/example:Example Application`). An application consists of a collection of endpoints that can be triggered by :term:`users`. Each endpoint can define an :ref:`developers/logging_cpp:API Schema` to validate user requests.
 
 These endpoints mutate the state of a unique :ref:`developers/kv/index:Key-Value Store` that represents the internal state of the application. Applications define a set of ``Maps`` (see :ref:`developers/kv/kv_how_to:Creating a Map`), mapping from a key to a value. When an application endpoint is triggered, the effects on the Store are committed atomically.
 

--- a/sphinx/source/developers/logging_cpp.rst
+++ b/sphinx/source/developers/logging_cpp.rst
@@ -41,7 +41,7 @@ The Logging application simply has:
 RPC Handler
 -----------
 
-The handler returned by :cpp:func:`ccfapp::getRpcHandler()` needs to subclass :cpp:class:`ccf::UserRpcFrontend`:
+The handler returned by :cpp:func:`ccfapp::getRpcHandler()` should subclass :cpp:class:`ccf::UserRpcFrontend`, providing an implementation of :cpp::func:`ccf::HandlerRegistry`:
 
 .. literalinclude:: ../../../src/apps/logging/logging.cpp
     :language: cpp
@@ -49,7 +49,7 @@ The handler returned by :cpp:func:`ccfapp::getRpcHandler()` needs to subclass :c
     :lines: 1
     :dedent: 2
 
-The constructor then needs to create a handler function or lambda for each transaction type. This takes a transaction object and the request's ``params``, interacts with the KV tables, and returns a result:
+The logging app defines :cpp::class:`ccfapp::LoggerHandlers`, which creates and installs handler functions or lambdas for each transaction type. These take a transaction object and the request's ``params``, interact with the KV tables, and return a result:
 
 .. literalinclude:: ../../../src/apps/logging/logging.cpp
     :language: cpp
@@ -71,16 +71,7 @@ A handler can either be installed as:
 - ``Read``: this handler can be executed on any node of the network.
 - ``MayWrite``: the execution of this handler on a specific node depends on the value of the ``"readonly"`` parameter in the JSON-RPC command.
 
-App-defined errors
-~~~~~~~~~~~~~~~~~~
-
-Applications can define their own error codes. These should be between ``-32050`` and ``-32099`` to avoid conflicting with CCF's error codes. The Logging application returns errors if the user tries to get an id which has not been logged, or tries to log an empty message. These error codes should be given their own ``enum class``, and a ``get_error_prefix`` function should be defined in the same namespace to help users distinguish error messages:
-
-.. literalinclude:: ../../../src/apps/logging/logging.cpp
-    :language: cpp
-    :start-after: SNIPPET_START: errors
-    :end-before: SNIPPET_END: errors
-    :dedent: 2
+.. warning:: These handlers currently return JSON-RPC error codes, and all responses are returned in the body of a ``200 OK`` HTTP response. In future these handlers will be able to directly set the HTTP return code and payload.
 
 API Schema
 ~~~~~~~~~~

--- a/sphinx/source/developers/logging_cpp.rst
+++ b/sphinx/source/developers/logging_cpp.rst
@@ -41,7 +41,7 @@ The Logging application simply has:
 RPC Handler
 -----------
 
-The handler returned by :cpp:func:`ccfapp::getRpcHandler()` should subclass :cpp:class:`ccf::UserRpcFrontend`, providing an implementation of :cpp::func:`ccf::HandlerRegistry`:
+The handler returned by :cpp:func:`ccfapp::get_rpc_handler()` should subclass :cpp:class:`ccf::UserRpcFrontend`, providing an implementation of :cpp:class:`ccf::HandlerRegistry`:
 
 .. literalinclude:: ../../../src/apps/logging/logging.cpp
     :language: cpp
@@ -49,7 +49,7 @@ The handler returned by :cpp:func:`ccfapp::getRpcHandler()` should subclass :cpp
     :lines: 1
     :dedent: 2
 
-The logging app defines :cpp::class:`ccfapp::LoggerHandlers`, which creates and installs handler functions or lambdas for each transaction type. These take a transaction object and the request's ``params``, interact with the KV tables, and return a result:
+The logging app defines :cpp:class:`ccfapp::LoggerHandlers`, which creates and installs handler functions or lambdas for each transaction type. These take a transaction object and the request's ``params``, interact with the KV tables, and return a result:
 
 .. literalinclude:: ../../../src/apps/logging/logging.cpp
     :language: cpp

--- a/sphinx/source/glossary.rst
+++ b/sphinx/source/glossary.rst
@@ -16,7 +16,7 @@ Glossary
     `Flexible Launch Control <https://github.com/intel/linux-sgx/blob/master/psw/ae/ref_le/ref_le.md#flexible-launch-control>`_ is a feature of the Intel :term:`SGX` architecture.
 
   JSON-RPC
-    `JSON-RPC <https://en.wikipedia.org/wiki/JSON-RPC>`_ is a remote procedure call protocol encoded in JSON. It is the format used by clients (i.e. members, users and operators) to interact with CCF.
+    `JSON-RPC <https://en.wikipedia.org/wiki/JSON-RPC>`_ is a remote procedure call protocol encoded in JSON.
 
   Members
     Constitute the consortium governing a CCF network. Their public identity should be registered in CCF.

--- a/sphinx/source/introduction.rst
+++ b/sphinx/source/introduction.rst
@@ -54,4 +54,4 @@ in one or many cloud-hosted data centers, including :term:`Microsoft Azure`, or 
 
 Ledger providers can use CCF to enable higher throughput and higher confidentiality guarantees for distributed ledger applications.
 CCF developers can write application logic (also known as smart contracts) and enforce application-level access control in several languages by conﬁguring CCF
-to embed one of several language runtimes on top of its key-value store. Clients then communicate with a running CCF service using :term:`JSON-RPC` interfaces over :term:`TLS`.
+to embed one of several language runtimes on top of its key-value store. Clients then communicate with a running CCF service over :term:`TLS`.

--- a/sphinx/source/members/open_network.rst
+++ b/sphinx/source/members/open_network.rst
@@ -26,7 +26,6 @@ Then, the certificates of trusted users should be registered in CCF via the memb
     }
 
     $ curl https://rpc_ip:rpc_port/members/propose --cacert network_cert --key member0_privk --cert member0_cert --data-binary @add_user.json
-
     {"commit":21,"global_commit":20,"id":0,"jsonrpc":"2.0","result":{"completed":false,"id":0},"term":2}
 
 Other members are then allowed to vote for the proposal, using the proposal id returned to the proposer member (here ``5``, as per ``"result":{"completed":false,"id":5}``). They may submit an unconditional approval, or their vote may query the current state and proposal. These votes `must` be signed.

--- a/sphinx/source/members/open_network.rst
+++ b/sphinx/source/members/open_network.rst
@@ -90,8 +90,21 @@ Registering the Lua Application
 
 .. code-block:: bash
 
-    $ memberclient --cert member1_cert --privk member1_privk --rpc-address rpc_ip:rpc_port --ca network_cert set_lua_app --lua-app-file /path/to/lua/app_script
-    {"commit":9,"global_commit":8,"id":0,"jsonrpc":"2.0","result":{"completed":false,"id":1},"term":2}
+    $ cat set_lua_app.json
+    {
+        "jsonrpc": "2.0",
+        "id": 0,
+        "method": "members/propose",
+        "params": {
+            "parameter": "<proposed lua app>",
+            "script": {
+                "text": "tables, app = ...; return Calls:call(\"set_lua_app\", app)"
+            }
+        }
+    }
+
+    $ curl https://rpc_ip:rpc_port/members/propose --cacert network_cert --key member0_privk --cert member0_cert --data-binary @set_lua_app.json
+    {"commit":36,"global_commit":35,"id":0,"jsonrpc":"2.0","result":{"completed":false,"id":1},"term":2}
 
 Other members are then able to vote for the proposal using the returned proposal id (here ``1``, as per ``"result":{"completed":false,"id":1}``).
 
@@ -104,7 +117,19 @@ Once users are added to the opening network, members should decide to make a pro
 
 .. code-block:: bash
 
-    $ memberclient --cert member1_cert --privk member1_privk --rpc-address rpc_ip:rpc_port --ca network_cert open_network
+    $ cat open_network.json
+    {
+        "jsonrpc": "2.0",
+        "id": 0,
+        "method": "members/propose",
+        "params": {
+            "script": {
+                "text": "return Calls:call(\"open_network\")"
+            }
+        }
+    }
+
+    $ curl https://rpc_ip:rpc_port/members/propose --cacert network_cert --key member0_privk --cert member0_cert --data-binary @open_network.json
     {"commit":15,"global_commit":14,"id":0,"jsonrpc":"2.0","result":{"completed":false,"id":2},"term":2}
 
 Other members are then able to vote for the proposal using the returned proposal id (here ``2``, as per ``"result":{"completed":false,"id":2}``).

--- a/sphinx/source/members/open_network.rst
+++ b/sphinx/source/members/open_network.rst
@@ -133,4 +133,4 @@ Once users are added to the opening network, members should decide to make a pro
 
 Other members are then able to vote for the proposal using the returned proposal id (here ``2``, as per ``"result":{"completed":false,"id":2}``).
 
-Once a quorum of members have approved the network opening (``"result":true``), the network is opened to users (see :ref:`developers/example:Example Application` for a simple business logic and :term:`JSON-RPC` transactions). It is only then that users are able to execute transactions on the business logic defined by the enclave file (``--enclave-file`` option to ``cchost``).
+Once a quorum of members have approved the network opening (``"result":true``), the network is opened to users (see :ref:`developers/example:Example Application` for a simple business logic and transactions). It is only then that users are able to execute transactions on the business logic defined by the enclave file (``--enclave-file`` option to ``cchost``).

--- a/sphinx/source/members/open_network.rst
+++ b/sphinx/source/members/open_network.rst
@@ -25,7 +25,7 @@ Then, the certificates of trusted users should be registered in CCF via the memb
         }
     }
 
-    $ curl https://rpc_ip:rpc_port/members/propose --cacert network_cert --key member0_privk --cert member0_cert --data-binary @add_user.json
+    $ curl https://<ccf-node-address>/members/propose --cacert network_cert --key member0_privk --cert member0_cert --data-binary @add_user.json
     {"commit":21,"global_commit":20,"id":0,"jsonrpc":"2.0","result":{"completed":false,"id":0},"term":2}
 
 Other members are then allowed to vote for the proposal, using the proposal id returned to the proposer member (here ``5``, as per ``"result":{"completed":false,"id":5}``). They may submit an unconditional approval, or their vote may query the current state and proposal. These votes `must` be signed.
@@ -45,7 +45,7 @@ Other members are then allowed to vote for the proposal, using the proposal id r
         }
     }
 
-    $ ./scurl.sh https://rpc_ip:rpc_port/members/vote --cacert network_cert --key member1_privk --cert member1_cert --data-binary @vote_accept.json
+    $ ./scurl.sh https://<ccf-node-address>/members/vote --cacert network_cert --key member1_privk --cert member1_cert --data-binary @vote_accept.json
     {"commit":29,"global_commit":28,"id":0,"jsonrpc":"2.0","result":false,"term":2}
 
     $ cat vote_conditional.json
@@ -61,7 +61,7 @@ Other members are then allowed to vote for the proposal, using the proposal id r
         }
     }
 
-    $ ./scurl.sh https://rpc_ip:rpc_port/members/vote --cacert network_cert --key member2_privk --cert member2_cert --data-binary @vote_conditional.json
+    $ ./scurl.sh https://<ccf-node-address>/members/vote --cacert network_cert --key member2_privk --cert member2_cert --data-binary @vote_conditional.json
     {"commit":31,"global_commit":30,"id":0,"jsonrpc":"2.0","result":true,"term":2}
 
 The user is successfully added once a :term:`quorum` of members have accepted the proposal (``"result":true"``).
@@ -77,7 +77,7 @@ The user can then make user RPCs, for example ``whoAmI`` to retrieve the unique 
         "method": "users/whoAmI"
     }
 
-    $ curl https://rpc_ip:rpc_port/users/whoAmI --cacert network_cert --key new_user_privk --cert new_user_cert --data-binary @whoAmI.json
+    $ curl https://<ccf-node-address>/users/whoAmI --cacert network_cert --key new_user_privk --cert new_user_cert --data-binary @whoAmI.json
     {"commit":34,"global_commit":34,"id":0,"jsonrpc":"2.0","result":{"caller_id":4},"term":2}
 
 For each user CCF also stores arbitrary user-data in a JSON object, which can only be written to by members, subject to the standard proposal-vote governance mechanism. This lets members define initial metadata for certain users; for example to grant specific privileges, associate a human-readable name, or categorise the users. This user-data can then be read (but not written) by user-facing apps.
@@ -102,7 +102,7 @@ Registering the Lua Application
         }
     }
 
-    $ curl https://rpc_ip:rpc_port/members/propose --cacert network_cert --key member0_privk --cert member0_cert --data-binary @set_lua_app.json
+    $ curl https://<ccf-node-address>/members/propose --cacert network_cert --key member0_privk --cert member0_cert --data-binary @set_lua_app.json
     {"commit":36,"global_commit":35,"id":0,"jsonrpc":"2.0","result":{"completed":false,"id":1},"term":2}
 
 Other members are then able to vote for the proposal using the returned proposal id (here ``1``, as per ``"result":{"completed":false,"id":1}``).
@@ -128,7 +128,7 @@ Once users are added to the opening network, members should decide to make a pro
         }
     }
 
-    $ curl https://rpc_ip:rpc_port/members/propose --cacert network_cert --key member0_privk --cert member0_cert --data-binary @open_network.json
+    $ curl https://<ccf-node-address>/members/propose --cacert network_cert --key member0_privk --cert member0_cert --data-binary @open_network.json
     {"commit":15,"global_commit":14,"id":0,"jsonrpc":"2.0","result":{"completed":false,"id":2},"term":2}
 
 Other members are then able to vote for the proposal using the returned proposal id (here ``2``, as per ``"result":{"completed":false,"id":2}``).

--- a/sphinx/source/operators/recovery.rst
+++ b/sphinx/source/operators/recovery.rst
@@ -26,7 +26,7 @@ To initiate the first phase of the recovery protocol, one or several nodes shoul
     --enclave-file /path/to/enclave_library
     --enclave-type debug
     --node-address node_ip:node_port
-    --rpc-address rpc_ip:rpc_port
+    --rpc-address <ccf-node-address>
     --public-rpc-address public_rpc_ip:public_rpc_port
     --ledger-file /path/to/ledger/to/recover
     --node-cert-file /path/to/node_certificate

--- a/sphinx/source/operators/recovery.rst
+++ b/sphinx/source/operators/recovery.rst
@@ -34,9 +34,9 @@ To initiate the first phase of the recovery protocol, one or several nodes shoul
     recover
     --network-cert-file /path/to/network_certificate
 
-Each node will then immediately restore the public entries of its ledger (``--ledger-file``). Because deserialising the public entries present in the ledger may take some time, operators can query the progress of the public recovery by running the ``getSignedIndex`` JSON-RPC which returns the version of the last signed recovered ledger entry. Once the public ledger is fully recovered, the recovered node automatically becomes part of the public network, allowing other nodes to join the network.
+Each node will then immediately restore the public entries of its ledger (``--ledger-file``). Because deserialising the public entries present in the ledger may take some time, operators can query the progress of the public recovery by calling ``getSignedIndex`` which returns the version of the last signed recovered ledger entry. Once the public ledger is fully recovered, the recovered node automatically becomes part of the public network, allowing other nodes to join the network.
 
-.. note:: If more than one node were started in ``recover`` mode, the node with the highest signed index (as per the response to the ``getSignedIndex`` JSON-RPC) should be preferred to start the new network. Other nodes should be shutdown and be restarted with the ``join`` option.
+.. note:: If more than one node were started in ``recover`` mode, the node with the highest signed index (as per the response to the ``getSignedIndex`` RPC) should be preferred to start the new network. Other nodes should be shutdown and be restarted with the ``join`` option.
 
 Similarly to the normal join protocol (see :ref:`operators/start_network:Adding a New Node to the Network`), other nodes are then able to join the network.
 

--- a/sphinx/source/operators/start_network.rst
+++ b/sphinx/source/operators/start_network.rst
@@ -79,7 +79,7 @@ Once a CCF network is successfully started and an acceptable number of nodes hav
 Summary diagram
 ---------------
 
-Once a node is part of the network (started with either the ``start`` or ``join`` option), members are authorised to issue governance transactions and eventually open the network (see :ref:`members/open_network:Opening a Network`). Only then are users authorised to issue JSON-RPC transactions to CCF.
+Once a node is part of the network (started with either the ``start`` or ``join`` option), members are authorised to issue governance transactions and eventually open the network (see :ref:`members/open_network:Opening a Network`). Only then are users authorised to issue commands to CCF.
 
 .. note:: After the network is open to users, members can still issue governance transactions to CCF (for example, adding new users or additional members to the consortium or updating the Lua app, when applicable). See :ref:`members/index:Member Governance` for more information about member governance.
 

--- a/sphinx/source/operators/start_network.rst
+++ b/sphinx/source/operators/start_network.rst
@@ -17,7 +17,7 @@ To create a new CCF network, the first node of the network should be started wit
     --enclave-file /path/to/enclave_library
     --enclave-type debug
     --node-address node_ip:node_port
-    --rpc-address rpc_ip:rpc_port
+    --rpc-address <ccf-node-address>
     --public-rpc-address public_rpc_ip:public_rpc_port
     --ledger-file /path/to/ledger
     --node-cert-file /path/to/node_certificate
@@ -32,7 +32,7 @@ To create a new CCF network, the first node of the network should be started wit
 
 When starting up, the node generates its own key pair and outputs the certificate associated with its public key at the location specified by ``--node-cert-file``. A quote file, required for remote attestation, is also output at the location specified by ``--quote-file``. The certificate of the freshly-created CCF network is also output at the location specified by ``--network-cert-file``.
 
-.. note:: The network certificate should be distributed to users and members to be used as the certificate authority (CA) when establishing a TLS connection with any of the nodes part of the CCF network. For the ``client`` and ``memberclient`` utilities, ``--ca /path/to/network_certificate`` should always be specified.
+.. note:: The network certificate should be distributed to users and members to be used as the certificate authority (CA) when establishing a TLS connection with any of the nodes part of the CCF network. When using curl, this is passed as the ``--cacert`` argument.
 
 The certificates of initial members of the consortium are specified via ``--member-cert``. For example, if 3 members (``member1_cert.pem``, ``member2_cert.pem`` and ``member3_cert.pem``) should be added to CCF, operators should specify ``--member-cert member1_cert.pem --member-cert member2_cert.pem --member-cert member3_cert.pem``.
 
@@ -53,7 +53,7 @@ To add a new node to an existing opening network, other nodes should be started 
     --enclave-file /path/to/enclave_library
     --enclave-type debug
     --node-address node_ip:node_port
-    --rpc-address rpc_ip:rpc_port
+    --rpc-address <ccf-node-address>
     --public-rpc-address public_rpc_ip:public_rpc_port
     --ledger-file /path/to/ledger
     --node-cert-file /path/to/node_certificate

--- a/sphinx/source/users/issue_commands.rst
+++ b/sphinx/source/users/issue_commands.rst
@@ -21,7 +21,7 @@ For example, to record a message at a specific id with the :ref:`developers/exam
       }
     }
 
-    $ curl https://127.116.132.53:41188/users/LOG_record -H 'Content-Type: application/json' --data-binary @request.json -w '\n' --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem
+    $ curl https://<ccf-node-address>/users/LOG_record --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem --data-binary @request.json
     {
       "commit": 23,
       "global_commit": 22,
@@ -75,9 +75,7 @@ To guarantee that their request is successfully committed to the ledger, a user 
       }
    }
 
-    $ client --pretty-print --rpc-address node_rpc_ip:node_rpc_port --ca networkcert.pem userrpc --req @get_commit.json --cert user_cert.pem --pk user_privk.pem
-    Sending RPC to node_rpc_ip:node_rpc_port
-    Doing user RPC:
+    $ curl https://<ccf-node-address>/users/getCommit --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem --data-binary @get_commit.json
     {
       "commit": 31,
       "global_commit": 31,
@@ -112,9 +110,7 @@ To obtain a receipt, a user needs to issue a ``getReceipt`` RPC for a particular
       }
    }
 
-    $ client --pretty-print --rpc-address node_rpc_ip:node_rpc_port --ca networkcert.pem userrpc --req @get_receipt.json --cert user_cert.pem --pk user_privk.pem
-    Sending RPC to node_rpc_ip:node_rpc_port
-    Doing user RPC:
+    $ curl https://<ccf-node-address>/users/getReceipt --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem --data-binary @get_receipt.json
     {
       "commit": 31,
       "global_commit": 31,
@@ -130,7 +126,7 @@ Receipts can be verified with the ``verifyReceipt`` RPC:
 
 .. code-block:: bash
 
-    $ cat get_receipt.json
+    $ cat verify_receipt.json
     {
       "id": 0,
       "method": "users/verifyReceipt",
@@ -141,9 +137,7 @@ Receipts can be verified with the ``verifyReceipt`` RPC:
       }
    }
 
-    $ client --pretty-print --rpc-address node_rpc_ip:node_rpc_port --ca networkcert.pem userrpc --req @get_receipt.json --cert user_cert.pem --pk user_privk.pem
-    Sending RPC to node_rpc_ip:node_rpc_port
-    Doing user RPC:
+    $ curl https://<ccf-node-address>/users/verifyReceipt --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem --data-binary @verify_receipt.json
     {
       "commit": 31,
       "global_commit": 31,

--- a/sphinx/source/users/rpc_api.rst
+++ b/sphinx/source/users/rpc_api.rst
@@ -7,12 +7,11 @@ The API can also be retrieved from a running service using the `listMethods`_ an
 
 .. code-block:: bash
 
-    $ client --pretty-print --rpc-address 127.99.16.14:36785 --ca networkcert.pem userrpc --req @listMethods.json --cert user1_cert.pem --pk user1_privk.pem
-    Doing user RPC:
+    $ curl https://<ccf-node-address>/users/listMethods --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem --data-binary @listMethods.json
     {
       "commit": 4,
       "global_commit": 4,
-      "id": 1,
+      "id": 0,
       "jsonrpc": "2.0",
       "result": {
         "methods": [
@@ -21,18 +20,22 @@ The API can also be retrieved from a running service using the `listMethods`_ an
           "LOG_record",
           "LOG_record_pub",
           "getCommit",
-          "getPrimaryInfo",
           "getMetrics",
+          "getNetworkInfo",
+          "getPrimaryInfo",
+          "getReceipt",
           "getSchema",
           "listMethods",
-          "mkSign"
+          "mkSign",
+          "verifyReceipt",
+          "whoAmI",
+          "whoIs"
         ]
       },
       "term": 2
     }
 
-    $ client --pretty-print --rpc-address 127.99.16.14:36785 --ca networkcert.pem userrpc --req @getSchema.json --cert user1_cert.pem --pk user1_privk.pem
-    Doing user RPC:
+    $ curl https://<ccf-node-address>/users/getSchema --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem --data-binary @getSchema.json
     {
       "commit": 4,
       "global_commit": 4,


### PR DESCRIPTION
Updating docs to describe current state, in particular HTTP-by-default. Replacing all `./client` and `./memberclient` sample commands with curl equivalents. Have removed some since I think we're repeating ourselves (don't need to show a sample vote for every proposal).

Most of these edits were done by hand and untested, so please read carefully for dumb mistakes. Doing raw proposals by hand in curl rather than by `memberclient` is still a little awkward (in particular things like "turn this binary file into a JSON array and put that in the correct field of this JSON object") - this should be mitigated once we support non-JSON-RPC payloads.

Opening as a draft for early review while I rewrite the remaining sections.