### PR TITLE
Switch to new playbook name

### DIFF
--- a/docker/ccf_ci
+++ b/docker/ccf_ci
@@ -12,7 +12,7 @@ COPY getting_started/setup_vm/ /setup_vm/
 RUN apt update \
     && apt install -y ansible software-properties-common bsdmainutils dnsutils \
     && cd setup_vm \
-    && ansible-playbook ccf-dependencies-no-driver.yml az-cli.yml \
+    && ansible-playbook ccf-dev.yml az-cli.yml \
     && rm -rf /tmp/* \
     && apt remove -y ansible software-properties-common \
     && apt -y autoremove \


### PR DESCRIPTION
Also renamed old container to ccfciteam/ccf-ci-18.04-oe-0.9.0:az-dcap-1.4, built and pushed ccfciteam/ccf-ci-18.04-oe-0.9.0:az-dcap-1.5 which latest now points to as well.

There should be a nicer, automated way to do this. It's not totally obvious what that is.