### PR TITLE
Do not stop uv loop from signal handler

### DIFF
--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -204,6 +204,9 @@ namespace enclave
           bp, AdminMessage::stop, [&bp, this](const uint8_t*, size_t) {
             bp.set_finished();
             threading::ThreadMessaging::thread_messaging.set_finished();
+            auto w = writer_factory.create_writer_to_outside();
+            LOG_INFO_FMT("Enclave stopped successfully. Stopping host...");
+            RINGBUFFER_WRITE_MESSAGE(AdminMessage::stopped, w);
           });
 
         DISPATCHER_SET_MESSAGE_HANDLER(

--- a/src/enclave/interface.h
+++ b/src/enclave/interface.h
@@ -86,6 +86,9 @@ enum AdminMessage : ringbuffer::Message
   /// Stop processing messages. Host -> Enclave
   DEFINE_RINGBUFFER_MSG_TYPE(stop),
 
+  /// Stop processing messages. Enclave -> Host
+  DEFINE_RINGBUFFER_MSG_TYPE(stopped),
+
   /// Send notification data. Enclave -> Host
   DEFINE_RINGBUFFER_MSG_TYPE(notification),
 
@@ -103,6 +106,7 @@ DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(
   std::string);
 DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(AdminMessage::fatal_error_msg, std::string);
 DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(AdminMessage::stop);
+DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(AdminMessage::stopped);
 DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(
   AdminMessage::notification, std::vector<uint8_t>);
 DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(AdminMessage::tick, size_t);

--- a/src/enclave/interface.h
+++ b/src/enclave/interface.h
@@ -86,7 +86,7 @@ enum AdminMessage : ringbuffer::Message
   /// Stop processing messages. Host -> Enclave
   DEFINE_RINGBUFFER_MSG_TYPE(stop),
 
-  /// Stop processing messages. Enclave -> Host
+  /// Stopped processing messages. Enclave -> Host
   DEFINE_RINGBUFFER_MSG_TYPE(stopped),
 
   /// Send notification data. Enclave -> Host

--- a/src/host/handle_ring_buffer.h
+++ b/src/host/handle_ring_buffer.h
@@ -55,6 +55,12 @@ namespace asynchost
           std::cerr << msg << std::endl << std::flush;
           throw std::logic_error(msg);
         });
+
+      DISPATCHER_SET_MESSAGE_HANDLER(
+        bp, AdminMessage::stopped, [](const uint8_t* data, size_t size) {
+          uv_stop(uv_default_loop());
+          LOG_INFO_FMT("Host stopped successfully");
+        });
     }
 
     void every()

--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -207,7 +207,7 @@ namespace asynchost
         });
 
       DISPATCHER_SET_MESSAGE_HANDLER(
-        disp, consensus::ledger_get, [&](const uint8_t* data, size_t size) {
+        disp, consensus::ledger_get, [this](const uint8_t* data, size_t size) {
           // The enclave has asked for a ledger entry.
           auto [idx, purpose] =
             ringbuffer::read_message<consensus::ledger_get>(data, size);

--- a/src/host/sig_term.h
+++ b/src/host/sig_term.h
@@ -23,7 +23,6 @@ namespace asynchost
     {
       LOG_INFO_FMT("SIGTERM: Shutting down enclave gracefully...");
       RINGBUFFER_WRITE_MESSAGE(AdminMessage::stop, to_enclave);
-      uv_stop(uv_default_loop());
     }
   };
 


### PR DESCRIPTION
Locally solves the CI issue experienced on #1274 

We were calling `uv_stop()`, which is not [async-signal-safe](https://github.com/libuv/libuv/issues/2173#issuecomment-460566756), from the signal handler for `SIGTERM`. This PR adds another `enclave -> host` ring buffer message so that the uv loop is only closed once the enclave has acknowledged to the host that it has stopped, leaving the `SIGTERM` handler very short.

It is not 100% clear to me whether the double free issue was caused by this but it seems like a necessary change anyway. Fixing #1274 will hopefully be confirmed once this PR is merged.