### PR TITLE
Redouble election timers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,7 +527,7 @@ if(BUILD_TESTS)
       NAME code_update_test
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/code_update.py
       CONSENSUS raft
-      ADDITIONAL_ARGS --oesign ${OE_SIGN_PATH} --raft-election-timeout 10000
+      ADDITIONAL_ARGS --oesign ${OE_SIGN_PATH} --raft-election-timeout 20000
     )
 
     add_e2e_test(
@@ -586,9 +586,9 @@ if(BUILD_TESTS)
     )
 
     if(${CONSENSUS} STREQUAL pbft)
-      set(ELECTION_TIMEOUT_ARG "--pbft-view-change-timeout" "2000")
+      set(ELECTION_TIMEOUT_ARG "--pbft-view-change-timeout" "4000")
     else()
-      set(ELECTION_TIMEOUT_ARG "--raft-election-timeout" "2000")
+      set(ELECTION_TIMEOUT_ARG "--raft-election-timeout" "4000")
     endif()
 
     if((${CONSENSUS} STREQUAL raft) OR (EXPERIMENTAL_PBFT_TESTS


### PR DESCRIPTION
It looks like the election-timeout-halving of #1011 wasn't as safe as hoped:

https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=6861&view=logs&j=8f3dc89c-3708-5926-47e7-27120a268dab&t=efdbc34d-c6b6-5dc6-e05c-1751d4c47c20&l=10624
https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=6860&view=logs&j=8f3dc89c-3708-5926-47e7-27120a268dab&t=efdbc34d-c6b6-5dc6-e05c-1751d4c47c20&l=10073


These are the only tests that set custom election timeouts, it seems they really do need them to be this large, so I've doubled them to match their old values :(