### PR TITLE
[DRAFT] Hosted jobs don't need a container

### DIFF
--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -3,7 +3,6 @@ parameters:
 
   env:
     Hosted:
-      container: nosgx
       pool:
         vmImage: ubuntu-18.04
     NoSGX:


### PR DESCRIPTION
I _think_ that the jobs we mark as `Hosted` don't actually need to run in our `nosgx` Docker container? Opening as a draft to check this. If true, this should knock the ~1m Docker spinup time off the Checks job.