### PR TITLE
Fast curve for users for performance tests with signatures

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -416,7 +416,7 @@ function(add_e2e_test)
       NAME ${PARSED_ARGS_NAME}
       COMMAND
         ${PYTHON} ${PARSED_ARGS_PYTHON_SCRIPT} -b . --label ${PARSED_ARGS_NAME}
-        ${CCF_NETWORK_TEST_ARGS} --participants-default-curve
+        ${CCF_NETWORK_TEST_ARGS} --participants-curve
         ${DEFAULT_PARTICIPANTS_CURVE} --consensus ${PARSED_ARGS_CONSENSUS}
         ${PARSED_ARGS_ADDITIONAL_ARGS}
     )

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -362,8 +362,6 @@ set(CCF_NETWORK_TEST_ARGS
     ${CCF_DIR}/src/runtime_config/gov.lua
     --worker_threads
     ${WORKER_THREADS}
-    --default-curve
-    ${DEFAULT_PARTICIPANTS_CURVE}
 )
 
 # SNIPPET_START: Lua generic application
@@ -418,8 +416,9 @@ function(add_e2e_test)
       NAME ${PARSED_ARGS_NAME}
       COMMAND
         ${PYTHON} ${PARSED_ARGS_PYTHON_SCRIPT} -b . --label ${PARSED_ARGS_NAME}
-        ${CCF_NETWORK_TEST_ARGS} ${PARSED_ARGS_ADDITIONAL_ARGS} --consensus
-        ${PARSED_ARGS_CONSENSUS}
+        ${CCF_NETWORK_TEST_ARGS} --participants-default-curve
+        ${DEFAULT_PARTICIPANTS_CURVE} --consensus ${PARSED_ARGS_CONSENSUS}
+        ${PARSED_ARGS_ADDITIONAL_ARGS}
     )
 
     # Make python test client framework importable
@@ -481,7 +480,7 @@ function(add_perf_test)
       ${PYTHON} ${PARSED_ARGS_PYTHON_SCRIPT} -b . -c ${PARSED_ARGS_CLIENT_BIN}
       ${CCF_NETWORK_TEST_ARGS} --consensus ${PARSED_ARGS_CONSENSUS}
       --write-tx-times ${VERIFICATION_ARG} --label ${LABEL_ARG}
-      ${PARSED_ARGS_ADDITIONAL_ARGS} ${RELAX_COMMIT_TARGET} ${NODES}
+      ${PARSED_ARGS_ADDITIONAL_ARGS} ${NODES}
   )
 
   # Make python test client framework importable

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -74,7 +74,7 @@ if(BUILD_TESTS)
         --max-writes-ahead
         1000
         --sign
-        --participants-default-curve "secp256k1"
+        --participants-curve "secp256k1"
         --metrics-file
         small_bank_${CONSENSUS}_sigs_metrics.json
     )
@@ -99,6 +99,6 @@ if(BUILD_TESTS)
       --send-tx-to
       backups
       --sign
-      --participants-default-curve "secp256k1"
+      --participants-curve "secp256k1"
   )
 endif()

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -74,6 +74,7 @@ if(BUILD_TESTS)
         --max-writes-ahead
         1000
         --sign
+        --participants-default-curve "secp256k1"
         --metrics-file
         small_bank_${CONSENSUS}_sigs_metrics.json
     )
@@ -98,5 +99,6 @@ if(BUILD_TESTS)
       --send-tx-to
       backups
       --sign
+      --participants-default-curve "secp256k1"
   )
 endif()

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -74,7 +74,8 @@ if(BUILD_TESTS)
         --max-writes-ahead
         1000
         --sign
-        --participants-curve "secp256k1"
+        --participants-curve
+        "secp256k1"
         --metrics-file
         small_bank_${CONSENSUS}_sigs_metrics.json
     )
@@ -99,6 +100,7 @@ if(BUILD_TESTS)
       --send-tx-to
       backups
       --sign
-      --participants-curve "secp256k1"
+      --participants-curve
+      "secp256k1"
   )
 endif()

--- a/samples/apps/txregulator/tests/txregulatorclient.py
+++ b/samples/apps/txregulator/tests/txregulatorclient.py
@@ -50,10 +50,10 @@ def run(args):
                 data = f.readlines()
             script = "".join(data)
 
-        manager = AppUser(network, "manager", "GB", args.participants_default_curve)
-        regulator = AppUser(network, "auditor", "GB", args.participants_default_curve)
+        manager = AppUser(network, "manager", "GB", args.participants_curve)
+        regulator = AppUser(network, "auditor", "GB", args.participants_curve)
         banks = [
-            AppUser(network, f"bank{country}", country, args.participants_default_curve)
+            AppUser(network, f"bank{country}", country, args.participants_curve)
             for country in ("US", "GB", "GR", "FR")
         ]
         transactions = []

--- a/samples/apps/txregulator/tests/txregulatorclient.py
+++ b/samples/apps/txregulator/tests/txregulatorclient.py
@@ -50,10 +50,10 @@ def run(args):
                 data = f.readlines()
             script = "".join(data)
 
-        manager = AppUser(network, "manager", "GB", args.default_curve)
-        regulator = AppUser(network, "auditor", "GB", args.default_curve)
+        manager = AppUser(network, "manager", "GB", args.participants_default_curve)
+        regulator = AppUser(network, "auditor", "GB", args.participants_default_curve)
         banks = [
-            AppUser(network, f"bank{country}", country, args.default_curve)
+            AppUser(network, f"bank{country}", country, args.participants_default_curve)
             for country in ("US", "GB", "GR", "FR")
         ]
         transactions = []

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -79,7 +79,7 @@ def test_anonymous_caller(network, args):
         primary, _ = network.find_primary()
 
         # Create a new user but do not record its identity
-        network.create_user(4, args.participants_default_curve)
+        network.create_user(4, args.participants_curve)
 
         log_id = 101
         msg = "This message is anonymous"

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -79,7 +79,7 @@ def test_anonymous_caller(network, args):
         primary, _ = network.find_primary()
 
         # Create a new user but do not record its identity
-        network.create_user(4, args.default_curve)
+        network.create_user(4, args.participants_default_curve)
 
         log_id = 101
         msg = "This message is anonymous"

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -243,10 +243,13 @@ class Network:
 
         initial_members = list(range(max(1, args.initial_member_count)))
         self.consortium = infra.consortium.Consortium(
-            initial_members, args.default_curve, self.key_generator, self.common_dir
+            initial_members,
+            args.participants_default_curve,
+            self.key_generator,
+            self.common_dir,
         )
         self.initial_users = list(range(max(0, args.initial_user_count)))
-        self.create_users(self.initial_users, args.default_curve)
+        self.create_users(self.initial_users, args.participants_default_curve)
 
         primary = self._start_all_nodes(args)
 

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -244,12 +244,12 @@ class Network:
         initial_members = list(range(max(1, args.initial_member_count)))
         self.consortium = infra.consortium.Consortium(
             initial_members,
-            args.participants_default_curve,
+            args.participants_curve,
             self.key_generator,
             self.common_dir,
         )
         self.initial_users = list(range(max(0, args.initial_user_count)))
-        self.create_users(self.initial_users, args.participants_default_curve)
+        self.create_users(self.initial_users, args.participants_curve)
 
         primary = self._start_all_nodes(args)
 

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -130,7 +130,7 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         default="example.com",
     )
     parser.add_argument(
-        "--participants-default-curve",
+        "--participants-curve",
         help="Curve to use for member and user identities",
         default=infra.ccf.ParticipantsCurve.secp384r1.name,
         type=lambda curve: infra.ccf.ParticipantsCurve[curve],

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -130,7 +130,7 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         default="example.com",
     )
     parser.add_argument(
-        "--default-curve",
+        "--participants-default-curve",
         help="Curve to use for member and user identities",
         default=infra.ccf.ParticipantsCurve.secp384r1.name,
         type=lambda curve: infra.ccf.ParticipantsCurve[curve],

--- a/tests/memberclient.py
+++ b/tests/memberclient.py
@@ -61,7 +61,7 @@ def run(args):
             0,
             primary,
             new_member_id=3,
-            curve=infra.ccf.ParticipantsCurve(args.default_curve).next(),
+            curve=infra.ccf.ParticipantsCurve(args.participants_default_curve).next(),
         )
         assert response.status == http.HTTPStatus.OK.value
 

--- a/tests/memberclient.py
+++ b/tests/memberclient.py
@@ -61,7 +61,7 @@ def run(args):
             0,
             primary,
             new_member_id=3,
-            curve=infra.ccf.ParticipantsCurve(args.participants_default_curve).next(),
+            curve=infra.ccf.ParticipantsCurve(args.participants_curve).next(),
         )
         assert response.status == http.HTTPStatus.OK.value
 


### PR DESCRIPTION
The performance tests now use the fast bitcoin curve when generating users' identities (and members).  Note that there is no need to recompile CCF for this. Also renamed `args.default_curve` to `args.participants_curve`. 