### PR TITLE
Fix hardcoded paths in CCF install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,25 +42,6 @@ option(BUILD_SMALLBANK "Build SmallBank sample app and clients" ON)
 # Build common library for CCF enclaves
 add_custom_target(ccf ALL)
 
-add_library(ccf.test STATIC ${CCF_DIR}/src/tls/main.cpp)
-target_include_directories(
-    ccf.test SYSTEM
-    PUBLIC
-      "$<BUILD_INTERFACE:${EVERCRYPT_INC}>"
-      $<BUILD_INTERFACE:${CCF_GENERATED_DIR}>
-      # "$<INSTALL_INTERFACE:${EVERCRYPT_INC}>"
-      $<INSTALL_INTERFACE:include/3rdparty/hacl-star/evercrypt>
-      $<INSTALL_INTERFACE:include/3rdparty/hacl-star/evercrypt/kremlin>
-      $<INSTALL_INTERFACE:include/3rdparty/hacl-star/evercrypt/kremlin/kremlib>
-)
-install(
-  TARGETS ccf.test
-  EXPORT ccf
-  DESTINATION lib
-)
-
-
-
 if("sgx" IN_LIST TARGET)
   # enclave version
   add_library(
@@ -78,7 +59,7 @@ if("sgx" IN_LIST TARGET)
   target_include_directories(
     ccf.enclave SYSTEM
     PUBLIC
-     "$<BUILD_INTERFACE:${EVERCRYPT_INC}>"
+      "$<BUILD_INTERFACE:${EVERCRYPT_INC}>"
       $<BUILD_INTERFACE:${CCF_GENERATED_DIR}>
       $<INSTALL_INTERFACE:include/3rdparty/hacl-star/evercrypt>
       $<INSTALL_INTERFACE:include/3rdparty/hacl-star/evercrypt/kremlin>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,9 @@ target_include_directories(
       "$<BUILD_INTERFACE:${EVERCRYPT_INC}>"
       $<BUILD_INTERFACE:${CCF_GENERATED_DIR}>
       # "$<INSTALL_INTERFACE:${EVERCRYPT_INC}>"
-      # $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt>
-      # $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt/kremlin>
-      # $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt/kremlin/kremlib>
+      $<INSTALL_INTERFACE:include/3rdparty/hacl-star/evercrypt>
+      $<INSTALL_INTERFACE:include/3rdparty/hacl-star/evercrypt/kremlin>
+      $<INSTALL_INTERFACE:include/3rdparty/hacl-star/evercrypt/kremlin/kremlib>
 )
 install(
   TARGETS ccf.test
@@ -80,9 +80,9 @@ if("sgx" IN_LIST TARGET)
     PUBLIC
      "$<BUILD_INTERFACE:${EVERCRYPT_INC}>"
       $<BUILD_INTERFACE:${CCF_GENERATED_DIR}>
-      # $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt>
-      # $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt/kremlin>
-      # $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt/kremlin/kremlib>
+      $<INSTALL_INTERFACE:include/3rdparty/hacl-star/evercrypt>
+      $<INSTALL_INTERFACE:include/3rdparty/hacl-star/evercrypt/kremlin>
+      $<INSTALL_INTERFACE:include/3rdparty/hacl-star/evercrypt/kremlin/kremlib>
   )
 
   target_link_libraries(ccf.enclave PUBLIC libbyz.enclave)
@@ -132,9 +132,9 @@ if("virtual" IN_LIST TARGET)
     PUBLIC
       "$<BUILD_INTERFACE:${EVERCRYPT_INC}>"
       $<BUILD_INTERFACE:${CCF_GENERATED_DIR}>
-      $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt>
-      $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt/kremlin>
-      $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt/kremlin/kremlib>
+      $<INSTALL_INTERFACE:include/3rdparty/hacl-star/evercrypt>
+      $<INSTALL_INTERFACE:include/3rdparty/hacl-star/evercrypt/kremlin>
+      $<INSTALL_INTERFACE:include/3rdparty/hacl-star/evercrypt/kremlin/kremlib>
   )
 
   target_link_libraries(ccf.virtual PUBLIC libbyz.host)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,25 @@ option(BUILD_SMALLBANK "Build SmallBank sample app and clients" ON)
 # Build common library for CCF enclaves
 add_custom_target(ccf ALL)
 
+add_library(ccf.test STATIC ${CCF_DIR}/src/tls/main.cpp)
+target_include_directories(
+    ccf.test SYSTEM
+    PUBLIC
+      "$<BUILD_INTERFACE:${EVERCRYPT_INC}>"
+      $<BUILD_INTERFACE:${CCF_GENERATED_DIR}>
+      # "$<INSTALL_INTERFACE:${EVERCRYPT_INC}>"
+      # $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt>
+      # $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt/kremlin>
+      # $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt/kremlin/kremlib>
+)
+install(
+  TARGETS ccf.test
+  EXPORT ccf
+  DESTINATION lib
+)
+
+
+
 if("sgx" IN_LIST TARGET)
   # enclave version
   add_library(
@@ -59,11 +78,11 @@ if("sgx" IN_LIST TARGET)
   target_include_directories(
     ccf.enclave SYSTEM
     PUBLIC
-      $<BUILD_INTERFACE:${EVERCRYPT_INC}>
+     "$<BUILD_INTERFACE:${EVERCRYPT_INC}>"
       $<BUILD_INTERFACE:${CCF_GENERATED_DIR}>
-      $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt>
-      $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt/kremlin>
-      $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt/kremlin/kremlib>
+      # $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt>
+      # $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt/kremlin>
+      # $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt/kremlin/kremlib>
   )
 
   target_link_libraries(ccf.enclave PUBLIC libbyz.enclave)
@@ -111,7 +130,7 @@ if("virtual" IN_LIST TARGET)
   target_include_directories(
     ccf.virtual SYSTEM
     PUBLIC
-      $<BUILD_INTERFACE:${EVERCRYPT_INC}>
+      "$<BUILD_INTERFACE:${EVERCRYPT_INC}>"
       $<BUILD_INTERFACE:${CCF_GENERATED_DIR}>
       $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt>
       $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/hacl-star/evercrypt/kremlin>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(${CCF_DIR}/cmake/preproject.cmake)
 
 project(
   ccf
-  VERSION 0.8.1
+  VERSION 0.8.2
   LANGUAGES C CXX
 )
 

--- a/cmake/secp256k1.cmake
+++ b/cmake/secp256k1.cmake
@@ -9,7 +9,7 @@ if("sgx" IN_LIST TARGET)
     secp256k1.enclave
     PUBLIC
       $<BUILD_INTERFACE:${CCF_DIR}/3rdparty/secp256k1>
-      $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/secp256k1>
+      $<INSTALL_INTERFACE:include/3rdparty/secp256k1>
   )
   target_compile_options(
     secp256k1.enclave PRIVATE -fvisibility=hidden -nostdinc
@@ -30,7 +30,7 @@ add_library(secp256k1.host STATIC ${CCF_DIR}/3rdparty/secp256k1/src/secp256k1.c)
 target_include_directories(
   secp256k1.host
   PUBLIC $<BUILD_INTERFACE:${CCF_DIR}/3rdparty/secp256k1>
-         $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/3rdparty/secp256k1>
+         $<INSTALL_INTERFACE:include/3rdparty/secp256k1>
 )
 target_compile_options(secp256k1.host PRIVATE -fvisibility=hidden)
 target_compile_definitions(secp256k1.host PRIVATE HAVE_CONFIG_H SECP256K1_BUILD)

--- a/cmake/secp256k1.cmake
+++ b/cmake/secp256k1.cmake
@@ -6,10 +6,8 @@ if("sgx" IN_LIST TARGET)
     secp256k1.enclave STATIC ${CCF_DIR}/3rdparty/secp256k1/src/secp256k1.c
   )
   target_include_directories(
-    secp256k1.enclave
-    PUBLIC
-      $<BUILD_INTERFACE:${CCF_DIR}/3rdparty/secp256k1>
-      $<INSTALL_INTERFACE:include/3rdparty/secp256k1>
+    secp256k1.enclave PUBLIC $<BUILD_INTERFACE:${CCF_DIR}/3rdparty/secp256k1>
+                             $<INSTALL_INTERFACE:include/3rdparty/secp256k1>
   )
   target_compile_options(
     secp256k1.enclave PRIVATE -fvisibility=hidden -nostdinc
@@ -28,9 +26,8 @@ endif()
 
 add_library(secp256k1.host STATIC ${CCF_DIR}/3rdparty/secp256k1/src/secp256k1.c)
 target_include_directories(
-  secp256k1.host
-  PUBLIC $<BUILD_INTERFACE:${CCF_DIR}/3rdparty/secp256k1>
-         $<INSTALL_INTERFACE:include/3rdparty/secp256k1>
+  secp256k1.host PUBLIC $<BUILD_INTERFACE:${CCF_DIR}/3rdparty/secp256k1>
+                        $<INSTALL_INTERFACE:include/3rdparty/secp256k1>
 )
 target_compile_options(secp256k1.host PRIVATE -fvisibility=hidden)
 target_compile_definitions(secp256k1.host PRIVATE HAVE_CONFIG_H SECP256K1_BUILD)

--- a/src/tls/main.cpp
+++ b/src/tls/main.cpp
@@ -1,0 +1,6 @@
+
+
+int main()
+{
+  return 0;
+}

--- a/src/tls/main.cpp
+++ b/src/tls/main.cpp
@@ -1,6 +1,0 @@
-
-
-int main()
-{
-  return 0;
-}


### PR DESCRIPTION
Fix https://github.com/microsoft/CCF/issues/948

This fixes two issues:
- `$<BUILD_INTERFACE:${EVERCRYPT_INC}>` was used without " " for the `ccf.enclave` and `ccf.host` targets, which means that the CCF source directory got exported as an installed include directory.
- The install prefix `${CMAKE_INSTALL_PREFIX}` was hardcoded in the `INSTALL_INTERFACE`, which means that it was only possible to install CCF in one given location (`/tmp/install-ccf`, as per the CI Release build).

I will create v0.8.2 when this is merged.