### PR TITLE
Make WORKER_THREADS a cached variable

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -387,11 +387,11 @@ else()
 endif()
 
 if((NOT CMAKE_BUILD_TYPE STREQUAL "Debug") AND NOT SAN)
-  set(WORKER_THREADS 2)
+  set(DEFAULT_WORKER_THREADS 2)
 else()
-  set(WORKER_THREADS 0)
+  set(DEFAULT_WORKER_THREADS 0)
 endif()
-message(STATUS "Setting default WORKER_THREADS to '${WORKER_THREADS}'")
+set(WORKER_THREADS "${DEFAULT_WORKER_THREADS}" CACHE STRING "Number of worker threads to start on each CCF node")
 
 set(CCF_NETWORK_TEST_ARGS
     ${TEST_IGNORE_QUOTE}

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -391,7 +391,10 @@ if((NOT CMAKE_BUILD_TYPE STREQUAL "Debug") AND NOT SAN)
 else()
   set(DEFAULT_WORKER_THREADS 0)
 endif()
-set(WORKER_THREADS "${DEFAULT_WORKER_THREADS}" CACHE STRING "Number of worker threads to start on each CCF node")
+set(WORKER_THREADS
+    "${DEFAULT_WORKER_THREADS}"
+    CACHE STRING "Number of worker threads to start on each CCF node"
+)
 
 set(CCF_NETWORK_TEST_ARGS
     ${TEST_IGNORE_QUOTE}


### PR DESCRIPTION
This lets us see it with `cmake .. -L` and override it with `cmake .. -DWORKER_THREADS=42`