### PR TITLE
Check that ledger file does not exist on start/join

### DIFF
--- a/src/ds/files.h
+++ b/src/ds/files.h
@@ -15,6 +15,18 @@
 namespace files
 {
   /**
+   * @brief Checks if a path exists
+   *
+   * @param path path to check
+   * @return true if the file exists.
+   */
+  bool exists(const std::string& file)
+  {
+    std::ifstream f(file.c_str());
+    return f.good();
+  }
+
+  /**
    * @brief Tries to read a file as byte vector.
    *
    * @param file the path
@@ -24,8 +36,7 @@ namespace files
    */
   std::vector<uint8_t> slurp(const std::string& file, bool optional = false)
   {
-    using namespace std;
-    ifstream f(file, ios::binary | ios::ate);
+    std::ifstream f(file, std::ios::binary | std::ios::ate);
 
     if (!f)
     {
@@ -41,9 +52,9 @@ namespace files
     }
 
     auto size = f.tellg();
-    f.seekg(0, ios::beg);
+    f.seekg(0, std::ios::beg);
 
-    vector<uint8_t> data(size);
+    std::vector<uint8_t> data(size);
     f.read((char*)data.data(), size);
 
     if (!optional && !f)

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -380,8 +380,17 @@ int main(int argc, char** argv)
     {
       throw std::logic_error(fmt::format(
         "--rpc-address ({}) does not appear to specify valid IP address. "
-        "Please specify a domain name via the --domain option.",
+        "Please specify a domain name via the --domain option",
         rpc_address.hostname));
+    }
+
+    if (*start || *join)
+    {
+      if (files::exists(ledger_file))
+      {
+        throw std::logic_error(fmt::format(
+          "Ledger file {} is created by node on start/join", ledger_file));
+      }
     }
 
     if (*start)


### PR DESCRIPTION
Resolves https://github.com/microsoft/CCF/issues/1097

Note that we can't use `CLI11`'s `NonexistentPath` validation as the `ledger_file` _should_ be specified when a node starts in `recover` mode.