### PR TITLE
Compatibility with msgpack-1.0.0

### DIFF
--- a/tests/ledger.py
+++ b/tests/ledger.py
@@ -47,7 +47,7 @@ class LedgerDomain:
     def __init__(self, buffer):
         self._buffer = buffer
         self._buffer_size = buffer.getbuffer().nbytes
-        self._unpacker = msgpack.Unpacker(self._buffer)
+        self._unpacker = msgpack.Unpacker(self._buffer, raw=True)
         self._version = self._read_next()
         self._read()
 
@@ -58,7 +58,6 @@ class LedgerDomain:
         return self._unpacker.unpack().decode()
 
     def _read(self):
-
         while self._buffer_size > self._unpacker.tell():
             map_start_indicator = self._read_next()
             map_name = self._read_next_string()

--- a/tests/ledger.py
+++ b/tests/ledger.py
@@ -47,7 +47,7 @@ class LedgerDomain:
     def __init__(self, buffer):
         self._buffer = buffer
         self._buffer_size = buffer.getbuffer().nbytes
-        self._unpacker = msgpack.Unpacker(self._buffer, raw=True)
+        self._unpacker = msgpack.Unpacker(self._buffer, raw=True, strict_map_key=False)
         self._version = self._read_next()
         self._read()
 

--- a/tests/votinghistory.py
+++ b/tests/votinghistory.py
@@ -6,7 +6,6 @@ import infra.proc
 import infra.remote
 import json
 import ledger
-import msgpack
 import coincurve
 from coincurve._libsecp256k1 import ffi, lib
 from coincurve.context import GLOBAL_CONTEXT


### PR DESCRIPTION
msgpack-python released v1.0.0 yesterday, which has some breaking changes causing our `voting_history_test` to fail. This resolves those, following the notes [here](https://github.com/msgpack/msgpack-python#major-breaking-changes-in-msgpack-10).