### PR TITLE
Fail on SAN errors, and fix SAN errors

### DIFF
--- a/src/apps/js_generic/js_generic.cpp
+++ b/src/apps/js_generic/js_generic.cpp
@@ -205,6 +205,7 @@ namespace ccfapp
         auto cstr = JS_ToCString(ctx, rval);
         auto response = nlohmann::json::parse(cstr);
 
+        JS_FreeValue(ctx, rval);
         JS_FreeCString(ctx, cstr);
         JS_FreeValue(ctx, val);
 

--- a/src/consensus/pbft/libbyz/replica.cpp
+++ b/src/consensus/pbft/libbyz/replica.cpp
@@ -480,7 +480,12 @@ void Replica::playback_request(ccf::Store::Tx& tx)
 
   exec_command(vec_exec_cmds, playback_byz_info, 1, 0);
   did_exec_gov_req = did_exec_gov_req || playback_byz_info.did_exec_gov_req;
-  brt.add_request(req.release());
+
+  auto owned_req = req.release();
+  if (!brt.add_request(owned_req))
+  {
+    delete owned_req;
+  }
 }
 
 void Replica::populate_certificates(Pre_prepare* pp, bool add_mine)

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -160,16 +160,20 @@ namespace asynchost
         }
 
         case CONNECTED:
+        {
           return send_write(req, len);
+        }
 
         case DISCONNECTED:
         {
           LOG_DEBUG_FMT("Disconnected: Ignoring write of size {}", len);
+          free_write(req);
           break;
         }
 
         default:
         {
+          free_write(req);
           throw std::logic_error(
             fmt::format("Unexpected status during write: {}", status));
         }

--- a/src/tls/verifier.h
+++ b/src/tls/verifier.h
@@ -204,9 +204,9 @@ namespace tls
     int rc = mbedtls_x509_crt_parse(&cert, cert_pem.data(), cert_pem.size());
     if (rc)
     {
-      std::stringstream s;
-      s << "Failed to parse certificate: " << rc;
-      throw std::invalid_argument(s.str());
+      mbedtls_x509_crt_free(&cert);
+      throw std::invalid_argument(
+        fmt::format("Failed to parse certificate: {}", error_string(rc)));
     }
 
     const auto curve = get_ec_from_context(cert.pk);

--- a/tests/e2e_batched.py
+++ b/tests/e2e_batched.py
@@ -116,6 +116,8 @@ def run_to_destruction(args):
                 network.nodes[0].remote.remote.proc.poll() is not None
             ), "Primary should have been terminated"
 
+            network.ignore_errors_on_shutdown()
+
 
 if __name__ == "__main__":
     args = infra.e2e_args.cli_args()

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -53,6 +53,10 @@ class CodeIdNotFound(Exception):
     pass
 
 
+class NodeShutdownError(Exception):
+    pass
+
+
 def get_common_folder_name(workspace, label):
     return os.path.join(workspace, f"{label}_{COMMON_FOLDER}")
 
@@ -289,9 +293,16 @@ class Network:
         LOG.success("All nodes joined recovered public network")
 
     def stop_all_nodes(self):
+        errors_found = False
         for node in self.nodes:
-            node.stop()
+            node_errors = node.stop()
+            if node_errors:
+                errors_found = True
+
         LOG.info("All remotes stopped...")
+
+        if errors_found:
+            raise NodeShutdownError(f"Non-empty error output during node shutdown")
 
     def create_and_add_pending_node(
         self, lib_name, host, args, target_node=None, timeout=JOIN_TIMEOUT

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -293,16 +293,16 @@ class Network:
         LOG.success("All nodes joined recovered public network")
 
     def stop_all_nodes(self):
-        errors_found = False
+        fatal_error_found = False
         for node in self.nodes:
-            node_errors = node.stop()
-            if node_errors:
-                errors_found = True
+            _, fatal_errors = node.stop()
+            if fatal_errors:
+                fatal_error_found = True
 
         LOG.info("All remotes stopped...")
 
-        if errors_found:
-            raise NodeShutdownError(f"Non-empty error output during node shutdown")
+        if fatal_error_found:
+            raise NodeShutdownError(f"Fatal error found during node shutdown")
 
     def create_and_add_pending_node(
         self, lib_name, host, args, target_node=None, timeout=JOIN_TIMEOUT
@@ -329,7 +329,7 @@ class Network:
             # The node can be safely discarded since it has not been
             # attributed a unique node_id by CCF
             LOG.error(f"New pending node {new_node.node_id} failed to join the network")
-            errors = new_node.stop()
+            errors, _ = new_node.stop()
             self.nodes.remove(new_node)
             if errors:
                 # Throw accurate exceptions if known errors found in

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -294,7 +294,6 @@ class Network:
         LOG.success("All nodes joined recovered public network")
 
     def ignore_errors_on_shutdown(self):
-        
         self.ignoring_shutdown_errors = True
 
     def stop_all_nodes(self):

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -294,6 +294,7 @@ class Network:
         LOG.success("All nodes joined recovered public network")
 
     def ignore_errors_on_shutdown(self):
+        
         self.ignoring_shutdown_errors = True
 
     def stop_all_nodes(self):

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -187,6 +187,7 @@ class Node:
         if self.remote and self.network_state is not NodeNetworkState.stopped:
             self.network_state = NodeNetworkState.stopped
             return self.remote.stop()
+        return [], []
 
     def is_stopped(self):
         return self.network_state == NodeNetworkState.stopped

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -185,9 +185,8 @@ class Node:
 
     def stop(self):
         if self.remote and self.network_state is not NodeNetworkState.stopped:
-            errors = self.remote.stop()
             self.network_state = NodeNetworkState.stopped
-            return errors
+            return self.remote.stop()
 
     def is_stopped(self):
         return self.network_state == NodeNetworkState.stopped

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -80,8 +80,7 @@ def log_errors(out_path, err_path):
         with open(err_path, "r", errors="replace") as lines:
             err_out_lines = lines.readlines()
             if err_out_lines:
-                LOG.error("Contents of {}:".format(err_path))
-                LOG.error('\n'.join(err_out_lines))
+                LOG.error(f"Contents of {err_path}:\n{''.join(err_out_lines)}")
                 error_lines.extend(err_out_lines)
     except IOError:
         LOG.exception("Could not read err output {}".format(err_path))


### PR DESCRIPTION
Daily build was failing on `logging_scenario_perf_test`, with what looked like a SAN-found memory violation. Actually this test was only failing because it timed out (SAN build is O(100)x slower, so we blow past the 90s limit). But _all_ of the SAN builds were reporting a memory leak in std err, and we were ignoring it _because there were no other errors_.

- If we find anything in std err, we log it, regardless of `[fail]`s or `[fatal]`s in std out
- If we have std error content on shutdown, we fail the test (resolves #938). NB: This is only done in `stop_all_nodes`, at the end of a test. Mid-test, we often manually shut down nodes, and sometimes we expect them to contain errors. We don't change the behaviour for those, but I believe we should expect all the final surviving nodes to shutdown cleanly (let's see if the CI agrees with that)
- Fixed the main leak that SAN was reporting (failing to cleanup `uv_write_t`s in failure case)
- Fixed some other SAN issues
