### PR TITLE
Right-align logging timestamp ns

### DIFF
--- a/src/ds/logger.h
+++ b/src/ds/logger.h
@@ -52,7 +52,7 @@ namespace logger
     std::string get_timestamp(const std::tm& tm, const ::timespec& ts)
     {
       // Sample: "2019-07-19 18:53:25.690267"
-      return fmt::format("{:%Y-%m-%dT%H:%M:%S}.{:0<6}Z", tm, ts.tv_nsec / 1000);
+      return fmt::format("{:%Y-%m-%dT%H:%M:%S}.{:0>6}Z", tm, ts.tv_nsec / 1000);
     }
 
     virtual std::string format(


### PR DESCRIPTION
Spent a while trying to work out how we were printing logs out-of-order:
```
2020-03-30T16:55:02.998596Z ...
2020-03-30T16:55:02.998613Z ...
2020-03-30T16:55:02.998634Z ...
2020-03-30T16:55:03.704000Z ...
2020-03-30T16:55:03.942000Z ...
2020-03-30T16:55:03.957000Z ...
2020-03-30T16:55:03.977000Z ...
2020-03-30T16:55:03.106200Z ...
2020-03-30T16:55:03.108100Z ...
2020-03-30T16:55:03.110100Z ...
2020-03-30T16:55:03.111800Z ...
2020-03-30T16:55:03.114100Z ...
2020-03-30T16:55:03.285500Z ...
2020-03-30T16:55:03.312000Z ...
2020-03-30T16:55:03.313600Z ...
2020-03-30T16:55:03.315800Z ...
2020-03-30T16:55:03.329600Z ...
2020-03-30T16:55:03.331900Z ...
2020-03-30T16:55:03.334000Z ...
```

Turns out the timestamp was just aligned to the wrong end (suffixing 0s rather than prefixing them).