### PR TITLE
turn off the replay_new_view_pbft for SAN builds

### DIFF
--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -26,7 +26,7 @@ jobs:
       cmake_args: '${{ parameters.build.debug.cmake_args }} ${{ parameters.build.NoSGX.cmake_args }}'
       suffix: 'Coverage'
       artifact_name: 'NoSGX_Coverage'
-      ctest_filter: '-LE "benchmark|perf|suite|replay_new_view_pbft "'
+      ctest_filter: '-LE "benchmark|perf|suite|replay_new_view_pbft"'
       ctest_timeout: '300'
 
   - template: common.yml

--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -26,7 +26,7 @@ jobs:
       cmake_args: '${{ parameters.build.debug.cmake_args }} ${{ parameters.build.NoSGX.cmake_args }}'
       suffix: 'Coverage'
       artifact_name: 'NoSGX_Coverage'
-      ctest_filter: '-LE "benchmark|perf|suite"'
+      ctest_filter: '-LE "benchmark|perf|suite|replay_new_view_pbft "'
       ctest_timeout: '300'
 
   - template: common.yml

--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -26,7 +26,7 @@ jobs:
       cmake_args: '${{ parameters.build.debug.cmake_args }} ${{ parameters.build.NoSGX.cmake_args }}'
       suffix: 'Coverage'
       artifact_name: 'NoSGX_Coverage'
-      ctest_filter: '-LE "benchmark|perf|suite|replay_new_view_pbft"'
+      ctest_filter: '-LE "benchmark|perf|suite -E replay_new_view_pbft"'
       ctest_timeout: '300'
 
   - template: common.yml

--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -26,7 +26,7 @@ jobs:
       cmake_args: '${{ parameters.build.debug.cmake_args }} ${{ parameters.build.NoSGX.cmake_args }}'
       suffix: 'Coverage'
       artifact_name: 'NoSGX_Coverage'
-      ctest_filter: '-LE "benchmark|perf|suite -E replay_new_view_pbft"'
+      ctest_filter: '-LE "benchmark|perf|suite" -E "replay_new_view_pbft"'
       ctest_timeout: '300'
 
   - template: common.yml


### PR DESCRIPTION
This test takes a long time to run with SAN turned on. It is on in all other configurations.

this is related to #1244