### PR TITLE
Set sphinx version to 2.4.4

### DIFF
--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -1,5 +1,5 @@
 breathe
-sphinx
+sphinx==2.4.4
 sphinx_rtd_theme
 pygments-style-solarized
 bottle


### PR DESCRIPTION
Sphinx 3.0.0 was released today (https://www.sphinx-doc.org/en/master/changes.html#release-3-0-0-released-apr-06-2020) but our GitHub Pages job now fails with:

```
Running Sphinx v3.0.0
making output directory... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 45 source files that are out of date
updating environment: [new config] 45 added, 0 changed, 0 removed
reading sources... [  2%] concepts
reading sources... [  4%] design/index
reading sources... [  6%] design/integration_progress
reading sources... [  8%] developers/api

Exception occurred:
  File "/__w/1/s/sphinx/env/lib/python3.7/site-packages/breathe/renderer/sphinxrenderer.py", line 60, in parse_definition
    parser = cpp.DefinitionParser(namestr, self)
TypeError: __init__() takes 2 positional arguments but 3 were given
```

Downgrading to our previous version should fix this for now.