### PR TITLE
Use start_test_network.sh for recovery

### DIFF
--- a/.azure-pipelines-templates/install.yml
+++ b/.azure-pipelines-templates/install.yml
@@ -18,15 +18,15 @@ steps:
       -g $(pwd)/../../src/runtime_config/gov.lua \
       -v
     cp ./workspace/start_network_0/0.ledger .
-    cp ./workspace/start_network_0/network_enc_pubk.pem
+    cp ./workspace/start_network_0/network_enc_pubk.pem .
     timeout --signal=SIGINT --kill-after=30s --preserve-status 30s \
       python ${{ parameters.install_prefix }}/bin/start_network.py \
       -p ../../build/liblogging \
       -b ${{ parameters.install_prefix }}/bin \
-      -v
-      --recover
-      --ledger 0.ledger
-      --network-enc-pubk network_enc_pubk.pem
+      -v \
+      --recover \
+      --ledger 0.ledger \
+      --network-enc-pubk network_enc_pubk.pem \
       --common-dir ./workspace/start_network_common/
   displayName: Test installed CCF
 

--- a/.azure-pipelines-templates/install.yml
+++ b/.azure-pipelines-templates/install.yml
@@ -15,7 +15,7 @@ steps:
       python ${{ parameters.install_prefix }}/bin/start_network.py \
       -p ../../build/liblogging \
       -b ${{ parameters.install_prefix }}/bin \
-      -g ../../src/runtime_config/gov.lua \
+      -g $(pwd)/../../src/runtime_config/gov.lua \
       -v
     cp ./workspace/start_network_0/0.ledger .
     cp ./workspace/start_network_0/network_enc_pubk.pem

--- a/.azure-pipelines-templates/install.yml
+++ b/.azure-pipelines-templates/install.yml
@@ -11,12 +11,21 @@ steps:
     source env/bin/activate
     python -m pip install -U -r ${{ parameters.install_prefix }}/bin/requirements.txt
     pip freeze > ${{ parameters.install_prefix }}/bin/requirements.txt
-    timeout --signal=SIGINT --kill-after=60s --preserve-status 60s \
+    timeout --signal=SIGINT --kill-after=30s --preserve-status 30s \
       python ${{ parameters.install_prefix }}/bin/start_network.py \
       -p ../../build/liblogging \
       -b ${{ parameters.install_prefix }}/bin \
       -g ../../src/runtime_config/gov.lua \
       -v
+    cp ./workspace/start_network_0/0.ledger .
+    timeout --signal=SIGINT --kill-after=30s --preserve-status 30s \
+      python ${{ parameters.install_prefix }}/bin/start_network.py \
+      -p ../../build/liblogging \
+      -b ${{ parameters.install_prefix }}/bin \
+      -v
+      --recover
+      --ledger 0.ledger
+      --common-dir ./workspace/start_network_common/
   displayName: Test installed CCF
 
 - script: |

--- a/.azure-pipelines-templates/install.yml
+++ b/.azure-pipelines-templates/install.yml
@@ -18,6 +18,7 @@ steps:
       -g ../../src/runtime_config/gov.lua \
       -v
     cp ./workspace/start_network_0/0.ledger .
+    cp ./workspace/start_network_0/network_enc_pubk.pem
     timeout --signal=SIGINT --kill-after=30s --preserve-status 30s \
       python ${{ parameters.install_prefix }}/bin/start_network.py \
       -p ../../build/liblogging \
@@ -25,6 +26,7 @@ steps:
       -v
       --recover
       --ledger 0.ledger
+      --network-enc-pubk network_enc_pubk.pem
       --common-dir ./workspace/start_network_common/
   displayName: Test installed CCF
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,6 +2,8 @@ CCF documentation
 =================
 
 .. image:: img/ccf.svg
+  :width: 250
+  :align: center
 
 .. include:: quickstart/index.rst
 

--- a/doc/members/accept_recovery.rst
+++ b/doc/members/accept_recovery.rst
@@ -3,6 +3,8 @@ Accepting Recovery and Submitting Shares
 
 .. note:: Before members can initiate the end of the recovery procedure, operators should have started a new network and recovered all public transactions. See :ref:`details for public recovery operator procedure <operators/recovery:Establishing a Recovered Public Network>`.
 
+.. note:: See :ref:`users/deploy_app:Recovering a Service` for an automated way to recover a defunct CCF service.
+
 Accepting Recovery
 ------------------
 

--- a/doc/users/deploy_app.rst
+++ b/doc/users/deploy_app.rst
@@ -36,22 +36,25 @@ In a different terminal, using the local IP address and port of the CCF nodes di
 Recovering a Service
 --------------------
 
-The ``start_test_network.sh`` script can also be used to automatically recover a defunct network, as per the steps described :ref:`here <members/accept_recovery:Accepting Recovery and Submitting Shares>`. The ledger to be recovered (``--ledger``) and the directory containing the members and users identities and the network encryption public key (``--common-dir``) should be passed as arguments to the script.
+The ``start_test_network.sh`` script can also be used to automatically recover a defunct network, as per the steps described :ref:`here <members/accept_recovery:Accepting Recovery and Submitting Shares>`. The ledger to be recovered (``--ledger``) , the defunct network encryption public key (``--network-enc-pubk``) and the directory containing the members and users identities and the network encryption public key (``--common-dir``) should be passed as arguments to the script.
 
 .. code-block:: bash
 
     $ cd CCF/build
     $ cp ./workspace/test_network_0/0.ledger .
-    $ ../start_test_network.sh -p liblogging.enclave.so.signed --recover --ledger 0.ledger --common-dir ./workspace/test_network_common/
-    [2020-05-14 11:12:56.580] Starting 3 CCF nodes...
-    [2020-05-14 11:12:56.580] Virtual mode enabled
-    [2020-05-14 11:12:56.580] Recovering network from ledger 0.ledger and common directory ./workspace/test_network_common/
-    [2020-05-14 11:13:01.154] Started CCF network with the following nodes:
-    [2020-05-14 11:13:01.155]   Node [ 3] = 127.213.21.224:60433
-    [2020-05-14 11:13:01.155]   Node [ 4] = 127.87.46.254:37443
-    [2020-05-14 11:13:01.155]   Node [ 5] = 127.136.206.136:34330
-    [2020-05-14 11:13:01.155] You can now issue business transactions to the liblogging.virtual.so application.
-    [2020-05-14 11:13:01.155] See https://microsoft.github.io/CCF/users/issue_commands.html for more information.
-    [2020-05-14 11:13:01.155] Press Ctrl+C to shutdown the network.
+    $ cp ./workspace/test_network_0/network_enc_pubk.pem .
+    $ ../start_test_network.sh -p liblogging.enclave.so.signed --recover --ledger 0.ledger --network-enc-pubk network_enc_pubk.pem --common-dir ./workspace/test_network_common/
+    [2020-05-14 14:50:19.746] Starting 3 CCF nodes...
+    [2020-05-14 14:50:19.746] Recovering network from:
+    [2020-05-14 14:50:19.746]  - Ledger: 0.ledger
+    [2020-05-14 14:50:19.746]  - Defunct network public encryption key: network_enc_pubk.pem
+    [2020-05-14 14:50:19.746]  - Common directory: ./workspace/test_network_common/
+    [2020-05-14 14:50:24.388] Started CCF network with the following nodes:
+    [2020-05-14 14:50:24.388]   Node [ 3] = 127.191.152.111:40371
+    [2020-05-14 14:50:24.388]   Node [ 4] = 127.184.250.157:35113
+    [2020-05-14 14:50:24.388]   Node [ 5] = 127.175.51.36:34699
+    [2020-05-14 14:50:24.388] You can now issue business transactions to the liblogging.enclave.so.signed application.
+    [2020-05-14 14:50:24.388] See https://microsoft.github.io/CCF/users/issue_commands.html for more information.
+    [2020-05-14 14:50:24.388] Press Ctrl+C to shutdown the network.
 
 The effects of transactions committed by the defunct network should then be recovered. Users can also :ref:`issue new business requests <users/issue_commands:Issuing Commands>`.

--- a/doc/users/deploy_app.rst
+++ b/doc/users/deploy_app.rst
@@ -22,7 +22,10 @@ For example, deploying the ``liblogging`` example application:
     [2019-10-29 14:48:12.138] See https://microsoft.github.io/CCF/users/issue_commands.html for more information.
     [2019-10-29 14:48:12.138] Press Ctrl+C to shutdown the network.
 
-.. note:: To use CCF `virtual` mode, the same command can be run with ``TEST_ENCLAVE=virtual`` set as environment variable and the virtual version of the enclave application passed to the script. For example ``$ TEST_ENCLAVE=virtual ../start_test_network.sh --package ./liblogging.virtual.so``.
+.. note::
+
+    - To use CCF `virtual` mode, the same command can be run with ``TEST_ENCLAVE=virtual`` set as environment variable and the virtual version of the enclave application passed to the script. For example ``$ TEST_ENCLAVE=virtual ../start_test_network.sh --package ./liblogging.virtual.so``.
+    - The ``--verbose`` argument can be used to display all commands issued by operators and members to start the network.
 
 The log files (``out`` and ``err``) and ledger (``<node_id>.ledger``) for each CCF node can be found under ``CCF/build/workspace/test_network_<node_id>``.
 
@@ -30,3 +33,25 @@ The log files (``out`` and ``err``) and ledger (``<node_id>.ledger``) for each C
 
 In a different terminal, using the local IP address and port of the CCF nodes displayed by the command (e.g. ``127.177.10.108:37765`` for node ``0``), it is then possible for users to :ref:`issue business requests <users/issue_commands:Issuing Commands>`.
 
+Recovering a Service
+--------------------
+
+The ``start_test_network.sh`` script can also be used to automatically recover a defunct network, as per the steps described :ref:`here <members/accept_recovery:Accepting Recovery and Submitting Shares>`. The ledger to be recovered (``--ledger``) and the directory containing the members and users identities and the network encryption public key (``--common-dir``) should be passed as arguments to the script.
+
+.. code-block:: bash
+
+    $ cd CCF/build
+    $ cp ./workspace/test_network_0/0.ledger .
+    $ ../start_test_network.sh -p liblogging.enclave.so.signed --recover --ledger 0.ledger --common-dir ./workspace/test_network_common/
+    [2020-05-14 11:12:56.580] Starting 3 CCF nodes...
+    [2020-05-14 11:12:56.580] Virtual mode enabled
+    [2020-05-14 11:12:56.580] Recovering network from ledger 0.ledger and common directory ./workspace/test_network_common/
+    [2020-05-14 11:13:01.154] Started CCF network with the following nodes:
+    [2020-05-14 11:13:01.155]   Node [ 3] = 127.213.21.224:60433
+    [2020-05-14 11:13:01.155]   Node [ 4] = 127.87.46.254:37443
+    [2020-05-14 11:13:01.155]   Node [ 5] = 127.136.206.136:34330
+    [2020-05-14 11:13:01.155] You can now issue business transactions to the liblogging.virtual.so application.
+    [2020-05-14 11:13:01.155] See https://microsoft.github.io/CCF/users/issue_commands.html for more information.
+    [2020-05-14 11:13:01.155] Press Ctrl+C to shutdown the network.
+
+The effects of transactions committed by the defunct network should then be recovered. Users can also :ref:`issue new business requests <users/issue_commands:Issuing Commands>`.

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -384,13 +384,15 @@ int main(int argc, char** argv)
         rpc_address.hostname));
     }
 
-    if (*start || *join)
+    if ((*start || *join) && files::exists(ledger_file))
     {
-      if (files::exists(ledger_file))
-      {
-        throw std::logic_error(fmt::format(
-          "Ledger file {} is created by node on start/join", ledger_file));
-      }
+      throw std::logic_error(fmt::format(
+        "On start/join, ledger file should not exist ({})", ledger_file));
+    }
+    else if (*recover && !files::exists(ledger_file))
+    {
+      throw std::logic_error(fmt::format(
+        "On recovery, ledger file should exist ({}) ", ledger_file));
     }
 
     if (*start)

--- a/tests/infra/ccf.py
+++ b/tests/infra/ccf.py
@@ -142,7 +142,10 @@ class Network:
 
         # Contact primary if no target node is set
         if target_node is None:
+            for n in self.nodes:
+                LOG.success(f"Node: {n.node_id}")
             target_node, _ = self.find_primary()
+            LOG.error(target_node.host)
 
         node.join(
             lib_name=lib_name,
@@ -200,7 +203,7 @@ class Network:
                 else:
                     self._add_node(node, args.package, args)
             except Exception:
-                LOG.exception("Failed to start node {}".format(i))
+                LOG.exception("Failed to start node {}".format(node.node_id))
                 raise
         LOG.info("All remotes started")
 
@@ -275,8 +278,8 @@ class Network:
         self.status = ServiceStatus.OPEN
         LOG.success("***** Network is now open *****")
 
-    def start_in_recovery(self, args, ledger_file):
-        self.common_dir = get_common_folder_name(args.workspace, args.label)
+    def start_in_recovery(self, args, ledger_file, common_dir=None):
+        self.common_dir = common_dir or get_common_folder_name(args.workspace, args.label)
         primary = self._start_all_nodes(args, recovery=True, ledger_file=ledger_file)
         self.wait_for_all_nodes_to_catch_up(primary)
         LOG.success("All nodes joined recovered public network")

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -50,7 +50,7 @@ class Consortium:
                         """
                     },
                 )
-                for m in r.result:
+                for m in r.result or []:
                     new_member = infra.member.Member(m[0], curve, self.common_dir)
                     if (
                         infra.member.MemberStatus[m[1]]

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -313,10 +313,12 @@ class Consortium:
         proposal = self.get_any_active_member().propose(remote_node, script)
         return self.vote_using_majority(remote_node, proposal)
 
-    def recover_with_shares(self, remote_node):
+    def recover_with_shares(self, remote_node, defunct_network_enc_pubk):
         submitted_shares_count = 0
         for m in self.get_active_members():
-            decrypted_share = m.get_and_decrypt_recovery_share(remote_node)
+            decrypted_share = m.get_and_decrypt_recovery_share(
+                remote_node, defunct_network_enc_pubk
+            )
             r = m.submit_recovery_share(remote_node, decrypted_share)
 
             submitted_shares_count += 1

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -52,9 +52,7 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         default=os.getenv("JSON_LOG_PATH", None),
     )
     parser.add_argument(
-        "-g",
-        "--gov-script",
-        help="Path to governance script",
+        "-g", "--gov-script", help="Path to governance script",
     )
     parser.add_argument("-s", "--app-script", help="Path to app script")
     parser.add_argument("-j", "--js-app-script", help="Path to js app script")

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -55,7 +55,6 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         "-g",
         "--gov-script",
         help="Path to governance script",
-        default="../src/runtime_config/gov.lua",
     )
     parser.add_argument("-s", "--app-script", help="Path to app script")
     parser.add_argument("-j", "--js-app-script", help="Path to js app script")

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -135,17 +135,17 @@ class Member:
             assert r.error is None, f"Error ACK: {r.error}"
             self.status = MemberStatus.ACTIVE
 
-    def get_and_decrypt_recovery_share(self, remote_node):
+    def get_and_decrypt_recovery_share(self, remote_node, defunct_network_enc_pubk):
         with remote_node.member_client(member_id=self.member_id) as mc:
             r = mc.get("getEncryptedRecoveryShare")
             if r.status != http.HTTPStatus.OK.value:
                 raise NoRecoveryShareFound(r)
 
-            # For now, members rely on a copy of the original network encryption
-            # public key to decrypt their shares
+            # Members rely on a copy of the original network encryption public
+            # key to decrypt their recovery shares
             ctx = infra.crypto.CryptoBoxCtx(
                 os.path.join(self.common_dir, f"member{self.member_id}_enc_priv.pem"),
-                os.path.join(self.common_dir, "network_enc_pubk_orig.pem"),
+                defunct_network_enc_pubk,
             )
 
             nonce_bytes = bytes(r.result["nonce"])

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -23,22 +23,23 @@ class MemberStatus(Enum):
 
 
 class Member:
-    def __init__(self, member_id, curve, key_generator, common_dir):
+    def __init__(self, member_id, curve, common_dir, key_generator=None):
         self.key_generator = key_generator
         self.common_dir = common_dir
         self.member_id = member_id
         self.status = MemberStatus.ACCEPTED
 
-        # For now, all members are given an encryption key (for recovery)
-        member = f"member{member_id}"
-        infra.proc.ccall(
-            self.key_generator,
-            f"--name={member}",
-            f"--curve={curve.name}",
-            "--gen-enc-key",
-            path=self.common_dir,
-            log_output=False,
-        ).check_returncode()
+        if key_generator:
+            # For now, all members are given an encryption key (for recovery)
+            member = f"member{member_id}"
+            infra.proc.ccall(
+                self.key_generator,
+                f"--name={member}",
+                f"--curve={curve.name}",
+                "--gen-enc-key",
+                path=self.common_dir,
+                log_output=False,
+            ).check_returncode()
 
     def is_active(self):
         return self.status == MemberStatus.ACTIVE

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -29,7 +29,7 @@ class Member:
         self.member_id = member_id
         self.status = MemberStatus.ACCEPTED
 
-        if key_generator:
+        if key_generator is not None:
             # For now, all members are given an encryption key (for recovery)
             member = f"member{member_id}"
             infra.proc.ccall(
@@ -40,6 +40,18 @@ class Member:
                 path=self.common_dir,
                 log_output=False,
             ).check_returncode()
+        else:
+            # If no key generator is passed in, the identity of the member
+            # should have been created in advance (e.g. by a previous network)
+            assert os.path.isfile(
+                os.path.join(self.common_dir, f"member{self.member_id}_privk.pem")
+            )
+            assert os.path.isfile(
+                os.path.join(self.common_dir, f"member{self.member_id}_cert.pem")
+            )
+            assert os.path.isfile(
+                os.path.join(self.common_dir, f"member{self.member_id}_enc_priv.pem")
+            )
 
     def is_active(self):
         return self.status == MemberStatus.ACTIVE

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -126,7 +126,6 @@ class Member:
     def get_and_decrypt_recovery_share(self, remote_node):
         with remote_node.member_client(member_id=self.member_id) as mc:
             r = mc.get("getEncryptedRecoveryShare")
-
             if r.status != http.HTTPStatus.OK.value:
                 raise NoRecoveryShareFound(r)
 

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -180,7 +180,7 @@ class Node:
                 self.remote.set_perf()
             self.remote.start()
         self.remote.get_startup_files(self.common_dir)
-        LOG.info("Remote {} started".format(self.node_id))
+        LOG.info("Node {} started".format(self.node_id))
 
     def stop(self):
         if self.remote and self.network_state is not NodeNetworkState.stopped:

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -542,7 +542,6 @@ class CCFRemote(object):
         self.BIN = infra.path.build_bin_path(
             self.BIN, enclave_type, binary_dir=binary_dir
         )
-        LOG.error(f"Ledger file {ledger_file}")
         self.ledger_file = ledger_file
         self.ledger_file_name = (
             os.path.basename(ledger_file) if ledger_file else f"{local_node_id}.ledger"

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -177,9 +177,8 @@ class SSHRemote(CmdMixin):
             stat = os.stat(path)
             session.chmod(tgt_path, stat.st_mode)
         for path in self.data_files:
-            src_path = os.path.join(self.common_dir, path)
             tgt_path = os.path.join(self.root, os.path.basename(src_path))
-            LOG.info("[{}] copy {} from {}".format(self.hostname, tgt_path, src_path))
+            LOG.info("[{}] copy {} from {}".format(self.hostname, tgt_path, path))
             session.put(src_path, tgt_path)
         session.close()
 
@@ -404,8 +403,7 @@ class LocalRemote(CmdMixin):
             assert self._rc("ln -s {} {}".format(src_path, dst_path)) == 0
         for path in self.data_files:
             dst_path = self.root
-            src_path = os.path.join(self.common_dir, path)
-            assert self._rc("cp {} {}".format(src_path, dst_path)) == 0
+            assert self._rc("cp {} {}".format(path, dst_path)) == 0
 
     def get(self, file_name, dst_path, timeout=60, target_name=None):
         path = os.path.join(self.root, file_name)
@@ -544,6 +542,7 @@ class CCFRemote(object):
         self.BIN = infra.path.build_bin_path(
             self.BIN, enclave_type, binary_dir=binary_dir
         )
+        LOG.error(f"Ledger file {ledger_file}")
         self.ledger_file = ledger_file
         self.ledger_file_name = (
             os.path.basename(ledger_file) if ledger_file else f"{local_node_id}.ledger"
@@ -619,9 +618,9 @@ class CCFRemote(object):
                 )
             for mc, mk in members_info:
                 cmd += [f"--member-info={mc},{mk}"]
-                data_files.append(mc)
-                data_files.append(mk)
-            data_files += [os.path.basename(gov_script)]
+                data_files.append(os.path.join(self.common_dir, mc))
+                data_files.append(os.path.join(self.common_dir, mk))
+            data_files += [os.path.join(os.path.basename(self.common_dir), gov_script)]
         elif start_type == StartType.join:
             cmd += [
                 "join",
@@ -629,7 +628,7 @@ class CCFRemote(object):
                 f"--target-rpc-address={target_rpc_address}",
                 f"--join-timer={join_timer}",
             ]
-            data_files += ["networkcert.pem"]
+            data_files += [os.path.join(self.common_dir, "networkcert.pem")]
         elif start_type == StartType.recover:
             cmd += ["recover", "--network-cert-file=networkcert.pem"]
         else:
@@ -704,7 +703,10 @@ class CCFRemote(object):
 
     def get_ledger(self):
         self.remote.get(self.ledger_file_name, self.common_dir)
-        return self.ledger_file_name
+        LOG.success(
+            f"Retrieve ledger file {self.ledger_file_name} to {self.common_dir}"
+        )
+        return os.path.join(self.common_dir, self.ledger_file_name)
 
     def ledger_path(self):
         return os.path.join(self.remote.root, self.ledger_file_name)

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -171,7 +171,6 @@ class SSHRemote(CmdMixin):
         # files (ledger, secrets) are copied to the remote
         session = self.client.open_sftp()
         for path in self.exe_files:
-            src_path = path
             tgt_path = os.path.join(self.root, os.path.basename(path))
             LOG.info("[{}] copy {} from {}".format(self.hostname, tgt_path, path))
             session.put(path, tgt_path)

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -178,9 +178,9 @@ class SSHRemote(CmdMixin):
             stat = os.stat(path)
             session.chmod(tgt_path, stat.st_mode)
         for path in self.data_files:
-            tgt_path = os.path.join(self.root, os.path.basename(src_path))
+            tgt_path = os.path.join(self.root, os.path.basename(path))
             LOG.info("[{}] copy {} from {}".format(self.hostname, tgt_path, path))
-            session.put(src_path, tgt_path)
+            session.put(path, tgt_path)
         session.close()
 
     def get(self, file_name, dst_path, timeout=FILE_TIMEOUT, target_name=None):

--- a/tests/memberclient.py
+++ b/tests/memberclient.py
@@ -76,7 +76,7 @@ def assert_recovery_shares_update(func, network, args, **kwargs):
 
     recovery_threshold_before = network.consortium.recovery_threshold
     active_members_before = network.consortium.get_active_members()
-    network.consortium.store_current_network_encryption_key()
+    network.store_current_network_encryption_key()
     already_active_member = network.consortium.get_any_active_member()
     saved_share = already_active_member.get_and_decrypt_recovery_share(primary)
 

--- a/tests/memberclient.py
+++ b/tests/memberclient.py
@@ -42,7 +42,9 @@ def test_add_member(network, args):
     )
 
     try:
-        new_member.get_and_decrypt_recovery_share(primary)
+        new_member.get_and_decrypt_recovery_share(
+            primary, network.store_current_network_encryption_key()
+        )
         assert False, "New accepted members are not given recovery shares"
     except infra.member.NoRecoveryShareFound as e:
         assert e.response.error == "Only active members are given recovery shares"
@@ -78,7 +80,10 @@ def assert_recovery_shares_update(func, network, args, **kwargs):
     active_members_before = network.consortium.get_active_members()
     network.store_current_network_encryption_key()
     already_active_member = network.consortium.get_any_active_member()
-    saved_share = already_active_member.get_and_decrypt_recovery_share(primary)
+    defunct_network_enc_pubk = network.store_current_network_encryption_key()
+    saved_share = already_active_member.get_and_decrypt_recovery_share(
+        primary, defunct_network_enc_pubk
+    )
 
     if func is test_retire_member:
         # When retiring a member, the active member which retrieved their share
@@ -98,7 +103,9 @@ def assert_recovery_shares_update(func, network, args, **kwargs):
         recovery_threshold_before != network.consortium.recovery_threshold
         or active_members_before != network.consortium.get_active_members
     ):
-        new_share = already_active_member.get_and_decrypt_recovery_share(primary)
+        new_share = already_active_member.get_and_decrypt_recovery_share(
+            primary, defunct_network_enc_pubk
+        )
         assert saved_share != new_share, "New recovery shares should have been issued"
 
 

--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -28,10 +28,15 @@ def run(args):
     ) as network:
         if args.recover:
             args.label = args.label + "_recover"
+            LOG.info("Recovering network from:")
+            LOG.info(f" - Ledger: {args.ledger}")
             LOG.info(
-                f"Recovering network from ledger {args.ledger} and common directory {args.common_dir}"
+                f" - Defunct network public encryption key: {args.network_enc_pubk}"
             )
-            network.start_in_recovery(args, args.ledger, args.common_dir)
+            LOG.info(f" - Common directory: {args.common_dir}")
+            network.start_in_recovery(
+                args, args.ledger, args.common_dir, args.network_enc_pubk
+            )
         else:
             network.start_and_join(args)
 
@@ -98,12 +103,20 @@ if __name__ == "__main__":
             "--ledger", help="Ledger to recover from",
         )
         parser.add_argument(
+            "--network-enc-pubk",
+            help="Defunct network public encryption key (used by members to decrypt recovery shares)",
+        )
+        parser.add_argument(
             "--common-dir",
             help="Directory containing previous network member identities and network encryption key",
         )
 
     args = infra.e2e_args.cli_args(add)
-    if args.recover and (args.ledger is None or args.common_dir is None):
-        print("Error: --recover requires --ledger and --common-dir arguments.")
+    if args.recover and (
+        args.ledger is None or args.common_dir is None or args.network_enc_pubk is None
+    ):
+        print(
+            "Error: --recover requires --ledger, --network-enc-pubk and --common-dir arguments."
+        )
         sys.exit(1)
     run(args)

--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -109,6 +109,7 @@ if __name__ == "__main__":
             help="Ledger to recover from",  # TODO: Only if recovering
             # required=True,
         )
+        # TODO: Add ID of at least one member?
 
     args = infra.e2e_args.cli_args(add)
     run(args)

--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -104,6 +104,6 @@ if __name__ == "__main__":
 
     args = infra.e2e_args.cli_args(add)
     if args.recover and (args.ledger is None or args.common_dir is None):
-        print(f"Error: --recover requires --ledger and --common-dir arguments.")
+        print("Error: --recover requires --ledger and --common-dir arguments.")
         sys.exit(1)
     run(args)

--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -95,16 +95,15 @@ if __name__ == "__main__":
             default=False,
         )
         parser.add_argument(
-            "--ledger",
-            help="Ledger to recover from",  # TODO: Only if recovering
-            # required=True,
+            "--ledger", help="Ledger to recover from",
         )
         parser.add_argument(
             "--common-dir",
-            help="Ledger to recover from",  # TODO: Only if recovering
-            # required=True,
+            help="Directory containing previous network member identities and network encryption key",
         )
-        # TODO: Add ID of at least one member?
 
     args = infra.e2e_args.cli_args(add)
+    if args.recover and (args.ledger is None or args.common_dir is None):
+        print(f"Error: --recover requires --ledger and --common-dir arguments.")
+        sys.exit(1)
     run(args)

--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -28,14 +28,14 @@ def run(args):
     ) as network:
         if args.recover:
             args.label = args.label + "_recover"
-            LOG.warning(
-                f"Recovering network from ledger {args.ledger} and common dir {args.common_dir}"
+            LOG.info(
+                f"Recovering network from ledger {args.ledger} and common directory {args.common_dir}"
             )
             network.start_in_recovery(args, args.ledger, args.common_dir)
         else:
             network.start_and_join(args)
-        primary, backups = network.find_nodes()
 
+        primary, backups = network.find_nodes()
         LOG.info("Started CCF network with the following nodes:")
         LOG.info(
             "  Node [{:2d}] = {}:{}".format(

--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -27,16 +27,11 @@ def run(args):
         hosts=hosts, binary_directory=args.binary_dir, dbg_nodes=args.debug_nodes
     ) as network:
         if args.recover:
-
-            # TODO: Problem:
-            # On recovery, we create a network above but never start it
-            # Instead, we need to discover the node id once we've started one node and use that instead as the offset
+            args.label = args.label + "_recover"
             LOG.warning(
                 f"Recovering network from ledger {args.ledger} and common dir {args.common_dir}"
             )
             network.start_in_recovery(args, args.ledger, args.common_dir)
-
-            # TODO: Do the rest
         else:
             network.start_and_join(args)
         primary, backups = network.find_nodes()


### PR DESCRIPTION
Resolves https://github.com/microsoft/CCF/issues/1095

This add a new feature to the `start_test_network.sh` script and underlying Python infra so that it is possible to recover a defunct service, i.e.:

```
$ ../start_test_network.sh -p liblogging.virtual.so
...
[2020-05-14 12:00:15.144]   Node [ 0] = 127.144.227.254:35945
[2020-05-14 12:00:15.144]   Node [ 1] = 127.29.10.59:44623
[2020-05-14 12:00:15.144]   Node [ 2] = 127.69.86.53:46645
...
^C
$ cp ./workspace/test_network_0/0.ledger .
$ cp ./workspace/test_network_0/network_enc_pubk.pem .
$ ../start_test_network.sh -p liblogging.enclave.so.signed --recover --ledger 0.ledger --network-enc-pubk network_enc_pubk.pem --common-dir ./workspace/test_network_common/ 
[2020-05-14 12:01:36.367] Starting 3 CCF nodes...
[2020-05-14 12:01:36.368] Recovering network from: 
[2020-05-14 12:01:36.368] - Ledger: 0.ledger
[2020-05-14 12:01:36.368] - Defunct network public encryption key: network_enc_pubk.pem
[2020-05-14 12:01:36.368] - Common directory: ./workspace/test_network_common/
[2020-05-14 12:01:41.148] Started CCF network with the following nodes:
[2020-05-14 12:01:41.148]   Node [ 3] = 127.48.40.201:34947
[2020-05-14 12:01:41.148]   Node [ 4] = 127.214.91.12:40041
[2020-05-14 12:01:41.148]   Node [ 5] = 127.42.131.18:34559
[2020-05-14 12:01:41.148] You can now issue business transactions to the liblogging.virtual.so application.
[2020-05-14 12:01:41.148] See https://microsoft.github.io/CCF/users/issue_commands.html for more information.
[2020-05-14 12:01:41.148] Press Ctrl+C to shutdown the network.
```

Notes:
- Most of the Python recovery capabilities have been moved to the `infra.ccf.Network` class.
- The tricky part is to reconstruct the state of the network from the point of view of the Python infra. For our existing end-to-end recovery test, we just take the state of the previous `infra.ccf.Network`. For this feature instead, we replay the ledger to find out the existing node IDs, the list of accepted/active members and the recovery threshold. The only thing we cannot find out in advance in the ID of the first recovered node (the one which will replay the ledger). Hence, the first recovery node is located at `test_network_recover_0` while the other recovered nodes are stored under their real node ID (i.e. `test_network_recover_4` and `test_network_recovery_5`).
- Added docs and relevant test in the Daily CI.