### PR TITLE
Fix no-op pre prepare

### DIFF
--- a/src/consensus/pbft/libbyz/pre_prepare.cpp
+++ b/src/consensus/pbft/libbyz/pre_prepare.cpp
@@ -104,12 +104,9 @@ Pre_prepare::Pre_prepare(
   if (prepared_cert == nullptr)
   {
     // if there are no pre-prepare proofs (e.g. no-op pre-prepare)
-    // then set zero out the rest of the allocated message
+    // then zero out the rest of the allocated message
     rep().num_prev_pp_sig = 0;
-    size_t s = sizeof(Pre_prepare_rep) + rep().rset_size +
-      rep().n_big_reqs * sizeof(Digest);
-    uint8_t* sigs = (uint8_t*)contents() + s;
-    std::memset(sigs, 0, size() - s);
+    std::memset(proofs(), 0, size() - size_to_proofs());
   }
   else
   {

--- a/src/consensus/pbft/libbyz/pre_prepare.cpp
+++ b/src/consensus/pbft/libbyz/pre_prepare.cpp
@@ -106,7 +106,9 @@ Pre_prepare::Pre_prepare(
     // if there are no pre-prepare proofs (e.g. no-op pre-prepare)
     // then zero out the rest of the allocated message
     rep().num_prev_pp_sig = 0;
-    std::memset(proofs(), 0, size() - size_to_proofs());
+    // same as proofs() + size() - size_to_proofs()
+    auto end_of_proofs = (uint8_t*)contents() + size();
+    std::fill(proofs(), end_of_proofs, 0);
   }
   else
   {

--- a/src/consensus/pbft/libbyz/pre_prepare.h
+++ b/src/consensus/pbft/libbyz/pre_prepare.h
@@ -275,6 +275,10 @@ private:
   uint8_t* proofs();
   // Effects: Returns a pointer to the first prepare proof in this.
 
+  size_t size_to_proofs();
+  // Effects: Returns the bytes we need to bypass to get to the start
+  // of the prepare proofs
+
   size_t proofs_size();
   // Effects: Returns the number of prepapre proofs in this
 };
@@ -301,7 +305,12 @@ inline Digest* Pre_prepare::big_reqs()
 
 inline uint8_t* Pre_prepare::proofs()
 {
-  return (uint8_t*)contents() + sizeof(Pre_prepare_rep) + rep().rset_size +
+  return (uint8_t*)contents() + size_to_proofs();
+}
+
+inline size_t Pre_prepare::size_to_proofs()
+{
+  return sizeof(Pre_prepare_rep) + rep().rset_size +
     rep().n_big_reqs * sizeof(Digest);
 }
 

--- a/src/consensus/pbft/libbyz/pre_prepare.h
+++ b/src/consensus/pbft/libbyz/pre_prepare.h
@@ -249,6 +249,9 @@ public:
   bool set_digest(int64_t signed_version = std::numeric_limits<int64_t>::min());
   // Effects: calculates and sets the digest.
 
+  void sign();
+  // Effects: signs the pre prepare
+
   bool is_signed();
   // Effects: checks if there is a signature over the pre_prepare message
 


### PR DESCRIPTION
Resolves problem described in #839 

The problem here is that the no-op pre-prepare digests were not being calculated consistently during view changes (no-op pre-prepares are created per-replica vs created by one replica and broadcasted to other replicas as is done in normal execution) and so the no-op pre-prepares would never complete.

This fixes that and also puts the no-op pre-prepares into the ledger during view changes. In order for the no-op pp's to go into the ledger, we need them to not be signed, as each no-op pre-prepare will be signed by the replica that created it, leading eventually to an inconsistent merkle tree. 

These pre-prepares will be signed _eventually_ as part of the next pre-prepare. 