### PR TITLE
Daily build

### DIFF
--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -17,5 +17,5 @@ jobs:
       env: parameters.env.NoSGX
       cmake_args: '${{ parameters.build.daily.cmake_args }} ${{ parameters.build.NoSGX.cmake_args }}'
       suffix: 'Coverage'
-      artifact_name: '${{ target }}_Coverage'
+      artifact_name: 'NoSGX_Coverage'
       ctest_filter: ''

--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -14,7 +14,7 @@ jobs:
   - template: common.yml
     parameters:
       target: NoSGX
-      env: parameters.env.NoSGX
+      env: '${{ parameters.env.NoSGX }}'
       cmake_args: '${{ parameters.build.daily.cmake_args }} ${{ parameters.build.NoSGX.cmake_args }}'
       suffix: 'Coverage'
       artifact_name: 'NoSGX_Coverage'

--- a/.daily.yml
+++ b/.daily.yml
@@ -1,7 +1,7 @@
 pr:
   branches:
     exclude:
-      - *
+      - '*'
 
 schedules:
 - cron: "0 3 * * Mon-Fri"

--- a/.daily.yml
+++ b/.daily.yml
@@ -2,16 +2,14 @@ pr:
   branches:
     include:
       - master
-#    exclude:
-#      - '*'
 
 schedules:
-  - cron: "0 3 * * Mon-Fri"
-    displayName: Daily build
-    branches:
-      include:
-        - master
-    always: true
+- cron: "0 3 * * Mon-Fri"
+  displayName: Daily build
+  branches:
+    include:
+    - master
+  always: true
 
 resources:
   containers:

--- a/.daily.yml
+++ b/.daily.yml
@@ -1,7 +1,4 @@
-pr:
-  branches:
-    include:
-      - master
+pr: none
 
 schedules:
 - cron: "0 3 * * Mon-Fri"

--- a/.daily.yml
+++ b/.daily.yml
@@ -6,12 +6,12 @@ pr:
 #      - '*'
 
 schedules:
-- cron: "0 3 * * Mon-Fri"
-  displayName: Daily build
-  branches:
-    include:
-      - master
-  always: true
+  - cron: "0 3 * * Mon-Fri"
+    displayName: Daily build
+    branches:
+      include:
+        - master
+    always: true
 
 resources:
   containers:

--- a/.daily.yml
+++ b/.daily.yml
@@ -1,7 +1,7 @@
 pr:
   branches:
     include:
-      - daily
+      - '*daily'
     exclude:
       - '*'
 

--- a/.daily.yml
+++ b/.daily.yml
@@ -1,7 +1,7 @@
 pr:
   branches:
     include:
-      - '*daily'
+      - master
     exclude:
       - '*'
 

--- a/.daily.yml
+++ b/.daily.yml
@@ -1,3 +1,8 @@
+pr:
+  branches:
+    exclude:
+      - *
+
 schedules:
 - cron: "0 3 * * Mon-Fri"
   displayName: Daily build

--- a/.daily.yml
+++ b/.daily.yml
@@ -10,7 +10,7 @@ schedules:
   displayName: Daily build
   branches:
     include:
-    - master
+      - master
   always: true
 
 resources:

--- a/.daily.yml
+++ b/.daily.yml
@@ -1,5 +1,7 @@
 pr:
   branches:
+    include:
+      - daily
     exclude:
       - '*'
 

--- a/.daily.yml
+++ b/.daily.yml
@@ -2,8 +2,8 @@ pr:
   branches:
     include:
       - master
-    exclude:
-      - '*'
+#    exclude:
+#      - '*'
 
 schedules:
 - cron: "0 3 * * Mon-Fri"

--- a/.daily.yml
+++ b/.daily.yml
@@ -17,4 +17,4 @@ resources:
       options: --publish-all --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /mnt/build:/__w/
 
 jobs:
-- template: .azure-pipelines-templates/matrix.yml
+- template: .azure-pipelines-templates/daily-matrix.yml


### PR DESCRIPTION
I think we want:

1. SAN
2. Coverage
3. Release build and tests
4. TLS compliance test
5. Randomised test "suite", aka end to end fuzzing (probably over the SAN build)

This only adds the first two, will do the rest after the release.