### PR TITLE
Don't run all tests in recovery-specific suite

### DIFF
--- a/tests/e2e_suite.py
+++ b/tests/e2e_suite.py
@@ -25,6 +25,10 @@ class TestStatus(Enum):
 def run(args):
 
     chosen_suite = []
+
+    if not args.test_suite:
+        args.test_suite = ["all"]
+
     for choice in args.test_suite:
         try:
             chosen_suite.extend(s.suites[choice])
@@ -151,7 +155,6 @@ if __name__ == "__main__":
             help="List of test suites should be run",
             action="append",
             choices=s.suites.keys(),
-            default=["all"],
         )
 
     args = infra.e2e_args.cli_args(add)


### PR DESCRIPTION
This fixes a bug in #1146 which caused a failure in the Daily CI. The `recovery_test_suite` should only be running the declared subset of tests, but since it appends to the default argument it always included `all` tests.