### PR TITLE
Enable more pbft tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,7 +482,6 @@ if(BUILD_TESTS)
     ADDITIONAL_ARGS --test-duration 150 --enforce-reqs
   )
 
-  # PBFT can't run due to max len < len in client proxy
   add_e2e_test(
     NAME lua_end_to_end_batched
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_batched.py
@@ -491,7 +490,6 @@ if(BUILD_TESTS)
                     ${CMAKE_SOURCE_DIR}/src/apps/batched/batched.lua
   )
 
-  # throws because of rollback that rolls back before last checkpoint
   add_e2e_test(
     NAME js_end_to_end_logging
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,14 +500,6 @@ if(BUILD_TESTS)
                     ${CMAKE_SOURCE_DIR}/src/apps/logging/loggingjs.lua
   )
 
-  if(NOT SAN)
-    add_e2e_test(
-      NAME connections
-      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/connections.py
-      CONSENSUS raft
-    )
-  endif()
-
   if(QUOTES_ENABLED)
     add_e2e_test(
       NAME reconfiguration_test
@@ -535,6 +527,14 @@ if(BUILD_TESTS)
   endif()
 
   foreach(CONSENSUS ${CONSENSUSES})
+    if(NOT SAN)
+      add_e2e_test(
+        NAME connections_${CONSENSUS}
+        PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/connections.py
+        CONSENSUS ${CONSENSUS}
+      )
+    endif()
+
     add_e2e_test(
       NAME lua_end_to_end_logging_${CONSENSUS}
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,22 +460,6 @@ if(BUILD_TESTS)
       ${CMAKE_CURRENT_SOURCE_DIR}/samples/apps/txregulator/dataset/sample_data.csv
   )
 
-  # Receipts end to end test
-  add_e2e_test(
-    NAME receipts_test
-    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/receipts.py
-    CONSENSUS raft
-  )
-
-  if(QUOTES_ENABLED)
-    add_e2e_test(
-      NAME governance_tests
-      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/governance.py
-      CONSENSUS raft
-      ADDITIONAL_ARGS --oesign ${OE_SIGN_PATH}
-    )
-  endif()
-
   add_e2e_test(
     NAME recovery_tests
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/recovery.py
@@ -498,6 +482,7 @@ if(BUILD_TESTS)
     ADDITIONAL_ARGS --test-duration 150 --enforce-reqs
   )
 
+  # PBFT can't run due to max len < len in client proxy
   add_e2e_test(
     NAME lua_end_to_end_batched
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_batched.py
@@ -506,28 +491,13 @@ if(BUILD_TESTS)
                     ${CMAKE_SOURCE_DIR}/src/apps/batched/batched.lua
   )
 
+  # throws because of rollback that rolls back before last checkpoint
   add_e2e_test(
     NAME js_end_to_end_logging
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py
     CONSENSUS raft
     ADDITIONAL_ARGS --js-app-script
                     ${CMAKE_SOURCE_DIR}/src/apps/logging/loggingjs.lua
-  )
-
-  add_e2e_test(
-    NAME lua_end_to_end_logging
-    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py
-    CONSENSUS raft
-    ADDITIONAL_ARGS --app-script
-                    ${CMAKE_SOURCE_DIR}/src/apps/logging/logging.lua
-  )
-
-  add_e2e_test(
-    NAME end_to_end_scenario
-    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_scenarios.py
-    CONSENSUS raft
-    ADDITIONAL_ARGS --scenario
-                    ${CMAKE_SOURCE_DIR}/tests/simple_logging_scenario.json
   )
 
   if(NOT SAN)
@@ -537,14 +507,6 @@ if(BUILD_TESTS)
       CONSENSUS raft
     )
   endif()
-
-  add_e2e_test(
-    NAME schema_tests
-    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/schema.py
-    CONSENSUS raft
-    ADDITIONAL_ARGS -p liblogging --schema-dir
-                    ${CMAKE_SOURCE_DIR}/sphinx/source/schemas
-  )
 
   if(QUOTES_ENABLED)
     add_e2e_test(
@@ -573,6 +535,45 @@ if(BUILD_TESTS)
   endif()
 
   foreach(CONSENSUS ${CONSENSUSES})
+    add_e2e_test(
+      NAME lua_end_to_end_logging_${CONSENSUS}
+      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py
+      CONSENSUS ${CONSENSUS}
+      ADDITIONAL_ARGS --app-script
+                      ${CMAKE_SOURCE_DIR}/src/apps/logging/logging.lua
+    )
+
+    if(QUOTES_ENABLED)
+      add_e2e_test(
+        NAME governance_tests_${CONSENSUS}
+        PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/governance.py
+        CONSENSUS ${CONSENSUS}
+        ADDITIONAL_ARGS --oesign ${OE_SIGN_PATH}
+      )
+    endif()
+
+    add_e2e_test(
+      NAME end_to_end_scenario_${CONSENSUS}
+      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_scenarios.py
+      CONSENSUS ${CONSENSUS}
+      ADDITIONAL_ARGS --scenario
+                      ${CMAKE_SOURCE_DIR}/tests/simple_logging_scenario.json
+    )
+
+    add_e2e_test(
+      NAME receipts_test_${CONSENSUS}
+      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/receipts.py
+      CONSENSUS ${CONSENSUS}
+    )
+
+    add_e2e_test(
+      NAME schema_tests_${CONSENSUS}
+      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/schema.py
+      CONSENSUS ${CONSENSUS}
+      ADDITIONAL_ARGS -p liblogging --schema-dir
+                      ${CMAKE_SOURCE_DIR}/sphinx/source/schemas
+    )
+
     add_e2e_test(
       NAME end_to_end_logging_${CONSENSUS}
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,6 +483,22 @@ if(BUILD_TESTS)
   )
 
   add_e2e_test(
+    NAME end_to_end_scenario
+    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_scenarios.py
+    CONSENSUS raft
+    ADDITIONAL_ARGS --scenario
+                    ${CMAKE_SOURCE_DIR}/tests/simple_logging_scenario.json
+  )
+
+  add_e2e_test(
+    NAME lua_end_to_end_logging
+    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py
+    CONSENSUS raft
+    ADDITIONAL_ARGS --app-script
+                    ${CMAKE_SOURCE_DIR}/src/apps/logging/logging.lua
+  )
+
+  add_e2e_test(
     NAME lua_end_to_end_batched
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_batched.py
     CONSENSUS raft
@@ -533,14 +549,6 @@ if(BUILD_TESTS)
       )
     endif()
 
-    add_e2e_test(
-      NAME lua_end_to_end_logging_${CONSENSUS}
-      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py
-      CONSENSUS ${CONSENSUS}
-      ADDITIONAL_ARGS --app-script
-                      ${CMAKE_SOURCE_DIR}/src/apps/logging/logging.lua
-    )
-
     if(QUOTES_ENABLED)
       add_e2e_test(
         NAME governance_tests_${CONSENSUS}
@@ -549,14 +557,6 @@ if(BUILD_TESTS)
         ADDITIONAL_ARGS --oesign ${OE_SIGN_PATH}
       )
     endif()
-
-    add_e2e_test(
-      NAME end_to_end_scenario_${CONSENSUS}
-      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_scenarios.py
-      CONSENSUS ${CONSENSUS}
-      ADDITIONAL_ARGS --scenario
-                      ${CMAKE_SOURCE_DIR}/tests/simple_logging_scenario.json
-    )
 
     add_e2e_test(
       NAME receipts_test_${CONSENSUS}

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -14,6 +14,18 @@ sign_app_library(
   ${CCF_DIR}/src/apps/sample_key.pem
 )
 
+if(${SERVICE_IDENTITY_CURVE_CHOICE} STREQUAL "secp256k1_bitcoin")
+  set(SMALL_BANK_SIGNED_VERIFICATION_FILE
+      ${CMAKE_CURRENT_LIST_DIR}/tests/verify_small_bank_50k.json
+  )
+  set(SMALL_BANK_SIGNED_ITERATIONS 50000)
+else()
+  set(SMALL_BANK_SIGNED_VERIFICATION_FILE
+      ${CMAKE_CURRENT_LIST_DIR}/tests/verify_small_bank_2k.json
+  )
+  set(SMALL_BANK_SIGNED_ITERATIONS 2000)
+endif()
+
 if(BUILD_TESTS)
   # Small Bank end to end and performance test
   foreach(CONSENSUS ${CONSENSUSES})
@@ -49,38 +61,26 @@ if(BUILD_TESTS)
         --metrics-file small_bank_${CONSENSUS}_metrics.json
     )
 
+    # These tests require client-signed signatures: - HTTP C++ perf clients
+    # don't currently sign correctly
+    add_perf_test(
+      NAME small_bank_sigs_client_test_${CONSENSUS}
+      PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/small_bank_client.py
+      CLIENT_BIN ./small_bank_client
+      VERIFICATION_FILE ${SMALL_BANK_SIGNED_VERIFICATION_FILE}
+      LABEL "SB_sig"
+      CONSENSUS ${CONSENSUS}
+      ADDITIONAL_ARGS
+        --transactions
+        ${SMALL_BANK_SIGNED_ITERATIONS}
+        --max-writes-ahead
+        1000
+        --sign
+        --metrics-file
+        small_bank_${CONSENSUS}_sigs_metrics.json
+    )
+
   endforeach()
-
-  if(${SERVICE_IDENTITY_CURVE_CHOICE} STREQUAL "secp256k1_bitcoin")
-    set(SMALL_BANK_SIGNED_VERIFICATION_FILE
-        ${CMAKE_CURRENT_LIST_DIR}/tests/verify_small_bank_50k.json
-    )
-    set(SMALL_BANK_SIGNED_ITERATIONS 50000)
-  else()
-    set(SMALL_BANK_SIGNED_VERIFICATION_FILE
-        ${CMAKE_CURRENT_LIST_DIR}/tests/verify_small_bank_2k.json
-    )
-    set(SMALL_BANK_SIGNED_ITERATIONS 2000)
-  endif()
-
-  # These tests require client-signed signatures: - PBFT doesn't yet verify
-  # these correctly - HTTP C++ perf clients don't currently sign correctly
-  add_perf_test(
-    NAME small_bank_sigs_client_test
-    PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/small_bank_client.py
-    CLIENT_BIN ./small_bank_client
-    VERIFICATION_FILE ${SMALL_BANK_SIGNED_VERIFICATION_FILE}
-    LABEL "SB_sig"
-    CONSENSUS raft
-    ADDITIONAL_ARGS
-      --transactions
-      ${SMALL_BANK_SIGNED_ITERATIONS}
-      --max-writes-ahead
-      1000
-      --sign
-      --metrics-file
-      small_bank_sigs_metrics.json
-  )
 
   # It is better to run performance tests with forwarding on different machines
   # (i.e. nodes and clients)

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -61,8 +61,6 @@ if(BUILD_TESTS)
         --metrics-file small_bank_${CONSENSUS}_metrics.json
     )
 
-    # These tests require client-signed signatures: - HTTP C++ perf clients
-    # don't currently sign correctly
     add_perf_test(
       NAME small_bank_sigs_client_test_${CONSENSUS}
       PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/small_bank_client.py

--- a/tests/code_update.py
+++ b/tests/code_update.py
@@ -92,7 +92,7 @@ def run(args):
             args.patched_file_name, "localhost", args
         )
         assert new_node
-        network.wait_for_node_commit_sync()
+        network.wait_for_node_commit_sync(args.consensus)
 
 
 if __name__ == "__main__":

--- a/tests/connections.py
+++ b/tests/connections.py
@@ -23,7 +23,7 @@ from loguru import logger as LOG
 
 
 def run(args):
-    hosts = ["localhost"]
+    hosts = ["localhost"] * (4 if args.consensus == "pbft" else 1)
 
     with infra.ccf.network(
         hosts, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -15,12 +15,18 @@ from loguru import logger as LOG
 @reqs.at_least_n_nodes(2)
 def test(network, args, notifications_queue=None, verify=True):
     txs = app.LoggingTxs(notifications_queue=notifications_queue)
-    txs.issue(network=network, number_txs=1, wait_for_sync=args.consensus == "raft")
+    txs.issue(
+        network=network,
+        number_txs=1,
+        wait_for_sync=args.consensus == "raft",
+        consensus=args.consensus,
+    )
     txs.issue(
         network=network,
         number_txs=1,
         on_backup=True,
         wait_for_sync=args.consensus == "raft",
+        consensus=args.consensus,
     )
     if verify:
         txs.verify(network)

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -16,17 +16,10 @@ from loguru import logger as LOG
 def test(network, args, notifications_queue=None, verify=True):
     txs = app.LoggingTxs(notifications_queue=notifications_queue)
     txs.issue(
-        network=network,
-        number_txs=1,
-        wait_for_sync=args.consensus == "raft",
-        consensus=args.consensus,
+        network=network, number_txs=1, consensus=args.consensus,
     )
     txs.issue(
-        network=network,
-        number_txs=1,
-        on_backup=True,
-        wait_for_sync=args.consensus == "raft",
-        consensus=args.consensus,
+        network=network, number_txs=1, on_backup=True, consensus=args.consensus,
     )
     if verify:
         txs.verify(network)

--- a/tests/e2e_scenarios.py
+++ b/tests/e2e_scenarios.py
@@ -21,6 +21,8 @@ def run(args):
         scenario = json.load(f)
 
     hosts = scenario.get("hosts", ["localhost", "localhost"])
+    if args.consensus == "pbft":
+        hosts = ["localhost"] * 4
     args.package = scenario["package"]
     # SNIPPET_END: parsing
 
@@ -70,7 +72,7 @@ def run(args):
                         else:
                             check_commit(r, result=lambda res: res is not None)
 
-                network.wait_for_node_commit_sync()
+                network.wait_for_node_commit_sync(args.consensus)
 
     if args.network_only:
         LOG.info("Keeping network alive with the following nodes:")

--- a/tests/governance.py
+++ b/tests/governance.py
@@ -20,13 +20,13 @@ from loguru import logger as LOG
 
 
 def run(args):
-    hosts = ["localhost", "localhost"]
+    hosts = ["localhost"] * (4 if args.consensus == "pbft" else 2)
 
     with infra.ccf.network(
         hosts, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
         network.start_and_join(args)
-        primary, (backup,) = network.find_nodes()
+        primary, backups = network.find_nodes()
 
         with primary.node_client() as mc:
             check_commit = infra.checker.Checker(mc)

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -472,7 +472,7 @@ class Network:
             self.get_joined_nodes()
         ), f"Only {len(caught_up_nodes)} (out of {len(self.get_joined_nodes())}) nodes have joined the network"
 
-    def wait_for_node_commit_sync(self, timeout=3):
+    def wait_for_node_commit_sync(self, consensus, timeout=3):
         """
         Wait for commit level to get in sync on all nodes. This is expected to
         happen once CFTR has been established, in the absence of new transactions.
@@ -486,7 +486,13 @@ class Network:
             if [commits[0]] * len(commits) == commits:
                 break
             time.sleep(1)
-        assert [commits[0]] * len(commits) == commits, "All nodes at the same commit"
+        # in pbft getCommit acts as a write, so commits will not be the same
+        # but they should be in ascending order
+        assert (
+            [commits[0]] * len(commits) == commits
+            if consensus == "raft"
+            else sorted(commits) == commits
+        ), "All nodes in sync"
 
     def wait_for_sealed_secrets_at_version(self, version, timeout=5):
         """

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -486,7 +486,7 @@ class Network:
             if [commits[0]] * len(commits) == commits:
                 break
             time.sleep(1)
-        # in pbft getCommit acts as a write, so commits will not be the same
+        # in pbft getCommit increments the commit version, so commits will not be the same
         # but they should be in ascending order
         assert (
             [commits[0]] * len(commits) == commits

--- a/tests/infra/logging_app.py
+++ b/tests/infra/logging_app.py
@@ -14,7 +14,9 @@ class LoggingTxs:
         self.next_priv_index = 0
         self.notifications_queue = notifications_queue
 
-    def issue(self, network, number_txs, on_backup=False, wait_for_sync=True):
+    def issue(
+        self, network, number_txs, consensus, on_backup=False, wait_for_sync=True
+    ):
         LOG.success(f"Applying {number_txs} logging txs")
         primary, backup = network.find_primary_and_any_backup()
         remote_node = backup if on_backup else primary
@@ -42,7 +44,7 @@ class LoggingTxs:
                     self.next_pub_index += 1
 
         if wait_for_sync:
-            network.wait_for_node_commit_sync()
+            network.wait_for_node_commit_sync(consensus)
 
     def verify(self, network):
         LOG.success(f"Verifying all logging txs")

--- a/tests/infra/logging_app.py
+++ b/tests/infra/logging_app.py
@@ -14,9 +14,7 @@ class LoggingTxs:
         self.next_priv_index = 0
         self.notifications_queue = notifications_queue
 
-    def issue(
-        self, network, number_txs, consensus, on_backup=False, wait_for_sync=True
-    ):
+    def issue(self, network, number_txs, consensus, on_backup=False):
         LOG.success(f"Applying {number_txs} logging txs")
         primary, backup = network.find_primary_and_any_backup()
         remote_node = backup if on_backup else primary
@@ -43,8 +41,7 @@ class LoggingTxs:
                     self.next_priv_index += 1
                     self.next_pub_index += 1
 
-        if wait_for_sync:
-            network.wait_for_node_commit_sync(consensus)
+        network.wait_for_node_commit_sync(consensus)
 
     def verify(self, network):
         LOG.success(f"Verifying all logging txs")

--- a/tests/receipts.py
+++ b/tests/receipts.py
@@ -47,10 +47,14 @@ def test(network, args, notifications_queue=None):
 
 
 def run(args):
-    hosts = ["localhost", "localhost"]
+    hosts = ["localhost"] * (4 if args.consensus == "pbft" else 2)
 
     with infra.notification.notification_server(args.notify_server) as notifications:
-        notifications_queue = notifications.get_queue()
+        notifications_queue = (
+            notifications.get_queue()
+            if (args.package == "liblogging" and args.consensus == "raft")
+            else None
+        )
 
         with infra.ccf.network(
             hosts, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -34,7 +34,7 @@ def test(network, args, use_shares=False):
 
     for node in recovered_network.nodes:
         recovered_network.wait_for_state(node, "partOfPublicNetwork")
-        recovered_network.wait_for_node_commit_sync()
+        recovered_network.wait_for_node_commit_sync(args.consensus)
     LOG.info("Public CFTR started")
 
     primary, term = recovered_network.find_primary()

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -17,7 +17,7 @@ from loguru import logger as LOG
 
 
 def run(args):
-    hosts = ["localhost", "localhost"]
+    hosts = ["localhost"] * (4 if args.consensus == "pbft" else 2)
     os.makedirs(args.schema_dir, exist_ok=True)
 
     changed_files = []

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -96,6 +96,7 @@ def recover(number_txs=5):
             network.txs.issue(
                 network=network,
                 number_txs=infra.e2e_args.get("msgs_per_recovery") or number_txs,
+                consensus=args.consensus,
             )
             new_network = func(*args, **kwargs)
             new_network.txs.verify(network=new_network)

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -96,7 +96,7 @@ def recover(number_txs=5):
             network.txs.issue(
                 network=network,
                 number_txs=infra.e2e_args.get("msgs_per_recovery") or number_txs,
-                consensus=args.consensus,
+                consensus=infra.e2e_args.get("consensus"),
             )
             new_network = func(*args, **kwargs)
             new_network.txs.verify(network=new_network)


### PR DESCRIPTION
Resolves #934 

Tests that are still not enabled are the recovery, reconfiguration related tests, code update test.

- `lua_end_to_end_batched` messages exceed `Max_message_size` so still can't be enabled

Tests that can't be enabled because they raise issues that need to be investigated and addressed separately (will open tickets) are:
 
- `lua_txregulator_test` and `js_end_to_end_logging` tests trigger a pbft view change which causes the replicas to roll back before the last checkpoint which in turn crashes the nodes #951 
- `lua_end_to_end_logging` and `end_to_end_scenario` are unstable (tagging them along with the above issue)
- `member_clients` test makes merkle roots between replicas un-matched #952
- `governance_history` test fails because it checks the ledger for governance results, and in pbft the governance maps are derived and do not go in the ledger #953

