### PR TITLE
Slow quote-retrieval breaks tests

### DIFF
--- a/src/node/nodestate.h
+++ b/src/node/nodestate.h
@@ -455,6 +455,13 @@ namespace ccf
         throw std::logic_error("Quote could not be retrieved");
       }
       quote = quote_opt.value();
+#elif defined(VIRTUAL_ENCLAVE)
+      constexpr auto sleep_time = std::chrono::seconds(10);
+      LOG_INFO_FMT(
+        "Simulating slow quote recovery by sleeping for {}s",
+        sleep_time.count());
+      std::this_thread::sleep_for(sleep_time);
+      LOG_INFO_FMT("Waking up");
 #endif
       join_rpc.params.quote = quote;
 


### PR DESCRIPTION
Opening as a draft - this is a demo of a crash, rather than a fix.

We have occasional timeouts in our CI, where a new node seems unreachable. This is blocking the merge of unrelated PRs. I believe this demonstrates the cause in a simple, reproducible way. When `get_quote` is too slow, the first `getCommit` message doesn't get processed. I've simulated this with a sleep in the virtual enclave, and we (at least what looks like) the same issue.

I'll work out why we're dropping the message, and then we can discuss if this behaviour is worth keeping in the virtual build.