### PR TITLE
Add ds/nonstd.h with some useful type traits

### DIFF
--- a/src/ds/json_schema.h
+++ b/src/ds/json_schema.h
@@ -1,27 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 #pragma once
+
+#include "ds/nonstd.h"
+
 #include <nlohmann/json.hpp>
 
 namespace ds
 {
   namespace json
   {
-    namespace
-    {
-      template <typename T, template <typename...> class U>
-      struct is_specialization : std::false_type
-      {};
-
-      template <template <typename...> class T, typename... Args>
-      struct is_specialization<T<Args...>, T> : std::true_type
-      {};
-
-      template <typename T>
-      struct dependent_false : public std::false_type
-      {};
-    };
-
     struct JsonSchema
     {
       static constexpr auto hyperschema =
@@ -82,18 +70,18 @@ namespace ds
     template <typename T>
     inline void fill_schema(nlohmann::json& schema)
     {
-      if constexpr (is_specialization<T, std::optional>::value)
+      if constexpr (nonstd::is_specialization<T, std::optional>::value)
       {
         fill_schema<typename T::value_type>(schema);
       }
-      else if constexpr (is_specialization<T, std::vector>::value)
+      else if constexpr (nonstd::is_specialization<T, std::vector>::value)
       {
         schema["type"] = "array";
         schema["items"] = schema_element<typename T::value_type>();
       }
       else if constexpr (
-        is_specialization<T, std::map>::value ||
-        is_specialization<T, std::unordered_map>::value)
+        nonstd::is_specialization<T, std::map>::value ||
+        nonstd::is_specialization<T, std::unordered_map>::value)
       {
         // Nlohmann serialises maps to an array of (K, V) pairs
         schema["type"] = "array";
@@ -108,7 +96,7 @@ namespace ds
         }
         schema["items"] = items;
       }
-      else if constexpr (is_specialization<T, std::pair>::value)
+      else if constexpr (nonstd::is_specialization<T, std::pair>::value)
       {
         schema["type"] = "array";
         auto items = nlohmann::json::array();

--- a/src/ds/nonstd.h
+++ b/src/ds/nonstd.h
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include <array>
+#include <type_traits>
+
+/**
+ * This file defines various type traits and utils that are not available in the
+ * standard library. Some are added in C++20, some are proposed, some are purely
+ * custom. They are defined here to avoid repetition in other locations
+ */
+namespace nonstd
+{
+  /** is_specialization detects type-specialized templates. This does not work
+   * for value-dependent types (eg - std::array)
+   */
+  template <typename T, template <typename...> class U>
+  struct is_specialization : std::false_type
+  {};
+
+  template <template <typename...> class T, typename... Args>
+  struct is_specialization<T<Args...>, T> : std::true_type
+  {};
+
+  /** Similar to is_specialization, but for detecting std::array specifically
+   */
+  template <typename T>
+  struct is_std_array : std::false_type
+  {};
+
+  template <typename T, size_t N>
+  struct is_std_array<std::array<T, N>> : public std::true_type
+  {};
+
+  /** dependent_false produces a static, compile-time false, dependent on a
+   * specific type or value instantiation. This is useful for producing a
+   * static_assert which will fail only when invalid paths are called, but
+   * allows compilation otherwise
+   */
+  template <typename T, T = T{}>
+  struct dependent_false : public std::false_type
+  {};
+
+  template <typename T, T t = T{}>
+  using dependent_false_v = dependent_false<T, t>::value;
+
+  /** remove_cvref combines remove_cv and remove_reference - this is present in
+   * C++20
+   */
+  template <class T>
+  struct remove_cvref
+  {
+    typedef std::remove_cv_t<std::remove_reference_t<T>> type;
+  };
+
+  template <class T>
+  using remove_cvref_t = typename remove_cvref<T>::type;
+}

--- a/src/ds/nonstd.h
+++ b/src/ds/nonstd.h
@@ -43,7 +43,7 @@ namespace nonstd
   {};
 
   template <typename T, T t = T{}>
-  using dependent_false_v = dependent_false<T, t>::value;
+  static constexpr bool dependent_false_v = dependent_false<T, t>::value;
 
   /** remove_cvref combines remove_cv and remove_reference - this is present in
    * C++20

--- a/src/ds/ring_buffer_types.h
+++ b/src/ds/ring_buffer_types.h
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ds/nonstd.h"
 #include "hash.h"
 #include "serializer.h"
 
@@ -128,19 +129,12 @@ namespace ringbuffer
 #define DEFINE_RINGBUFFER_MSG_TYPE(NAME) \
   NAME = ds::fnv_1a<ringbuffer::Message>(#NAME)
 
-  /// Machinery for writing and reading typed messages
-  namespace
-  {
-    template <ringbuffer::Message m>
-    struct dependent_false : public std::false_type
-    {};
-  };
-
   template <ringbuffer::Message m>
   struct MessageSerializers
   {
     static_assert(
-      dependent_false<m>::value, "No payload specialization for this Message");
+      nonstd::dependent_false<ringbuffer::Message, m>::value,
+      "No payload specialization for this Message");
   };
 
 #define DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(MTYPE, ...) \

--- a/src/ds/serializer.h
+++ b/src/ds/serializer.h
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ds/nonstd.h"
 #include "serialized.h"
 
 #include <memory>
@@ -77,8 +78,8 @@ namespace serializer
       struct close_enough_at
       {
         using CanonTarget =
-          remove_cvref_t<typename std::tuple_element_t<I, Tup>>;
-        using CanonArgument = remove_cvref_t<T>;
+          nonstd::remove_cvref_t<typename std::tuple_element_t<I, Tup>>;
+        using CanonArgument = nonstd::remove_cvref_t<T>;
 
         // This determines what types a Serializer will accept as arguments to
         // serialize(...), relative to the declared param types.
@@ -301,7 +302,7 @@ namespace serializer
     template <typename T, typename... Ts>
     static auto deserialize_impl(const uint8_t* data, size_t size)
     {
-      using StrippedT = details::remove_cvref_t<T>;
+      using StrippedT = nonstd::remove_cvref_t<T>;
 
       if constexpr (
         std::is_same_v<StrippedT, std::vector<uint8_t>> ||

--- a/src/ds/serializer.h
+++ b/src/ds/serializer.h
@@ -59,16 +59,6 @@ namespace serializer
       }
     }
 
-    // C++20
-    template <class T>
-    struct remove_cvref
-    {
-      typedef std::remove_cv_t<std::remove_reference_t<T>> type;
-    };
-
-    template <class T>
-    using remove_cvref_t = typename remove_cvref<T>::type;
-
     template <typename Tup>
     struct TupMatcher
     {

--- a/src/kv/serialise_entry_blit.h
+++ b/src/kv/serialise_entry_blit.h
@@ -2,25 +2,11 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ds/nonstd.h"
 #include "serialised_entry.h"
 
 namespace kv::serialisers
 {
-  namespace
-  {
-    template <typename T>
-    struct is_std_array : std::false_type
-    {};
-
-    template <typename T, size_t N>
-    struct is_std_array<std::array<T, N>> : public std::true_type
-    {};
-
-    template <typename T>
-    struct dependent_false : public std::false_type
-    {};
-  }
-
   template <typename T>
   struct BlitSerialiser
   {
@@ -30,7 +16,7 @@ namespace kv::serialisers
       {
         return SerialisedEntry(t.begin(), t.end());
       }
-      else if constexpr (is_std_array<T>::value)
+      else if constexpr (nonstd::is_std_array<T>::value)
       {
         return SerialisedEntry(t.begin(), t.end());
       }
@@ -42,7 +28,8 @@ namespace kv::serialisers
       }
       else
       {
-        static_assert(dependent_false<T>::value, "Can't serialise this type");
+        static_assert(
+          nonstd::dependent_false<T>::value, "Can't serialise this type");
       }
     }
 
@@ -52,7 +39,7 @@ namespace kv::serialisers
       {
         return T(rep.begin(), rep.end());
       }
-      else if constexpr (is_std_array<T>::value)
+      else if constexpr (nonstd::is_std_array<T>::value)
       {
         return T(rep.begin(), rep.end());
       }
@@ -66,7 +53,8 @@ namespace kv::serialisers
       }
       else
       {
-        static_assert(dependent_false<T>::value, "Can't deserialise this type");
+        static_assert(
+          nonstd::dependent_false<T>::value, "Can't deserialise this type");
       }
     }
   };


### PR DESCRIPTION
I keep finding reasons to redefine `dependent_false`. This moves it, and some other potentially generally useful trait helpers, to a single location.