### PR TITLE
Fix e2e test

### DIFF
--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -424,7 +424,7 @@ def test_tx_statuses(network, args):
 
 
 def run(args):
-    hosts = ["localhost"] * (4 if args.consensus == "pbft" else 2)
+    hosts = ["localhost"] * (3 if args.consensus == "pbft" else 2)
 
     with infra.notification.notification_server(args.notify_server) as notifications:
         # Lua apps do not support notifications

--- a/tests/e2e_scenarios.py
+++ b/tests/e2e_scenarios.py
@@ -18,7 +18,7 @@ def run(args):
 
     hosts = scenario.get("hosts", ["localhost", "localhost"])
     if args.consensus == "pbft":
-        hosts = ["localhost"] * 4
+        hosts = ["localhost"] * 3
     args.package = scenario["package"]
     # SNIPPET_END: parsing
 


### PR DESCRIPTION
We were not waiting for the other replicas to catchup properly. Since there are tests that validate catchup these tests do not need to do that so only use 3 replicas.

This also resolves the issue of a replica crashing and us not seeing the crash because recovery masks the failure.