### PR TITLE
Deco DC_v1 pool

### DIFF
--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -17,7 +17,7 @@ parameters:
       pool: Ubuntu-1804-D16s_v3
     Release:
       container: sgx
-      pool: Ubuntu-1804-DC4s
+      pool: Ubuntu-1804-DC8_v2
     Metrics:
       container: nosgx
       pool: Ubuntu-1804-D8s_v3


### PR DESCRIPTION
Consolidating on DC_v2, DC_v1 is slower and of limited interest at this point.