### PR TITLE
Construct perf TESTS_SUFFIX in cmake

### DIFF
--- a/.azure-pipelines-templates/common_test.yml
+++ b/.azure-pipelines-templates/common_test.yml
@@ -14,7 +14,6 @@ jobs:
       parameters:
         artifact_name: ${{ parameters.artifact_name }}
         cmake_args: ${{ parameters.cmake_args }}
-        suite_label_suffix: '${{ parameters.target }}_${{ parameters.consensus }}'
     - template: test.yml
       parameters:
         ctest_filter: ${{ parameters.ctest_filter }}

--- a/.azure-pipelines-templates/download_build.yml
+++ b/.azure-pipelines-templates/download_build.yml
@@ -15,7 +15,5 @@ steps:
 
 - script: | 
     cmake -L ${{ parameters.cmake_args }} -GNinja ..
-  env:
-    TESTS_SUFFIX: ${{ parameters.suite_label_suffix }}
   displayName: Re-generate test metadata 
   workingDirectory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,6 @@ project(
   LANGUAGES C CXX
 )
 
-set(TESTS_SUFFIX $ENV{TESTS_SUFFIX})
-message(STATUS "Setting TESTS_SUFFIX on performance tests to '${TESTS_SUFFIX}'")
 set(ENV{BETTER_EXCEPTIONS} 1)
 
 # Set the default install prefix for CCF. Users may override this value with the

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -467,10 +467,20 @@ function(add_perf_test)
     unset(VERIFICATION_ARG)
   endif()
 
+  set(TESTS_SUFFIX "")
+  if("sgx" IN_LIST TARGET)
+    set(TESTS_SUFFIX "${TESTS_SUFFIX}_SGX")
+  endif()
+  if("raft" STREQUAL ${PARSED_ARGS_CONSENSUS})
+    set(TESTS_SUFFIX "${TESTS_SUFFIX}_CFT")
+  elseif("pbft" STREQUAL ${PARSED_ARGS_CONSENSUS})
+    set(TESTS_SUFFIX "${TESTS_SUFFIX}_BFT")
+  endif()
+
   if(PARSED_ARGS_LABEL)
-    set(LABEL_ARG "${PARSED_ARGS_LABEL}_${TESTS_SUFFIX}^")
+    set(LABEL_ARG "${PARSED_ARGS_LABEL}${TESTS_SUFFIX}^")
   else()
-    set(LABEL_ARG "${PARSED_ARGS_NAME}_${TESTS_SUFFIX}^")
+    set(LABEL_ARG "${PARSED_ARGS_NAME}${TESTS_SUFFIX}^")
   endif()
 
   add_test(

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -42,7 +42,7 @@ if(BUILD_TESTS)
       PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/small_bank_client.py
       CLIENT_BIN ./small_bank_client
       VERIFICATION_FILE ${SMALL_BANK_VERIFICATION_FILE}
-      LABEL SB_${CONSENSUS}
+      LABEL SB
       CONSENSUS ${CONSENSUS}
       ADDITIONAL_ARGS
         --transactions ${SMALL_BANK_ITERATIONS} --max-writes-ahead 1000


### PR DESCRIPTION
In #922 I recommended naming replacing `SB` with `SB_${CONSENSUS}` in the call to `add_perf_test`. My concern was that the `pbft` and `raft` variants would produce identical labels, so use the same workspace dir in local builds. This caused our CIMetrics labels to no longer match the old values, and to duplicate the consensus (`SB_pbft_SGX_BFT`). I believe this should resolved both issues - we construct the full label in CMake rather than trying to pass it from the CI yaml. The local labels should match the labels produced on the CI, the tests should get unique names, and they should match the _old_ names so we keep our full history.