### PR TITLE
Remove usage of NoKV transaction seqnos

### DIFF
--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -285,17 +285,15 @@ def test_historical_query(network, args):
 
 
 @reqs.description("Testing forwarding on member and node frontends")
-@reqs.supports_methods("mkSign")
+@reqs.supports_methods("tx")
 @reqs.at_least_n_nodes(2)
 def test_forwarding_frontends(network, args):
     primary, backup = network.find_primary_and_any_backup()
 
     with primary.node_client() as nc:
         check_commit = infra.checker.Checker(nc)
-        with backup.node_client() as c:
-            check_commit(c.rpc("mkSign"), result=True)
-        with backup.member_client() as c:
-            check_commit(c.rpc("mkSign"), result=True)
+        ack = network.consortium.get_any_active_member().ack(backup)
+        check_commit(ack)
 
     return network
 

--- a/tests/e2e_scenarios.py
+++ b/tests/e2e_scenarios.py
@@ -37,8 +37,6 @@ def run(args):
 
             check = infra.checker.Checker()
             check_commit = infra.checker.Checker(mc)
-            with primary.user_client() as uc:
-                check_commit(uc.rpc("mkSign"), result=True)
 
             for connection in scenario["connections"]:
                 with (

--- a/tests/infra/checker.py
+++ b/tests/infra/checker.py
@@ -69,6 +69,8 @@ class Checker:
                     result, rpc_result.result
                 )
 
+            assert rpc_result.seqno and rpc_result.view, rpc_result
+
             if self.client:
                 wait_for_global_commit(self.client, rpc_result.seqno, rpc_result.view)
 

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -83,6 +83,15 @@ class Response:
             d["error"] = self.error
         return d
 
+    def __str__(self):
+        versioned = (self.view, self.seqno) != (None, None)
+        body = self.result if f"{self.status}"[0] == "2" else self.error
+        return (
+            f"{self.status} "
+            + (f"@{self.view}.{self.seqno} " if versioned else "")
+            + truncate(f"{body}")
+        )
+
     @staticmethod
     def from_requests_response(rr):
         content_type = rr.headers.get("content-type")
@@ -157,19 +166,7 @@ class RPCLogger:
         )
 
     def log_response(self, response):
-        LOG.debug(
-            truncate(
-                "{}".format(
-                    {
-                        k: v
-                        for k, v in (response.__dict__ or {}).items()
-                        if not k.startswith("_")
-                    }
-                    if response
-                    else None,
-                )
-            )
-        )
+        LOG.debug(response)
 
 
 class RPCFileLogger(RPCLogger):

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -140,6 +140,7 @@ class Member:
             r = mc.rpc("ack", params={"state_digest": list(state_digest)}, signed=True)
             assert r.error is None, f"Error ACK: {r.error}"
             self.status = MemberStatus.ACTIVE
+            return r
 
     def get_and_decrypt_recovery_share(self, remote_node, defunct_network_enc_pubk):
         with remote_node.member_client(member_id=self.member_id) as mc:

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -4,15 +4,21 @@ import infra.e2e_args
 import infra.ccf
 import infra.proc
 import suite.test_requirements as reqs
+import time
 
 from loguru import logger as LOG
 
 
-def check_can_progress(node):
+def check_can_progress(node, timeout=3):
     with node.node_client() as mc:
-        check_commit = infra.checker.Checker(mc)
-        with node.node_client() as c:
-            check_commit(c.rpc("mkSign"), result=True)
+        r = c.rpc("commit")
+        c.rpc("mkSign")
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            if c.rpc("commit").result["seqno"] > r.result["seqno"]:
+                return
+            time.sleep(0.1)
+        assert False, f"Stuck at {r}"
 
 
 @reqs.description("Adding a valid node from primary")

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -10,7 +10,7 @@ from loguru import logger as LOG
 
 
 def check_can_progress(node, timeout=3):
-    with node.node_client() as mc:
+    with node.node_client() as c:
         r = c.rpc("commit")
         c.rpc("mkSign")
         end_time = time.time() + timeout

--- a/tests/rekey.py
+++ b/tests/rekey.py
@@ -8,7 +8,7 @@ import infra.e2e_args
 
 
 @reqs.description("Rekey the ledger once")
-@reqs.supports_methods("mkSign")
+@reqs.supports_methods("primary_info")
 @reqs.at_least_n_nodes(1)
 def test(network, args):
     primary, _ = network.find_primary()


### PR DESCRIPTION
Transactions that contain no KV reads nor writes effectively have no position in the total order. We should never rely on the seqno they current return (pending removal) for anything.