### PR TITLE
Fix race condition in the code update test

### DIFF
--- a/docker/ccf_ci
+++ b/docker/ccf_ci
@@ -12,7 +12,7 @@ COPY getting_started/setup_vm/ /setup_vm/
 RUN apt update \
     && apt install -y ansible software-properties-common bsdmainutils dnsutils \
     && cd setup_vm \
-    && ansible-playbook ccf-dependencies-no-driver.yml az-cli.yml \
+    && ansible-playbook ccf-dev.yml az-cli.yml \
     && rm -rf /tmp/* \
     && apt remove -y ansible software-properties-common \
     && apt -y autoremove \

--- a/src/host/node_connections.h
+++ b/src/host/node_connections.h
@@ -32,7 +32,7 @@ namespace asynchost
 
       void on_read(size_t len, uint8_t*& incoming)
       {
-        LOG_DEBUG_FMT("from node {} received {}", node, len);
+        LOG_DEBUG_FMT("from node {} received {} bytes", node, len);
 
         pending.insert(pending.end(), incoming, incoming + len);
 
@@ -53,7 +53,7 @@ namespace asynchost
 
           if (size < msg_size)
           {
-            LOG_DEBUG_FMT("from node {} have {}/{}", node, size, msg_size);
+            LOG_DEBUG_FMT("from node {} have {}/{} bytes", node, size, msg_size);
             break;
           }
 

--- a/src/host/node_connections.h
+++ b/src/host/node_connections.h
@@ -53,7 +53,8 @@ namespace asynchost
 
           if (size < msg_size)
           {
-            LOG_DEBUG_FMT("from node {} have {}/{} bytes", node, size, msg_size);
+            LOG_DEBUG_FMT(
+              "from node {} have {}/{} bytes", node, size, msg_size);
             break;
           }
 

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -111,7 +111,11 @@ class Member:
             and wait_for_global_commit
         ):
             with remote_node.node_client() as mc:
-                infra.checker.wait_for_global_commit(mc, r.seqno, r.view, True)
+                # If we vote in a new node, which becomes part of quorum, the transaction
+                # can only commit after it has successfully joined and caught up.
+                # Given that the retry timer on join RPC is 4 seconds, anything less is very
+                # likely to time out!
+                infra.checker.wait_for_global_commit(mc, r.seqno, r.view, True, timeout=6)
 
         return r
 

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -115,7 +115,9 @@ class Member:
                 # can only commit after it has successfully joined and caught up.
                 # Given that the retry timer on join RPC is 4 seconds, anything less is very
                 # likely to time out!
-                infra.checker.wait_for_global_commit(mc, r.seqno, r.view, True, timeout=6)
+                infra.checker.wait_for_global_commit(
+                    mc, r.seqno, r.view, True, timeout=6
+                )
 
         return r
 


### PR DESCRIPTION
fix #1147 

The gist of the problem is that when a node joins a network, and become a tie-breaker for the consensus (eg. an 8th node joining a 7 node network where 3 nodes are dead, in the case of the code update), there is a race between the join rpc poll and the waiting for the vote to be globally committed.

The new dcap client, which results in faster quote verification seems to have triggered this by making the initial delay shorter in the join RPC, which leads to the vote happening sooner, and the timeout sooner too, before the join RPC has time to poll again.

The code update test is a useful corner case test but not an accurate representation of what we expect a vanilla code update to look like. We ought to refactor it in a similar way to the reconfiguration test, modify it to represent the normal case, and establish variants for pathological cases like this one (which are still interesting!).