### PR TITLE
Fix some performance related issues

### DIFF
--- a/src/consensus/pbft/libbyz/Big_req_table.cpp
+++ b/src/consensus/pbft/libbyz/Big_req_table.cpp
@@ -198,7 +198,8 @@ bool Big_req_table::add_unmatched(BR_entry* e, Request*& old_req)
 
   if (centry.num_requests >= Max_unmatched_requests_per_client)
   {
-    LOG_FAIL_FMT("Too many Requests pending from client: {}", e->r->client_id());
+    LOG_FAIL_FMT(
+      "Too many Requests pending from client: {}", e->r->client_id());
     old_req = centry.list.pop_tail()->r;
   }
   else

--- a/src/consensus/pbft/libbyz/Big_req_table.cpp
+++ b/src/consensus/pbft/libbyz/Big_req_table.cpp
@@ -191,7 +191,8 @@ bool Big_req_table::add_unmatched(BR_entry* e, Request*& old_req)
   {
     // client is expected to send requests in request id order
     LOG_FAIL_FMT(
-      "client is expected to send requests in request id order {}, last seen {}",
+      "client is expected to send requests in request id order {}, last seen "
+      "{}",
       e->r->client_id(),
       centry.last_value_seen[e->r->user_id()]);
     return false;

--- a/src/consensus/pbft/libbyz/Big_req_table.cpp
+++ b/src/consensus/pbft/libbyz/Big_req_table.cpp
@@ -10,30 +10,6 @@
 #include "Request.h"
 #include "ds/logger.h"
 
-struct Waiting_pp
-{
-  Seqno n;
-  View v;
-  int i;
-};
-
-class BR_entry
-{
-public:
-  inline BR_entry() : r(0), maxn(-1), maxv(-1) {}
-  inline ~BR_entry()
-  {
-    delete r;
-  }
-
-  Digest rd; // Request's digest
-  Request* r; // Request or 0 is request not received
-  // if r=0, Seqnos of pre-prepares waiting for request
-  std::vector<Waiting_pp> waiting;
-  Seqno maxn; // Maximum seqno of pre-prepare referencing request
-  View maxv; // Maximum view in which this entry was marked useful
-};
-
 Big_req_table::Big_req_table(size_t num_of_replicas) :
   breqs(max_out),
   last_stable(0),
@@ -67,7 +43,7 @@ inline void Big_req_table::remove_unmatched(BR_entry* bre)
     PBFT_ASSERT(bre->r != 0, "Invalid state");
     auto& centry = unmatched[bre->r->client_id()];
 
-    centry.requests.remove(bre->r);
+    centry.list.remove(bre);
     centry.num_requests--;
     PBFT_ASSERT(centry.num_requests >= 0, "Should be positive");
   }
@@ -204,35 +180,34 @@ bool Big_req_table::check_pcerts(BR_entry* bre)
   return false;
 }
 
-bool Big_req_table::add_unmatched(Request* r, Request*& old_req)
+bool Big_req_table::add_unmatched(BR_entry* e, Request*& old_req)
 {
-  auto& centry = unmatched[r->client_id()];
+  auto& centry = unmatched[e->r->client_id()];
   old_req = 0;
 
   if (
-    !centry.requests.empty() &&
-    centry.last_value_seen[r->user_id()] >= r->request_id())
+    !centry.list.is_empty() &&
+    centry.last_value_seen[e->r->user_id()] >= e->r->request_id())
   {
     // client is expected to send requests in request id order
     LOG_FAIL_FMT(
       "client is expected to send requests in request id order {}",
-      r->client_id());
+      e->r->client_id());
     return false;
   }
 
   if (centry.num_requests >= Max_unmatched_requests_per_client)
   {
-    LOG_FAIL_FMT("Too many Requests pending from client: {}", r->client_id());
-    old_req = centry.requests.back();
-    centry.requests.pop_back();
+    LOG_FAIL_FMT("Too many Requests pending from client: {}", e->r->client_id());
+    old_req = centry.list.pop_tail()->r;
   }
   else
   {
     centry.num_requests++;
   }
 
-  centry.last_value_seen[r->user_id()] = r->request_id();
-  centry.requests.push_front(r);
+  centry.last_value_seen[e->r->user_id()] = e->r->request_id();
+  centry.list.insert(e);
   return true;
 }
 
@@ -294,13 +269,13 @@ bool Big_req_table::add_request(Request* r, bool verified)
     // Buffer up to Max_unmatched_requests_per_client requests with the
     // largest timestamps from client.
     Request* old_req = 0;
-    bool added = add_unmatched(r, old_req);
+    auto bre = std::make_unique<BR_entry>();
+    bre->rd = rd;
+    bre->r = r;
+    bool added = add_unmatched(bre.get(), old_req);
     if (added)
     {
-      auto bre = new BR_entry;
-      bre->rd = rd;
-      bre->r = r;
-      breqs.insert({rd, bre});
+      breqs.insert({rd, bre.release()});
 
       if (old_req)
       {

--- a/src/consensus/pbft/libbyz/Big_req_table.h
+++ b/src/consensus/pbft/libbyz/Big_req_table.h
@@ -8,14 +8,41 @@
 #include "Digest.h"
 #include "Req_queue.h"
 #include "ds/thread_messaging.h"
+#include "ds/dllist.h"
 #include "types.h"
 
 #include <list>
 #include <unordered_map>
 #include <vector>
 
-class BR_entry;
 class Request;
+
+struct Waiting_pp
+{
+  Seqno n;
+  View v;
+  int i;
+};
+
+class BR_entry
+{
+public:
+  inline BR_entry() : r(0), maxn(-1), maxv(-1), next(nullptr), prev(nullptr) {}
+  inline ~BR_entry()
+  {
+    delete r;
+  }
+
+  Digest rd; // Request's digest
+  Request* r; // Request or 0 is request not received
+  // if r=0, Seqnos of pre-prepares waiting for request
+  std::vector<Waiting_pp> waiting;
+  Seqno maxn; // Maximum seqno of pre-prepare referencing request
+  View maxv; // Maximum view in which this entry was marked useful
+
+  BR_entry* next;
+  BR_entry* prev;
+};
 
 class Big_req_table
 {
@@ -98,7 +125,7 @@ private:
   // Effects: Removes bre->r from unmatched if it was not previously matched
   // to a pre-prepare.
 
-  bool add_unmatched(Request* r, Request*& old_req);
+  bool add_unmatched(BR_entry* e, Request*& old_req);
   // Effects: Adds r to the list of requests for the client if the request
   // id is greater than the largest in the list and returns true. If this causes
   // the number of requests to exceed Max_unmatched_requests_per_client,
@@ -114,7 +141,7 @@ private:
   struct Unmatched_requests
   {
     Unmatched_requests() : num_requests(0) {}
-    std::list<Request*> requests;
+    snmalloc::DLList<BR_entry> list;
     int num_requests;
     std::array<uint64_t, enclave::ThreadMessaging::max_num_threads>
       last_value_seen = {0};

--- a/src/consensus/pbft/libbyz/Big_req_table.h
+++ b/src/consensus/pbft/libbyz/Big_req_table.h
@@ -7,8 +7,8 @@
 
 #include "Digest.h"
 #include "Req_queue.h"
-#include "ds/thread_messaging.h"
 #include "ds/dllist.h"
+#include "ds/thread_messaging.h"
 #include "types.h"
 
 #include <list>

--- a/src/consensus/pbft/libbyz/Checkpoint.cpp
+++ b/src/consensus/pbft/libbyz/Checkpoint.cpp
@@ -35,8 +35,7 @@ Checkpoint::Checkpoint(Seqno s, Digest& d, bool stable) :
   auth_len = sizeof(Checkpoint_rep);
   auth_src_offset = 0;
 #else
-  rep().sig_size = pbft::GlobalState::get_node().gen_signature(
-    contents(), sizeof(Checkpoint_rep), contents() + sizeof(Checkpoint_rep));
+  rep().sig_size = 0;
 #endif
 }
 
@@ -52,8 +51,7 @@ void Checkpoint::re_authenticate(Principal* p, bool stable)
   if (rep().extra != 1 && stable)
   {
     rep().extra = 1;
-    rep().sig_size = pbft::GlobalState::get_node().gen_signature(
-      contents(), sizeof(Checkpoint_rep), contents() + sizeof(Checkpoint_rep));
+    rep().sig_size = 0;
   }
 #endif
 }
@@ -62,14 +60,6 @@ bool Checkpoint::pre_verify()
 {
   // Checkpoints must be sent by replicas.
   if (!pbft::GlobalState::get_node().is_replica(id()))
-  {
-    return false;
-  }
-
-  // Check signature size.
-  if (
-    size() - (int)sizeof(Checkpoint_rep) <
-    pbft::GlobalState::get_node().auth_size(id()))
   {
     return false;
   }

--- a/src/consensus/pbft/libbyz/Replica.cpp
+++ b/src/consensus/pbft/libbyz/Replica.cpp
@@ -313,7 +313,7 @@ Message* Replica::create_message(const uint8_t* data, uint32_t size)
 
     default:
       // Unknown message type.
-      LOG_FAIL << "Unknown message type:" << Message::get_tag(data) << std::endl;
+      LOG_FAIL_FMT("Unknown message type:{}", Message::get_tag(data));
       delete m;
       return nullptr;
   }
@@ -330,7 +330,7 @@ void Replica::receive_message(const uint8_t* data, uint32_t size)
     LOG_FAIL << "Received message size exceeds message: " << size << std::endl;
   }
   Message* m = create_message(data, size);
-  if (m == nullptr) 
+  if (m == nullptr)
   {
     return;
   }

--- a/src/consensus/pbft/libbyz/Replica.cpp
+++ b/src/consensus/pbft/libbyz/Replica.cpp
@@ -313,6 +313,7 @@ Message* Replica::create_message(const uint8_t* data, uint32_t size)
 
     default:
       // Unknown message type.
+      LOG_FAIL << "Unknown message type:" << Message::get_tag(data) << std::endl;
       delete m;
       return nullptr;
   }
@@ -329,6 +330,11 @@ void Replica::receive_message(const uint8_t* data, uint32_t size)
     LOG_FAIL << "Received message size exceeds message: " << size << std::endl;
   }
   Message* m = create_message(data, size);
+  if (m == nullptr) 
+  {
+    return;
+  }
+
   uint32_t target_thread = 0;
 
   if (enclave::ThreadMessaging::thread_count > 1 && m->tag() == Request_tag)

--- a/src/consensus/pbft/libbyz/Req_queue.cpp
+++ b/src/consensus/pbft/libbyz/Req_queue.cpp
@@ -114,6 +114,8 @@ bool Req_queue::remove(int cid, Request_id rid)
 void Req_queue::clear()
 {
   uint32_t tcount = enclave::ThreadMessaging::thread_count;
+  // There is a corner case when we run the very first transaction that
+  // thread_count can be 0. The use of std::max is a work around.
   tcount = std::max(tcount, (uint32_t)1);
   for (uint32_t i = 0; i < tcount; ++i)
   {

--- a/src/consensus/pbft/libbyz/Req_queue.cpp
+++ b/src/consensus/pbft/libbyz/Req_queue.cpp
@@ -11,8 +11,6 @@
 
 Req_queue::Req_queue() :
   reqs(Max_num_replicas),
-  head(nullptr),
-  tail(nullptr),
   nelems(0),
   nbytes(0)
 {}
@@ -21,7 +19,7 @@ bool Req_queue::append(Request* r)
 {
   size_t cid = r->client_id();
   Request_id rid = r->request_id();
-
+  int user_id = r->user_id();
   auto it = reqs.find({cid, rid});
   if (it == reqs.end())
   {
@@ -30,18 +28,7 @@ bool Req_queue::append(Request* r)
     auto rn = std::make_unique<RNode>();
     rn->r.reset(r);
 
-    if (head == nullptr)
-    {
-      head = tail = rn.get();
-      rn->prev = rn->next = nullptr;
-    }
-    else
-    {
-      tail->next = rn.get();
-      rn->prev = tail;
-      rn->next = nullptr;
-      tail = rn.get();
-    }
+    rnodes[user_id].insert_back(rn.get());
 
     reqs.insert({Key{cid, rid}, std::move(rn)});
     return true;
@@ -66,23 +53,28 @@ bool Req_queue::is_in_rqueue(Request* r)
 
 Request* Req_queue::remove()
 {
-  if (head == nullptr)
+  uint32_t tcount = enclave::ThreadMessaging::thread_count;
+  tcount = std::max(tcount, (uint32_t)1);
+
+  bool found = false;
+  for (uint i = 0; i < tcount; ++i)
+  {
+      if (!rnodes[count % tcount].is_empty())
+      {
+        found = true;
+        break;
+      }
+    count++;
+  }
+
+  if (!found)
   {
     return nullptr;
   }
 
-  Request* ret = head->r.release();
+  auto rn = rnodes[count % tcount].pop();
+  Request* ret = rn->r.release();
   PBFT_ASSERT(ret != 0, "Invalid state");
-
-  head = head->next;
-  if (head != nullptr)
-  {
-    head->prev = nullptr;
-  }
-  else
-  {
-    tail = nullptr;
-  }
 
   nelems--;
   nbytes -= ret->size();
@@ -108,23 +100,13 @@ bool Req_queue::remove(int cid, Request_id rid)
   bool ret = false;
   if (rn->prev == nullptr)
   {
-    PBFT_ASSERT(head == rn.get(), "Invalid state");
-    head = rn->next;
+    PBFT_ASSERT(rnodes[rn->r->user_id()].get_head() == rn.get(), "Invalid state");
+    rnodes[rn->r->user_id()].remove(rn.get());
     ret = true;
   }
   else
   {
     rn->prev->next = rn->next;
-  }
-
-  if (rn->next == nullptr)
-  {
-    PBFT_ASSERT(tail == rn.get(), "Invalid state");
-    tail = rn->prev;
-  }
-  else
-  {
-    rn->next->prev = rn->prev;
   }
 
   reqs.erase(it);
@@ -134,8 +116,15 @@ bool Req_queue::remove(int cid, Request_id rid)
 
 void Req_queue::clear()
 {
+  uint32_t tcount = enclave::ThreadMessaging::thread_count;
+  tcount = std::max(tcount, (uint32_t)1);
   reqs.clear();
-  head = tail = nullptr;
+  for (uint32_t i = 0; i < tcount; ++i)
+  {
+    while(!rnodes[i].is_empty()){
+      rnodes[i].pop();
+    }
+  }
   nelems = nbytes = 0;
 }
 

--- a/src/consensus/pbft/libbyz/Req_queue.cpp
+++ b/src/consensus/pbft/libbyz/Req_queue.cpp
@@ -9,11 +9,7 @@
 #include "Pre_prepare.h"
 #include "Request.h"
 
-Req_queue::Req_queue() :
-  reqs(Max_num_replicas),
-  nelems(0),
-  nbytes(0)
-{}
+Req_queue::Req_queue() : reqs(Max_num_replicas), nelems(0), nbytes(0) {}
 
 bool Req_queue::append(Request* r)
 {
@@ -57,13 +53,13 @@ Request* Req_queue::remove()
   tcount = std::max(tcount, (uint32_t)1);
 
   bool found = false;
-  for (uint i = 0; i < tcount; ++i)
+  for (uint32_t i = 0; i < tcount; ++i)
   {
-      if (!rnodes[count % tcount].is_empty())
-      {
-        found = true;
-        break;
-      }
+    if (!rnodes[count % tcount].is_empty())
+    {
+      found = true;
+      break;
+    }
     count++;
   }
 
@@ -100,7 +96,8 @@ bool Req_queue::remove(int cid, Request_id rid)
   bool ret = false;
   if (rn->prev == nullptr)
   {
-    PBFT_ASSERT(rnodes[rn->r->user_id()].get_head() == rn.get(), "Invalid state");
+    PBFT_ASSERT(
+      rnodes[rn->r->user_id()].get_head() == rn.get(), "Invalid state");
     rnodes[rn->r->user_id()].remove(rn.get());
     ret = true;
   }
@@ -121,7 +118,8 @@ void Req_queue::clear()
   reqs.clear();
   for (uint32_t i = 0; i < tcount; ++i)
   {
-    while(!rnodes[i].is_empty()){
+    while (!rnodes[i].is_empty())
+    {
       rnodes[i].pop();
     }
   }

--- a/src/consensus/pbft/libbyz/Req_queue.cpp
+++ b/src/consensus/pbft/libbyz/Req_queue.cpp
@@ -123,6 +123,7 @@ void Req_queue::clear()
       rnodes[i].pop();
     }
   }
+  reqs.clear();
   nelems = nbytes = 0;
 }
 

--- a/src/consensus/pbft/libbyz/Req_queue.cpp
+++ b/src/consensus/pbft/libbyz/Req_queue.cpp
@@ -115,7 +115,6 @@ void Req_queue::clear()
 {
   uint32_t tcount = enclave::ThreadMessaging::thread_count;
   tcount = std::max(tcount, (uint32_t)1);
-  reqs.clear();
   for (uint32_t i = 0; i < tcount; ++i)
   {
     while (!rnodes[i].is_empty())

--- a/src/consensus/pbft/libbyz/Req_queue.h
+++ b/src/consensus/pbft/libbyz/Req_queue.h
@@ -8,8 +8,11 @@
 #include "Request.h"
 #include "pbft_assert.h"
 #include "types.h"
+#include "ds/thread_messaging.h"
+#include "ds/dllist.h"
 
 #include <unordered_map>
+#include <algorithm>
 
 class Req_queue
 {
@@ -83,9 +86,8 @@ private:
     }
   };
   std::unordered_map<Key, std::unique_ptr<RNode>, KeyHash> reqs;
-
-  RNode* head;
-  RNode* tail;
+  mutable snmalloc::DLList<RNode> rnodes[enclave::ThreadMessaging::max_num_threads];
+  mutable uint64_t count = 0;
 
   int nelems; // Number of elements in queue
   int nbytes; // Number of bytes in queue
@@ -103,10 +105,18 @@ inline int Req_queue::num_bytes() const
 
 inline Request* Req_queue::first() const
 {
-  if (head)
+  uint32_t tcount = enclave::ThreadMessaging::thread_count;
+  tcount = std::max(tcount, (uint32_t)1);
+
+  for (uint32_t i = 0; i < tcount; ++i)
   {
-    PBFT_ASSERT(head->r != 0, "Invalid state");
-    return head->r.get();
+    count++;
+    auto rn = rnodes[count % tcount].get_head();
+    if (rn != nullptr)
+    {
+      PBFT_ASSERT(rn->r != 0, "Invalid state");
+      return rn->r.get();
+    }
   }
   return 0;
 }

--- a/src/consensus/pbft/libbyz/Req_queue.h
+++ b/src/consensus/pbft/libbyz/Req_queue.h
@@ -6,13 +6,13 @@
 #pragma once
 
 #include "Request.h"
+#include "ds/dllist.h"
+#include "ds/thread_messaging.h"
 #include "pbft_assert.h"
 #include "types.h"
-#include "ds/thread_messaging.h"
-#include "ds/dllist.h"
 
-#include <unordered_map>
 #include <algorithm>
+#include <unordered_map>
 
 class Req_queue
 {
@@ -86,7 +86,8 @@ private:
     }
   };
   std::unordered_map<Key, std::unique_ptr<RNode>, KeyHash> reqs;
-  mutable snmalloc::DLList<RNode> rnodes[enclave::ThreadMessaging::max_num_threads];
+  mutable snmalloc::DLList<RNode>
+    rnodes[enclave::ThreadMessaging::max_num_threads];
   mutable uint64_t count = 0;
 
   int nelems; // Number of elements in queue

--- a/src/ds/dllist.h
+++ b/src/ds/dllist.h
@@ -1,0 +1,257 @@
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include <type_traits>
+
+namespace snmalloc
+{
+  /**
+   * The type used for an address.  Currently, all addresses are assumed to be
+   * provenance-carrying values and so it is possible to cast back from the
+   * result of arithmetic on an address_t.  Eventually, this will want to be
+   * separated into two types, one for raw addresses and one for addresses that
+   * can be cast back to pointers.
+   */
+  using address_t = uintptr_t;
+
+  /**
+   * Invalid pointer class.  This is similar to `std::nullptr_t`, but allows
+   * other values.
+   */
+  template<address_t Sentinel>
+  struct InvalidPointer
+  {
+    /**
+     * Equality comparison. Two invalid pointer values with the same sentinel
+     * are always the same, invalid pointer values with different sentinels are
+     * always different.
+     */
+    template<uintptr_t OtherSentinel>
+    constexpr bool operator==(const InvalidPointer<OtherSentinel>&)
+    {
+      return Sentinel == OtherSentinel;
+    }
+    /**
+     * Equality comparison. Two invalid pointer values with the same sentinel
+     * are always the same, invalid pointer values with different sentinels are
+     * always different.
+     */
+    template<uintptr_t OtherSentinel>
+    constexpr bool operator!=(const InvalidPointer<OtherSentinel>&)
+    {
+      return Sentinel != OtherSentinel;
+    }
+    /**
+     * Implicit conversion, creates a pointer with the value of the sentinel.
+     * On CHERI and other provenance-tracking systems, this is a
+     * provenance-free integer and so will trap if dereferenced, on other
+     * systems the sentinel should be a value in unmapped memory.
+     */
+    template<typename T>
+    operator T*() const
+    {
+      return reinterpret_cast<T*>(Sentinel);
+    }
+    /**
+     * Implicit conversion to an address, returns the sentinel value.
+     */
+    operator address_t() const
+    {
+      return Sentinel;
+    }
+  };
+
+  template<class T, class Terminator = std::nullptr_t>
+  class DLList
+  {
+  private:
+    static_assert(
+      std::is_same<decltype(T::prev), T*>::value, "T->prev must be a T*");
+    static_assert(
+      std::is_same<decltype(T::next), T*>::value, "T->next must be a T*");
+
+    T* head = Terminator();
+    T* tail = Terminator();
+
+  public:
+    virtual ~DLList()
+    {
+      clear();
+    }
+
+    DLList() = default;
+
+    DLList(DLList&& o) noexcept
+    {
+      head = o.head;
+      tail = o.tail;
+
+      o.head = nullptr;
+      o.tail = nullptr;
+    }
+
+    DLList& operator=(DLList&& o) noexcept
+    {
+      head = o.head;
+      tail = o.tail;
+
+      o.head = nullptr;
+      o.tail = nullptr;
+      return *this;
+    }
+
+    bool is_empty()
+    {
+      return head == Terminator();
+    }
+
+    T* get_head()
+    {
+      return head;
+    }
+
+    T* get_tail()
+    {
+      return tail;
+    }
+
+    T* pop()
+    {
+      T* item = head;
+
+      if (item != Terminator())
+        remove(item);
+
+      return item;
+    }
+
+    T* pop_tail()
+    {
+      T* item = tail;
+
+      if (item != Terminator())
+        remove(item);
+
+      return item;
+    }
+
+    void insert(T* item)
+    {
+#ifndef NDEBUG
+      debug_check_not_contains(item);
+#endif
+
+      item->next = head;
+      item->prev = Terminator();
+
+      if (head != Terminator())
+        head->prev = item;
+      else
+        tail = item;
+
+      head = item;
+#ifndef NDEBUG
+      debug_check();
+#endif
+    }
+
+    void insert_back(T* item)
+    {
+#ifndef NDEBUG
+      debug_check_not_contains(item);
+#endif
+
+      item->prev = tail;
+      item->next = Terminator();
+
+      if (tail != Terminator())
+        tail->next = item;
+      else
+        head = item;
+
+      tail = item;
+#ifndef NDEBUG
+      debug_check();
+#endif
+    }
+
+    void remove(T* item)
+    {
+#ifndef NDEBUG
+      debug_check_contains(item);
+#endif
+
+      if (item->next != Terminator())
+        item->next->prev = item->prev;
+      else
+        tail = item->prev;
+
+      if (item->prev != Terminator())
+        item->prev->next = item->next;
+      else
+        head = item->next;
+
+#ifndef NDEBUG
+      debug_check();
+#endif
+    }
+
+    void clear()
+    {
+      while (head != nullptr)
+      {
+        auto c = head;
+        remove(c);
+        delete c;
+      }
+    }
+
+    void debug_check_contains(T* item)
+    {
+#ifndef NDEBUG
+      debug_check();
+      T* curr = head;
+
+      while (curr != item)
+      {
+        assert(curr != Terminator());
+        curr = curr->next;
+      }
+#else
+      UNUSED(item);
+#endif
+    }
+
+    void debug_check_not_contains(T* item)
+    {
+#ifndef NDEBUG
+      debug_check();
+      T* curr = head;
+
+      while (curr != Terminator())
+      {
+        assert(curr != item);
+        curr = curr->next;
+      }
+#else
+      UNUSED(item);
+#endif
+    }
+
+    void debug_check()
+    {
+#ifndef NDEBUG
+      T* item = head;
+      T* prev = Terminator();
+
+      while (item != Terminator())
+      {
+        assert(item->prev == prev);
+        prev = item;
+        item = item->next;
+      }
+#endif
+    }
+  };
+} // namespace snmalloc

--- a/src/ds/dllist.h
+++ b/src/ds/dllist.h
@@ -68,7 +68,7 @@ namespace snmalloc
     class T,
     class Terminator = std::nullptr_t,
     bool delete_on_clear = false>
-  class DLList
+  class DLList final
   {
   private:
     static_assert(
@@ -80,7 +80,7 @@ namespace snmalloc
     T* tail = Terminator();
 
   public:
-    virtual ~DLList()
+    ~DLList()
     {
       clear();
     }

--- a/src/ds/dllist.h
+++ b/src/ds/dllist.h
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
 #pragma once
 
 #include <cassert>
@@ -19,7 +21,7 @@ namespace snmalloc
    * Invalid pointer class.  This is similar to `std::nullptr_t`, but allows
    * other values.
    */
-  template<address_t Sentinel>
+  template <address_t Sentinel>
   struct InvalidPointer
   {
     /**
@@ -27,7 +29,7 @@ namespace snmalloc
      * are always the same, invalid pointer values with different sentinels are
      * always different.
      */
-    template<uintptr_t OtherSentinel>
+    template <uintptr_t OtherSentinel>
     constexpr bool operator==(const InvalidPointer<OtherSentinel>&)
     {
       return Sentinel == OtherSentinel;
@@ -37,7 +39,7 @@ namespace snmalloc
      * are always the same, invalid pointer values with different sentinels are
      * always different.
      */
-    template<uintptr_t OtherSentinel>
+    template <uintptr_t OtherSentinel>
     constexpr bool operator!=(const InvalidPointer<OtherSentinel>&)
     {
       return Sentinel != OtherSentinel;
@@ -48,7 +50,7 @@ namespace snmalloc
      * provenance-free integer and so will trap if dereferenced, on other
      * systems the sentinel should be a value in unmapped memory.
      */
-    template<typename T>
+    template <typename T>
     operator T*() const
     {
       return reinterpret_cast<T*>(Sentinel);
@@ -62,7 +64,7 @@ namespace snmalloc
     }
   };
 
-  template<class T, class Terminator = std::nullptr_t>
+  template <class T, class Terminator = std::nullptr_t>
   class DLList
   {
   private:

--- a/src/ds/dllist.h
+++ b/src/ds/dllist.h
@@ -64,7 +64,10 @@ namespace snmalloc
     }
   };
 
-  template <class T, class Terminator = std::nullptr_t>
+  template <
+    class T,
+    class Terminator = std::nullptr_t,
+    bool delete_on_clear = false>
   class DLList
   {
   private:
@@ -205,7 +208,10 @@ namespace snmalloc
       {
         auto c = head;
         remove(c);
-        delete c;
+        if (delete_on_clear)
+        {
+          delete c;
+        }
       }
     }
 

--- a/src/node/rpc/metrics.h
+++ b/src/node/rpc/metrics.h
@@ -29,7 +29,6 @@ namespace metrics
     Hist histogram = Hist(global);
     std::array<uint64_t, 100> times = {0};
 
-
     ccf::GetMetrics::HistogramResults get_histogram_results()
     {
       ccf::GetMetrics::HistogramResults result;

--- a/src/node/rpc/metrics.h
+++ b/src/node/rpc/metrics.h
@@ -60,6 +60,13 @@ namespace metrics
           result[std::to_string(i)]["duration"] = tx_time_passed[i];
         }
       }
+
+      LOG_INFO << "Printing time series" << std::endl;
+      for (uint32_t i = 0; i < times.size(); ++i)
+      {
+        LOG_INFO << i << " - " << times[i] << std::endl;
+      }
+
       return result;
     }
 
@@ -72,6 +79,8 @@ namespace metrics
 
       return result;
     }
+
+    std::array<uint64_t, 100> times = {0};
 
     void track_tx_rates(
       const std::chrono::milliseconds& elapsed, size_t tx_count)
@@ -91,6 +100,12 @@ namespace metrics
           tx_time_passed[tick_count] = rate_duration;
         }
         tick_count++;
+
+        uint32_t bucket = rate_time_elapsed.count() / 1000.0;
+        if (bucket < times.size())
+        {
+          times[bucket] += tx_count;
+        }
       }
     }
   };

--- a/src/node/rpc/metrics.h
+++ b/src/node/rpc/metrics.h
@@ -27,6 +27,8 @@ namespace metrics
     histogram::Global<Hist> global =
       histogram::Global<Hist>("histogram", __FILE__, __LINE__);
     Hist histogram = Hist(global);
+    std::array<uint64_t, 100> times = {0};
+
 
     ccf::GetMetrics::HistogramResults get_histogram_results()
     {
@@ -79,8 +81,6 @@ namespace metrics
 
       return result;
     }
-
-    std::array<uint64_t, 100> times = {0};
 
     void track_tx_rates(
       const std::chrono::milliseconds& elapsed, size_t tx_count)

--- a/src/node/rpc/metrics.h
+++ b/src/node/rpc/metrics.h
@@ -65,7 +65,7 @@ namespace metrics
       LOG_INFO << "Printing time series" << std::endl;
       for (uint32_t i = 0; i < times.size(); ++i)
       {
-        LOG_INFO << i << " - " << times[i] << std::endl;
+        LOG_INFO_FMT("{} - {}", i, times[i]);
       }
 
       return result;


### PR DESCRIPTION
- big request table will use an intrusive linked list so when an item is removed it can be done in O(1)
- the checkpoint in pbft is now only used for marking stable and therefore does not need to be signed
- the request queue will now have a queue per thread. This allows us to maintain session consistency while ensuring that we have enough work for all execution threads 
- bring the intrusive double linked list from snmalloc
- print a request time series (second granularity) when collecting other metrics