### PR TITLE
Set default enclave type by env var, not Python arg

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -119,10 +119,10 @@ if("sgx" IN_LIST COMPILE_TARGETS)
   endif()
 
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(TEST_ENCLAVE_TYPE -e debug)
+    set(DEFAULT_ENCLAVE_TYPE debug)
   endif()
 else()
-  set(TEST_ENCLAVE_TYPE -e virtual)
+  set(DEFAULT_ENCLAVE_TYPE virtual)
 endif()
 
 # Lua module
@@ -312,13 +312,8 @@ set(WORKER_THREADS
 )
 
 set(CCF_NETWORK_TEST_ARGS
-    ${TEST_ENCLAVE_TYPE}
-    -l
-    ${TEST_HOST_LOGGING_LEVEL}
-    -g
-    ${CCF_DIR}/src/runtime_config/gov.lua
-    --worker-threads
-    ${WORKER_THREADS}
+    -l ${TEST_HOST_LOGGING_LEVEL} -g ${CCF_DIR}/src/runtime_config/gov.lua
+    --worker-threads ${WORKER_THREADS}
 )
 
 # SNIPPET_START: Lua generic application
@@ -401,6 +396,11 @@ function(add_e2e_test)
     endif()
     set_property(
       TEST ${PARSED_ARGS_NAME} APPEND PROPERTY LABELS ${PARSED_ARGS_CONSENSUS}
+    )
+
+    set_property(
+      TEST ${PARSED_ARGS_NAME} APPEND
+      PROPERTY ENVIRONMENT "DEFAULT_ENCLAVE_TYPE=${DEFAULT_ENCLAVE_TYPE}"
     )
   endif()
 endfunction()

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -35,7 +35,7 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         "-e",
         "--enclave-type",
         help="Enclave type",
-        default=os.getenv("TEST_ENCLAVE", "release"),
+        default=os.getenv("TEST_ENCLAVE", os.getenv("DEFAULT_ENCLAVE_TYPE", "release")),
         choices=("release", "debug", "virtual"),
     )
     parser.add_argument(


### PR DESCRIPTION
Fallout from #1083:

If you're in a `-CMAKE_BUILD_TYPE=Debug` folder, you may still want to run (and debug!) the virtual enclaves. But since we appended `-e debug` to the test argument, and your override option (env var `TEST_ENCLAVE`) is only used as the _default for --enclave-type_, this is not possible.

This fixes that. Rather than appending to the command line, a `Debug` or virtual-only build sets another env var, which is used as the default of `TEST_ENCLAVE` is unset. If `ctest` let us append args at runtime, without a rebuild, this would look a lot less weird (our manual override could be an additional arg, rather than an env var).