### PR TITLE
sgxinfo should run on driverless machines

### DIFF
--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -637,8 +637,7 @@ class CCFRemote(object):
                 f"Unexpected CCFRemote start type {start_type}. Should be start, join or recover"
             )
 
-        # Necessary for the az-dcap-client >=1.1 (https://github.com/microsoft/Azure-DCAP-Client/issues/84)
-        env = {"HOME": os.environ["HOME"]}
+        env = {}
         self.profraw = None
         if enclave_type == "virtual":
             env["UBSAN_OPTIONS"] = "print_stacktrace=1"

--- a/tests/sgxinfo.sh
+++ b/tests/sgxinfo.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-set -e
+set +e
 
 echo "DRIVER INFO:"
 modinfo intel_sgx

--- a/tests/sgxinfo.sh
+++ b/tests/sgxinfo.sh
@@ -9,6 +9,11 @@ modinfo intel_sgx
 echo ""
 echo ""
 
+echo "DRIVER LOADED:"
+lsmod | grep intel_sgx || echo "Not loaded"
+echo ""
+echo ""
+
 echo "PSW INFO:"
 apt list --installed 2>/dev/null | grep libsgx
 echo ""


### PR DESCRIPTION
Failing to run one of these steps shouldn't halt the entire script. Changes output on driverless boxes from

```
$ ./tests/sgxinfo.sh 
DRIVER INFO:
libkmod: ERROR ../libkmod/libkmod.c:586 kmod_search_moddep: could not open moddep file '/lib/modules/4.4.0-18362-Microsoft/modules.dep.bin'
modinfo: ERROR: Module alias intel_sgx not found.
```

to

```
$ ./tests/sgxinfo.sh 
DRIVER INFO:
libkmod: ERROR ../libkmod/libkmod.c:586 kmod_search_moddep: could not open moddep file '/lib/modules/4.4.0-18362-Microsoft/modules.dep.bin'
modinfo: ERROR: Module alias intel_sgx not found.

PSW INFO:
...

DCAP CLIENT INFO:
...

SGX INFO:
./tests/sgxinfo.sh: line 23: /opt/openenclave/bin/oesgx: No such file or directory
```