### PR TITLE
Remove copy when sending messages in PBFT

### DIFF
--- a/src/consensus/pbft/libbyz/append_entries.cpp
+++ b/src/consensus/pbft/libbyz/append_entries.cpp
@@ -23,6 +23,6 @@ bool Append_entries::verify()
 
 Append_entries_rep& Append_entries::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((Append_entries_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((Append_entries_rep*)msg_buf);
 }

--- a/src/consensus/pbft/libbyz/checkpoint.h
+++ b/src/consensus/pbft/libbyz/checkpoint.h
@@ -76,8 +76,8 @@ private:
 
 inline Checkpoint_rep& Checkpoint::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((Checkpoint_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((Checkpoint_rep*)msg_buf);
 }
 
 inline Seqno Checkpoint::seqno() const

--- a/src/consensus/pbft/libbyz/commit.h
+++ b/src/consensus/pbft/libbyz/commit.h
@@ -83,8 +83,8 @@ private:
 
 inline Commit_rep& Commit::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((Commit_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((Commit_rep*)msg_buf);
 }
 
 inline View Commit::view() const

--- a/src/consensus/pbft/libbyz/data.h
+++ b/src/consensus/pbft/libbyz/data.h
@@ -55,8 +55,8 @@ private:
 
 inline Data_rep& Data::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((Data_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((Data_rep*)msg_buf);
 }
 
 inline size_t Data::index() const

--- a/src/consensus/pbft/libbyz/fetch.h
+++ b/src/consensus/pbft/libbyz/fetch.h
@@ -88,8 +88,8 @@ private:
 
 inline Fetch_rep& Fetch::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((Fetch_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((Fetch_rep*)msg_buf);
 }
 
 inline Request_id Fetch::request_id() const

--- a/src/consensus/pbft/libbyz/message.cpp
+++ b/src/consensus/pbft/libbyz/message.cpp
@@ -10,19 +10,19 @@
 
 #include <stdlib.h>
 
-Message::Message(unsigned sz) : msg(0), max_size(ALIGNED_SIZE(sz))
+Message::Message(unsigned sz)
 {
   if (sz != 0)
   {
-    should_delete = true;
-
-    msg = (Message_rep*)malloc(max_size);
-    if (msg != nullptr)
+    int max_size = (ALIGNED_SIZE(sz));
+    msg_buf = (Message_rep*)malloc(max_size);
+    msg = std::move(make_Ref<MsgBufCounter>(msg_buf, max_size, true));
+    if (msg_buf != nullptr)
     {
-      PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-      msg->tag = -1;
-      msg->size = 0;
-      msg->extra = 0;
+      PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+      msg_buf->tag = -1;
+      msg_buf->size = 0;
+      msg_buf->extra = 0;
     }
   }
   auth_type = Auth_type::unknown;
@@ -33,14 +33,14 @@ Message::Message(unsigned sz) : msg(0), max_size(ALIGNED_SIZE(sz))
 
 Message::Message(int t, unsigned sz)
 {
-  should_delete = true;
+  int max_size = ALIGNED_SIZE(sz);
+  msg_buf = (Message_rep*)malloc(max_size);
+  msg = std::move(make_Ref<MsgBufCounter>(msg_buf, max_size, true));
 
-  max_size = ALIGNED_SIZE(sz);
-  msg = (Message_rep*)malloc(max_size);
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  msg->tag = t;
-  msg->size = max_size;
-  msg->extra = 0;
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  msg_buf->tag = t;
+  msg_buf->size = max_size;
+  msg_buf->extra = 0;
   auth_type = Auth_type::unknown;
   auth_len = 0;
   auth_dst_offset = 0;
@@ -50,50 +50,43 @@ Message::Message(int t, unsigned sz)
 Message::Message(Message_rep* cont)
 {
   PBFT_ASSERT(ALIGNED(cont), "Improperly aligned pointer");
-  msg = cont;
-  max_size = -1; // To prevent contents from being deallocated or trimmed
+  int max_size = -1; // To prevent contents from being deallocated or trimmed
+  msg = std::move(make_Ref<MsgBufCounter>(cont, max_size, false));
+  msg_buf = cont;
   auth_type = Auth_type::unknown;
   auth_len = 0;
   auth_dst_offset = 0;
   next = nullptr;
-  should_delete = false;
-}
-
-Message::~Message()
-{
-  if (max_size > 0 && msg != nullptr)
-  {
-    free(msg);
-  }
 }
 
 void Message::trim()
 {
-  if (max_size > 0)
+  if (msg->max_size > 0)
   {
-    max_size = msg->size;
+    msg->max_size = msg_buf->size;
   }
 }
 
 void Message::set_size(int size)
 {
-  PBFT_ASSERT(msg && ALIGNED(msg), "Invalid state");
-  if (!(max_size < 0 || ALIGNED_SIZE(size) <= max_size))
+  PBFT_ASSERT(msg_buf && ALIGNED(msg_buf), "Invalid state");
+  if (!(msg->max_size < 0 || ALIGNED_SIZE(size) <= msg->max_size))
   {
     LOG_INFO << "Error - size:" << size
              << ", aligned_size:" << ALIGNED_SIZE(size)
-             << ", max_size:" << max_size << std::endl;
+             << ", max_size:" << msg->max_size << std::endl;
   }
-  PBFT_ASSERT(max_size < 0 || ALIGNED_SIZE(size) <= max_size, "Invalid state");
+  PBFT_ASSERT(
+    msg->max_size < 0 || ALIGNED_SIZE(size) <= msg->max_size, "Invalid state");
   int aligned = ALIGNED_SIZE(size);
   for (int i = size; i < aligned; i++)
   {
-    ((char*)msg)[i] = 0;
+    ((char*)msg_buf)[i] = 0;
   }
-  msg->size = aligned;
+  msg_buf->size = aligned;
 }
 
-bool Message::convert(char* src, unsigned len, int t, int sz, Message& m)
+bool Message::convert(char* src, unsigned len, int t, int sz, Message& msg_buf)
 {
   // First check if src is large enough to hold a Message_rep
   if (len < sizeof(Message_rep))
@@ -114,7 +107,7 @@ bool Message::convert(char* src, unsigned len, int t, int sz, Message& m)
     return false;
   }
 
-  m = ret;
+  msg_buf = ret;
   return true;
 }
 

--- a/src/consensus/pbft/libbyz/message.h
+++ b/src/consensus/pbft/libbyz/message.h
@@ -138,8 +138,6 @@ public:
 
     Message_rep* msg; // Pointer to the contents of the message.
     int max_size; // Maximum number of bytes that can be stored in "msg"
-                  // or "-1" if this instance is not responsible for
-                  // deallocating the storage in msg.
     int32_t counter;
     bool should_delete = false;
   };

--- a/src/consensus/pbft/libbyz/message.h
+++ b/src/consensus/pbft/libbyz/message.h
@@ -144,7 +144,7 @@ public:
     bool should_delete = false;
   };
 
-  Ref<MsgBufCounter> get_msg_buffer()
+  Ref<MsgBufCounter> get_msg_buffer() const
   {
     return msg;
   }

--- a/src/consensus/pbft/libbyz/meta_data.h
+++ b/src/consensus/pbft/libbyz/meta_data.h
@@ -122,8 +122,8 @@ private:
 
 inline Meta_data_rep& Meta_data::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((Meta_data_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((Meta_data_rep*)msg_buf);
 }
 
 inline Part_info* Meta_data::parts()

--- a/src/consensus/pbft/libbyz/meta_data_d.h
+++ b/src/consensus/pbft/libbyz/meta_data_d.h
@@ -98,8 +98,8 @@ private:
 
 inline Meta_data_d_rep& Meta_data_d::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((Meta_data_d_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((Meta_data_d_rep*)msg_buf);
 }
 
 inline Request_id Meta_data_d::request_id() const

--- a/src/consensus/pbft/libbyz/network_open.cpp
+++ b/src/consensus/pbft/libbyz/network_open.cpp
@@ -22,6 +22,6 @@ int Network_open::id() const
 
 Network_open_rep& Network_open::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((Network_open_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((Network_open_rep*)msg_buf);
 }

--- a/src/consensus/pbft/libbyz/new_principal.cpp
+++ b/src/consensus/pbft/libbyz/new_principal.cpp
@@ -45,8 +45,8 @@ bool New_principal::verify()
 
 New_principal_rep& New_principal::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((New_principal_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((New_principal_rep*)msg_buf);
 }
 
 NodeId New_principal::id() const

--- a/src/consensus/pbft/libbyz/new_view.h
+++ b/src/consensus/pbft/libbyz/new_view.h
@@ -138,8 +138,8 @@ private:
 
 inline New_view_rep& New_view::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((New_view_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((New_view_rep*)msg_buf);
 }
 
 inline VC_info* New_view::vc_info()

--- a/src/consensus/pbft/libbyz/pre_prepare.cpp
+++ b/src/consensus/pbft/libbyz/pre_prepare.cpp
@@ -178,8 +178,8 @@ void Pre_prepare::cleanup_after_send()
 
 Pre_prepare* Pre_prepare::clone(View v) const
 {
-  Pre_prepare* ret = (Pre_prepare*)new Message(max_size);
-  memcpy(ret->msg, msg, msg->size);
+  Pre_prepare* ret = (Pre_prepare*)new Message(msg->max_size);
+  memcpy(ret->msg_buf, msg_buf, msg_buf->size);
   ret->rep().view = v;
   return ret;
 }

--- a/src/consensus/pbft/libbyz/pre_prepare.h
+++ b/src/consensus/pbft/libbyz/pre_prepare.h
@@ -278,8 +278,8 @@ private:
 
 inline Pre_prepare_rep& Pre_prepare::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((Pre_prepare_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((Pre_prepare_rep*)msg_buf);
 }
 
 inline char* Pre_prepare::requests()

--- a/src/consensus/pbft/libbyz/prepare.h
+++ b/src/consensus/pbft/libbyz/prepare.h
@@ -113,8 +113,8 @@ private:
 
 inline Prepare_rep& Prepare::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((Prepare_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((Prepare_rep*)msg_buf);
 }
 
 inline View Prepare::view() const

--- a/src/consensus/pbft/libbyz/query_stable.h
+++ b/src/consensus/pbft/libbyz/query_stable.h
@@ -57,8 +57,8 @@ private:
 
 inline Query_stable_rep& Query_stable::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((Query_stable_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((Query_stable_rep*)msg_buf);
 }
 
 inline int Query_stable::id() const

--- a/src/consensus/pbft/libbyz/reply.cpp
+++ b/src/consensus/pbft/libbyz/reply.cpp
@@ -69,8 +69,8 @@ Reply::Reply(
 
 Reply* Reply::copy(int id) const
 {
-  Reply* ret = (Reply*)new Reply(msg->size);
-  memcpy(ret->msg, msg, msg->size);
+  Reply* ret = (Reply*)new Reply(msg_buf->size);
+  memcpy(ret->msg_buf, msg_buf, msg_buf->size);
   ret->rep().replica = id;
   return ret;
 }

--- a/src/consensus/pbft/libbyz/reply.h
+++ b/src/consensus/pbft/libbyz/reply.h
@@ -133,8 +133,8 @@ private:
 
 inline Reply_rep& Reply::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((Reply_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((Reply_rep*)msg_buf);
 }
 
 inline View Reply::view() const

--- a/src/consensus/pbft/libbyz/reply_stable.h
+++ b/src/consensus/pbft/libbyz/reply_stable.h
@@ -70,8 +70,8 @@ private:
 
 inline Reply_stable_rep& Reply_stable::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((Reply_stable_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((Reply_stable_rep*)msg_buf);
 }
 
 inline Seqno Reply_stable::last_checkpoint() const

--- a/src/consensus/pbft/libbyz/request.cpp
+++ b/src/consensus/pbft/libbyz/request.cpp
@@ -40,8 +40,8 @@ Request::Request(Request_id r, short rr, uint32_t msg_size) :
 
 Request* Request::clone() const
 {
-  Request* ret = (Request*)new Request(max_size);
-  memcpy(ret->msg, msg, msg->size);
+  Request* ret = (Request*)new Request(msg->max_size);
+  memcpy(ret->msg_buf, msg_buf, msg_buf->size);
   return ret;
 }
 

--- a/src/consensus/pbft/libbyz/request.h
+++ b/src/consensus/pbft/libbyz/request.h
@@ -154,8 +154,8 @@ private:
 
 inline Request_rep& Request::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((Request_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((Request_rep*)msg_buf);
 }
 
 inline int Request::client_id() const

--- a/src/consensus/pbft/libbyz/status.h
+++ b/src/consensus/pbft/libbyz/status.h
@@ -220,8 +220,8 @@ private:
 
 inline Status_rep& Status::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((Status_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((Status_rep*)msg_buf);
 }
 
 inline char* Status::prepared()

--- a/src/consensus/pbft/libbyz/view_change.h
+++ b/src/consensus/pbft/libbyz/view_change.h
@@ -189,8 +189,8 @@ private:
 
 inline View_change_rep& View_change::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((View_change_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((View_change_rep*)msg_buf);
 }
 
 inline Req_info* View_change::req_info()

--- a/src/consensus/pbft/libbyz/view_change_ack.h
+++ b/src/consensus/pbft/libbyz/view_change_ack.h
@@ -75,8 +75,8 @@ private:
 
 inline View_change_ack_rep& View_change_ack::rep() const
 {
-  PBFT_ASSERT(ALIGNED(msg), "Improperly aligned pointer");
-  return *((View_change_ack_rep*)msg);
+  PBFT_ASSERT(ALIGNED(msg_buf), "Improperly aligned pointer");
+  return *((View_change_ack_rep*)msg_buf);
 }
 
 inline View View_change_ack::view() const

--- a/src/ds/ref.h
+++ b/src/ds/ref.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <utility>
+
+template <typename T>
+class Ref final
+{
+public:
+  Ref(T* t_) : t(t_)
+  {
+    ++t_->counter;
+  }
+
+  Ref() : t(nullptr) {}
+
+  Ref(const Ref& r) : t(r.t)
+  {
+    ++r.t->counter;
+  }
+
+  Ref<T>& operator=(const Ref<T>& other)
+  {
+    this->~Ref<T>();
+    t = other.t;
+    ++t->counter;
+    return *this;
+  }
+
+  Ref(Ref&& r) : t(r.t)
+  {
+    r.t = nullptr;
+  }
+
+  Ref<T>& operator=(Ref<T>&& other)
+  {
+    this->~Ref<T>();
+    t = other.t;
+    other.t = nullptr;
+    return *this;
+  }
+
+  ~Ref()
+  {
+    if (t != nullptr)
+    {
+      --t->counter;
+      if (t->counter == 0)
+      {
+        delete t;
+      }
+      t = nullptr;
+    }
+  }
+
+  T* operator->() const
+  {
+    return t;
+  }
+
+  T* operator*() const
+  {
+    return t;
+  }
+
+  bool operator!() const
+  {
+    return !t;
+  }
+
+private:
+  T* t;
+};
+
+template <typename T, typename... Args>
+Ref<T> make_Ref(Args&&... args)
+{
+  return Ref<T>(new T(std::forward<Args>(args)...));
+}

--- a/src/ds/ref.h
+++ b/src/ds/ref.h
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
 #pragma once
 
 #include <utility>


### PR DESCRIPTION
Add a counter to the PBFT message so that we do not need to create a copy every time we attempt to send a message

related to #803