### PR TITLE
Some PBFT cleanup

### DIFF
--- a/src/consensus/pbft/libbyz/digest.cpp
+++ b/src/consensus/pbft/libbyz/digest.cpp
@@ -15,13 +15,11 @@ Digest::Digest(char* s, unsigned n)
 {
 #ifndef NODIGESTS
   INCR_OP(num_digests);
-  START_CC(digest_cycles);
 
   // creates a digest for string "s" with length "n"
   EverCrypt_Hash_hash(
     Spec_Hash_Definitions_SHA2_256, (uint8_t*)d, (uint8_t*)s, (uint32_t)n);
 
-  STOP_CC(digest_cycles);
 #else
   for (int i = 0; i < 4; i++)
     d[i] = 3;

--- a/src/consensus/pbft/libbyz/node.cpp
+++ b/src/consensus/pbft/libbyz/node.cpp
@@ -243,7 +243,6 @@ size_t Node::gen_signature(const char* src, unsigned src_len, char* sig)
   auto signature = key_pair->sign(CBuffer{(uint8_t*)src, src_len});
   std::copy(signature.begin(), signature.end(), sig);
 
-
   return signature.size();
 }
 

--- a/src/consensus/pbft/libbyz/parameters.h
+++ b/src/consensus/pbft/libbyz/parameters.h
@@ -25,7 +25,7 @@ const int checkpoint_interval = 32;
 // unable to make progress.
 const int max_out = 512;
 
-//static const size_t Max_requests_in_batch = 1500;
+// static const size_t Max_requests_in_batch = 1500;
 static const size_t Max_requests_in_batch = 2000;
 
 static const size_t num_senders = 2;

--- a/src/consensus/pbft/libbyz/parameters.h
+++ b/src/consensus/pbft/libbyz/parameters.h
@@ -25,7 +25,8 @@ const int checkpoint_interval = 32;
 // unable to make progress.
 const int max_out = 512;
 
-static const size_t Max_requests_in_batch = 1500;
+//static const size_t Max_requests_in_batch = 1500;
+static const size_t Max_requests_in_batch = 2000;
 
 static const size_t num_senders = 2;
 // number of sender threads

--- a/src/consensus/pbft/libbyz/parameters.h
+++ b/src/consensus/pbft/libbyz/parameters.h
@@ -25,7 +25,6 @@ const int checkpoint_interval = 32;
 // unable to make progress.
 const int max_out = 512;
 
-// static const size_t Max_requests_in_batch = 1500;
 static const size_t Max_requests_in_batch = 2000;
 
 static const size_t num_senders = 2;

--- a/src/consensus/pbft/libbyz/pre_prepare.cpp
+++ b/src/consensus/pbft/libbyz/pre_prepare.cpp
@@ -45,7 +45,6 @@ Pre_prepare::Pre_prepare(
   dh.finalize(context);
   rep().hashed_nonce = dh;
 
-  START_CC(pp_digest_cycles);
   INCR_OP(pp_digest);
 
   // Fill in the request portion with as many requests as possible
@@ -116,7 +115,6 @@ Pre_prepare::Pre_prepare(
   }
   rep().n_big_reqs = n_big_reqs;
 
-  STOP_CC(pp_digest_cycles);
   INCR_CNT(sum_batch_size, requests_in_batch);
   INCR_OP(batch_size_histogram[requests_in_batch]);
 
@@ -252,7 +250,6 @@ bool Pre_prepare::calculate_digest(Digest& d)
 #endif
   if (size() >= min_size)
   {
-    START_CC(pp_digest_cycles);
     INCR_OP(pp_digest);
 
     // Check digest.
@@ -296,7 +293,6 @@ bool Pre_prepare::calculate_digest(Digest& d)
       context, (char*)big_reqs(), rep().n_big_reqs * sizeof(Digest));
     d.finalize(context);
 
-    STOP_CC(pp_digest_cycles);
     return true;
   }
   return false;

--- a/src/consensus/pbft/libbyz/principal.cpp
+++ b/src/consensus/pbft/libbyz/principal.cpp
@@ -51,10 +51,8 @@ bool Principal::verify_signature(
   }
 
   INCR_OP(num_sig_ver);
-  START_CC(sig_ver_cycles);
 
   bool ret = verifier->verify((uint8_t*)src, src_len, sig, sig_size);
 
-  STOP_CC(sig_ver_cycles);
   return ret;
 }

--- a/src/consensus/pbft/libbyz/rep_info.cpp
+++ b/src/consensus/pbft/libbyz/rep_info.cpp
@@ -27,12 +27,6 @@ Rep_info::Rep_info(char* m, int sz) : reps(Max_num_replicas)
   total_processed = (Seqno*)mem;
 }
 
-void Rep_info::count_request()
-{
-  pbft::GlobalState::get_replica().modify(mem, sizeof(Seqno));
-  (*total_processed)++;
-}
-
 char* Rep_info::new_reply(
   int pid, Request_id rid, Seqno n, uint64_t nonce, uint32_t message_size)
 {

--- a/src/consensus/pbft/libbyz/rep_info.h
+++ b/src/consensus/pbft/libbyz/rep_info.h
@@ -37,11 +37,6 @@ public:
   Seqno total_requests_processed() const;
   // Returns the number of individual requests processed by the replica
 
-  void count_request();
-  // Effects: increases the total_processed counter that holds
-  // how many individual requests have been processes since the
-  // replica was initialized. Should be called once for each request.
-
   char* new_reply(
     int pid, Request_id rid, Seqno n, uint64_t nonce, uint32_t message_size);
   // Effects: Allocates a new reply for request rid from

--- a/src/consensus/pbft/libbyz/rep_info_exactly_once.cpp
+++ b/src/consensus/pbft/libbyz/rep_info_exactly_once.cpp
@@ -83,13 +83,6 @@ char* Rep_info_exactly_once::new_reply(int pid)
   return r->contents() + sizeof(Reply_rep);
 }
 
-void Rep_info_exactly_once::count_request()
-{
-  pbft::GlobalState::get_replica().modify(
-    mem + size() - sizeof(Seqno), sizeof(Seqno));
-  (*total_processed)++;
-}
-
 int Rep_info_exactly_once::new_reply_size() const
 {
   return Max_rep_size - sizeof(Reply_rep) - MAC_size;
@@ -145,14 +138,11 @@ void Rep_info_exactly_once::send_reply(int pid, View v, int id, bool tentative)
   rr.replica = id;
 
   INCR_OP(reply_auth);
-  START_CC(reply_auth_cycles);
 
   r->auth_type = Auth_type::out;
   r->auth_len = sizeof(Reply_rep);
   r->auth_src_offset = 0;
   r->auth_dst_offset = old_size;
-
-  STOP_CC(reply_auth_cycles);
 
   pbft::GlobalState::get_node().send(r, pid);
 

--- a/src/consensus/pbft/libbyz/rep_info_exactly_once.h
+++ b/src/consensus/pbft/libbyz/rep_info_exactly_once.h
@@ -57,11 +57,6 @@ public:
   // Effects: Returns a pointer to a buffer where the new reply value
   // for principal "pid" can be placed. Sets the reply to tentative.
 
-  void count_request();
-  // Effects: increases the total_processed counter that holds
-  // how many individual requests have been processes since the
-  // replica was initialized. Should be called once for each request.
-
   int new_reply_size() const;
   // Returns the size of the reply buffer size
 

--- a/src/consensus/pbft/libbyz/replica.cpp
+++ b/src/consensus/pbft/libbyz/replica.cpp
@@ -2311,7 +2311,6 @@ std::unique_ptr<ExecCommandMsg> Replica::execute_tentative_request(
 {
   auto stash_replier = request.replier();
   request.set_replier(-1);
-  replies.count_request();
   int client_id = request.client_id();
 
   auto cmd = std::make_unique<ExecCommandMsg>(
@@ -3084,7 +3083,6 @@ void Replica::handle(Reply_stable* m)
 
       LOG_INFO << "sending recovery request" << std::endl;
       // Send recovery request.
-      START_CC(rr_time);
       rr = new Request(new_rid(), -1);
 
       int len;
@@ -3094,7 +3092,6 @@ void Replica::handle(Reply_stable* m)
 
       rr->sign(sizeof(recovery_point));
       send(rr, primary());
-      STOP_CC(rr_time);
 
       LOG_INFO << "Starting state checking" << std::endl;
 

--- a/src/consensus/pbft/libbyz/reply.cpp
+++ b/src/consensus/pbft/libbyz/reply.cpp
@@ -65,7 +65,6 @@ Reply::Reply(
   auth_len = sizeof(Reply_rep);
   auth_src_offset = 0;
   auth_dst_offset = sizeof(Reply_rep);
-
 }
 
 Reply* Reply::copy(int id) const
@@ -118,7 +117,6 @@ void Reply::re_authenticate(Principal* p)
   auth_len = sizeof(Reply_rep);
   auth_src_offset = 0;
   auth_dst_offset = old_size;
-
 }
 
 void Reply::commit(Principal* p)

--- a/src/consensus/pbft/libbyz/reply.cpp
+++ b/src/consensus/pbft/libbyz/reply.cpp
@@ -58,7 +58,6 @@ Reply::Reply(
   rep().reply_size = -1;
 
   INCR_OP(reply_auth);
-  START_CC(reply_auth_cycles);
   // p->gen_mac_out(contents(), sizeof(Reply_rep),
   // contents()+sizeof(Reply_rep));
 
@@ -67,7 +66,6 @@ Reply::Reply(
   auth_src_offset = 0;
   auth_dst_offset = sizeof(Reply_rep);
 
-  STOP_CC(reply_auth_cycles);
 }
 
 Reply* Reply::copy(int id) const
@@ -100,14 +98,11 @@ void Reply::authenticate(Principal* p, int act_len, bool tentative)
   set_size(old_size + MAC_size);
 
   INCR_OP(reply_auth);
-  START_CC(reply_auth_cycles);
 
   auth_type = Auth_type::out;
   auth_len = sizeof(Reply_rep);
   auth_src_offset = 0;
   auth_dst_offset = old_size;
-
-  STOP_CC(reply_auth_cycles);
 
   trim();
 }
@@ -117,7 +112,6 @@ void Reply::re_authenticate(Principal* p)
   int old_size = sizeof(Reply_rep) + rep().reply_size;
 
   INCR_OP(reply_auth);
-  START_CC(reply_auth_cycles);
   // p->gen_mac_out(contents(), sizeof(Reply_rep), contents()+old_size);
 
   auth_type = Auth_type::out;
@@ -125,7 +119,6 @@ void Reply::re_authenticate(Principal* p)
   auth_src_offset = 0;
   auth_dst_offset = old_size;
 
-  STOP_CC(reply_auth_cycles);
 }
 
 void Reply::commit(Principal* p)
@@ -162,7 +155,6 @@ bool Reply::pre_verify()
 
   // Check signature.
   INCR_OP(reply_auth_ver);
-  START_CC(reply_auth_ver_cycles);
 
   std::shared_ptr<Principal> replica =
     pbft::GlobalState::get_node().get_principal(rep().replica);
@@ -171,8 +163,6 @@ bool Reply::pre_verify()
     return false;
   }
   int size_wo_MAC = sizeof(Reply_rep) + rep_size;
-
-  STOP_CC(reply_auth_ver_cycles);
 
   return true;
 }

--- a/src/consensus/pbft/libbyz/request.cpp
+++ b/src/consensus/pbft/libbyz/request.cpp
@@ -48,13 +48,11 @@ char* Request::store_command(int& max_len)
 inline void Request::comp_digest(Digest& d)
 {
   INCR_OP(num_digests);
-  START_CC(digest_cycles);
 
   d = Digest(
     (char*)&(rep().cid),
     sizeof(int) + sizeof(uint64_t) + sizeof(Request_id) + rep().command_size);
 
-  STOP_CC(digest_cycles);
 }
 
 void Request::authenticate(int act_len, bool read_only)

--- a/src/consensus/pbft/libbyz/request.cpp
+++ b/src/consensus/pbft/libbyz/request.cpp
@@ -52,7 +52,6 @@ inline void Request::comp_digest(Digest& d)
   d = Digest(
     (char*)&(rep().cid),
     sizeof(int) + sizeof(uint64_t) + sizeof(Request_id) + rep().command_size);
-
 }
 
 void Request::authenticate(int act_len, bool read_only)

--- a/src/consensus/pbft/libbyz/state.cpp
+++ b/src/consensus/pbft/libbyz/state.cpp
@@ -305,7 +305,6 @@ void State::cow_single(int i)
 
   checkpoint_log.fetch(lc).append(PLevels - 1, i, bcp);
   cowb.set(i);
-
 }
 
 void State::cow(char* m, int size)
@@ -712,7 +711,6 @@ void State::send_fetch(bool change_replier)
       cert->add(mdd, true);
     }
   }
-
 }
 
 bool State::handle(Fetch* m, Seqno ls)

--- a/src/consensus/pbft/libbyz/state.cpp
+++ b/src/consensus/pbft/libbyz/state.cpp
@@ -296,7 +296,6 @@ void State::cow_single(int i)
   PBFT_ASSERT(i >= 0 && i < nb, "Invalid argument");
 
   INCR_OP(num_cows);
-  START_CC(cow_cycles);
   // Append a copy of the block to the last checkpoint
   Part& p = ptree[PLevels - 1][i];
   bcp = new BlockCopy;
@@ -307,7 +306,6 @@ void State::cow_single(int i)
   checkpoint_log.fetch(lc).append(PLevels - 1, i, bcp);
   cowb.set(i);
 
-  STOP_CC(cow_cycles);
 }
 
 void State::cow(char* m, int size)
@@ -459,7 +457,6 @@ void State::update_ptree(Seqno n)
 void State::checkpoint(Seqno seqno)
 {
   INCR_OP(num_ckpts);
-  START_CC(ckpt_cycles);
 
   update_ptree(seqno);
 
@@ -468,8 +465,6 @@ void State::checkpoint(Seqno seqno)
   nr.sd = ptree[0][0].d;
 
   cowb.clear();
-
-  STOP_CC(ckpt_cycles);
 }
 
 Seqno State::rollback(Seqno last_executed)
@@ -477,7 +472,6 @@ Seqno State::rollback(Seqno last_executed)
   PBFT_ASSERT(lc >= 0 && !fetching, "Invalid state");
 
   INCR_OP(num_rollbacks);
-  START_CC(rollback_cycles);
 
   LOG_INFO << "Rolling back to checkpoint before " << last_executed << "\n";
 
@@ -519,7 +513,6 @@ Seqno State::rollback(Seqno last_executed)
 
     lc--;
   }
-  STOP_CC(rollback_cycles);
 
   LOG_DEBUG << "Rolled back to  " << lc << "\n";
 
@@ -618,8 +611,6 @@ Part& State::get_meta_data(Seqno c, int l, int i)
 
 void State::start_fetch(Seqno le, Seqno c, Digest* cd, bool stable)
 {
-  START_CC(fetch_cycles);
-
   LOG_DEBUG << "Starting fetch le: " << le << "c:" << c << std::endl;
   if (!fetching)
   {
@@ -651,16 +642,12 @@ void State::start_fetch(Seqno le, Seqno c, Digest* cd, bool stable)
       ptree[0][0].lm,
       c,
       ((cd != nullptr) ? *cd : Digest()));
-    STOP_CC(fetch_cycles);
     send_fetch(true);
   }
-  STOP_CC(fetch_cycles);
 }
 
 void State::send_fetch(bool change_replier)
 {
-  START_CC(fetch_cycles);
-
   last_fetch_t = ITimer::current_time();
   Request_id rid = pbft::GlobalState::get_replica().new_rid();
   pbft::GlobalState::get_replica().principal()->set_last_fetch_rid(rid);
@@ -726,7 +713,6 @@ void State::send_fetch(bool change_replier)
     }
   }
 
-  STOP_CC(fetch_cycles);
 }
 
 bool State::handle(Fetch* m, Seqno ls)
@@ -851,7 +837,6 @@ bool State::handle(Fetch* m, Seqno ls)
 void State::handle(Data* m)
 {
   INCR_OP(num_fetched);
-  START_CC(fetch_cycles);
 
   int l = PLevels - 1;
   if (fetching && flevel == l)
@@ -903,19 +888,16 @@ void State::handle(Data* m)
 
         if (stalep[l]->size() == 0)
         {
-          STOP_CC(fetch_cycles);
           done_with_level();
           delete m;
           return;
         }
       }
 
-      STOP_CC(fetch_cycles);
       send_fetch();
     }
   }
   delete m;
-  STOP_CC(fetch_cycles);
 }
 
 bool State::check_digest(Digest& d, Meta_data* m)
@@ -981,7 +963,6 @@ void State::handle(Meta_data* m)
 {
   INCR_OP(meta_data_fetched);
   INCR_CNT(meta_data_bytes, m->size());
-  START_CC(fetch_cycles);
 
   Request_id crid =
     pbft::GlobalState::get_replica().principal()->last_fetch_rid();
@@ -1039,7 +1020,6 @@ void State::handle(Meta_data* m)
         }
 
         cert->clear();
-        STOP_CC(fetch_cycles);
 
         if (stalep[flevel]->size() == 0)
         {
@@ -1054,14 +1034,12 @@ void State::handle(Meta_data* m)
   }
 
   delete m;
-  STOP_CC(fetch_cycles);
 }
 
 void State::handle(Meta_data_d* m)
 {
   INCR_OP(meta_datad_fetched);
   INCR_CNT(meta_datad_bytes, m->size());
-  START_CC(fetch_cycles);
 
   LOG_TRACE << "Got meta_data_d from " << m->id() << "index" << m->index()
             << std::endl;
@@ -1110,8 +1088,6 @@ void State::handle(Meta_data_d* m)
               to_check->emplace_back(flevel, wp.index);
             }
 
-            STOP_CC(fetch_cycles);
-
             if (flevel > 0)
             {
               stalep[flevel]->pop_back();
@@ -1127,24 +1103,19 @@ void State::handle(Meta_data_d* m)
             }
             return;
           }
-          STOP_CC(fetch_cycles);
           send_fetch(true);
         }
       }
 
-      STOP_CC(fetch_cycles);
       return;
     }
   }
 
-  STOP_CC(fetch_cycles);
   delete m;
 }
 
 void State::done_with_level()
 {
-  START_CC(fetch_cycles);
-
   PBFT_ASSERT(stalep[flevel]->size() == 0, "Invalid state");
   PBFT_ASSERT(flevel > 0, "Invalid state");
 
@@ -1237,8 +1208,6 @@ void State::done_with_level()
       refetch_level = 0;
       poll_cnt = 16;
 
-      STOP_CC(fetch_cycles);
-
       pbft::GlobalState::get_replica().new_state(lc);
 
       return;
@@ -1248,7 +1217,6 @@ void State::done_with_level()
       stalep[l]->pop_back();
       if (stalep[l]->size() == 0)
       {
-        STOP_CC(fetch_cycles);
         done_with_level();
         return;
       }
@@ -1268,8 +1236,6 @@ void State::done_with_level()
       refetch_level = flevel;
     }
   }
-
-  STOP_CC(fetch_cycles);
 
   send_fetch();
 }
@@ -1302,8 +1268,6 @@ inline bool State::check_data(int i)
 
 void State::check_state()
 {
-  START_CC(check_time);
-
   int count = 1;
   while (to_check->size() > 0)
   {
@@ -1326,7 +1290,6 @@ void State::check_state()
         count % poll_cnt == 0 &&
         pbft::GlobalState::get_replica().has_messages(0))
       {
-        STOP_CC(check_time);
         return;
       }
 
@@ -1349,7 +1312,6 @@ void State::check_state()
     to_check->at(0) = to_check->back();
     to_check->pop_back();
   }
-  STOP_CC(check_time);
 
   if (!fetching)
   {

--- a/src/consensus/pbft/pbft_config.h
+++ b/src/consensus/pbft/pbft_config.h
@@ -86,8 +86,9 @@ namespace pbft
 
       if (
         info.pending_cmd_callbacks %
-          PbftConfigCcf::max_update_merkle_tree_interval ==
-        0 || info.pending_cmd_callbacks < 10)
+            PbftConfigCcf::max_update_merkle_tree_interval ==
+          0 ||
+        info.pending_cmd_callbacks < 10)
       {
         try
         {

--- a/src/consensus/pbft/pbft_config.h
+++ b/src/consensus/pbft/pbft_config.h
@@ -90,7 +90,7 @@ namespace pbft
             PbftConfigCcf::max_update_merkle_tree_interval ==
           0 ||
         info.pending_cmd_callbacks <
-          PbftConfigCcf::max_update_merkle_tree_interval)
+          PbftConfigCcf::min_update_merkle_tree_interval)
       {
         try
         {

--- a/src/consensus/pbft/pbft_config.h
+++ b/src/consensus/pbft/pbft_config.h
@@ -87,7 +87,7 @@ namespace pbft
       if (
         info.pending_cmd_callbacks %
           PbftConfigCcf::max_update_merkle_tree_interval ==
-        0)
+        0 || info.pending_cmd_callbacks < 10)
       {
         try
         {

--- a/src/consensus/pbft/pbft_config.h
+++ b/src/consensus/pbft/pbft_config.h
@@ -22,6 +22,7 @@ namespace pbft
   class PbftConfigCcf : public AbstractPbftConfig
   {
     static constexpr uint32_t max_update_merkle_tree_interval = 50;
+    static constexpr uint32_t min_update_merkle_tree_interval = 10;
 
   public:
     PbftConfigCcf(std::shared_ptr<enclave::RPCMap> rpc_map_) : rpc_map(rpc_map_)
@@ -88,7 +89,8 @@ namespace pbft
         info.pending_cmd_callbacks %
             PbftConfigCcf::max_update_merkle_tree_interval ==
           0 ||
-        info.pending_cmd_callbacks < 10)
+        info.pending_cmd_callbacks <
+          PbftConfigCcf::max_update_merkle_tree_interval)
       {
         try
         {


### PR DESCRIPTION
- remove unused stats info
- increase batch size
- when we have less than 10 pending tx to run in a batch always write to the Merkle tree instead of waiting.