### PR TITLE
Python linter + cleanup

### DIFF
--- a/tests/code_update.py
+++ b/tests/code_update.py
@@ -4,8 +4,6 @@ import infra.e2e_args
 import infra.ccf
 import infra.path
 import infra.proc
-import json
-import logging
 import os
 import subprocess
 import sys
@@ -33,7 +31,7 @@ def run(args):
         hosts, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
         network.start_and_join(args)
-        primary, others = network.find_nodes()
+        primary, _ = network.find_nodes()
 
         LOG.info("Adding a new node")
         new_node = network.create_and_trust_node(args.package, "localhost", args)

--- a/tests/connections.py
+++ b/tests/connections.py
@@ -5,6 +5,7 @@ import infra.proc
 import infra.e2e_args
 import getpass
 import os
+import time
 import infra.ccf
 import infra.proc
 import contextlib

--- a/tests/connections.py
+++ b/tests/connections.py
@@ -1,18 +1,12 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
-import sys
-import os
 import infra.proc
 
 import infra.e2e_args
 import getpass
 import os
-import time
-import logging
-from random import seed
 import infra.ccf
 import infra.proc
-import json
 import contextlib
 import resource
 import psutil
@@ -29,7 +23,7 @@ def run(args):
     ) as network:
         check = infra.checker.Checker()
         network.start_and_join(args)
-        primary, others = network.find_nodes()
+        primary, _ = network.find_nodes()
 
         primary_pid = primary.remote.remote.proc.pid
         num_fds = psutil.Process(primary_pid).num_fds()

--- a/tests/connections.py
+++ b/tests/connections.py
@@ -9,7 +9,6 @@ import getpass
 import os
 import time
 import logging
-import multiprocessing
 from random import seed
 import infra.ccf
 import infra.proc

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -154,7 +154,7 @@ def test_forwarding_frontends(network, args):
 def test_update_lua(network, args):
     if args.package == "liblua_generic":
         LOG.info("Updating Lua application")
-        primary, term = network.find_primary()
+        primary, _ = network.find_primary()
 
         check = infra.checker.Checker()
 

--- a/tests/e2e_scenarios.py
+++ b/tests/e2e_scenarios.py
@@ -5,7 +5,6 @@ import getpass
 import json
 import time
 import logging
-import multiprocessing
 import shutil
 import random
 import infra.ccf

--- a/tests/e2e_scenarios.py
+++ b/tests/e2e_scenarios.py
@@ -1,11 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 import os
-import getpass
 import json
-import time
-import logging
-import shutil
+import http
 import random
 import infra.ccf
 import infra.proc

--- a/tests/e2e_suite.py
+++ b/tests/e2e_suite.py
@@ -107,8 +107,20 @@ def run(args):
 
     network.stop_all_nodes()
 
-    LOG.success(f"Ran {len(run_tests)}/{len(s.tests)} tests:")
-    LOG.success(f"\n{json.dumps(run_tests, indent=4)}")
+    if success:
+        LOG.success(f"All tests passed. Ran {len(run_tests)}/{len(s.tests)}")
+    else:
+        LOG.error(f"Test failed. Ran {len(run_tests)}/{len(s.tests)}")
+
+    for idx, test in run_tests.items():
+        status = test["status"]
+        if status == TestStatus.success.name:
+            log_fn = LOG.success
+        elif status == TestStatus.skipped.name:
+            log_fn = LOG.warning
+        else:
+            log_fn = LOG.error
+        log_fn(f"Test #{idx}:\n{json.dumps(test, indent=4)}")
 
     if not success:
         sys.exit(1)

--- a/tests/election.py
+++ b/tests/election.py
@@ -1,11 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
-import os
-import getpass
-import logging
 import time
 import math
-import http
 import infra.ccf
 import infra.proc
 import infra.e2e_args

--- a/tests/governance.py
+++ b/tests/governance.py
@@ -5,7 +5,6 @@ import sys
 import getpass
 import time
 import logging
-import multiprocessing
 import shutil
 import subprocess
 from random import seed

--- a/tests/governance.py
+++ b/tests/governance.py
@@ -2,12 +2,7 @@
 # Licensed under the Apache 2.0 License.
 import os
 import sys
-import getpass
-import time
-import logging
-import shutil
 import subprocess
-from random import seed
 import infra.ccf
 import infra.path
 import infra.proc
@@ -25,11 +20,9 @@ def run(args):
         hosts, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
         network.start_and_join(args)
-        primary, backups = network.find_nodes()
+        primary, _ = network.find_nodes()
 
         with primary.node_client() as mc:
-            check_commit = infra.checker.Checker(mc)
-            check = infra.checker.Checker()
             r = mc.get("getQuotes")
             quotes = r.result["quotes"]
             assert len(quotes) == len(hosts)

--- a/tests/governance_history.py
+++ b/tests/governance_history.py
@@ -7,7 +7,6 @@ import infra.remote
 import infra.crypto
 import infra.ledger
 from infra.proposal import ProposalState
-import json
 import http
 
 from loguru import logger as LOG
@@ -60,7 +59,7 @@ def run(args):
         hosts, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
         network.start_and_join(args)
-        primary, term = network.find_primary()
+        primary, _ = network.find_primary()
 
         ledger_filename = network.find_primary()[0].remote.ledger_path()
         ledger = infra.ledger.Ledger(ledger_filename)
@@ -71,10 +70,7 @@ def run(args):
         ) = count_governance_operations(ledger)
 
         LOG.info("Add new member proposal (implicit vote)")
-        (
-            new_member_proposal,
-            new_member,
-        ) = network.consortium.generate_and_propose_new_member(
+        new_member_proposal, _ = network.consortium.generate_and_propose_new_member(
             primary, curve=infra.ccf.ParticipantsCurve.secp256k1
         )
         proposals_issued += 1
@@ -92,10 +88,7 @@ def run(args):
         assert response.status == http.HTTPStatus.UNAUTHORIZED.value
 
         LOG.info("Create new proposal but withdraw it before it is accepted")
-        (
-            new_member_proposal,
-            new_member,
-        ) = network.consortium.generate_and_propose_new_member(
+        new_member_proposal, _ = network.consortium.generate_and_propose_new_member(
             primary, curve=infra.ccf.ParticipantsCurve.secp256k1
         )
         proposals_issued += 1

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -1,11 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
-import json
 import os
 import time
 import logging
 from contextlib import contextmanager
-from glob import glob
 from enum import Enum, IntEnum
 import infra.clients
 import infra.path
@@ -14,7 +12,6 @@ import infra.node
 import infra.consortium
 import ssl
 import random
-import http
 from math import ceil
 
 from loguru import logger as LOG

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -10,7 +10,6 @@ import infra.path
 import infra.proc
 import infra.node
 import infra.consortium
-import ssl
 import random
 from math import ceil
 
@@ -167,7 +166,7 @@ class Network:
     def _start_all_nodes(
         self, args, recovery=False, ledger_file=None, sealed_secrets=None
     ):
-        hosts = self.hosts or ["localhost"] * number_of_local.nodes()
+        hosts = self.hosts
 
         if not args.package:
             raise ValueError("A package name must be specified.")
@@ -208,7 +207,7 @@ class Network:
                 raise
         LOG.info("All remotes started")
 
-        primary, term = self.find_primary()
+        primary, _ = self.find_primary()
         self.consortium.check_for_service(primary, status=ServiceStatus.OPENING)
 
         return primary
@@ -326,7 +325,7 @@ class Network:
                     else infra.node.NodeStatus.TRUSTED
                 ),
             )
-        except TimeoutError as err:
+        except TimeoutError:
             # The node can be safely discarded since it has not been
             # attributed a unique node_id by CCF
             LOG.error(f"New pending node {new_node.node_id} failed to join the network")
@@ -406,7 +405,7 @@ class Network:
             self.status = ServiceStatus.OPEN
 
     def wait_for_all_nodes_to_be_trusted(self, timeout=3):
-        primary, term = self.find_primary()
+        primary, _ = self.find_primary()
         for n in self.nodes:
             self.consortium.wait_for_node_to_exist_in_store(
                 primary, n.node_id, timeout, infra.node.NodeStatus.TRUSTED
@@ -447,14 +446,14 @@ class Network:
 
     def find_backups(self, primary=None, timeout=3):
         if primary is None:
-            primary, term = self.find_primary(timeout=timeout)
+            primary, _ = self.find_primary(timeout=timeout)
         return [n for n in self.get_joined_nodes() if n != primary]
 
     def find_any_backup(self, primary=None, timeout=3):
         return random.choice(self.find_backups(primary=primary, timeout=timeout))
 
     def find_nodes(self, timeout=3):
-        primary, term = self.find_primary(timeout=timeout)
+        primary, _ = self.find_primary(timeout=timeout)
         backups = self.find_backups(primary=primary, timeout=timeout)
         return primary, backups
 

--- a/tests/infra/checker.py
+++ b/tests/infra/checker.py
@@ -1,11 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-import infra.node
 import json
 import time
-
-from loguru import logger as LOG
 
 
 def wait_for_global_commit(node_client, commit_index, term, mksign=False, timeout=3):

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -72,6 +72,7 @@ class Response:
             d["error"] = self.error
         return d
 
+    @staticmethod
     def from_requests_response(rr):
         content_type = rr.headers.get("content-type")
         if content_type == "application/json":
@@ -92,6 +93,7 @@ class Response:
             global_commit=int_or_none(rr.headers.get(CCF_GLOBAL_COMMIT_HEADER)),
         )
 
+    @staticmethod
     def from_raw(raw):
         sock = FakeSocket(raw)
         response = HTTPResponse(sock)

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -1,24 +1,16 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
-import socket
-import ssl
-import struct
-import select
 import contextlib
 import json
 import time
 import os
 import subprocess
 import tempfile
-import base64
 import requests
 import urllib.parse
 from requests_http_signature import HTTPSignatureAuth
 from http.client import HTTPResponse
 from io import BytesIO
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import asymmetric
 from websocket import create_connection
 from loguru import logger as LOG
 

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -3,7 +3,6 @@
 
 import array
 import os
-import json
 import time
 import http
 import random

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -26,12 +26,10 @@ class Consortium:
         self.key_generator = key_generator
         self.common_dir = common_dir
         for m_id in member_ids:
-            new_member = infra.member.Member(
-                len(self.members), curve, key_generator, common_dir
-            )
+            new_member = infra.member.Member(m_id, curve, key_generator, common_dir)
             new_member.set_active()
             self.members.append(new_member)
-        self.recovery_threshold = recovery_threshold or len(self.members)
+        self.recovery_threshold = recovery_threshold if recovery_threshold is not None else len(self.members)
 
     def generate_and_propose_new_member(self, remote_node, curve):
         # The Member returned by this function is in state ACCEPTED. The new Member

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -29,7 +29,9 @@ class Consortium:
             new_member = infra.member.Member(m_id, curve, key_generator, common_dir)
             new_member.set_active()
             self.members.append(new_member)
-        self.recovery_threshold = recovery_threshold if recovery_threshold is not None else len(self.members)
+        self.recovery_threshold = (
+            recovery_threshold if recovery_threshold is not None else len(self.members)
+        )
 
     def generate_and_propose_new_member(self, remote_node, curve):
         # The Member returned by this function is in state ACCEPTED. The new Member

--- a/tests/infra/crypto.py
+++ b/tests/infra/crypto.py
@@ -11,6 +11,7 @@ from coincurve.context import GLOBAL_CONTEXT
 from nacl.public import PrivateKey, PublicKey, Box
 from nacl.encoding import RawEncoder
 
+from cryptography.exceptions import InvalidSignature
 from cryptography.x509 import load_der_x509_certificate
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import (
@@ -135,7 +136,7 @@ def verify_request_sig(raw_cert, sig, req, request_body, md):
         pub_key = cert.public_key()
         hash_alg = ec.ECDSA(digest)
         pub_key.verify(sig, req, hash_alg)
-    except cryptography.exceptions.InvalidSignature as e:
+    except InvalidSignature as e:
         # we support a non-standard curve, which is also being
         # used for bitcoin.
         if pub_key._curve.name != "secp256k1":

--- a/tests/infra/crypto.py
+++ b/tests/infra/crypto.py
@@ -11,7 +11,7 @@ from coincurve.context import GLOBAL_CONTEXT
 from nacl.public import PrivateKey, PublicKey, Box
 from nacl.encoding import RawEncoder
 
-from cryptography.x509 import load_der_x509_certificate, load_pem_x509_certificate
+from cryptography.x509 import load_der_x509_certificate
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import (
     load_pem_private_key,

--- a/tests/infra/ledger.py
+++ b/tests/infra/ledger.py
@@ -29,6 +29,7 @@ class GcmHeader:
         self._gcm_tag = struct.unpack(f"@{GCM_SIZE_TAG}B", buffer[:GCM_SIZE_TAG])
         self._gcm_iv = struct.unpack(f"@{GCM_SIZE_IV}B", buffer[GCM_SIZE_TAG:])
 
+    @staticmethod
     def size():
         return GCM_SIZE_TAG + GCM_SIZE_IV
 

--- a/tests/infra/libbyz/e2e_test.py
+++ b/tests/infra/libbyz/e2e_test.py
@@ -7,8 +7,6 @@ import time
 import math
 import json
 import create_config
-from node import LocalNode
-from subprocess import PIPE, Popen, run
 import netifaces
 from loguru import logger
 

--- a/tests/infra/libbyz/node.py
+++ b/tests/infra/libbyz/node.py
@@ -1,8 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-import logging
 from loguru import logger
-from subprocess import PIPE, Popen
+from subprocess import Popen
 import paramiko
 
 

--- a/tests/infra/logging_app.py
+++ b/tests/infra/logging_app.py
@@ -45,10 +45,10 @@ class LoggingTxs:
 
     def verify(self, network):
         LOG.success(f"Verifying all logging txs")
-        primary, term = network.find_primary()
+        primary, _ = network.find_primary()
 
-        with primary.node_client() as mc:
-            check = infra.checker.Checker()
+        with primary.node_client() as nc:
+            check = infra.checker.Checker(nc)
 
             with primary.user_client() as uc:
 

--- a/tests/infra/logging_app.py
+++ b/tests/infra/logging_app.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-import infra.ccf
+import infra.checker
 
 from loguru import logger as LOG
 

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -10,9 +10,6 @@ import http
 import os
 
 
-from loguru import logger as LOG
-
-
 class NoRecoveryShareFound(Exception):
     pass
 

--- a/tests/infra/net.py
+++ b/tests/infra/net.py
@@ -26,7 +26,7 @@ def ephemeral_range():
                 "tcp",
             ]
         )
-        match = re.compile("Start Port\s+: (?P<port>\d+)", re.MULTILINE).search(
+        match = re.compile(r"Start Port\s+: (?P<port>\d+)", re.MULTILINE).search(
             str(output)
         )
         if not match:

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -7,7 +7,6 @@ import infra.remote
 import infra.net
 import infra.path
 import infra.clients
-import time
 import json
 import os
 

--- a/tests/infra/notification.py
+++ b/tests/infra/notification.py
@@ -1,11 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-import os
 import threading
 import http.server
 import queue
-import json
 from contextlib import contextmanager
 
 from loguru import logger as LOG

--- a/tests/infra/path.py
+++ b/tests/infra/path.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache 2.0 License.
 import os
 from contextlib import contextmanager
-import logging
 
 from loguru import logger as LOG
 

--- a/tests/infra/perfclient.py
+++ b/tests/infra/perfclient.py
@@ -16,7 +16,7 @@ def cli_args(add=lambda x: None, accept_unknown=False):
     parser.add_argument(
         "-n",
         "--nodes",
-        help="List of hostnames[,pub_hostnames:ports]. If empty, two nodes are spawned locally",
+        help="List of hostnames[,pub_hostnames:ports]. If empty, spawn minimum working number of local nodes (minimum depends on consensus)",
         action="append",
     )
     client_args_group = parser.add_mutually_exclusive_group()

--- a/tests/infra/perfclient.py
+++ b/tests/infra/perfclient.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache 2.0 License.
 import argparse
 import os
-import logging
 import infra.runner
 import infra.e2e_args
 from infra.perf import PERF_COLUMNS

--- a/tests/infra/perfclient.py
+++ b/tests/infra/perfclient.py
@@ -13,7 +13,7 @@ def cli_args(add=lambda x: None, accept_unknown=False):
     parser.add_argument(
         "-n",
         "--nodes",
-        help="List of hostnames[,pub_hostnames:ports]. If empty, spawn minimum working number of local nodes (minimum depends on consensus)",
+        help="List of hostnames[,pub_hostnames:ports]. If empty, spawn minimum working number of local nodes (minimum depends on consensus and other args)",
         action="append",
     )
     client_args_group = parser.add_mutually_exclusive_group()

--- a/tests/infra/perfclient.py
+++ b/tests/infra/perfclient.py
@@ -6,8 +6,6 @@ import infra.runner
 import infra.e2e_args
 from infra.perf import PERF_COLUMNS
 
-from loguru import logger as LOG
-
 
 def cli_args(add=lambda x: None, accept_unknown=False):
     parser = argparse.ArgumentParser()

--- a/tests/infra/proc.py
+++ b/tests/infra/proc.py
@@ -1,6 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
-import logging
 import subprocess
 from subprocess import run
 

--- a/tests/infra/proposal.py
+++ b/tests/infra/proposal.py
@@ -3,8 +3,6 @@
 
 from enum import Enum
 
-from loguru import logger as LOG
-
 
 class ProposalNotCreated(Exception):
     pass

--- a/tests/infra/rates.py
+++ b/tests/infra/rates.py
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 import json
-import infra.proc
-import collections
 from statistics import mean, harmonic_mean, median, pstdev
 
 from loguru import logger as LOG

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -4,12 +4,9 @@ import os
 import time
 from enum import Enum
 import paramiko
-import logging
 import subprocess
-import getpass
 from contextlib import contextmanager
 import infra.path
-import json
 import uuid
 import ctypes
 import signal

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -347,11 +347,11 @@ class SSHRemote(CmdMixin):
 
 
 @contextmanager
-def ssh_remote(name, hostname, files, cmd):
+def ssh_remote(*args, **kwargs):
     """
     Context Manager wrapper for SSHRemote
     """
-    remote = SSHRemote(name, hostname, files, cmd)
+    remote = SSHRemote(*args, **kwargs)
     try:
         remote.setup()
         remote.start()
@@ -725,15 +725,11 @@ class CCFRemote(object):
 
 
 @contextmanager
-def ccf_remote(
-    lib_path, local_node_id, host, pubhost, node_port, rpc_port, args, remote_class
-):
+def ccf_remote(*args, **kwargs):
     """
     Context Manager wrapper for CCFRemote
     """
-    remote = CCFRemote(
-        lib_path, local_node_id, host, pubhost, node_port, rpc_port, args, remote_class
-    )
+    remote = CCFRemote(*args, **kwargs)
     try:
         remote.setup()
         remote.start()

--- a/tests/infra/remote_client.py
+++ b/tests/infra/remote_client.py
@@ -1,14 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 import os
-import time
-import paramiko
-import logging
-import getpass
 import infra.ccf
-from contextlib import contextmanager
 import infra.remote
-from glob import glob
 
 from loguru import logger as LOG
 

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -18,11 +18,13 @@ logging.getLogger("paramiko").setLevel(logging.WARNING)
 
 def minimum_number_of_local_nodes(args):
     """
-    If we are using pbft then we need to have 4 nodes. Otherwise with CFT
-    we start just 1
+    If we are using pbft then we need to have 4 nodes. CFT will run with 1 nodes, unless it expects a backup
     """
     if args.consensus == "pbft":
         return 4
+
+    if args.send_tx_to == "backups":
+        return 2
 
     return 1
 

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -3,7 +3,6 @@
 import getpass
 import time
 import logging
-import multiprocessing
 import json
 from random import seed
 import infra.ccf
@@ -20,19 +19,15 @@ logging.getLogger("matplotlib").setLevel(logging.WARNING)
 logging.getLogger("paramiko").setLevel(logging.WARNING)
 
 
-def number_of_local_nodes(args):
+def minimum_number_of_local_nodes(args):
     """
     If we are using pbft then we need to have 4 nodes. Otherwise with CFT
-    on 2-core VMs, we start only one node, but on 4 core, we want to start 2.
-    Not 3, because the client is typically running two threads.
+    we start just 1
     """
     if args.consensus == "pbft":
         return 4
 
-    if multiprocessing.cpu_count() > 2:
-        return 4
-    else:
-        return 1
+    return 1
 
 
 def get_command_args(args, get_command):
@@ -83,7 +78,7 @@ def run(get_command, args):
 
     hosts = args.nodes
     if not hosts:
-        hosts = ["localhost"] * number_of_local_nodes(args)
+        hosts = ["localhost"] * minimum_number_of_local_nodes(args)
 
     LOG.info("Starting nodes on {}".format(hosts))
 

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -3,14 +3,11 @@
 import getpass
 import time
 import logging
-import json
 from random import seed
 import infra.ccf
 import infra.proc
 import infra.remote_client
 import infra.rates
-import os
-import re
 import cimetrics.upload
 
 from loguru import logger as LOG

--- a/tests/late_joiners.py
+++ b/tests/late_joiners.py
@@ -4,7 +4,6 @@ import os
 import getpass
 import time
 import logging
-import multiprocessing
 import shutil
 from random import seed
 import infra.ccf

--- a/tests/late_joiners.py
+++ b/tests/late_joiners.py
@@ -1,11 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
-import os
-import getpass
 import time
-import logging
-import shutil
-from random import seed
 import infra.ccf
 import infra.proc
 import infra.notification
@@ -140,7 +135,7 @@ def run(args):
         hosts, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
         network.start_and_join(args)
-        first_node, backups = network.find_nodes()
+        first_node, _ = network.find_nodes()
         all_nodes = network.get_joined_nodes()
         term_info = find_primary(network)
         first_msg = "Hello, world!"
@@ -149,8 +144,7 @@ def run(args):
         final_msg = "Goodbye, world!"
 
         with first_node.node_client() as mc:
-            check_commit = infra.checker.Checker(mc)
-            check = infra.checker.Checker()
+            check = infra.checker.Checker(mc)
 
             run_requests(all_nodes, TOTAL_REQUESTS, 0, first_msg, 1000)
             term_info.update(find_primary(network))

--- a/tests/memberclient.py
+++ b/tests/memberclient.py
@@ -1,7 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
-import sys
-import os
 import http
 
 import infra.e2e_args
@@ -10,7 +8,6 @@ import infra.consortium
 from infra.proposal import ProposalState
 
 import suite.test_requirements as reqs
-import random
 
 from loguru import logger as LOG
 
@@ -22,6 +19,8 @@ def test_set_recovery_threshold(network, args, recovery_threshold=None):
         # we should select a random threshold between 1 and the
         # total number of active members
         return
+
+    primary, _ = network.find_primary()
 
     already_active_member = network.consortium.get_any_active_member()
     saved_share = already_active_member.get_and_decrypt_recovery_share(primary)

--- a/tests/patch_binary.py
+++ b/tests/patch_binary.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 import argparse
-import os
 import subprocess
 
 OPCODE_MOV_EAX_DWORD = 0xB8

--- a/tests/receipts.py
+++ b/tests/receipts.py
@@ -4,7 +4,6 @@ import os
 import getpass
 import time
 import logging
-import multiprocessing
 import shutil
 from random import seed
 import infra.ccf

--- a/tests/receipts.py
+++ b/tests/receipts.py
@@ -1,11 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
-import os
-import getpass
-import time
-import logging
-import shutil
-from random import seed
 import infra.ccf
 import infra.proc
 import infra.notification
@@ -20,7 +14,7 @@ from loguru import logger as LOG
 @reqs.supports_methods("getReceipt", "verifyReceipt", "LOG_get")
 @reqs.at_least_n_nodes(2)
 def test(network, args, notifications_queue=None):
-    primary, backup = network.find_primary_and_any_backup()
+    primary, _ = network.find_primary_and_any_backup()
 
     with primary.node_client() as mc:
         check_commit = infra.checker.Checker(mc, notifications_queue)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -1,14 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
-import sys
 import infra.e2e_args
 import infra.ccf
 import infra.proc
 import suite.test_requirements as reqs
-import json
-
-import logging
-import time
 
 from loguru import logger as LOG
 

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -1,16 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
-import argparse
-import getpass
-import os
-import time
-import logging
-import 
 import infra.e2e_args
-from random import seed
 import infra.ccf
 import infra.logging_app as app
-import json
 import suite.test_requirements as reqs
 
 from loguru import logger as LOG
@@ -22,7 +14,7 @@ def test(network, args, use_shares=False):
     if use_shares:
         LOG.warning("Using member key shares for recovery (experimental)")
 
-    primary, backups = network.find_nodes()
+    primary, _ = network.find_nodes()
 
     ledger = primary.get_ledger()
     sealed_secrets = primary.get_sealed_secrets()
@@ -40,7 +32,7 @@ def test(network, args, use_shares=False):
         recovered_network.wait_for_node_commit_sync(args.consensus)
     LOG.info("Public CFTR started")
 
-    primary, term = recovered_network.find_primary()
+    primary, _ = recovered_network.find_primary()
 
     LOG.info("Members verify that the new nodes have joined the network")
     recovered_network.wait_for_all_nodes_to_be_trusted()
@@ -78,7 +70,7 @@ def run(args):
     ) as network:
         network.start_and_join(args)
 
-        for recovery_idx in range(args.recovery):
+        for _ in range(args.recovery):
             recovered_network = test(network, args, use_shares=args.use_shares)
             network.stop_all_nodes()
             network = recovered_network

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -5,7 +5,7 @@ import getpass
 import os
 import time
 import logging
-import multiprocessing
+import 
 import infra.e2e_args
 from random import seed
 import infra.ccf

--- a/tests/rekey.py
+++ b/tests/rekey.py
@@ -4,9 +4,6 @@ import infra.ccf
 import infra.notification
 import suite.test_requirements as reqs
 import infra.e2e_args
-import time
-
-from loguru import logger as LOG
 
 
 @reqs.description("Rekey the ledger once")

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -2,13 +2,8 @@
 # Licensed under the Apache 2.0 License.
 import os
 import sys
-import getpass
 import json
 import http
-import time
-import logging
-import shutil
-import random
 import infra.ccf
 import infra.proc
 import infra.e2e_args
@@ -70,7 +65,7 @@ def run(args):
         hosts, args.binary_dir, args.debug_nodes, args.perf_nodes
     ) as network:
         network.start_and_join(args)
-        primary, term = network.find_primary()
+        primary, _ = network.find_primary()
 
         check = infra.checker.Checker()
 

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -7,7 +7,6 @@ import json
 import http
 import time
 import logging
-import multiprocessing
 import shutil
 import random
 import infra.ccf

--- a/tests/suite/test_suite.py
+++ b/tests/suite/test_suite.py
@@ -1,11 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-import e2e_logging
 import reconfiguration
 import recovery
 import rekey
-import random
 
 from inspect import signature, Parameter
 

--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -1,10 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
-import os
-import getpass
-import time
-import logging
-import shutil
 import infra.ccf
 import infra.proc
 import infra.notification
@@ -12,8 +7,6 @@ import infra.net
 import suite.test_requirements as reqs
 import infra.e2e_args
 import subprocess
-
-from loguru import logger as LOG
 
 
 @reqs.description("Running TLS test against CCF")


### PR DESCRIPTION
I intended to make a few minor changes to the Python infra, including cleaning up unused imports. The linter found a few other issues which I've also fixed.

Interesting changes (non-linter):
- `e2e_suite` no longer prints errors in success-green
- `perfclient`'s `--nodes` argument has an accurate comment, and we aim for the _minimum_ number of nodes by default rather than a maybe-interesting-if-there-are-2-threads number
