### PR TITLE
Keep PR up-to-date and merge automatically

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -30,5 +30,5 @@ jobs:
           MERGE_METHOD: "squash"
           MERGE_REMOVE_LABELS: "automerge,wip"
           MERGE_FORKS: true
-          UPDATE_LABELS: "" # All branches are automatically kept up-to-date
+          UPDATE_LABELS: "sync,!wip"
           UPDATE_METHOD: "merge"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@135f0bdb927d9807b5446f7ca9ecc2c51de03c4a"
-        with:
-          args: "--trace"
         env:
           GITHUB_TOKEN: "${{ secrets.AUTOMERGE_TOKEN }}"
           # https://github.com/pascalgn/automerge-action#configuration

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@135f0bdb927d9807b5446f7ca9ecc2c51de03c4a"
+        with:
+          args: "--trace"
         env:
           GITHUB_TOKEN: "${{ secrets.AUTOMERGE_TOKEN }}"
           # https://github.com/pascalgn/automerge-action#configuration

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -28,7 +28,7 @@ jobs:
           # https://github.com/pascalgn/automerge-action#configuration
           MERGE_LABELS: "automerge,!wip"
           MERGE_METHOD: "squash"
-          MERGE_REMOVE_LABELS: "automerge,wip"
+          MERGE_REMOVE_LABELS: "automerge,wip,sync"
           MERGE_FORKS: true
           UPDATE_LABELS: "sync,!wip"
           UPDATE_METHOD: "merge"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -24,7 +24,7 @@ jobs:
       - name: automerge
         uses: "pascalgn/automerge-action@135f0bdb927d9807b5446f7ca9ecc2c51de03c4a"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.AUTOMERGE_TOKEN }}"
           # https://github.com/pascalgn/automerge-action#configuration
           MERGE_LABELS: "automerge,!wip"
           MERGE_METHOD: "squash"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,34 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@135f0bdb927d9807b5446f7ca9ecc2c51de03c4a"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          # https://github.com/pascalgn/automerge-action#configuration
+          MERGE_LABELS: "automerge,!wip"
+          MERGE_METHOD: "squash"
+          MERGE_REMOVE_LABELS: "automerge,wip"
+          MERGE_FORKS: true
+          UPDATE_LABELS: "" # All branches are automatically kept up-to-date
+          UPDATE_METHOD: "merge"


### PR DESCRIPTION
It turns out, I think GitHub Actions are the solution to what we've been discussing for a while now. This PR introduces our first GitHub Action that will take care of (based on https://github.com/pascalgn/automerge-action): 
- Auto-merging a PR if the `automerge` label has been set on a PR (and if the other CI/reviewers requirements are met). Note that the `wip` label would explicitly disable this and no label has no effect.
- Auto-updating all PRs if the `sync` label has been set on a PR.
