### PR TITLE
Simplify signature of handler install

### DIFF
--- a/sphinx/source/developers/logging_cpp.rst
+++ b/sphinx/source/developers/logging_cpp.rst
@@ -61,8 +61,8 @@ Each function is installed as the handler for a specific RPC ``method``, optiona
 
 .. literalinclude:: ../../../src/apps/logging/logging.cpp
     :language: cpp
-    :start-after: SNIPPET: install_get
-    :lines: 1
+    :start-after: SNIPPET_START: install_get
+    :end-before: SNIPPET_END: install_get
     :dedent: 6
 
 These handlers use the simple signature provided by the ``handler_adapter`` wrapper function, which pre-parses a JSON params object from the HTTP request body.

--- a/src/apps/logging/logging.cpp
+++ b/src/apps/logging/logging.cpp
@@ -195,11 +195,11 @@ namespace ccfapp
       };
       // SNIPPET_END: log_record_prefix_cert
 
-      install_with_auto_schema<LoggingRecord::In, bool>(
-        Procs::LOG_RECORD, json_adapter(record), Write);
+      install(Procs::LOG_RECORD, json_adapter(record), Write)
+        .set_auto_schema<LoggingRecord::In, bool>();
       // SNIPPET: install_get
-      install_with_auto_schema<LoggingGet>(
-        Procs::LOG_GET, json_adapter(get), Read);
+      install(Procs::LOG_GET, json_adapter(get), Read)
+        .set_auto_schema<LoggingGet>();
 
       install(Procs::LOG_RECORD_PUBLIC, json_adapter(record_public), Write)
         .set_params_schema(record_public_params_schema)

--- a/src/apps/logging/logging.cpp
+++ b/src/apps/logging/logging.cpp
@@ -197,9 +197,10 @@ namespace ccfapp
 
       install(Procs::LOG_RECORD, json_adapter(record), Write)
         .set_auto_schema<LoggingRecord::In, bool>();
-      // SNIPPET: install_get
+      // SNIPPET_START: install_get
       install(Procs::LOG_GET, json_adapter(get), Read)
         .set_auto_schema<LoggingGet>();
+      // SNIPPET_END: install_get
 
       install(Procs::LOG_RECORD_PUBLIC, json_adapter(record_public), Write)
         .set_params_schema(record_public_params_schema)

--- a/src/apps/logging/logging.cpp
+++ b/src/apps/logging/logging.cpp
@@ -201,18 +201,15 @@ namespace ccfapp
       install_with_auto_schema<LoggingGet>(
         Procs::LOG_GET, json_adapter(get), Read);
 
-      install(
-        Procs::LOG_RECORD_PUBLIC,
-        json_adapter(record_public),
-        Write,
-        record_public_params_schema,
-        record_public_result_schema);
-      install(
-        Procs::LOG_GET_PUBLIC,
-        json_adapter(get_public),
-        Read,
-        get_public_params_schema,
-        get_public_result_schema);
+      auto& record_public_handler =
+        install(Procs::LOG_RECORD_PUBLIC, json_adapter(record_public), Write);
+      record_public_handler.params_schema = record_public_params_schema;
+      record_public_handler.result_schema = record_public_result_schema;
+
+      auto& get_public_handler =
+        install(Procs::LOG_GET_PUBLIC, json_adapter(get_public), Read);
+      get_public_handler.params_schema = get_public_params_schema;
+      get_public_handler.result_schema = get_public_result_schema;
 
       install(Procs::LOG_RECORD_PREFIX_CERT, log_record_prefix_cert, Write);
 

--- a/src/apps/logging/logging.cpp
+++ b/src/apps/logging/logging.cpp
@@ -201,15 +201,13 @@ namespace ccfapp
       install_with_auto_schema<LoggingGet>(
         Procs::LOG_GET, json_adapter(get), Read);
 
-      auto& record_public_handler =
-        install(Procs::LOG_RECORD_PUBLIC, json_adapter(record_public), Write);
-      record_public_handler.params_schema = record_public_params_schema;
-      record_public_handler.result_schema = record_public_result_schema;
+      install(Procs::LOG_RECORD_PUBLIC, json_adapter(record_public), Write)
+        .set_params_schema(record_public_params_schema)
+        .set_result_schema(record_public_result_schema);
 
-      auto& get_public_handler =
-        install(Procs::LOG_GET_PUBLIC, json_adapter(get_public), Read);
-      get_public_handler.params_schema = get_public_params_schema;
-      get_public_handler.result_schema = get_public_result_schema;
+      install(Procs::LOG_GET_PUBLIC, json_adapter(get_public), Read)
+        .set_params_schema(get_public_params_schema)
+        .set_result_schema(get_public_result_schema);
 
       install(Procs::LOG_RECORD_PREFIX_CERT, log_record_prefix_cert, Write);
 

--- a/src/node/rpc/commonhandlerregistry.h
+++ b/src/node/rpc/commonhandlerregistry.h
@@ -237,29 +237,31 @@ namespace ccf
           HTTP_STATUS_INTERNAL_SERVER_ERROR, "Unable to verify receipt");
       };
 
-      install_with_auto_schema<GetCommit>(
-        GeneralProcs::GET_COMMIT, json_adapter(get_commit), Read);
-      auto& metrics_handler = install_with_auto_schema<void, GetMetrics::Out>(
-        GeneralProcs::GET_METRICS, json_adapter(get_metrics), Read);
-      metrics_handler.execute_locally = true;
-      install_with_auto_schema<void, bool>(
-        GeneralProcs::MK_SIGN, json_adapter(make_signature), Write);
-      install_with_auto_schema<void, WhoAmI::Out>(
-        GeneralProcs::WHO_AM_I, json_adapter(who_am_i), Read);
-      install_with_auto_schema<WhoIs::In, WhoIs::Out>(
-        GeneralProcs::WHO_IS, json_adapter(who_is), Read);
-      install_with_auto_schema<void, GetPrimaryInfo::Out>(
-        GeneralProcs::GET_PRIMARY_INFO, json_adapter(get_primary_info), Read);
-      install_with_auto_schema<void, GetNetworkInfo::Out>(
-        GeneralProcs::GET_NETWORK_INFO, json_adapter(get_network_info), Read);
-      install_with_auto_schema<void, ListMethods::Out>(
-        GeneralProcs::LIST_METHODS, json_adapter(list_methods_fn), Read);
-      install_with_auto_schema<GetSchema>(
-        GeneralProcs::GET_SCHEMA, json_adapter(get_schema), Read);
-      install_with_auto_schema<GetReceipt>(
-        GeneralProcs::GET_RECEIPT, json_adapter(get_receipt), Read);
-      install_with_auto_schema<VerifyReceipt>(
-        GeneralProcs::VERIFY_RECEIPT, json_adapter(verify_receipt), Read);
+      install(GeneralProcs::GET_COMMIT, json_adapter(get_commit), Read)
+        .set_auto_schema<GetCommit>();
+      install(GeneralProcs::GET_METRICS, json_adapter(get_metrics), Read)
+        .set_auto_schema<void, GetMetrics::Out>()
+        .set_execute_locally(true);
+      install(GeneralProcs::MK_SIGN, json_adapter(make_signature), Write)
+        .set_auto_schema<void, bool>();
+      install(GeneralProcs::WHO_AM_I, json_adapter(who_am_i), Read)
+        .set_auto_schema<void, WhoAmI::Out>();
+      install(GeneralProcs::WHO_IS, json_adapter(who_is), Read)
+        .set_auto_schema<WhoIs::In, WhoIs::Out>();
+      install(
+        GeneralProcs::GET_PRIMARY_INFO, json_adapter(get_primary_info), Read)
+        .set_auto_schema<void, GetPrimaryInfo::Out>();
+      install(
+        GeneralProcs::GET_NETWORK_INFO, json_adapter(get_network_info), Read)
+        .set_auto_schema<void, GetNetworkInfo::Out>();
+      install(GeneralProcs::LIST_METHODS, json_adapter(list_methods_fn), Read)
+        .set_auto_schema<void, ListMethods::Out>();
+      install(GeneralProcs::GET_SCHEMA, json_adapter(get_schema), Read)
+        .set_auto_schema<GetSchema>();
+      install(GeneralProcs::GET_RECEIPT, json_adapter(get_receipt), Read)
+        .set_auto_schema<GetReceipt>();
+      install(GeneralProcs::VERIFY_RECEIPT, json_adapter(verify_receipt), Read)
+        .set_auto_schema<VerifyReceipt>();
     }
 
     void tick(std::chrono::milliseconds elapsed, size_t tx_count) override

--- a/src/node/rpc/commonhandlerregistry.h
+++ b/src/node/rpc/commonhandlerregistry.h
@@ -239,12 +239,9 @@ namespace ccf
 
       install_with_auto_schema<GetCommit>(
         GeneralProcs::GET_COMMIT, json_adapter(get_commit), Read);
-      install_with_auto_schema<void, GetMetrics::Out>(
-        GeneralProcs::GET_METRICS,
-        json_adapter(get_metrics),
-        Read,
-        false, // does not require client signature
-        true); // executed locally
+      auto& metrics_handler = install_with_auto_schema<void, GetMetrics::Out>(
+        GeneralProcs::GET_METRICS, json_adapter(get_metrics), Read);
+      metrics_handler.execute_locally = true;
       install_with_auto_schema<void, bool>(
         GeneralProcs::MK_SIGN, json_adapter(make_signature), Write);
       install_with_auto_schema<void, WhoAmI::Out>(

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -475,7 +475,7 @@ namespace ccf
 
       if (!is_primary && consensus->type() == ConsensusType::RAFT)
       {
-        switch (handler->rw)
+        switch (handler->read_write)
         {
           case HandlerRegistry::Read:
           {

--- a/src/node/rpc/handlerregistry.h
+++ b/src/node/rpc/handlerregistry.h
@@ -130,6 +130,7 @@ namespace ccf
      * @param method Method name
      * @param f Method implementation
      * @param read_write Flag if method will Read, Write, MayWrite
+     * @return Returns the installed Handler for further modification
      */
     Handler& install(
       const std::string& method, HandleFunction f, ReadWrite read_write)
@@ -148,6 +149,7 @@ namespace ccf
      *
      * @param f Method implementation
      * @param read_write Flag if method will Read, Write, MayWrite
+     * @return Returns the installed Handler for further modification
      */
     Handler& set_default(HandleFunction f, ReadWrite read_write)
     {

--- a/src/node/rpc/handlerregistry.h
+++ b/src/node/rpc/handlerregistry.h
@@ -141,21 +141,6 @@ namespace ccf
       return handler;
     }
 
-    template <typename In, typename Out, typename F>
-    Handler& install_with_auto_schema(
-      const std::string& method, F&& f, ReadWrite read_write)
-    {
-      return install(method, std::forward<F>(f), read_write)
-        .template set_auto_schema<In, Out>();
-    }
-
-    template <typename T, typename... Ts>
-    Handler& install_with_auto_schema(const std::string& method, Ts&&... ts)
-    {
-      return install_with_auto_schema<typename T::In, typename T::Out>(
-        method, std::forward<Ts>(ts)...);
-    }
-
     /** Set a default HandleFunction
      *
      * The default HandleFunction is only invoked if no specific HandleFunction

--- a/src/node/rpc/handlerregistry.h
+++ b/src/node/rpc/handlerregistry.h
@@ -35,14 +35,40 @@ namespace ccf
     {
       HandleFunction func;
       ReadWrite read_write = Write;
+
       nlohmann::json params_schema = nullptr;
+
+      Handler& set_params_schema(const nlohmann::json& j)
+      {
+        params_schema = j;
+        return *this;
+      }
+
       nlohmann::json result_schema = nullptr;
+
+      Handler& set_result_schema(const nlohmann::json& j)
+      {
+        result_schema = j;
+        return *this;
+      }
 
       // If true, client request must be signed
       bool require_client_signature = false;
 
+      Handler& set_require_client_signature(bool v)
+      {
+        require_client_signature = v;
+        return *this;
+      }
+
       // If true, request is executed without consensus (PBFT only)
       bool execute_locally = false;
+
+      Handler& set_execute_locally(bool v)
+      {
+        execute_locally = v;
+        return *this;
+      }
     };
 
   protected:

--- a/src/node/rpc/memberfrontend.h
+++ b/src/node/rpc/memberfrontend.h
@@ -719,10 +719,11 @@ namespace ccf
 
           return make_success(ma.value());
         };
-      install_with_auto_schema<void, StateDigest>(
+      install(
         MemberProcs::UPDATE_ACK_STATE_DIGEST,
         json_adapter(update_state_digest),
-        Write);
+        Write)
+        .set_auto_schema<void, StateDigest>();
 
       auto get_encrypted_recovery_share =
         [this](RequestArgs& args, const nlohmann::json& params) {
@@ -761,10 +762,11 @@ namespace ccf
 
           return make_success(enc_s.value());
         };
-      install_with_auto_schema<void, EncryptedShare>(
+      install(
         MemberProcs::GET_ENCRYPTED_RECOVERY_SHARE,
         json_adapter(get_encrypted_recovery_share),
-        Read);
+        Read)
+        .set_auto_schema<void, EncryptedShare>();
 
       auto submit_recovery_share = [this](
                                      RequestArgs& args,
@@ -812,10 +814,11 @@ namespace ccf
         pending_shares.clear();
         return make_success(true);
       };
-      install_with_auto_schema<SubmitRecoveryShare, bool>(
+      install(
         MemberProcs::SUBMIT_RECOVERY_SHARE,
         json_adapter(submit_recovery_share),
-        Write);
+        Write)
+        .set_auto_schema<SubmitRecoveryShare, bool>();
 
       auto create = [this](Store::Tx& tx, const nlohmann::json& params) {
         LOG_DEBUG_FMT("Processing create RPC");

--- a/src/node/rpc/memberfrontend.h
+++ b/src/node/rpc/memberfrontend.h
@@ -582,8 +582,10 @@ namespace ccf
 
         return make_success(get_proposal_info(proposal_id, proposal.value()));
       };
-      install_with_auto_schema<ProposalAction, ProposalInfo>(
-        MemberProcs::WITHDRAW, json_adapter(withdraw), Write, true);
+      auto& withdraw_handler =
+        install_with_auto_schema<ProposalAction, ProposalInfo>(
+          MemberProcs::WITHDRAW, json_adapter(withdraw), Write);
+      withdraw_handler.require_client_signature = true;
 
       auto vote = [this](RequestArgs& args, const nlohmann::json& params) {
         if (!check_member_active(args.tx, args.caller_id))
@@ -628,8 +630,9 @@ namespace ccf
         return make_success(
           complete_proposal(args.tx, vote.id, proposal.value()));
       };
-      install_with_auto_schema<Vote, ProposalInfo>(
-        MemberProcs::VOTE, json_adapter(vote), Write, true);
+      auto& vote_handler = install_with_auto_schema<Vote, ProposalInfo>(
+        MemberProcs::VOTE, json_adapter(vote), Write);
+      vote_handler.require_client_signature = true;
 
       auto complete =
         [this](
@@ -654,8 +657,10 @@ namespace ccf
           return make_success(
             complete_proposal(tx, proposal_id, proposal.value()));
         };
-      install_with_auto_schema<ProposalAction, ProposalInfo>(
-        MemberProcs::COMPLETE, json_adapter(complete), Write, true);
+      auto& complete_handler =
+        install_with_auto_schema<ProposalAction, ProposalInfo>(
+          MemberProcs::COMPLETE, json_adapter(complete), Write);
+      complete_handler.require_client_signature = true;
 
       //! A member acknowledges state
       auto ack = [this](RequestArgs& args, const nlohmann::json& params) {
@@ -692,8 +697,9 @@ namespace ccf
         members->put(args.caller_id, *member);
         return make_success(true);
       };
-      install_with_auto_schema<StateDigest, bool>(
-        MemberProcs::ACK, json_adapter(ack), Write, true);
+      auto& ack_handler = install_with_auto_schema<StateDigest, bool>(
+        MemberProcs::ACK, json_adapter(ack), Write);
+      ack_handler.require_client_signature = true;
 
       //! A member asks for a fresher state digest
       auto update_state_digest =

--- a/src/node/rpc/memberfrontend.h
+++ b/src/node/rpc/memberfrontend.h
@@ -492,8 +492,8 @@ namespace ccf
 
         return make_success(value);
       };
-      install_with_auto_schema<KVRead>(
-        MemberProcs::READ, json_adapter(read), Read);
+      install(MemberProcs::READ, json_adapter(read), Read)
+        .set_auto_schema<KVRead>();
 
       auto query =
         [this](
@@ -507,8 +507,8 @@ namespace ccf
           return make_success(tsr.run<nlohmann::json>(
             tx, {script, {}, WlIds::MEMBER_CAN_READ, {}}));
         };
-      install_with_auto_schema<Script, nlohmann::json>(
-        MemberProcs::QUERY, json_adapter(query), Read);
+      install(MemberProcs::QUERY, json_adapter(query), Read)
+        .set_auto_schema<Script, nlohmann::json>();
 
       auto propose = [this](RequestArgs& args, const nlohmann::json& params) {
         if (!check_member_active(args.tx, args.caller_id))
@@ -531,8 +531,8 @@ namespace ccf
         return make_success(
           Propose::Out{complete_proposal(args.tx, proposal_id, proposal)});
       };
-      install_with_auto_schema<Propose>(
-        MemberProcs::PROPOSE, json_adapter(propose), Write);
+      install(MemberProcs::PROPOSE, json_adapter(propose), Write)
+        .set_auto_schema<Propose>();
 
       auto withdraw = [this](RequestArgs& args, const nlohmann::json& params) {
         if (!check_member_active(args.tx, args.caller_id))
@@ -582,10 +582,9 @@ namespace ccf
 
         return make_success(get_proposal_info(proposal_id, proposal.value()));
       };
-      auto& withdraw_handler =
-        install_with_auto_schema<ProposalAction, ProposalInfo>(
-          MemberProcs::WITHDRAW, json_adapter(withdraw), Write);
-      withdraw_handler.require_client_signature = true;
+      install(MemberProcs::WITHDRAW, json_adapter(withdraw), Write)
+        .set_auto_schema<ProposalAction, ProposalInfo>()
+        .set_require_client_signature(true);
 
       auto vote = [this](RequestArgs& args, const nlohmann::json& params) {
         if (!check_member_active(args.tx, args.caller_id))
@@ -630,9 +629,9 @@ namespace ccf
         return make_success(
           complete_proposal(args.tx, vote.id, proposal.value()));
       };
-      auto& vote_handler = install_with_auto_schema<Vote, ProposalInfo>(
-        MemberProcs::VOTE, json_adapter(vote), Write);
-      vote_handler.require_client_signature = true;
+      install(MemberProcs::VOTE, json_adapter(vote), Write)
+        .set_auto_schema<Vote, ProposalInfo>()
+        .set_require_client_signature(true);
 
       auto complete =
         [this](
@@ -657,10 +656,9 @@ namespace ccf
           return make_success(
             complete_proposal(tx, proposal_id, proposal.value()));
         };
-      auto& complete_handler =
-        install_with_auto_schema<ProposalAction, ProposalInfo>(
-          MemberProcs::COMPLETE, json_adapter(complete), Write);
-      complete_handler.require_client_signature = true;
+      install(MemberProcs::COMPLETE, json_adapter(complete), Write)
+        .set_auto_schema<ProposalAction, ProposalInfo>()
+        .set_require_client_signature(true);
 
       //! A member acknowledges state
       auto ack = [this](RequestArgs& args, const nlohmann::json& params) {
@@ -697,9 +695,9 @@ namespace ccf
         members->put(args.caller_id, *member);
         return make_success(true);
       };
-      auto& ack_handler = install_with_auto_schema<StateDigest, bool>(
-        MemberProcs::ACK, json_adapter(ack), Write);
-      ack_handler.require_client_signature = true;
+      install(MemberProcs::ACK, json_adapter(ack), Write)
+        .set_auto_schema<StateDigest, bool>()
+        .set_require_client_signature(true);
 
       //! A member asks for a fresher state digest
       auto update_state_digest =

--- a/src/node/rpc/nodefrontend.h
+++ b/src/node/rpc/nodefrontend.h
@@ -299,12 +299,12 @@ namespace ccf
       };
 
       install(NodeProcs::JOIN, json_adapter(accept), Write);
-      install_with_auto_schema<GetSignedIndex>(
-        NodeProcs::GET_SIGNED_INDEX, json_adapter(get_signed_index), Read);
-      install_with_auto_schema<GetQuotes>(
-        NodeProcs::GET_NODE_QUOTE, json_adapter(get_quote), Read);
-      install_with_auto_schema<GetQuotes>(
-        NodeProcs::GET_QUOTES, json_adapter(get_quotes), Read);
+      install(NodeProcs::GET_SIGNED_INDEX, json_adapter(get_signed_index), Read)
+        .set_auto_schema<GetSignedIndex>();
+      install(NodeProcs::GET_NODE_QUOTE, json_adapter(get_quote), Read)
+        .set_auto_schema<GetQuotes>();
+      install(NodeProcs::GET_QUOTES, json_adapter(get_quotes), Read)
+        .set_auto_schema<GetQuotes>();
     }
   };
 

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -49,9 +49,9 @@ public:
     auto empty_function_signed = [this](RequestArgs& args) {
       args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
-    auto& signed_handler = install(
-      "empty_function_signed", empty_function_signed, HandlerRegistry::Read);
-    signed_handler.require_client_signature = true;
+    install(
+      "empty_function_signed", empty_function_signed, HandlerRegistry::Read)
+      .set_require_client_signature(true);
   }
 };
 

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -49,11 +49,9 @@ public:
     auto empty_function_signed = [this](RequestArgs& args) {
       args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
-    install(
-      "empty_function_signed",
-      empty_function_signed,
-      HandlerRegistry::Read,
-      true);
+    auto& signed_handler = install(
+      "empty_function_signed", empty_function_signed, HandlerRegistry::Read);
+    signed_handler.require_client_signature = true;
   }
 };
 

--- a/src/node/rpc/userfrontend.h
+++ b/src/node/rpc/userfrontend.h
@@ -57,9 +57,9 @@ namespace ccf
     // This is simply so apps can write install(...); rather than
     // handlers.install(...);
     template <typename... Ts>
-    void install(Ts&&... ts)
+    ccf::HandlerRegistry::Handler& install(Ts&&... ts)
     {
-      handlers.install(std::forward<Ts>(ts)...);
+      return handlers.install(std::forward<Ts>(ts)...);
     }
   };
 


### PR DESCRIPTION
Resolves #914.

We have several parameters to tweak the behaviour of installed RPC handlers, and we're likely to add more. Rather than needing to specify all of these in the call to `install` (with signficant overload complications), they should be set manually on the few handlers they actually affect.

This PR lets you set those parameters in 2 ways. Manually:

```
auto& foo_handler = install("FOO", foo_func, Read);
foo_handler.execute_locally = true;
foo_handler.params_schema = ...;
```

Or with chaining methods:

```
install("FOO", foo_func, Read)
  .set_execute_locally(true)
  .set_params_schema(...);
```

I prefer the second, but I think its worth keeping both in general.