### PR TITLE
clear mym if we reset f

### DIFF
--- a/src/consensus/pbft/libbyz/Certificate.h
+++ b/src/consensus/pbft/libbyz/Certificate.h
@@ -347,6 +347,7 @@ void Certificate<T>::reset_f()
   {
     complete = pbft::GlobalState::get_node().num_correct_replicas();
   }
+  mym = 0;
 }
 
 template <class T>


### PR DESCRIPTION
When we reset `f` we don't delete `mym` which stands for `my message` (i.e. the message that the replica generated for a seqno). 