### PR TITLE
Fix recently introduced SAN errors

### DIFF
--- a/src/node/history.h
+++ b/src/node/history.h
@@ -227,21 +227,20 @@ namespace ccf
       path = std::make_shared<Path>();
     }
 
-    static Receipt from_v(const std::vector<uint8_t>& v)
+    Receipt(const std::vector<uint8_t>& v)
     {
-      Receipt r;
+      path = std::make_shared<Path>();
       const uint8_t* buf = v.data();
       size_t s = v.size();
-      r.index = serialized::read<decltype(index)>(buf, s);
-      r.max_index = serialized::read<decltype(max_index)>(buf, s);
-      std::copy(buf, buf + r.root.h.size(), r.root.h.data());
-      buf += r.root.h.size();
-      s -= r.root.h.size();
-      for (size_t i = 0; i < s; i += r.root.SIZE)
+      index = serialized::read<decltype(index)>(buf, s);
+      max_index = serialized::read<decltype(max_index)>(buf, s);
+      std::copy(buf, buf + root.h.size(), root.h.data());
+      buf += root.h.size();
+      s -= root.h.size();
+      for (size_t i = 0; i < s; i += root.SIZE)
       {
-        path_insert(r.path->raw, const_cast<uint8_t*>(buf + i));
+        path_insert(path->raw, const_cast<uint8_t*>(buf + i));
       }
-      return r;
     }
 
     Receipt(merkle_tree* tree, uint64_t index_)
@@ -256,6 +255,8 @@ namespace ccf
 
       max_index = mt_get_path(tree, index, path->raw, root.h.data());
     }
+
+    Receipt(const Receipt&) = delete;
 
     bool verify(merkle_tree* tree) const
     {
@@ -742,7 +743,7 @@ namespace ccf
 
     bool verify_receipt(const std::vector<uint8_t>& v) override
     {
-      auto r = Receipt::from_v(v);
+      Receipt r(v);
       return replicated_state_tree.verify(r);
     }
   };

--- a/src/node/test/merkle_bench.cpp
+++ b/src/node/test/merkle_bench.cpp
@@ -145,7 +145,7 @@ static void append_get_receipt_verify_v(picobench::state& s)
     t.append(hashes[index++]);
 
     auto v = t.get_receipt(index).to_v();
-    auto r = ccf::Receipt::from_v(v);
+    ccf::Receipt r(v);
     if (!t.verify(r))
       throw std::runtime_error("Bad path");
 


### PR DESCRIPTION
Daily SAN build caught an issue, fixed in `enclave.h`. Accessing members inside a constructor's initializer list is dodgy, and in this case hit UB that the SAN noticed (space for the objects is allocated, but they've not actually been constructed, so accessing any of their fields is frowned upon). To break this circular dependency, we construct the `NodeState` _after_ the initializer list has completed, when it can safely access `context.notifier`.

The `Receipt` change is probably unnecessary, but just for safety, disabling its copy constructor.