### PR TITLE
Correct language statistics via linguist gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,7 @@
 *.pdf binary
 *.png binary
 *.jpg binary
+
+*.h linguist-language=C++
+*.cpp linguist-language=C++
+


### PR DESCRIPTION
An odd diversion. This is wrong:
![image](https://user-images.githubusercontent.com/6000239/85411918-e44d9900-b560-11ea-95b6-2f1b0927c81f.png)

[This](https://github.com/github/linguist#overrides) is the system that builds this, and how it is overridden.

Before:
```
$ github-linguist --breakdown
83.44%  C++
11.33%  Python
2.34%   CMake
1.32%   Objective-C
0.73%   Shell
0.48%   Lua
0.22%   C
0.10%   XSLT
0.03%   JavaScript

...
C:
src/consensus/pbft/libbyz/bits.h
src/consensus/pbft/libbyz/ledger.h
src/consensus/pbft/libbyz/partition.h
src/consensus/pbft/libbyz/time_types.h
src/enclave/consensus_type.h
src/kv/kv_serialiser.h
src/tls/random_bytes.h
src/tls/tls.h

Objective-C:
src/ds/ccf_deprecated.h
src/ds/test/siphash_known_hashes.h
...
```

After:
```
$ github-linguist 
85.03%  C++
11.28%  Python
2.36%   CMake
0.73%   Shell
0.47%   Lua
0.10%   XSLT
0.03%   JavaScript
```
