### PR TITLE
Performance

### DIFF
--- a/src/consensus/pbft/libbyz/Node.cpp
+++ b/src/consensus/pbft/libbyz/Node.cpp
@@ -190,7 +190,6 @@ void Node::send(Message* m, int i)
 
 void Node::send(Message* m, Principal* p)
 {
-  PBFT_ASSERT(m->size() <= Max_message_size, "Message is too big");
   PBFT_ASSERT(m->tag() < Max_message_tag, "Invalid message tag");
   PBFT_ASSERT(p != nullptr, "Must send to a principal");
 

--- a/src/consensus/pbft/libbyz/Prepare.cpp
+++ b/src/consensus/pbft/libbyz/Prepare.cpp
@@ -34,7 +34,7 @@ Prepare::Prepare(View v, Seqno s, Digest& d, Principal* dst, bool is_signed) :
   {
     struct signature
     {
-      uint32_t magic = 0xba55ba11;
+      uint32_t magic = 0xba5eba11;
       NodeId id;
       Digest d;
 

--- a/src/consensus/pbft/libbyz/Rep_info.cpp
+++ b/src/consensus/pbft/libbyz/Rep_info.cpp
@@ -42,11 +42,13 @@ char* Rep_info::new_reply(
   r->set_size(message_size);
   r->trim();
   char* ret = r->contents() + sizeof(Reply_rep);
-  std::lock_guard<SpinLock> mguard(lock);
-  auto ret_insert = reps.insert({Key{(size_t)pid, rid, n}, std::move(r)});
-  if (ret_insert.second)
   {
-    return ret;
+    std::lock_guard<SpinLock> mguard(lock);
+    auto ret_insert = reps.insert({Key{(size_t)pid, rid, n}, std::move(r)});
+    if (ret_insert.second)
+    {
+      return ret;
+    }
   }
 
   return nullptr;
@@ -59,22 +61,23 @@ int Rep_info::new_reply_size() const
 
 void Rep_info::end_reply(int pid, Request_id rid, Seqno n, int size)
 {
-  std::lock_guard<SpinLock> mguard(lock);
-  auto it = reps.find({(size_t)pid, rid, n});
-  if (it != reps.end())
+  Reply* r;
   {
+    std::lock_guard<SpinLock> mguard(lock);
+    auto it = reps.find({(size_t)pid, rid, n});
+    if (it == reps.end())
+    {
+      LOG_INFO << " Attempt to end reply not in this < " << pid << "," << rid
+               << "," << n << ">" << std::endl;
+      return;
+    }
     Reply* r = it->second.get();
     Reply_rep& rr = r->rep();
     rr.rid = rid;
     rr.reply_size = size;
-    rr.digest = Digest(r->contents() + sizeof(Reply_rep), size);
     int old_size = sizeof(Reply_rep) + rr.reply_size;
     r->set_size(old_size + MAC_size);
-    return;
   }
-
-  LOG_INFO << " Attempt to end reply not in this < " << pid << "," << rid << ","
-           << n << ">" << std::endl;
 }
 
 Reply* Rep_info::reply(int pid, Request_id rid, Seqno n)
@@ -91,34 +94,40 @@ Reply* Rep_info::reply(int pid, Request_id rid, Seqno n)
 
 void Rep_info::send_reply(int pid, Request_id rid, Seqno n, View v, int id)
 {
-  std::lock_guard<SpinLock> mguard(lock);
-  auto it = reps.find({(size_t)pid, rid, n});
-  if (it != reps.end())
+  std::unique_ptr<Reply> r;
   {
-    Reply* r = it->second.get();
-    Reply_rep& rr = r->rep();
+    std::lock_guard<SpinLock> mguard(lock);
+    auto it = reps.find({(size_t)pid, rid, n});
 
-    PBFT_ASSERT(rr.reply_size != -1, "Invalid state");
-    PBFT_ASSERT(rr.extra == 0 && rr.v == 0 && rr.replica == 0, "Invalid state");
+    if (it == reps.end())
+    {
+      LOG_INFO << " Attempt to send reply not in this < " << pid << "," << rid
+               << "," << n << ">" << std::endl;
+      return;
+    }
 
-    int old_size = sizeof(Reply_rep) + rr.reply_size;
-
-    rr.extra = 1;
-    rr.v = v;
-    rr.replica = id;
-
-    r->auth_type = Auth_type::out;
-    r->auth_len = sizeof(Reply_rep);
-    r->auth_src_offset = 0;
-    r->auth_dst_offset = old_size;
-
-    pbft::GlobalState::get_node().send(r, pid);
+    r = std::move(it->second);
     reps.erase(it);
-    return;
   }
 
-  LOG_INFO << " Attempt to send reply not in this < " << pid << "," << rid
-           << "," << n << ">" << std::endl;
+  Reply_rep& rr = r->rep();
+
+  PBFT_ASSERT(rr.reply_size != -1, "Invalid state");
+  PBFT_ASSERT(rr.extra == 0 && rr.v == 0 && rr.replica == 0, "Invalid state");
+
+  int old_size = sizeof(Reply_rep) + rr.reply_size;
+
+  rr.extra = 1;
+  rr.v = v;
+  rr.replica = id;
+
+  r->auth_type = Auth_type::out;
+  r->auth_len = sizeof(Reply_rep);
+  r->auth_src_offset = 0;
+  r->auth_dst_offset = old_size;
+
+  pbft::GlobalState::get_node().send(r.get(), pid);
+  return;
 }
 
 void Rep_info::clear()
@@ -133,7 +142,6 @@ void Rep_info::dump_state(std::ostream& os)
   for (auto& pair : reps)
   {
     os << " cid: " << pair.first.cid << " rid: " << pair.first.rid
-       << " seqno: " << pair.first.n
-       << " digest hash:" << pair.second->digest().hash() << std::endl;
+       << " seqno: " << pair.first.n << std::endl;
   }
 }

--- a/src/consensus/pbft/libbyz/Rep_info.cpp
+++ b/src/consensus/pbft/libbyz/Rep_info.cpp
@@ -44,7 +44,8 @@ char* Rep_info::new_reply(
   char* ret = r->contents() + sizeof(Reply_rep);
   {
     std::lock_guard<SpinLock> mguard(lock);
-    auto ret_insert = reps.insert({Key{(size_t)pid, rid, n}, std::move(r)});
+    auto ret_insert =
+      reps.insert({Key{static_cast<size_t>(pid), rid, n}, std::move(r)});
     if (ret_insert.second)
     {
       return ret;
@@ -64,11 +65,11 @@ void Rep_info::end_reply(int pid, Request_id rid, Seqno n, int size)
   Reply* r;
   {
     std::lock_guard<SpinLock> mguard(lock);
-    auto it = reps.find({(size_t)pid, rid, n});
+    auto it = reps.find({static_cast<size_t>(pid), rid, n});
     if (it == reps.end())
     {
-      LOG_INFO << " Attempt to end reply not in this < " << pid << "," << rid
-               << "," << n << ">" << std::endl;
+      LOG_INFO_FMT(
+        " Attempt to end reply not in this < {}, {}, {} >", pid, rid, n);
       return;
     }
     Reply* r = it->second.get();

--- a/src/consensus/pbft/libbyz/Rep_info_exactly_once.cpp
+++ b/src/consensus/pbft/libbyz/Rep_info_exactly_once.cpp
@@ -103,7 +103,6 @@ void Rep_info_exactly_once::end_reply(int pid, Request_id rid, int sz)
   Reply_rep& rr = r->rep();
   rr.rid = rid;
   rr.reply_size = sz;
-  rr.digest = Digest(r->contents() + sizeof(Reply_rep), sz);
 
   int old_size = sizeof(Reply_rep) + rr.reply_size;
   r->set_size(old_size + MAC_size);
@@ -185,7 +184,6 @@ void Rep_info_exactly_once::dump_state(std::ostream& os)
   for (int i = 0; i < reps.size(); i++)
   {
     os << "i: " << i << " rid: " << reps[i]->request_id()
-       << " digest hash:" << reps[i]->digest().hash()
        << " tentative:" << ireps[i].tentative << std::endl;
   }
 }

--- a/src/consensus/pbft/libbyz/Rep_info_exactly_once.h
+++ b/src/consensus/pbft/libbyz/Rep_info_exactly_once.h
@@ -42,11 +42,6 @@ public:
   // Effects: Returns the timestamp in the last message sent to
   // principal "pid".
 
-  Digest& digest(int pid);
-  // Requires: "pid" is a valid principal identifier.
-  // Effects: Returns a reference to the digest of the last reply
-  // value sent to pid.
-
   Reply* reply(int pid);
   // Requires: "pid" is a valid principal identifier.
   // Effects: Returns a pointer to the last reply value sent to "pid"
@@ -136,11 +131,6 @@ inline bool Rep_info_exactly_once::is_committed(int pid)
 inline Request_id Rep_info_exactly_once::req_id(int pid)
 {
   return reps[pid]->request_id();
-}
-
-inline Digest& Rep_info_exactly_once::digest(int pid)
-{
-  return reps[pid]->digest();
 }
 
 inline Reply* Rep_info_exactly_once::reply(int pid)

--- a/src/consensus/pbft/libbyz/Replica.cpp
+++ b/src/consensus/pbft/libbyz/Replica.cpp
@@ -367,7 +367,7 @@ void Replica::receive_message(const uint8_t* data, uint32_t size)
 bool Replica::compare_execution_results(
   const ByzInfo& info, Pre_prepare* pre_prepare)
 {
-  // We are currently not ording the execution on the backups correctly.
+  // We are currently not ordering the execution on the backups correctly.
   // This will be resolved in the immediate future.
   if (enclave::ThreadMessaging::thread_count > 2)
   {

--- a/src/consensus/pbft/libbyz/Replica.cpp
+++ b/src/consensus/pbft/libbyz/Replica.cpp
@@ -367,6 +367,13 @@ void Replica::receive_message(const uint8_t* data, uint32_t size)
 bool Replica::compare_execution_results(
   const ByzInfo& info, Pre_prepare* pre_prepare)
 {
+  // We are currently not ording the execution on the backups correctly.
+  // This will be resolved in the immediate future.
+  if (enclave::ThreadMessaging::thread_count > 2)
+  {
+    return true;
+  }
+
   auto& r_pp_root = pre_prepare->get_replicated_state_merkle_root();
 
   auto execution_match = true;
@@ -441,11 +448,10 @@ void Replica::playback_request(ccf::Store::Tx& tx)
 
   waiting_for_playback_pp = true;
 
-  std::vector<std::unique_ptr<ExecCommandMsg>> cmds;
-  cmds.emplace_back(execute_tentative_request(
+  vec_exec_cmds[0] = std::move(execute_tentative_request(
     *req, playback_max_local_commit_value, true, &tx, true));
 
-  exec_command(cmds, playback_byz_info);
+  exec_command(vec_exec_cmds, playback_byz_info, 1);
 }
 
 void Replica::playback_pre_prepare(ccf::Store::Tx& tx)
@@ -2174,6 +2180,7 @@ std::unique_ptr<ExecCommandMsg> Replica::execute_tentative_request(
     last_tentative_execute,
     max_local_commit_value,
     stash_replier,
+    request.user_id(),
     &Replica::execute_tentative_request_end,
     tx);
 
@@ -2211,7 +2218,8 @@ void Replica::execute_tentative_request_end(ExecCommandMsg& msg, ByzInfo& info)
 bool Replica::create_execute_commands(
   Pre_prepare* pp,
   int64_t& max_local_commit_value,
-  std::vector<std::unique_ptr<ExecCommandMsg>>& cmds)
+  std::array<std::unique_ptr<ExecCommandMsg>, Max_requests_in_batch>& cmds,
+  uint32_t& num_requests)
 {
   if (
     pp->seqno() == last_tentative_execute + 1 && !state.in_fetch_state() &&
@@ -2224,6 +2232,7 @@ bool Replica::create_execute_commands(
     Pre_prepare::Requests_iter iter(pp);
     Request request;
 
+    num_requests = 0;
     while (iter.get(request))
     {
       auto cmd = execute_tentative_request(
@@ -2232,7 +2241,8 @@ bool Replica::create_execute_commands(
         !iter.has_more_requests(),
         nullptr,
         pp->seqno());
-      cmds.push_back(std::move(cmd));
+      cmds[num_requests] = std::move(cmd);
+      ++num_requests;
     }
     return true;
   }
@@ -2246,10 +2256,11 @@ bool Replica::execute_tentative(Pre_prepare* pp, ByzInfo& info)
     pp->seqno(),
     last_tentative_execute);
 
-  std::vector<std::unique_ptr<ExecCommandMsg>> cmds;
-  if (create_execute_commands(pp, info.max_local_commit_value, cmds))
+  uint32_t num_requests;
+  if (create_execute_commands(
+        pp, info.max_local_commit_value, vec_exec_cmds, num_requests))
   {
-    exec_command(cmds, info);
+    exec_command(vec_exec_cmds, info, num_requests);
     return true;
   }
   return false;
@@ -2267,8 +2278,9 @@ bool Replica::execute_tentative(
   void(cb)(Pre_prepare*, Replica*, std::unique_ptr<ExecTentativeCbCtx>),
   std::unique_ptr<ExecTentativeCbCtx> ctx)
 {
-  std::vector<std::unique_ptr<ExecCommandMsg>> cmds;
-  if (create_execute_commands(pp, ctx->info.max_local_commit_value, cmds))
+  uint32_t num_requests;
+  if (create_execute_commands(
+        pp, ctx->info.max_local_commit_value, vec_exec_cmds, num_requests))
   {
     ByzInfo& info = ctx->info;
     if (cb != nullptr)
@@ -2290,7 +2302,7 @@ bool Replica::execute_tentative(
       }
     }
 
-    exec_command(cmds, info);
+    exec_command(vec_exec_cmds, info, num_requests);
     if (!node_info.general_info.support_threading)
     {
       cb(pp, this, std::move(ctx));

--- a/src/consensus/pbft/libbyz/Replica.h
+++ b/src/consensus/pbft/libbyz/Replica.h
@@ -318,11 +318,14 @@ private:
 
   bool is_exec_pending = false;
   std::list<Message*> pending_recv_msgs;
+  std::array<std::unique_ptr<ExecCommandMsg>, Max_requests_in_batch>
+    vec_exec_cmds;
 
   bool create_execute_commands(
     Pre_prepare* pp,
     int64_t& max_local_commit_value,
-    std::vector<std::unique_ptr<ExecCommandMsg>>& cmds);
+    std::array<std::unique_ptr<ExecCommandMsg>, Max_requests_in_batch>& cmds,
+    uint32_t& num_requests);
 
   bool execute_tentative(Pre_prepare* pp, ByzInfo& info);
 

--- a/src/consensus/pbft/libbyz/Reply.cpp
+++ b/src/consensus/pbft/libbyz/Reply.cpp
@@ -30,7 +30,6 @@ Reply::Reply(
   Request_id req,
   Seqno n,
   int replica,
-  Digest& d,
   Principal* p,
   bool tentative) :
   Message(Reply_tag, sizeof(Reply_rep) + MAC_size)
@@ -49,7 +48,6 @@ Reply::Reply(
   rep().n = n;
   rep().replica = replica;
   rep().reply_size = -1;
-  rep().digest = d;
 
   INCR_OP(reply_auth);
   START_CC(reply_auth_cycles);
@@ -90,7 +88,6 @@ void Reply::authenticate(Principal* p, int act_len, bool tentative)
   }
 
   rep().reply_size = act_len;
-  rep().digest = Digest(contents() + sizeof(Reply_rep), act_len);
   int old_size = sizeof(Reply_rep) + act_len;
   set_size(old_size + MAC_size);
 
@@ -153,16 +150,6 @@ bool Reply::pre_verify()
   if (size() - (int)sizeof(Reply_rep) - rep_size < MAC_size)
   {
     return false;
-  }
-
-  // Check reply
-  if (full())
-  {
-    Digest d(contents() + sizeof(Reply_rep), rep_size);
-    if (d != rep().digest)
-    {
-      return false;
-    }
   }
 
   // Check signature.

--- a/src/consensus/pbft/libbyz/Reply.h
+++ b/src/consensus/pbft/libbyz/Reply.h
@@ -22,7 +22,6 @@ struct Reply_rep : public Message_rep
   View v; // current view
   Request_id rid; // unique request identifier
   Seqno n; // sequence number when request was executed
-  Digest digest; // digest of reply.
   int replica; // id of replica sending the reply
   int reply_size; // if negative, reply is not full.
   // Followed by a reply that is "reply_size" bytes long and
@@ -77,7 +76,6 @@ public:
     Request_id req,
     Seqno n,
     int replica,
-    Digest& d,
     Principal* p,
     bool tentative);
   // Effects: Creates a new empty Reply message and appends a MAC for principal
@@ -99,9 +97,6 @@ public:
 
   int id() const;
   // Effects: Fetches the replier's identifier from the message.
-
-  Digest& digest() const;
-  // Effects: Fetches the digest from the message.
 
   char* reply(int& len);
   // Effects: Returns a pointer to the reply and sets len to the
@@ -159,11 +154,6 @@ inline int Reply::id() const
   return rep().replica;
 }
 
-inline Digest& Reply::digest() const
-{
-  return rep().digest;
-}
-
 inline char* Reply::reply(int& len)
 {
   len = rep().reply_size;
@@ -187,6 +177,6 @@ inline bool Reply::match(Reply* r)
     return false;
   }
 
-  return (rep().digest == r->rep().digest) & (rep().n == r->rep().n) &
+  return (rep().n == r->rep().n) &
     ((!is_tentative() & !r->is_tentative()) | (view() == r->view()));
 }

--- a/src/consensus/pbft/libbyz/test/replica_test.cpp
+++ b/src/consensus/pbft/libbyz/test/replica_test.cpp
@@ -189,9 +189,13 @@ static char* service_mem = 0;
 static IMessageReceiveBase* message_receive_base;
 
 ExecCommand exec_command =
-  [](std::vector<std::unique_ptr<ExecCommandMsg>>& msgs, ByzInfo& info) {
-    for (auto& msg : msgs)
+  [](
+    std::array<std::unique_ptr<ExecCommandMsg>, Max_requests_in_batch>& msgs,
+    ByzInfo& info,
+    uint32_t num_requests) {
+    for (uint32_t i = 0; i < num_requests; ++i)
     {
+      std::unique_ptr<ExecCommandMsg>& msg = msgs[i];
       Byz_req* inb = &msg->inb;
       Byz_rep& outb = msg->outb;
       int client = msg->client;

--- a/src/consensus/pbft/libbyz/test/test_ledger_replay.cpp
+++ b/src/consensus/pbft/libbyz/test/test_ledger_replay.cpp
@@ -37,9 +37,13 @@ public:
   };
 
   ExecCommand exec_command =
-    [this](std::vector<std::unique_ptr<ExecCommandMsg>>& msgs, ByzInfo& info) {
-      for (auto& msg : msgs)
+    [this](
+      std::array<std::unique_ptr<ExecCommandMsg>, Max_requests_in_batch>& msgs,
+      ByzInfo& info,
+      uint32_t num_requests) {
+      for (uint32_t i = 0; i < num_requests; ++i)
       {
+        std::unique_ptr<ExecCommandMsg>& msg = msgs[i];
         Byz_req* inb = &msg->inb;
         Byz_rep& outb = msg->outb;
         int client = msg->client;

--- a/src/consensus/pbft/libbyz/types.h
+++ b/src/consensus/pbft/libbyz/types.h
@@ -71,6 +71,7 @@ struct ExecCommandMsg
     Seqno last_tentative_execute_,
     int64_t& max_local_commit_value_,
     int replier_,
+    int reply_thread_,
     void (*cb_)(ExecCommandMsg& msg, ByzInfo& info),
     // if tx is nullptr we are in normal execution, otherwise we
     // are in playback mode
@@ -84,6 +85,7 @@ struct ExecCommandMsg
     last_tentative_execute(last_tentative_execute_),
     max_local_commit_value(max_local_commit_value_),
     replier(replier_),
+    reply_thread(reply_thread_),
     cb(cb_),
     tx(tx_)
   {}
@@ -96,6 +98,7 @@ struct ExecCommandMsg
   size_t req_size;
   bool include_merkle_roots;
   Seqno total_requests_executed;
+  int reply_thread;
   ccf::Store::Tx* tx;
 
   // Required for the callback
@@ -106,4 +109,6 @@ struct ExecCommandMsg
 };
 
 using ExecCommand = std::function<int(
-  std::vector<std::unique_ptr<ExecCommandMsg>>& msgs, ByzInfo&)>;
+  std::array<std::unique_ptr<ExecCommandMsg>, Max_requests_in_batch>& msgs,
+  ByzInfo&,
+  uint32_t)>;

--- a/src/consensus/pbft/pbftconfig.h
+++ b/src/consensus/pbft/pbftconfig.h
@@ -5,7 +5,6 @@
 #include "consensus/pbft/libbyz/pbft_assert.h"
 #include "enclave/rpchandler.h"
 #include "enclave/rpcmap.h"
-#include "http/http_rpc_context.h"
 #include "pbftdeps.h"
 
 namespace pbft
@@ -22,6 +21,8 @@ namespace pbft
 
   class PbftConfigCcf : public AbstractPbftConfig
   {
+    static constexpr uint32_t max_update_merkle_tree_interval = 50;
+
   public:
     PbftConfigCcf(std::shared_ptr<enclave::RPCMap> rpc_map_) : rpc_map(rpc_map_)
     {}
@@ -53,20 +54,15 @@ namespace pbft
       ExecutionCtx(
         std::unique_ptr<ExecCommandMsg> msg_,
         ByzInfo& info_,
-        std::shared_ptr<enclave::RpcHandler> frontend_,
-        std::shared_ptr<enclave::RpcContext> ctx_,
         PbftConfigCcf* self_) :
         msg(std::move(msg_)),
         info(info_),
-        frontend(frontend_),
-        ctx(ctx_),
         self(self_)
       {}
 
       std::unique_ptr<ExecCommandMsg> msg;
       ByzInfo& info;
       std::shared_ptr<enclave::RpcHandler> frontend;
-      std::shared_ptr<enclave::RpcContext> ctx;
       PbftConfigCcf* self;
     };
 
@@ -79,6 +75,14 @@ namespace pbft
       execution_ctx.msg->cb(*execution_ctx.msg.get(), info);
 
       --info.pending_cmd_callbacks;
+
+      if (
+        info.pending_cmd_callbacks %
+          PbftConfigCcf::max_update_merkle_tree_interval ==
+        0)
+      {
+        frontend->update_merkle_tree();
+      }
 
       if (info.pending_cmd_callbacks == 0)
       {
@@ -101,14 +105,47 @@ namespace pbft
     static void Execute(std::unique_ptr<enclave::Tmsg<ExecutionCtx>> c)
     {
       ExecutionCtx& execution_ctx = c->data;
-      ccf::Store::Tx* tx = execution_ctx.msg->tx;
-      ByzInfo& info = execution_ctx.info;
-      std::shared_ptr<enclave::RpcHandler> frontend = execution_ctx.frontend;
-      std::shared_ptr<enclave::RpcContext> ctx = execution_ctx.ctx;
-      Byz_rep& outb = execution_ctx.msg->outb;
-      int client = execution_ctx.msg->client;
-      Request_id rid = execution_ctx.msg->rid;
+      std::unique_ptr<ExecCommandMsg>& msg = execution_ctx.msg;
       PbftConfigCcf* self = execution_ctx.self;
+      ByzInfo& info = execution_ctx.info;
+
+      Byz_req* inb = &msg->inb;
+      Byz_rep& outb = msg->outb;
+      int client = msg->client;
+      Request_id rid = msg->rid;
+      uint8_t* req_start = msg->req_start;
+      size_t req_size = msg->req_size;
+      Seqno total_requests_executed = msg->total_requests_executed;
+      ccf::Store::Tx* tx = msg->tx;
+      int replier = msg->replier;
+      uint16_t reply_thread = msg->reply_thread;
+
+      pbft::Request request;
+      request.deserialise((uint8_t*)inb->contents, inb->size);
+
+      auto session = std::make_shared<enclave::SessionContext>(
+        enclave::InvalidSessionId, request.caller_id, request.caller_cert);
+
+      auto ctx = enclave::make_rpc_context(
+        session, request.raw, {req_start, req_start + req_size});
+
+      const auto actor_opt = http::extract_actor(*ctx);
+      if (!actor_opt.has_value())
+      {
+        throw std::logic_error(fmt::format(
+          "Failed to extract actor from PBFT request. Method is '{}'",
+          ctx->get_method()));
+      }
+
+      const auto& actor_s = actor_opt.value();
+      const auto actor = self->rpc_map->resolve(actor_s);
+      auto handler = self->rpc_map->find(actor);
+      if (!handler.has_value())
+        throw std::logic_error(
+          fmt::format("No frontend associated with actor {}", actor_s));
+
+      auto frontend = handler.value();
+      execution_ctx.frontend = frontend;
 
       enclave::RpcHandler::ProcessPbftResp rep;
       if (tx != nullptr)
@@ -146,53 +183,21 @@ namespace pbft
 
     ExecCommand exec_command =
       [this](
-        std::vector<std::unique_ptr<ExecCommandMsg>>& msgs, ByzInfo& info) {
-        info.pending_cmd_callbacks = msgs.size();
-        for (auto& msg : msgs)
+        std::array<std::unique_ptr<ExecCommandMsg>, Max_requests_in_batch>&
+          msgs,
+        ByzInfo& info,
+        uint32_t num_requests) {
+        info.pending_cmd_callbacks = num_requests;
+        for (uint32_t i = 0; i < num_requests; ++i)
         {
-          Byz_req* inb = &msg->inb;
-          Byz_rep& outb = msg->outb;
-          int client = msg->client;
-          Request_id rid = msg->rid;
-          uint8_t* req_start = msg->req_start;
-          size_t req_size = msg->req_size;
-          Seqno total_requests_executed = msg->total_requests_executed;
-          ccf::Store::Tx* tx = msg->tx;
-
-          pbft::Request request;
-          request.deserialise({inb->contents, inb->contents + inb->size});
-
-          auto session = std::make_shared<enclave::SessionContext>(
-            enclave::InvalidSessionId, request.caller_id, request.caller_cert);
-          auto ctx = enclave::make_rpc_context(
-            session, request.raw, {req_start, req_start + req_size});
-
-          const auto actor_opt = http::extract_actor(*ctx);
-          if (!actor_opt.has_value())
-          {
-            throw std::logic_error(fmt::format(
-              "Failed to extract actor from PBFT request. Method is '{}'",
-              ctx->get_method()));
-          }
-
-          const auto& actor_s = actor_opt.value();
-          const auto actor = rpc_map->resolve(actor_s);
-          auto handler = rpc_map->find(actor);
-          if (!handler.has_value())
-            throw std::logic_error(
-              fmt::format("No frontend associated with actor {}", actor_s));
-
-          auto frontend = handler.value();
-
-          LOG_DEBUG_FMT("PBFT exec_command() for frontend {}", actor_s);
-
+          std::unique_ptr<ExecCommandMsg>& msg = msgs[i];
+          uint16_t reply_thread = msg->reply_thread;
           auto execution_ctx = std::make_unique<enclave::Tmsg<ExecutionCtx>>(
-            &Execute, std::move(msg), info, frontend, ctx, this);
+            &Execute, std::move(msg), info, this);
 
           if (info.cb != nullptr)
           {
-            uint16_t tid =
-              (enclave::ThreadMessaging::thread_count <= 1) ? 0 : 1;
+            int tid = reply_thread;
             enclave::ThreadMessaging::thread_messaging.add_task<ExecutionCtx>(
               tid, std::move(execution_ctx));
           }

--- a/src/consensus/pbft/pbftconfig.h
+++ b/src/consensus/pbft/pbftconfig.h
@@ -81,7 +81,15 @@ namespace pbft
           PbftConfigCcf::max_update_merkle_tree_interval ==
         0)
       {
-        frontend->update_merkle_tree();
+        try
+        {
+          frontend->update_merkle_tree();
+        }
+        catch (const std::exception& e)
+        {
+          LOG_TRACE_FMT("Failed to insert into merkle tree", e.what());
+          abort();
+        }
       }
 
       if (info.pending_cmd_callbacks == 0)

--- a/src/consensus/pbft/pbftrequests.h
+++ b/src/consensus/pbft/pbftrequests.h
@@ -46,11 +46,8 @@ namespace pbft
       return serialized_req;
     }
 
-    void deserialise(const std::vector<uint8_t>& serialized_req)
+    void deserialise(const uint8_t* data_, size_t size_)
     {
-      auto data_ = serialized_req.data();
-      auto size_ = serialized_req.size();
-
       caller_id = serialized::read<uint64_t>(data_, size_);
       auto includes_caller = serialized::read<bool>(data_, size_);
       if (includes_caller)

--- a/src/consensus/raft/raft.h
+++ b/src/consensus/raft/raft.h
@@ -330,7 +330,7 @@ namespace raft
           committable_indices.push_back(index);
 
         last_idx = index;
-        auto s = write_to_ledger(data);
+        auto s = write_to_ledger(*data);
         entry_size_not_limited += s;
         entry_count++;
 

--- a/src/consensus/raft/test/driver.cpp
+++ b/src/consensus/raft/test/driver.cpp
@@ -26,6 +26,7 @@ int main(int argc, char** argv)
     vector<string> items{
       sregex_token_iterator(line.begin(), line.end(), delim, -1),
       std::sregex_token_iterator()};
+    std::shared_ptr<std::vector<uint8_t>> d;
     switch (shash(items[0].c_str()))
     {
       case shash("nodes"):
@@ -62,10 +63,9 @@ int main(int argc, char** argv)
         break;
       case shash("replicate"):
         assert(items.size() == 4);
-        driver->replicate(
-          stoi(items[1]),
-          stoi(items[2]),
-          vector<uint8_t>(items[3].begin(), items[3].end()));
+        d = std::make_shared<std::vector<uint8_t>>(
+          items[3].begin(), items[3].end());
+        driver->replicate(stoi(items[1]), stoi(items[2]), d);
         break;
       case shash("disconnect"):
         assert(items.size() == 3);

--- a/src/consensus/raft/test/driver.cpp
+++ b/src/consensus/raft/test/driver.cpp
@@ -26,7 +26,7 @@ int main(int argc, char** argv)
     vector<string> items{
       sregex_token_iterator(line.begin(), line.end(), delim, -1),
       std::sregex_token_iterator()};
-    std::shared_ptr<std::vector<uint8_t>> d;
+    std::shared_ptr<std::vector<uint8_t>> data;
     switch (shash(items[0].c_str()))
     {
       case shash("nodes"):
@@ -63,9 +63,9 @@ int main(int argc, char** argv)
         break;
       case shash("replicate"):
         assert(items.size() == 4);
-        d = std::make_shared<std::vector<uint8_t>>(
+        data = std::make_shared<std::vector<uint8_t>>(
           items[3].begin(), items[3].end());
-        driver->replicate(stoi(items[1]), stoi(items[2]), d);
+        driver->replicate(stoi(items[1]), stoi(items[2]), data);
         break;
       case shash("disconnect"):
         assert(items.size() == 3);

--- a/src/consensus/raft/test/driver.h
+++ b/src/consensus/raft/test/driver.h
@@ -217,7 +217,9 @@ public:
   }
 
   void replicate(
-    raft::NodeId node_id, raft::Index idx, const std::vector<uint8_t>& data)
+    raft::NodeId node_id,
+    raft::Index idx,
+    std::shared_ptr<std::vector<uint8_t>> data)
   {
     std::cout << "  KV" << node_id << "->>Node" << node_id
               << ": replicate idx: " << idx << std::endl;

--- a/src/consensus/test/stub_consensus.h
+++ b/src/consensus/test/stub_consensus.h
@@ -13,7 +13,7 @@ namespace kv
   class StubConsensus : public Consensus
   {
   private:
-    std::vector<std::vector<uint8_t>> replica;
+    std::vector<std::shared_ptr<std::vector<uint8_t>>> replica;
     ConsensusType consensus_type;
 
   public:
@@ -35,7 +35,7 @@ namespace kv
     std::pair<std::vector<uint8_t>, bool> get_latest_data()
     {
       if (!replica.empty())
-        return std::make_pair(replica.back(), true);
+        return std::make_pair(*replica.back(), true);
       else
         return std::make_pair(std::vector<uint8_t>(), false);
     }
@@ -44,7 +44,7 @@ namespace kv
     {
       if (!replica.empty())
       {
-        auto pair = std::make_pair(replica.front(), true);
+        auto pair = std::make_pair(*replica.front(), true);
         replica.erase(replica.begin());
         return pair;
       }

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -98,14 +98,14 @@ extern "C"
         thread_ids.emplace(std::pair<std::thread::id, uint16_t>(
           std::this_thread::get_id(), tid));
 
-        LOG_DEBUG_FMT("Starting thread: {}", tid);
+        LOG_INFO_FMT("Starting thread: {}", tid);
       }
 
       while (num_pending_threads != 0)
       {
       }
 
-      LOG_DEBUG_FMT("All threads are ready!");
+      LOG_INFO_FMT("All threads are ready!");
 
       if (tid == 0)
       {

--- a/src/enclave/rpchandler.h
+++ b/src/enclave/rpchandler.h
@@ -42,5 +42,6 @@ namespace enclave
       ccf::Store::Tx& tx,
       bool playback) = 0;
     virtual crypto::Sha256Hash get_merkle_root() = 0;
+    virtual void update_merkle_tree() = 0;
   };
 }

--- a/src/kv/kv.h
+++ b/src/kv/kv.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ds/champmap.h"
+#include "ds/dllist.h"
 #include "ds/logger.h"
 #include "ds/spinlock.h"
 #include "kvtypes.h"
@@ -86,11 +87,22 @@ namespace kv
 
     struct LocalCommit
     {
+      LocalCommit() = default;
+      LocalCommit(Version v, State s, Write w) :
+        version(std::move(v)),
+        state(std::move(s)),
+        writes(std::move(w)),
+        next(nullptr),
+        prev(nullptr)
+      {}
+
       Version version;
       State state;
       Write writes;
+      LocalCommit* next;
+      LocalCommit* prev;
     };
-    using LocalCommits = std::list<LocalCommit>;
+    using LocalCommits = snmalloc::DLList<LocalCommit>;
 
     Store<S, D>* store;
     std::string name;
@@ -102,6 +114,8 @@ namespace kv
     SpinLock sl;
     const SecurityDomain security_domain;
     const bool replicated;
+
+    LocalCommits empty_commits;
 
     Map(
       Store<S, D>* store_,
@@ -119,10 +133,26 @@ namespace kv
       local_hook(local_hook_),
       global_hook(global_hook_)
     {
-      roll->push_back({0, State(), Write()});
+      LocalCommit* c = CreateNewLocalCommit(0, State(), Write());
+      roll->insert_back(c);
     }
 
     Map(const Map& that) = delete;
+
+    template <typename... Args>
+    LocalCommit* CreateNewLocalCommit(Args&&... args)
+    {
+      LocalCommit* c = empty_commits.pop();
+      if (c == nullptr)
+      {
+        c = new LocalCommit(std::forward<Args>(args)...);
+      }
+      else
+      {
+        new (c) LocalCommit(std::forward<Args>(args)...);
+      }
+      return c;
+    }
 
   public:
     virtual AbstractMap<S, D>* clone(AbstractStore* store) override
@@ -201,22 +231,22 @@ namespace kv
       if (name != p->name)
         return false;
 
-      auto& state1 = roll->back();
-      auto& state2 = p->roll->back();
+      auto state1 = roll->get_tail();
+      auto state2 = p->roll->get_tail();
 
-      if (state1.version != state2.version)
+      if (state1->version != state2->version)
         return false;
 
       size_t count = 0;
-      state2.state.foreach([&count](const K& k, const VersionV& v) {
+      state2->state.foreach([&count](const K& k, const VersionV& v) {
         count++;
         return true;
       });
 
       size_t i = 0;
       bool ok =
-        state1.state.foreach([&state2, &i](const K& k, const VersionV& v) {
-          auto search = state2.state.get(k);
+        state1->state.foreach([&state2, &i](const K& k, const VersionV& v) {
+          auto search = state2->state.get(k);
 
           if (search.has_value())
           {
@@ -272,7 +302,7 @@ namespace kv
       TxView(This& parent, State& s, Version v, size_t r) :
         map(parent),
         state(s),
-        committed(parent.roll->front().state),
+        committed(parent.roll->get_head()->state),
         start_version(v),
         rollback_counter(r),
         read_version(NoVersion),
@@ -515,9 +545,9 @@ namespace kv
           return false;
 
         // If we have iterated over the map, check for a global version match.
-        auto& current = map.roll->back();
+        auto current = map.roll->get_tail();
 
-        if ((read_version != NoVersion) && (read_version != current.version))
+        if ((read_version != NoVersion) && (read_version != current->version))
         {
           LOG_DEBUG_FMT("Read version {} is invalid", read_version);
           return false;
@@ -527,7 +557,7 @@ namespace kv
         for (auto it = reads.begin(); it != reads.end(); ++it)
         {
           // Get the value from the current state.
-          auto search = current.state.get(it->first);
+          auto search = current->state.get(it->first);
 
           if (it->second == NoVersion)
           {
@@ -567,7 +597,7 @@ namespace kv
 
         if (!writes.empty())
         {
-          auto state = map.roll->back().state;
+          auto state = map.roll->get_tail()->state;
 
           for (auto it = writes.begin(); it != writes.end(); ++it)
           {
@@ -591,7 +621,7 @@ namespace kv
           }
 
           if (changes)
-            map.roll->push_back({v, state, writes});
+            map.roll->insert_back(map.CreateNewLocalCommit(v, state, writes));
         }
       }
 
@@ -605,8 +635,8 @@ namespace kv
 
         if (map.local_hook)
         {
-          auto& roll = map.roll->back();
-          map.local_hook(roll.version, roll.state, roll.writes);
+          auto roll = map.roll->get_tail();
+          map.local_hook(roll->version, roll->state, roll->writes);
         }
       }
 
@@ -641,7 +671,7 @@ namespace kv
           }
           else
           {
-            auto search = map.roll->back().state.get(it->first);
+            auto search = map.roll->get_tail()->state.get(it->first);
             if (search.has_value())
               ++remove_ctr;
           }
@@ -716,11 +746,13 @@ namespace kv
       // Find the last entry committed at or before this version.
       TxView* view = nullptr;
 
-      for (auto it = roll->rbegin(); it != roll->rend(); ++it)
+      for (auto current = roll->get_tail(); current != nullptr;
+           current = current->prev)
       {
-        if (it->version <= version)
+        if (current->version <= version)
         {
-          view = new TxView(*this, it->state, it->version, rollback_counter);
+          view = new TxView(
+            *this, current->state, current->version, rollback_counter);
           break;
         }
       }
@@ -728,7 +760,10 @@ namespace kv
       if (view == nullptr)
       {
         view = new TxView(
-          *this, roll->front().state, roll->front().version, rollback_counter);
+          *this,
+          roll->get_head()->state,
+          roll->get_head()->version,
+          rollback_counter);
       }
 
       unlock();
@@ -740,46 +775,56 @@ namespace kv
       // This discards available rollback state before version v, and populates
       // the commit_deltas to be passed to the global commit hook, if there is
       // one, up to version v. The Map expects to be locked during compaction.
-      while (roll->size() > 1)
+      while (roll->get_head() != roll->get_tail())
       {
-        auto r = roll->begin();
+        auto r = roll->get_head();
 
         // Globally committed but not discardable.
         if (r->version == v)
         {
           // We know that write set is not empty.
           if (global_hook)
-            commit_deltas.emplace_back(
-              LocalCommit{r->version, r->state, move(r->writes)});
+          {
+            commit_deltas.insert_back(
+              CreateNewLocalCommit(r->version, r->state, move(r->writes)));
+          }
           return;
         }
 
         // Discardable, so move to commit_deltas.
         if (global_hook && !r->writes.empty())
-          std::move(r, std::next(r), std::back_inserter(commit_deltas));
+        {
+          commit_deltas.insert_back(
+            CreateNewLocalCommit(r->version, r->state, move(r->writes)));
+        }
 
         // Stop if the next state may be rolled back or is the only state.
         // This ensures there is always a state present.
-        if (std::next(r)->version > v)
+        if (r->next->version > v)
           return;
 
-        roll->pop_front();
+        auto c = roll->pop();
+        empty_commits.insert(c);
       }
 
       // There is only one roll. We may need to call the commit hook.
-      auto r = roll->begin();
+      auto r = roll->get_head();
 
       if (global_hook && !r->writes.empty())
-        commit_deltas.emplace_back(
-          LocalCommit{r->version, r->state, move(r->writes)});
+      {
+        commit_deltas.insert_back(
+          CreateNewLocalCommit(r->version, r->state, move(r->writes)));
+      }
     }
 
     void post_compact() override
     {
       if (global_hook)
       {
-        for (auto& r : commit_deltas)
-          global_hook(r.version, r.state, r.writes);
+        for (auto r = commit_deltas.get_head(); r != nullptr; r = r->next)
+        {
+          global_hook(r->version, r->state, r->writes);
+        }
       }
 
       commit_deltas.clear();
@@ -791,17 +836,18 @@ namespace kv
       // The Map expects to be locked during rollback.
       bool advance = false;
 
-      while (roll->size() > 1)
+      while (roll->get_head() != roll->get_tail())
       {
-        auto& r = roll->back();
+        auto r = roll->get_tail();
 
         // The initial empty state has v = 0, so will not be discarded if it
         // is present.
-        if (r.version <= v)
+        if (r->version <= v)
           break;
 
         advance = true;
-        roll->pop_back();
+        auto c = roll->pop_tail();
+        empty_commits.insert(c);
       }
 
       if (advance)
@@ -813,7 +859,7 @@ namespace kv
       // This discards all entries in the roll and resets the compacted value
       // and rollback counter. The Map expects to be locked before clearing it.
       roll->clear();
-      roll->push_back({0, State(), Write()});
+      roll->insert_back(new LocalCommit(0, State(), Write()));
       rollback_counter = 0;
     }
 
@@ -1757,6 +1803,7 @@ namespace kv
            std::make_pair(std::move(pending_tx), globally_committable)});
 
         auto h = get_history();
+        auto c = get_consensus();
 
         for (Version offset = 1; true; ++offset)
         {
@@ -1766,6 +1813,8 @@ namespace kv
 
           auto& [pending_tx_, committable_] = search->second;
           auto [success_, reqid, data_] = pending_tx_();
+          auto data_shared =
+            std::make_shared<std::vector<uint8_t>>(std::move(data_));
 
           // NB: this cannot happen currently. Regular Tx only make it here if
           // they did succeed, and signatures cannot conflict because they
@@ -1776,13 +1825,21 @@ namespace kv
 
           if (h)
           {
-            h->add_result(reqid, version, data_.data(), data_.size());
+            if (c->type() == ConsensusType::RAFT)
+            {
+              h->add_result(
+                reqid, version, data_shared->data(), data_shared->size());
+            }
+            else
+            {
+              h->add_pending_result(reqid, version, data_shared);
+            }
           }
 
           LOG_DEBUG_FMT(
-            "Batching {} ({})", last_replicated + offset, data_.size());
+            "Batching {} ({})", last_replicated + offset, data_shared->size());
           batch.emplace_back(
-            last_replicated + offset, std::move(data_), committable_);
+            last_replicated + offset, data_shared, committable_);
           pending_txs.erase(search);
         }
 
@@ -1800,12 +1857,13 @@ namespace kv
         if (
           last_replicated == previous_last_replicated &&
           previous_rollback_count == rollback_count)
+        {
           last_replicated = next_last_replicated;
+        }
         return CommitSuccess::OK;
       }
       else
       {
-        std::lock_guard<SpinLock> vguard(version_lock);
         LOG_DEBUG_FMT("Failed to replicate");
         return CommitSuccess::NO_REPLICATE;
       }
@@ -1844,13 +1902,15 @@ namespace kv
       for (auto& map : maps)
         map.second->unlock();
 
-      std::lock_guard<SpinLock> vguard(version_lock);
-      version = 0;
-      compacted = 0;
-      last_replicated = 0;
-      last_committable = 0;
-      rollback_count = 0;
-      pending_txs.clear();
+      {
+        std::lock_guard<SpinLock> vguard(version_lock);
+        version = 0;
+        compacted = 0;
+        last_replicated = 0;
+        last_committable = 0;
+        rollback_count = 0;
+        pending_txs.clear();
+      }
     }
 
     /** This is only safe in very restricted circumstances, and is only

--- a/src/kv/kv.h
+++ b/src/kv/kv.h
@@ -1827,15 +1827,7 @@ namespace kv
 
           if (h)
           {
-            if (c->type() == ConsensusType::RAFT)
-            {
-              h->add_result(
-                reqid, version, data_shared->data(), data_shared->size());
-            }
-            else
-            {
-              h->add_pending_result(reqid, version, data_shared);
-            }
+            h->add_pending(reqid, version, data_shared);
           }
 
           LOG_DEBUG_FMT(

--- a/src/kv/kvtypes.h
+++ b/src/kv/kvtypes.h
@@ -27,8 +27,8 @@ namespace kv
   using NodeId = uint64_t;
   static const Version NoVersion = std::numeric_limits<Version>::min();
 
-  using BatchVector =
-    std::vector<std::tuple<kv::Version, std::vector<uint8_t>, bool>>;
+  using BatchVector = std::vector<
+    std::tuple<kv::Version, std::shared_ptr<std::vector<uint8_t>>, bool>>;
 
   enum CommitSuccess
   {
@@ -130,6 +130,11 @@ namespace kv
       RequestID id,
       kv::Version version,
       const std::vector<uint8_t>& replicated) = 0;
+    virtual void add_pending_result(
+      RequestID id,
+      kv::Version version,
+      std::shared_ptr<std::vector<uint8_t>> replicated) = 0;
+    virtual void execute_pending() = 0;
     virtual void add_result(
       RequestID id,
       kv::Version version,

--- a/src/kv/kvtypes.h
+++ b/src/kv/kvtypes.h
@@ -130,7 +130,7 @@ namespace kv
       RequestID id,
       kv::Version version,
       const std::vector<uint8_t>& replicated) = 0;
-    virtual void add_pending_result(
+    virtual void add_pending(
       RequestID id,
       kv::Version version,
       std::shared_ptr<std::vector<uint8_t>> replicated) = 0;

--- a/src/kv/test/kv_bench.cpp
+++ b/src/kv/test/kv_bench.cpp
@@ -123,7 +123,7 @@ static void commit_latency(picobench::state& s)
           "Transaction commit failed: " + std::to_string(rc));
     }
     s.start_timer();
-    kv_store.compact(0);
+    kv_store.compact(kv_store.current_version());
     clobber_memory();
     s.stop_timer();
   }

--- a/src/kv/test/kv_bench.cpp
+++ b/src/kv/test/kv_bench.cpp
@@ -130,10 +130,7 @@ const uint32_t sample_size = 100;
 using SD = kv::SecurityDomain;
 
 PICOBENCH_SUITE("commit_latency");
-PICOBENCH(commit_latency)
-  .iterations(tx_count)
-  .samples(10)
-  .baseline();
+PICOBENCH(commit_latency).iterations(tx_count).samples(10).baseline();
 
 PICOBENCH_SUITE("serialise");
 PICOBENCH(serialise<SD::PUBLIC>)

--- a/src/kv/test/kv_bench.cpp
+++ b/src/kv/test/kv_bench.cpp
@@ -89,10 +89,51 @@ static void deserialise(picobench::state& s)
   s.stop_timer();
 }
 
-const std::vector<int> tx_count = {10, 100, 200};
+static void commit_latency(picobench::state& s)
+{
+  logger::config::level() = logger::INFO;
+
+  Store kv_store;
+  auto secrets = create_ledger_secrets();
+  auto encryptor = std::make_shared<ccf::RaftTxEncryptor>(1, secrets);
+  kv_store.set_encryptor(encryptor);
+
+  auto& map0 = kv_store.create<std::string, std::string>("map0");
+  auto& map1 = kv_store.create<std::string, std::string>("map1");
+
+  for (int j = 0; j < s.iterations(); j++)
+  {
+    Store::Tx tx;
+    auto [tx0, tx1] = tx.get_view(map0, map1);
+
+    for (int i = 0; i < s.iterations(); i++)
+    {
+      auto key = "key" + std::to_string(i);
+      tx0->put(key, "value");
+      tx1->put(key, "value");
+    }
+    auto rc = tx.commit();
+    if (rc != kv::CommitSuccess::OK)
+      throw std::logic_error(
+        "Transaction commit failed: " + std::to_string(rc));
+  }
+
+  kv_store.compact(0);
+
+  s.start_timer();
+  s.stop_timer();
+}
+
+const std::vector<int> tx_count = {10, 100, 1000};
 const uint32_t sample_size = 100;
 
 using SD = kv::SecurityDomain;
+
+PICOBENCH_SUITE("commit_latency");
+PICOBENCH(commit_latency)
+  .iterations(tx_count)
+  .samples(10)
+  .baseline();
 
 PICOBENCH_SUITE("serialise");
 PICOBENCH(serialise<SD::PUBLIC>)

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -4,6 +4,7 @@
 
 #include "consensus/pbft/pbfttypes.h"
 #include "crypto/hash.h"
+#include "ds/dllist.h"
 #include "ds/logger.h"
 #include "entities.h"
 #include "kv/kvtypes.h"
@@ -147,6 +148,14 @@ namespace ccf
       kv::Version version,
       const std::vector<uint8_t>& replicated) override
     {}
+
+    void add_pending_result(
+      kv::TxHistory::RequestID id,
+      kv::Version version,
+      std::shared_ptr<std::vector<uint8_t>> replicated) override
+    {}
+
+    void execute_pending() override {}
 
     virtual void add_result(
       RequestID id,
@@ -538,6 +547,54 @@ namespace ccf
       }
 
       return consensus->on_request({id, request, caller_id, caller_cert});
+    }
+
+    struct PendingInsert
+    {
+      PendingInsert(
+        kv::TxHistory::RequestID i,
+        kv::Version v,
+        std::shared_ptr<std::vector<uint8_t>> r) :
+        id(i),
+        version(v),
+        replicated(std::move(r)),
+        next(nullptr),
+        prev(nullptr)
+      {}
+
+      kv::TxHistory::RequestID id;
+      kv::Version version;
+      std::shared_ptr<std::vector<uint8_t>> replicated;
+      PendingInsert* next;
+      PendingInsert* prev;
+    };
+
+    SpinLock version_lock;
+    snmalloc::DLList<PendingInsert> pending_inserts;
+
+    void add_pending_result(
+      kv::TxHistory::RequestID id,
+      kv::Version version,
+      std::shared_ptr<std::vector<uint8_t>> replicated) override
+    {
+      std::lock_guard<SpinLock> vguard(version_lock);
+      pending_inserts.insert_back(new PendingInsert(id, version, replicated));
+    }
+
+    void execute_pending() override
+    {
+      snmalloc::DLList<PendingInsert> pi;
+      {
+        std::lock_guard<SpinLock> vguard(version_lock);
+        pi = std::move(pending_inserts);
+      }
+
+      PendingInsert* p = pi.get_head();
+      while (p != nullptr)
+      {
+        add_result(p->id, p->version, *p->replicated);
+        p = p->next;
+      }
     }
 
     void add_result(

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -587,7 +587,6 @@ namespace ccf
       {
         std::lock_guard<SpinLock> vguard(version_lock);
         pi = std::move(pending_inserts);
-        assert (pending_inserts.is_empty());
       }
 
       PendingInsert* p = pi.get_head();

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -570,7 +570,7 @@ namespace ccf
     };
 
     SpinLock version_lock;
-    snmalloc::DLList<PendingInsert> pending_inserts;
+    snmalloc::DLList<PendingInsert, std::nullptr_t, true> pending_inserts;
 
     void add_pending_result(
       kv::TxHistory::RequestID id,
@@ -583,10 +583,11 @@ namespace ccf
 
     void execute_pending() override
     {
-      snmalloc::DLList<PendingInsert> pi;
+      snmalloc::DLList<PendingInsert, std::nullptr_t, true> pi;
       {
         std::lock_guard<SpinLock> vguard(version_lock);
         pi = std::move(pending_inserts);
+        assert (pending_inserts.is_empty());
       }
 
       PendingInsert* p = pi.get_head();

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -378,6 +378,11 @@ namespace ccf
       return history->get_replicated_state_root();
     }
 
+    void update_merkle_tree() override
+    {
+      history->execute_pending();
+    }
+
     /** Process a serialised input forwarded from another node
      *
      * This function assumes that ctx contains the caller_id as read by the

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -32,7 +32,7 @@ public:
     if (store)
     {
       REQUIRE(entries.size() == 1);
-      return store->deserialise(std::get<1>(entries[0]));
+      return store->deserialise(*std::get<1>(entries[0]));
     }
     return true;
   }


### PR DESCRIPTION
- Reduce the cost of the roll data structure in the KV
- Reply's do not need a digest in addition to the node-to-node integrity check
- for PBFT do not add to the Merkle tree at the same time as commit, do this on another thread
- other misc PBFT optimizations