### PR TITLE
Historical queries - verify that expected hash is in signature's merkle tree

### DIFF
--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -167,36 +167,32 @@ namespace ccf::historical
       while (it != requests.end())
       {
         auto& request = it->second;
+        const auto& untrusted_idx = it->first;
 
-        if (request.current_stage == RequestStage::Untrusted)
+        if (
+          request.current_stage == RequestStage::Untrusted &&
+          tree.in_range(untrusted_idx))
         {
-          const auto& untrusted_idx = it->first;
+          // Compare signed hash, from signature mini-tree, with hash of the
+          // entry used to populate the store
           const auto& untrusted_hash = request.entry_hash;
-          const auto& untrusted_store = request.store;
-
-          // Use try-catch to find whether this signature covers the target
-          // transaction ID
-          ccf::Receipt receipt;
-          try
+          const auto trusted_hash = tree.get_leaf(untrusted_idx);
+          if (trusted_hash != untrusted_hash)
           {
-            receipt = tree.get_receipt(untrusted_idx);
-            LOG_DEBUG_FMT(
-              "From signature at {}, constructed a receipt for {}",
+            LOG_FAIL_FMT(
+              "Signature at {} has a different transaction at {} than "
+              "previously received",
               sig_idx,
               untrusted_idx);
-          }
-          catch (const std::exception& e)
-          {
-            // This signature doesn't cover this untrusted idx, try the next
-            // request
-            ++it;
+            // We trust the signature but not the store - delete this untrusted
+            // store. If it is re-requested, maybe the host will give us a valid
+            // pair of transaction+sig next time
+            it = requests.erase(it);
             continue;
           }
 
-          // This is where full verification should go, checking that the entry
-          // we have is in the signed merkle tree
-
-          // Move stores from untrusted to trusted
+          // Move store from untrusted to trusted
+          const auto& untrusted_store = request.store;
           LOG_DEBUG_FMT(
             "Now trusting {} due to signature at {}", untrusted_idx, sig_idx);
           request.current_stage = RequestStage::Trusted;
@@ -204,7 +200,8 @@ namespace ccf::historical
         }
         else
         {
-          // Already trusted or still fetching, skip it
+          // Already trusted or still fetching, or this signature doesn't cover
+          // this transaction - skip it and try the next
           ++it;
         }
       }

--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -174,7 +174,7 @@ namespace ccf::historical
           tree.in_range(untrusted_idx))
         {
           // Compare signed hash, from signature mini-tree, with hash of the
-          // entry used to populate the store
+          // entry which was used to populate the store
           const auto& untrusted_hash = request.entry_hash;
           const auto trusted_hash = tree.get_leaf(untrusted_idx);
           if (trusted_hash != untrusted_hash)

--- a/src/node/test/historical_queries.cpp
+++ b/src/node/test/historical_queries.cpp
@@ -227,6 +227,30 @@ TEST_CASE("StateCache")
   }
 
   {
+    INFO(
+      "Cache accepts _wrong_ requested entry, and the range of supporting "
+      "entries");
+    // NB: This is _a_ valid entry, but not at this index. In fact this stage
+    // will accept anything that looks quite like a valid entry, even if it
+    // never came from a legitimate node - they should all fail at the signature
+    // check
+    REQUIRE(cache.get_store_at(low_index) == nullptr);
+    REQUIRE(cache.handle_ledger_entry(low_index, ledger.at(low_index + 1)));
+
+    // Count up to next signature
+    for (size_t i = low_index + 1; i < high_signature_transaction; ++i)
+    {
+      REQUIRE(provide_ledger_entry(i));
+      REQUIRE(cache.get_store_at(low_index) == nullptr);
+    }
+
+    // Signature is good
+    REQUIRE(provide_ledger_entry(high_signature_transaction));
+    // Junk entry is still not available
+    REQUIRE(cache.get_store_at(low_index) == nullptr);
+  }
+
+  {
     INFO("Historical state can be retrieved from provided entries");
     auto store_at_index = cache.get_store_at(high_index);
     REQUIRE(store_at_index != nullptr);


### PR DESCRIPTION
Following #1267 and #1273, enable the intended merkle tree verification.