### PR TITLE
Get time in enclave from host memory, not OCall

### DIFF
--- a/edl/ccf.edl
+++ b/edl/ccf.edl
@@ -24,7 +24,7 @@ enclave {
             StartType start_type,
             ConsensusType consensus_type,
             size_t num_worker_thread,
-            [user_check] void* rdtsc_location
+            [user_check] void* time_location
         );
 
         public bool enclave_run();

--- a/edl/ccf.edl
+++ b/edl/ccf.edl
@@ -23,7 +23,8 @@ enclave {
             [out] size_t* network_enc_pubk_len,
             StartType start_type,
             ConsensusType consensus_type,
-            size_t num_worker_thread
+            size_t num_worker_thread,
+            [user_check] void* rdtsc_location
         );
 
         public bool enclave_run();

--- a/src/enclave/ccf_v.h
+++ b/src/enclave/ccf_v.h
@@ -123,7 +123,7 @@ extern "C"
     StartType start_type,
     ConsensusType consensus_type,
     size_t num_worker_thread,
-    void* rdtsc_location)
+    void* time_location)
   {
     static create_node_func_t create_node_func =
       get_enclave_exported_function<create_node_func_t>("enclave_create_node");
@@ -144,7 +144,7 @@ extern "C"
       start_type,
       consensus_type,
       num_worker_thread,
-      rdtsc_location);
+      time_location);
     return *_retval ? OE_OK : OE_FAILURE;
   }
 

--- a/src/enclave/ccf_v.h
+++ b/src/enclave/ccf_v.h
@@ -79,7 +79,8 @@ extern "C"
     size_t*,
     StartType,
     ConsensusType,
-    size_t);
+    size_t,
+    void*);
 
   using run_func_t = bool (*)();
 
@@ -121,7 +122,8 @@ extern "C"
     size_t* network_enc_pubk_len,
     StartType start_type,
     ConsensusType consensus_type,
-    size_t num_worker_thread)
+    size_t num_worker_thread,
+    void* rdtsc_location)
   {
     static create_node_func_t create_node_func =
       get_enclave_exported_function<create_node_func_t>("enclave_create_node");
@@ -141,7 +143,8 @@ extern "C"
       network_enc_pubk_len,
       start_type,
       consensus_type,
-      num_worker_thread);
+      num_worker_thread,
+      rdtsc_location);
     return *_retval ? OE_OK : OE_FAILURE;
   }
 

--- a/src/enclave/enclave_time.h
+++ b/src/enclave/enclave_time.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include <atomic>
+
+namespace enclave
+{
+  extern std::atomic<uint64_t>* rdtsc_source;
+  extern uint64_t last_rdtsc_value;
+
+  static uint64_t get_enclave_time()
+  {
+    // Update cached value if possible, but never move backwards
+    if (rdtsc_source != nullptr)
+    {
+      const auto current_rdtsc_value = rdtsc_source->load();
+      if (current_rdtsc_value > last_rdtsc_value)
+      {
+        last_rdtsc_value = current_rdtsc_value;
+      }
+    }
+
+    return last_rdtsc_value;
+  }
+}

--- a/src/enclave/enclave_time.h
+++ b/src/enclave/enclave_time.h
@@ -3,24 +3,25 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 
 namespace enclave
 {
-  extern std::atomic<uint64_t>* rdtsc_source;
-  extern uint64_t last_rdtsc_value;
+  extern std::atomic<std::chrono::microseconds>* host_time;
+  extern std::chrono::microseconds last_value;
 
-  static uint64_t get_enclave_time()
+  static std::chrono::microseconds get_enclave_time()
   {
     // Update cached value if possible, but never move backwards
-    if (rdtsc_source != nullptr)
+    if (host_time != nullptr)
     {
-      const auto current_rdtsc_value = rdtsc_source->load();
-      if (current_rdtsc_value > last_rdtsc_value)
+      const auto current_time = host_time->load();
+      if (current_time > last_value)
       {
-        last_rdtsc_value = current_rdtsc_value;
+        last_value = current_time;
       }
     }
 
-    return last_rdtsc_value;
+    return last_value;
   }
 }

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -22,8 +22,8 @@ std::atomic<uint16_t> enclave::ThreadMessaging::thread_count = 0;
 
 namespace enclave
 {
-  std::atomic<uint64_t>* rdtsc_source = nullptr;
-  uint64_t last_rdtsc_value = 0u;
+  std::atomic<std::chrono::microseconds>* host_time = nullptr;
+  std::chrono::microseconds last_value(0);
 }
 
 extern "C"
@@ -44,7 +44,7 @@ extern "C"
     StartType start_type,
     ConsensusType consensus_type,
     size_t num_worker_threads,
-    void* rdtsc_location)
+    void* time_location)
   {
     std::lock_guard<SpinLock> guard(create_lock);
 
@@ -62,8 +62,8 @@ extern "C"
       return false;
     }
 
-    enclave::rdtsc_source =
-      static_cast<decltype(enclave::rdtsc_source)>(rdtsc_location);
+    enclave::host_time =
+      static_cast<decltype(enclave::host_time)>(time_location);
 
     EnclaveConfig* ec = (EnclaveConfig*)enclave_config;
 

--- a/src/host/enclave.h
+++ b/src/host/enclave.h
@@ -76,7 +76,8 @@ namespace host
       std::vector<uint8_t>& network_enc_pubk,
       StartType start_type,
       ConsensusType consensus_type,
-      size_t num_worker_thread)
+      size_t num_worker_thread,
+      std::atomic<uint64_t>* rdtsc_location)
     {
       bool ret;
       size_t node_cert_len = 0;
@@ -103,7 +104,8 @@ namespace host
         &network_enc_pubk_len,
         start_type,
         consensus_type,
-        num_worker_thread);
+        num_worker_thread,
+        rdtsc_location);
 
       if (err != OE_OK)
       {

--- a/src/host/enclave.h
+++ b/src/host/enclave.h
@@ -77,7 +77,7 @@ namespace host
       StartType start_type,
       ConsensusType consensus_type,
       size_t num_worker_thread,
-      std::atomic<uint64_t>* rdtsc_location)
+      void* time_location)
     {
       bool ret;
       size_t node_cert_len = 0;
@@ -105,7 +105,7 @@ namespace host
         start_type,
         consensus_type,
         num_worker_thread,
-        rdtsc_location);
+        time_location);
 
       if (err != OE_OK)
       {

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -471,9 +471,6 @@ int main(int argc, char** argv)
   // regularly update the time given to the enclave
   asynchost::TimeUpdater time_updater(1);
 
-  // set initial time for logger
-  logger::config::set_start(std::chrono::system_clock::now());
-
   // handle outbound messages from the enclave
   asynchost::HandleRingbuffer handle_ringbuffer(
     bp, circuit.read_from_inside(), non_blocking_factory);

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -467,7 +467,7 @@ int main(int argc, char** argv)
   asynchost::Ticker ticker(tick_period_ms, writer_factory, [](auto s) {
     logger::config::set_start(s);
   });
-  
+
   // regularly update the time given to the enclave
   asynchost::TimeUpdater time_updater(1);
 

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -539,6 +539,8 @@ int main(int argc, char** argv)
     start_type = StartType::Recover;
   }
 
+  std::atomic<uint64_t> rdtsc_location;
+
   enclave.create_node(
     enclave_config,
     ccf_config,
@@ -547,7 +549,8 @@ int main(int argc, char** argv)
     network_enc_pubk,
     start_type,
     consensus,
-    num_worker_threads);
+    num_worker_threads,
+    &rdtsc_location);
 
   LOG_INFO_FMT("Created new node");
 

--- a/src/host/time_updater.h
+++ b/src/host/time_updater.h
@@ -5,24 +5,30 @@
 #include "timer.h"
 
 #include <atomic>
+#include <chrono>
 
 namespace asynchost
 {
   class TimeUpdaterImpl
   {
-    std::atomic<uint64_t> rdtsc_value;
+    using TClock = std::chrono::high_resolution_clock;
+    TClock::time_point creation_time;
+
+    std::atomic<std::chrono::microseconds> us_since_creation;
 
   public:
-    TimeUpdaterImpl() {}
+    TimeUpdaterImpl() : creation_time(TClock::now()) {}
 
-    std::atomic<uint64_t>* get_value()
+    std::atomic<std::chrono::microseconds>* get_value()
     {
-      return &rdtsc_value;
+      return &us_since_creation;
     }
 
     void on_timer()
     {
-      rdtsc_value = __rdtsc();
+      const auto now = TClock::now();
+      us_since_creation = std::chrono::duration_cast<std::chrono::microseconds>(
+        now - creation_time);
     }
   };
 

--- a/src/host/time_updater.h
+++ b/src/host/time_updater.h
@@ -11,7 +11,7 @@ namespace asynchost
 {
   class TimeUpdaterImpl
   {
-    using TClock = std::chrono::high_resolution_clock;
+    using TClock = std::chrono::steady_clock;
     TClock::time_point creation_time;
 
     std::atomic<std::chrono::microseconds> us_since_creation;

--- a/src/host/time_updater.h
+++ b/src/host/time_updater.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "timer.h"
+
+#include <atomic>
+
+namespace asynchost
+{
+  class TimeUpdaterImpl
+  {
+    std::atomic<uint64_t> rdtsc_value;
+
+  public:
+    TimeUpdaterImpl() {}
+
+    std::atomic<uint64_t>* get_value()
+    {
+      return &rdtsc_value;
+    }
+
+    void on_timer()
+    {
+      rdtsc_value = __rdtsc();
+    }
+  };
+
+  using TimeUpdater = proxy_ptr<Timer<TimeUpdaterImpl>>;
+}

--- a/src/host/timer.h
+++ b/src/host/timer.h
@@ -11,9 +11,11 @@ namespace asynchost
   template <typename Behaviour>
   class Timer : public with_uv_handle<uv_timer_t>
   {
+  public:
+    Behaviour behaviour;
+
   private:
     friend class close_ptr<Timer<Behaviour>>;
-    Behaviour behaviour;
 
     template <typename... Args>
     Timer(uint64_t repeat_ms, Args&&... args) :


### PR DESCRIPTION
Opening as a draft to see how this affects performance.

We have worker threads inside the enclave, and sometimes they want to idle because there is no work today. Currently they busy-wait with `__mm_pause`, which may do nothing, and wastes processor time. To actually idle, they need some concept of time, and a way to sleep. This PR adds that concept of time (with a uv job on the host writing time to a known memory location, which the enclave reads), and a sketch of backoff behaviour (busy-wait for a while, then start sleeping for chunks of time). If this works, I'll look at a more precise idle notification system (OCalling to wait on a `condition_variable` in host-space).