### PR TITLE
Fix for pylint 2.5.0

### DIFF
--- a/.azure-pipelines-templates/checks.yml
+++ b/.azure-pipelines-templates/checks.yml
@@ -46,12 +46,12 @@ jobs:
         cmake-format --check CMakeLists.txt $(find ./cmake ./samples ./src ./tests -name "*.cmake" | tr "\n" " ")
       displayName: 'Check CMake code format'
       condition: succeededOrFailed()
-      
+
     - script: |
         python3.7 -m venv env
         source env/bin/activate
         pip install -U -r tests/requirements.txt
         pip install pylint
-        pylint $(python_files)
+        find $(python_files) -type f -name "*.py" | xargs python -m pylint
       displayName: 'Run pylint'
       condition: succeededOrFailed()

--- a/tests/connections.py
+++ b/tests/connections.py
@@ -50,7 +50,7 @@ def run(args):
 
             num_fds = psutil.Process(primary_pid).num_fds()
             LOG.info(f"{primary_pid} has {num_fds} open file descriptors")
-            LOG.info(f"Disconnecting clients")
+            LOG.info("Disconnecting clients")
 
         time.sleep(1)
         num_fds = psutil.Process(primary_pid).num_fds()
@@ -71,7 +71,7 @@ def run(args):
 
             num_fds = psutil.Process(primary_pid).num_fds()
             LOG.info(f"{primary_pid} has {num_fds} open file descriptors")
-            LOG.info(f"Disconnecting clients")
+            LOG.info("Disconnecting clients")
 
         time.sleep(1)
         num_fds = psutil.Process(primary_pid).num_fds()

--- a/tests/e2e_batched.py
+++ b/tests/e2e_batched.py
@@ -107,7 +107,7 @@ def run_to_destruction(args):
                 wsm += 5000
         except Exception as e:
             sleep_time = 3
-            LOG.info(f"Large write set caused an exception, as expected")
+            LOG.info("Large write set caused an exception, as expected")
             LOG.info(f"Exception was: {e}")
             LOG.info(f"Waiting {sleep_time}s for node to terminate")
 

--- a/tests/e2e_suite.py
+++ b/tests/e2e_suite.py
@@ -73,7 +73,7 @@ def run(args):
             reason = str(ce)
             new_network = network
 
-        except Exception as e:
+        except Exception:
             LOG.exception(f"Test {s.test_name(test)} failed")
             status = TestStatus.failure
             new_network = network

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -34,9 +34,6 @@ class ParticipantsCurve(IntEnum):
     secp256k1 = 1
     # ed25519 = 2 TODO: Unsupported for now
 
-    def __str__(self):
-        return self.name
-
     def next(self):
         return ParticipantsCurve((self.value + 1) % len(ParticipantsCurve))
 
@@ -304,7 +301,7 @@ class Network:
             if self.ignoring_shutdown_errors:
                 LOG.warning("Ignoring shutdown errors")
             else:
-                raise NodeShutdownError(f"Fatal error found during node shutdown")
+                raise NodeShutdownError("Fatal error found during node shutdown")
 
     def create_and_add_pending_node(
         self, lib_name, host, args, target_node=None, timeout=JOIN_TIMEOUT

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -175,7 +175,7 @@ class RPCFileLogger(RPCLogger):
 
     def log_response(self, response):
         with open(self.path, "a") as f:
-            f.write(f"<< Response:" + os.linesep)
+            f.write("<< Response:" + os.linesep)
             json.dump(response.to_dict() if response else "None", f, indent=2)
             f.write(os.linesep)
 

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -295,8 +295,8 @@ class Consortium:
     def store_current_network_encryption_key(self):
         cmd = [
             "cp",
-            os.path.join(self.common_dir, f"network_enc_pubk.pem"),
-            os.path.join(self.common_dir, f"network_enc_pubk_orig.pem"),
+            os.path.join(self.common_dir, "network_enc_pubk.pem"),
+            os.path.join(self.common_dir, "network_enc_pubk_orig.pem"),
         ]
         infra.proc.ccall(*cmd).check_returncode()
 

--- a/tests/infra/logging_app.py
+++ b/tests/infra/logging_app.py
@@ -44,7 +44,7 @@ class LoggingTxs:
         network.wait_for_node_commit_sync(consensus)
 
     def verify(self, network):
-        LOG.success(f"Verifying all logging txs")
+        LOG.success("Verifying all logging txs")
         for n in network.get_joined_nodes():
             with n.node_client() as mc:
                 check = infra.checker.Checker(mc)

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -135,7 +135,7 @@ class Member:
                 os.path.join(
                     self.common_dir, f"member{self.member_id}_kshare_priv.pem"
                 ),
-                os.path.join(self.common_dir, f"network_enc_pubk_orig.pem"),
+                os.path.join(self.common_dir, "network_enc_pubk_orig.pem"),
             )
 
             nonce_bytes = bytes(r.result["nonce"])

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -208,7 +208,7 @@ class Node:
                 assert (
                     rep.error is None and rep.result is not None
                 ), f"An error occured after node {self.node_id} joined the network"
-        except infra.clients.CCFConnectionException as e:
+        except infra.clients.CCFConnectionException:
             raise TimeoutError(f"Node {self.node_id} failed to join the network")
 
     def get_ledger(self):

--- a/tests/late_joiners.py
+++ b/tests/late_joiners.py
@@ -105,7 +105,6 @@ def run_requests(
 ):
     with nodes[0].node_client() as mc:
         check_commit = infra.checker.Checker(mc)
-        check = infra.checker.Checker()
         clients = []
         with contextlib.ExitStack() as es:
             for node in nodes:

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -28,7 +28,7 @@ def run(args):
 
         for method in methods:
             schema_found = False
-            schema_response = client.get(f"getSchema", params={"method": method})
+            schema_response = client.get("getSchema", params={"method": method})
             check(
                 schema_response,
                 error=lambda status, msg: status == http.HTTPStatus.OK.value,

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -48,7 +48,7 @@ def ensure_reqs(check_reqs):
 
 def supports_methods(*methods):
     def check(network, args, *nargs, **kwargs):
-        primary, term = network.find_primary()
+        primary, _ = network.find_primary()
         with primary.user_client() as c:
             response = c.get("listMethods")
             supported_methods = response.result["methods"]

--- a/tests/suite/test_suite.py
+++ b/tests/suite/test_suite.py
@@ -22,19 +22,19 @@ suite_rekey_recovery = [
 
 # This suite tests that membership changes and recoveries can be interleaved
 suite_membership_recovery = [
-    # memberclient.test_add_member,
-    # recovery.test,
-    # memberclient.test_retire_member,
-    # recovery.test,
+    memberclient.test_add_member,
+    recovery.test,
+    memberclient.test_retire_member,
+    recovery.test,
     memberclient.test_set_recovery_threshold,
-    # recovery.test,
-    # memberclient.test_update_recovery_shares,
-    # recovery.test,
+    recovery.test,
+    memberclient.test_update_recovery_shares,
+    recovery.test,
 ]
 
 
 full_suite = []
-# full_suite.extend(suite_rekey_recovery)
+full_suite.extend(suite_rekey_recovery)
 full_suite.extend(suite_membership_recovery)
 
 #

--- a/tests/suite/test_suite.py
+++ b/tests/suite/test_suite.py
@@ -22,19 +22,19 @@ suite_rekey_recovery = [
 
 # This suite tests that membership changes and recoveries can be interleaved
 suite_membership_recovery = [
-    memberclient.test_add_member,
-    recovery.test,
-    memberclient.test_retire_member,
-    recovery.test,
+    # memberclient.test_add_member,
+    # recovery.test,
+    # memberclient.test_retire_member,
+    # recovery.test,
     memberclient.test_set_recovery_threshold,
-    recovery.test,
-    memberclient.test_update_recovery_shares,
-    recovery.test,
+    # recovery.test,
+    # memberclient.test_update_recovery_shares,
+    # recovery.test,
 ]
 
 
 full_suite = []
-full_suite.extend(suite_rekey_recovery)
+# full_suite.extend(suite_rekey_recovery)
 full_suite.extend(suite_membership_recovery)
 
 #


### PR DESCRIPTION
Fixes failed CI with new pylint version:
```
************* Module tests
1,0,fatal,parse-error:error while code parsing: Unable to load file tests/__init__.py:
[Errno 2] No such file or directory: 'tests/__init__.py'
```