### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,29 @@
-| | Link |
-|- |- |
-| Community Chat | [![Gitter](https://badges.gitter.im/MSRC-CCF/community.svg)](https://gitter.im/MSRC-CCF/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) |
-| Continuous Integration | [![Build Status](https://dev.azure.com/MSRC-CCF/CCF/_apis/build/status/CCF%20Github%20CI?branchName=master)](https://dev.azure.com/MSRC-CCF/CCF/_build/latest?definitionId=3&branchName=master) |
-| Documentation | [![docs](https://dev.azure.com/MSRC-CCF/CCF/_apis/build/status/CCF%20GitHub%20Pages?branchName=master)](https://microsoft.github.io/CCF/) |
-| Daily Build | [![Build Status](https://dev.azure.com/MSRC-CCF/CCF/_apis/build/status/CCF%20GitHub%20Daily?branchName=master)](https://dev.azure.com/MSRC-CCF/CCF/_build/latest?definitionId=7&branchName=master) |
-
-
 # The Confidential Consortium Framework 
+
+[![Gitter](https://badges.gitter.im/MSRC-CCF/community.svg)](https://gitter.im/MSRC-CCF/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) [![Build Status](https://dev.azure.com/MSRC-CCF/CCF/_apis/build/status/CCF%20GitHub%20Daily?branchName=master)](https://dev.azure.com/MSRC-CCF/CCF/_build/latest?definitionId=7&branchName=master)
 
 <img alt="ccf" align="right" src="https://microsoft.github.io/CCF/master/_images/ccf.svg" width="300">
 
 The Confidential Consortium Framework (CCF) is an open-source framework for building a new category of secure, highly available,
-and performant applications that focus on multi-party compute and data. While not limited just to blockchain applications,
-CCF can enable high-scale, confidential blockchain networks that meet key enterprise requirements
-— providing a means to accelerate production enterprise adoption of blockchain technology.
+and performant applications that focus on multi-party compute and data.
+CCF can enable high-scale, confidential networks that meet key enterprise requirements
+— providing a means to accelerate production consortium based enterprise adoption of blockchain and multi-party compute technology.
 
-Leveraging the power of trusted execution environments (TEEs), decentralized systems concepts, and cryptography,
-CCF enables enterprise-ready computation or blockchain networks that deliver:
-
- * **Throughput and latency approaching database speeds.** Through its use of TEEs, the framework creates a network of remotely attestable enclaves.
-   This gives a web of trust across the distributed system, allowing a user that verifies a single cryptographic quote from a CCF node to
-   effectively verify the entire network. This simplifies consensus and thus improves transaction speed and latency — all without compromising security or assuming trust.
-
- * **Richer, more flexible confidentiality models.** Beyond safeguarding data access with encryption-in-use via TEEs, we use industry standards (TLS and remote attestation)
-   to ensure secure node communication. Transactions can be processed in the clear or revealed only to authorized parties, without requiring complicated confidentiality schemes.
-
- * **Network and service policy management through non-centralized governance.** The framework provides a network and service configuration to express and manage consortium
-   and multi-party policies. Governance actions, such as adding members to the governing consortium or initiating catastrophic recovery, can be managed and recorded through
-   standard ledger transactions agreed upon via stakeholder voting.
-
- * **Improved efficiency versus traditional blockchain networks.** The framework improves on bottlenecks and energy consumption by eliminating computationally intensive
-   consensus algorithms for data integrity, such as proof-of-work or proof-of-stake.
-
-## A consortium first approach
-
-In a public blockchain network, anyone can transact on the network, actors on the network are pseudo-anonymous and untrusted, and anyone can add nodes to the network
-— with full access to the ledger and with the ability to participate in consensus. Similarly, other distributed data technologies (such as distributed databases)
-can have challenges in multi-party scenarios when it comes to deciding what party operates it and whether that party could choose or could be compelled to act maliciously.
-
-In contrast, in a consortium or multi-party network backed by TEEs, such as CCF, consortium member identities and node identities are known and controlled.
-A trusted network of enclaves running on physical nodes is established without requiring the actors that control those nodes to trust one another
-—  what code is run is controlled and correctness of its output can be guaranteed, simplifying the consensus methods and reducing duplicative validation of data.
-
-Microsoft has taken this approach in developing CCF: using TEE technology, the enclave of each node in the network (where cryptographically protected data is processed)
-can decide whether it can trust the enclaves of other nodes based on mutual attestation exchange and mutual authentication, regardless of whether the parties involved
-trust each other or not. This enables a network of verifiable, remotely attestable enclaves on which to run a distributed ledger and execute confidential and secure
-transactions in highly performant and highly available fashion.
-
-## A flexible confidentiality layer for any multi-party computation application or blockchain ledger to build upon
-
-CCF currently runs on [Intel SGX](https://software.intel.com/en-us/sgx)-enabled platforms. Because CCF uses the [Open Enclave SDK](https://github.com/openenclave/openenclave)
-as the foundation for running in an enclave, as Open Enclave supports new TEE technologies, CCF will be able to run on new platforms. Networks can be run on-premises,
-in one or many cloud-hosted data centers, including [Microsoft Azure](https://azure.microsoft.com/), or in any hybrid configuration.
-
-Ledger providers can use CCF to enable higher throughput and higher confidentiality guarantees for distributed ledger applications.
-CCF developers can write application logic (also known as smart contracts) and enforce application-level access control in several languages by conﬁguring CCF
-to embed one of several language runtimes on top of its key-value store. Clients then communicate with a running CCF service using HTTP requests over TLS.
+Leveraging the power of trusted execution environments (TEEs), decentralized systems concepts, and cryptography, CCF enables enterprise-ready multiparty computation or blockchains.
 
 ## Learn more and get started
 
- * Read the [CCF Technical Report](CCF-TECHNICAL-REPORT.pdf) for a more detailed description.
  * Browse the [CCF Documentation](https://microsoft.github.io/CCF/).
- * Explore the CCF open-source GitHub repo, which also contains application examples and sample scripts for provisioning and setting up confidential computing VMs using Azure.
+ * Read the [CCF Technical Report](CCF-TECHNICAL-REPORT.pdf) for a more detailed description.
  * Learn more about [Azure Confidential Computing](https://azure.microsoft.com/solutions/confidential-compute/) offerings like Azure DC-series (which support Intel SGX TEE)
    and [Open Enclave](https://github.com/openenclave/openenclave) that CCF can run on.
 
-## Getting Started on Azure Confidential Computing
+## Getting Started with CCF
 
-First, if you are checking out the CCF repository, run `git clone`:
-```bash
-git clone https://github.com/microsoft/CCF.git
-```
-
-Then, under `CCF/getting_started/`:
- * `create_vm/` contains scripts to create an ACC VM (`make_vm.sh`).
-   This script expects a valid Azure subscription name to be set, eg: `export SUBSCRIPTION=sub_name`.
- * `setup_vm/` contains ansible playbooks that need to be run on the VM once created, for it to be able to build CCF.
-   Running `./run.sh driver.yml ccf-dev.yml` will apply those playbooks to the VM.
-
-## Build and Test
-
-```bash
-cd CCF
-mkdir build
-cd build
-cmake -GNinja ..
-ninja
-```
-
-Run the tests.
-
-```bash
-cd build
-./tests.sh
-```
+* [Getting started](https://microsoft.github.io/CCF/master/quickstart/index.html) with Azure confidentual compute and CCF. 
+* Learn how to [build](https://microsoft.github.io/CCF/master/quickstart/build.html) and [run](https://microsoft.github.io/CCF/master/quickstart/build.html#running-tests) a test network.
+* Start [building](https://microsoft.github.io/CCF/master/developers/index.html) your first CCF network.
+* Submit [bugs](https://github.com/microsoft/CCF/issues/new?assignees=&labels=bug&template=bug_report.md&title=) and [feature requests](https://github.com/microsoft/CCF/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=), and help us verify those that are checked in.
 
 ## Third-party components
 


### PR DESCRIPTION
This is a proposal for a cut down version of the README.md

Couple of notes:
- It only reports the azure-pipeline results for the daily build. While we care about the other build results I don't think people that land on our page care that we have multiple pipelines and that they all passed. If we do remove the other badges we should put them in a sticky ticket just like we are doing for the code coverage.
- I have cut down on the text a lot and rely on links out to the documentation.
- The getting started is just links to the documentation, this allows us to have everything in one place.