### PR TITLE
Maintain ordering of enum CLI options

### DIFF
--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
     VIRTUAL
   };
 
-  std::map<std::string, EnclaveType> enclave_type_map = {
+  std::vector<std::pair<std::string, EnclaveType>> enclave_type_map = {
     {"debug", EnclaveType::DEBUG}, {"virtual", EnclaveType::VIRTUAL}};
 
   EnclaveType enclave_type;
@@ -61,7 +61,7 @@ int main(int argc, char** argv)
     ->transform(CLI::CheckedTransformer(enclave_type_map, CLI::ignore_case));
 
   ConsensusType consensus;
-  std::map<std::string, ConsensusType> consensus_map{
+  std::vector<std::pair<std::string, ConsensusType>> consensus_map{
     {"raft", ConsensusType::RAFT}, {"pbft", ConsensusType::PBFT}};
   app.add_option("-c,--consensus", consensus, "Consensus")
     ->required()
@@ -104,10 +104,11 @@ int main(int argc, char** argv)
     ->capture_default_str();
 
   logger::Level host_log_level{logger::Level::INFO};
-  std::map<std::string, logger::Level> level_map;
+  std::vector<std::pair<std::string, logger::Level>> level_map;
   for (int i = logger::TRACE; i < logger::MAX_LOG_LEVEL; i++)
   {
-    level_map[logger::config::LevelNames[i]] = static_cast<logger::Level>(i);
+    level_map.emplace_back(
+      logger::config::LevelNames[i], static_cast<logger::Level>(i));
   }
   app
     .add_option(


### PR DESCRIPTION
`std::map`s are ordered by key, so if we pass these to CLI11 our enum options get lexicographically sorted. I think its more readable if we maintain the enum-order.

Before:
`-l,--host-log-level ENUM:value in {debug->1,fail->3,fatal->4,info->2,trace->0} OR {1,3,4,2,0}=2`

After:
`-l,--host-log-level ENUM:value in {trace->0,debug->1,info->2,fail->3,fatal->4} OR {0,1,2,3,4}=2`
 