### PR TITLE
Make the foreach early-exit semantics consistent

### DIFF
--- a/src/kv/experimental.h
+++ b/src/kv/experimental.h
@@ -132,14 +132,14 @@ namespace kv
       }
 
       template <class F>
-      bool foreach(F&& f)
+      void foreach(F&& f)
       {
         auto g = [&](const SerialisedRep& k_rep, const SerialisedRep& v_rep) {
           return f(
             KSerialiser::from_serialised(k_rep),
             VSerialiser::from_serialised(v_rep));
         };
-        return untyped_view.foreach(g);
+        untyped_view.foreach(g);
       }
     };
 

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -316,7 +316,7 @@ TEST_CASE_TEMPLATE("foreach", MapImpl, RawMapTypes, ExperimentalMapTypes)
         size_t ctr = 0;
         view->foreach([&ctr](const auto&, const auto&) {
           ++ctr;
-          return ctr < 4; //< See mix of old and state
+          return ctr < 4; //< See mix of old state and new writes
         });
         REQUIRE(ctr == 4);
       }

--- a/src/kv/tx_view.h
+++ b/src/kv/tx_view.h
@@ -229,29 +229,41 @@ namespace kv
      * whether the iteration should continue (true) or stop (false)
      */
     template <class F>
-    bool foreach(F&& f)
+    void foreach(F&& f)
     {
       // Record a global read dependency.
       tx_changes.read_version = tx_changes.start_version;
       auto& w = tx_changes.writes;
+      bool should_continue = true;
 
-      tx_changes.state.foreach([&w, &f](const K& k, const VersionV<V>& v) {
-        auto write = w.find(k);
+      tx_changes.state.foreach(
+        [&w, &f, &should_continue](const K& k, const VersionV<V>& v) {
+          auto write = w.find(k);
 
-        if ((write == w.end()) && !is_deleted(v.version))
-          return f(k, v.value);
-        return true;
-      });
+          if ((write == w.end()) && !is_deleted(v.version))
+          {
+            should_continue = f(k, v.value);
+          }
 
-      for (auto write = tx_changes.writes.begin();
-           write != tx_changes.writes.end();
-           ++write)
+          return should_continue;
+        });
+
+      if (should_continue)
       {
-        if (!is_deleted(write->second.version))
-          if (!f(write->first, write->second.value))
-            return false;
+        for (auto write = tx_changes.writes.begin();
+             write != tx_changes.writes.end();
+             ++write)
+        {
+          if (!is_deleted(write->second.version))
+            if (!f(write->first, write->second.value))
+              should_continue = f(write->first, write->second.value);
+
+          if (!should_continue)
+          {
+            break;
+          }
+        }
       }
-      return true;
     }
   };
 }

--- a/src/kv/tx_view.h
+++ b/src/kv/tx_view.h
@@ -255,8 +255,9 @@ namespace kv
              ++write)
         {
           if (!is_deleted(write->second.version))
-            if (!f(write->first, write->second.value))
-              should_continue = f(write->first, write->second.value);
+          {
+            should_continue = f(write->first, write->second.value);
+          }
 
           if (!should_continue)
           {


### PR DESCRIPTION
Noticed as part of #1221 (and one need manually merging when the other goes in, due to similar changes in `tx_view.h`):

`TxView::foreach` takes a visitor lambda, and returning false is supposed to mean "I'm done, don't call me again". We need to run this twice, for both the original state and the current write set. The early-out-on-false behaviour only applied to the writes - if you decided you were done after looking at something in the state, you still get called with something in the write set. This fixes that - return false means you won't get called again at all.

On a related point, `foreach` itself returned a bool with no meaning. It could return "the lambda returned false at some point", or "you saw everything", but none of these seem particularly clear or useful. For clarity, I've just removed the return type entirely.

++unit tests