### PR TITLE
Build common helper/adapter for historical queries

### DIFF
--- a/src/apps/logging/logging.cpp
+++ b/src/apps/logging/logging.cpp
@@ -259,51 +259,13 @@ namespace loggingapp
       };
       // SNIPPET_END: log_record_text
 
-      auto& historical_state = context.get_historical_state();
-      auto get_historical = [this, &historical_state](ccf::RequestArgs& args) {
+      auto get_historical = [this](
+                              ccf::RequestArgs& args,
+                              ccf::historical::StorePtr historical_store,
+                              kv::Consensus::View historical_view,
+                              kv::Consensus::SeqNo historical_seqno) {
         const auto [pack, params] =
           ccf::jsonhandler::get_json_params(args.rpc_ctx);
-        const auto in = params.get<LoggingGetHistorical::In>();
-
-        // Check that the requested transaction ID is committed
-        {
-          const auto tx_view = consensus->get_view(in.seqno);
-          const auto committed_seqno = consensus->get_committed_seqno();
-          const auto committed_view = consensus->get_view(committed_seqno);
-
-          const auto tx_status = ccf::get_tx_status(
-            in.view, in.seqno, tx_view, committed_view, committed_seqno);
-          if (tx_status != ccf::TxStatus::Committed)
-          {
-            args.rpc_ctx->set_response_status(HTTP_STATUS_BAD_REQUEST);
-            args.rpc_ctx->set_response_header(
-              http::headers::CONTENT_TYPE,
-              http::headervalues::contenttype::TEXT);
-            args.rpc_ctx->set_response_body(fmt::format(
-              "Only committed transactions can be retrieved historically. "
-              "Transaction {}.{} is {}",
-              in.view,
-              in.seqno,
-              ccf::tx_status_to_str(tx_status)));
-            return;
-          }
-        }
-
-        auto historical_store = historical_state.get_store_at(in.seqno);
-        if (historical_store == nullptr)
-        {
-          args.rpc_ctx->set_response_status(HTTP_STATUS_ACCEPTED);
-          static constexpr size_t retry_after_seconds = 3;
-          args.rpc_ctx->set_response_header(
-            http::headers::RETRY_AFTER, retry_after_seconds);
-          args.rpc_ctx->set_response_header(
-            http::headers::CONTENT_TYPE, http::headervalues::contenttype::TEXT);
-          args.rpc_ctx->set_response_body(fmt::format(
-            "Historical transaction {}.{} is not currently available.",
-            in.view,
-            in.seqno));
-          return;
-        }
 
         auto* historical_map = historical_store->get(records);
         if (historical_map == nullptr)
@@ -312,9 +274,14 @@ namespace loggingapp
           args.rpc_ctx->set_response_header(
             http::headers::CONTENT_TYPE, http::headervalues::contenttype::TEXT);
           args.rpc_ctx->set_response_body(fmt::format(
-            "Unable to get historical table '{}'.", records.get_name()));
+            "Unable to get table '{}' at {}.{}",
+            records.get_name(),
+            historical_view,
+            historical_seqno));
           return;
         }
+
+        const auto in = params.get<LoggingGetHistorical::In>();
 
         kv::Tx historical_tx;
         auto view = historical_tx.get_view(*historical_map);
@@ -358,7 +325,11 @@ namespace loggingapp
         .set_auto_schema<LoggingRecord::In, bool>()
         .set_require_client_identity(false);
       install(Procs::LOG_RECORD_RAW_TEXT, log_record_text, Write);
-      install(Procs::LOG_GET_HISTORICAL, get_historical, Read);
+      install(
+        Procs::LOG_GET_HISTORICAL,
+        ccf::historical::adapter(
+          get_historical, context.get_historical_state()),
+        Read);
 
       auto& notifier = context.get_notifier();
       nwt.signatures.set_global_hook(

--- a/src/apps/logging/logging_schema.h
+++ b/src/apps/logging/logging_schema.h
@@ -47,6 +47,8 @@ namespace loggingapp
       size_t seqno;
       size_t id;
     };
+
+    using Out = LoggingGet::Out;
   };
 
   DECLARE_JSON_TYPE(LoggingGetHistorical::In);

--- a/src/apps/logging/logging_schema.h
+++ b/src/apps/logging/logging_schema.h
@@ -39,20 +39,7 @@ namespace loggingapp
   DECLARE_JSON_REQUIRED_FIELDS(LoggingGet::Out, msg);
   // SNIPPET_END: macro_validation_macros
 
-  struct LoggingGetHistorical
-  {
-    struct In
-    {
-      size_t view;
-      size_t seqno;
-      size_t id;
-    };
-
-    using Out = LoggingGet::Out;
-  };
-
-  DECLARE_JSON_TYPE(LoggingGetHistorical::In);
-  DECLARE_JSON_REQUIRED_FIELDS(LoggingGetHistorical::In, view, seqno, id);
+  using LoggingGetHistorical = LoggingGet;
 
   // Public record/get
   // Manual schemas, verified then parsed in handler

--- a/src/apps/lua_generic/test/lua_generic_test.cpp
+++ b/src/apps/lua_generic/test/lua_generic_test.cpp
@@ -37,7 +37,8 @@ namespace ccf
 }
 
 constexpr auto default_format = jsonrpc::Pack::MsgPack;
-constexpr auto content_type = details::pack_to_content_type(default_format);
+constexpr auto content_type =
+  ccf::jsonhandler::pack_to_content_type(default_format);
 
 using TResponse = http::SimpleResponseProcessor::Response;
 

--- a/src/lua_interp/lua_args.h
+++ b/src/lua_interp/lua_args.h
@@ -44,7 +44,8 @@ namespace ccf
       push_raw(l, args.rpc_ctx->get_method());
       lua_setfield(l, -2, "method");
 
-      const auto [pack, params] = ccf::jsonhandler::get_json_params(args.rpc_ctx);
+      const auto [pack, params] =
+        ccf::jsonhandler::get_json_params(args.rpc_ctx);
       push_raw(l, params);
       lua_setfield(l, -2, "params");
 

--- a/src/lua_interp/lua_args.h
+++ b/src/lua_interp/lua_args.h
@@ -44,7 +44,7 @@ namespace ccf
       push_raw(l, args.rpc_ctx->get_method());
       lua_setfield(l, -2, "method");
 
-      const auto [pack, params] = ccf::details::get_json_params(args.rpc_ctx);
+      const auto [pack, params] = ccf::jsonhandler::get_json_params(args.rpc_ctx);
       push_raw(l, params);
       lua_setfield(l, -2, "params");
 

--- a/src/node/historical_queries_interface.h
+++ b/src/node/historical_queries_interface.h
@@ -4,6 +4,7 @@
 
 #include "consensus/ledger_enclave_types.h"
 #include "kv/store.h"
+#include "node/rpc/handler_registry.h"
 
 #include <memory>
 
@@ -27,4 +28,112 @@ namespace ccf::historical
       return nullptr;
     }
   };
+
+  using HandleHistoricalQuery = std::function<void(
+    ccf::RequestArgs& args,
+    StorePtr store,
+    kv::Consensus::View view,
+    kv::Consensus::SeqNo seqno)>;
+
+  static ccf::HandleFunction adapter(
+    const HandleHistoricalQuery& f, AbstractStateCache& state_cache)
+  {
+    return [f, &state_cache](RequestArgs& args) {
+      // Extract the requested transaction ID
+      kv::Consensus::View target_view;
+      kv::Consensus::SeqNo target_seqno;
+
+      {
+        const auto target_view_opt =
+          args.rpc_ctx->get_request_header(http::headers::CCF_TX_VIEW);
+        if (!target_view_opt.has_value())
+        {
+          args.rpc_ctx->set_response_status(HTTP_STATUS_BAD_REQUEST);
+          args.rpc_ctx->set_response_body(fmt::format(
+            "Historical query is missing '{}' header",
+            http::headers::CCF_TX_VIEW));
+          return;
+        }
+
+        target_view =
+          std::strtoul(target_view_opt.value().c_str(), nullptr, 10);
+        if (target_view == 0)
+        {
+          args.rpc_ctx->set_response_status(HTTP_STATUS_BAD_REQUEST);
+          args.rpc_ctx->set_response_body(fmt::format(
+            "The value '{}' in header '{}' could not be converted to a valid "
+            "view",
+            target_view_opt.value(),
+            http::headers::CCF_TX_VIEW));
+          return;
+        }
+
+        const auto target_seqno_opt =
+          args.rpc_ctx->get_request_header(http::headers::CCF_TX_SEQNO);
+        if (!target_seqno_opt.has_value())
+        {
+          args.rpc_ctx->set_response_status(HTTP_STATUS_BAD_REQUEST);
+          args.rpc_ctx->set_response_body(fmt::format(
+            "Historical query is missing '{}' header",
+            http::headers::CCF_TX_SEQNO));
+          return;
+        }
+
+        target_seqno =
+          std::strtoul(target_seqno_opt.value().c_str(), nullptr, 10);
+        if (target_view == 0)
+        {
+          args.rpc_ctx->set_response_status(HTTP_STATUS_BAD_REQUEST);
+          args.rpc_ctx->set_response_body(fmt::format(
+            "The value '{}' in header '{}' could not be converted to a valid "
+            "seqno",
+            target_seqno_opt.value(),
+            http::headers::CCF_TX_SEQNO));
+          return;
+        }
+      }
+
+      // TODO: How to access consensus here?
+      // // Check that the requested transaction ID is committed
+      // {
+      //   const auto tx_view = consensus->get_view(in.seqno);
+      //   const auto committed_seqno = consensus->get_committed_seqno();
+      //   const auto committed_view = consensus->get_view(committed_seqno);
+
+      //   const auto tx_status = ccf::get_tx_status(
+      //     in.view, in.seqno, tx_view, committed_view, committed_seqno);
+      //   if (tx_status != ccf::TxStatus::Committed)
+      //   {
+      //     args.rpc_ctx->set_response_status(HTTP_STATUS_BAD_REQUEST);
+      //     args.rpc_ctx->set_response_header(
+      //       http::headers::CONTENT_TYPE,
+      //       http::headervalues::contenttype::TEXT);
+      //     args.rpc_ctx->set_response_body(fmt::format(
+      //       "Only committed transactions can be retrieved historically. "
+      //       "Transaction {}.{} is {}",
+      //       in.view,
+      //       in.seqno,
+      //       ccf::tx_status_to_str(tx_status)));
+      //     return;
+      //   }
+      // }
+
+      auto historical_store = state_cache.get_store_at(target_seqno);
+      if (historical_store == nullptr)
+      {
+        args.rpc_ctx->set_response_status(HTTP_STATUS_ACCEPTED);
+        static constexpr size_t retry_after_seconds = 3;
+        args.rpc_ctx->set_response_header(
+          http::headers::RETRY_AFTER, retry_after_seconds);
+        args.rpc_ctx->set_response_body(fmt::format(
+          "Historical transaction at seqno {} in view {} is not currently "
+          "available.",
+          target_seqno,
+          target_view));
+        return;
+      }
+
+      f(args, historical_store, target_view, target_seqno);
+    };
+  }
 }

--- a/src/node/historical_queries_interface.h
+++ b/src/node/historical_queries_interface.h
@@ -45,7 +45,7 @@ namespace ccf::historical
     AbstractStateCache& state_cache,
     const CheckAvailability& available)
   {
-    return [f, &state_cache, &available](RequestArgs& args) {
+    return [f, &state_cache, available](RequestArgs& args) {
       // Extract the requested transaction ID
       kv::Consensus::View target_view;
       kv::Consensus::SeqNo target_seqno;

--- a/src/node/rpc/handler_registry.h
+++ b/src/node/rpc/handler_registry.h
@@ -29,20 +29,6 @@ namespace ccf
     return 1ul << verb;
   }
 
-  static bool is_committed(
-    kv::Consensus::View view,
-    kv::Consensus::SeqNo seqno,
-    kv::Consensus& consensus)
-  {
-    const auto tx_view = consensus.get_view(seqno);
-    const auto committed_seqno = consensus.get_committed_seqno();
-    const auto committed_view = consensus.get_view(committed_seqno);
-
-    const auto tx_status =
-      ccf::get_tx_status(view, seqno, tx_view, committed_view, committed_seqno);
-    return tx_status == TxStatus::Committed;
-  }
-
   using HandleFunction = std::function<void(RequestArgs& args)>;
 
   /** The HandlerRegistry records the user-defined Handlers for a given

--- a/src/node/rpc/handler_registry.h
+++ b/src/node/rpc/handler_registry.h
@@ -29,6 +29,20 @@ namespace ccf
     return 1ul << verb;
   }
 
+  static bool is_committed(
+    kv::Consensus::View view,
+    kv::Consensus::SeqNo seqno,
+    kv::Consensus& consensus)
+  {
+    const auto tx_view = consensus.get_view(seqno);
+    const auto committed_seqno = consensus.get_committed_seqno();
+    const auto committed_view = consensus.get_view(committed_seqno);
+
+    const auto tx_status =
+      ccf::get_tx_status(view, seqno, tx_view, committed_view, committed_seqno);
+    return tx_status == TxStatus::Committed;
+  }
+
   using HandleFunction = std::function<void(RequestArgs& args)>;
 
   /** The HandlerRegistry records the user-defined Handlers for a given

--- a/src/node/rpc/json_handler.h
+++ b/src/node/rpc/json_handler.h
@@ -62,7 +62,7 @@ namespace ccf
    * });
    */
 
-  namespace details
+  namespace jsonhandler
   {
     struct ErrorDetails
     {
@@ -236,68 +236,70 @@ namespace ccf
     }
   }
 
-  static details::JsonAdapterResponse make_success(
+  static jsonhandler::JsonAdapterResponse make_success(
     nlohmann::json&& result_payload)
   {
     return std::move(result_payload);
   }
 
-  static details::JsonAdapterResponse make_success(
+  static jsonhandler::JsonAdapterResponse make_success(
     const nlohmann::json& result_payload)
   {
     return result_payload;
   }
 
-  static details::JsonAdapterResponse make_error(
+  static jsonhandler::JsonAdapterResponse make_error(
     http_status status, const std::string& msg = "")
   {
-    return details::ErrorDetails{status, msg};
+    return jsonhandler::ErrorDetails{status, msg};
   }
 
-  using HandlerTxOnly = std::function<details::JsonAdapterResponse(kv::Tx& tx)>;
+  using HandlerTxOnly =
+    std::function<jsonhandler::JsonAdapterResponse(kv::Tx& tx)>;
 
   static HandleFunction json_adapter(const HandlerTxOnly& f)
   {
     return [f](RequestArgs& args) {
-      const auto [packing, params] = details::get_json_params(args.rpc_ctx);
-      details::set_response(f(args.tx), args.rpc_ctx, packing);
+      const auto [packing, params] = jsonhandler::get_json_params(args.rpc_ctx);
+      jsonhandler::set_response(f(args.tx), args.rpc_ctx, packing);
     };
   }
 
-  using HandlerJsonParamsOnly = std::function<details::JsonAdapterResponse(
+  using HandlerJsonParamsOnly = std::function<jsonhandler::JsonAdapterResponse(
     kv::Tx& tx, nlohmann::json&& params)>;
 
   static HandleFunction json_adapter(const HandlerJsonParamsOnly& f)
   {
     return [f](RequestArgs& args) {
-      auto [packing, params] = details::get_json_params(args.rpc_ctx);
-      details::set_response(
+      auto [packing, params] = jsonhandler::get_json_params(args.rpc_ctx);
+      jsonhandler::set_response(
         f(args.tx, std::move(params)), args.rpc_ctx, packing);
     };
   }
 
   using HandlerJsonParamsAndCallerId =
-    std::function<details::JsonAdapterResponse(
+    std::function<jsonhandler::JsonAdapterResponse(
       kv::Tx& tx, CallerId caller_id, nlohmann::json&& params)>;
 
   static HandleFunction json_adapter(const HandlerJsonParamsAndCallerId& f)
   {
     return [f](RequestArgs& args) {
-      auto [packing, params] = details::get_json_params(args.rpc_ctx);
-      details::set_response(
+      auto [packing, params] = jsonhandler::get_json_params(args.rpc_ctx);
+      jsonhandler::set_response(
         f(args.tx, args.caller_id, std::move(params)), args.rpc_ctx, packing);
     };
   }
 
   using HandlerJsonParamsAndForward =
-    std::function<details::JsonAdapterResponse(
+    std::function<jsonhandler::JsonAdapterResponse(
       RequestArgs& args, nlohmann::json&& params)>;
 
   static HandleFunction json_adapter(const HandlerJsonParamsAndForward& f)
   {
     return [f](RequestArgs& args) {
-      auto [packing, params] = details::get_json_params(args.rpc_ctx);
-      details::set_response(f(args, std::move(params)), args.rpc_ctx, packing);
+      auto [packing, params] = jsonhandler::get_json_params(args.rpc_ctx);
+      jsonhandler::set_response(
+        f(args, std::move(params)), args.rpc_ctx, packing);
     };
   }
 }

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -320,7 +320,7 @@ auto create_simple_request(
 {
   http::Request request(method);
   request.set_header(
-    http::headers::CONTENT_TYPE, details::pack_to_content_type(pack));
+    http::headers::CONTENT_TYPE, ccf::jsonhandler::pack_to_content_type(pack));
   return request;
 }
 

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -239,11 +239,15 @@ def test_historical_query(network, args):
 
                 timeout = 15
                 found = False
-                params = {"view": view, "seqno": seqno, "id": log_id}
+                headers = {
+                    infra.clients.CCF_TX_VIEW_HEADER: str(view),
+                    infra.clients.CCF_TX_SEQNO_HEADER: str(seqno),
+                }
+                params = {"id": log_id}
                 end_time = time.time() + timeout
 
                 while time.time() < end_time:
-                    get_response = c.get("LOG_get_historical", params)
+                    get_response = c.get("LOG_get_historical", params, headers=headers)
                     if get_response.status == http.HTTPStatus.ACCEPTED:
                         retry_after = get_response.headers.get("retry-after")
                         if retry_after is None:
@@ -264,7 +268,7 @@ def test_historical_query(network, args):
                         )
                     else:
                         raise ValueError(
-                            f"Unexpected response status {get_response.status}: {get_response}"
+                            f"Unexpected response status {get_response.status}: {get_response.error}"
                         )
 
                 if not found:
@@ -510,24 +514,24 @@ def run(args):
             hosts, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb,
         ) as network:
             network.start_and_join(args)
-            network = test(
-                network,
-                args,
-                notifications_queue,
-                verify=args.package is not "libjs_generic",
-            )
-            network = test_illegal(
-                network, args, verify=args.package is not "libjs_generic"
-            )
-            network = test_large_messages(network, args)
-            network = test_remove(network, args)
-            network = test_forwarding_frontends(network, args)
-            network = test_update_lua(network, args)
-            network = test_cert_prefix(network, args)
-            network = test_anonymous_caller(network, args)
-            network = test_raw_text(network, args)
+            # network = test(
+            #     network,
+            #     args,
+            #     notifications_queue,
+            #     verify=args.package is not "libjs_generic",
+            # )
+            # network = test_illegal(
+            #     network, args, verify=args.package is not "libjs_generic"
+            # )
+            # network = test_large_messages(network, args)
+            # network = test_remove(network, args)
+            # network = test_forwarding_frontends(network, args)
+            # network = test_update_lua(network, args)
+            # network = test_cert_prefix(network, args)
+            # network = test_anonymous_caller(network, args)
+            # network = test_raw_text(network, args)
             network = test_historical_query(network, args)
-            network = test_view_history(network, args)
+            # network = test_view_history(network, args)
 
 
 if __name__ == "__main__":

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -510,24 +510,24 @@ def run(args):
             hosts, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb,
         ) as network:
             network.start_and_join(args)
-            # network = test(
-            #     network,
-            #     args,
-            #     notifications_queue,
-            #     verify=args.package is not "libjs_generic",
-            # )
-            # network = test_illegal(
-            #     network, args, verify=args.package is not "libjs_generic"
-            # )
-            # network = test_large_messages(network, args)
-            # network = test_remove(network, args)
-            # network = test_forwarding_frontends(network, args)
-            # network = test_update_lua(network, args)
-            # network = test_cert_prefix(network, args)
-            # network = test_anonymous_caller(network, args)
-            # network = test_raw_text(network, args)
+            network = test(
+                network,
+                args,
+                notifications_queue,
+                verify=args.package is not "libjs_generic",
+            )
+            network = test_illegal(
+                network, args, verify=args.package is not "libjs_generic"
+            )
+            network = test_large_messages(network, args)
+            network = test_remove(network, args)
+            network = test_forwarding_frontends(network, args)
+            network = test_update_lua(network, args)
+            network = test_cert_prefix(network, args)
+            network = test_anonymous_caller(network, args)
+            network = test_raw_text(network, args)
             network = test_historical_query(network, args)
-            # network = test_view_history(network, args)
+            network = test_view_history(network, args)
 
 
 if __name__ == "__main__":

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -243,7 +243,7 @@ def test_historical_query(network, args):
                 end_time = time.time() + timeout
 
                 while time.time() < end_time:
-                    get_response = c.rpc("LOG_get_historical", params)
+                    get_response = c.get("LOG_get_historical", params)
                     if get_response.status == http.HTTPStatus.ACCEPTED:
                         retry_after = get_response.headers.get("retry-after")
                         if retry_after is None:
@@ -251,12 +251,11 @@ def test_historical_query(network, args):
                                 f"Response with status {get_response.status} is missing 'retry-after' header"
                             )
                         retry_after = int(retry_after)
-                        LOG.warning(f"Sleeping for {retry_after}s")
                         time.sleep(retry_after)
                     elif get_response.status == http.HTTPStatus.OK:
                         assert (
-                            get_response.result == msg
-                        ), f"{get_response.body} != {msg}"
+                            get_response.result["msg"] == msg
+                        ), f"{get_response.result}"
                         found = True
                         break
                     elif get_response.status == http.HTTPStatus.NO_CONTENT:
@@ -511,24 +510,24 @@ def run(args):
             hosts, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb,
         ) as network:
             network.start_and_join(args)
-            network = test(
-                network,
-                args,
-                notifications_queue,
-                verify=args.package is not "libjs_generic",
-            )
-            network = test_illegal(
-                network, args, verify=args.package is not "libjs_generic"
-            )
-            network = test_large_messages(network, args)
-            network = test_remove(network, args)
-            network = test_forwarding_frontends(network, args)
-            network = test_update_lua(network, args)
-            network = test_cert_prefix(network, args)
-            network = test_anonymous_caller(network, args)
-            network = test_raw_text(network, args)
+            # network = test(
+            #     network,
+            #     args,
+            #     notifications_queue,
+            #     verify=args.package is not "libjs_generic",
+            # )
+            # network = test_illegal(
+            #     network, args, verify=args.package is not "libjs_generic"
+            # )
+            # network = test_large_messages(network, args)
+            # network = test_remove(network, args)
+            # network = test_forwarding_frontends(network, args)
+            # network = test_update_lua(network, args)
+            # network = test_cert_prefix(network, args)
+            # network = test_anonymous_caller(network, args)
+            # network = test_raw_text(network, args)
             network = test_historical_query(network, args)
-            network = test_view_history(network, args)
+            # network = test_view_history(network, args)
 
 
 if __name__ == "__main__":

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -514,24 +514,24 @@ def run(args):
             hosts, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb,
         ) as network:
             network.start_and_join(args)
-            # network = test(
-            #     network,
-            #     args,
-            #     notifications_queue,
-            #     verify=args.package is not "libjs_generic",
-            # )
-            # network = test_illegal(
-            #     network, args, verify=args.package is not "libjs_generic"
-            # )
-            # network = test_large_messages(network, args)
-            # network = test_remove(network, args)
-            # network = test_forwarding_frontends(network, args)
-            # network = test_update_lua(network, args)
-            # network = test_cert_prefix(network, args)
-            # network = test_anonymous_caller(network, args)
-            # network = test_raw_text(network, args)
+            network = test(
+                network,
+                args,
+                notifications_queue,
+                verify=args.package is not "libjs_generic",
+            )
+            network = test_illegal(
+                network, args, verify=args.package is not "libjs_generic"
+            )
+            network = test_large_messages(network, args)
+            network = test_remove(network, args)
+            network = test_forwarding_frontends(network, args)
+            network = test_update_lua(network, args)
+            network = test_cert_prefix(network, args)
+            network = test_anonymous_caller(network, args)
+            network = test_raw_text(network, args)
             network = test_historical_query(network, args)
-            # network = test_view_history(network, args)
+            network = test_view_history(network, args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow up to #1267.

Pulls some common functionality that will be required for many historical queries (find out what transaction it is asking for, find out whether the transaction is valid, find out whether we have that transaction cached) into `ccf::historical::adapter`. I think this is a useful simplification; the body of `get_historical` in `logging.cpp` is now far more readable.

Remaining TODOs, currently aimed at future PRs:
- Finish verification of historical stores (#1278)
- Handle range queries