### PR TITLE
Add and install Platform Info script

### DIFF
--- a/.azure-pipelines-templates/cmake.yml
+++ b/.azure-pipelines-templates/cmake.yml
@@ -3,8 +3,9 @@ parameters:
 
 steps:
 - script: |
-    cat /proc/cpuinfo
-  displayName: /proc/cpuinfo
+    tests/sgxinfo.sh
+    cat /proc/cpuinfo | grep flags | uniq
+  displayName: Platform Info
   condition: succeededOrFailed()
 
 - script: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -37,11 +37,11 @@ resources:
   containers:
     - container: nosgx
       image: ccfciteam/ccf-ci-18.04-oe-8fe3697:latest
-      options: --publish-all --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /mnt/build:/__w/
+      options: --publish-all --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /mnt/build:/__w/ -v /lib/modules:/lib/modules:ro
 
     - container: sgx
       image: ccfciteam/ccf-ci-18.04-oe-8fe3697:latest
-      options: --publish-all --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /mnt/build:/__w/
+      options: --publish-all --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /mnt/build:/__w/ -v /lib/modules:/lib/modules:ro
 
 variables:
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/v') }}:

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -101,7 +101,7 @@ endforeach()
 
 # Install specific utilities
 install(PROGRAMS ${CCF_DIR}/tests/scurl.sh ${CCF_DIR}/tests/keygenerator.sh
-        DESTINATION bin
+                 ${CCF_DIR}/tests/sgxinfo.sh DESTINATION bin
 )
 
 # Install getting_started scripts for VM creation and setup

--- a/getting_started/setup_vm/roles/ccf_dependencies/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_dependencies/vars/common.yml
@@ -15,6 +15,7 @@ debs:
   - libcurl4-openssl-dev
   - ccache
   - doxygen
+  - kmod
 mbedtls_ver: "2.16.2"
 mbedtls_dir: "mbedtls-{{ mbedtls_ver }}"
 mbedtls_src: "{{ mbedtls_dir }}.tar.gz"

--- a/tests/sgxinfo.sh
+++ b/tests/sgxinfo.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+echo "DRIVER INFO:"
+modinfo intel_sgx
+echo ""
+echo ""
+
+echo "PSW INFO:"
+apt list --installed 2>/dev/null | grep libsgx
+echo ""
+echo ""
+
+echo "DCAP CLIENT INFO:"
+apt list --installed 2>/dev/null | grep az-dcap
+echo ""
+echo ""
+
+echo "SGX INFO:"
+/opt/openenclave/bin/oesgx

--- a/tests/sgxinfo.sh
+++ b/tests/sgxinfo.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
 
 set -e
 


### PR DESCRIPTION
fix #639 

Sample output:

```
DRIVER INFO:
filename:       /lib/modules/5.0.0-1036-azure/kernel/ubuntu/sgx/intel_sgx.ko
version:        1.22
license:        Dual BSD/GPL
author:         Jarkko Sakkinen <jarkko.sakkinen@linux.intel.com>
description:    Intel SGX Driver
srcversion:     B01FB72C0AB4B8EA7883F6E
alias:          acpi*:INT0E0C:*
depends:        
retpoline:      Y
intree:         Y
name:           intel_sgx
vermagic:       5.0.0-1036-azure SMP mod_unload 
signat:         PKCS#7
signer:         
sig_key:        
sig_hashalgo:   md4


PSW INFO:
libsgx-ae-pce/unknown,now 2.9.100.2-bionic1 amd64 [installed,upgradable to: 2.9.101.2-bionic1]
libsgx-ae-qe3/unknown,now 1.5.100.2-bionic1 amd64 [installed,upgradable to: 1.6.100.2-bionic1]
libsgx-ae-qve/unknown,now 1.5.100.2-bionic1 amd64 [installed,upgradable to: 1.6.100.2-bionic1]
libsgx-dcap-ql/unknown,now 1.5.100.2-bionic1 amd64 [installed,upgradable to: 1.6.100.2-bionic1]
libsgx-dcap-ql-dev/unknown,now 1.5.100.2-bionic1 amd64 [installed,upgradable to: 1.6.100.2-bionic1]
libsgx-enclave-common/unknown,now 2.9.100.2-bionic1 amd64 [installed,upgradable to: 2.9.101.2-bionic1]
libsgx-enclave-common-dev/unknown,now 2.9.100.2-bionic1 amd64 [installed,upgradable to: 2.9.101.2-bionic1]
libsgx-urts/unknown,now 2.9.100.2-bionic1 amd64 [installed,upgradable to: 2.9.101.2-bionic1]


DCAP CLIENT INFO:
az-dcap-client/bionic,now 1.3 amd64 [installed]


SGX INFO:
CPU supports SGX_FLC:Flexible Launch Control
CPU supports Software Guard Extensions:SGX1
MaxEnclaveSize_64: 2^(36)
EPC size on the platform: 174063616
```

I've modified the CI to run that (I think it's more useful that cpuinfo, although I've kept the flags), and it's also installed because it seems like the kind of thing users should have!