### PR TITLE
Copy OE into install dir

### DIFF
--- a/.azure-pipelines-templates/install.yml
+++ b/.azure-pipelines-templates/install.yml
@@ -20,7 +20,7 @@ steps:
   displayName: Test installed CCF
 
 - script: |
-    cp -r /opt/openclave ${{ parameters.install_prefix }}
+    cp -r /opt/openenclave ${{ parameters.install_prefix }}
   displayName: Copy OE into install dir
 
 - task: ArchiveFiles@2

--- a/.azure-pipelines-templates/install.yml
+++ b/.azure-pipelines-templates/install.yml
@@ -19,6 +19,10 @@ steps:
       -v
   displayName: Test installed CCF
 
+- script: |
+    cp -r /opt/openclave ${{ parameters.install_prefix }}
+  displayName: Copy OE into install dir
+
 - task: ArchiveFiles@2
   inputs:
     rootFolderOrFile: ${{ parameters.install_prefix }}

--- a/check-cmake-version-vs-tag.sh
+++ b/check-cmake-version-vs-tag.sh
@@ -4,11 +4,17 @@
 
 git_tag=$(git describe --tags --abbrev=0)
 git_tag=${git_tag#v}
-cmake_version=$(grep CCF_VERSION CMakeLists.txt | grep -Po "(\d)+(\.(\d)+)*")
-# Check git tag is <= CMake version. Use sort --version-sort to handle semver (0.9 < 0.10)
-if echo "$git_tag $cmake_version" | tr " " "\n" | sort --version-sort -c ; then
-  echo "Git tag ($git_tag) is safely <= CMake version ($cmake_version)"
+
+# Check if git tag looks like a semver value - ignore if not
+if [[ ${git_tag} =~ ^([[:digit:]])+(\.([[:digit:]])+)*(-.*)?$ ]]; then
+  cmake_version=$(grep CCF_VERSION CMakeLists.txt | grep -Po "(\d)+(\.(\d)+)*")
+  # Check git tag is <= CMake version. Use sort --version-sort to handle semver (0.9 < 0.10)
+  if echo "$git_tag $cmake_version" | tr " " "\n" | sort --version-sort -c ; then
+    echo "Git tag ($git_tag) is safely <= CMake version ($cmake_version)"
+  else
+    echo "Git tag ($git_tag) is later than CMake version ($cmake_version) - please update CMake version!"
+    exit 1
+  fi
 else
-  echo "Git tag ($git_tag) is later than CMake version ($cmake_version) - please update CMake version!"
-  exit 1
+  echo "Skipping check - ${git_tag} doesn't look like semver"
 fi

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -34,7 +34,6 @@ find_package(
   OpenEnclave
   0.9
   CONFIG
-  REQUIRED
   PATHS
   ${CMAKE_CURRENT_LIST_DIR}/../openenclave
   NO_DEFAULT_PATH

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -29,13 +29,10 @@ if((NOT ${IS_VALID_TARGET}))
   )
 endif()
 
-# Find OpenEnclave package, preferring local version if found (in the install case)
+# Find OpenEnclave package, preferring local version if found (in the install
+# case)
 find_package(
-  OpenEnclave
-  0.9
-  CONFIG
-  PATHS
-  ${CMAKE_CURRENT_LIST_DIR}/../openenclave
+  OpenEnclave 0.9 CONFIG PATHS ${CMAKE_CURRENT_LIST_DIR}/../openenclave
   NO_DEFAULT_PATH
 )
 find_package(OpenEnclave 0.9 CONFIG REQUIRED)

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -29,6 +29,16 @@ if((NOT ${IS_VALID_TARGET}))
   )
 endif()
 
+# Find OpenEnclave package, preferring local version if found (in the install case)
+find_package(
+  OpenEnclave
+  0.9
+  CONFIG
+  REQUIRED
+  PATHS
+  ${CMAKE_CURRENT_LIST_DIR}/../openenclave
+  NO_DEFAULT_PATH
+)
 find_package(OpenEnclave 0.9 CONFIG REQUIRED)
 # As well as pulling in openenclave:: targets, this sets variables which can be
 # used for our edge cases (eg - for virtual libraries). These do not follow the

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -29,7 +29,7 @@ if((NOT ${IS_VALID_TARGET}))
   )
 endif()
 
-find_package(OpenEnclave 0.8 CONFIG REQUIRED)
+find_package(OpenEnclave 0.9 CONFIG REQUIRED)
 # As well as pulling in openenclave:: targets, this sets variables which can be
 # used for our edge cases (eg - for virtual libraries). These do not follow the
 # standard naming patterns, for example use OE_INCLUDEDIR rather than


### PR DESCRIPTION
2-part fix for #1120:
- When building install folder in ADO, include the current OE installed dir
- When trying to find the OE package in CMake, prefer a local instance if found

Sample release available here until I delete it: https://github.com/microsoft/CCF/releases/tag/untagged-bfa184e16a4d52090092

This only increases the size of our install package slightly - from 55.4MB in 0.9.3 to 63.5MB on current master with OE.