### PR TITLE
Safe read access to thread_ids

### DIFF
--- a/src/apps/lua_generic/test/lua_generic_test.cpp
+++ b/src/apps/lua_generic/test/lua_generic_test.cpp
@@ -266,7 +266,7 @@ TEST_CASE("simple lua apps")
     );
 
     // (3) attempt to read non-existing key (set of integers)
-    const auto packed = make_pc("load", {{"k", set{5, 6, 7}}});
+    const auto packed = make_pc("load", {{"k", set<int>{5, 6, 7}}});
     auto rpc_ctx = enclave::make_rpc_context(user_session, packed);
     check_error(frontend->process(rpc_ctx).value(), HTTP_STATUS_BAD_REQUEST);
   }

--- a/src/consensus/pbft/libbyz/replica.cpp
+++ b/src/consensus/pbft/libbyz/replica.cpp
@@ -211,8 +211,8 @@ static void pre_verify_cb(std::unique_ptr<threading::Tmsg<PreVerifyCbMsg>> req)
   Message* m = req->data.m;
   Replica* self = req->data.self;
 
-  auto resp =
-    std::make_unique<threading::Tmsg<PreVerifyResultCbMsg>>(&pre_verify_reply_cb);
+  auto resp = std::make_unique<threading::Tmsg<PreVerifyResultCbMsg>>(
+    &pre_verify_reply_cb);
 
   resp->data.m = m;
   resp->data.self = self;
@@ -341,7 +341,8 @@ void Replica::receive_message(const uint8_t* data, uint32_t size)
 
   if (f() != 0 && target_thread != 0)
   {
-    auto msg = std::make_unique<threading::Tmsg<PreVerifyCbMsg>>(&pre_verify_cb);
+    auto msg =
+      std::make_unique<threading::Tmsg<PreVerifyCbMsg>>(&pre_verify_cb);
 
     msg->data.m = m;
     msg->data.self = this;

--- a/src/consensus/pbft/libbyz/replica.cpp
+++ b/src/consensus/pbft/libbyz/replica.cpp
@@ -189,7 +189,7 @@ struct PreVerifyResultCbMsg
 };
 
 static void pre_verify_reply_cb(
-  std::unique_ptr<enclave::Tmsg<PreVerifyResultCbMsg>> req)
+  std::unique_ptr<threading::Tmsg<PreVerifyResultCbMsg>> req)
 {
   Message* m = req->data.m;
   Replica* self = req->data.self;
@@ -206,20 +206,20 @@ static void pre_verify_reply_cb(
   }
 }
 
-static void pre_verify_cb(std::unique_ptr<enclave::Tmsg<PreVerifyCbMsg>> req)
+static void pre_verify_cb(std::unique_ptr<threading::Tmsg<PreVerifyCbMsg>> req)
 {
   Message* m = req->data.m;
   Replica* self = req->data.self;
 
   auto resp =
-    std::make_unique<enclave::Tmsg<PreVerifyResultCbMsg>>(&pre_verify_reply_cb);
+    std::make_unique<threading::Tmsg<PreVerifyResultCbMsg>>(&pre_verify_reply_cb);
 
   resp->data.m = m;
   resp->data.self = self;
   resp->data.result = self->pre_verify(m);
 
-  enclave::ThreadMessaging::thread_messaging.add_task<PreVerifyResultCbMsg>(
-    enclave::ThreadMessaging::main_thread, std::move(resp));
+  threading::ThreadMessaging::thread_messaging.add_task<PreVerifyResultCbMsg>(
+    threading::ThreadMessaging::main_thread, std::move(resp));
 }
 
 static uint64_t verification_thread = 0;
@@ -333,20 +333,20 @@ void Replica::receive_message(const uint8_t* data, uint32_t size)
 
   uint32_t target_thread = 0;
 
-  if (enclave::ThreadMessaging::thread_count > 1 && m->tag() == Request_tag)
+  if (threading::ThreadMessaging::thread_count > 1 && m->tag() == Request_tag)
   {
-    uint32_t num_worker_thread = enclave::ThreadMessaging::thread_count - 1;
+    uint32_t num_worker_thread = threading::ThreadMessaging::thread_count - 1;
     target_thread = (((Request*)m)->user_id() % num_worker_thread) + 1;
   }
 
   if (f() != 0 && target_thread != 0)
   {
-    auto msg = std::make_unique<enclave::Tmsg<PreVerifyCbMsg>>(&pre_verify_cb);
+    auto msg = std::make_unique<threading::Tmsg<PreVerifyCbMsg>>(&pre_verify_cb);
 
     msg->data.m = m;
     msg->data.self = this;
 
-    enclave::ThreadMessaging::thread_messaging.add_task<PreVerifyCbMsg>(
+    threading::ThreadMessaging::thread_messaging.add_task<PreVerifyCbMsg>(
       target_thread, std::move(msg));
   }
   else
@@ -377,7 +377,7 @@ bool Replica::compare_execution_results(
 {
   // We are currently not ordering the execution on the backups correctly.
   // This will be resolved in the immediate future.
-  if (enclave::ThreadMessaging::thread_count > 2)
+  if (threading::ThreadMessaging::thread_count > 2)
   {
     return true;
   }

--- a/src/consensus/pbft/libbyz/req_queue.cpp
+++ b/src/consensus/pbft/libbyz/req_queue.cpp
@@ -52,7 +52,7 @@ bool Req_queue::is_in_rqueue(Request* r)
 
 Request* Req_queue::remove()
 {
-  uint32_t tcount = enclave::ThreadMessaging::thread_count;
+  uint32_t tcount = threading::ThreadMessaging::thread_count;
   tcount = std::max(tcount, (uint32_t)1);
 
   bool found = false;
@@ -106,7 +106,7 @@ bool Req_queue::remove(int cid, Request_id rid, int user_id)
 
 void Req_queue::clear()
 {
-  uint32_t tcount = enclave::ThreadMessaging::thread_count;
+  uint32_t tcount = threading::ThreadMessaging::thread_count;
   // There is a corner case when we run the very first transaction that
   // thread_count can be 0. The use of std::max is a work around.
   tcount = std::max(tcount, (uint32_t)1);

--- a/src/consensus/pbft/libbyz/req_queue.h
+++ b/src/consensus/pbft/libbyz/req_queue.h
@@ -86,9 +86,9 @@ private:
     }
   };
   std::unordered_map<Key, std::unique_ptr<RNode>, KeyHash>
-    reqs[enclave::ThreadMessaging::max_num_threads];
+    reqs[threading::ThreadMessaging::max_num_threads];
   mutable snmalloc::DLList<RNode>
-    rnodes[enclave::ThreadMessaging::max_num_threads];
+    rnodes[threading::ThreadMessaging::max_num_threads];
   mutable uint64_t count = 0;
 
   int nelems; // Number of elements in queue
@@ -107,7 +107,7 @@ inline int Req_queue::num_bytes() const
 
 inline Request* Req_queue::first() const
 {
-  uint32_t tcount = enclave::ThreadMessaging::thread_count;
+  uint32_t tcount = threading::ThreadMessaging::thread_count;
   tcount = std::max(tcount, (uint32_t)1);
 
   for (uint32_t i = 0; i < tcount; ++i)

--- a/src/consensus/pbft/libbyz/request.cpp
+++ b/src/consensus/pbft/libbyz/request.cpp
@@ -32,7 +32,7 @@ Request::Request(Request_id r, short rr, uint32_t msg_size) :
 {
   rep().cid = pbft::GlobalState::get_node().id();
   rep().rid = r;
-  rep().uid = thread_ids[std::this_thread::get_id()];
+  rep().uid = threading::get_current_thread_id();
   rep().replier = rr;
   rep().command_size = 0;
   set_size(sizeof(Request_rep));

--- a/src/consensus/pbft/libbyz/test/replica_unit_tests.cpp
+++ b/src/consensus/pbft/libbyz/test/replica_unit_tests.cpp
@@ -19,8 +19,8 @@
 #include <cstdio>
 #include <doctest/doctest.h>
 
-enclave::ThreadMessaging enclave::ThreadMessaging::thread_messaging;
-std::atomic<uint16_t> enclave::ThreadMessaging::thread_count = 0;
+threading::ThreadMessaging threading::ThreadMessaging::thread_messaging;
+std::atomic<uint16_t> threading::ThreadMessaging::thread_count = 0;
 
 // power of 2 since ringbuffer circuit size depends on total_requests
 static constexpr size_t total_requests = 32;

--- a/src/consensus/pbft/pbft.h
+++ b/src/consensus/pbft/pbft.h
@@ -119,17 +119,17 @@ namespace pbft
         nodes[to] = end_idx;
       }
 
-      auto tmsg = std::make_unique<enclave::Tmsg<SendAuthenticatedAEMsg>>(
+      auto tmsg = std::make_unique<threading::Tmsg<SendAuthenticatedAEMsg>>(
         &send_authenticated_ae_msg_cb,
         ae,
         this,
         ccf::NodeMsgType::consensus_msg,
         to);
 
-      if (enclave::ThreadMessaging::thread_count > 1)
+      if (threading::ThreadMessaging::thread_count > 1)
       {
-        uint16_t tid = enclave::ThreadMessaging::get_execution_thread(to);
-        enclave::ThreadMessaging::thread_messaging
+        uint16_t tid = threading::ThreadMessaging::get_execution_thread(to);
+        threading::ThreadMessaging::thread_messaging
           .add_task<SendAuthenticatedAEMsg>(tid, std::move(tmsg));
       }
       else
@@ -193,7 +193,7 @@ namespace pbft
     };
 
     static void send_authenticated_ae_msg_cb(
-      std::unique_ptr<enclave::Tmsg<SendAuthenticatedAEMsg>> msg)
+      std::unique_ptr<threading::Tmsg<SendAuthenticatedAEMsg>> msg)
     {
       msg->data.self->n2n_channels->send_authenticated(
         msg->data.type, msg->data.to, msg->data.ae);
@@ -222,7 +222,7 @@ namespace pbft
     };
 
     static void send_authenticated_msg_cb(
-      std::unique_ptr<enclave::Tmsg<SendAuthenticatedMsg>> msg)
+      std::unique_ptr<threading::Tmsg<SendAuthenticatedMsg>> msg)
     {
       if (msg->data.should_encrypt)
       {
@@ -285,7 +285,7 @@ namespace pbft
         serialize_message(data_, space, msg);
       }
 
-      auto tmsg = std::make_unique<enclave::Tmsg<SendAuthenticatedMsg>>(
+      auto tmsg = std::make_unique<threading::Tmsg<SendAuthenticatedMsg>>(
         &send_authenticated_msg_cb,
         encrypt,
         std::move(serialized_msg),
@@ -293,11 +293,11 @@ namespace pbft
         ccf::NodeMsgType::consensus_msg,
         to);
 
-      if (enclave::ThreadMessaging::thread_count > 1)
+      if (threading::ThreadMessaging::thread_count > 1)
       {
-        uint16_t tid = enclave::ThreadMessaging::get_execution_thread(
+        uint16_t tid = threading::ThreadMessaging::get_execution_thread(
           ++execution_thread_counter);
-        enclave::ThreadMessaging::thread_messaging
+        threading::ThreadMessaging::thread_messaging
           .add_task<SendAuthenticatedMsg>(tid, std::move(tmsg));
       }
       else
@@ -639,7 +639,7 @@ namespace pbft
     };
 
     static void recv_authenticated_msg_cb(
-      std::unique_ptr<enclave::Tmsg<RecvAuthenticatedMsg>> msg)
+      std::unique_ptr<threading::Tmsg<RecvAuthenticatedMsg>> msg)
     {
       if (msg->data.should_decrypt)
       {
@@ -675,13 +675,13 @@ namespace pbft
       }
 
       msg->data.result = true;
-      enclave::ThreadMessaging::ChangeTmsgCallback(
+      threading::ThreadMessaging::ChangeTmsgCallback(
         msg, &recv_authenticated_msg_process_cb);
-      if (enclave::ThreadMessaging::thread_count > 1)
+      if (threading::ThreadMessaging::thread_count > 1)
       {
-        enclave::ThreadMessaging::thread_messaging
+        threading::ThreadMessaging::thread_messaging
           .add_task<RecvAuthenticatedMsg>(
-            enclave::ThreadMessaging::main_thread, std::move(msg));
+            threading::ThreadMessaging::main_thread, std::move(msg));
       }
       else
       {
@@ -690,7 +690,7 @@ namespace pbft
     }
 
     static void recv_authenticated_msg_process_cb(
-      std::unique_ptr<enclave::Tmsg<RecvAuthenticatedMsg>> msg)
+      std::unique_ptr<threading::Tmsg<RecvAuthenticatedMsg>> msg)
     {
       assert(msg->data.result);
       msg->data.self->message_receiver_base->receive_message(
@@ -708,7 +708,7 @@ namespace pbft
         case pbft_message:
         {
           bool should_decrypt = (hdr.msg == encrypted_pbft_message);
-          auto tmsg = std::make_unique<enclave::Tmsg<RecvAuthenticatedMsg>>(
+          auto tmsg = std::make_unique<threading::Tmsg<RecvAuthenticatedMsg>>(
             &recv_authenticated_msg_cb, should_decrypt, std::move(d), this);
 
           ccf::RecvNonce recv_nonce(0);
@@ -724,11 +724,11 @@ namespace pbft
               tmsg->data.d.data(), tmsg->data.d.size());
           }
 
-          if (enclave::ThreadMessaging::thread_count > 1)
+          if (threading::ThreadMessaging::thread_count > 1)
           {
-            enclave::ThreadMessaging::thread_messaging
+            threading::ThreadMessaging::thread_messaging
               .add_task<RecvAuthenticatedMsg>(
-                recv_nonce.tid % enclave::ThreadMessaging::thread_count,
+                recv_nonce.tid % threading::ThreadMessaging::thread_count,
                 std::move(tmsg));
           }
           else

--- a/src/consensus/pbft/pbft_config.h
+++ b/src/consensus/pbft/pbft_config.h
@@ -81,7 +81,7 @@ namespace pbft
       uint64_t nonce;
     };
 
-    static void ExecuteCb(std::unique_ptr<enclave::Tmsg<ExecutionCtx>> c)
+    static void ExecuteCb(std::unique_ptr<threading::Tmsg<ExecutionCtx>> c)
     {
       ExecutionCtx& execution_ctx = c->data;
       ByzInfo& info = execution_ctx.info;
@@ -131,7 +131,7 @@ namespace pbft
       }
     }
 
-    static void Execute(std::unique_ptr<enclave::Tmsg<ExecutionCtx>> c)
+    static void Execute(std::unique_ptr<threading::Tmsg<ExecutionCtx>> c)
     {
       ExecutionCtx& execution_ctx = c->data;
       std::unique_ptr<ExecCommandMsg>& msg = execution_ctx.msg;
@@ -204,10 +204,10 @@ namespace pbft
 
       if (info.cb != nullptr)
       {
-        enclave::ThreadMessaging::thread_messaging
+        threading::ThreadMessaging::thread_messaging
           .ChangeTmsgCallback<ExecutionCtx>(c, &ExecuteCb);
-        enclave::ThreadMessaging::thread_messaging.add_task<ExecutionCtx>(
-          enclave::ThreadMessaging::main_thread, std::move(c));
+        threading::ThreadMessaging::thread_messaging.add_task<ExecutionCtx>(
+          threading::ThreadMessaging::main_thread, std::move(c));
       }
       else
       {
@@ -230,7 +230,7 @@ namespace pbft
         {
           std::unique_ptr<ExecCommandMsg>& msg = msgs[i];
           uint16_t reply_thread = msg->reply_thread;
-          auto execution_ctx = std::make_unique<enclave::Tmsg<ExecutionCtx>>(
+          auto execution_ctx = std::make_unique<threading::Tmsg<ExecutionCtx>>(
             &Execute, std::move(msg), info, this, is_first_request, nonce);
           is_first_request = false;
 
@@ -239,9 +239,9 @@ namespace pbft
             int tid = reply_thread;
             if (executed_single_threaded && tid > 1)
             {
-              tid = (enclave::ThreadMessaging::thread_count - 1);
+              tid = (threading::ThreadMessaging::thread_count - 1);
             }
-            enclave::ThreadMessaging::thread_messaging.add_task<ExecutionCtx>(
+            threading::ThreadMessaging::thread_messaging.add_task<ExecutionCtx>(
               tid, std::move(execution_ctx));
           }
           else

--- a/src/crypto/symmetric_key.cpp
+++ b/src/crypto/symmetric_key.cpp
@@ -79,7 +79,7 @@ namespace crypto
     uint8_t* cipher,
     uint8_t tag[GCM_SIZE_TAG]) const
   {
-    auto ctx = ctxs[thread_ids[std::this_thread::get_id()]];
+    auto ctx = ctxs[threading::get_current_thread_id()];
     int rc = mbedtls_gcm_crypt_and_tag(
       ctx,
       MBEDTLS_GCM_ENCRYPT,
@@ -106,7 +106,7 @@ namespace crypto
     CBuffer aad,
     uint8_t* plain) const
   {
-    auto ctx = ctxs[thread_ids[std::this_thread::get_id()]];
+    auto ctx = ctxs[threading::get_current_thread_id()];
     return !mbedtls_gcm_auth_decrypt(
       ctx,
       cipher.n,

--- a/src/crypto/symmetric_key.h
+++ b/src/crypto/symmetric_key.h
@@ -125,7 +125,7 @@ namespace crypto
   {
   private:
     mutable std::
-      array<mbedtls_gcm_context*, enclave::ThreadMessaging::max_num_threads>
+      array<mbedtls_gcm_context*, threading::ThreadMessaging::max_num_threads>
         ctxs;
 
   public:

--- a/src/ds/logger.h
+++ b/src/ds/logger.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ring_buffer.h"
+#include "thread_ids.h"
 
 #include <chrono>
 #include <cstring>
@@ -19,8 +20,6 @@
 #include <sstream>
 #include <string>
 #include <thread>
-
-extern std::map<std::thread::id, uint16_t> thread_ids;
 
 namespace logger
 {
@@ -317,7 +316,7 @@ namespace logger
       line_number(line_number),
       log_level(ll),
 #ifdef INSIDE_ENCLAVE
-      thread_id(thread_ids[std::this_thread::get_id()])
+      thread_id(threading::get_current_thread_id())
 #else
       thread_id(100)
 #endif

--- a/src/ds/messaging.h
+++ b/src/ds/messaging.h
@@ -5,7 +5,6 @@
 #include "logger.h"
 #include "ring_buffer.h"
 #include "spin_lock.h"
-#include "thread_messaging.h"
 
 #include <atomic>
 #include <condition_variable>
@@ -212,19 +211,12 @@ namespace messaging
       size_t total_read = 0;
       size_t consecutive_idles = 0u;
 
-      uint16_t tid = threading::get_current_thread_id();
-      threading::Task& task =
-        threading::ThreadMessaging::thread_messaging.get_task(tid);
-
       while (!finished.load())
       {
         auto num_read = read_n(-1, r);
         total_read += num_read;
 
-        bool task_run =
-          threading::ThreadMessaging::thread_messaging.run_one(task);
-
-        if (num_read == 0 && !task_run)
+        if (num_read == 0)
         {
           idler(consecutive_idles++);
         }

--- a/src/ds/messaging.h
+++ b/src/ds/messaging.h
@@ -212,9 +212,9 @@ namespace messaging
       size_t total_read = 0;
       size_t consecutive_idles = 0u;
 
-      uint16_t tid = thread_ids[std::this_thread::get_id()];
-      enclave::Task& task =
-        enclave::ThreadMessaging::thread_messaging.get_task(tid);
+      uint16_t tid = threading::get_current_thread_id();
+      threading::Task& task =
+        threading::ThreadMessaging::thread_messaging.get_task(tid);
 
       while (!finished.load())
       {
@@ -222,7 +222,7 @@ namespace messaging
         total_read += num_read;
 
         bool task_run =
-          enclave::ThreadMessaging::thread_messaging.run_one(task);
+          threading::ThreadMessaging::thread_messaging.run_one(task);
 
         if (num_read == 0 && !task_run)
         {

--- a/src/ds/test/messaging.cpp
+++ b/src/ds/test/messaging.cpp
@@ -17,7 +17,7 @@
 using namespace messaging;
 using namespace ringbuffer;
 
-enclave::ThreadMessaging enclave::ThreadMessaging::thread_messaging;
+threading::ThreadMessaging threading::ThreadMessaging::thread_messaging;
 
 template <typename Ex, typename F>
 void require_throws_with(

--- a/src/ds/test/messaging.cpp
+++ b/src/ds/test/messaging.cpp
@@ -17,8 +17,6 @@
 using namespace messaging;
 using namespace ringbuffer;
 
-threading::ThreadMessaging threading::ThreadMessaging::thread_messaging;
-
 template <typename Ex, typename F>
 void require_throws_with(
   F&& f,

--- a/src/ds/thread_ids.h
+++ b/src/ds/thread_ids.h
@@ -11,6 +11,11 @@ namespace threading
 
   static inline uint16_t get_current_thread_id()
   {
+    if (thread_ids.empty())
+    {
+      return 0;
+    }
+
     const auto tid = std::this_thread::get_id();
     const auto it = thread_ids.find(tid);
     if (it == thread_ids.end())

--- a/src/ds/thread_ids.h
+++ b/src/ds/thread_ids.h
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include <map>
+#include <thread>
+
+namespace threading
+{
+  extern std::map<std::thread::id, uint16_t> thread_ids;
+
+  static inline uint16_t get_current_thread_id()
+  {
+    return thread_ids[std::this_thread::get_id()];
+  }
+}

--- a/src/ds/thread_ids.h
+++ b/src/ds/thread_ids.h
@@ -2,6 +2,9 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#define FMT_HEADER_ONLY
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <map>
 #include <thread>
 
@@ -21,7 +24,7 @@ namespace threading
     if (it == thread_ids.end())
     {
       throw std::runtime_error(
-        "Accessed uninitialised thread_ids - ID unknown");
+        fmt::format("Accessed uninitialised thread_ids - ID {} unknown", tid));
     }
 
     return it->second;

--- a/src/ds/thread_ids.h
+++ b/src/ds/thread_ids.h
@@ -11,6 +11,14 @@ namespace threading
 
   static inline uint16_t get_current_thread_id()
   {
-    return thread_ids[std::this_thread::get_id()];
+    const auto tid = std::this_thread::get_id();
+    const auto it = thread_ids.find(tid);
+    if (it == thread_ids.end())
+    {
+      throw std::runtime_error(
+        "Accessed uninitialised thread_ids - ID unknown");
+    }
+
+    return it->second;
   }
 }

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -256,6 +256,21 @@ namespace enclave
             idling_start_time = time_now;
           }
 
+          // If we have pending thread messages, handle them now (and don't sleep)
+          {
+            uint16_t tid = threading::get_current_thread_id();
+            threading::Task& task =
+              threading::ThreadMessaging::thread_messaging.get_task(tid);
+
+            bool task_run =
+              threading::ThreadMessaging::thread_messaging.run_one(task);
+
+            if (task_run)
+            {
+              return;
+            }
+          }
+
           // Handle initial idles by pausing, eventually sleep (in host)
           constexpr std::chrono::milliseconds timeout(5);
 

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -256,7 +256,8 @@ namespace enclave
             idling_start_time = time_now;
           }
 
-          // If we have pending thread messages, handle them now (and don't sleep)
+          // If we have pending thread messages, handle them now (and don't
+          // sleep)
           {
             uint16_t tid = threading::get_current_thread_id();
             threading::Task& task =

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -169,7 +169,7 @@ namespace enclave
         DISPATCHER_SET_MESSAGE_HANDLER(
           bp, AdminMessage::stop, [&bp, this](const uint8_t*, size_t) {
             bp.set_finished();
-            enclave::ThreadMessaging::thread_messaging.set_finished();
+            threading::ThreadMessaging::thread_messaging.set_finished();
           });
 
         DISPATCHER_SET_MESSAGE_HANDLER(
@@ -286,7 +286,7 @@ namespace enclave
       uint64_t tid;
     };
 
-    static void init_thread_cb(std::unique_ptr<enclave::Tmsg<Msg>> msg)
+    static void init_thread_cb(std::unique_ptr<threading::Tmsg<Msg>> msg)
     {
       LOG_DEBUG_FMT("First thread CB:{}", msg->data.tid);
     }
@@ -298,12 +298,12 @@ namespace enclave
       try
 #endif
       {
-        auto msg = std::make_unique<enclave::Tmsg<Msg>>(&init_thread_cb);
-        msg->data.tid = thread_ids[std::this_thread::get_id()];
-        enclave::ThreadMessaging::thread_messaging.add_task<Msg>(
+        auto msg = std::make_unique<threading::Tmsg<Msg>>(&init_thread_cb);
+        msg->data.tid = threading::get_current_thread_id();
+        threading::ThreadMessaging::thread_messaging.add_task<Msg>(
           msg->data.tid, std::move(msg));
 
-        enclave::ThreadMessaging::thread_messaging.run();
+        threading::ThreadMessaging::thread_messaging.run();
       }
 #ifndef VIRTUAL_ENCLAVE
       catch (const std::exception& e)

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -17,8 +17,8 @@ std::atomic<std::chrono::milliseconds> logger::config::ms =
   std::chrono::milliseconds::zero();
 std::atomic<uint16_t> num_pending_threads = 0;
 
-enclave::ThreadMessaging enclave::ThreadMessaging::thread_messaging;
-std::atomic<uint16_t> enclave::ThreadMessaging::thread_count = 0;
+threading::ThreadMessaging threading::ThreadMessaging::thread_messaging;
+std::atomic<uint16_t> threading::ThreadMessaging::thread_count = 0;
 
 namespace enclave
 {
@@ -57,7 +57,7 @@ extern "C"
 
     if (
       num_pending_threads >
-      enclave::ThreadMessaging::thread_messaging.max_num_threads)
+      threading::ThreadMessaging::thread_messaging.max_num_threads)
     {
       return false;
     }
@@ -104,10 +104,10 @@ extern "C"
       {
         std::lock_guard<SpinLock> guard(create_lock);
 
-        tid = enclave::ThreadMessaging::thread_count.fetch_add(1);
-        num_pending_threads.fetch_sub(1);
-        thread_ids.emplace(std::pair<std::thread::id, uint16_t>(
+        tid = threading::ThreadMessaging::thread_count.fetch_add(1);
+        threading::thread_ids.emplace(std::pair<std::thread::id, uint16_t>(
           std::this_thread::get_id(), tid));
+        num_pending_threads.fetch_sub(1);
 
         LOG_INFO_FMT("Starting thread: {}", tid);
       }

--- a/src/enclave/thread_local.cpp
+++ b/src/enclave/thread_local.cpp
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
-#include <cstdint>
-#include <map>
-#include <thread>
+#include "ds/thread_ids.h"
 
-std::map<std::thread::id, uint16_t> thread_ids;
+namespace threading
+{
+  std::map<std::thread::id, uint16_t> thread_ids;
+}

--- a/src/enclave/tls_endpoint.h
+++ b/src/enclave/tls_endpoint.h
@@ -180,8 +180,7 @@ namespace enclave
         }
 
         default:
-        {
-        }
+        {}
       }
 
       if (r < 0)
@@ -348,8 +347,7 @@ namespace enclave
         }
 
         default:
-        {
-        }
+        {}
       }
     }
 
@@ -448,8 +446,7 @@ namespace enclave
           return;
 
         default:
-        {
-        }
+        {}
       }
 
       status = status_;
@@ -479,8 +476,7 @@ namespace enclave
         }
 
         default:
-        {
-        }
+        {}
       }
     }
 

--- a/src/enclave/tls_endpoint.h
+++ b/src/enclave/tls_endpoint.h
@@ -5,6 +5,7 @@
 #include "ds/logger.h"
 #include "ds/messaging.h"
 #include "ds/ring_buffer.h"
+#include "ds/thread_messaging.h"
 #include "endpoint.h"
 #include "tls/context.h"
 #include "tls/msg_types.h"
@@ -179,7 +180,8 @@ namespace enclave
         }
 
         default:
-        {}
+        {
+        }
       }
 
       if (r < 0)
@@ -346,7 +348,8 @@ namespace enclave
         }
 
         default:
-        {}
+        {
+        }
       }
     }
 
@@ -445,7 +448,8 @@ namespace enclave
           return;
 
         default:
-        {}
+        {
+        }
       }
 
       status = status_;
@@ -475,7 +479,8 @@ namespace enclave
         }
 
         default:
-        {}
+        {
+        }
       }
     }
 

--- a/src/enclave/tls_endpoint.h
+++ b/src/enclave/tls_endpoint.h
@@ -65,10 +65,10 @@ namespace enclave
       ctx(move(ctx_)),
       status(handshake)
     {
-      if (enclave::ThreadMessaging::thread_count > 1)
+      if (threading::ThreadMessaging::thread_count > 1)
       {
         execution_thread =
-          (session_id_ % (enclave::ThreadMessaging::thread_count - 1)) + 1;
+          (session_id_ % (threading::ThreadMessaging::thread_count - 1)) + 1;
       }
       else
       {
@@ -207,7 +207,7 @@ namespace enclave
 
     void recv_buffered(const uint8_t* data, size_t size)
     {
-      if (thread_ids[std::this_thread::get_id()] != execution_thread)
+      if (threading::get_current_thread_id() != execution_thread)
       {
         throw std::exception();
       }
@@ -221,7 +221,7 @@ namespace enclave
       std::shared_ptr<Endpoint> self;
     };
 
-    static void send_raw_cb(std::unique_ptr<enclave::Tmsg<SendRecvMsg>> msg)
+    static void send_raw_cb(std::unique_ptr<threading::Tmsg<SendRecvMsg>> msg)
     {
       reinterpret_cast<TLSEndpoint*>(msg->data.self.get())
         ->send_raw_thread(msg->data.data);
@@ -229,17 +229,17 @@ namespace enclave
 
     void send_raw(const std::vector<uint8_t>& data)
     {
-      auto msg = std::make_unique<enclave::Tmsg<SendRecvMsg>>(&send_raw_cb);
+      auto msg = std::make_unique<threading::Tmsg<SendRecvMsg>>(&send_raw_cb);
       msg->data.self = this->shared_from_this();
       msg->data.data = data;
 
-      enclave::ThreadMessaging::thread_messaging.add_task<SendRecvMsg>(
+      threading::ThreadMessaging::thread_messaging.add_task<SendRecvMsg>(
         execution_thread, std::move(msg));
     }
 
     void send_raw_thread(std::vector<uint8_t>& data)
     {
-      if (thread_ids[std::this_thread::get_id()] != execution_thread)
+      if (threading::get_current_thread_id() != execution_thread)
       {
         throw std::runtime_error("running from incorrect thread");
       }
@@ -264,7 +264,7 @@ namespace enclave
 
     void send_buffered(const std::vector<uint8_t>& data)
     {
-      if (thread_ids[std::this_thread::get_id()] != execution_thread)
+      if (threading::get_current_thread_id() != execution_thread)
       {
         throw std::runtime_error("running from incorrect thread");
       }
@@ -274,7 +274,7 @@ namespace enclave
 
     void flush()
     {
-      if (thread_ids[std::this_thread::get_id()] != execution_thread)
+      if (threading::get_current_thread_id() != execution_thread)
       {
         throw std::runtime_error("running from incorrect thread");
       }
@@ -496,7 +496,7 @@ namespace enclave
 
     int handle_recv(uint8_t* buf, size_t len)
     {
-      if (thread_ids[std::this_thread::get_id()] != execution_thread)
+      if (threading::get_current_thread_id() != execution_thread)
       {
         throw std::runtime_error("running from incorrect thread");
       }

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -27,7 +27,7 @@ namespace http
     {}
 
   public:
-    static void recv_cb(std::unique_ptr<enclave::Tmsg<SendRecvMsg>> msg)
+    static void recv_cb(std::unique_ptr<threading::Tmsg<SendRecvMsg>> msg)
     {
       reinterpret_cast<HTTPEndpoint*>(msg->data.self.get())
         ->recv_(msg->data.data.data(), msg->data.data.size());
@@ -35,11 +35,11 @@ namespace http
 
     void recv(const uint8_t* data, size_t size) override
     {
-      auto msg = std::make_unique<enclave::Tmsg<SendRecvMsg>>(&recv_cb);
+      auto msg = std::make_unique<threading::Tmsg<SendRecvMsg>>(&recv_cb);
       msg->data.self = this->shared_from_this();
       msg->data.data.assign(data, data + size);
 
-      enclave::ThreadMessaging::thread_messaging.add_task<SendRecvMsg>(
+      threading::ThreadMessaging::thread_messaging.add_task<SendRecvMsg>(
         execution_thread, std::move(msg));
     }
 

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -62,7 +62,7 @@ namespace ccf
       SeqNo main_thread_seqno;
       SeqNo tid_seqno;
     };
-    std::array<ChannelSeqno, enclave::ThreadMessaging::max_num_threads>
+    std::array<ChannelSeqno, threading::ThreadMessaging::max_num_threads>
       local_recv_nonce = {0};
 
     bool verify_or_decrypt(
@@ -80,14 +80,13 @@ namespace ccf
       auto tid = recv_nonce.tid;
       auto& channel_nonce = local_recv_nonce[tid];
 
-      uint16_t current_tid =
-        enclave::ThreadMessaging::thread_messaging.get_thread_id();
+      uint16_t current_tid = threading::get_current_thread_id();
       assert(
-        current_tid == enclave::ThreadMessaging::main_thread ||
-        current_tid % enclave::ThreadMessaging::thread_count == tid);
+        current_tid == threading::ThreadMessaging::main_thread ||
+        current_tid % threading::ThreadMessaging::thread_count == tid);
 
       SeqNo* local_nonce;
-      if (current_tid == enclave::ThreadMessaging::main_thread)
+      if (current_tid == threading::ThreadMessaging::main_thread)
       {
         local_nonce = &local_recv_nonce[tid].main_thread_seqno;
       }
@@ -179,7 +178,7 @@ namespace ccf
         throw std::logic_error("Channel is not established for tagging");
       }
       RecvNonce nonce(
-        send_nonce.fetch_add(1), thread_ids[std::this_thread::get_id()]);
+        send_nonce.fetch_add(1), threading::get_current_thread_id());
 
       header.set_iv_seq(nonce.get_val());
       key->encrypt(header.get_iv(), nullb, aad, nullptr, header.tag);
@@ -203,7 +202,7 @@ namespace ccf
       }
 
       RecvNonce nonce(
-        send_nonce.fetch_add(1), thread_ids[std::this_thread::get_id()]);
+        send_nonce.fetch_add(1), threading::get_current_thread_id());
 
       header.set_iv_seq(nonce.get_val());
       key->encrypt(header.get_iv(), plain, aad, cipher.p, header.tag);

--- a/src/node/test/channels.cpp
+++ b/src/node/test/channels.cpp
@@ -6,8 +6,8 @@
 
 #include <doctest/doctest.h>
 
-enclave::ThreadMessaging enclave::ThreadMessaging::thread_messaging;
-std::atomic<uint16_t> enclave::ThreadMessaging::thread_count = 0;
+threading::ThreadMessaging threading::ThreadMessaging::thread_messaging;
+std::atomic<uint16_t> threading::ThreadMessaging::thread_count = 0;
 
 using namespace ccf;
 


### PR DESCRIPTION
Fix for #1162. I believe this leak could only happen in the unit test, so this _removes_ the unrelated thread-messaging from this unit and adds some checks to make sure we don't trigger a similar issue in real nodes.

There's a few aspects to this fix:

- Rather than accessing the `thread_ids` map directly by `operator []`, call `get_current_thread_id` which uses `find` and throws an error if the thread hasn't been registered yet
- Move thread-message handling into the `IdleHandler`, so it doesn't need to be initialised in the messaging unit tests or benchmarks

Separately I've moved these from `enclave::` to `threading::`. There's still an awkward case around startup where we may access the thread ID (eg - for logging) before we've initialised the map (in the `enclave_run` ECALL). Here I match the old behaviour where the initial thread is given ID 0 - this should be safe since all the code in `enclave_create_node` is guarded by the `create_lock`. We could handle this more neatly by initialising this thread's ID earlier, but I think we then strongly assume the same thread returns to `run` later (true in the current code, but not enforced). We should be able to simplify this initialisation logic once we flatten to a single ECALL.