### PR TITLE
Shorten WS tests

### DIFF
--- a/tests/ws_scaffold.py
+++ b/tests/ws_scaffold.py
@@ -19,13 +19,13 @@ def test(network, args, notifications_queue=None):
     msg = "Hello world"
     LOG.info("Write on primary")
     with primary.user_client(ws=True) as c:
-        for i in range(1, 501):
+        for i in [1, 50, 500]:
             r = c.rpc("LOG_record", {"id": 42, "msg": msg * i})
             assert r.result == True, r.result
 
     LOG.info("Write on secondary through forwarding")
     with other.user_client(ws=True) as c:
-        for i in range(1, 501):
+        for i in [1, 50, 500]:
             r = c.rpc("LOG_record", {"id": 42, "msg": msg * i})
             assert r.result == True, r.result
 


### PR DESCRIPTION
The PBFT version takes a particularly long time, because a full consensus round trip happens for each of the 1k requests (>1 minute), so making this test a bit more lightweight in requests.