### PR TITLE
get_rpc_handler returns UserRpcFrontend

### DIFF
--- a/samples/apps/smallbank/app/smallbank.cpp
+++ b/samples/apps/smallbank/app/smallbank.cpp
@@ -382,7 +382,7 @@ namespace ccfapp
     }
   };
 
-  std::shared_ptr<enclave::RpcHandler> get_rpc_handler(
+  std::shared_ptr<ccf::UserRpcFrontend> get_rpc_handler(
     NetworkTables& nwt, AbstractNotifier& notifier)
   {
     return make_shared<SmallBank>(*nwt.tables);

--- a/src/apps/jsgeneric/jsgeneric.cpp
+++ b/src/apps/jsgeneric/jsgeneric.cpp
@@ -240,7 +240,7 @@ namespace ccfapp
     {}
   };
 
-  std::shared_ptr<enclave::RpcHandler> get_rpc_handler(
+  std::shared_ptr<ccf::UserRpcFrontend> get_rpc_handler(
     NetworkTables& network, AbstractNotifier& notifier)
   {
     return make_shared<JS>(network);

--- a/src/apps/logging/logging.cpp
+++ b/src/apps/logging/logging.cpp
@@ -278,7 +278,7 @@ namespace ccfapp
   };
 
   // SNIPPET_START: rpc_handler
-  std::shared_ptr<enclave::RpcHandler> get_rpc_handler(
+  std::shared_ptr<ccf::UserRpcFrontend> get_rpc_handler(
     NetworkTables& nwt, AbstractNotifier& notifier)
   {
     return make_shared<Logger>(nwt, notifier);

--- a/src/apps/luageneric/luageneric.cpp
+++ b/src/apps/luageneric/luageneric.cpp
@@ -222,7 +222,7 @@ namespace ccfapp
     {}
   };
 
-  std::shared_ptr<enclave::RpcHandler> get_rpc_handler(
+  std::shared_ptr<ccf::UserRpcFrontend> get_rpc_handler(
     NetworkTables& network, AbstractNotifier& notifier)
   {
     return std::make_shared<Lua>(network);

--- a/src/enclave/appinterface.h
+++ b/src/enclave/appinterface.h
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 #pragma once
-#include "enclave/rpchandler.h"
-#include "node/networktables.h"
-#include "node/rpc/nodeinterface.h"
+
+#include "node/rpc/userfrontend.h"
 
 namespace ccfapp
 {
@@ -17,7 +16,7 @@ namespace ccfapp
    *
    * @see `ccf::RpcFrontend`
    */
-  std::shared_ptr<enclave::RpcHandler> get_rpc_handler(
+  std::shared_ptr<ccf::UserRpcFrontend> get_rpc_handler(
     ccf::NetworkTables& network, ccf::AbstractNotifier& notifier);
   // SNIPPET_END: rpc_handler
 }

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -2,6 +2,8 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 #include "commonhandlerregistry.h"
+#include "consensus/pbft/pbftrequests.h"
+#include "consensus/pbft/pbfttables.h"
 #include "consts.h"
 #include "ds/buffer.h"
 #include "ds/spinlock.h"

--- a/src/node/rpc/userfrontend.h
+++ b/src/node/rpc/userfrontend.h
@@ -4,6 +4,7 @@
 
 #include "frontend.h"
 #include "node/clientsignatures.h"
+#include "node/networktables.h"
 
 namespace ccf
 {


### PR DESCRIPTION
Resolves #786.

This was a minor TODO we noticed a while ago - User apps should really be inheriting from `UserRpcFrontend` (ensuring standard user-cert lookup is followed), rather than from the more abstract RpcFrontend. This PR makes that the case, renaming the return type from `get_rpc_handler` and fixing some related includes.