### PR TITLE
Minor renames for consistency

### DIFF
--- a/cmake/pbft.cmake
+++ b/cmake/pbft.cmake
@@ -158,11 +158,11 @@ if("virtual" IN_LIST TARGET)
   pbft_add_executable(replica-test)
 
   add_executable(
-    test-controller
+    controller-test
     ${CMAKE_SOURCE_DIR}/src/consensus/pbft/libbyz/test/test_controller_main.cpp
     ${CCF_DIR}/src/enclave/thread_local.cpp
   )
-  pbft_add_executable(test-controller)
+  pbft_add_executable(controller-test)
 
   add_executable(
     client-test
@@ -173,17 +173,17 @@ if("virtual" IN_LIST TARGET)
 
   # Unit tests
   add_unit_test(
-    test_ledger_replay
+    ledger_replay_test
     ${CMAKE_SOURCE_DIR}/src/consensus/pbft/libbyz/test/test_ledger_replay.cpp
   )
   target_include_directories(
-    test_ledger_replay
+    ledger_replay_test
     PRIVATE ${CMAKE_SOURCE_DIR}/src/consensus/pbft/libbyz/test/mocks
   )
-  target_link_libraries(test_ledger_replay PRIVATE libcommontest.mock)
-  use_libbyz(test_ledger_replay)
-  add_san(test_ledger_replay)
-  set_property(TEST test_ledger_replay PROPERTY LABELS pbft)
+  target_link_libraries(ledger_replay_test PRIVATE libcommontest.mock)
+  use_libbyz(ledger_replay_test)
+  add_san(ledger_replay_test)
+  set_property(TEST ledger_replay_test PROPERTY LABELS pbft)
 
   add_test(
     NAME test_UDP_with_delay

--- a/cmake/pbft.cmake
+++ b/cmake/pbft.cmake
@@ -150,26 +150,26 @@ if("virtual" IN_LIST TARGET)
   endfunction()
 
   add_executable(
-    replica-test
+    pbft_replica_test
     ${CMAKE_SOURCE_DIR}/src/consensus/pbft/libbyz/test/replica_test.cpp
     ${CCF_DIR}/src/enclave/thread_local.cpp
   )
-  target_link_libraries(replica-test PRIVATE ccfcrypto.host)
-  pbft_add_executable(replica-test)
+  target_link_libraries(pbft_replica_test PRIVATE ccfcrypto.host)
+  pbft_add_executable(pbft_replica_test)
 
   add_executable(
-    controller-test
+    pbft_controller_test
     ${CMAKE_SOURCE_DIR}/src/consensus/pbft/libbyz/test/test_controller_main.cpp
     ${CCF_DIR}/src/enclave/thread_local.cpp
   )
-  pbft_add_executable(controller-test)
+  pbft_add_executable(pbft_controller_test)
 
   add_executable(
-    client-test
+    pbft_client_test
     ${CMAKE_SOURCE_DIR}/src/consensus/pbft/libbyz/test/client_test.cpp
     ${CCF_DIR}/src/enclave/thread_local.cpp
   )
-  pbft_add_executable(client-test)
+  pbft_add_executable(pbft_client_test)
 
   # Unit tests
   add_unit_test(

--- a/src/kv/kv.h
+++ b/src/kv/kv.h
@@ -133,13 +133,13 @@ namespace kv
       local_hook(local_hook_),
       global_hook(global_hook_)
     {
-      roll->insert_back(CreateNewLocalCommit(0, State(), Write()));
+      roll->insert_back(create_new_local_commit(0, State(), Write()));
     }
 
     Map(const Map& that) = delete;
 
     template <typename... Args>
-    LocalCommit* CreateNewLocalCommit(Args&&... args)
+    LocalCommit* create_new_local_commit(Args&&... args)
     {
       LocalCommit* c = empty_commits.pop();
       if (c == nullptr)
@@ -622,7 +622,8 @@ namespace kv
 
           if (changes)
           {
-            map.roll->insert_back(map.CreateNewLocalCommit(v, state, writes));
+            map.roll->insert_back(
+              map.create_new_local_commit(v, state, writes));
           }
         }
       }
@@ -788,7 +789,7 @@ namespace kv
           if (global_hook)
           {
             commit_deltas.insert_back(
-              CreateNewLocalCommit(r->version, r->state, move(r->writes)));
+              create_new_local_commit(r->version, r->state, move(r->writes)));
           }
           return;
         }
@@ -797,7 +798,7 @@ namespace kv
         if (global_hook && !r->writes.empty())
         {
           commit_deltas.insert_back(
-            CreateNewLocalCommit(r->version, r->state, move(r->writes)));
+            create_new_local_commit(r->version, r->state, move(r->writes)));
         }
 
         // Stop if the next state may be rolled back or is the only state.
@@ -815,7 +816,7 @@ namespace kv
       if (global_hook && !r->writes.empty())
       {
         commit_deltas.insert_back(
-          CreateNewLocalCommit(r->version, r->state, move(r->writes)));
+          create_new_local_commit(r->version, r->state, move(r->writes)));
       }
     }
 
@@ -861,7 +862,7 @@ namespace kv
       // This discards all entries in the roll and resets the compacted value
       // and rollback counter. The Map expects to be locked before clearing it.
       roll->clear();
-      roll->insert_back(CreateNewLocalCommit(0, State(), Write()));
+      roll->insert_back(create_new_local_commit(0, State(), Write()));
       rollback_counter = 0;
     }
 

--- a/tests/coverage/generate_coverage.sh
+++ b/tests/coverage/generate_coverage.sh
@@ -12,8 +12,13 @@ LLVM_PROFDATA=llvm-profdata-${LLVM_VER}
 
 objects=()
 for f in *_test; do
-    objects+=( -object "$f")
-    echo "$f".profraw >> prof_files
+    PROF_PATH = "$f".profraw
+    if [ -f "$PROF_PATH" ]; then
+        objects+=( -object "$f")
+        echo "$PROF_PATH" >> prof_files
+    else
+        echo "Ignoring $PROF_PATH - no corresponding .profraw file"
+    fi
 done
 
 # Merge coverage report for all unit tests

--- a/tests/coverage/generate_coverage.sh
+++ b/tests/coverage/generate_coverage.sh
@@ -12,7 +12,7 @@ LLVM_PROFDATA=llvm-profdata-${LLVM_VER}
 
 objects=()
 for f in *_test; do
-    PROF_PATH = "$f".profraw
+    PROF_PATH="$f".profraw
     if [ -f "$PROF_PATH" ]; then
         objects+=( -object "$f")
         echo "$PROF_PATH" >> prof_files

--- a/tests/infra/libbyz/node.py
+++ b/tests/infra/libbyz/node.py
@@ -12,8 +12,8 @@ class Node:
         self.port = port
         self.private_key = private_key
         self.is_replica = is_replica
-        self.client_exe = "client-test"
-        self.server_exe = "replica-test"
+        self.client_exe = "pbft_client_test"
+        self.server_exe = "pbft_replica_test"
         self.proc = None
         self.cmd = None
 

--- a/tests/late_joiners.py
+++ b/tests/late_joiners.py
@@ -77,7 +77,7 @@ def assert_node_up_to_date(check, node, final_msg, final_msg_id):
                 LOG.error(f"Timeout error for LOG_get on node {node.node_id}")
             except AssertionError as e:
                 LOG.error(
-                    f"assert error error for LOG_get on node {node.node_id}, error:{e.message}"
+                    f"Assertion error for LOG_get on node {node.node_id}, error:{e.message}"
                 )
         raise AssertionError(f"{node.nodeid} is not up to date")
 


### PR DESCRIPTION
Most of our unit tests are `_test`, this renames the few exceptions that were `test_` (so now `./te[TAB]` will auto-complete to `./tests.sh`).

++Some other renames that were bothering me.