### PR TITLE
Only compare versions in release, and support pre-release identifiers

### DIFF
--- a/.azure-pipelines-templates/checks.yml
+++ b/.azure-pipelines-templates/checks.yml
@@ -28,10 +28,6 @@ jobs:
       displayName: 'Check CCF copyright notices'
       condition: succeededOrFailed()
 
-    - script: ./check-cmake-version-vs-tag.sh
-      displayName: 'Check project version in CMake against git tag'
-      condition: succeededOrFailed()
-
     - script: |
         python3.7 -m venv env
         source env/bin/activate

--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -70,6 +70,10 @@ jobs:
 
   # Release
   - ${{ if eq(parameters.perf_or_release, 'release') }}:
+    - template: release_checks.yml
+      parameters:
+        env: ${{ parameters.env.Hosted }}
+
     - template: common.yml
       parameters:
         target: SGX
@@ -79,6 +83,7 @@ jobs:
         artifact_name: 'SGX_Release'
         install_prefix: '${{ parameters.build.install.install_prefix }}'
         ctest_timeout: '240'
+        depends_on: 'Release_Checks'
 
     - template: release.yml
       parameters:

--- a/.azure-pipelines-templates/release_checks.yml
+++ b/.azure-pipelines-templates/release_checks.yml
@@ -1,0 +1,14 @@
+jobs:
+- job: Release_Checks
+  displayName: 'Check code is ready for release'
+
+  ${{ insert }}: ${{ parameters.env }}
+
+  steps:
+    - checkout: self
+      clean: true
+      submodules: true
+
+    - script: ./check-cmake-version-vs-tag.sh
+      displayName: 'Check project version in CMake matches git tag'
+      condition: succeededOrFailed()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,16 @@ include(${CCF_DIR}/cmake/preproject.cmake)
 
 project(
   ccf
-  VERSION 0.11 # CCF_VERSION < This is a search marker for CI version check
+  VERSION 0.11
   LANGUAGES C CXX
 )
 
 set(ENV{BETTER_EXCEPTIONS} 1)
+
+set(CCF_PROJECT_NAME_SUFFIX "")
+set(CCF_PROJECT_NAME "${PROJECT_VERSION}${CCF_PROJECT_NAME_SUFFIX}")
+
+message(STATUS "CCF version=${CCF_PROJECT_NAME}")
 
 # Set the default install prefix for CCF. Users may override this value with the
 # cmake command. For example:
@@ -20,7 +25,7 @@ set(ENV{BETTER_EXCEPTIONS} 1)
 #
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX
-      "/opt/ccf/ccf-${PROJECT_VERSION}"
+      "/opt/ccf/ccf-${CCF_PROJECT_NAME}"
       CACHE PATH "Default install prefix" FORCE
   )
 endif()

--- a/check-cmake-version-vs-tag.sh
+++ b/check-cmake-version-vs-tag.sh
@@ -7,14 +7,19 @@ git_tag=${git_tag#v}
 
 # Check if git tag looks like a semver value - ignore if not
 if [[ ${git_tag} =~ ^([[:digit:]])+(\.([[:digit:]])+)*(-.*)?$ ]]; then
-  cmake_version=$(grep CCF_VERSION CMakeLists.txt | grep -Po "(\d)+(\.(\d)+)*")
-  # Check git tag is <= CMake version. Use sort --version-sort to handle semver (0.9 < 0.10)
-  if echo "$git_tag $cmake_version" | tr " " "\n" | sort --version-sort -c ; then
-    echo "Git tag ($git_tag) is safely <= CMake version ($cmake_version)"
+  mkdir -p build
+  cd build
+  cmake_version=$(cmake .. -L | grep "CCF version=")
+  cmake_version=${cmake_version#*=}
+  echo "Comparing git tag ($git_tag) with CMake version ($cmake_version)"
+  if [[ ${git_tag} == ${cmake_version} ]]; then
+    echo "Git tag ($git_tag) matches CMake version ($cmake_version)"
+    exit 0
   else
-    echo "Git tag ($git_tag) is later than CMake version ($cmake_version) - please update CMake version!"
+    echo "Git tag ($git_tag) does not match CMake version ($cmake_version) - please update CMake version"
     exit 1
   fi
 else
   echo "Skipping check - ${git_tag} doesn't look like semver"
+  exit 0
 fi

--- a/check-cmake-version-vs-tag.sh
+++ b/check-cmake-version-vs-tag.sh
@@ -8,11 +8,11 @@ git_tag=${git_tag#v}
 # Check if git tag looks like a semver value - ignore if not
 if [[ ${git_tag} =~ ^([[:digit:]])+(\.([[:digit:]])+)*(-.*)?$ ]]; then
   mkdir -p build
-  cd build
+  pushd build
   cmake_version=$(cmake .. -L | grep "CCF version=")
   cmake_version=${cmake_version#*=}
   echo "Comparing git tag ($git_tag) with CMake version ($cmake_version)"
-  if [[ ${git_tag} == ${cmake_version} ]]; then
+  if [[ "${git_tag}" == "${cmake_version}" ]]; then
     echo "Git tag ($git_tag) matches CMake version ($cmake_version)"
     exit 0
   else


### PR DESCRIPTION
We used to run `check-cmake-version-vs-tag` on every CI run. It checked that the most recent git tag specified a version <= the cmake version. The idea was to stop us releasing 0.42 with binaries that claimed they were 0.41. This didn't support pre-release identifiers.

Now we can specify pre-release identifiers in CMake (via `CCF_PROJECT_NAME_SUFFIX`), the script looks for exact equality, and it only runs in the release CI. So master's VERSION, as specified in CMake, can jump backwards and forwards as much as we like, but at the point we produce a _tag_  it must exactly match the tag's version.