### PR TITLE
Fix report size 

### DIFF
--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -48,7 +48,7 @@ extensions = [
     "breathe",
     "sphinxcontrib.mermaid",
     "sphinx.ext.autosectionlabel",
-    "sphinx.ext.githubpages"
+    "sphinx.ext.githubpages",
 ]
 
 autosectionlabel_prefix_document = True

--- a/src/node/quote.h
+++ b/src/node/quote.h
@@ -132,7 +132,7 @@ namespace ccf
       crypto::Sha256Hash hash{raw_cert_pem};
 
       if (
-        parsed_quote.report_data_size != crypto::Sha256Hash::SIZE &&
+        parsed_quote.report_data_size != OE_REPORT_DATA_SIZE ||
         memcmp(
           hash.h.data(), parsed_quote.report_data, crypto::Sha256Hash::SIZE) !=
           0)


### PR DESCRIPTION
Resolves https://github.com/microsoft/CCF/issues/1086

`crypto::Sha256Hash::SIZE` is `32` while `parsed_quote.report_data_size` is `64`.