### PR TITLE
Update devcontainer.json to use oe-0.9.0 container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"name": "Sample Development Environment for CCF",
 	"context": "..",
-	"image": "ccfciteam/ccf-ci-18.04-oe-0.8.0:latest",
+	"image": "ccfciteam/ccf-ci-18.04-oe-0.9.0:latest",
 	"runArgs": [],
 	"extensions": ["ms-vscode.cpptools", "ms-python.python"]
 }


### PR DESCRIPTION
Making this change as OpenEnclave 0.9 release is being installed in new setups due to #1103