### PR TITLE
Close connection on malformed input, test. When forwarding, catch invalid requests

### DIFF
--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -100,7 +100,7 @@ namespace http
           catch (const std::exception& e)
           {
             LOG_FAIL_FMT("Error parsing request: {}", e.what());
-            return;
+            close();
           }
         }
       }

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -101,6 +101,7 @@ namespace http
           {
             LOG_FAIL_FMT("Error parsing request: {}", e.what());
             close();
+            break;
           }
         }
       }

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -113,9 +113,16 @@ namespace ccf
       auto session = std::make_shared<enclave::SessionContext>(
         client_session_id, caller_id, caller_cert);
 
-      auto context = enclave::make_rpc_context(session, raw_request);
-
-      return std::make_tuple(context, r.first.from_node);
+      try
+      {
+        auto context = enclave::make_rpc_context(session, raw_request);
+        return std::make_tuple(context, r.first.from_node);
+      }
+      catch (const std::exception& err)
+      {
+        LOG_FAIL_FMT("Invalid forwarded request: {}", err.what());
+        return std::nullopt;
+      }
     }
 
     bool send_forwarded_response(

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -34,7 +34,7 @@ def test(network, args, notifications_queue=None, verify=True):
 
 
 @reqs.description("Protocol-illegal traffic")
-@reqs.supports_methods("LOG_record")
+@reqs.supports_methods("LOG_record", "LOG_record_pub", "LOG_get", "LOG_get_pub")
 @reqs.at_least_n_nodes(2)
 def test_illegal(network, args, notifications_queue=None, verify=True):
     # Send malformed HTTP traffic and check the connection is closed
@@ -286,7 +286,9 @@ def run(args):
                 notifications_queue,
                 verify=args.package is not "libjs_generic",
             )
-            network = test_illegal(network, args)
+            network = test_illegal(
+                network, args, verify=args.package is not "libjs_generic"
+            )
             network = test_large_messages(network, args)
             network = test_remove(network, args)
             network = test_forwarding_frontends(network, args)


### PR DESCRIPTION
Fix #1105 