### PR TITLE
Add and verify view change signatures in new view message

### DIFF
--- a/src/consensus/pbft/libbyz/new_view.cpp
+++ b/src/consensus/pbft/libbyz/new_view.cpp
@@ -136,5 +136,5 @@ bool New_view::pre_verify()
   }
   LOG_TRACE_FMT("new view has verified {} view change messages", proof_count);
 
-  return proof_count >= (2 * pbft::GlobalState::get_node().f() + 1);
+  return proof_count >= pbft::GlobalState::get_node().num_correct_replicas();
 }

--- a/src/consensus/pbft/libbyz/new_view.cpp
+++ b/src/consensus/pbft/libbyz/new_view.cpp
@@ -115,6 +115,7 @@ bool New_view::pre_verify()
   {
     if (vc_info()[i].d == Digest())
     {
+      // we don't have a view change message from this replica
       continue;
     }
     auto sender_principal = pbft::GlobalState::get_node().get_principal(i);

--- a/src/consensus/pbft/libbyz/new_view.h
+++ b/src/consensus/pbft/libbyz/new_view.h
@@ -20,6 +20,8 @@
 struct VC_info
 {
   Digest d; // digest of view-change message
+  PbftSignature sig; // signature of view-change message
+  size_t sig_size; // signature size
 };
 
 struct New_view_rep : public Message_rep
@@ -73,7 +75,7 @@ public:
   // Effects: Creates a new (unsigned) New_view message with an empty
   // set of view change messages.
 
-  void add_view_change(int id, Digest& d);
+  void add_view_change(int id, Digest& d, PbftSignature& sig, size_t sig_size);
   // Requires: Only one view-change per id may be added and id must be
   // a valid replica id.
   // Effects: Adds information to the set of view changes in this.

--- a/src/consensus/pbft/libbyz/node.cpp
+++ b/src/consensus/pbft/libbyz/node.cpp
@@ -242,6 +242,16 @@ size_t Node::gen_signature(
   return sig_size;
 }
 
+void Node::copy_signature(const PbftSignature& signature, PbftSignature& dest)
+{
+  std::copy(signature.begin(), signature.end(), dest.begin());
+  std::fill(
+    dest.end(),
+    dest.end() + ALIGNED_SIZE(pbft_max_signature_size) -
+      pbft_max_signature_size,
+    0);
+}
+
 Request_id Node::new_rid()
 {
   return request_id_generator.next_rid();

--- a/src/consensus/pbft/libbyz/node.h
+++ b/src/consensus/pbft/libbyz/node.h
@@ -108,6 +108,12 @@ public:
   // Effects: Generates a signature "sig" (from this principal) for
   // "src_len" bytes starting at "src" and puts the result in "sig" and
   // returns the length of the signature
+  static void copy_signature(
+    const PbftSignature& signature, PbftSignature& dest);
+  // Helper method
+  // Effects: copies the signature array to the destination. If the signature
+  // size is smaller than the pbft_max_signature_size, it zeroes out the end of
+  // dest
 
 protected:
   std::string service_name;

--- a/src/consensus/pbft/libbyz/nv_info.cpp
+++ b/src/consensus/pbft/libbyz/nv_info.cpp
@@ -208,13 +208,13 @@ void NV_info::add(std::unique_ptr<View_change> m)
 #ifdef USE_PKEY_VIEW_CHANGES
   if (is_primary)
   {
-    nv->add_view_change(vcid, vc->digest());
+    nv->add_view_change(vcid, vc->digest(), vc->signature(), vc->sig_size());
     summarize(vc);
   }
 #else
   if (is_primary && vcid == pbft::GlobalState::get_node().id())
   {
-    nv->add_view_change(vcid, vc->digest());
+    nv->add_view_change(vcid, vc->digest(), vc->signature(), vc->sig_size());
     summarize(vc);
   }
 #endif
@@ -280,7 +280,7 @@ bool NV_info::add(View_change_ack* m)
     {
       // This view change has enough acks: add it to the new-view.
       auto vc = vcs[vci].vc.get();
-      nv->add_view_change(vci, vc->digest());
+      nv->add_view_change(vci, vc->digest(), vc->signature(), vc->sig_size());
       summarize(vc);
     }
   }

--- a/src/consensus/pbft/libbyz/pre_prepare.cpp
+++ b/src/consensus/pbft/libbyz/pre_prepare.cpp
@@ -122,13 +122,7 @@ Pre_prepare::Pre_prepare(
     {
       IncludedSig* ic = reinterpret_cast<IncludedSig*>(sigs);
       ic->pid = p.first;
-      std::copy(
-        p.second.signature.begin(), p.second.signature.end(), ic->sig.begin());
-      std::fill(
-        ic->sig.end(),
-        ic->sig.end() + ALIGNED_SIZE(pbft_max_signature_size) -
-          pbft_max_signature_size,
-        0);
+      Node::copy_signature(p.second.signature, ic->sig);
       ic->sig_size = p.second.sig_size;
       ic->nonce = p.second.nonce;
       sigs += ALIGNED_SIZE(sizeof(IncludedSig));

--- a/src/consensus/pbft/libbyz/prepared_cert.h
+++ b/src/consensus/pbft/libbyz/prepared_cert.h
@@ -158,8 +158,7 @@ inline bool Prepared_cert::add(Prepare* m)
 #ifdef SIGN_BATCH
   PbftSignature& digest_sig = m->digest_sig();
   PrePrepareProof proof;
-  std::copy(
-    std::begin(digest_sig), std::end(digest_sig), std::begin(proof.signature));
+  Node::copy_signature(digest_sig, proof.signature);
   proof.nonce = m->get_hashed_nonce();
   proof.sig_size = m->digest_sig_size();
 #endif

--- a/src/consensus/pbft/libbyz/view_change.cpp
+++ b/src/consensus/pbft/libbyz/view_change.cpp
@@ -38,10 +38,6 @@ View_change::View_change(View v, Seqno ls, int id) :
   rep().digest_signature.fill(0);
   rep().padding.fill(0);
 #endif
-
-#ifdef USE_PKEY_VIEW_CHANGES
-  rep().vc_sig_size = 0;
-#endif
   PBFT_ASSERT(ALIGNED(req_info()), "Improperly aligned pointer");
 }
 
@@ -166,9 +162,6 @@ void View_change::re_authenticate(Principal* p)
     rep().digest_signature.fill(0);
 #endif
 
-#ifdef USE_PKEY_VIEW_CHANGES
-    rep().vc_sig_size = 0;
-#endif
     rep().digest = Digest(contents(), old_size);
 
 #ifdef SIGN_BATCH
@@ -178,10 +171,7 @@ void View_change::re_authenticate(Principal* p)
       rep().digest_signature);
 #endif
 
-#ifdef USE_PKEY_VIEW_CHANGES
-    rep().vc_sig_size = pbft::GlobalState::get_node().gen_signature(
-      contents(), old_size, contents() + old_size);
-#else
+#ifndef USE_PKEY_VIEW_CHANGES
     auth_type = Auth_type::out;
     auth_len = old_size;
     auth_dst_offset = old_size;
@@ -261,11 +251,6 @@ bool View_change::verify_digest()
   rep().digest_sig_size = 0;
 #endif
 
-#ifdef USE_PKEY_VIEW_CHANGES
-  auto previous_vc_sig_size = rep().vc_sig_size;
-  rep().vc_sig_size = 0;
-#endif
-
   bool verified =
     (d ==
      Digest(
@@ -275,9 +260,6 @@ bool View_change::verify_digest()
 #ifdef SIGN_BATCH
   rep().digest_signature = previous_digest_signature; // restore signature
   rep().digest_sig_size = previous_digest_sig_size; // restore signature size
-#endif
-#ifdef USE_PKEY_VIEW_CHANGES
-  rep().vc_sig_size = previous_vc_sig_size;
 #endif
   return verified;
 }

--- a/src/consensus/pbft/libbyz/view_change.h
+++ b/src/consensus/pbft/libbyz/view_change.h
@@ -74,10 +74,6 @@ struct View_change_rep : public Message_rep
   std::array<uint8_t, padding_size> padding;
 #endif
 
-#ifdef USE_PKEY_VIEW_CHANGES
-  size_t vc_sig_size;
-#endif
-
   /*
      Followed by:
      Req_info req_info[n_reqs];
@@ -130,6 +126,7 @@ public:
 
 #ifdef SIGN_BATCH
   PbftSignature& signature();
+  size_t sig_size();
 #endif
 
   Seqno last_stable() const;
@@ -230,6 +227,11 @@ inline Digest& View_change::digest()
 inline PbftSignature& View_change::signature()
 {
   return rep().digest_signature;
+}
+
+inline size_t View_change::sig_size()
+{
+  return rep().digest_sig_size;
 }
 #endif
 


### PR DESCRIPTION
Regarding #459 

- Add `View_change` message digest signatures in `New_view` 
- Verify those signatures in `New_view::pre_verify()` and check that we have at least `2 * f + 1` of them, and if not verification fails
- Remove redundant signing over the contents of `View_change` messages, since we already sign over the digest of the contents
- Added a helper method to copy signatures when needed

Next: process new view messages during playback