### PR TITLE
Clean up logging

### DIFF
--- a/src/consensus/pbft/libbyz/certificate.h
+++ b/src/consensus/pbft/libbyz/certificate.h
@@ -452,7 +452,7 @@ bool Certificate<T>::add(T* msg)
       else
       {
         // Should only happen for replies to read-only requests.
-        LOG_FAIL << "More than f+1 distinct values in certificate" << std::endl;
+        LOG_FAIL_FMT("More than f+1 distinct values in certificate");
         clear();
       }
     }

--- a/src/consensus/pbft/libbyz/certificate.h
+++ b/src/consensus/pbft/libbyz/certificate.h
@@ -482,7 +482,9 @@ bool Certificate<T>::add_mine(T* msg)
   {
     CCF_ASSERT(
       false, "Node is faulty, more than f faulty replicas or faulty primary ");
-    LOG_FATAL_FMT("Node is faulty, more than f faulty replicas or faulty primary {}", msg->stag());
+    LOG_FATAL_FMT(
+      "Node is faulty, more than f faulty replicas or faulty primary {}",
+      msg->stag());
     delete msg;
     return false;
   }

--- a/src/consensus/pbft/libbyz/certificate.h
+++ b/src/consensus/pbft/libbyz/certificate.h
@@ -482,9 +482,7 @@ bool Certificate<T>::add_mine(T* msg)
   {
     CCF_ASSERT(
       false, "Node is faulty, more than f faulty replicas or faulty primary ");
-    LOG_FATAL
-      << "Node is faulty, more than f faulty replicas or faulty primary "
-      << msg->stag() << std::endl;
+    LOG_FATAL_FMT("Node is faulty, more than f faulty replicas or faulty primary {}", msg->stag());
     delete msg;
     return false;
   }

--- a/src/consensus/pbft/libbyz/client_proxy.h
+++ b/src/consensus/pbft/libbyz/client_proxy.h
@@ -211,7 +211,7 @@ bool ClientProxy<T, C>::send_request(
   if (current_outstanding.fetch_add(1) >= Max_outstanding)
   {
     current_outstanding.fetch_sub(1);
-    LOG_FAIL_FMT("Too many outstanding requests, rejecting!");
+    LOG_FAIL_FMT("Too many outstanding requests, rejecting");
     return false;
   }
 

--- a/src/consensus/pbft/libbyz/client_proxy.h
+++ b/src/consensus/pbft/libbyz/client_proxy.h
@@ -211,7 +211,7 @@ bool ClientProxy<T, C>::send_request(
   if (current_outstanding.fetch_add(1) >= Max_outstanding)
   {
     current_outstanding.fetch_sub(1);
-    LOG_FAIL << "Too many outstanding requests, rejecting!" << std::endl;
+    LOG_FAIL_FMT("Too many outstanding requests, rejecting!");
     return false;
   }
 
@@ -242,7 +242,8 @@ bool ClientProxy<T, C>::send_request(
   }
   catch (const std::exception& e)
   {
-    LOG_FAIL_FMT("Failed to parse arguments, e.what:", e.what());
+    LOG_FAIL_FMT("Failed to parse arguments");
+    LOG_DEBUG_FMT("Failed to parse arguments, e.what:", e.what());
     return false;
   }
 

--- a/src/consensus/pbft/libbyz/digest.cpp
+++ b/src/consensus/pbft/libbyz/digest.cpp
@@ -64,6 +64,5 @@ void Digest::finalize(Digest::Context& ctx)
 
 void Digest::print()
 {
-  LOG_INFO << "digest=[" << d[0] << "," << d[1] << "," << d[2] << "," << d[3]
-           << "]" << std::endl;
+  LOG_INFO_FMT("digest=[{},{},{},{}]", d[0], d[1], d[2], d[3]);
 }

--- a/src/consensus/pbft/libbyz/digest.cpp
+++ b/src/consensus/pbft/libbyz/digest.cpp
@@ -64,5 +64,5 @@ void Digest::finalize(Digest::Context& ctx)
 
 void Digest::print()
 {
-  LOG_INFO_FMT("digest=[{},{},{},{}]", d[0], d[1], d[2], d[3]);
+  LOG_INFO_FMT("Digest=[{},{},{},{}]", d[0], d[1], d[2], d[3]);
 }

--- a/src/consensus/pbft/libbyz/message.cpp
+++ b/src/consensus/pbft/libbyz/message.cpp
@@ -80,9 +80,11 @@ void Message::set_size(int size)
   CCF_ASSERT(msg && ALIGNED(msg), "Invalid state");
   if (!(max_size < 0 || ALIGNED_SIZE(size) <= max_size))
   {
-    LOG_INFO << "Error - size:" << size
-             << ", aligned_size:" << ALIGNED_SIZE(size)
-             << ", max_size:" << max_size << std::endl;
+    LOG_INFO_FMT(
+      "Error - size:{}, aligned_size:{}, max_size:{}",
+      size,
+      ALIGNED_SIZE(size),
+      max_size);
   }
   CCF_ASSERT(max_size < 0 || ALIGNED_SIZE(size) <= max_size, "Invalid state");
   int aligned = ALIGNED_SIZE(size);

--- a/src/consensus/pbft/libbyz/node.cpp
+++ b/src/consensus/pbft/libbyz/node.cpp
@@ -71,8 +71,8 @@ Node::Node(const NodeInfo& node_info_) : node_info(node_info_)
     threshold = num_replicas - max_faulty;
   }
 
-  LOG_INFO << " max faulty (f): " << max_faulty
-           << " num replicas: " << num_replicas << std::endl;
+  LOG_INFO_FMT(
+    " max faulty (f): {} num replicas: {}", max_faulty, num_replicas);
 
   // Read authentication timeout
   int at = node_info.general_info.auth_timeout;
@@ -87,7 +87,7 @@ Node::Node(const NodeInfo& node_info_) : node_info(node_info_)
     PBFT_FAIL("Could not find my principal");
   }
 
-  LOG_INFO << "My id is " << node_id << std::endl;
+  LOG_INFO_FMT("My id is {}", node_id);
 
   // Initialize current view number and primary.
   v = 0;
@@ -104,13 +104,12 @@ Node::Node(const NodeInfo& node_info_) : node_info(node_info_)
 
 void Node::add_principal(const PrincipalInfo& principal_info)
 {
-  LOG_INFO << "Adding principal with id:" << principal_info.id << std::endl;
+  LOG_INFO_FMT("Adding principal with id:{}", principal_info.id);
   auto principals = get_principals();
   auto it = principals->find(principal_info.id);
   if (it != principals->end())
   {
-    LOG_INFO << "Principal with id: " << principal_info.id
-             << " has already been configured" << std::endl;
+    LOG_INFO_FMT("Principal with id:{} has already been configured", principal_info.id);
     auto& principal = it->second;
     if (principal->get_cert().empty())
     {
@@ -135,7 +134,7 @@ void Node::add_principal(const PrincipalInfo& principal_info)
 
   std::atomic_store(&atomic_principals, new_principals);
 
-  LOG_INFO << "Added principal with id:" << principal_info.id << std::endl;
+  LOG_INFO_FMT("Added principal with id:{}", principal_info.id);
 
   if (principal_info.is_replica)
   {
@@ -149,7 +148,7 @@ void Node::configure_principals()
   {
     if (pi.id != node_id)
     {
-      LOG_INFO << "Adding principal: " << pi.id << std::endl;
+      LOG_INFO_FMT("Adding principal:{}", pi.id);
       add_principal(pi);
     }
   }
@@ -158,7 +157,7 @@ void Node::configure_principals()
 void Node::init_network(std::unique_ptr<INetwork>&& network_)
 {
   auto principals = get_principals();
-  LOG_INFO << "principals - count:" << principals->size() << std::endl;
+  LOG_INFO_FMT("principals - count:{}", principals->size());
   network = std::move(network_);
   auto it = principals->find(node_id);
   assert(it != principals->end());
@@ -282,7 +281,7 @@ void Node::send_to_replicas(Message* m)
 
 void Node::set_f(size_t f)
 {
-  LOG_INFO << "***** setting f to " << f << "*****" << std::endl;
+  LOG_INFO_FMT("***** setting f to {} *****", f);
   max_faulty = f;
   send_only_to_self = (f == 0);
   threshold = f * 2 + 1;

--- a/src/consensus/pbft/libbyz/node.cpp
+++ b/src/consensus/pbft/libbyz/node.cpp
@@ -72,8 +72,7 @@ Node::Node(const NodeInfo& node_info_) : node_info(node_info_)
     threshold = num_replicas - max_faulty;
   }
 
-  LOG_INFO_FMT(
-    " max faulty (f): {} num replicas: {}", max_faulty, num_replicas);
+  LOG_INFO_FMT("Max faulty (f): {} num replicas: {}", max_faulty, num_replicas);
 
   // Read authentication timeout
   int at = node_info.general_info.auth_timeout;
@@ -157,7 +156,7 @@ void Node::configure_principals()
 void Node::init_network(std::unique_ptr<INetwork>&& network_)
 {
   auto principals = get_principals();
-  LOG_INFO_FMT("principals - count:{}", principals->size());
+  LOG_INFO_FMT("Principals - count:{}", principals->size());
   network = std::move(network_);
   auto it = principals->find(node_id);
   assert(it != principals->end());

--- a/src/consensus/pbft/libbyz/node.cpp
+++ b/src/consensus/pbft/libbyz/node.cpp
@@ -49,8 +49,7 @@ Node::Node(const NodeInfo& node_info_) : node_info(node_info_)
   num_replicas = node_info.general_info.num_replicas;
   if (num_replicas <= 2 * max_faulty)
   {
-    LOG_FATAL << "Not enough replicas: " << num_replicas
-              << " for desired f: " << max_faulty << std::endl;
+    LOG_FATAL_FMT("Not enough replicas: {} for desired f: {}", num_replicas, max_faulty);
     throw std::logic_error(
       "Not enough replicas: " + std::to_string(num_replicas) +
       " for desired f: " + std::to_string(max_faulty));

--- a/src/consensus/pbft/libbyz/node.cpp
+++ b/src/consensus/pbft/libbyz/node.cpp
@@ -49,7 +49,8 @@ Node::Node(const NodeInfo& node_info_) : node_info(node_info_)
   num_replicas = node_info.general_info.num_replicas;
   if (num_replicas <= 2 * max_faulty)
   {
-    LOG_FATAL_FMT("Not enough replicas: {} for desired f: {}", num_replicas, max_faulty);
+    LOG_FATAL_FMT(
+      "Not enough replicas: {} for desired f: {}", num_replicas, max_faulty);
     throw std::logic_error(
       "Not enough replicas: " + std::to_string(num_replicas) +
       " for desired f: " + std::to_string(max_faulty));
@@ -87,8 +88,6 @@ Node::Node(const NodeInfo& node_info_) : node_info(node_info_)
     PBFT_FAIL("Could not find my principal");
   }
 
-  LOG_INFO_FMT("My id is {}", node_id);
-
   // Initialize current view number and primary.
   v = 0;
   cur_primary = 0;
@@ -109,7 +108,8 @@ void Node::add_principal(const PrincipalInfo& principal_info)
   auto it = principals->find(principal_info.id);
   if (it != principals->end())
   {
-    LOG_INFO_FMT("Principal with id:{} has already been configured", principal_info.id);
+    LOG_INFO_FMT(
+      "Principal with id:{} has already been configured", principal_info.id);
     auto& principal = it->second;
     if (principal->get_cert().empty())
     {

--- a/src/consensus/pbft/libbyz/nv_info.cpp
+++ b/src/consensus/pbft/libbyz/nv_info.cpp
@@ -226,7 +226,8 @@ void NV_info::add(std::unique_ptr<View_change> m)
     if (!check_new_view())
     {
       // Primary is faulty.
-      LOG_FAIL_FMT("Primary {} is faulty", pbft::GlobalState::get_node().primary(v));
+      LOG_FAIL_FMT(
+        "Primary {} is faulty", pbft::GlobalState::get_node().primary(v));
     }
   }
 }

--- a/src/consensus/pbft/libbyz/nv_info.cpp
+++ b/src/consensus/pbft/libbyz/nv_info.cpp
@@ -226,8 +226,7 @@ void NV_info::add(std::unique_ptr<View_change> m)
     if (!check_new_view())
     {
       // Primary is faulty.
-      LOG_FAIL << "Primary " << pbft::GlobalState::get_node().primary(v)
-               << " is faulty" << std::endl;
+      LOG_FAIL_FMT("Primary {} is faulty", pbft::GlobalState::get_node().primary(v));
     }
   }
 }

--- a/src/consensus/pbft/libbyz/pre_prepare.cpp
+++ b/src/consensus/pbft/libbyz/pre_prepare.cpp
@@ -348,7 +348,7 @@ bool Pre_prepare::pre_verify()
             rep().sig_size))
       {
         LOG_FAIL_FMT(
-          "failed to verify signature on the digest, seqno:{}", rep().seqno);
+          "Failed to verify signature on the digest, seqno:{}", rep().seqno);
         return false;
       }
     }
@@ -488,7 +488,7 @@ bool Pre_prepare::ValidProofs_iter::get(
           reinterpret_cast<char*>(&s), sizeof(s), ic->sig.data(), ic->sig_size))
     {
       LOG_INFO_FMT(
-        "failed to verify signature on the digest, seqno:{}", msg->seqno());
+        "Failed to verify signature on the digest, seqno:{}", msg->seqno());
       is_valid_proof = false;
     }
   }

--- a/src/consensus/pbft/libbyz/pre_prepare.cpp
+++ b/src/consensus/pbft/libbyz/pre_prepare.cpp
@@ -347,8 +347,7 @@ bool Pre_prepare::pre_verify()
             get_digest_sig().data(),
             rep().sig_size))
       {
-        LOG_INFO << "failed to verify signature on the digest, seqno:"
-                 << rep().seqno << std::endl;
+        LOG_INFO_FMT("failed to verify signature on the digest, seqno:{}", rep().seqno);
         return false;
       }
     }
@@ -487,8 +486,7 @@ bool Pre_prepare::ValidProofs_iter::get(
     if (!sender_principal->verify_signature(
           reinterpret_cast<char*>(&s), sizeof(s), ic->sig.data(), ic->sig_size))
     {
-      LOG_INFO << "failed to verify signature on the digest, seqno:"
-               << msg->seqno() << std::endl;
+      LOG_INFO_FMT("failed to verify signature on the digest, seqno:{}", msg->seqno());
       is_valid_proof = false;
     }
   }

--- a/src/consensus/pbft/libbyz/pre_prepare.cpp
+++ b/src/consensus/pbft/libbyz/pre_prepare.cpp
@@ -347,7 +347,8 @@ bool Pre_prepare::pre_verify()
             get_digest_sig().data(),
             rep().sig_size))
       {
-        LOG_INFO_FMT("failed to verify signature on the digest, seqno:{}", rep().seqno);
+        LOG_FAIL_FMT(
+          "failed to verify signature on the digest, seqno:{}", rep().seqno);
         return false;
       }
     }
@@ -486,7 +487,8 @@ bool Pre_prepare::ValidProofs_iter::get(
     if (!sender_principal->verify_signature(
           reinterpret_cast<char*>(&s), sizeof(s), ic->sig.data(), ic->sig_size))
     {
-      LOG_INFO_FMT("failed to verify signature on the digest, seqno:{}", msg->seqno());
+      LOG_INFO_FMT(
+        "failed to verify signature on the digest, seqno:{}", msg->seqno());
       is_valid_proof = false;
     }
   }

--- a/src/consensus/pbft/libbyz/rep_info.cpp
+++ b/src/consensus/pbft/libbyz/rep_info.cpp
@@ -93,8 +93,8 @@ void Rep_info::send_reply(int pid, Request_id rid, Seqno n, View v, int id)
 
     if (it == reps.end())
     {
-      LOG_INFO << " Attempt to send reply not in this < " << pid << "," << rid
-               << "," << n << ">" << std::endl;
+      LOG_INFO_FMT(
+        " Attempt to send reply not in this <{},{},{}>", pid, rid, n);
       return;
     }
 

--- a/src/consensus/pbft/libbyz/rep_info.cpp
+++ b/src/consensus/pbft/libbyz/rep_info.cpp
@@ -93,8 +93,7 @@ void Rep_info::send_reply(int pid, Request_id rid, Seqno n, View v, int id)
 
     if (it == reps.end())
     {
-      LOG_INFO_FMT(
-        " Attempt to send reply not in this <{},{},{}>", pid, rid, n);
+      LOG_INFO_FMT("Attempt to send reply not in this <{},{},{}>", pid, rid, n);
       return;
     }
 

--- a/src/consensus/pbft/libbyz/replica.cpp
+++ b/src/consensus/pbft/libbyz/replica.cpp
@@ -1059,7 +1059,7 @@ void Replica::send_pre_prepare(bool do_not_wait_for_batch_size)
           do_not_wait_for_batch_size))))
   {
     LOG_INFO_FMT(
-      "req_size:{}, btimer_state:{}, do_not_wait:{}",
+      "Req_size:{}, btimer_state:{}, do_not_wait:{}",
       rqueue.size(),
       btimer->get_state(),
       (do_not_wait_for_batch_size ? "true" : "false"));

--- a/src/consensus/pbft/libbyz/replica.cpp
+++ b/src/consensus/pbft/libbyz/replica.cpp
@@ -100,7 +100,8 @@ Replica::Replica(
   size_t max_mem_bytes = PLevelSize[PLevels - 1] * Block_size;
   if (nbytes > max_mem_bytes)
   {
-    LOG_FATAL_FMT("Unable to support requested memory size {} > {}", nbytes , max_mem_bytes);
+    LOG_FATAL_FMT(
+      "Unable to support requested memory size {} > {}", nbytes, max_mem_bytes);
   }
 
   init_network(std::unique_ptr<INetwork>(network));
@@ -1894,7 +1895,7 @@ void Replica::handle(View_change* m)
 
 void Replica::handle(New_view* m)
 {
-  LOG_INFO_FMT("Received new view for {} from {}",  m->view() , m->id());
+  LOG_INFO_FMT("Received new view for {} from {}", m->view(), m->id());
   vi.add(m);
 }
 
@@ -2011,7 +2012,8 @@ void Replica::handle(Network_open* m)
   std::shared_ptr<Principal> p = get_principal(m->id());
   if (p == nullptr)
   {
-    LOG_FAIL_FMT("Received network open from unknown principal, id:{}", m->id());
+    LOG_FAIL_FMT(
+      "Received network open from unknown principal, id:{}", m->id());
   }
 
   if (p->received_network_open_msg())
@@ -2037,7 +2039,9 @@ void Replica::handle(Network_open* m)
 
   if (num_open == principals->size())
   {
-    LOG_INFO_FMT("Finished waiting for machines to network open. starting to process requests");
+    LOG_INFO_FMT(
+      "Finished waiting for machines to network open. starting to process "
+      "requests");
     wait_for_network_to_open = false;
     if (primary() == id())
     {

--- a/src/consensus/pbft/libbyz/replica.cpp
+++ b/src/consensus/pbft/libbyz/replica.cpp
@@ -93,15 +93,14 @@ Replica::Replica(
   // Fail if node is not a replica.
   if (!is_replica(id()))
   {
-    LOG_FATAL << "Node is not a replica " << id() << std::endl;
+    LOG_FATAL_FMT("Node is not a replica {}", id());
   }
 
   // Fail if the state Merkle tree cannot support the requested number of bytes
   size_t max_mem_bytes = PLevelSize[PLevels - 1] * Block_size;
   if (nbytes > max_mem_bytes)
   {
-    LOG_FATAL << "Unable to support requested memory size " << nbytes << " > "
-              << max_mem_bytes << std::endl;
+    LOG_FATAL_FMT("Unable to support requested memory size {} > {}", nbytes , max_mem_bytes);
   }
 
   init_network(std::unique_ptr<INetwork>(network));
@@ -3297,7 +3296,7 @@ void Replica::ntimer_handler(void* owner)
 void Replica::debug_slow_timer_handler(void* owner)
 {
   ((Replica*)owner)->dump_state(std::cout);
-  LOG_FATAL << "Execution took too long" << std::endl;
+  LOG_FATAL_FMT("Execution took too long");
 }
 
 void Replica::dump_state(std::ostream& os)

--- a/src/consensus/pbft/libbyz/replica.cpp
+++ b/src/consensus/pbft/libbyz/replica.cpp
@@ -403,19 +403,22 @@ bool Replica::compare_execution_results(
         std::end(r_pp_root),
         std::begin(info.replicated_state_merkle_root)))
   {
-    LOG_FAIL << "Replicated state merkle root between execution and the "
-                "pre_prepare message does not match, seqno:"
-             << pre_prepare->seqno() << std::endl;
+    LOG_FAIL_FMT(
+      "Replicated state merkle root between execution and the pre_prepare "
+      "message does not match, seqno:{}",
+      pre_prepare->seqno());
     execution_match = false;
   }
 
   auto tx_ctx = pre_prepare->get_ctx();
   if (tx_ctx != info.ctx && info.ctx != std::numeric_limits<int64_t>::min())
   {
-    LOG_FAIL << "User ctx between execution and the pre_prepare message "
-                "does not match, seqno:"
-             << pre_prepare->seqno() << ", tx_ctx:" << tx_ctx
-             << ", info.ctx:" << info.ctx << std::endl;
+    LOG_FAIL_FMT(
+      "User ctx between execution and the pre_prepare message "
+      "does not match, seqno:{}, tx_ctx:{}, info.ctx:{}",
+      pre_prepare->seqno(),
+      tx_ctx,
+      info.ctx);
     execution_match = false;
   }
 
@@ -2000,17 +2003,17 @@ void Replica::handle(Network_open* m)
   std::shared_ptr<Principal> p = get_principal(m->id());
   if (p == nullptr)
   {
-    LOG_FAIL << "Received network open from unknown principal, id:" << m->id()
-             << std::endl;
+    LOG_FAIL_FMT("Received network open from unknown principal, id:{}", m->id());
   }
 
   if (p->received_network_open_msg())
   {
-    LOG_FAIL << "Received network open from, id:" << m->id() << "already"
-             << std::endl;
+    LOG_FAIL_FMT("Received network open from, id:{} already", m->id());
   }
-
-  LOG_INFO << "Received network open from, id:" << m->id() << std::endl;
+  else
+  {
+    LOG_INFO_FMT("Received network open from, id:{}", m->id());
+  }
 
   p->set_received_network_open_msg();
 
@@ -2026,8 +2029,7 @@ void Replica::handle(Network_open* m)
 
   if (num_open == principals->size())
   {
-    LOG_INFO << "Finished waiting for machines to network open. "
-             << "starting to process requests" << std::endl;
+    LOG_INFO_FMT("Finished waiting for machines to network open. starting to process requests");
     wait_for_network_to_open = false;
     if (primary() == id())
     {
@@ -3056,8 +3058,7 @@ void Replica::enforce_bound(Seqno b)
   Seqno known_stable = se.low_estimate();
   if (!correct)
   {
-    LOG_FAIL << "Incorrect state setting low bound to " << known_stable
-             << std::endl;
+    LOG_FAIL_FMT("Incorrect state setting low bound to {}", known_stable);
     next_pp_seqno = last_prepared = low_bound = last_stable = known_stable;
     last_tentative_execute = last_executed = 0;
     limbo = false;

--- a/src/consensus/pbft/libbyz/replica.cpp
+++ b/src/consensus/pbft/libbyz/replica.cpp
@@ -1926,7 +1926,7 @@ void Replica::send_view_change()
   ntimer->restop();
 
   LOG_INFO_FMT(
-    "send_view_change last_executed: {}, last_tentative_execute: {}, "
+    "Send_view_change last_executed: {}, last_tentative_execute: {}, "
     "last_stable: {}, last_prepared: {}, next_pp_seqno: {}",
     last_executed,
     last_tentative_execute,
@@ -1934,11 +1934,11 @@ void Replica::send_view_change()
     last_prepared,
     next_pp_seqno);
 
-  LOG_INFO_FMT("plog:");
+  LOG_INFO_FMT("Plog:");
   plog.dump_state(std::cout);
-  LOG_INFO_FMT("clog:");
+  LOG_INFO_FMT("Clog:");
   clog.dump_state(std::cout);
-  LOG_INFO_FMT("elog:");
+  LOG_INFO_FMT("Elog:");
   elog.dump_state(std::cout);
 
   replies.clear();
@@ -1998,7 +1998,7 @@ void Replica::write_new_view_to_ledger()
 
 void Replica::handle(New_principal* m)
 {
-  LOG_INFO_FMT("received new message to add principal, id:{}", m->id());
+  LOG_INFO_FMT("Received new message to add principal, id:{}", m->id());
 
   std::vector<uint8_t> cert(m->cert().begin(), m->cert().end());
   PrincipalInfo info{
@@ -2703,7 +2703,7 @@ void Replica::new_state(Seqno c)
 
   if (c < last_stable)
   {
-    LOG_INFO_FMT("new_state c:{}, last_stable:{}", c, last_stable);
+    LOG_INFO_FMT("New_state c:{}, last_stable:{}", c, last_stable);
   }
 
   if (c > next_pp_seqno)
@@ -3102,7 +3102,7 @@ void Replica::handle(Reply_stable* m)
       enforce_bound(recovery_point);
       STOP_CC(est_time);
 
-      LOG_INFO_FMT("sending recovery request");
+      LOG_INFO_FMT("Sending recovery request");
       // Send recovery request.
       rr = new Request(new_rid(), -1, sizeof(recovery_point));
 
@@ -3161,7 +3161,7 @@ void Replica::send_null()
       // Send null request if there is a recovery in progress and there
       // are no outstanding requests.
       next_pp_seqno++;
-      LOG_INFO_FMT("sending null pp for seqno {}", next_pp_seqno);
+      LOG_INFO_FMT("Sending null pp for seqno {}", next_pp_seqno);
       Req_queue empty;
       size_t requests_in_batch;
 

--- a/src/consensus/pbft/libbyz/request.cpp
+++ b/src/consensus/pbft/libbyz/request.cpp
@@ -207,7 +207,7 @@ bool Request::convert(char* m1, unsigned max_len, Request& m2)
 {
   if (!Message::convert(m1, max_len, Request_tag, sizeof(Request_rep), m2))
   {
-    LOG_INFO_FMT("convert request false");
+    LOG_INFO_FMT("Convert request false");
     return false;
   }
 

--- a/src/consensus/pbft/libbyz/request.cpp
+++ b/src/consensus/pbft/libbyz/request.cpp
@@ -164,7 +164,8 @@ bool Request::pre_verify(VerifyAndParseCommand& e)
   }
   catch (const std::exception& e)
   {
-    LOG_FAIL_FMT("Failed to parse arguments, e.what:", e.what());
+    LOG_FAIL_FMT("Failed to parse arguments");
+    LOG_DEBUG_FMT("Failed to parse arguments, e.what: {}", e.what());
     return false;
   }
   Digest d;

--- a/src/consensus/pbft/libbyz/request.cpp
+++ b/src/consensus/pbft/libbyz/request.cpp
@@ -207,7 +207,7 @@ bool Request::convert(char* m1, unsigned max_len, Request& m2)
 {
   if (!Message::convert(m1, max_len, Request_tag, sizeof(Request_rep), m2))
   {
-    LOG_INFO << "convert request false" << std::endl;
+    LOG_INFO_FMT("convert request false");
     return false;
   }
 

--- a/src/consensus/pbft/libbyz/state.cpp
+++ b/src/consensus/pbft/libbyz/state.cpp
@@ -197,12 +197,11 @@ void Checkpoint_rec::dump_state(std::ostream& os)
 
 void Checkpoint_rec::print()
 {
-  LOG_INFO << "Checkpoint record: " << parts.size() << " blocks" << std::endl;
+  LOG_INFO_FMT("Checkpoint record: {} blocks", parts.size());
   for (auto const& p : parts)
   {
-    LOG_INFO << "Block: level= " << p.first.level << " index= " << p.first.index
-             << std::endl;
-    LOG_INFO << "last mod= " << p.second->lm << std::endl;
+    LOG_INFO_FMT("Block: level={}, index={}", p.first.level, p.first.index);
+    LOG_INFO_FMT("last mod={}", p.second->lm);
     p.second->d.print();
   }
 }
@@ -390,7 +389,7 @@ void State::compute_full_digest()
   checkpoint(0);
 #ifndef INSIDE_ENCLAVE
   cc.stop();
-  LOG_INFO << "Compute full digest elapsed " << cc.elapsed() << std::endl;
+  LOG_INFO_FMT("Compute full digest elapsed {}", cc.elapsed());
 #endif
 
   d.print();
@@ -472,7 +471,7 @@ Seqno State::rollback(Seqno last_executed)
 
   INCR_OP(num_rollbacks);
 
-  LOG_INFO << "Rolling back to checkpoint before " << last_executed << "\n";
+  LOG_INFO_FMT("Rolling back to checkpoint before {}",last_executed);
 
   while (1)
   {
@@ -934,8 +933,12 @@ bool State::check_digest(Digest& d, Meta_data* m)
   bool match = (d == dp);
   if (!match)
   {
-    LOG_INFO << "Digest does not match l=" << l << ", i=" << i
-             << " d=" << d.hash() << " dp=" << dp.hash() << std::endl;
+    LOG_INFO_FMT(
+      "Digest does not match l={}, i={}, d={}, dp={}",
+      l,
+      i,
+      d.hash(),
+      dp.hash());
   }
 
   // undo changes to stree

--- a/src/consensus/pbft/libbyz/state.cpp
+++ b/src/consensus/pbft/libbyz/state.cpp
@@ -200,8 +200,11 @@ void Checkpoint_rec::print()
   LOG_INFO_FMT("Checkpoint record: {} blocks", parts.size());
   for (auto const& p : parts)
   {
-    LOG_INFO_FMT("Block: level={}, index={}", p.first.level, p.first.index);
-    LOG_INFO_FMT("last mod={}", p.second->lm);
+    LOG_INFO_FMT(
+      "Block: level={}, index={}, last mode={}",
+      p.first.level,
+      p.first.index,
+      p.second->lm);
     p.second->d.print();
   }
 }
@@ -471,7 +474,7 @@ Seqno State::rollback(Seqno last_executed)
 
   INCR_OP(num_rollbacks);
 
-  LOG_INFO_FMT("Rolling back to checkpoint before {}",last_executed);
+  LOG_INFO_FMT("Rolling back to checkpoint before {}", last_executed);
 
   while (1)
   {

--- a/src/consensus/pbft/libbyz/status.cpp
+++ b/src/consensus/pbft/libbyz/status.cpp
@@ -69,7 +69,7 @@ bool Status::pre_verify()
     if (sender == nullptr)
     {
       // Received message from unknown sender
-      LOG_INFO << "Request from unknown pricipal, id:" << id() << std::endl;
+      LOG_INFO_FMT("Request from unknown pricipal, id:{}", id());
 
       PrincipalInfo info;
       info.id = id();

--- a/src/consensus/pbft/libbyz/view_info.cpp
+++ b/src/consensus/pbft/libbyz/view_info.cpp
@@ -314,7 +314,7 @@ void View_info::view_change(View vi, Seqno last_executed, State* state)
   vc->re_authenticate();
   vc_sent = ITimer::current_time();
 
-  LOG_INFO << "Sending view change view: " << vc->view() << std::endl;
+  LOG_INFO_FMT("Sending view change view: {}", vc->view());
   pbft::GlobalState::get_node().send(vc.get(), Node::All_replicas);
 
   // Record that this message was sent.
@@ -336,8 +336,7 @@ void View_info::view_change(View vi, Seqno last_executed, State* state)
         View_change_ack* vack = new View_change_ack(v, id, i, lvc->digest());
         my_vacks[i] = vack;
 
-        LOG_INFO << "Sending view change ack for " << vack->view() << " from "
-                 << i << "\n";
+        LOG_INFO_FMT("Sending view change ack for {} from {}", vack->view(), i);
         pbft::GlobalState::get_node().send(vack, primv);
       }
     }
@@ -439,8 +438,7 @@ bool View_info::add(std::unique_ptr<View_change> vc)
       if (id != primv && vci != primv && vcv == v)
       {
         // Send view-change ack.
-        LOG_INFO << " Sending view change ack for " << v << " from " << vci
-                 << "\n";
+        LOG_INFO_FMT(" Sending view change ack for {} from {}", v, vci);
         View_change_ack* vack = new View_change_ack(v, id, vci, vc->digest());
         CCF_ASSERT(my_vacks[vci] == 0, "Invalid state");
 
@@ -480,8 +478,8 @@ void View_info::add(New_view* nv)
     }
   }
 
-  LOG_INFO << "Rejected new view message for " << nv->view() << " from "
-           << nv->id() << "\n";
+  LOG_INFO_FMT(
+    "Rejected new view message for {} from {}", nv->view(), nv->id());
 
   delete nv;
 }

--- a/src/consensus/pbft/libbyz/view_info.cpp
+++ b/src/consensus/pbft/libbyz/view_info.cpp
@@ -438,7 +438,7 @@ bool View_info::add(std::unique_ptr<View_change> vc)
       if (id != primv && vci != primv && vcv == v)
       {
         // Send view-change ack.
-        LOG_INFO_FMT(" Sending view change ack for {} from {}", v, vci);
+        LOG_INFO_FMT("Sending view change ack for {} from {}", v, vci);
         View_change_ack* vack = new View_change_ack(v, id, vci, vc->digest());
         CCF_ASSERT(my_vacks[vci] == 0, "Invalid state");
 

--- a/src/consensus/pbft/pbft.h
+++ b/src/consensus/pbft/pbft.h
@@ -681,7 +681,8 @@ namespace pbft
         }
         catch (const std::logic_error& err)
         {
-          LOG_FAIL_FMT("Invalid encrypted pbft message: {}", err.what());
+          LOG_FAIL_FMT("Invalid encrypted pbft message");
+          LOG_DEBUG_FMT("Invalid encrypted pbft message: {}", err.what());
           return;
         }
       }
@@ -697,7 +698,8 @@ namespace pbft
         }
         catch (const std::logic_error& err)
         {
-          LOG_FAIL_FMT("Invalid pbft message: {}", err.what());
+          LOG_FAIL_FMT("Invalid pbft message");
+          LOG_DEBUG_FMT("Invalid pbft message: {}", err.what());
           return;
         }
       }
@@ -770,8 +772,7 @@ namespace pbft
         {
           if (message_receiver_base->IsExecutionPending())
           {
-            LOG_FAIL << "Pending Execution, skipping append entries request"
-                     << std::endl;
+            LOG_FAIL_FMT("Pending Execution, skipping append entries request");
             return;
           }
 
@@ -786,7 +787,7 @@ namespace pbft
           }
           catch (const std::logic_error& err)
           {
-            LOG_FAIL_FMT(err.what());
+            LOG_FAIL_FMT("Failed to authenticate message: {}", err.what());
             return;
           }
 

--- a/src/ds/ccf_assert.h
+++ b/src/ds/ccf_assert.h
@@ -22,7 +22,7 @@
       { \
         if ((expr) == 0) \
         { \
-          LOG_INFO_FMT(" Assertion failed: {} {}",#expr,(msg)); \
+          LOG_FAIL_FMT(" Assertion failed: {} {}", #expr, (msg)); \
           logger::print_stacktrace(); \
           throw std::logic_error(msg); \
         } \
@@ -34,7 +34,7 @@
 #  define PBFT_FAIL(msg) \
     do \
     { \
-      LOG_INFO_FMT(" FATAL_ERROR: {}", (msg)); \
+      LOG_FAIL_FMT(" FATAL_ERROR: {}", (msg)); \
       logger::print_stacktrace(); \
       std::terminate(); \
     } while (0)
@@ -45,7 +45,7 @@
       { \
         if ((expr) == 0) \
         { \
-          LOG_INFO_FMT(" Assertion failed: {} {}", #expr, (msg)); \
+          LOG_FAIL_FMT(" Assertion failed: {} {}", #expr, (msg)); \
           throw std::logic_error(msg); \
         } \
       } while (0)
@@ -56,7 +56,7 @@
 #  define PBFT_FAIL(msg) \
     do \
     { \
-      LOG_INFO_FMT(" FATAL_ERROR: {}",(msg)); \
+      LOG_FAIL_FMT(" FATAL_ERROR: {}", (msg)); \
       std::terminate(); \
     } while (0)
 #endif

--- a/src/ds/ccf_assert.h
+++ b/src/ds/ccf_assert.h
@@ -22,7 +22,7 @@
       { \
         if ((expr) == 0) \
         { \
-          LOG_INFO << " Assertion failed: " << #expr << " " << (msg) << "\n"; \
+          LOG_INFO_FMT(" Assertion failed: {} {}",#expr,(msg)); \
           logger::print_stacktrace(); \
           throw std::logic_error(msg); \
         } \
@@ -34,7 +34,7 @@
 #  define PBFT_FAIL(msg) \
     do \
     { \
-      LOG_INFO << " FATAL_ERROR: " << (msg) << "\n"; \
+      LOG_INFO_FMT(" FATAL_ERROR: {}", (msg)); \
       logger::print_stacktrace(); \
       std::terminate(); \
     } while (0)
@@ -45,7 +45,7 @@
       { \
         if ((expr) == 0) \
         { \
-          LOG_INFO << " Assertion failed: " << #expr << " " << (msg) << "\n"; \
+          LOG_INFO_FMT(" Assertion failed: {} {}", #expr, (msg)); \
           throw std::logic_error(msg); \
         } \
       } while (0)
@@ -56,7 +56,7 @@
 #  define PBFT_FAIL(msg) \
     do \
     { \
-      LOG_INFO << " FATAL_ERROR: " << (msg) << "\n"; \
+      LOG_INFO_FMT(" FATAL_ERROR: {}",(msg)); \
       std::terminate(); \
     } while (0)
 #endif

--- a/src/ds/ccf_assert.h
+++ b/src/ds/ccf_assert.h
@@ -22,7 +22,7 @@
       { \
         if ((expr) == 0) \
         { \
-          LOG_FAIL_FMT(" Assertion failed: {} {}", #expr, (msg)); \
+          LOG_FAIL_FMT("Assertion failed: {} {}", #expr, (msg)); \
           logger::print_stacktrace(); \
           throw std::logic_error(msg); \
         } \
@@ -34,7 +34,7 @@
 #  define PBFT_FAIL(msg) \
     do \
     { \
-      LOG_FAIL_FMT(" FATAL_ERROR: {}", (msg)); \
+      LOG_FAIL_FMT("FATAL_ERROR: {}", (msg)); \
       logger::print_stacktrace(); \
       std::terminate(); \
     } while (0)
@@ -45,7 +45,7 @@
       { \
         if ((expr) == 0) \
         { \
-          LOG_FAIL_FMT(" Assertion failed: {} {}", #expr, (msg)); \
+          LOG_FAIL_FMT("Assertion failed: {} {}", #expr, (msg)); \
           throw std::logic_error(msg); \
         } \
       } while (0)
@@ -56,7 +56,7 @@
 #  define PBFT_FAIL(msg) \
     do \
     { \
-      LOG_FAIL_FMT(" FATAL_ERROR: {}", (msg)); \
+      LOG_FAIL_FMT("FATAL_ERROR: {}", (msg)); \
       std::terminate(); \
     } while (0)
 #endif

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -453,7 +453,8 @@ int main(int argc, char** argv)
   }
   catch (const std::logic_error& e)
   {
-    LOG_FATAL_FMT("{}. Exiting.", e.what());
+    LOG_DEBUG_FMT("{}. Exiting.", e.what());
+    LOG_FATAL_FMT("Logic_error thrown. Exiting.");
     return static_cast<int>(CLI::ExitCodes::ValidationError);
   }
 

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -453,8 +453,7 @@ int main(int argc, char** argv)
   }
   catch (const std::logic_error& e)
   {
-    LOG_DEBUG_FMT("{}. Exiting.", e.what());
-    LOG_FATAL_FMT("Logic_error thrown. Exiting.");
+    LOG_FATAL_FMT("{}. Exiting.", e.what());
     return static_cast<int>(CLI::ExitCodes::ValidationError);
   }
 

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -125,7 +125,8 @@ namespace http
           }
           catch (const std::exception& e)
           {
-            LOG_FAIL_FMT("Error parsing request: {}", e.what());
+            LOG_FAIL_FMT("Error parsing request");
+            LOG_DEBUG_FMT("Error parsing request: {}", e.what());
             close();
             break;
           }

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -325,14 +325,16 @@ namespace kv
         auto search = maps.find(map_name);
         if (search == maps.end())
         {
-          LOG_FAIL_FMT("No such map {} at version {}", map_name, v);
+          LOG_FAIL_FMT("failed to deserialize");
+          LOG_DEBUG_FMT("No such map {} at version {}", map_name, v);
           return DeserialiseSuccess::FAILED;
         }
 
         auto view_search = views.find(map_name);
         if (view_search != views.end())
         {
-          LOG_FAIL_FMT("Multiple writes on {} at version {}", map_name, v);
+          LOG_FAIL_FMT("failed to deserialize");
+          LOG_DEBUG_FMT("Multiple writes on {} at version {}", map_name, v);
           return DeserialiseSuccess::FAILED;
         }
 
@@ -344,7 +346,8 @@ namespace kv
           search->second->deserialise(*d, deserialise_version);
         if (deserialised_write_set == nullptr)
         {
-          LOG_FAIL_FMT(
+          LOG_FAIL_FMT("failed to deserialize");
+          LOG_DEBUG_FMT(
             "Could not deserialise Tx for map {} at version {}",
             map_name,
             deserialise_version);
@@ -360,7 +363,8 @@ namespace kv
 
       if (!d->end())
       {
-        LOG_FAIL_FMT("Unexpected content in Tx at version {}", v);
+        LOG_FAIL_FMT("failed to deserialize");
+        LOG_DEBUG_FMT("Unexpected content in Tx at version {}", v);
         return DeserialiseSuccess::FAILED;
       }
 
@@ -383,14 +387,16 @@ namespace kv
             // a signature and must be verified
             if (views.size() > 1)
             {
-              LOG_FAIL_FMT(
+              LOG_FAIL_FMT("failed to deserialize");
+              LOG_DEBUG_FMT(
                 "Unexpected contents in signature transaction {}", v);
               return DeserialiseSuccess::FAILED;
             }
 
             if (!h->verify(term))
             {
-              LOG_FAIL_FMT("Signature in transaction {} failed to verify", v);
+              LOG_FAIL_FMT("failed to deserialize");
+              LOG_DEBUG_FMT("Signature in transaction {} failed to verify", v);
               return DeserialiseSuccess::FAILED;
             }
             success = DeserialiseSuccess::PASS_SIGNATURE;
@@ -405,7 +411,8 @@ namespace kv
         // contain anything else
         if (views.size() > 1)
         {
-          LOG_FAIL_FMT("Unexpected contents in pbft transaction {}", v);
+          LOG_FAIL_FMT("failed to deserialize");
+          LOG_DEBUG_FMT("Unexpected contents in pbft transaction {}", v);
           return DeserialiseSuccess::FAILED;
         }
 

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -325,7 +325,7 @@ namespace kv
         auto search = maps.find(map_name);
         if (search == maps.end())
         {
-          LOG_FAIL_FMT("failed to deserialize");
+          LOG_FAIL_FMT("Failed to deserialize");
           LOG_DEBUG_FMT("No such map {} at version {}", map_name, v);
           return DeserialiseSuccess::FAILED;
         }
@@ -333,7 +333,7 @@ namespace kv
         auto view_search = views.find(map_name);
         if (view_search != views.end())
         {
-          LOG_FAIL_FMT("failed to deserialize");
+          LOG_FAIL_FMT("Failed to deserialize");
           LOG_DEBUG_FMT("Multiple writes on {} at version {}", map_name, v);
           return DeserialiseSuccess::FAILED;
         }
@@ -346,7 +346,7 @@ namespace kv
           search->second->deserialise(*d, deserialise_version);
         if (deserialised_write_set == nullptr)
         {
-          LOG_FAIL_FMT("failed to deserialize");
+          LOG_FAIL_FMT("Failed to deserialize");
           LOG_DEBUG_FMT(
             "Could not deserialise Tx for map {} at version {}",
             map_name,
@@ -363,7 +363,7 @@ namespace kv
 
       if (!d->end())
       {
-        LOG_FAIL_FMT("failed to deserialize");
+        LOG_FAIL_FMT("Failed to deserialize");
         LOG_DEBUG_FMT("Unexpected content in Tx at version {}", v);
         return DeserialiseSuccess::FAILED;
       }
@@ -387,7 +387,7 @@ namespace kv
             // a signature and must be verified
             if (views.size() > 1)
             {
-              LOG_FAIL_FMT("failed to deserialize");
+              LOG_FAIL_FMT("Failed to deserialize");
               LOG_DEBUG_FMT(
                 "Unexpected contents in signature transaction {}", v);
               return DeserialiseSuccess::FAILED;
@@ -395,7 +395,7 @@ namespace kv
 
             if (!h->verify(term))
             {
-              LOG_FAIL_FMT("failed to deserialize");
+              LOG_FAIL_FMT("Failed to deserialize");
               LOG_DEBUG_FMT("Signature in transaction {} failed to verify", v);
               return DeserialiseSuccess::FAILED;
             }

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -411,7 +411,7 @@ namespace kv
         // contain anything else
         if (views.size() > 1)
         {
-          LOG_FAIL_FMT("failed to deserialize");
+          LOG_FAIL_FMT("Failed to deserialize");
           LOG_DEBUG_FMT("Unexpected contents in pbft transaction {}", v);
           return DeserialiseSuccess::FAILED;
         }

--- a/src/kv/tx.h
+++ b/src/kv/tx.h
@@ -215,7 +215,8 @@ namespace kv
         {
           committed = false;
 
-          LOG_FAIL_FMT("Error during serialisation: {}", e.what());
+          LOG_FAIL_FMT("Error during serialisation");
+          LOG_DEBUG_FMT("Error during serialisation: {}", e.what());
 
           // Discard original exception type, throw as now fatal
           // KvSerialiserException

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -402,8 +402,7 @@ namespace ccf
 
           if (status != HTTP_STATUS_OK)
           {
-            LOG_FAIL_FMT(
-              "An error occurred while joining the network");
+            LOG_FAIL_FMT("An error occurred while joining the network");
 
             LOG_DEBUG_FMT(
               "An error occurred while joining the network: {} {}{}",
@@ -1226,8 +1225,7 @@ namespace ccf
       const auto body = jsonrpc::unpack(r.body, jsonrpc::Pack::Text);
       if (!body.is_boolean())
       {
-        LOG_FAIL_FMT(
-          "Expected boolean body in create response");
+        LOG_FAIL_FMT("Expected boolean body in create response");
         LOG_DEBUG_FMT(
           "Expected boolean body in create response: {}", body.dump());
         return false;

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -403,6 +403,9 @@ namespace ccf
           if (status != HTTP_STATUS_OK)
           {
             LOG_FAIL_FMT(
+              "An error occurred while joining the network");
+
+            LOG_DEBUG_FMT(
               "An error occurred while joining the network: {} {}{}",
               status,
               http_status_str(status),
@@ -422,6 +425,8 @@ namespace ccf
           catch (const std::exception& e)
           {
             LOG_FAIL_FMT(
+              "An error occurred while parsing the join network response");
+            LOG_DEBUG_FMT(
               "An error occurred while parsing the join network response: {}",
               j.dump());
             return false;
@@ -1222,6 +1227,8 @@ namespace ccf
       if (!body.is_boolean())
       {
         LOG_FAIL_FMT(
+          "Expected boolean body in create response");
+        LOG_DEBUG_FMT(
           "Expected boolean body in create response: {}", body.dump());
         return false;
       }

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -402,8 +402,7 @@ namespace ccf
 
           if (status != HTTP_STATUS_OK)
           {
-            LOG_FAIL_FMT("An error occurred while joining the network");
-            LOG_DEBUG_FMT(
+            LOG_FAIL_FMT(
               "An error occurred while joining the network: {} {}{}",
               status,
               http_status_str(status),

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -403,7 +403,6 @@ namespace ccf
           if (status != HTTP_STATUS_OK)
           {
             LOG_FAIL_FMT("An error occurred while joining the network");
-
             LOG_DEBUG_FMT(
               "An error occurred while joining the network: {} {}{}",
               status,

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -92,7 +92,8 @@ namespace ccf
       }
       catch (const std::logic_error& err)
       {
-        LOG_FAIL_FMT("Invalid forwarded command: {}", err.what());
+        LOG_FAIL_FMT("Invalid forwarded command");
+        LOG_DEBUG_FMT("Invalid forwarded command: {}", err.what());
         return {};
       }
 
@@ -122,7 +123,8 @@ namespace ccf
       }
       catch (const std::exception& err)
       {
-        LOG_FAIL_FMT("Invalid forwarded request: {}", err.what());
+        LOG_FAIL_FMT("Invalid forwarded request");
+        LOG_DEBUG_FMT("Invalid forwarded request: {}", err.what());
         return std::nullopt;
       }
     }
@@ -156,7 +158,8 @@ namespace ccf
       }
       catch (const std::logic_error& err)
       {
-        LOG_FAIL_FMT("Invalid forwarded response: {}", err.what());
+        LOG_FAIL_FMT("Invalid forwarded response");
+        LOG_DEBUG_FMT("Invalid forwarded response: {}", err.what());
         return {};
       }
 
@@ -194,6 +197,8 @@ namespace ccf
             if (!actor_opt.has_value())
             {
               LOG_FAIL_FMT(
+                "Failed to extract actor from forwarded context.");
+              LOG_DEBUG_FMT(
                 "Failed to extract actor from forwarded context. Method is "
                 "'{}'",
                 ctx->get_method());
@@ -205,6 +210,8 @@ namespace ccf
             if (actor == ccf::ActorsType::unknown || !handler.has_value())
             {
               LOG_FAIL_FMT(
+                "Failed to process forwarded command: unknown actor");
+              LOG_DEBUG_FMT(
                 "Failed to process forwarded command: unknown actor {}",
                 actor_s);
               return;

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -196,8 +196,7 @@ namespace ccf
             const auto actor_opt = http::extract_actor(*ctx);
             if (!actor_opt.has_value())
             {
-              LOG_FAIL_FMT(
-                "Failed to extract actor from forwarded context.");
+              LOG_FAIL_FMT("Failed to extract actor from forwarded context.");
               LOG_DEBUG_FMT(
                 "Failed to extract actor from forwarded context. Method is "
                 "'{}'",

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -518,7 +518,8 @@ namespace ccf
                 ctx->get_serialised_request(),
                 ctx->frame_format()))
           {
-            LOG_FAIL_FMT(
+            LOG_FAIL_FMT("Adding request failed");
+            LOG_DEBUG_FMT(
               "Adding request failed: {}, {}, {}",
               std::get<0>(reqid),
               std::get<1>(reqid),

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -424,7 +424,8 @@ namespace ccf
           // If serialising the committed transaction fails, there is no way
           // to recover safely (https://github.com/microsoft/CCF/issues/338).
           // Better to abort.
-          LOG_FATAL_FMT("Failed to serialise: {}", e.what());
+          LOG_DEBUG_FMT("Failed to serialise: {}", e.what());
+          LOG_FATAL_FMT("Failed to serialise");
           abort();
         }
         catch (const std::exception& e)


### PR DESCRIPTION
- remove any data that should not be printed on a prod service that has a log level of Info+
- change to use LOG_*_FMT for fatal, fail, and info.

resolves #1239 
part of #691