### PR TITLE
Remove full Merkle root from PBFT

### DIFF
--- a/src/consensus/pbft/libbyz/Pre_prepare.cpp
+++ b/src/consensus/pbft/libbyz/Pre_prepare.cpp
@@ -19,7 +19,6 @@ Pre_prepare::Pre_prepare(
 {
   rep().view = v;
   rep().seqno = s;
-  rep().full_state_merkle_root.fill(0);
   rep().replicated_state_merkle_root.fill(0);
 
   START_CC(pp_digest_cycles);
@@ -218,10 +217,6 @@ bool Pre_prepare::calculate_digest(Digest& d)
     d.update_last(context, (char*)&(rep().seqno), sizeof(Seqno));
     d.update_last(
       context,
-      (const char*)rep().full_state_merkle_root.data(),
-      rep().full_state_merkle_root.size());
-    d.update_last(
-      context,
       (const char*)rep().replicated_state_merkle_root.data(),
       rep().replicated_state_merkle_root.size());
     d.update_last(context, (char*)&rep().ctx, sizeof(rep().ctx));
@@ -407,25 +402,14 @@ bool Pre_prepare::convert(Message* m1, Pre_prepare*& m2)
 }
 
 void Pre_prepare::set_merkle_roots_and_ctx(
-  const std::array<uint8_t, MERKLE_ROOT_SIZE>& full_state_merkle_root,
   const std::array<uint8_t, MERKLE_ROOT_SIZE>& replicated_state_merkle_root,
   int64_t ctx)
 {
-  std::copy(
-    std::begin(full_state_merkle_root),
-    std::end(full_state_merkle_root),
-    std::begin(rep().full_state_merkle_root));
   std::copy(
     std::begin(replicated_state_merkle_root),
     std::end(replicated_state_merkle_root),
     std::begin(rep().replicated_state_merkle_root));
   rep().ctx = ctx;
-}
-
-const std::array<uint8_t, MERKLE_ROOT_SIZE>& Pre_prepare::
-  get_full_state_merkle_root() const
-{
-  return rep().full_state_merkle_root;
 }
 
 const std::array<uint8_t, MERKLE_ROOT_SIZE>& Pre_prepare::

--- a/src/consensus/pbft/libbyz/Pre_prepare.h
+++ b/src/consensus/pbft/libbyz/Pre_prepare.h
@@ -24,7 +24,6 @@ struct Pre_prepare_rep : public Message_rep
 {
   View view;
   Seqno seqno;
-  std::array<uint8_t, MERKLE_ROOT_SIZE> full_state_merkle_root;
   std::array<uint8_t, MERKLE_ROOT_SIZE> replicated_state_merkle_root;
   int64_t ctx; // a context provided when a the batch is executed
                // the contents are opaque
@@ -96,12 +95,9 @@ public:
   // Effects: Fetches the digest from the message.
 
   void set_merkle_roots_and_ctx(
-    const std::array<uint8_t, MERKLE_ROOT_SIZE>& full_state_merkle_root,
     const std::array<uint8_t, MERKLE_ROOT_SIZE>& replicated_state_merkle_root,
     int64_t ctx);
 
-  const std::array<uint8_t, MERKLE_ROOT_SIZE>& get_full_state_merkle_root()
-    const;
   const std::array<uint8_t, MERKLE_ROOT_SIZE>&
   get_replicated_state_merkle_root() const;
 

--- a/src/consensus/pbft/libbyz/Replica.cpp
+++ b/src/consensus/pbft/libbyz/Replica.cpp
@@ -814,9 +814,7 @@ void Replica::send_pre_prepare(bool do_not_wait_for_batch_size)
     {
       LOG_DEBUG << "adding to plog from pre prepare: " << next_pp_seqno
                 << std::endl;
-      pp->set_merkle_roots_and_ctx(
-        info.replicated_state_merkle_root,
-        info.ctx);
+      pp->set_merkle_roots_and_ctx(info.replicated_state_merkle_root, info.ctx);
       pp->set_digest(signed_version.load());
       plog.fetch(next_pp_seqno).add_mine(pp);
 

--- a/src/consensus/pbft/libbyz/Replica.cpp
+++ b/src/consensus/pbft/libbyz/Replica.cpp
@@ -364,7 +364,6 @@ void Replica::receive_message(const uint8_t* data, uint32_t size)
 bool Replica::compare_execution_results(
   const ByzInfo& info, Pre_prepare* pre_prepare)
 {
-  auto& pp_root = pre_prepare->get_full_state_merkle_root();
   auto& r_pp_root = pre_prepare->get_replicated_state_merkle_root();
 
   auto execution_match = true;
@@ -387,17 +386,6 @@ bool Replica::compare_execution_results(
                 "does not match, seqno:"
              << pre_prepare->seqno() << ", tx_ctx:" << tx_ctx
              << ", info.ctx:" << info.ctx << std::endl;
-    execution_match = false;
-  }
-
-  if (!std::equal(
-        std::begin(pp_root),
-        std::end(pp_root),
-        std::begin(info.full_state_merkle_root)))
-  {
-    LOG_FAIL << "Full state merkle root between execution and the pre_prepare "
-                "message does not match, seqno:"
-             << pre_prepare->seqno() << std::endl;
     execution_match = false;
   }
 
@@ -827,7 +815,6 @@ void Replica::send_pre_prepare(bool do_not_wait_for_batch_size)
       LOG_DEBUG << "adding to plog from pre prepare: " << next_pp_seqno
                 << std::endl;
       pp->set_merkle_roots_and_ctx(
-        info.full_state_merkle_root,
         info.replicated_state_merkle_root,
         info.ctx);
       pp->set_digest(signed_version.load());

--- a/src/consensus/pbft/libbyz/test/replica_test.cpp
+++ b/src/consensus/pbft/libbyz/test/replica_test.cpp
@@ -212,8 +212,6 @@ ExecCommand exec_command =
       counter++;
       have_executed_request = true;
 
-      info.full_state_merkle_root.fill(0);
-      ((Long*)(info.full_state_merkle_root.data()))[0] = counter;
       info.replicated_state_merkle_root.fill(0);
       ((Long*)(info.replicated_state_merkle_root.data()))[0] = counter;
       info.ctx = counter;

--- a/src/consensus/pbft/libbyz/test/test_ledger_replay.cpp
+++ b/src/consensus/pbft/libbyz/test/test_ledger_replay.cpp
@@ -58,9 +58,7 @@ public:
         outb.size = 0;
         auto request = reinterpret_cast<fake_req*>(inb->contents);
         info.ctx = request->ctx;
-        info.full_state_merkle_root.fill(0);
         info.replicated_state_merkle_root.fill(0);
-        info.full_state_merkle_root.data()[0] = request->rt;
         info.replicated_state_merkle_root.data()[0] = request->rt;
 
         REQUIRE(request->rt == command_counter);
@@ -270,14 +268,11 @@ TEST_CASE("Test Ledger Replay")
       // imitate exec command
       ByzInfo info;
       info.ctx = i;
-      info.full_state_merkle_root.fill(0);
       info.replicated_state_merkle_root.fill(0);
       // mess up merkle roots
-      info.full_state_merkle_root.data()[0] = i + 1;
       info.replicated_state_merkle_root.data()[0] = i + 1;
 
       pp->set_merkle_roots_and_ctx(
-        info.full_state_merkle_root,
         info.replicated_state_merkle_root,
         info.ctx);
 

--- a/src/consensus/pbft/libbyz/test/test_ledger_replay.cpp
+++ b/src/consensus/pbft/libbyz/test/test_ledger_replay.cpp
@@ -272,9 +272,7 @@ TEST_CASE("Test Ledger Replay")
       // mess up merkle roots
       info.replicated_state_merkle_root.data()[0] = i + 1;
 
-      pp->set_merkle_roots_and_ctx(
-        info.replicated_state_merkle_root,
-        info.ctx);
+      pp->set_merkle_roots_and_ctx(info.replicated_state_merkle_root, info.ctx);
 
       ledger_writer.write_pre_prepare(pp.get());
     }

--- a/src/consensus/pbft/libbyz/types.h
+++ b/src/consensus/pbft/libbyz/types.h
@@ -47,7 +47,6 @@ typedef struct _Byz_buffer Byz_rep;
 static const uint32_t MERKLE_ROOT_SIZE = 32;
 struct ByzInfo
 {
-  std::array<uint8_t, MERKLE_ROOT_SIZE> full_state_merkle_root;
   std::array<uint8_t, MERKLE_ROOT_SIZE> replicated_state_merkle_root;
   int64_t ctx;
 };

--- a/src/consensus/pbft/pbftconfig.h
+++ b/src/consensus/pbft/pbftconfig.h
@@ -96,16 +96,10 @@ namespace pbft
           }
 
           static_assert(
-            sizeof(info.full_state_merkle_root) == sizeof(crypto::Sha256Hash));
-          static_assert(
             sizeof(info.replicated_state_merkle_root) ==
             sizeof(crypto::Sha256Hash));
           if (msg->include_merkle_roots)
           {
-            std::copy(
-              std::begin(rep.full_state_merkle_root.h),
-              std::end(rep.full_state_merkle_root.h),
-              std::begin(info.full_state_merkle_root));
             std::copy(
               std::begin(rep.replicated_state_merkle_root.h),
               std::end(rep.replicated_state_merkle_root.h),

--- a/src/enclave/rpchandler.h
+++ b/src/enclave/rpchandler.h
@@ -32,7 +32,6 @@ namespace enclave
     struct ProcessPbftResp
     {
       std::vector<uint8_t> result;
-      crypto::Sha256Hash full_state_merkle_root;
       crypto::Sha256Hash replicated_state_merkle_root;
       kv::Version version;
     };

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -370,9 +370,7 @@ namespace ccf
         replicated_state_merkle_root = history->get_replicated_state_root();
       }
 
-      return {rep.value(),
-              replicated_state_merkle_root,
-              version};
+      return {rep.value(), replicated_state_merkle_root, version};
     }
 
     /** Process a serialised input forwarded from another node

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -343,7 +343,6 @@ namespace ccf
       bool playback,
       bool include_merkle_roots) override
     {
-      crypto::Sha256Hash full_state_merkle_root;
       crypto::Sha256Hash replicated_state_merkle_root;
       kv::Version version = kv::NoVersion;
 
@@ -368,12 +367,10 @@ namespace ccf
       version = tx.get_version();
       if (include_merkle_roots)
       {
-        full_state_merkle_root = history->get_full_state_root();
         replicated_state_merkle_root = history->get_replicated_state_root();
       }
 
       return {rep.value(),
-              full_state_merkle_root,
               replicated_state_merkle_root,
               version};
     }


### PR DESCRIPTION
Part of #762 and #774

We do not need the full state Merkle tree. It does not give us enough goodness to outweigh the performance overhead. This PR only remove the Merkle root from PBFT, there will be followup remove this from the KV.