### PR TITLE
Expose add_enclave_library_c in ccf_app.cmake

### DIFF
--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -167,3 +167,12 @@ function(add_ccf_app name)
     endif()
   endif()
 endfunction()
+
+# Convenience wrapper to build C-libraries that can be linked in
+# enclave, ie. in a CCF application.
+function(add_enclave_library_c name files)
+  add_library(${name} STATIC ${files})
+  target_compile_options(${name} PRIVATE -nostdinc)
+  target_link_libraries(${name} PRIVATE openenclave::oelibc)
+  set_property(TARGET ${name} PROPERTY POSITION_INDEPENDENT_CODE ON)
+endfunction()

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -168,8 +168,8 @@ function(add_ccf_app name)
   endif()
 endfunction()
 
-# Convenience wrapper to build C-libraries that can be linked in
-# enclave, ie. in a CCF application.
+# Convenience wrapper to build C-libraries that can be linked in enclave, ie. in
+# a CCF application.
 function(add_enclave_library_c name files)
   add_library(${name} STATIC ${files})
   target_compile_options(${name} PRIVATE -nostdinc)

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -22,14 +22,6 @@ else()
   unset(NODES)
 endif()
 
-option(COLORED_OUTPUT "Always produce ANSI-colored output (Clang only)." TRUE)
-
-if(${COLORED_OUTPUT})
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    add_compile_options(-fcolor-diagnostics)
-  endif()
-endif()
-
 option(VERBOSE_LOGGING "Enable verbose logging" OFF)
 set(TEST_HOST_LOGGING_LEVEL "info")
 if(VERBOSE_LOGGING)
@@ -164,13 +156,6 @@ set(LUA_SOURCES
 set(HTTP_PARSER_SOURCES ${CCF_DIR}/3rdparty/http-parser/http_parser.c)
 
 find_library(CRYPTO_LIBRARY crypto)
-
-function(add_enclave_library_c name files)
-  add_library(${name} STATIC ${files})
-  target_compile_options(${name} PRIVATE -nostdinc)
-  target_link_libraries(${name} PRIVATE openenclave::oelibc)
-  set_property(TARGET ${name} PROPERTY POSITION_INDEPENDENT_CODE ON)
-endfunction()
 
 include(${CCF_DIR}/cmake/crypto.cmake)
 include(${CCF_DIR}/cmake/secp256k1.cmake)

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -177,7 +177,11 @@ function(add_unit_test name)
   add_san(${name})
 
   add_test(NAME ${name} COMMAND ${CCF_DIR}/tests/unit_test_wrapper.sh ${name})
-  set_property(TEST ${name} APPEND PROPERTY LABELS unit_test)
+  set_property(
+    TEST ${name}
+    APPEND
+    PROPERTY LABELS unit_test
+  )
 endfunction()
 
 if("sgx" IN_LIST COMPILE_TARGETS)

--- a/cmake/preproject.cmake
+++ b/cmake/preproject.cmake
@@ -2,9 +2,9 @@
 # Licensed under the Apache 2.0 License.
 
 # Note: this needs to be done before project(), otherwise CMAKE_*_COMPILER is
-# already set by CMake If the user has not expressed any choice, we attempt to
+# already set by CMake. If the user has not expressed any choice, we attempt to
 # default to Clang >= 7 If they have expressed even a partial choice, the usual
-# CMake selection logic applies If we cannot find both a suitable clang and a
+# CMake selection logic applies. If we cannot find both a suitable clang and a
 # suitable clang++, the usual CMake selection logic applies
 if((NOT CMAKE_C_COMPILER)
    AND (NOT CMAKE_CXX_COMPILER)
@@ -51,6 +51,14 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel"
                                     "RelWithDebInfo"
   )
+endif()
+
+option(COLORED_OUTPUT "Always produce ANSI-colored output (Clang only)." TRUE)
+
+if(${COLORED_OUTPUT})
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    add_compile_options(-fcolor-diagnostics)
+  endif()
 endif()
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Expose add_enclave_library_c in ccf_app.cmake for applications that want to build and bring in C libraries. 