### PR TITLE
Unpin sphinx version

### DIFF
--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -1,5 +1,5 @@
 breathe
-sphinx==2.4.4
+sphinx
 sphinx_rtd_theme
 pygments-style-solarized
 bottle


### PR DESCRIPTION
Breathe 4.15 has been [released](https://github.com/michaeljones/breathe/pull/491#issuecomment-610543065), which is compatible with Sphinx 3.0, so we can remove the pinned version requirement.