### PR TITLE
Serialize the Maps

### DIFF
--- a/src/ds/champ_map.h
+++ b/src/ds/champ_map.h
@@ -465,7 +465,7 @@ namespace champ
 
         size += (key_size + value_size);
 
-        serialized_state.push_back(pair(k, static_cast<Hash>(H()(key)), v));
+        serialized_state.emplace_back(k, static_cast<Hash>(H()(key)), v);
 
         return true;
       });

--- a/src/ds/champ_map.h
+++ b/src/ds/champ_map.h
@@ -438,10 +438,15 @@ namespace champ
     Snapshot(
       Map<K, V, H> map_,
       std::function<uint32_t(const K& key)> k_size_,
-      std::function<uint32_t(const K& key, uint8_t*& data, size_t& size)> k_serialize_,
+      std::function<uint32_t(const K& key, uint8_t*& data, size_t& size)>
+        k_serialize_,
       std::function<uint32_t(const V& value)> v_size_,
-      std::function<uint32_t(const V& value, uint8_t*& data, size_t& size)> v_serialize_)
-      :k_size(k_size_), k_serialize(k_serialize_), v_size(v_size_), v_serialize(v_serialize_)
+      std::function<uint32_t(const V& value, uint8_t*& data, size_t& size)>
+        v_serialize_) :
+      k_size(k_size_),
+      k_serialize(k_serialize_),
+      v_size(v_size_),
+      v_serialize(v_serialize_)
     {
       map = map_;
     }
@@ -455,10 +460,10 @@ namespace champ
       map.foreach([&](auto& key, auto& value) {
         K* k = &key;
         V* v = &value;
-        uint32_t key_size =  k_size(key) + get_padding(k_size(key));
+        uint32_t key_size = k_size(key) + get_padding(k_size(key));
         uint32_t value_size = v_size(value) + get_padding(v_size(value));
 
-        size += (key_size+value_size);
+        size += (key_size + value_size);
 
         serialized_state.push_back(pair(k, static_cast<Hash>(H()(key)), v));
 

--- a/src/ds/test/map_test.cpp
+++ b/src/ds/test/map_test.cpp
@@ -181,12 +181,37 @@ TEST_CASE("serialize map")
     REQUIRE_EQ(num_elements, keys.size());
   }
 
-  INFO("Serialize map to and from array");
+  std::function<uint32_t(const K& key)> fn_size_k = [](const K& k) {
+    return sizeof(K) + sizeof(uint64_t);
+  };
+  std::function<uint32_t(const K& key, uint8_t*& data, size_t& size)>
+    fn_serialize_k = [](const K& k, uint8_t*& data, size_t& size) {
+      uint64_t key_size = sizeof(K);
+      serialized::write(
+        data, size, reinterpret_cast<const uint8_t*>(&key_size), sizeof(K));
+      serialized::write(
+        data, size, reinterpret_cast<const uint8_t*>(&k), sizeof(K));
+      return 2*sizeof(K);
+    };
+  std::function<uint32_t(const V& value)> fn_size_v = [](const V& v) {
+    return sizeof(V) + sizeof(uint64_t);
+  };
+  std::function<uint32_t(const V& value, uint8_t*& data, size_t& size)>
+    fn_serialize_v = [](const V& v, uint8_t*& data, size_t& size) {
+      uint64_t value_size = sizeof(V);
+      serialized::write(
+        data, size, reinterpret_cast<const uint8_t*>(&value_size), sizeof(V));
+      serialized::write(
+        data, size, reinterpret_cast<const uint8_t*>(&v), sizeof(V));
+      return 2*sizeof(V);
+    };
+
+
+  INFO("Serialize map to array");
   {
     champ::Snapshot<K, V, H> snapshot(
-      map,
-      [](const K& k) { return sizeof(K); },
-      [](const V& v) { return sizeof(V); });
+      map, fn_size_k, fn_serialize_k, fn_size_v, fn_serialize_v);
+
     const std::vector<uint8_t>& s = snapshot.get_buffer();
 
     champ::Map<K, V, H> new_map = champ::Map<K, V, H>::deserialize_map(
@@ -220,15 +245,11 @@ TEST_CASE("serialize map")
   INFO("Ensure serialized state is byte identical");
   {
     champ::Snapshot<K, V, H> snapshot_1(
-      map,
-      [](const K& k) { return sizeof(K); },
-      [](const V& v) { return sizeof(V); });
+      map, fn_size_k, fn_serialize_k, fn_size_v, fn_serialize_v);
     const std::vector<uint8_t>& s_1 = snapshot_1.get_buffer();
 
     champ::Snapshot<K, V, H> snapshot_2(
-      map,
-      [](const K& k) { return sizeof(K); },
-      [](const V& v) { return sizeof(V); });
+      map, fn_size_k, fn_serialize_k, fn_size_v, fn_serialize_v);
     const std::vector<uint8_t>& s_2 = snapshot_2.get_buffer();
 
     REQUIRE_EQ(s_1.size(), s_2.size());

--- a/src/ds/test/map_test.cpp
+++ b/src/ds/test/map_test.cpp
@@ -191,7 +191,7 @@ TEST_CASE("serialize map")
         data, size, reinterpret_cast<const uint8_t*>(&key_size), sizeof(K));
       serialized::write(
         data, size, reinterpret_cast<const uint8_t*>(&k), sizeof(K));
-      return 2*sizeof(K);
+      return 2 * sizeof(K);
     };
   std::function<uint32_t(const V& value)> fn_size_v = [](const V& v) {
     return sizeof(V) + sizeof(uint64_t);
@@ -203,9 +203,8 @@ TEST_CASE("serialize map")
         data, size, reinterpret_cast<const uint8_t*>(&value_size), sizeof(V));
       serialized::write(
         data, size, reinterpret_cast<const uint8_t*>(&v), sizeof(V));
-      return 2*sizeof(V);
+      return 2 * sizeof(V);
     };
-
 
   INFO("Serialize map to array");
   {

--- a/src/ds/test/map_test.cpp
+++ b/src/ds/test/map_test.cpp
@@ -210,7 +210,6 @@ TEST_CASE("serialize map")
   {
     champ::Snapshot<K, V, H> snapshot(
       map, fn_size_k, fn_serialize_k, fn_size_v, fn_serialize_v);
-
     const std::vector<uint8_t>& s = snapshot.get_buffer();
 
     champ::Map<K, V, H> new_map = champ::Map<K, V, H>::deserialize_map(

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -280,7 +280,9 @@ namespace kv
       CommitSuccess success_,
       TxHistory::RequestID reqid_,
       std::vector<uint8_t>&& data_) :
-      success(success_), reqid(std::move(reqid_)), data(std::move(data_))
+      success(success_),
+      reqid(std::move(reqid_)),
+      data(std::move(data_))
     {}
   };
 
@@ -295,7 +297,8 @@ namespace kv
   public:
     MovePendingTx(
       std::vector<uint8_t>&& data_, kv::TxHistory::RequestID req_id_) :
-      data(std::move(data_)), req_id(std::move(req_id_))
+      data(std::move(data_)),
+      req_id(std::move(req_id_))
     {}
 
     MovePendingTx(MovePendingTx&& other) = default;
@@ -403,6 +406,10 @@ namespace kv
         snapshots.push_back(std::move(snapshot));
       }
 
+      std::vector<std::unique_ptr<kv::AbstractMap::Snapshot>>& get_snapshots()
+      {
+        return snapshots;
+      }
     };
 
     virtual ~AbstractStore() {}

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -442,5 +442,4 @@ namespace kv
     virtual size_t commit_gap() = 0;
   };
 
-
 }

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -366,6 +366,9 @@ namespace kv
     public:
       virtual ~Snapshot() = default;
       virtual std::vector<uint8_t> get_buffer() = 0;
+      virtual std::string& get_name() = 0;
+      virtual SecurityDomain get_security_domain() = 0;
+      virtual bool get_is_replicated() = 0;
     };
 
     virtual ~AbstractMap() {}

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -280,9 +280,7 @@ namespace kv
       CommitSuccess success_,
       TxHistory::RequestID reqid_,
       std::vector<uint8_t>&& data_) :
-      success(success_),
-      reqid(std::move(reqid_)),
-      data(std::move(data_))
+      success(success_), reqid(std::move(reqid_)), data(std::move(data_))
     {}
   };
 
@@ -297,8 +295,7 @@ namespace kv
   public:
     MovePendingTx(
       std::vector<uint8_t>&& data_, kv::TxHistory::RequestID req_id_) :
-      data(std::move(data_)),
-      req_id(std::move(req_id_))
+      data(std::move(data_)), req_id(std::move(req_id_))
     {}
 
     MovePendingTx(MovePendingTx&& other) = default;
@@ -366,9 +363,9 @@ namespace kv
       bool public_only = false,
       Term* term = nullptr) = 0;
     virtual void compact(Version v) = 0;
+    virtual void snapshot(Version v) = 0;
     virtual void rollback(Version v, std::optional<Term> t = std::nullopt) = 0;
     virtual void set_term(Term t) = 0;
-
     virtual CommitSuccess commit(
       const TxID& txid, PendingTx pt, bool globally_committable) = 0;
 
@@ -390,6 +387,12 @@ namespace kv
   class AbstractMap
   {
   public:
+    class Snapshot
+    {
+    public:
+      virtual ~Snapshot() = default;
+    };
+
     virtual ~AbstractMap() {}
     virtual bool operator==(const AbstractMap& that) const = 0;
     virtual bool operator!=(const AbstractMap& that) const = 0;
@@ -401,6 +404,7 @@ namespace kv
       KvStoreDeserialiser& d, Version version) = 0;
     virtual const std::string& get_name() const = 0;
     virtual void compact(Version v) = 0;
+    virtual Snapshot&& snapshot(Version v) = 0;
     virtual void post_compact() = 0;
     virtual void rollback(Version v) = 0;
     virtual void lock() = 0;

--- a/src/kv/map.h
+++ b/src/kv/map.h
@@ -77,9 +77,6 @@ namespace kv
       return untyped_map.compact(v);
     }
 
-    class Snapshot : public AbstractMap::Snapshot
-    {};
-
     std::unique_ptr<AbstractMap::Snapshot> snapshot(Version v) override
     {
       return untyped_map.snapshot(v);

--- a/src/kv/map.h
+++ b/src/kv/map.h
@@ -81,7 +81,7 @@ namespace kv
     {
     };
 
-    AbstractMap::Snapshot&& snapshot(Version v) override
+    std::unique_ptr<AbstractMap::Snapshot> snapshot(Version v) override
     {
       return untyped_map.snapshot(v);
     }

--- a/src/kv/map.h
+++ b/src/kv/map.h
@@ -78,8 +78,7 @@ namespace kv
     }
 
     class Snapshot : public AbstractMap::Snapshot
-    {
-    };
+    {};
 
     std::unique_ptr<AbstractMap::Snapshot> snapshot(Version v) override
     {

--- a/src/kv/map.h
+++ b/src/kv/map.h
@@ -77,6 +77,15 @@ namespace kv
       return untyped_map.compact(v);
     }
 
+    class Snapshot : public AbstractMap::Snapshot
+    {
+    };
+
+    AbstractMap::Snapshot&& snapshot(Version v) override
+    {
+      return untyped_map.snapshot(v);
+    }
+
     void post_compact() override
     {
       return untyped_map.post_compact();

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -217,7 +217,7 @@ namespace kv
       maps[name] = std::unique_ptr<AbstractMap>(result);
       return *result;
     }
-    
+
     std::unique_ptr<Snapshot> snapshot(Version v) override
     {
       std::lock_guard<SpinLock> mguard(maps_lock);

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -218,6 +218,40 @@ namespace kv
       return *result;
     }
 
+    //TODO: we want something similar but serialize
+    void snapshot(Version v) override
+    {
+      std::cout << "baz:" << maps.size() << std::endl;
+      std::lock_guard<SpinLock> mguard(maps_lock);
+
+      if (v > current_version())
+        return;
+
+      for (auto& map : maps)
+        map.second->lock();
+
+      for (auto& map : maps)
+        map.second->snapshot(v);
+
+      for (auto& map : maps)
+        map.second->unlock();
+
+      /*
+      {
+        std::lock_guard<SpinLock> vguard(version_lock);
+        compacted = v;
+
+        auto h = get_history();
+        if (h)
+          h->compact(v);
+
+        auto e = get_encryptor();
+        if (e)
+          e->compact(v);
+      }
+      */
+    }
+
     void compact(Version v) override
     {
       // This is called when the store will never be rolled back to any

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -223,7 +223,9 @@ namespace kv
       std::lock_guard<SpinLock> mguard(maps_lock);
 
       if (v > current_version())
+      {
         return nullptr;
+      }
 
       auto snapshot = std::make_unique<Snapshot>();
 
@@ -253,16 +255,24 @@ namespace kv
       std::lock_guard<SpinLock> mguard(maps_lock);
 
       if (v > current_version())
+      {
         return;
+      }
 
       for (auto& map : maps)
+      {
         map.second->lock();
+      }
 
       for (auto& map : maps)
+      {
         map.second->compact(v);
+      }
 
       for (auto& map : maps)
+      {
         map.second->unlock();
+      }
 
       {
         std::lock_guard<SpinLock> vguard(version_lock);
@@ -270,15 +280,21 @@ namespace kv
 
         auto h = get_history();
         if (h)
+        {
           h->compact(v);
+        }
 
         auto e = get_encryptor();
         if (e)
+        {
           e->compact(v);
+        }
       }
 
       for (auto& map : maps)
+      {
         map.second->post_compact();
+      }
     }
 
     void rollback(Version v, std::optional<Term> t = std::nullopt) override

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -6,6 +6,7 @@
 #include "kv_types.h"
 #include "map.h"
 #include "view_containers.h"
+#include "ds/ccf_exception.h"
 
 #include <fmt/format.h>
 
@@ -224,7 +225,10 @@ namespace kv
 
       if (v > current_version())
       {
-        return nullptr;
+        throw ccf::ccf_logic_error(fmt::format(
+          "Attempting to snapshot at invalid version v:{}, current_version:{}",
+          v,
+          current_version()));
       }
 
       auto snapshot = std::make_unique<Snapshot>();

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -2,11 +2,11 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ds/ccf_exception.h"
 #include "kv_serialiser.h"
 #include "kv_types.h"
 #include "map.h"
 #include "view_containers.h"
-#include "ds/ccf_exception.h"
 
 #include <fmt/format.h>
 

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -1025,3 +1025,49 @@ TEST_CASE("Conflict resolution")
   REQUIRE_THROWS(tx1.commit());
   REQUIRE_THROWS(tx2.commit());
 }
+
+TEST_CASE("Serialization")
+{
+      std::cout << "AAAAA" << std::endl;
+  kv::Store kv_store;
+  auto& map =
+    kv_store.create<MapTypes::StringString>("map", kv::SecurityDomain::PUBLIC);
+
+  auto try_write = [&](kv::Tx& tx, const std::string& s) {
+    auto view = tx.get_view(map);
+
+    // Numroduce read-dependency
+    view->get("foo");
+    view->put("foo", s);
+
+    view->put(s, s);
+  };
+
+  // Simulate parallel execution by interleaving tx steps
+  kv::Tx tx1;
+  kv::Tx tx2;
+
+  // First transaction tries to write a value, depending on initial version
+  try_write(tx1, "bar");
+
+  {
+    // A second transaction is committed, conflicting with the first
+    try_write(tx2, "baz");
+    const auto res2 = tx2.commit();
+    REQUIRE(res2 == kv::CommitSuccess::OK);
+  }
+
+  // Trying to commit first transaction produces a conflict
+  auto res1 = tx1.commit();
+  REQUIRE(res1 == kv::CommitSuccess::CONFLICT);
+
+  // First transaction is rerun with same object, producing different result
+  try_write(tx1, "buzz");
+
+  // Expected results are committed
+  res1 = tx1.commit();
+  REQUIRE(res1 == kv::CommitSuccess::OK);
+
+  kv_store.snapshot(1);
+      std::cout << "ZZZZZ" << std::endl;
+}

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -1069,5 +1069,10 @@ TEST_CASE("Serialization")
     REQUIRE(res1 == kv::CommitSuccess::OK);
   }
 
-  kv_store.snapshot(1);
+  std::unique_ptr<kv::AbstractStore::Snapshot> s = kv_store.snapshot(1);
+  auto& vec_s = s->get_snapshots();
+  for (auto& s : vec_s)
+  {
+    s->get_buffer();
+  }
 }

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -1028,7 +1028,6 @@ TEST_CASE("Conflict resolution")
 
 TEST_CASE("Serialization")
 {
-      std::cout << "AAAAA" << std::endl;
   kv::Store kv_store;
   auto& map =
     kv_store.create<MapTypes::StringString>("map", kv::SecurityDomain::PUBLIC);
@@ -1043,31 +1042,32 @@ TEST_CASE("Serialization")
     view->put(s, s);
   };
 
-  // Simulate parallel execution by interleaving tx steps
-  kv::Tx tx1;
-  kv::Tx tx2;
-
-  // First transaction tries to write a value, depending on initial version
-  try_write(tx1, "bar");
-
+  INFO("Simulate parallel execution by interleaving tx steps");
   {
-    // A second transaction is committed, conflicting with the first
-    try_write(tx2, "baz");
-    const auto res2 = tx2.commit();
-    REQUIRE(res2 == kv::CommitSuccess::OK);
+    kv::Tx tx1;
+    kv::Tx tx2;
+
+    // First transaction tries to write a value, depending on initial version
+    try_write(tx1, "bar");
+
+    {
+      // A second transaction is committed, conflicting with the first
+      try_write(tx2, "baz");
+      const auto res2 = tx2.commit();
+      REQUIRE(res2 == kv::CommitSuccess::OK);
+    }
+
+    // Trying to commit first transaction produces a conflict
+    auto res1 = tx1.commit();
+    REQUIRE(res1 == kv::CommitSuccess::CONFLICT);
+
+    // First transaction is rerun with same object, producing different result
+    try_write(tx1, "buzz");
+
+    // Expected results are committed
+    res1 = tx1.commit();
+    REQUIRE(res1 == kv::CommitSuccess::OK);
   }
 
-  // Trying to commit first transaction produces a conflict
-  auto res1 = tx1.commit();
-  REQUIRE(res1 == kv::CommitSuccess::CONFLICT);
-
-  // First transaction is rerun with same object, producing different result
-  try_write(tx1, "buzz");
-
-  // Expected results are committed
-  res1 = tx1.commit();
-  REQUIRE(res1 == kv::CommitSuccess::OK);
-
   kv_store.snapshot(1);
-      std::cout << "ZZZZZ" << std::endl;
 }

--- a/src/kv/untyped_map.h
+++ b/src/kv/untyped_map.h
@@ -607,7 +607,9 @@ namespace kv::untyped
       }
 
       std::function<uint32_t(const SerialisedEntry& key)> k_size =
-        [](const SerialisedEntry& key) { return sizeof(uint64_t) + key.size(); };
+        [](const SerialisedEntry& key) {
+          return sizeof(uint64_t) + key.size();
+        };
 
       std::function<uint32_t(
         const SerialisedEntry& key, uint8_t*& data, size_t& size)>
@@ -617,10 +619,13 @@ namespace kv::untyped
                         size_t& size) {
           uint64_t key_size = key.size();
           serialized::write(
-            data, size, reinterpret_cast<const uint8_t*>(&key_size), sizeof(uint64_t));
+            data,
+            size,
+            reinterpret_cast<const uint8_t*>(&key_size),
+            sizeof(uint64_t));
           serialized::write(
             data, size, reinterpret_cast<const uint8_t*>(key.data()), key_size);
-          return sizeof(uint64_t) + key_size; 
+          return sizeof(uint64_t) + key_size;
         };
 
       std::function<uint32_t(const kv::VersionV<SerialisedEntry>& value)>
@@ -643,16 +648,26 @@ namespace kv::untyped
             reinterpret_cast<const uint8_t*>(&value_size),
             sizeof(uint64_t));
           serialized::write(
-            data, size, reinterpret_cast<const uint8_t*>(&value.version), sizeof(value.version));
+            data,
+            size,
+            reinterpret_cast<const uint8_t*>(&value.version),
+            sizeof(value.version));
           serialized::write(
-            data, size, reinterpret_cast<const uint8_t*>(value.value.data()), value.value.size());
+            data,
+            size,
+            reinterpret_cast<const uint8_t*>(value.value.data()),
+            value.value.size());
           return sizeof(uint64_t) + sizeof(value.version) + value.value.size();
         };
 
-      champ::Snapshot<SerialisedEntry, kv::VersionV<SerialisedEntry>, SerialisedKeyHasher>
+      champ::Snapshot<
+        SerialisedEntry,
+        kv::VersionV<SerialisedEntry>,
+        SerialisedKeyHasher>
         snapshot(r->state, k_size, k_serialize, v_size, v_serialize);
 
-      return std::move(std::make_unique<Snapshot>(name, security_domain, replicated, std::move(snapshot)));
+      return std::move(std::make_unique<Snapshot>(
+        name, security_domain, replicated, std::move(snapshot)));
     }
 
     void compact(Version v) override

--- a/src/kv/untyped_map.h
+++ b/src/kv/untyped_map.h
@@ -309,6 +309,21 @@ namespace kv::untyped
       {
         return map_snapshot.get_buffer();
       }
+
+      std::string& get_name() override
+      {
+        return name;
+      }
+
+      SecurityDomain get_security_domain() override
+      {
+        return security_domain;
+      }
+
+      bool get_is_replicated() override
+      {
+        return replicated;
+      }
     };
 
     // Public typedef for external consumption

--- a/src/kv/untyped_map.h
+++ b/src/kv/untyped_map.h
@@ -304,6 +304,11 @@ namespace kv::untyped
         replicated(replicated_),
         map_snapshot(std::move(map_snapshot_))
       {}
+
+      std::vector<uint8_t> get_buffer() override
+      {
+        return map_snapshot.get_buffer();
+      }
     };
 
     // Public typedef for external consumption
@@ -580,14 +585,11 @@ namespace kv::untyped
       return !(*this == that);
     }
 
-    AbstractMap::Snapshot&& snapshot(Version v) override
+    std::unique_ptr<AbstractMap::Snapshot> snapshot(Version v) override
     {
-      std::cout << "1 foobar - target version:" << v << std::endl;
       auto r = roll.commits->get_head();
-      std::cout << "2 foobar - version:" << r->version << std::endl;
       while (r != nullptr)
       {
-        std::cout << "3 foobar - version:" << r->version << std::endl;
         if (v < r->version)
         {
           break;
@@ -604,7 +606,6 @@ namespace kv::untyped
         r = r->prev;
       }
 
-      std::cout << "4 foobar - version:" << r->version << std::endl;
       std::function<uint32_t(const SerialisedEntry& key)> k_size =
         [](const SerialisedEntry& key) { return sizeof(uint64_t) + key.size(); };
 
@@ -636,31 +637,22 @@ namespace kv::untyped
                         uint8_t*& data,
                         size_t& size) {
           uint64_t value_size = sizeof(value.version) + value.value.size();
-          //std::cout << "1 remaining size:" << size << std::endl;
           serialized::write(
             data,
             size,
             reinterpret_cast<const uint8_t*>(&value_size),
             sizeof(uint64_t));
-
-          //std::cout << "2 remaining size:" << size << std::endl;
-
           serialized::write(
             data, size, reinterpret_cast<const uint8_t*>(&value.version), sizeof(value.version));
-          //std::cout << "3 remaining size:" << size << std::endl;
-
           serialized::write(
             data, size, reinterpret_cast<const uint8_t*>(value.value.data()), value.value.size());
-          //std::cout << "4 remaining size:" << size << std::endl;
-          return sizeof(uint64_t) + sizeof(value.version) + value_size;
+          return sizeof(uint64_t) + sizeof(value.version) + value.value.size();
         };
 
-      std::cout << "5 foobar - version:" << r->version << std::endl;
       champ::Snapshot<SerialisedEntry, kv::VersionV<SerialisedEntry>, SerialisedKeyHasher>
         snapshot(r->state, k_size, k_serialize, v_size, v_serialize);
 
-      std::cout << "99 foobar" << std::endl;
-      return std::move(Snapshot(name, security_domain, replicated, std::move(snapshot)));
+      return std::move(std::make_unique<Snapshot>(name, security_domain, replicated, std::move(snapshot)));
     }
 
     void compact(Version v) override


### PR DESCRIPTION
- serialize all the maps
- only lock the maps when taking a copy of the required champ map
- add key and value serializers to enable serializing complex types

part of #1299 