### PR TITLE
Add transaction rate setting to perfclient

### DIFF
--- a/samples/perf_client/perf_client.h
+++ b/samples/perf_client/perf_client.h
@@ -64,7 +64,7 @@ namespace client
     size_t max_writes_ahead = 0;
     size_t latency_rounds = 1;
     size_t generator_seed = 42u;
-    size_t ttransactions_per_s = 0;
+    size_t transactions_per_s = 0;
 
     bool sign = false;
     bool no_create = false;
@@ -127,7 +127,7 @@ namespace client
 
       app.add_option(
         "--transaction-rate", 
-        ttransactions_per_s,
+        transactions_per_s,
         "The number of transactions per second to send"
       );
 
@@ -391,8 +391,8 @@ namespace client
       size_t read;
       size_t written;
 
-      if (options.ttransactions_per_s > 0) {
-        write_delay_us = 1000000 / options.ttransactions_per_s;
+      if (options.transactions_per_s > 0) {
+        write_delay_us = 1000000 / options.transactions_per_s;
       }
 
       last_write_time = std::chrono::high_resolution_clock::now();

--- a/samples/perf_client/perf_client.h
+++ b/samples/perf_client/perf_client.h
@@ -393,6 +393,7 @@ namespace client
 
       if (options.transactions_per_s > 0) {
         write_delay_us = 1000000 / options.transactions_per_s;
+        connection->set_tcp_nodelay(true);
       }
 
       last_write_time = std::chrono::high_resolution_clock::now();

--- a/src/clients/tls_client.h
+++ b/src/clients/tls_client.h
@@ -16,6 +16,8 @@
 #include <mbedtls/error.h>
 #include <mbedtls/net_sockets.h>
 #include <mbedtls/ssl.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <string>
 #include <vector>
 
@@ -184,5 +186,16 @@ public:
     }
 
     return buf;
+  }
+
+  void set_tcp_nodelay(bool on) {
+    int option = on ? 1 : 0;
+    setsockopt(
+      server_fd.fd,
+      IPPROTO_TCP,
+      TCP_NODELAY,
+      (char *) &option,
+      sizeof(int)
+    );
   }
 };

--- a/src/clients/tls_client.h
+++ b/src/clients/tls_client.h
@@ -188,14 +188,10 @@ public:
     return buf;
   }
 
-  void set_tcp_nodelay(bool on) {
+  void set_tcp_nodelay(bool on)
+  {
     int option = on ? 1 : 0;
     setsockopt(
-      server_fd.fd,
-      IPPROTO_TCP,
-      TCP_NODELAY,
-      (char *) &option,
-      sizeof(int)
-    );
+      server_fd.fd, IPPROTO_TCP, TCP_NODELAY, (char*)&option, sizeof(int));
   }
 };


### PR DESCRIPTION
The `--transaction-rate` flag allows one to specify the transaction rate (tx/s) of the client. If a transaction rate is specified, the client computes the interval between writes needed to maintain this rate, and waits this amount between writes.