### PR TITLE
Fix start_test_network gov script issue

### DIFF
--- a/sphinx/source/quickstart/index.rst
+++ b/sphinx/source/quickstart/index.rst
@@ -8,7 +8,7 @@ Once this is done, you can quickly spin up a CCF network and start :ref:`issuing
 .. code-block:: bash
 
     $ cd CCF/build
-    $ ../start_test_network.sh ./liblogging.enclave.so.signed
+    $ ../start_test_network.sh --package ./liblogging.enclave.so.signed
     Setting up Python environment...
     Python environment successfully setup
     [2019-10-29 14:47:41.562] Starting 3 CCF nodes...

--- a/sphinx/source/users/deploy_app.rst
+++ b/sphinx/source/users/deploy_app.rst
@@ -10,7 +10,7 @@ For example, deploying the ``liblogging`` example application:
 .. code-block:: bash
 
     $ cd CCF/build
-    $ ../start_test_network.sh ./liblogging.enclave.so.signed
+    $ ../start_test_network.sh --package ./liblogging.enclave.so.signed
     Setting up Python environment...
     Python environment successfully setup
     [2019-10-29 14:47:41.562] Starting 3 CCF nodes...
@@ -22,7 +22,7 @@ For example, deploying the ``liblogging`` example application:
     [2019-10-29 14:48:12.138] See https://microsoft.github.io/CCF/users/issue_commands.html for more information.
     [2019-10-29 14:48:12.138] Press Ctrl+C to shutdown the network.
 
-.. note:: To use CCF `virtual` mode, the same command can be run with ``TEST_ENCLAVE=virtual`` set as environment variable and the virtual version of the enclave application passed to the script. For example ``$ TEST_ENCLAVE=virtual ../start_test_network.sh ./liblogging.virtual.so``.
+.. note:: To use CCF `virtual` mode, the same command can be run with ``TEST_ENCLAVE=virtual`` set as environment variable and the virtual version of the enclave application passed to the script. For example ``$ TEST_ENCLAVE=virtual ../start_test_network.sh --package ./liblogging.virtual.so``.
 
 The log files (``out`` and ``err``) and ledger (``<node_id>.ledger``) for each CCF node can be found under ``CCF/build/workspace/test_network_<node_id>``.
 

--- a/start_test_network.sh
+++ b/start_test_network.sh
@@ -4,14 +4,6 @@
 
 set -e
 
-if [ -z "$1" ]; then
-    echo "The application enclave file should be specified (e.g. liblogging)"
-    exit 1
-fi
-
-PACKAGE="$1"
-shift
-
 echo "Setting up Python environment..."
 if [ ! -f "env/bin/activate" ]
     then
@@ -24,4 +16,8 @@ PATH_HERE=$(dirname "$(realpath -s "$0")")
 pip install -q -U -r "${PATH_HERE}"/tests/requirements.txt
 echo "Python environment successfully setup"
 
-CURL_CLIENT=ON python "${PATH_HERE}"/tests/start_network.py --package "${PACKAGE}" --label test_network "$@"
+CURL_CLIENT=ON \
+    python "${PATH_HERE}"/tests/start_network.py \
+    --gov-script "${PATH_HERE}"/src/runtime_config/gov.lua \
+    --label test_network \
+    "$@"

--- a/tests/K6.md
+++ b/tests/K6.md
@@ -9,7 +9,7 @@ Running K6 against CCF
 1. Start CCF, eg.
 
 ```
-$ ../start_test_network.sh liblogging.enclave.so.signed
+$ ../start_test_network.sh --package ./liblogging.enclave.so.signed
 ...
 [2020-02-14 11:26:46.525] Started CCF network with the following nodes:
 [2020-02-14 11:26:46.525]   Node [ 0] = 127.37.160.46:40523

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -625,7 +625,7 @@ class CCFRemote(object):
                 cmd += [f"--member-info={mc},{mk}"]
                 data_files.append(mc)
                 data_files.append(mk)
-            data_files += [gov_script]
+            data_files += [os.path.basename(gov_script)]
         elif start_type == StartType.join:
             cmd += [
                 "join",


### PR DESCRIPTION
The new `common/` directory broke our `start_test_network.sh` script because the governance script was not copied properly. This PR fixes it and also removes the expectation that the first argument to the script was the path to the enclave application - we should use the existing `--package` option instead.

https://github.com/microsoft/CCF/issues/493 will need a little more thought to get the script working out of the box so I propose that we defer it until after v0.8.