### PR TITLE
Handle proposals correctly with single member

### DIFF
--- a/tests/governance_history.py
+++ b/tests/governance_history.py
@@ -76,10 +76,9 @@ def run(args):
         proposals_issued += 1
 
         LOG.info("2/3 members accept the proposal")
-        response = network.consortium.vote_using_majority(primary, new_member_proposal)
+        network.consortium.vote_using_majority(primary, new_member_proposal)
         votes_issued += 1
-        assert response.status == http.HTTPStatus.OK.value
-        assert response.result["state"] == ProposalState.Accepted.value
+        assert new_member_proposal.state == infra.proposal.ProposalState.Accepted
 
         LOG.info("Unsigned votes are rejected")
         response = network.consortium.get_member_by_id(2).vote(

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -121,7 +121,7 @@ class Consortium:
 
         if proposal.state is not ProposalState.Accepted:
             raise infra.proposal.ProposalNotAccepted(proposal)
-        return response
+        return proposal
 
     def get_proposals(self, remote_node):
         script = """
@@ -315,9 +315,8 @@ class Consortium:
         proposal = self.get_any_active_member().propose(
             remote_node, script, recovery_threshold
         )
-        r = self.vote_using_majority(remote_node, proposal)
         self.recovery_threshold = recovery_threshold
-        return r
+        return self.vote_using_majority(remote_node, proposal)
 
     def add_new_code(self, remote_node, new_code_id):
         script = """

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -149,8 +149,8 @@ class Consortium:
                     infra.proposal.Proposal(
                         proposal_id=int(proposal_id),
                         proposer_id=int(attr["proposer"]),
-                        has_proposer_voted_for=has_proposer_voted_for,
                         state=infra.proposal.ProposalState(attr["state"]),
+                        has_proposer_voted_for=has_proposer_voted_for,
                     )
                 )
         return proposals

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -62,7 +62,10 @@ class Member:
                 raise infra.proposal.ProposalNotCreated(r)
 
             return infra.proposal.Proposal(
-                self.member_id, r.result["proposal_id"], vote_for
+                proposer_id=self.member_id,
+                proposal_id=r.result["proposal_id"],
+                state=infra.proposal.ProposalState(r.result["state"]),
+                has_proposer_voted_for=vote_for,
             )
 
     def vote(

--- a/tests/infra/proposal.py
+++ b/tests/infra/proposal.py
@@ -27,11 +27,7 @@ class ProposalState(Enum):
 
 class Proposal:
     def __init__(
-        self,
-        proposer_id,
-        proposal_id,
-        state,
-        has_proposer_voted_for=True,
+        self, proposer_id, proposal_id, state, has_proposer_voted_for=True,
     ):
         self.proposer_id = proposer_id
         self.proposal_id = proposal_id

--- a/tests/infra/proposal.py
+++ b/tests/infra/proposal.py
@@ -30,8 +30,8 @@ class Proposal:
         self,
         proposer_id,
         proposal_id,
+        state,
         has_proposer_voted_for=True,
-        state=ProposalState.Open,
     ):
         self.proposer_id = proposer_id
         self.proposal_id = proposal_id

--- a/tests/memberclient.py
+++ b/tests/memberclient.py
@@ -119,7 +119,7 @@ def run(args):
         assert proposal_entry.state == ProposalState.Open
 
         LOG.info("Rest of consortium accept the proposal")
-        response = network.consortium.vote_using_majority(primary, new_member_proposal)
+        network.consortium.vote_using_majority(primary, new_member_proposal)
         assert new_member_proposal.state == ProposalState.Accepted
 
         # Manually add new member to consortium
@@ -180,7 +180,7 @@ def run(args):
         trust_node_proposal = new_member.propose(primary, script, 0, vote_for=True)
 
         LOG.debug("Members vote to accept the accept node proposal")
-        response = network.consortium.vote_using_majority(primary, trust_node_proposal)
+        network.consortium.vote_using_majority(primary, trust_node_proposal)
         assert trust_node_proposal.state == infra.proposal.ProposalState.Accepted
 
         LOG.info("New member makes a new proposal")


### PR DESCRIPTION
Fixes #1075.

The problem was the default value of `state` in the `Proposal` constructor - we should read this state from the response, can't assume it is `Open`.

Then the logic in `vote_using_majority` is mostly sound, except for trying to return the last response, which may not exist. Instead, it now returns the `proposal`. This changes the return type of a bunch of functions which `return vote_using_majority(...)`, but it looks like nothing was using _their_ return values so this has no impact.