### PR TITLE
Support automatic port assignment

### DIFF
--- a/src/ds/cli_helper.h
+++ b/src/ds/cli_helper.h
@@ -26,14 +26,11 @@ namespace cli
 
       auto addr = results[0];
       auto found = addr.find_last_of(":");
-      if (found == std::string::npos)
-      {
-        throw CLI::ValidationError(
-          option_name, "Address is not in format host:port");
-      }
-
       auto hostname = addr.substr(0, found);
-      auto port = addr.substr(found + 1);
+
+      // If no port is specified, use port 0 (auto-assign a free port)
+      const auto port =
+        found == std::string::npos ? "0" : addr.substr(found + 1);
 
       // Check if port is in valid range
       int port_int;
@@ -45,10 +42,10 @@ namespace cli
       {
         throw CLI::ValidationError(option_name, "Port is not a number");
       }
-      if (port_int <= 0 || port_int > 65535)
+      if (port_int < 0 || port_int > 65535)
       {
         throw CLI::ValidationError(
-          option_name, "Port number is not in range 1-65535");
+          option_name, "Port number is not in range 0-65535");
       }
 
       parsed.hostname = hostname;

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -556,7 +556,6 @@ int main(int argc, char** argv)
                                  pbft_view_change_timeout,
                                  pbft_status_interval};
   ccf_config.signature_intervals = {sig_max_tx, sig_max_ms};
-  // TODO: Need to do port assignment _before_ this!
   ccf_config.node_info_network = {rpc_address.hostname,
                                   public_rpc_address.hostname,
                                   node_address.hostname,

--- a/src/host/node_connections.h
+++ b/src/host/node_connections.h
@@ -155,6 +155,12 @@ namespace asynchost
 
       NodeServerBehaviour(NodeConnections& parent) : parent(parent) {}
 
+      void on_listening(
+        const std::string& host, const std::string& service) override
+      {
+        LOG_INFO_FMT("Listening for node-to-node on {}:{}", host, service);
+      }
+
       void on_accept(TCP& peer) override
       {
         auto id = parent.get_next_id();

--- a/src/host/node_connections.h
+++ b/src/host/node_connections.h
@@ -148,14 +148,14 @@ namespace asynchost
       }
     };
 
-    class ServerBehaviour : public TCPBehaviour
+    class NodeServerBehaviour : public TCPServerBehaviour
     {
     public:
       NodeConnections& parent;
 
-      ServerBehaviour(NodeConnections& parent) : parent(parent) {}
+      NodeServerBehaviour(NodeConnections& parent) : parent(parent) {}
 
-      void on_accept(TCP& peer)
+      void on_accept(TCP& peer) override
       {
         auto id = parent.get_next_id();
         peer->set_behaviour(std::make_unique<IncomingBehaviour>(parent, id));
@@ -184,7 +184,7 @@ namespace asynchost
       ledger(ledger),
       to_enclave(writer_factory.create_writer_to_inside())
     {
-      listener->set_behaviour(std::make_unique<ServerBehaviour>(*this));
+      listener->set_behaviour(std::make_unique<NodeServerBehaviour>(*this));
       listener->listen(host, service);
 
       register_message_handlers(disp);

--- a/src/host/node_connections.h
+++ b/src/host/node_connections.h
@@ -180,11 +180,14 @@ namespace asynchost
       Ledger& ledger,
       ringbuffer::AbstractWriterFactory& writer_factory,
       const std::string& host,
-      const std::string& service) :
+      const std::string& service,
+      const std::optional<std::string>& listen_address_file = std::nullopt) :
       ledger(ledger),
       to_enclave(writer_factory.create_writer_to_inside())
     {
-      listener->set_behaviour(std::make_unique<NodeServerBehaviour>(*this));
+      auto behaviour = std::make_unique<NodeServerBehaviour>(*this);
+      behaviour->listen_address_file = listen_address_file;
+      listener->set_behaviour(std::move(behaviour));
       listener->listen(host, service);
 
       register_message_handlers(disp);

--- a/src/host/node_connections.h
+++ b/src/host/node_connections.h
@@ -179,16 +179,15 @@ namespace asynchost
       messaging::Dispatcher<ringbuffer::Message>& disp,
       Ledger& ledger,
       ringbuffer::AbstractWriterFactory& writer_factory,
-      const std::string& host,
-      const std::string& service,
-      const std::optional<std::string>& listen_address_file = std::nullopt) :
+      std::string& host,
+      std::string& service) :
       ledger(ledger),
       to_enclave(writer_factory.create_writer_to_inside())
     {
-      auto behaviour = std::make_unique<NodeServerBehaviour>(*this);
-      behaviour->listen_address_file = listen_address_file;
-      listener->set_behaviour(std::move(behaviour));
+      listener->set_behaviour(std::make_unique<NodeServerBehaviour>(*this));
       listener->listen(host, service);
+      host = listener->get_host();
+      service = listener->get_service();
 
       register_message_handlers(disp);
     }

--- a/src/host/rpc_connections.h
+++ b/src/host/rpc_connections.h
@@ -99,7 +99,11 @@ namespace asynchost
       to_enclave(writer_factory.create_writer_to_inside())
     {}
 
-    bool listen(int64_t id, const std::string& host, const std::string& service)
+    bool listen(
+      int64_t id,
+      const std::string& host,
+      const std::string& service,
+      const std::optional<std::string>& listen_address_file = std::nullopt)
     {
       if (id == 0)
         id = get_next_id();
@@ -111,7 +115,9 @@ namespace asynchost
       }
 
       TCP s;
-      s->set_behaviour(std::make_unique<RPCServerBehaviour>(*this, id));
+      auto behaviour = std::make_unique<RPCServerBehaviour>(*this, id);
+      behaviour->listen_address_file = listen_address_file;
+      s->set_behaviour(std::move(behaviour));
 
       if (!s->listen(host, service))
         return false;

--- a/src/host/rpc_connections.h
+++ b/src/host/rpc_connections.h
@@ -99,11 +99,7 @@ namespace asynchost
       to_enclave(writer_factory.create_writer_to_inside())
     {}
 
-    bool listen(
-      int64_t id,
-      const std::string& host,
-      const std::string& service,
-      const std::optional<std::string>& listen_address_file = std::nullopt)
+    bool listen(int64_t id, std::string& host, std::string& service)
     {
       if (id == 0)
         id = get_next_id();
@@ -115,12 +111,13 @@ namespace asynchost
       }
 
       TCP s;
-      auto behaviour = std::make_unique<RPCServerBehaviour>(*this, id);
-      behaviour->listen_address_file = listen_address_file;
-      s->set_behaviour(std::move(behaviour));
+      s->set_behaviour(std::make_unique<RPCServerBehaviour>(*this, id));
 
       if (!s->listen(host, service))
         return false;
+
+      host = s->get_host();
+      service = s->get_service();
 
       sockets.emplace(id, s);
       return true;

--- a/src/host/rpc_connections.h
+++ b/src/host/rpc_connections.h
@@ -58,28 +58,16 @@ namespace asynchost
       }
     };
 
-    class ServerBehaviour : public TCPBehaviour
+    class RPCServerBehaviour : public TCPServerBehaviour
     {
     public:
       RPCConnections& parent;
       int64_t id;
 
-      ServerBehaviour(RPCConnections& parent, int64_t id) :
+      RPCServerBehaviour(RPCConnections& parent, int64_t id) :
         parent(parent),
         id(id)
       {}
-
-      void on_resolve_failed()
-      {
-        LOG_DEBUG_FMT("rpc resolve failed {}", id);
-        cleanup();
-      }
-
-      void on_listen_failed()
-      {
-        LOG_DEBUG_FMT("rpc connect failed {}", id);
-        cleanup();
-      }
 
       void on_accept(TCP& peer)
       {
@@ -123,7 +111,7 @@ namespace asynchost
       }
 
       TCP s;
-      s->set_behaviour(std::make_unique<ServerBehaviour>(*this, id));
+      s->set_behaviour(std::make_unique<RPCServerBehaviour>(*this, id));
 
       if (!s->listen(host, service))
         return false;

--- a/src/host/rpc_connections.h
+++ b/src/host/rpc_connections.h
@@ -69,7 +69,13 @@ namespace asynchost
         id(id)
       {}
 
-      void on_accept(TCP& peer)
+      void on_listening(
+        const std::string& host, const std::string& service) override
+      {
+        LOG_INFO_FMT("Listening for RPCs on {}:{}", host, service);
+      }
+
+      void on_accept(TCP& peer) override
       {
         auto client_id = parent.get_next_id();
         peer->set_behaviour(

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -345,6 +345,7 @@ namespace asynchost
         }
 
         assert_status(LISTENING_RESOLVING, LISTENING);
+        LOG_INFO_FMT("Listening on {}", get_address_name());
         return;
       }
 

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -18,6 +18,11 @@ namespace asynchost
 
     virtual void on_resolve_failed() {}
     virtual void on_listen_failed() {}
+    virtual void on_listening(
+      const std::string& host, const std::string& service)
+    {
+      LOG_INFO_FMT("Listening on {}:{}", host, service);
+    }
     virtual void on_accept(TCP& peer) {}
     virtual void on_connect() {}
     virtual void on_connect_failed() {}
@@ -345,7 +350,7 @@ namespace asynchost
         }
 
         assert_status(LISTENING_RESOLVING, LISTENING);
-        LOG_INFO_FMT("Listening on {}", get_address_name());
+        behaviour->on_listening(host, service);
         return;
       }
 

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -25,6 +25,20 @@ namespace asynchost
     virtual void on_disconnect() {}
   };
 
+  class TCPServerBehaviour : public TCPBehaviour
+  {
+  public:
+    virtual void on_resolve_failed() override
+    {
+      throw std::runtime_error("TCP server resolve failed");
+    }
+
+    virtual void on_listen_failed() override
+    {
+      throw std::runtime_error("TCP server listen failed");
+    }
+  };
+
   class TCPImpl : public with_uv_handle<uv_tcp_t>
   {
   private:

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -18,9 +18,6 @@ namespace asynchost
 
     virtual void on_resolve_failed() {}
     virtual void on_listen_failed() {}
-    virtual void on_listening(
-      const std::string& host, const std::string& service)
-    {}
     virtual void on_accept(TCP& peer) {}
     virtual void on_connect() {}
     virtual void on_connect_failed() {}
@@ -31,7 +28,7 @@ namespace asynchost
   class TCPServerBehaviour : public TCPBehaviour
   {
   public:
-    std::optional<std::string> listen_address_file = std::nullopt;
+    std::string listen_address_file = "";
 
     virtual void on_resolve_failed() override
     {
@@ -41,16 +38,6 @@ namespace asynchost
     virtual void on_listen_failed() override
     {
       throw std::runtime_error("TCP server listen failed");
-    }
-
-    virtual void on_listening(
-      const std::string& host, const std::string& service) override
-    {
-      if (listen_address_file.has_value())
-      {
-        files::dump(
-          fmt::format("{}\n{}", host, service), listen_address_file.value());
-      }
     }
   };
 
@@ -142,6 +129,16 @@ namespace asynchost
     void set_behaviour(std::unique_ptr<TCPBehaviour> b)
     {
       behaviour = std::move(b);
+    }
+
+    std::string get_host() const
+    {
+      return host;
+    }
+
+    std::string get_service() const
+    {
+      return service;
     }
 
     bool connect(const std::string& host, const std::string& service)
@@ -348,7 +345,6 @@ namespace asynchost
         }
 
         assert_status(LISTENING_RESOLVING, LISTENING);
-        behaviour->on_listening(host, service);
         return;
       }
 

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -33,8 +33,6 @@ namespace asynchost
   class TCPServerBehaviour : public TCPBehaviour
   {
   public:
-    std::string listen_address_file = "";
-
     virtual void on_resolve_failed() override
     {
       throw std::runtime_error("TCP server resolve failed");

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -204,7 +204,6 @@ class Node:
             rpc_host, rpc_port = f.read().splitlines()
             assert rpc_host == self.host, f"Unexpected change in RPC address from {self.host} to {rpc_host}"
             self.rpc_port = rpc_port
-        LOG.warning(f"Parsed node port {self.node_port} and RPC port {self.rpc_port}")
 
     def stop(self):
         if self.remote and self.network_state is not NodeNetworkState.stopped:

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -8,8 +8,6 @@ import infra.net
 import infra.path
 import infra.clients
 import os
-import socket
-import time
 
 from loguru import logger as LOG
 
@@ -39,13 +37,12 @@ class Node:
         hosts, *port = host.split(":")
         self.host, *self.pubhost = hosts.split(",")
         self.rpc_port = port[0] if port else None
+        self.node_port = None
 
         if self.host == "localhost":
             self.host = infra.net.expand_localhost()
-            self._set_ports(infra.net.probably_free_local_port)
             self.remote_impl = infra.remote.LocalRemote
         else:
-            self._set_ports(infra.net.probably_free_remote_port)
             self.remote_impl = infra.remote.SSHRemote
 
         self.pubhost = self.pubhost[0] if self.pubhost else self.host
@@ -55,16 +52,6 @@ class Node:
 
     def __eq__(self, other):
         return self.node_id == other.node_id
-
-    def _set_ports(self, probably_free_function):
-        self.rpc_port = 0
-        self.node_port = 0
-        # if self.rpc_port is None:
-        #     self.node_port, self.rpc_port = infra.net.two_different(
-        #         probably_free_function, self.host
-        #     )
-        # else:
-        #     self.node_port = probably_free_function(self.host)
 
     def start(
         self,
@@ -182,27 +169,34 @@ class Node:
         else:
             if self.perf:
                 self.remote.set_perf()
-            sock = socket.socket()
-            LOG.warning(f"Deliberately binding {self.host}:{self.node_port}")
-            sock.bind((self.host, int(self.node_port)))
             self.remote.start()
-            LOG.warning("And sleeping briefly")
-            time.sleep(1)
         self.remote.get_startup_files(self.common_dir)
-        self._update_ports()
+        self._read_ports()
         LOG.info("Remote {} started".format(self.node_id))
 
-    def _update_ports(self):
+    def _read_ports(self):
         node_address_path = os.path.join(self.common_dir, self.remote.node_address_path)
         with open(node_address_path, "r") as f:
             node_host, node_port = f.read().splitlines()
-            assert node_host == self.host, f"Unexpected change in node address from {self.host} to {node_host}"
+            assert (
+                node_host == self.host
+            ), f"Unexpected change in node address from {self.host} to {node_host}"
+            if self.node_port is not None:
+                assert (
+                    node_port == self.node_port
+                ), f"Unexpected change in node port from {self.node_port} to {node_port}"
             self.node_port = node_port
 
         rpc_address_path = os.path.join(self.common_dir, self.remote.rpc_address_path)
         with open(rpc_address_path, "r") as f:
             rpc_host, rpc_port = f.read().splitlines()
-            assert rpc_host == self.host, f"Unexpected change in RPC address from {self.host} to {rpc_host}"
+            assert (
+                rpc_host == self.host
+            ), f"Unexpected change in RPC address from {self.host} to {rpc_host}"
+            if self.rpc_port is not None:
+                assert (
+                    rpc_port == self.rpc_port
+                ), f"Unexpected change in RPC port from {self.rpc_port} to {rpc_port}"
             self.rpc_port = rpc_port
 
     def stop(self):

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -8,6 +8,8 @@ import infra.net
 import infra.path
 import infra.clients
 import os
+import socket
+import time
 
 from loguru import logger as LOG
 
@@ -178,7 +180,12 @@ class Node:
         else:
             if self.perf:
                 self.remote.set_perf()
+            sock = socket.socket()
+            LOG.warning(f"Deliberately binding {self.host}:{self.node_port}")
+            sock.bind((self.host, int(self.node_port)))
             self.remote.start()
+            LOG.warning("And sleeping briefly")
+            time.sleep(1)
         self.remote.get_startup_files(self.common_dir)
         LOG.info("Remote {} started".format(self.node_id))
 

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -36,7 +36,7 @@ class Node:
 
         hosts, *port = host.split(":")
         self.host, *self.pubhost = hosts.split(",")
-        self.rpc_port = port[0] if port else None
+        self.rpc_port = int(port[0]) if port else None
         self.node_port = None
 
         if self.host == "localhost":
@@ -178,6 +178,7 @@ class Node:
         node_address_path = os.path.join(self.common_dir, self.remote.node_address_path)
         with open(node_address_path, "r") as f:
             node_host, node_port = f.read().splitlines()
+            node_port = int(node_port)
             assert (
                 node_host == self.host
             ), f"Unexpected change in node address from {self.host} to {node_host}"
@@ -190,6 +191,7 @@ class Node:
         rpc_address_path = os.path.join(self.common_dir, self.remote.rpc_address_path)
         with open(rpc_address_path, "r") as f:
             rpc_host, rpc_port = f.read().splitlines()
+            rpc_port = int(rpc_port)
             assert (
                 rpc_host == self.host
             ), f"Unexpected change in RPC address from {self.host} to {rpc_host}"

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -16,6 +16,7 @@ from collections import deque
 from loguru import logger as LOG
 
 DBG = os.getenv("DBG", "cgdb")
+FILE_TIMEOUT = 10
 
 _libc = ctypes.CDLL("libc.so.6")
 
@@ -183,7 +184,7 @@ class SSHRemote(CmdMixin):
             session.put(src_path, tgt_path)
         session.close()
 
-    def get(self, file_name, dst_path, timeout=60, target_name=None):
+    def get(self, file_name, dst_path, timeout=FILE_TIMEOUT, target_name=None):
         """
         Get file called `file_name` under the root of the remote. If the
         file is missing, wait for timeout, and raise an exception.
@@ -215,7 +216,7 @@ class SSHRemote(CmdMixin):
             else:
                 raise ValueError(file_name)
 
-    def list_files(self, timeout=60):
+    def list_files(self, timeout=FILE_TIMEOUT):
         files = []
         with sftp_session(self.hostname) as session:
             end_time = time.time() + timeout
@@ -407,7 +408,7 @@ class LocalRemote(CmdMixin):
             src_path = os.path.join(self.common_dir, path)
             assert self._rc("cp {} {}".format(src_path, dst_path)) == 0
 
-    def get(self, file_name, dst_path, timeout=60, target_name=None):
+    def get(self, file_name, dst_path, timeout=FILE_TIMEOUT, target_name=None):
         path = os.path.join(self.root, file_name)
         end_time = time.time() + timeout
         while time.time() < end_time:
@@ -424,7 +425,7 @@ class LocalRemote(CmdMixin):
     def list_files(self):
         return os.listdir(self.root)
 
-    def start(self, timeout=10):
+    def start(self):
         """
         Start cmd. stdout and err are captured to file locally.
         """

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -539,9 +539,9 @@ class CCFRemote(object):
         self.local_node_id = local_node_id
         self.host = host
         self.pubhost = pubhost
-        self.node_port = node_port
-        self.rpc_port = rpc_port
-        self.pem = "{}.pem".format(local_node_id)
+        self.pem = f"{local_node_id}.pem"
+        self.node_address_path = f"{local_node_id}.node_address"
+        self.rpc_address_path = f"{local_node_id}.rpc_address"
         self.BIN = infra.path.build_bin_path(
             self.BIN, enclave_type, binary_dir=binary_dir
         )
@@ -571,7 +571,9 @@ class CCFRemote(object):
             f"--enclave-file={enclave_path}",
             f"--enclave-type={enclave_type}",
             f"--node-address={host}:{node_port}",
+            f"--node-address-file={self.node_address_path}",
             f"--rpc-address={host}:{rpc_port}",
+            f"--rpc-address-file={self.rpc_address_path}",
             f"--public-rpc-address={pubhost}:{rpc_port}",
             f"--ledger-file={self.ledger_file_name}",
             f"--node-cert-file={self.pem}",
@@ -677,6 +679,8 @@ class CCFRemote(object):
 
     def get_startup_files(self, dst_path):
         self.remote.get(self.pem, dst_path)
+        self.remote.get(self.node_address_path, dst_path)
+        self.remote.get(self.rpc_address_path, dst_path)
         if self.start_type in {StartType.new, StartType.recover}:
             self.remote.get("networkcert.pem", dst_path)
             self.remote.get("network_enc_pubk.pem", dst_path)

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -497,6 +497,12 @@ CCF_TO_OE_LOG_LEVEL = {
 }
 
 
+def make_address(host, port=None):
+    if port is not None:
+        return f"{host}:{port}"
+    return host
+
+
 class CCFRemote(object):
     BIN = "cchost"
     DEPS = []
@@ -537,8 +543,6 @@ class CCFRemote(object):
         """
         self.start_type = start_type
         self.local_node_id = local_node_id
-        self.host = host
-        self.pubhost = pubhost
         self.pem = f"{local_node_id}.pem"
         self.node_address_path = f"{local_node_id}.node_address"
         self.rpc_address_path = f"{local_node_id}.rpc_address"
@@ -570,11 +574,11 @@ class CCFRemote(object):
             bin_path,
             f"--enclave-file={enclave_path}",
             f"--enclave-type={enclave_type}",
-            f"--node-address={host}:{node_port}",
+            f"--node-address={make_address(host, node_port)}",
             f"--node-address-file={self.node_address_path}",
-            f"--rpc-address={host}:{rpc_port}",
+            f"--rpc-address={make_address(host, rpc_port)}",
             f"--rpc-address-file={self.rpc_address_path}",
-            f"--public-rpc-address={pubhost}:{rpc_port}",
+            f"--public-rpc-address={make_address(pubhost, rpc_port)}",
             f"--ledger-file={self.ledger_file_name}",
             f"--node-cert-file={self.pem}",
             f"--host-log-level={host_log_level}",

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -16,7 +16,7 @@ from collections import deque
 from loguru import logger as LOG
 
 DBG = os.getenv("DBG", "cgdb")
-FILE_TIMEOUT = 10
+FILE_TIMEOUT = 60
 
 _libc = ctypes.CDLL("libc.so.6")
 


### PR DESCRIPTION
This PR adds support in a CCF node for specifying port 0 (or, equivalently, not giving a port at all), in which case a port is automatically assigned by the OS, for the RPC and node-to-node listen addresses. The bound address (whether assigned or specified explicitly) and DNS-resolved IP address are logged, and optionally dumped to a file for automated parsing.

The Python infra uses this automatic assignment for all nodes, rather than probing for a free port (and hoping both that this is released by the OS before the node gets there, and not rebound by something else).

Fixes #1164.