### PR TITLE
In pbft keep tracks of the last pre-prepare that performed a governance request

### DIFF
--- a/src/consensus/pbft/libbyz/governance_update_tracking.h
+++ b/src/consensus/pbft/libbyz/governance_update_tracking.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "ds/dl_list.h"
+#include "types.h"
+
+class GovernanceRequestTracking
+{
+public:
+  bool was_updated_in(Seqno seqno)
+  {
+    SeqnoWithMemberReq* current = seqnoWithMemberReqs.get_head();
+    while (current != nullptr && current->seqno >= seqno)
+    {
+      if (current->seqno == seqno)
+      {
+        return true;
+      }
+      current = current->next;
+    }
+    return false;
+  }
+
+  void rollback(Seqno seqno)
+  {
+    mark_stable(seqno);
+  }
+
+  void update(Seqno seqno)
+  {
+    seqnoWithMemberReqs.insert(new SeqnoWithMemberReq{seqno, nullptr, nullptr});
+  }
+
+  void mark_stable(Seqno seqno)
+  {
+    while (seqnoWithMemberReqs.get_tail() != seqnoWithMemberReqs.get_head() &&
+           seqnoWithMemberReqs.get_tail()->seqno < seqno)
+    {
+      delete seqnoWithMemberReqs.pop_tail();
+    }
+  }
+
+  Seqno last_seqno()
+  {
+    if (seqnoWithMemberReqs.is_empty())
+    {
+      return 0;
+    }
+    return seqnoWithMemberReqs.get_head()->seqno;
+  }
+
+private:
+  struct SeqnoWithMemberReq
+  {
+    Seqno seqno;
+    SeqnoWithMemberReq* next;
+    SeqnoWithMemberReq* prev;
+  };
+
+  snmalloc::DLList<SeqnoWithMemberReq> seqnoWithMemberReqs;
+};

--- a/src/consensus/pbft/libbyz/pre_prepare.h
+++ b/src/consensus/pbft/libbyz/pre_prepare.h
@@ -35,6 +35,8 @@ struct Pre_prepare_rep : public Message_rep
   View view;
   Seqno seqno;
   std::array<uint8_t, MERKLE_ROOT_SIZE> replicated_state_merkle_root;
+  uint64_t contains_gov_req;
+  Seqno last_gov_req_updated;
   int64_t ctx; // a context provided when a the batch is executed
                // the contents are opaque
   Digest digest; // digest of request set concatenated with
@@ -105,9 +107,18 @@ public:
   Digest& digest() const;
   // Effects: Fetches the digest from the message.
 
+  bool did_exec_gov_req() const;
+  // Effects: Fetches if a governance request was executed.
+
+  Seqno last_exec_gov_req() const;
+  // Effects: The last pp that executed a governance request.
+
   void set_merkle_roots_and_ctx(
     const std::array<uint8_t, MERKLE_ROOT_SIZE>& replicated_state_merkle_root,
     int64_t ctx);
+
+  void set_last_gov_request(
+    Seqno last_seqno_with_gov_req, bool did_exec_gov_req);
 
   const std::array<uint8_t, MERKLE_ROOT_SIZE>&
   get_replicated_state_merkle_root() const;
@@ -258,4 +269,14 @@ inline Digest& Pre_prepare::big_req_digest(int i)
 {
   PBFT_ASSERT(i >= 0 && i < num_big_reqs(), "Invalid argument");
   return *(big_reqs() + i);
+}
+
+inline Seqno Pre_prepare::last_exec_gov_req() const
+{
+  return rep().last_gov_req_updated;
+}
+
+inline bool Pre_prepare::did_exec_gov_req() const
+{
+  return rep().contains_gov_req;
 }

--- a/src/consensus/pbft/libbyz/pre_prepare.h
+++ b/src/consensus/pbft/libbyz/pre_prepare.h
@@ -35,7 +35,8 @@ struct Pre_prepare_rep : public Message_rep
   View view;
   Seqno seqno;
   std::array<uint8_t, MERKLE_ROOT_SIZE> replicated_state_merkle_root;
-  uint64_t contains_gov_req;
+  uint64_t contains_gov_req; // should be a bool, but need to use 8 bytes to
+                             // maintain alignment
   Seqno last_gov_req_updated;
   int64_t ctx; // a context provided when a the batch is executed
                // the contents are opaque

--- a/src/consensus/pbft/libbyz/replica.h
+++ b/src/consensus/pbft/libbyz/replica.h
@@ -9,6 +9,7 @@
 #include "certificate.h"
 #include "digest.h"
 #include "global_state.h"
+#include "governance_update_tracking.h"
 #include "ledger_writer.h"
 #include "libbyz.h"
 #include "log.h"
@@ -23,7 +24,6 @@
 #include "state.h"
 #include "types.h"
 #include "view_info.h"
-#include "governance_update_tracking.h"
 
 #ifdef ENFORCE_EXACTLY_ONCE
 #  include "rep_info_exactly_once.h"

--- a/src/consensus/pbft/libbyz/replica.h
+++ b/src/consensus/pbft/libbyz/replica.h
@@ -23,6 +23,7 @@
 #include "state.h"
 #include "types.h"
 #include "view_info.h"
+#include "governance_update_tracking.h"
 
 #ifdef ENFORCE_EXACTLY_ONCE
 #  include "rep_info_exactly_once.h"
@@ -478,6 +479,7 @@ private:
 #endif
 
   ByzInfo playback_byz_info;
+  bool did_exec_gov_req = false;
   size_t playback_before_f = 0;
   // Latest byz info when we are in playback mode. Used to compare the latest
   // execution mt roots and version with the ones in the pre prepare we will get
@@ -496,6 +498,10 @@ private:
   void* rep_cb_ctx;
   // used to register a callback for a client proxy to collect replies sent to
   // this replica
+
+  GovernanceRequestTracking gov_req_track;
+  // used to track the last series of pre-prepares that had requests that
+  // affected the governance of the service
 
   pbft::RequestsMap& pbft_requests_map;
   pbft::PrePreparesMap& pbft_pre_prepares_map;

--- a/src/consensus/pbft/libbyz/types.h
+++ b/src/consensus/pbft/libbyz/types.h
@@ -53,6 +53,8 @@ struct ByzInfo
   void* cb_ctx = nullptr;
   int64_t max_local_commit_value = INT64_MIN;
   uint32_t pending_cmd_callbacks;
+  bool did_exec_gov_req;
+  Seqno last_exec_gov_req;
 };
 
 class Request;

--- a/src/enclave/rpc_handler.h
+++ b/src/enclave/rpc_handler.h
@@ -35,6 +35,7 @@ namespace enclave
       kv::Version version;
     };
 
+    virtual bool is_members_frontend() = 0;
     virtual ProcessPbftResp process_pbft(
       std::shared_ptr<enclave::RpcContext> ctx) = 0;
     virtual ProcessPbftResp process_pbft(

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -653,5 +653,10 @@ namespace ccf
     {
       return true;
     }
+
+    virtual bool is_members_frontend() override
+    {
+      return false;
+    }
   };
 }

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -965,5 +965,10 @@ namespace ccf
       ctx->session->caller_cert = caller.value().cert;
       return true;
     }
+
+    virtual bool is_members_frontend() override
+    {
+      return true;
+    }
   };
 } // namespace ccf


### PR DESCRIPTION
related to #953

This change creates a "chain" of pre-prepares that contain requests that performed some kind of governance operation.  What this means that when a user gets their receipt (which covers a pre-prepare) they can make a determination if they want to audit the log and if they do they do not need to look into every pre-prepare.