### PR TITLE
Split keypair.h

### DIFF
--- a/src/consensus/pbft/libbyz/parameters.h
+++ b/src/consensus/pbft/libbyz/parameters.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "tls/keypair.h"
+#include "tls/verifier.h"
 
 #include <cstddef>
 

--- a/src/enclave/httpsig.h
+++ b/src/enclave/httpsig.h
@@ -5,7 +5,7 @@
 #include "httpparser.h"
 #include "node/clientsignatures.h"
 #include "tls/base64.h"
-#include "tls/keypair.h"
+#include "tls/hash.h"
 
 #include <fmt/format_header_only.h>
 #include <optional>

--- a/src/node/genesisgen.h
+++ b/src/node/genesisgen.h
@@ -12,7 +12,7 @@
 #include "rpc/consts.h"
 #include "rpc/jsonrpc.h"
 #include "runtime_config/default_whitelists.h"
-#include "tls/keypair.h"
+#include "tls/verifier.h"
 #include "values.h"
 
 #include <algorithm>

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -2,15 +2,15 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
-#include "../consensus/pbft/pbfttypes.h"
-#include "../crypto/hash.h"
-#include "../ds/logger.h"
-#include "../kv/kvtypes.h"
-#include "../tls/keypair.h"
-#include "../tls/tls.h"
+#include "consensus/pbft/pbfttypes.h"
+#include "crypto/hash.h"
+#include "ds/logger.h"
 #include "entities.h"
+#include "kv/kvtypes.h"
 #include "nodes.h"
 #include "signatures.h"
+#include "tls/tls.h"
+#include "tls/verifier.h"
 
 #include <array>
 #include <deque>

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -12,6 +12,7 @@
 #include "node/nodes.h"
 #include "nodeinterface.h"
 #include "rpcexception.h"
+#include "tls/verifier.h"
 
 #include <fmt/format_header_only.h>
 #include <mutex>

--- a/src/node/rpc/test/nodefrontend_test.cpp
+++ b/src/node/rpc/test/nodefrontend_test.cpp
@@ -10,6 +10,7 @@
 #include "node/rpc/nodefrontend.h"
 #include "node_stub.h"
 #include "tls/pem.h"
+#include "tls/verifier.h"
 
 using namespace ccf;
 using namespace nlohmann;

--- a/src/tls/curve.h
+++ b/src/tls/curve.h
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "tls.h"
+
+#include <stdexcept>
+#include <string>
+
+namespace tls
+{
+  enum class CurveImpl
+  {
+    secp384r1 = 1,
+#ifdef MOD_MBEDTLS
+    ed25519 = 2,
+#endif
+    secp256k1_mbedtls = 3,
+    secp256k1_bitcoin = 4,
+
+#if SERVICE_IDENTITY_CURVE_CHOICE_SECP384R1
+    service_identity_curve_choice = secp384r1,
+#elif SERVICE_IDENTITY_CURVE_CHOICE_ED25519
+    service_identity_curve_choice = ed25519,
+#elif SERVICE_IDENTITY_CURVE_CHOICE_SECP256K1_MBEDTLS
+    service_identity_curve_choice = secp256k1_mbedtls,
+#elif SERVICE_IDENTITY_CURVE_CHOICE_SECP256K1_BITCOIN
+    service_identity_curve_choice = secp256k1_bitcoin,
+#else
+#  pragma message( \
+    "No service identity curve specified - defaulting to secp384r1")
+    service_identity_curve_choice = secp384r1,
+#endif
+  };
+
+  // 2 implementations of secp256k1 are available - mbedtls and bitcoin. Either
+  // can be asked for explicitly via the CurveImpl enum. For cases where we
+  // receive a raw 256k1 key/signature/cert only, this flag determines which
+  // implementation is used
+  static constexpr bool prefer_bitcoin_secp256k1 = true;
+
+  // Helper to access elliptic curve id from context
+  inline mbedtls_ecp_group_id get_ec_from_context(const mbedtls_pk_context& ctx)
+  {
+    return mbedtls_pk_ec(ctx)->grp.id;
+  }
+
+  // Get mbedtls elliptic curve for given CCF curve implementation
+  inline mbedtls_ecp_group_id get_ec_for_curve_impl(CurveImpl curve)
+  {
+    switch (curve)
+    {
+      case CurveImpl::secp384r1:
+      {
+        return MBEDTLS_ECP_DP_SECP384R1;
+      }
+#ifdef MOD_MBEDTLS
+      case CurveImpl::ed25519:
+      {
+        return MBEDTLS_ECP_DP_CURVE25519;
+      }
+#endif
+      case CurveImpl::secp256k1_mbedtls:
+      case CurveImpl::secp256k1_bitcoin:
+      {
+        return MBEDTLS_ECP_DP_SECP256K1;
+      }
+      default:
+      {
+        throw std::logic_error(
+          "Unhandled curve type: " +
+          std::to_string(static_cast<size_t>(curve)));
+      }
+    }
+  }
+
+  // Get message digest algorithm to use for given elliptic curve
+  inline mbedtls_md_type_t get_md_for_ec(mbedtls_ecp_group_id ec)
+  {
+    switch (ec)
+    {
+      case MBEDTLS_ECP_DP_SECP384R1:
+      {
+        return MBEDTLS_MD_SHA384;
+      }
+#ifdef MOD_MBEDTLS
+      case MBEDTLS_ECP_DP_CURVE25519:
+      {
+        return MBEDTLS_MD_SHA512;
+      }
+#endif
+      case MBEDTLS_ECP_DP_SECP256K1:
+      {
+        return MBEDTLS_MD_SHA256;
+      }
+      default:
+      {
+        throw std::logic_error(
+          std::string("Unhandled ecp group id: ") +
+          mbedtls_ecp_curve_info_from_grp_id(ec)->name);
+      }
+    }
+  }
+
+}

--- a/src/tls/curve.h
+++ b/src/tls/curve.h
@@ -2,8 +2,11 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ds/logger.h"
 #include "tls.h"
 
+#include <secp256k1/include/secp256k1.h>
+#include <secp256k1/include/secp256k1_recovery.h>
 #include <stdexcept>
 #include <string>
 
@@ -102,4 +105,64 @@ namespace tls
     }
   }
 
+  inline bool verify_secp256k_bc(
+    secp256k1_context* ctx,
+    const uint8_t* signature,
+    size_t signature_size,
+    const uint8_t* hash,
+    size_t hash_size,
+    const secp256k1_pubkey* public_key)
+  {
+    if (hash_size != 32)
+      return false;
+
+    secp256k1_ecdsa_signature sig;
+    if (
+      secp256k1_ecdsa_signature_parse_der(
+        ctx, &sig, signature, signature_size) != 1)
+      return false;
+
+    secp256k1_ecdsa_signature norm_sig;
+    if (secp256k1_ecdsa_signature_normalize(ctx, &norm_sig, &sig) == 1)
+    {
+      LOG_TRACE_FMT("secp256k1 normalized a signature to lower-S form");
+    }
+
+    return secp256k1_ecdsa_verify(ctx, &norm_sig, hash, public_key) == 1;
+  }
+
+  static void secp256k1_illegal_callback(const char* str, void*)
+  {
+    throw std::logic_error(
+      fmt::format("[libsecp256k1] illegal argument: {}", str));
+  }
+
+  // Wrap calls to secp256k1_context_create, setting illegal callback to throw
+  // catchable errors rather than aborting, and ensuring destroy is called when
+  // this goes out of scope
+  class BCk1Context
+  {
+  public:
+    secp256k1_context* p = nullptr;
+
+    BCk1Context(unsigned int flags)
+    {
+      p = secp256k1_context_create(flags);
+
+      secp256k1_context_set_illegal_callback(
+        p, secp256k1_illegal_callback, nullptr);
+    }
+
+    ~BCk1Context()
+    {
+      secp256k1_context_destroy(p);
+    }
+  };
+
+  using BCk1ContextPtr = std::unique_ptr<BCk1Context>;
+
+  inline BCk1ContextPtr make_bc_context(unsigned int flags)
+  {
+    return std::make_unique<BCk1Context>(flags);
+  }
 }

--- a/src/tls/hash.h
+++ b/src/tls/hash.h
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "curve.h"
+
+#include <vector>
+
+namespace tls
+{
+  using HashBytes = std::vector<uint8_t>;
+
+  /**
+   * Hash the given data, with the specified digest algorithm
+   *
+   * @return 0 on success
+   */
+  inline int do_hash(
+    const uint8_t* data_ptr,
+    size_t data_size,
+    HashBytes& o_hash,
+    mbedtls_md_type_t md_type)
+  {
+    const auto md_info = mbedtls_md_info_from_type(md_type);
+    const auto hash_size = mbedtls_md_get_size(md_info);
+
+    if (o_hash.size() < hash_size)
+    {
+      o_hash.resize(hash_size);
+    }
+
+    return mbedtls_md(md_info, data_ptr, data_size, o_hash.data());
+  }
+
+  /**
+   * Hash the given data, with an algorithm chosen by key type
+   *
+   * @return 0 on success
+   */
+  inline int do_hash(
+    const mbedtls_pk_context& ctx,
+    const uint8_t* data_ptr,
+    size_t data_size,
+    HashBytes& o_hash,
+    mbedtls_md_type_t md_type_ = MBEDTLS_MD_NONE)
+  {
+    const auto ec = get_ec_from_context(ctx);
+    mbedtls_md_type_t md_type;
+    if (md_type_ != MBEDTLS_MD_NONE)
+    {
+      md_type = md_type_;
+    }
+    else
+    {
+      md_type = get_md_for_ec(ec);
+    }
+    const auto md_info = mbedtls_md_info_from_type(md_type);
+    const auto hash_size = mbedtls_md_get_size(md_info);
+
+    if (o_hash.size() < hash_size)
+      o_hash.resize(hash_size);
+
+    return mbedtls_md(md_info, data_ptr, data_size, o_hash.data());
+  }
+
+}

--- a/src/tls/keypair.h
+++ b/src/tls/keypair.h
@@ -3,16 +3,12 @@
 #pragma once
 
 #include "asn1_san.h"
-#include "cert.h"
-#include "crypto/hash.h"
 #include "csr.h"
 #include "curve.h"
-#include "ds/logger.h"
 #include "entropy.h"
 #include "error_string.h"
 #include "hash.h"
-#include "secp256k1/include/secp256k1.h"
-#include "secp256k1/include/secp256k1_recovery.h"
+#include "pem.h"
 
 #include <cstring>
 #include <iomanip>
@@ -27,41 +23,7 @@
 namespace tls
 {
   static constexpr size_t ecp_num_size = 100;
-
   static constexpr size_t max_pem_key_size = 2048;
-  static constexpr size_t max_pem_cert_size = 4096;
-
-  // As these are not exposed by mbedlts, define them here to allow simple
-  // conversion from DER to PEM format
-  static constexpr auto PEM_CERTIFICATE_HEADER =
-    "-----BEGIN CERTIFICATE-----\n";
-  static constexpr auto PEM_CERTIFICATE_FOOTER = "-----END CERTIFICATE-----\n";
-
-  inline bool verify_secp256k_bc(
-    secp256k1_context* ctx,
-    const uint8_t* signature,
-    size_t signature_size,
-    const uint8_t* hash,
-    size_t hash_size,
-    const secp256k1_pubkey* public_key)
-  {
-    if (hash_size != 32)
-      return false;
-
-    secp256k1_ecdsa_signature sig;
-    if (
-      secp256k1_ecdsa_signature_parse_der(
-        ctx, &sig, signature, signature_size) != 1)
-      return false;
-
-    secp256k1_ecdsa_signature norm_sig;
-    if (secp256k1_ecdsa_signature_normalize(ctx, &norm_sig, &sig) == 1)
-    {
-      LOG_TRACE_FMT("secp256k1 normalized a signature to lower-S form");
-    }
-
-    return secp256k1_ecdsa_verify(ctx, &norm_sig, hash, public_key) == 1;
-  }
 
   inline void parse_secp256k_bc(
     const mbedtls_pk_context& ctx,
@@ -90,41 +52,6 @@ namespace tls
     {
       throw std::logic_error("secp256k1_ec_pubkey_parse failed");
     }
-  }
-
-  static void secp256k1_illegal_callback(const char* str, void*)
-  {
-    throw std::logic_error(
-      fmt::format("[libsecp256k1] illegal argument: {}", str));
-  }
-
-  // Wrap calls to secp256k1_context_create, setting illegal callback to throw
-  // catchable errors rather than aborting, and ensuring destroy is called when
-  // this goes out of scope
-  class BCk1Context
-  {
-  public:
-    secp256k1_context* p = nullptr;
-
-    BCk1Context(unsigned int flags)
-    {
-      p = secp256k1_context_create(flags);
-
-      secp256k1_context_set_illegal_callback(
-        p, secp256k1_illegal_callback, nullptr);
-    }
-
-    ~BCk1Context()
-    {
-      secp256k1_context_destroy(p);
-    }
-  };
-
-  using BCk1ContextPtr = std::unique_ptr<BCk1Context>;
-
-  inline BCk1ContextPtr make_bc_context(unsigned int flags)
-  {
-    return std::make_unique<BCk1Context>(flags);
   }
 
   struct RecoverableSignature
@@ -975,219 +902,5 @@ namespace tls
     {
       return std::make_shared<KeyPair>(std::move(key));
     }
-  }
-
-  class Verifier
-  {
-  protected:
-    mutable mbedtls_x509_crt cert;
-
-  public:
-    /**
-     * Construct from a pre-parsed cert
-     *
-     * @param c Initialised and parsed x509 cert
-     */
-    Verifier(const mbedtls_x509_crt& c) : cert(c) {}
-
-    Verifier(const Verifier&) = delete;
-
-    /**
-     * Verify that a signature was produced on a hash with the private key
-     * associated with the public key contained in the certificate.
-     *
-     * @param hash First byte in hash sequence
-     * @param hash_size Number of bytes in hash sequence
-     * @param signature First byte in signature sequence
-     * @param signature_size Number of bytes in signature sequence
-     *
-     * @return Whether the signature matches the hash and the key
-     */
-    virtual bool verify_hash(
-      const uint8_t* hash,
-      size_t hash_size,
-      const uint8_t* signature,
-      size_t signature_size) const
-    {
-      const auto md_type = get_md_for_ec(get_ec_from_context(cert.pk));
-
-      int rc = mbedtls_pk_verify(
-        &cert.pk, md_type, hash, hash_size, signature, signature_size);
-
-      if (rc)
-        LOG_DEBUG_FMT("Failed to verify signature: {}", error_string(rc));
-
-      return rc == 0;
-    }
-
-    /**
-     * Verify that a signature was produced on a hash with the private key
-     * associated with the public key contained in the certificate.
-     *
-     * @param hash Hash produced from contents as a sequence of bytes
-     * @param signature Signature as a sequence of bytes
-     *
-     * @return Whether the signature matches the hash and the key
-     */
-    bool verify_hash(
-      const std::vector<uint8_t>& hash,
-      const std::vector<uint8_t>& signature) const
-    {
-      return verify_hash(
-        hash.data(), hash.size(), signature.data(), signature.size());
-    }
-
-    bool verify_hash(
-      const std::vector<uint8_t>& hash,
-      const uint8_t* sig,
-      size_t sig_size) const
-    {
-      return verify_hash(hash.data(), hash.size(), sig, sig_size);
-    }
-
-    /**
-     * Verify that a signature was produced on contents with the private key
-     * associated with the public key contained in the certificate.
-     *
-     * @param contents Sequence of bytes that was signed
-     * @param signature Signature as a sequence of bytes
-     * @param md_type Digest algorithm to use. Derived from the
-     * public key if MBEDTLS_MD_NONE.
-     *
-     * @return Whether the signature matches the contents and the key
-     */
-    bool verify(
-      const std::vector<uint8_t>& contents,
-      const std::vector<uint8_t>& signature,
-      mbedtls_md_type_t md_type = {}) const
-    {
-      return verify(
-        contents.data(),
-        contents.size(),
-        signature.data(),
-        signature.size(),
-        md_type);
-    }
-
-    bool verify(
-      const uint8_t* contents,
-      size_t contents_size,
-      const uint8_t* sig,
-      size_t sig_size,
-      mbedtls_md_type_t md_type = {}) const
-    {
-      HashBytes hash;
-      do_hash(cert.pk, contents, contents_size, hash, md_type);
-
-      return verify_hash(hash, sig, sig_size);
-    }
-
-    const mbedtls_x509_crt* raw()
-    {
-      return &cert;
-    }
-
-    std::vector<uint8_t> der_cert_data()
-    {
-      const auto crt = raw();
-      return {crt->raw.p, crt->raw.p + crt->raw.len};
-    }
-
-    Pem cert_pem()
-    {
-      unsigned char buf[max_pem_cert_size];
-      size_t len;
-      const auto crt = raw();
-
-      auto rc = mbedtls_pem_write_buffer(
-        PEM_CERTIFICATE_HEADER,
-        PEM_CERTIFICATE_FOOTER,
-        crt->raw.p,
-        crt->raw.len,
-        buf,
-        max_pem_cert_size,
-        &len);
-
-      if (rc != 0)
-      {
-        throw std::logic_error(
-          "mbedtls_pem_write_buffer failed: " + error_string(rc));
-      }
-
-      return Pem({buf, len});
-    }
-
-    virtual ~Verifier()
-    {
-      mbedtls_x509_crt_free(&cert);
-    }
-  };
-
-  class Verifier_k1Bitcoin : public Verifier
-  {
-  protected:
-    BCk1ContextPtr bc_ctx = make_bc_context(SECP256K1_CONTEXT_VERIFY);
-
-    secp256k1_pubkey bc_pub;
-
-  public:
-    template <typename... Ts>
-    Verifier_k1Bitcoin(Ts... ts) : Verifier(std::forward<Ts>(ts)...)
-    {
-      parse_secp256k_bc(cert.pk, bc_ctx->p, &bc_pub);
-    }
-
-    bool verify_hash(
-      const uint8_t* hash,
-      size_t hash_size,
-      const uint8_t* signature,
-      size_t signature_size) const override
-    {
-      bool ok = verify_secp256k_bc(
-        bc_ctx->p, signature, signature_size, hash, hash_size, &bc_pub);
-
-      return ok;
-    }
-  };
-
-  using VerifierPtr = std::shared_ptr<Verifier>;
-  using VerifierUniquePtr = std::unique_ptr<Verifier>;
-  /**
-   * Construct Verifier from a certificate in PEM format
-   *
-   * @param public_pem Sequence of bytes containing the certificate in PEM
-   * format
-   */
-  inline VerifierUniquePtr make_unique_verifier(
-    const std::vector<uint8_t>& cert_pem,
-    bool use_bitcoin_impl = prefer_bitcoin_secp256k1)
-  {
-    mbedtls_x509_crt cert;
-    mbedtls_x509_crt_init(&cert);
-    int rc = mbedtls_x509_crt_parse(&cert, cert_pem.data(), cert_pem.size());
-    if (rc)
-    {
-      std::stringstream s;
-      s << "Failed to parse certificate: " << rc;
-      throw std::invalid_argument(s.str());
-    }
-
-    const auto curve = get_ec_from_context(cert.pk);
-
-    if (curve == MBEDTLS_ECP_DP_SECP256K1 && use_bitcoin_impl)
-    {
-      return std::make_unique<Verifier_k1Bitcoin>(cert);
-    }
-    else
-    {
-      return std::make_unique<Verifier>(cert);
-    }
-  }
-
-  inline VerifierPtr make_verifier(
-    const std::vector<uint8_t>& cert_pem,
-    bool use_bitcoin_impl = prefer_bitcoin_secp256k1)
-  {
-    return make_unique_verifier(cert_pem, use_bitcoin_impl);
   }
 }

--- a/src/tls/test/main.cpp
+++ b/src/tls/test/main.cpp
@@ -3,6 +3,7 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "../base64.h"
 #include "../keypair.h"
+#include "../verifier.h"
 
 #include <chrono>
 #include <doctest/doctest.h>

--- a/src/tls/verifier.h
+++ b/src/tls/verifier.h
@@ -1,0 +1,231 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "curve.h"
+
+namespace tls
+{
+  static constexpr size_t max_pem_cert_size = 4096;
+
+  // As these are not exposed by mbedlts, define them here to allow simple
+  // conversion from DER to PEM format
+  static constexpr auto PEM_CERTIFICATE_HEADER =
+    "-----BEGIN CERTIFICATE-----\n";
+  static constexpr auto PEM_CERTIFICATE_FOOTER = "-----END CERTIFICATE-----\n";
+
+  class Verifier
+  {
+  protected:
+    mutable mbedtls_x509_crt cert;
+
+  public:
+    /**
+     * Construct from a pre-parsed cert
+     *
+     * @param c Initialised and parsed x509 cert
+     */
+    Verifier(const mbedtls_x509_crt& c) : cert(c) {}
+
+    Verifier(const Verifier&) = delete;
+
+    /**
+     * Verify that a signature was produced on a hash with the private key
+     * associated with the public key contained in the certificate.
+     *
+     * @param hash First byte in hash sequence
+     * @param hash_size Number of bytes in hash sequence
+     * @param signature First byte in signature sequence
+     * @param signature_size Number of bytes in signature sequence
+     *
+     * @return Whether the signature matches the hash and the key
+     */
+    virtual bool verify_hash(
+      const uint8_t* hash,
+      size_t hash_size,
+      const uint8_t* signature,
+      size_t signature_size) const
+    {
+      const auto md_type = get_md_for_ec(get_ec_from_context(cert.pk));
+
+      int rc = mbedtls_pk_verify(
+        &cert.pk, md_type, hash, hash_size, signature, signature_size);
+
+      if (rc)
+        LOG_DEBUG_FMT("Failed to verify signature: {}", error_string(rc));
+
+      return rc == 0;
+    }
+
+    /**
+     * Verify that a signature was produced on a hash with the private key
+     * associated with the public key contained in the certificate.
+     *
+     * @param hash Hash produced from contents as a sequence of bytes
+     * @param signature Signature as a sequence of bytes
+     *
+     * @return Whether the signature matches the hash and the key
+     */
+    bool verify_hash(
+      const std::vector<uint8_t>& hash,
+      const std::vector<uint8_t>& signature) const
+    {
+      return verify_hash(
+        hash.data(), hash.size(), signature.data(), signature.size());
+    }
+
+    bool verify_hash(
+      const std::vector<uint8_t>& hash,
+      const uint8_t* sig,
+      size_t sig_size) const
+    {
+      return verify_hash(hash.data(), hash.size(), sig, sig_size);
+    }
+
+    /**
+     * Verify that a signature was produced on contents with the private key
+     * associated with the public key contained in the certificate.
+     *
+     * @param contents Sequence of bytes that was signed
+     * @param signature Signature as a sequence of bytes
+     * @param md_type Digest algorithm to use. Derived from the
+     * public key if MBEDTLS_MD_NONE.
+     *
+     * @return Whether the signature matches the contents and the key
+     */
+    bool verify(
+      const std::vector<uint8_t>& contents,
+      const std::vector<uint8_t>& signature,
+      mbedtls_md_type_t md_type = {}) const
+    {
+      return verify(
+        contents.data(),
+        contents.size(),
+        signature.data(),
+        signature.size(),
+        md_type);
+    }
+
+    bool verify(
+      const uint8_t* contents,
+      size_t contents_size,
+      const uint8_t* sig,
+      size_t sig_size,
+      mbedtls_md_type_t md_type = {}) const
+    {
+      HashBytes hash;
+      do_hash(cert.pk, contents, contents_size, hash, md_type);
+
+      return verify_hash(hash, sig, sig_size);
+    }
+
+    const mbedtls_x509_crt* raw()
+    {
+      return &cert;
+    }
+
+    std::vector<uint8_t> der_cert_data()
+    {
+      const auto crt = raw();
+      return {crt->raw.p, crt->raw.p + crt->raw.len};
+    }
+
+    Pem cert_pem()
+    {
+      unsigned char buf[max_pem_cert_size];
+      size_t len;
+      const auto crt = raw();
+
+      auto rc = mbedtls_pem_write_buffer(
+        PEM_CERTIFICATE_HEADER,
+        PEM_CERTIFICATE_FOOTER,
+        crt->raw.p,
+        crt->raw.len,
+        buf,
+        max_pem_cert_size,
+        &len);
+
+      if (rc != 0)
+      {
+        throw std::logic_error(
+          "mbedtls_pem_write_buffer failed: " + error_string(rc));
+      }
+
+      return Pem({buf, len});
+    }
+
+    virtual ~Verifier()
+    {
+      mbedtls_x509_crt_free(&cert);
+    }
+  };
+
+  class Verifier_k1Bitcoin : public Verifier
+  {
+  protected:
+    BCk1ContextPtr bc_ctx = make_bc_context(SECP256K1_CONTEXT_VERIFY);
+
+    secp256k1_pubkey bc_pub;
+
+  public:
+    template <typename... Ts>
+    Verifier_k1Bitcoin(Ts... ts) : Verifier(std::forward<Ts>(ts)...)
+    {
+      parse_secp256k_bc(cert.pk, bc_ctx->p, &bc_pub);
+    }
+
+    bool verify_hash(
+      const uint8_t* hash,
+      size_t hash_size,
+      const uint8_t* signature,
+      size_t signature_size) const override
+    {
+      bool ok = verify_secp256k_bc(
+        bc_ctx->p, signature, signature_size, hash, hash_size, &bc_pub);
+
+      return ok;
+    }
+  };
+
+  using VerifierPtr = std::shared_ptr<Verifier>;
+  using VerifierUniquePtr = std::unique_ptr<Verifier>;
+  /**
+   * Construct Verifier from a certificate in PEM format
+   *
+   * @param public_pem Sequence of bytes containing the certificate in PEM
+   * format
+   */
+  inline VerifierUniquePtr make_unique_verifier(
+    const std::vector<uint8_t>& cert_pem,
+    bool use_bitcoin_impl = prefer_bitcoin_secp256k1)
+  {
+    mbedtls_x509_crt cert;
+    mbedtls_x509_crt_init(&cert);
+    int rc = mbedtls_x509_crt_parse(&cert, cert_pem.data(), cert_pem.size());
+    if (rc)
+    {
+      std::stringstream s;
+      s << "Failed to parse certificate: " << rc;
+      throw std::invalid_argument(s.str());
+    }
+
+    const auto curve = get_ec_from_context(cert.pk);
+
+    if (curve == MBEDTLS_ECP_DP_SECP256K1 && use_bitcoin_impl)
+    {
+      return std::make_unique<Verifier_k1Bitcoin>(cert);
+    }
+    else
+    {
+      return std::make_unique<Verifier>(cert);
+    }
+  }
+
+  inline VerifierPtr make_verifier(
+    const std::vector<uint8_t>& cert_pem,
+    bool use_bitcoin_impl = prefer_bitcoin_secp256k1)
+  {
+    return make_unique_verifier(cert_pem, use_bitcoin_impl);
+  }
+
+}


### PR DESCRIPTION
Resolves https://github.com/microsoft/CCF/issues/785

`keypair.h` is now split into `keypair.h`, `curve.h`, `verifier.h` and `hash.h` (all under `tls/`).