### PR TITLE
Remove incorrect error on tx status RPC

### DIFF
--- a/src/node/rpc/common_handler_registry.h
+++ b/src/node/rpc/common_handler_registry.h
@@ -269,7 +269,6 @@ namespace ccf
         .set_execute_locally(true);
       install(GeneralProcs::GET_TX_STATUS, json_adapter(get_tx_status), Read)
         .set_auto_schema<GetTxStatus>()
-        .set_execute_locally(true)
         .set_http_get_only();
       install(GeneralProcs::GET_METRICS, json_adapter(get_metrics), Read)
         .set_auto_schema<void, GetMetrics::Out>()

--- a/src/node/rpc/test/tx_status_test.cpp
+++ b/src/node/rpc/test/tx_status_test.cpp
@@ -92,19 +92,6 @@ TEST_CASE("edge cases")
   {
     INFO("Node is in a newer view");
 
-    // Impossible: cannot have local progress in a view without an initial
-    // global point in that view
-    // get_tx_status(a, b, N, <N, c)
-    CHECK_THROWS(get_tx_status(3, 10, 2, 1, 8));
-    CHECK_THROWS(get_tx_status(3, 10, 2, 1, 10));
-    CHECK_THROWS(get_tx_status(3, 10, 2, 1, 12));
-    CHECK_THROWS(get_tx_status(3, 10, 3, 2, 8));
-    CHECK_THROWS(get_tx_status(3, 10, 3, 2, 10));
-    CHECK_THROWS(get_tx_status(3, 10, 3, 2, 12));
-    CHECK_THROWS(get_tx_status(3, 10, 4, 3, 8));
-    CHECK_THROWS(get_tx_status(3, 10, 4, 3, 10));
-    CHECK_THROWS(get_tx_status(3, 10, 4, 3, 12));
-
     CHECK(get_tx_status(3, 10, 0, 4, 8) == TxStatus::Invalid);
     CHECK(get_tx_status(3, 10, 4, 4, 8) == TxStatus::Invalid);
     CHECK(get_tx_status(3, 10, 4, 4, 10) == TxStatus::Invalid);

--- a/src/node/rpc/tx_status.h
+++ b/src/node/rpc/tx_status.h
@@ -42,16 +42,6 @@ namespace ccf
         target_seqno));
     }
 
-    if (local_view > committed_view)
-    {
-      throw std::logic_error(fmt::format(
-        "Should not believe {} occurred in view {}, ahead of the current "
-        "committed view {}",
-        target_view,
-        local_view,
-        committed_view));
-    }
-
     if (is_committed)
     {
       // The requested seqno has been committed, so we know for certain whether
@@ -65,7 +55,7 @@ namespace ccf
         return TxStatus::Invalid;
       }
     }
-    else if (local_view == target_view)
+    else if (views_match)
     {
       // This node knows about the requested tx id, but it is not globally
       // committed


### PR DESCRIPTION
The assumption in the removed tests is incorrect: after we win an election, there is a period where we can serve RPCs (producing valid new `Pending` Tx IDs) but the highest committed Tx ID is still in the previous view. So this case shouldn't throw an error, it should fall through to `views_match => Pending`.

This RPC should also not be `execute_locally` (this was my misunderstanding - the common case of `getCommit` still requires consensus, so `tx` does as well).

These should resolve some of our transient CI failures.