### PR TITLE
Use 0.9 release of OpenEnclave

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -15,7 +15,7 @@ pr:
 
 jobs:
 - job: build_and_publish_docs
-  container: ccfciteam/ccf-ci-18.04-oe-0.9.0-rc1:latest
+  container: ccfciteam/ccf-ci-18.04-oe-0.9.0:latest
   pool:
     vmImage: ubuntu-18.04
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -36,11 +36,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfciteam/ccf-ci-18.04-oe-0.9.0-rc1:latest
+      image: ccfciteam/ccf-ci-18.04-oe-0.9.0:latest
       options: --publish-all --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /mnt/build:/__w/ -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfciteam/ccf-ci-18.04-oe-0.9.0-rc1:latest
+      image: ccfciteam/ccf-ci-18.04-oe-0.9.0:latest
       options: --publish-all --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /mnt/build:/__w/ -v /lib/modules:/lib/modules:ro
 
 variables:

--- a/.daily.yml
+++ b/.daily.yml
@@ -20,11 +20,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfciteam/ccf-ci-18.04-oe-0.9.0-rc1:latest
+      image: ccfciteam/ccf-ci-18.04-oe-0.9.0:latest
       options: --publish-all --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /mnt/build:/__w/
 
     - container: sgx
-      image: ccfciteam/ccf-ci-18.04-oe-0.9.0-rc1:latest
+      image: ccfciteam/ccf-ci-18.04-oe-0.9.0:latest
       options: --publish-all --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /mnt/build:/__w/
 
 jobs:

--- a/docker/app_ci
+++ b/docker/app_ci
@@ -1,4 +1,4 @@
-FROM ccfciteam/ccf-ci-18.04-oe-0.9.0-rc1:latest
+FROM ccfciteam/ccf-ci-18.04-oe-0.9.0:latest
 
 ARG VERSION=0.9.3
 ARG TARBALL=ccf.tar.gz

--- a/getting_started/setup_vm/roles/openenclave/vars/common.yml
+++ b/getting_started/setup_vm/roles/openenclave/vars/common.yml
@@ -1,5 +1,5 @@
 workspace: "/tmp/"
-oe_ver: "v0.9.0-rc1"
+oe_ver: "v0.9.0"
 oe_src: "oe-{{ oe_ver }}.tar.gz"
 oe_prefix: "/opt/openenclave"
 oe_repo: "https://github.com/openenclave/openenclave.git"


### PR DESCRIPTION
I've rebuilt the perf CI machines on OE 0.9 as well.