### PR TITLE
Make it harder to mistake deletions for legitimate writes in commit hooks

### DIFF
--- a/src/kv/experimental.h
+++ b/src/kv/experimental.h
@@ -132,14 +132,14 @@ namespace kv
       }
 
       template <class F>
-      bool foreach(F&& f)
+      void foreach(F&& f)
       {
         auto g = [&](const SerialisedRep& k_rep, const SerialisedRep& v_rep) {
           return f(
             KSerialiser::from_serialised(k_rep),
             VSerialiser::from_serialised(v_rep));
         };
-        return untyped_view.foreach(g);
+        untyped_view.foreach(g);
       }
     };
 

--- a/src/kv/experimental.h
+++ b/src/kv/experimental.h
@@ -132,14 +132,14 @@ namespace kv
       }
 
       template <class F>
-      void foreach(F&& f)
+      bool foreach(F&& f)
       {
         auto g = [&](const SerialisedRep& k_rep, const SerialisedRep& v_rep) {
           return f(
             KSerialiser::from_serialised(k_rep),
             VSerialiser::from_serialised(v_rep));
         };
-        untyped_view.foreach(g);
+        return untyped_view.foreach(g);
       }
     };
 

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -281,55 +281,18 @@ TEST_CASE_TEMPLATE("foreach", MapImpl, RawMapTypes, ExperimentalMapTypes)
 
   SUBCASE("Early termination")
   {
-    {
-      kv::Tx tx;
-      auto view = tx.get_view(map);
-      view->put("key1", "value1");
-      view->put("key2", "value2");
-      view->put("key3", "value3");
-      size_t ctr = 0;
-      view->foreach([&ctr](const auto& key, const auto& value) {
-        ++ctr;
-        return ctr < 2; // Continue after the first, but not the second (so
-                        // never see the third)
-      });
-      REQUIRE(ctr == 2);
-      REQUIRE(tx.commit() == kv::CommitSuccess::OK);
-    }
-
-    {
-      kv::Tx tx;
-      auto view = tx.get_view(map);
-      view->put("key4", "value4");
-      view->put("key5", "value5");
-
-      {
-        size_t ctr = 0;
-        view->foreach([&ctr](const auto&, const auto&) {
-          ++ctr;
-          return ctr < 2; //< See only committed state
-        });
-        REQUIRE(ctr == 2);
-      }
-
-      {
-        size_t ctr = 0;
-        view->foreach([&ctr](const auto&, const auto&) {
-          ++ctr;
-          return ctr < 4; //< See mix of old and state
-        });
-        REQUIRE(ctr == 4);
-      }
-
-      {
-        size_t ctr = 0;
-        view->foreach([&ctr](const auto&, const auto&) {
-          ++ctr;
-          return ctr < 100; //< See as much as possible
-        });
-        REQUIRE(ctr == 5);
-      }
-    }
+    kv::Tx tx;
+    auto view = tx.get_view(map);
+    view->put("key1", "value1");
+    view->put("key2", "value2");
+    view->put("key3", "value3");
+    size_t ctr = 0;
+    view->foreach([&ctr](const auto& key, const auto& value) {
+      ++ctr;
+      return ctr <= 1; // Continue after the first, but not the second (so never
+                       // see the third)
+    });
+    REQUIRE(ctr == 2);
   }
 }
 

--- a/src/kv/tx_view.h
+++ b/src/kv/tx_view.h
@@ -226,29 +226,42 @@ namespace kv
      * whether the iteration should continue (true) or stop (false)
      */
     template <class F>
-    bool foreach(F&& f)
+    void foreach(F&& f)
     {
       // Record a global read dependency.
       tx_changes.read_version = tx_changes.start_version;
       auto& w = tx_changes.writes;
+      bool should_continue = true;
 
-      tx_changes.state.foreach([&w, &f](const K& k, const VersionV<V>& v) {
-        auto write = w.find(k);
+      tx_changes.state.foreach(
+        [&w, &f, &should_continue](const K& k, const VersionV<V>& v) {
+          auto write = w.find(k);
 
-        if ((write == w.end()) && !is_deleted(v.version))
-          return f(k, v.value);
-        return true;
-      });
+          if ((write == w.end()) && !is_deleted(v.version))
+          {
+            should_continue = f(k, v.value);
+          }
 
-      for (auto write = tx_changes.writes.begin();
-           write != tx_changes.writes.end();
-           ++write)
+          return should_continue;
+        });
+
+      if (should_continue)
       {
-        if (write->second.has_value())
-          if (!f(write->first, write->second.value()))
-            return false;
+        for (auto write = tx_changes.writes.begin();
+             write != tx_changes.writes.end();
+             ++write)
+        {
+          if (write->second.has_value())
+          {
+            should_continue = f(write->first, write->second.value());
+          }
+
+          if (!should_continue)
+          {
+            break;
+          }
+        }
       }
-      return true;
     }
   };
 }

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1321,7 +1321,8 @@ namespace ccf
           {
             if (!opt_ni.has_value())
             {
-              throw std::logic_error("Unexpected: removal from nodes table");
+              throw std::logic_error(fmt::format(
+                "Unexpected: removal from nodes table ({})", node_id));
             }
 
             const auto& ni = opt_ni.value();
@@ -1359,7 +1360,8 @@ namespace ccf
         {
           if (!opt_secret_set.has_value())
           {
-            throw std::logic_error("Unexpected: removal from secrets table");
+            throw std::logic_error(
+              fmt::format("Unexpected: removal from secrets table ({})", v));
           }
 
           const auto& secret_set = opt_secret_set.value();
@@ -1450,7 +1452,8 @@ namespace ccf
           {
             if (!opt_v.has_value())
             {
-              throw std::logic_error("Unexpected: removal from shares table");
+              throw std::logic_error(
+                fmt::format("Unexpected: removal from shares table ({})", k));
             }
 
             const auto& v = opt_v.value();
@@ -1539,7 +1542,8 @@ namespace ccf
           {
             if (!opt_ni.has_value())
             {
-              throw std::logic_error("Unexpected: removal from nodes table");
+              throw std::logic_error(fmt::format(
+                "Unexpected: removal from nodes table ({})", node_id));
             }
 
             const auto& ni = opt_ni.value();
@@ -1700,7 +1704,8 @@ namespace ccf
           {
             if (!opt_ni.has_value())
             {
-              throw std::logic_error("Unexpected: removal from nodes table");
+              throw std::logic_error(fmt::format(
+                "Unexpected: removal from nodes table ({})", node_id));
             }
 
             const auto& ni = opt_ni.value();

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1707,9 +1707,7 @@ namespace ccf
             add_node(node_id, ni.nodehost, ni.nodeport);
 
             consensus->add_configuration(
-              version,
-              {},
-              {node_id, ni.nodehost, ni.nodeport, ni.cert});
+              version, {}, {node_id, ni.nodehost, ni.nodeport, ni.cert});
           }
         });
 


### PR DESCRIPTION
Fixes #1208.

The value type in a `Write` is now `std::optional<V>` instead of `VersionV<V>`. The version was supposed to be `NoVersion` to indicate a deletion, but all of our own hooks were ignoring `version` and accessing `value` directly. assuming it was a real written value. This is a breaking API change - even if you want to ignore the possibility of deletions, you now need to access the actual values by `.value()` (preferably gated by a check to `.has_value()`,) not `.value`.

Our hooks don't expect deletions and don't have anything sensible to do if they do occur, so they all simply throw an exception. It would be nice to have this expectation statically enforced (some kind of `NoRemovals` modifier type for a `kv::Map`, which returned `TxView`s with no `remove` method, and whose `Write` type could store values directly), but this is an unnecessary extra bit of machinery for now.