### PR TITLE
Adjustable initial member/client

### DIFF
--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -210,7 +210,7 @@ class Network:
         cmd = ["rm", "-f"] + glob("member*.pem")
         infra.proc.ccall(*cmd)
 
-        initial_members = list(range(max(1, args.initial_member_count))) 
+        initial_members = list(range(max(1, args.initial_member_count)))
         self.consortium = infra.consortium.Consortium(
             initial_members, args.default_curve, self.key_generator
         )

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -210,10 +210,11 @@ class Network:
         cmd = ["rm", "-f"] + glob("member*.pem")
         infra.proc.ccall(*cmd)
 
+        initial_members = list(range(max(1, args.initial_member_count))) 
         self.consortium = infra.consortium.Consortium(
-            [0, 1, 2], args.default_curve, self.key_generator
+            initial_members, args.default_curve, self.key_generator
         )
-        self.initial_users = [0, 1, 2]
+        self.initial_users = list(range(max(0, args.initial_user_count)))
         self.create_users(self.initial_users, args.default_curve)
 
         primary = self._start_all_nodes(args)
@@ -225,7 +226,7 @@ class Network:
         if args.app_script:
             infra.proc.ccall("cp", args.app_script, args.binary_dir).check_returncode()
             self.consortium.set_lua_app(
-                member_id=1, remote_node=primary, app_script=args.app_script
+                member_id=0, remote_node=primary, app_script=args.app_script
             )
 
         if args.js_app_script:
@@ -233,14 +234,14 @@ class Network:
                 "cp", args.js_app_script, args.binary_dir
             ).check_returncode()
             self.consortium.set_js_app(
-                member_id=1, remote_node=primary, app_script=args.js_app_script
+                member_id=0, remote_node=primary, app_script=args.js_app_script
             )
 
         self.consortium.add_users(primary, self.initial_users)
         LOG.info("Initial set of users added")
 
         self.consortium.open_network(
-            member_id=1, remote_node=primary, pbft_open=args.consensus == "pbft"
+            member_id=0, remote_node=primary, pbft_open=args.consensus == "pbft"
         )
         self.status = ServiceStatus.OPEN
         LOG.success("***** Network is now open *****")

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -79,6 +79,8 @@ class Consortium:
         # There is no need to stop after n / 2 + 1 members have voted,
         # but this could prove to be useful in detecting errors
         # related to the voting mechanism
+        if len(self.members) == 1:
+            return True
         majority_count = int(len(self.members) / 2 + 1)
         for i, member in enumerate(self.members):
             if i >= majority_count:
@@ -209,7 +211,7 @@ class Consortium:
             tables, user_cert = ...
             return Calls:call("new_user", user_cert)
             """
-            result, error = self.propose(1, remote_node, script, user_cert)
+            result, error = self.propose(0, remote_node, script, user_cert)
             self.vote_using_majority(remote_node, result["id"])
 
     def set_lua_app(self, member_id, remote_node, app_script):

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -136,6 +136,19 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         type=int,
         default=4000,
     )
+    parser.add_argument(
+        "--initial-member-count",
+        help="Number of members when intializing the network",
+        type=int,
+        default=3,
+    )
+    parser.add_argument(
+        "--initial-user-count",
+        help="Number of users when intializing the network",
+        type=int,
+        default=3,
+    )
+
     add(parser)
 
     if accept_unknown:

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -218,7 +218,7 @@ class Node:
             **kwargs,
         )
 
-    def member_client(self, member_id=1, **kwargs):
+    def member_client(self, member_id=0, **kwargs):
         return infra.clients.client(
             self.host,
             self.rpc_port,


### PR DESCRIPTION
Added arguments to adjust initial member/client count on network start
--initial-member-count
--initial-user-count

Changed default value of member_id to 0 in calls for cases when there is one member. 

Addressing issue #889 

Signed-off-by: Daniel Peroni <daperoni@microsoft.com>

