### PR TITLE
Cannot trust or retire a retired node

### DIFF
--- a/src/node/rpc/memberfrontend.h
+++ b/src/node/rpc/memberfrontend.h
@@ -141,7 +141,14 @@ namespace ccf
            auto nodes = tx.get_view(this->network.nodes);
            auto info = nodes->get(id);
            if (!info)
+           {
              throw std::logic_error(fmt::format("Node {} does not exist", id));
+           }
+           if (info->status == NodeStatus::RETIRED)
+           {
+             throw std::logic_error(
+               fmt::format("Node {} is already retired", id));
+           }
            info->status = NodeStatus::TRUSTED;
            nodes->put(id, *info);
            LOG_INFO_FMT("Node {} is now {}", id, info->status);
@@ -154,9 +161,17 @@ namespace ccf
            auto nodes = tx.get_view(this->network.nodes);
            auto info = nodes->get(id);
            if (!info)
+           {
              throw std::logic_error(fmt::format("Node {} does not exist", id));
+           }
+           if (info->status == NodeStatus::RETIRED)
+           {
+             throw std::logic_error(
+               fmt::format("Node {} is already retired", id));
+           }
            info->status = NodeStatus::RETIRED;
            nodes->put(id, *info);
+           LOG_INFO_FMT("Node {} is now {}", id, info->status);
            return true;
          }},
         // accept new code

--- a/src/runtime_config/default_whitelists.h
+++ b/src/runtime_config/default_whitelists.h
@@ -32,7 +32,6 @@ namespace ccf
       Tables::MEMBER_CERTS,
       Tables::USERS,
       Tables::USER_CERTS,
-      Tables::NODES,
       Tables::VALUES,
       Tables::WHITELISTS,
       Tables::GOV_SCRIPTS,


### PR DESCRIPTION
Follow up from https://github.com/microsoft/CCF/issues/778

It should not be possible to trust a node that is already retired. Also, the `ccf.nodes` tables should not be writable from Lua - we really want to limit what members can change in that table (i.e. only trust and retire nodes, via C++ functions).