### PR TITLE
Restore historical receipts

### DIFF
--- a/src/node/history.h
+++ b/src/node/history.h
@@ -558,7 +558,12 @@ namespace ccf
     void compact(kv::Version v) override
     {
       flush_pending();
-      replicated_state_tree.flush(v);
+      // Receipts can only be retrieved to the flushed index. Keep a range of
+      // history so that a range of receipts are available.
+      if (v > MAX_HISTORY_LEN)
+      {
+        replicated_state_tree.flush(v - MAX_HISTORY_LEN);
+      }
       log_hash(replicated_state_tree.get_root(), COMPACT);
     }
 

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -357,6 +357,18 @@ namespace ccf
 
     Receipt get_receipt(uint64_t index)
     {
+      if (index < begin_index())
+      {
+        throw std::logic_error(fmt::format(
+          "Cannot produce receipt for {}: index is too old and has been "
+          "flushed from memory",
+          index));
+      }
+      if (index > end_index())
+      {
+        throw std::logic_error(fmt::format(
+          "Cannot produce receipt for {}: index is not yet known", index));
+      }
       return Receipt(tree, index);
     }
 

--- a/tests/receipts.py
+++ b/tests/receipts.py
@@ -32,8 +32,7 @@ def test(network, args, notifications_queue=None):
                     "LOG_record", {"id": 43, "msg": "Additional messages"},
                 )
             check_commit(
-                c.rpc("LOG_record", {"id": 43, "msg": "Additional messages"},),
-                result=True,
+                c.rpc("LOG_record", {"id": 43, "msg": "A final message"}), result=True,
             )
             r = c.get("getReceipt", {"commit": r.seqno})
             check(

--- a/tests/receipts.py
+++ b/tests/receipts.py
@@ -24,9 +24,17 @@ def test(network, args, notifications_queue=None):
 
         LOG.info("Write/Read on primary")
         with primary.user_client() as c:
-            check_commit(c.rpc("LOG_record", {"id": 42, "msg": msg}), result=True)
-            r = c.get("LOG_get", {"id": 42})
-            check(r, result={"msg": msg})
+            r = c.rpc("LOG_record", {"id": 42, "msg": msg})
+            check_commit(r, result=True)
+            check(c.get("LOG_get", {"id": 42}), result={"msg": msg})
+            for _ in range(10):
+                c.rpc(
+                    "LOG_record", {"id": 43, "msg": "Additional messages"},
+                )
+            check_commit(
+                c.rpc("LOG_record", {"id": 43, "msg": "Additional messages"},),
+                result=True,
+            )
             r = c.get("getReceipt", {"commit": r.seqno})
             check(
                 c.rpc("verifyReceipt", {"receipt": r.result["receipt"]}),


### PR DESCRIPTION
In #1278 I changed our compaction behaviour, to compact all the way to the requested index rather than maintaining `MAX_HISTORY_LEN` old entries. I've worked out why that was a mistake - we can only generate receipts for the in-memory, non-flushed tree. We could look at using the historical state cache to serve arbitrarily old receipts instead, but for now I'm restoring the old behaviour.