### PR TITLE
Rename URI prefixes

### DIFF
--- a/doc/developers/api.rst
+++ b/doc/developers/api.rst
@@ -4,7 +4,7 @@ Developer API
 A CCF application is composed of the following:
 
 - The :ref:`Application Entry Point <developers/api:Application Entry Point>` which registers the application in CCF.
-- A collection of :cpp:class:`ccf::EndpointRegistry::Endpoint` handling HTTP requests and grouped in a single :cpp:class:`ccf::EndpointRegistry`. A :cpp:class:`ccf::EndpointRegistry::Endpoint` reads and writes to the key-value store via the :ref:`Key-Value Store API <developers/kv/api:Key-Value Store API>`.
+- A collection of :cpp:class:`endpoints <ccf::EndpointRegistry::Endpoint>` handling HTTP requests and grouped in a single :cpp:class:`ccf::EndpointRegistry`. An :cpp:class:`endpoint <ccf::EndpointRegistry::Endpoint>` reads and writes to the key-value store via the :ref:`Key-Value Store API <developers/kv/api:Key-Value Store API>`.
 
 Application Entry Point
 -----------------------

--- a/doc/developers/api.rst
+++ b/doc/developers/api.rst
@@ -4,7 +4,7 @@ Developer API
 A CCF application is composed of the following:
 
 - The :ref:`Application Entry Point <developers/api:Application Entry Point>` which registers the application in CCF.
-- A collection of :cpp:class:`ccf::EndpointRegistry::Endpoint`s to user HTTP requests and grouped in a single :cpp:class:`ccf::EndpointRegistry`. A :cpp:class:`ccf::EndpointRegistry::Endpoint` reads and writes to the key-value store via the :ref:`Key-Value Store API <developers/kv/api:Key-Value Store API>`.
+- A collection of :cpp:class:`ccf::EndpointRegistry::Endpoint` handling HTTP requests and grouped in a single :cpp:class:`ccf::EndpointRegistry`. A :cpp:class:`ccf::EndpointRegistry::Endpoint` reads and writes to the key-value store via the :ref:`Key-Value Store API <developers/kv/api:Key-Value Store API>`.
 
 Application Entry Point
 -----------------------

--- a/doc/developers/logging_cpp.rst
+++ b/doc/developers/logging_cpp.rst
@@ -67,7 +67,7 @@ Each function is installed as the handler for a specific HTTP resource, defined 
     :end-before: SNIPPET_END: install_record
     :dedent: 6
 
-This example installs at ``"LOG_record", HTTP_POST``, so will be invoked for requests beginning ``POST /users/LOG_record``.
+This example installs at ``"LOG_record", HTTP_POST``, so will be invoked for requests beginning ``POST /app/LOG_record``.
 
 The return value from ``make_endpoint`` is an ``Endpoint&`` object which can be used to alter how the handler is executed. For example, the handler for ``LOG_record`` shown above sets a `schema` for the handler, declaring the types of its request and response bodies. These will be used in calls to the ``/api/schema`` endpoint to generate JSON documents describing the API. Since this is the only handler installed for ``"LOG_record"`` only HTTP ``POST``s will be accepted for this URI - the framework will return a ``405 Method Not Allowed`` for requests with any other verb.
 

--- a/doc/members/accept_recovery.rst
+++ b/doc/members/accept_recovery.rst
@@ -21,16 +21,16 @@ A member proposes to recover the network and other members can vote on the propo
         }
     }
 
-    $ ./scurl.sh https://<ccf-node-address>/members/propose --cacert network_cert --key member1_privk --cert member1_cert --data-binary @accept_recovery.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/propose --cacert network_cert --key member1_privk --cert member1_cert --data-binary @accept_recovery.json -H "content-type: application/json"
     {
         "completed": false,
         "id": 1
     }
 
-    $ ./scurl.sh https://<ccf-node-address>/members/vote --cacert network_cert --key member2_privk --cert member2_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/vote --cacert network_cert --key member2_privk --cert member2_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
     false
 
-    $ ./scurl.sh https://<ccf-node-address>/members/vote --cacert network_cert --key member3_privk --cert member3_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/vote --cacert network_cert --key member3_privk --cert member3_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
     true
 
 Once the proposal to recover the network has passed under the rules of the :term:`Constitution`, the recovered service is ready for members to submit their recovery shares.

--- a/doc/members/adding_member.rst
+++ b/doc/members/adding_member.rst
@@ -43,7 +43,7 @@ First, the new member should update and retrieve the latest state digest via the
 
 .. code-block:: bash
 
-    $ curl https://<ccf-node-address>/members/ack/update_state_digest  --cacert networkcert.pem --key new_member_privk.pem --cert new_member_cert.pem
+    $ curl https://<ccf-node-address>/gov/ack/update_state_digest  --cacert networkcert.pem --key new_member_privk.pem --cert new_member_cert.pem
     {
         "state_digest": <...>
     }
@@ -53,7 +53,7 @@ Then, the new member should sign the state digest returned by the ``members/ack/
 
 .. code-block:: bash
 
-    $ ./scurl.sh https://<ccf-node-address>/members/ack  --cacert networkcert.pem --key new_member_privk.pem --cert new_member_cert.pem --header "Content-Type: application/json" --data-binary '{"state_digest": <...>}'
+    $ ./scurl.sh https://<ccf-node-address>/gov/ack  --cacert networkcert.pem --key new_member_privk.pem --cert new_member_cert.pem --header "Content-Type: application/json" --data-binary '{"state_digest": <...>}'
     true
 
 Once the command completes, the new member becomes active and can take part in governance operations (e.g. creating a new proposal or voting for an existing one).

--- a/doc/members/common_member_operations.rst
+++ b/doc/members/common_member_operations.rst
@@ -59,16 +59,16 @@ To limit the scope of key compromise, members of the consortium can refresh the 
         }
     }
 
-    $ ./scurl.sh https://<ccf-node-address>/members/propose --cacert network_cert --key member1_privk --cert member1_cert --data-binary @rekey_ledger.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/propose --cacert network_cert --key member1_privk --cert member1_cert --data-binary @rekey_ledger.json -H "content-type: application/json"
     {
         "completed": false,
         "id": 1
     }
 
-    $ ./scurl.sh https://<ccf-node-address>/members/vote --cacert network_cert --key member2_privk --cert member2_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/vote --cacert network_cert --key member2_privk --cert member2_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
     false
 
-    $ ./scurl.sh https://<ccf-node-address>/members/vote --cacert network_cert --key member3_privk --cert member3_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/vote --cacert network_cert --key member3_privk --cert member3_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
     true
 
 Once the proposal is accepted (``"result":true``), all subsequent transactions will be encrypted with a fresh new ledger encryption key.
@@ -92,16 +92,16 @@ The number of member shares required to restore the private ledger (``recovery_t
         }
     }
 
-    $ ./scurl.sh https://<ccf-node-address>/members/propose --cacert network_cert --key member1_privk --cert member1_cert --data-binary @set_recovery_threshold.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/propose --cacert network_cert --key member1_privk --cert member1_cert --data-binary @set_recovery_threshold.json -H "content-type: application/json"
     {
         "completed": false,
         "id": 1
     }
 
-    $ ./scurl.sh https://<ccf-node-address>/members/vote --cacert network_cert --key member2_privk --cert member2_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/vote --cacert network_cert --key member2_privk --cert member2_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
     false
 
-    $ ./scurl.sh https://<ccf-node-address>/members/vote --cacert network_cert --key member3_privk --cert member3_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/vote --cacert network_cert --key member3_privk --cert member3_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
     true
 
 .. note:: The new recovery threshold has to be in the range between 1 and the current number of active members.

--- a/doc/members/member_rpc_api.rst
+++ b/doc/members/member_rpc_api.rst
@@ -44,7 +44,7 @@ read
     :language: json
 
 ack/update_state_digest
---------------------
+-----------------------
 
 .. literalinclude:: ../schemas/ack/update_state_digest_result.json
     :language: json
@@ -66,13 +66,13 @@ withdraw
     :language: json
 
 recovery_share
--------------------------
+--------------
 
 .. literalinclude:: ../schemas/recovery_share_result.json
     :language: json
 
 recovery_share/submit
--------------------
+---------------------
 
 .. literalinclude:: ../schemas/recovery_share/submit_params.json
     :language: json

--- a/doc/members/open_network.rst
+++ b/doc/members/open_network.rst
@@ -53,11 +53,11 @@ Other members are then allowed to vote for the proposal, using the proposal id r
 
 The user is successfully added once a the proposal has received enough votes under the rules of the :term:`Constitution` (indicated by the response body ``true``).
 
-The user can then make user RPCs, for example ``whoAmI`` to retrieve the unique caller ID assigned to them by CCF:
+The user can then make user RPCs, for example ``user_id`` to retrieve the unique caller ID assigned to them by CCF:
 
 .. code-block:: bash
 
-    $ curl https://<ccf-node-address>/app/whoAmI --cacert network_cert --key new_user_privk --cert new_user_cert
+    $ curl https://<ccf-node-address>/app/user_id --cacert network_cert --key new_user_privk --cert new_user_cert
     {
         "caller_id": 4
     }

--- a/doc/members/open_network.rst
+++ b/doc/members/open_network.rst
@@ -19,7 +19,7 @@ Then, the certificates of trusted users should be registered in CCF via the memb
             "text": "tables, user_cert = ...; return Calls:call(\"new_user\", user_cert)"
     }
 
-    $ ./scurl.sh https://<ccf-node-address>/members/propose --cacert network_cert --key member0_privk --cert member0_cert --data-binary @add_user.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/propose --cacert network_cert --key member0_privk --cert member0_cert --data-binary @add_user.json -H "content-type: application/json"
     {
         "completed": false,
         "id": 5
@@ -37,7 +37,7 @@ Other members are then allowed to vote for the proposal, using the proposal id r
         "id": 5
     }
 
-    $ ./scurl.sh https://<ccf-node-address>/members/vote --cacert network_cert --key member1_privk --cert member1_cert --data-binary @vote_accept.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/vote --cacert network_cert --key member1_privk --cert member1_cert --data-binary @vote_accept.json -H "content-type: application/json"
     false
 
     $ cat vote_conditional.json
@@ -48,7 +48,7 @@ Other members are then allowed to vote for the proposal, using the proposal id r
         "id": 5
     }
 
-    $ ./scurl.sh https://<ccf-node-address>/members/vote --cacert network_cert --key member2_privk --cert member2_cert --data-binary @vote_conditional.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/vote --cacert network_cert --key member2_privk --cert member2_cert --data-binary @vote_conditional.json -H "content-type: application/json"
     true
 
 The user is successfully added once a the proposal has received enough votes under the rules of the :term:`Constitution` (indicated by the response body ``true``).
@@ -57,7 +57,7 @@ The user can then make user RPCs, for example ``whoAmI`` to retrieve the unique 
 
 .. code-block:: bash
 
-    $ curl https://<ccf-node-address>/users/whoAmI --cacert network_cert --key new_user_privk --cert new_user_cert
+    $ curl https://<ccf-node-address>/app/whoAmI --cacert network_cert --key new_user_privk --cert new_user_cert
     {
         "caller_id": 4
     }
@@ -79,7 +79,7 @@ Registering the Lua Application
         }
     }
 
-    $ ./scurl.sh https://<ccf-node-address>/members/propose --cacert network_cert --key member0_privk --cert member0_cert --data-binary @set_lua_app.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/propose --cacert network_cert --key member0_privk --cert member0_cert --data-binary @set_lua_app.json -H "content-type: application/json"
     {
         "completed": false,
         "id": 1
@@ -103,7 +103,7 @@ Once users are added to the opening network, members should decide to make a pro
         }
     }
 
-    $ ./scurl.sh https://<ccf-node-address>/members/propose --cacert network_cert --key member0_privk --cert member0_cert --data-binary @open_network.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/propose --cacert network_cert --key member0_privk --cert member0_cert --data-binary @open_network.json -H "content-type: application/json"
     {
         "completed": false,
         "id": 2

--- a/doc/members/proposals.rst
+++ b/doc/members/proposals.rst
@@ -26,7 +26,7 @@ For example, ``member1`` may submit a proposal to add a new member (``member4``)
         }
     }
 
-    $ ./scurl.sh https://<ccf-node-address>/members/propose --cacert network_cert --key member1_privk --cert member1_cert --data-binary @add_member.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/propose --cacert network_cert --key member1_privk --cert member1_cert --data-binary @add_member.json -H "content-type: application/json"
     {
       "completed": false,
       "id": 1
@@ -55,11 +55,11 @@ In this case, a new proposal with id ``1`` has successfully been created and the
     }
 
     // Member 2 rejects the proposal (votes: 1/3)
-    $ ./scurl.sh https://<ccf-node-address>/members/vote --cacert network_cert --key member2_privk --cert member2_cert --data-binary @vote_reject.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/vote --cacert network_cert --key member2_privk --cert member2_cert --data-binary @vote_reject.json -H "content-type: application/json"
     false
 
     // Member 3 accepts the proposal (votes: 2/3)
-    $ ./scurl.sh https://<ccf-node-address>/members/vote --cacert network_cert --key member3_privk --cert member3_cert --data-binary @vote_accept.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/vote --cacert network_cert --key member3_privk --cert member3_cert --data-binary @vote_accept.json -H "content-type: application/json"
     true
 
     // As a majority of members have accepted the proposal, member4 is added to the consortium
@@ -80,7 +80,7 @@ The details of pending proposals, including the proposer member id, proposal scr
       "text": "tables = ...; local proposals = {}; tables[\"ccf.proposals\"]:foreach( function(k, v) proposals[tostring(k)] = v; end ) return proposals;"
     }
 
-    $ ./scurl.sh https://<ccf-node-address>/members/query --cacert networkcert.pem --key member0_privk.pem --cert member0_cert.pem --data-binary @display_proposals.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/query --cacert networkcert.pem --key member0_privk.pem --cert member0_cert.pem --data-binary @display_proposals.json -H "content-type: application/json"
     {
       "1": {
         "parameter": [...],
@@ -119,7 +119,7 @@ At any stage during the voting process and before the proposal is completed, the
       "id": 0
     }
 
-    $ ./scurl.sh https://<ccf-node-address>/members/withdraw --cacert networkcert.pem --key member0_privk.pem --cert member0_cert.pem --data-binary @withdraw_0.json -H "content-type: application/json"
+    $ ./scurl.sh https://<ccf-node-address>/gov/withdraw --cacert networkcert.pem --key member0_privk.pem --cert member0_cert.pem --data-binary @withdraw_0.json -H "content-type: application/json"
     true
 
 This means future votes will be ignored, and the proposal will never be accepted. However it will remain visible as a proposal so members can easily audit historic proposals.

--- a/doc/schemas/user_id_params.json
+++ b/doc/schemas/user_id_params.json
@@ -13,6 +13,6 @@
   "required": [
     "cert"
   ],
-  "title": "who/params",
+  "title": "user_id/params",
   "type": "object"
 }

--- a/doc/schemas/user_id_result.json
+++ b/doc/schemas/user_id_result.json
@@ -10,6 +10,6 @@
   "required": [
     "caller_id"
   ],
-  "title": "who/result",
+  "title": "user_id/result",
   "type": "object"
 }

--- a/doc/users/issue_commands.rst
+++ b/doc/users/issue_commands.rst
@@ -15,7 +15,7 @@ For example, to record a message at a specific id with the :ref:`developers/exam
       "msg": "Hello There"
     }
 
-    $ curl https://<ccf-node-address>/users/LOG_record --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem --data-binary @request.json -H "content-type: application/json" -i
+    $ curl https://<ccf-node-address>/app/LOG_record --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem --data-binary @request.json -H "content-type: application/json" -i
     HTTP/1.1 200 OK
     content-length: 5
     content-type: application/json
@@ -54,7 +54,7 @@ To guarantee that their request is successfully committed to the ledger, a user 
 
 .. code-block:: bash
 
-    $ curl -X GET "https://<ccf-node-address>/users/tx?view=2&seqno=18" --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem -i
+    $ curl -X GET "https://<ccf-node-address>/app/tx?view=2&seqno=18" --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem -i
     HTTP/1.1 200 OK
     content-length: 23
     content-type: application/json
@@ -94,7 +94,7 @@ To obtain a receipt, a user needs to issue a ``getReceipt`` RPC for a particular
 
 .. code-block:: bash
 
-    $ curl -X GET "https://<ccf-node-address>/users/getReceipt?commit=23" --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem
+    $ curl -X GET "https://<ccf-node-address>/app/getReceipt?commit=23" --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem
     {
       "receipt": [ ... ],
     }
@@ -108,7 +108,7 @@ Receipts can be verified with the ``verifyReceipt`` RPC:
       "receipt": [ ... ]
     }
 
-    $ curl https://<ccf-node-address>/users/verifyReceipt --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem --data-binary @verify_receipt.json
+    $ curl https://<ccf-node-address>/app/verifyReceipt --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem --data-binary @verify_receipt.json
     {
       "valid": true,
     }

--- a/doc/users/rpc_api.rst
+++ b/doc/users/rpc_api.rst
@@ -7,7 +7,7 @@ The API can also be retrieved from a running service using the `api`_ and `api/s
 
 .. code-block:: bash
 
-    $ curl https://<ccf-node-address>/users/api --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem
+    $ curl https://<ccf-node-address>/app/api --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem
     {
       "methods": [
         "api",
@@ -28,7 +28,7 @@ The API can also be retrieved from a running service using the `api`_ and `api/s
       ]
     }
 
-    $ curl https://127.78.96.224:36363/nodes/api/schema?method="tx" -X GET --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem -H "Content-Type: application/json"
+    $ curl https://<ccf-node-address>/node/api/schema?method="tx" -X GET --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem -H "Content-Type: application/json"
     {
       "params_schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/samples/apps/txregulator/clients/loader.py
+++ b/samples/apps/txregulator/clients/loader.py
@@ -23,7 +23,7 @@ class AppUser:
         network.consortium.add_users(primary, [self.name])
 
         with primary.user_client(user_id=self.name) as client:
-            self.ccf_id = client.get("who").result["caller_id"]
+            self.ccf_id = client.get("user_id").result["caller_id"]
 
     def __str__(self):
         return f"{self.ccf_id} ({self.name})"

--- a/samples/apps/txregulator/tests/txregulatorclient.py
+++ b/samples/apps/txregulator/tests/txregulatorclient.py
@@ -23,7 +23,7 @@ class AppUser:
         network.consortium.add_users(primary, [self.name])
 
         with primary.user_client(user_id=self.name) as client:
-            self.ccf_id = client.get("who").result["caller_id"]
+            self.ccf_id = client.get("user_id").result["caller_id"]
 
     def __str__(self):
         return f"{self.ccf_id} ({self.name})"

--- a/samples/perf_client/perf_client.h
+++ b/samples/perf_client/perf_client.h
@@ -320,7 +320,7 @@ namespace client
         conn->create_key_pair(key);
       }
 
-      conn->set_prefix("users");
+      conn->set_prefix("app");
 
       // Report ciphersuite of first client (assume it is the same for each)
       if (is_first)

--- a/src/consensus/pbft/pbft_config.h
+++ b/src/consensus/pbft/pbft_config.h
@@ -178,7 +178,8 @@ namespace pbft
         }
 
         const auto& actor_s = actor_opt.value();
-        const auto actor = rpc_map->resolve(actor_s);
+        std::string preferred_actor_s;
+        const auto actor = rpc_map->resolve(actor_s, preferred_actor_s);
         auto handler = rpc_map->find(actor);
         if (!handler.has_value())
           throw std::logic_error(

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -103,8 +103,7 @@ namespace enclave
         {"users"}, ccfapp::get_rpc_handler(network, context));
 
       rpc_map->register_frontend<ccf::ActorsType::nodes>(
-        {"nodes"},
-        std::make_unique<ccf::NodeRpcFrontend>(network, *node));
+        {"nodes"}, std::make_unique<ccf::NodeRpcFrontend>(network, *node));
 
       for (auto& [actor, fe] : rpc_map->get_map())
       {

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -94,17 +94,17 @@ namespace enclave
         timers,
         share_manager);
 
-      REGISTER_FRONTEND(
-        rpc_map,
-        members,
+      rpc_map->register_frontend<ccf::ActorsType::members>(
+        {"members"},
         std::make_unique<ccf::MemberRpcFrontend>(
           network, *node, share_manager));
 
-      REGISTER_FRONTEND(
-        rpc_map, users, ccfapp::get_rpc_handler(network, context));
+      rpc_map->register_frontend<ccf::ActorsType::users>(
+        {"users"}, ccfapp::get_rpc_handler(network, context));
 
-      REGISTER_FRONTEND(
-        rpc_map, nodes, std::make_unique<ccf::NodeRpcFrontend>(network, *node));
+      rpc_map->register_frontend<ccf::ActorsType::nodes>(
+        {"nodes"},
+        std::make_unique<ccf::NodeRpcFrontend>(network, *node));
 
       for (auto& [actor, fe] : rpc_map->get_map())
       {

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -249,13 +249,37 @@ namespace http
         }
 
         const auto& actor_s = actor_opt.value();
-        auto actor = rpc_map->resolve(actor_s);
+        LOG_DEBUG_FMT("Processing {}", actor_s);
+        std::string preferred_actor_s;
+        auto actor = rpc_map->resolve(actor_s, preferred_actor_s);
+        LOG_DEBUG_FMT("Found preferred {}", preferred_actor_s);
         auto search = rpc_map->find(actor);
         if (actor == ccf::ActorsType::unknown || !search.has_value())
         {
           send_raw(rpc_ctx->serialise_error(
             HTTP_STATUS_NOT_FOUND,
             fmt::format("Unknown session '{}'.\n", actor_s)));
+          return;
+        }
+
+        if (actor_s != preferred_actor_s)
+        {
+          auto response = http::Response(HTTP_STATUS_PERMANENT_REDIRECT);
+
+          const auto body = fmt::format(
+            "'{}' is deprecated. Please use '{}' instead",
+            actor_s,
+            preferred_actor_s);
+          response.set_header(
+            http::headers::CONTENT_TYPE, http::headervalues::contenttype::TEXT);
+          response.set_body((const uint8_t*)body.data(), body.size());
+
+          auto redirect_url =
+            fmt::format("/{}/{}", preferred_actor_s, rpc_ctx->get_method());
+          response.set_header(http::headers::LOCATION, redirect_url);
+
+          LOG_DEBUG_FMT("Redirecting from deprected '{}' to '{}'", actor_s, redirect_url);
+          send_raw(response.build_response());
           return;
         }
 

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -249,10 +249,8 @@ namespace http
         }
 
         const auto& actor_s = actor_opt.value();
-        LOG_DEBUG_FMT("Processing {}", actor_s);
         std::string preferred_actor_s;
         auto actor = rpc_map->resolve(actor_s, preferred_actor_s);
-        LOG_DEBUG_FMT("Found preferred {}", preferred_actor_s);
         auto search = rpc_map->find(actor);
         if (actor == ccf::ActorsType::unknown || !search.has_value())
         {

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -276,7 +276,8 @@ namespace http
             fmt::format("/{}/{}", preferred_actor_s, rpc_ctx->get_method());
           response.set_header(http::headers::LOCATION, redirect_url);
 
-          LOG_DEBUG_FMT("Redirecting from deprecated '{}' to '{}'", actor_s, redirect_url);
+          LOG_DEBUG_FMT(
+            "Redirecting from deprecated '{}' to '{}'", actor_s, redirect_url);
           send_raw(response.build_response());
           return;
         }

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -276,7 +276,7 @@ namespace http
             fmt::format("/{}/{}", preferred_actor_s, rpc_ctx->get_method());
           response.set_header(http::headers::LOCATION, redirect_url);
 
-          LOG_DEBUG_FMT("Redirecting from deprected '{}' to '{}'", actor_s, redirect_url);
+          LOG_DEBUG_FMT("Redirecting from deprecated '{}' to '{}'", actor_s, redirect_url);
           send_raw(response.build_response());
           return;
         }

--- a/src/node/entities.h
+++ b/src/node/entities.h
@@ -26,13 +26,6 @@ namespace ccf
   static constexpr size_t CODE_DIGEST_BYTES = 256 / 8;
   using CodeDigest = std::array<uint8_t, CODE_DIGEST_BYTES>;
 
-  struct Actors
-  {
-    static constexpr auto MEMBERS = "members";
-    static constexpr auto USERS = "users";
-    static constexpr auto NODES = "nodes";
-  };
-
   enum class ActorsType : uint64_t
   {
     members = 0,
@@ -41,6 +34,29 @@ namespace ccf
     // not to be used
     unknown
   };
+  
+  constexpr auto get_actor_prefix(ActorsType at)
+  {
+    switch (at)
+    {
+      case ActorsType::members:
+      {
+        return "gov";
+      }
+      case ActorsType::users:
+      {
+        return "app";
+      }
+      case ActorsType::nodes:
+      {
+        return "node";
+      }
+      default:
+      {
+        return "";
+      }
+    }
+  }
 
   struct Tables
   {

--- a/src/node/entities.h
+++ b/src/node/entities.h
@@ -34,7 +34,7 @@ namespace ccf
     // not to be used
     unknown
   };
-  
+
   constexpr auto get_actor_prefix(ActorsType at)
   {
     switch (at)

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -502,7 +502,8 @@ namespace ccf
 
       const auto body = jsonrpc::pack(join_params, jsonrpc::Pack::Text);
 
-      http::Request r(fmt::format("/{}/{}", ccf::Actors::NODES, "join"));
+      http::Request r(fmt::format(
+        "/{}/{}", ccf::get_actor_prefix(ccf::ActorsType::nodes), "join"));
       r.set_header(
         http::headers::CONTENT_TYPE, http::headervalues::contenttype::JSON);
       r.set_body(&body);
@@ -1181,8 +1182,8 @@ namespace ccf
 
       const auto body = jsonrpc::pack(create_params, jsonrpc::Pack::Text);
 
-      http::Request request(
-        fmt::format("/{}/{}", ccf::Actors::MEMBERS, "create"));
+      http::Request request(fmt::format(
+        "/{}/{}", ccf::get_actor_prefix(ccf::ActorsType::members), "create"));
       request.set_header(
         http::headers::CONTENT_TYPE, http::headervalues::contenttype::JSON);
 
@@ -1252,7 +1253,9 @@ namespace ccf
         throw std::logic_error("Unable to get actor for create request");
       }
 
-      const auto actor = rpc_map->resolve(actor_opt.value());
+      std::string preferred_actor_name;
+      const auto actor =
+        rpc_map->resolve(actor_opt.value(), preferred_actor_name);
       auto frontend_opt = this->rpc_map->find(actor);
       if (!frontend_opt.has_value())
       {

--- a/src/node/rpc/call_types.h
+++ b/src/node/rpc/call_types.h
@@ -86,12 +86,7 @@ namespace ccf
     CallerId caller_id;
   };
 
-  struct WhoAmI
-  {
-    using Out = CallerInfo;
-  };
-
-  struct WhoIs
+  struct GetUserId
   {
     struct In
     {

--- a/src/node/rpc/common_endpoint_registry.h
+++ b/src/node/rpc/common_endpoint_registry.h
@@ -111,19 +111,19 @@ namespace ccf
 
       if (certs != nullptr)
       {
-        auto who = [this](auto& args, nlohmann::json&& params) {
+        auto user_id = [this](auto& args, nlohmann::json&& params) {
           if (certs == nullptr)
           {
             return make_error(
               HTTP_STATUS_INTERNAL_SERVER_ERROR,
-              "This frontend does not support 'who'");
+              "This frontend does not support 'user_id'");
           }
 
           auto caller_id = args.caller_id;
 
           if (!params.is_null())
           {
-            const WhoIs::In in = params;
+            const GetUserId::In in = params;
             auto certs_view = args.tx.get_read_only_view(*certs);
             auto caller_id_opt = certs_view->get(in.cert);
 
@@ -136,10 +136,11 @@ namespace ccf
             caller_id = caller_id_opt.value();
           }
 
-          return make_success(WhoAmI::Out{caller_id});
+          return make_success(GetUserId::Out{caller_id});
         };
-        make_read_only_endpoint("who", HTTP_GET, json_read_only_adapter(who))
-          .set_auto_schema<WhoIs::In, WhoAmI::Out>()
+        make_read_only_endpoint(
+          "user_id", HTTP_GET, json_read_only_adapter(user_id))
+          .set_auto_schema<GetUserId::In, GetUserId::Out>()
           .install();
       }
 

--- a/src/node/rpc/endpoint_registry.h
+++ b/src/node/rpc/endpoint_registry.h
@@ -261,10 +261,6 @@ namespace ccf
 
       http_method verb = HTTP_POST;
 
-      /** Indicates which HTTP verb the endpoint should respond to.
-       *
-       * @return This Endpoint for further modification
-       */
       CCF_DEPRECATED(
         "HTTP Verb should not be changed after installation: pass verb to "
         "install()")
@@ -274,10 +270,6 @@ namespace ccf
         return registry->reinstall(*this, method, previous_verb);
       }
 
-      /** Indicates that the endpoint is only accessible via the GET HTTP verb.
-       *
-       * @return This Endpoint for further modification
-       */
       CCF_DEPRECATED(
         "HTTP Verb should not be changed after installation: use "
         "install(...HTTP_GET...)")
@@ -286,10 +278,6 @@ namespace ccf
         return set_allowed_verb(HTTP_GET);
       }
 
-      /** Indicates that the endpoint is only accessible via the POST HTTP verb.
-       *
-       * @return This Endpoint for further modification
-       */
       CCF_DEPRECATED(
         "HTTP Verb should not be changed after installation: use "
         "install(...HTTP_POST...)")

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -204,7 +204,8 @@ namespace ccf
             }
 
             const auto& actor_s = actor_opt.value();
-            auto actor = rpc_map->resolve(actor_s);
+            std::string preferred_actor_s;
+            auto actor = rpc_map->resolve(actor_s, preferred_actor_s);
             auto handler = rpc_map->find(actor);
             if (actor == ccf::ActorsType::unknown || !handler.has_value())
             {

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -98,8 +98,8 @@ namespace ccf
   DECLARE_JSON_TYPE(CallerInfo)
   DECLARE_JSON_REQUIRED_FIELDS(CallerInfo, caller_id)
 
-  DECLARE_JSON_TYPE(WhoIs::In)
-  DECLARE_JSON_REQUIRED_FIELDS(WhoIs::In, cert)
+  DECLARE_JSON_TYPE(GetUserId::In)
+  DECLARE_JSON_REQUIRED_FIELDS(GetUserId::In, cert)
 
   DECLARE_JSON_TYPE(ListMethods::Out)
   DECLARE_JSON_REQUIRED_FIELDS(ListMethods::Out, methods)

--- a/tests/governance_history.py
+++ b/tests/governance_history.py
@@ -37,11 +37,11 @@ def count_governance_operations(ledger):
                 request_body = signed_request[0][2]
                 digest = signed_request[0][3]
                 infra.crypto.verify_request_sig(cert, sig, req, request_body, digest)
-                if "members/propose" in req.decode():
+                if "gov/propose" in req.decode():
                     verified_proposals += 1
-                elif "members/vote" in req.decode():
+                elif "gov/vote" in req.decode():
                     verified_votes += 1
-                elif "members/withdraw" in req.decode():
+                elif "gov/withdraw" in req.decode():
                     verified_withdrawals += 1
 
     return (verified_proposals, verified_votes, verified_withdrawals)

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -252,7 +252,7 @@ class Node:
             key=os.path.join(self.common_dir, f"user{user_id}_privk.pem"),
             ca=os.path.join(self.common_dir, "networkcert.pem"),
             description=f"node {self.node_id} (user {user_id})",
-            prefix="users",
+            prefix="app",
             binary_dir=self.binary_dir,
             **kwargs,
         )
@@ -265,7 +265,7 @@ class Node:
             key=None,
             ca=os.path.join(self.common_dir, "networkcert.pem"),
             description=f"node {self.node_id} (node)",
-            prefix="nodes",
+            prefix="node",
             binary_dir=self.binary_dir,
             **kwargs,
         )
@@ -278,7 +278,7 @@ class Node:
             key=os.path.join(self.common_dir, f"member{member_id}_privk.pem"),
             ca=os.path.join(self.common_dir, "networkcert.pem"),
             description=f"node {self.node_id} (member {member_id})",
-            prefix="members",
+            prefix="gov",
             binary_dir=self.binary_dir,
             **kwargs,
         )

--- a/tests/submit_recovery_share.sh
+++ b/tests/submit_recovery_share.sh
@@ -58,7 +58,7 @@ if [ -z "$network_enc_pubk" ]; then
 fi
 
 # Retrieve encrypted recovery share and nonce
-resp=$(curl -sS --fail -X GET https://"${node_rpc_address}"/members/recovery_share "${@}")
+resp=$(curl -sS --fail -X GET https://"${node_rpc_address}"/gov/recovery_share "${@}")
 encrypted_share="$(echo "${resp}" | jq -r .encrypted_recovery_share)"
 nonce="$(echo "${resp}" | jq -r .nonce)"
 
@@ -82,4 +82,4 @@ encrypted_share_b64_url=$(echo "${encrypted_share}" | sed 's/+/-/g; s/\//_/g')
 
 # Decrypt encrypted share with nonce, member private key and defunct network public key and submit share
 # All in one line so that the recovery share is not exposed
-echo "${encrypted_share_b64_url}" | step crypto nacl box open base64:"${nonce}" "${tmp_dir}/network_enc_pubk.raw" "${tmp_dir}/member_enc_privk.raw" | openssl base64 -A | curl -i -sS --fail https://"${node_rpc_address}"/members/recovery_share/submit "${@}" -d @-
+echo "${encrypted_share_b64_url}" | step crypto nacl box open base64:"${nonce}" "${tmp_dir}/network_enc_pubk.raw" "${tmp_dir}/member_enc_privk.raw" | openssl base64 -A | curl -i -sS --fail https://"${node_rpc_address}"/gov/recovery_share/submit "${@}" -d @-


### PR DESCRIPTION
Fixes #1322.

Renames:
- `/users` => `/app`
- `/members` => `/gov`
- `/nodes` => `/node`

If the old names are used, returns a `308 Permanent Redirect` response pointing to the new prefix. We only do this check on the first node, which I think is safe? Perhaps a mismatch (between "what prefix did they give me" and "what prefix would I like to see") in the pbft or forwarded cases should be an error?