### PR TITLE
Add docs on custom KV serialisers

### DIFF
--- a/doc/developers/kv/api.rst
+++ b/doc/developers/kv/api.rst
@@ -3,7 +3,7 @@ Key-Value Store API
 
 This page presents the API that a CCF application must use to read and mutate the replicated key-value store.
 
-A CCF application should define one or multiple public or private :cpp:class:`kv::Map`. Then, each :cpp:class:`ccf::EndpointRegistry::Endpoint` should use the :cpp:class:`kv::Tx` transaction object to read and write to specific :cpp:class:`kv::Map`.
+A CCF application should define one or multiple public or private :cpp:type:`kv::Map`. Then, each :cpp:class:`ccf::EndpointRegistry::Endpoint` should use the :cpp:class:`kv::Tx` transaction object to read and write to specific :cpp:type:`kv::Map`.
 
 Store
 -----
@@ -25,7 +25,7 @@ Map
    :project: CCF
    :members: get_name, set_global_hook
 
-.. doxygenclass:: kv::Map
+.. doxygentypedef:: kv::Map
    :project: CCF
 
 Transaction

--- a/doc/developers/kv/api.rst
+++ b/doc/developers/kv/api.rst
@@ -21,20 +21,27 @@ Map
 .. doxygenvariable:: kv::NoVersion
    :project: CCF
 
-.. doxygenclass:: kv::Map
+.. doxygenclass:: kv::TypedMap
    :project: CCF
    :members: get_name, set_global_hook
+
+.. doxygenclass:: kv::Map
+   :project: CCF
 
 Transaction
 -----------
 
+.. doxygenclass:: kv::ReadOnlyTx
+   :project: CCF
+   :members: get_read_only_view
+
 .. doxygenclass:: kv::Tx
    :project: CCF
-   :members: get_view,
+   :members: get_view
 
 Transaction View
 ----------------
 
-.. doxygenclass:: kv::Map::TxView
+.. doxygenclass:: kv::TxView
    :project: CCF
    :members: get, put, remove, foreach

--- a/doc/developers/kv/kv_how_to.rst
+++ b/doc/developers/kv/kv_how_to.rst
@@ -139,32 +139,6 @@ The :cpp:class:`kv::Map::TxView::get_globally_committed` member function returns
 Miscellaneous
 -------------
 
-Custom key and value types
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-User-defined types can be used for both the key and value types of a :cpp:class:`kv::Map`. It must be possible to user the key type as the key of an ``std::map`` (so it must be copyable, assignable, and less-comparable), and both types must be serialisable. By default, when using a :cpp:class:`kv::Map`, serialisation converts to `MessagePack`_ using `msgpack-c`_. To add support to your custom types, it should usually be possible to use the ``MSGPACK_DEFINE`` macro:
-
-.. literalinclude:: ../../../src/kv/test/kv_serialisation.cpp
-    :language: cpp
-    :start-after: SNIPPET_START: CustomClass definition
-    :end-before: SNIPPET_END: CustomClass definition
-
-Custom serialisers can also be defined. The serialiser itself must be a type implementing ``to_serialised`` and ``from_serialised`` functions for the target type:
-
-.. literalinclude:: ../../../src/kv/test/kv_serialisation.cpp
-    :language: cpp
-    :start-after: SNIPPET_START: CustomSerialiser definition
-    :end-before: SNIPPET_END: CustomSerialiser definition
-
-To use these serialised for a specific map declare the map as a :cpp:class:`kv::TypedMap`, adding the appropriate serialiser types for the key and value types:
-
-.. literalinclude:: ../../../src/kv/test/kv_serialisation.cpp
-    :language: cpp
-    :start-after: SNIPPET_START: CustomSerialisedMap definition
-    :end-before: SNIPPET_END: CustomSerialisedMap definition
-
-.. note:: Any external tools which wish to parse the ledger will need to know the serialisation format of the tables they care about. It is recommended, though not enforced, that you size-prefix each entry so it can be skipped by tools which do not understand the serialised format.
-
 ``foreach()``
 ~~~~~~~~~~~~~
 
@@ -210,5 +184,3 @@ By default CCF decides which transactions are successful (so should be applied t
      // Apply this, even though it has an error response
     args.rpc_ctx->set_apply_writes(true);
 
-.. _MessagePack: https://msgpack.org/
-.. _msgpack-c: https://github.com/msgpack/msgpack-c

--- a/doc/developers/kv/kv_how_to.rst
+++ b/doc/developers/kv/kv_how_to.rst
@@ -142,35 +142,28 @@ Miscellaneous
 Custom key and value types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-User-defined types can also be used for the types of the key and value mapping of each :cpp:class:`kv::Map`. When defining each custom type, the following conditions must be met:
+User-defined types can be used for both the key and value types of a :cpp:class:`kv::Map`. It must be possible to user the key type as the key of an ``std::map`` (so it must be copyable, assignable, and less-comparable), and both types must be serialisable. By default, when using a :cpp:class:`kv::Map`, serialisation converts to `MessagePack`_ using `msgpack-c`_. To add support to your custom types, it should usually be possible to use the ``MSGPACK_DEFINE`` macro:
 
-- For both the custom key and value types, the ``MSGPACK_DEFINE();`` macro should be used to declare each member of the custom type for serialisation.
-- For the custom key type, the ``==`` operator should be defined.
+.. literalinclude:: ../../src/kv/test/kv_serialisation.cpp
+    :language: cpp
+    :start-after: SNIPPET_START: CustomClass definition
+    :end-before: SNIPPET_END: CustomClass definition
 
-.. code-block:: cpp
+Custom serialisers can also be defined. The serialiser itself must be a type implementing ``to_serialised`` and ``from_serialised`` functions for the target type:
 
-    struct CustomKey
-    {
-        uint64_t id;
-        std::string name;
+.. literalinclude:: ../../src/kv/test/kv_serialisation.cpp
+    :language: cpp
+    :start-after: SNIPPET_START: CustomSerialiser definition
+    :end-before: SNIPPET_END: CustomSerialiser definition
 
-        bool operator==(const CustomKey& other) const
-        {
-            return id == other.id && name == other.name;
-        }
+To use these serialised for a specific map declare the map as a :cpp:class:`kv::TypedMap`, adding the appropriate serialiser types for the key and value types:
 
-        MSGPACK_DEFINE(id, name);
-    };
+.. literalinclude:: ../../src/kv/test/kv_serialisation.cpp
+    :language: cpp
+    :start-after: SNIPPET_START: CustomSerialisedMap definition
+    :end-before: SNIPPET_END: CustomSerialisedMap definition
 
-    struct CustomValue
-    {
-        uint64_t value;
-        std::string name;
-
-        MSGPACK_DEFINE(value, name);
-    };
-
-    auto& map = tables.create<CustomKey, CustomValue>("map");
+.. note:: Any external tools which wish to parse the ledger will need to know the serialisation format of the tables they care about. It is recommended, though not enforced, that you size-prefix each entry so it can be skipped by tools which do not understand the serialised format.
 
 ``foreach()``
 ~~~~~~~~~~~~~
@@ -216,3 +209,6 @@ By default CCF decides which transactions are successful (so should be applied t
 
      // Apply this, even though it has an error response
     args.rpc_ctx->set_apply_writes(true);
+
+.. _MessagePack: https://msgpack.org/
+.. _msgpack-c: https://github.com/msgpack/msgpack-c

--- a/doc/developers/kv/kv_how_to.rst
+++ b/doc/developers/kv/kv_how_to.rst
@@ -144,21 +144,21 @@ Custom key and value types
 
 User-defined types can be used for both the key and value types of a :cpp:class:`kv::Map`. It must be possible to user the key type as the key of an ``std::map`` (so it must be copyable, assignable, and less-comparable), and both types must be serialisable. By default, when using a :cpp:class:`kv::Map`, serialisation converts to `MessagePack`_ using `msgpack-c`_. To add support to your custom types, it should usually be possible to use the ``MSGPACK_DEFINE`` macro:
 
-.. literalinclude:: ../../src/kv/test/kv_serialisation.cpp
+.. literalinclude:: ../../../src/kv/test/kv_serialisation.cpp
     :language: cpp
     :start-after: SNIPPET_START: CustomClass definition
     :end-before: SNIPPET_END: CustomClass definition
 
 Custom serialisers can also be defined. The serialiser itself must be a type implementing ``to_serialised`` and ``from_serialised`` functions for the target type:
 
-.. literalinclude:: ../../src/kv/test/kv_serialisation.cpp
+.. literalinclude:: ../../../src/kv/test/kv_serialisation.cpp
     :language: cpp
     :start-after: SNIPPET_START: CustomSerialiser definition
     :end-before: SNIPPET_END: CustomSerialiser definition
 
 To use these serialised for a specific map declare the map as a :cpp:class:`kv::TypedMap`, adding the appropriate serialiser types for the key and value types:
 
-.. literalinclude:: ../../src/kv/test/kv_serialisation.cpp
+.. literalinclude:: ../../../src/kv/test/kv_serialisation.cpp
     :language: cpp
     :start-after: SNIPPET_START: CustomSerialisedMap definition
     :end-before: SNIPPET_END: CustomSerialisedMap definition

--- a/doc/developers/kv/kv_serialisation.rst
+++ b/doc/developers/kv/kv_serialisation.rst
@@ -57,5 +57,3 @@ The following table describes the structure of a serialised KV Store transaction
 | | Private| **Optional**                                                                                                       |
 | | Domain | | Encrypted serialised private domain blob.                                                                        |
 +----------+--------------------------------------------------------------------------------------------------------------------+
-
-.. _MessagePack: https://github.com/msgpack/msgpack-c

--- a/doc/developers/kv/kv_serialisation.rst
+++ b/doc/developers/kv/kv_serialisation.rst
@@ -3,12 +3,12 @@ KV Serialisation
 
 Every transaction executed by the primary on its key-value store is serialised before being replicated to all backups of the CCF network and written to the ledger.
 
-Transactions on private :cpp:class:`kv::Map` are encrypted before being serialised while transactions on public :cpp:class:`kv::Map` are only integrity-protected and readable by anyone with access to the ledger.
+Writes to private :cpp:class:`kv::Map`\s are encrypted before being serialised, and can only be decrypted by other nodes within the service. Writes to public :cpp:class:`kv::Map`\s are only integrity-protected; they are readable by anyone with access to the ledger.
 
 .. note:: Transactions are serialised to MessagePack_ with a prepended header for integrity protection.
 
-Serialised Format
------------------
+Serialised Transaction Format
+-----------------------------
 
 The ledger is stored as a series of a 4 byte transaction length field followed by a transaction.
 
@@ -58,4 +58,31 @@ The following table describes the structure of a serialised KV Store transaction
 | | Domain | | Encrypted serialised private domain blob.                                                                        |
 +----------+--------------------------------------------------------------------------------------------------------------------+
 
+Custom key and value types
+--------------------------
+
+User-defined types can be used for both the key and value types of a :cpp:class:`kv::Map`. It must be possible to use the key type as the key of an ``std::map`` (so it must be copyable, assignable, and less-comparable), and both types must be serialisable. By default, when using a :cpp:class:`kv::Map`, serialisation converts to `MessagePack`_ using `msgpack-c`_. To add support to your custom types, it should usually be possible to use the ``MSGPACK_DEFINE`` macro:
+
+.. literalinclude:: ../../../src/kv/test/kv_serialisation.cpp
+    :language: cpp
+    :start-after: SNIPPET_START: CustomClass definition
+    :end-before: SNIPPET_END: CustomClass definition
+
+Custom serialisers can also be defined. The serialiser itself must be a type implementing ``to_serialised`` and ``from_serialised`` functions for the target type:
+
+.. literalinclude:: ../../../src/kv/test/kv_serialisation.cpp
+    :language: cpp
+    :start-after: SNIPPET_START: CustomSerialiser definition
+    :end-before: SNIPPET_END: CustomSerialiser definition
+
+To use these serialised for a specific map declare the map as a :cpp:class:`kv::TypedMap`, adding the appropriate serialiser types for the key and value types:
+
+.. literalinclude:: ../../../src/kv/test/kv_serialisation.cpp
+    :language: cpp
+    :start-after: SNIPPET_START: CustomSerialisedMap definition
+    :end-before: SNIPPET_END: CustomSerialisedMap definition
+
+.. note:: Any external tools which wish to parse the ledger will need to know the serialisation format of the tables they care about. It is recommended, though not enforced, that you size-prefix each entry so it can be skipped by tools which do not understand the serialised format.
+
 .. _MessagePack: https://msgpack.org/
+.. _msgpack-c: https://github.com/msgpack/msgpack-c

--- a/doc/developers/kv/kv_serialisation.rst
+++ b/doc/developers/kv/kv_serialisation.rst
@@ -5,7 +5,7 @@ Every transaction executed by the primary on its key-value store is serialised b
 
 Transactions on private :cpp:class:`kv::Map` are encrypted before being serialised while transactions on public :cpp:class:`kv::Map` are only integrity-protected and readable by anyone with access to the ledger.
 
-.. note:: Transactions are serialised using MessagePack_ and to which is prepended a header for integrity protection.
+.. note:: Transactions are serialised to MessagePack_ with a prepended header for integrity protection.
 
 Serialised Format
 -----------------
@@ -57,3 +57,5 @@ The following table describes the structure of a serialised KV Store transaction
 | | Private| **Optional**                                                                                                       |
 | | Domain | | Encrypted serialised private domain blob.                                                                        |
 +----------+--------------------------------------------------------------------------------------------------------------------+
+
+.. _MessagePack: https://msgpack.org/

--- a/doc/developers/kv/kv_serialisation.rst
+++ b/doc/developers/kv/kv_serialisation.rst
@@ -3,7 +3,7 @@ KV Serialisation
 
 Every transaction executed by the primary on its key-value store is serialised before being replicated to all backups of the CCF network and written to the ledger.
 
-Writes to private :cpp:class:`kv::Map`\s are encrypted before being serialised, and can only be decrypted by other nodes within the service. Writes to public :cpp:class:`kv::Map`\s are only integrity-protected; they are readable by anyone with access to the ledger.
+Writes to private :cpp:class:`kv::Map`\s are encrypted before being written to the ledger, and can only be decrypted by other nodes within the service. Writes to public :cpp:class:`kv::Map`\s are only integrity-protected; they are readable by anyone with access to the ledger.
 
 .. note:: Transactions are serialised to MessagePack_ with a prepended header for integrity protection.
 

--- a/doc/developers/ledger.rst
+++ b/doc/developers/ledger.rst
@@ -14,7 +14,7 @@ When a transaction is committed, each affected ``Store::Map`` is serialised in d
 
 Ledger entries are integrity-protected and encrypted using a symmetric key shared by all trusted nodes (see :ref:`developers/cryptography:Algorithms and Curves`). This key is kept secure inside each enclave. See :ref:`members/common_member_operations:Rekeying Ledger` for details on how members can rotate the ledger encryption key.
 
-Note that even if a transaction only affects a private ``Store::Map``, unencrypted information such as the version number is always present in the serialised entry. More information about the ledger entry format is available in the :ref:`developers/kv/kv_serialisation:Serialised Format` section.
+Note that even if a transaction only affects a private ``Store::Map``, unencrypted information such as the version number is always present in the serialised entry. More information about the ledger entry format is available in the :ref:`developers/kv/kv_serialisation:Serialised Transaction Format` section.
 
 Ledger Replication
 ------------------

--- a/src/kv/map.h
+++ b/src/kv/map.h
@@ -215,8 +215,9 @@ namespace kv
   using MsgPackSerialisedMap =
     MapSerialisedWith<K, V, kv::serialisers::MsgPackSerialiser>;
 
-  // The default kv::Map will use msgpack serialisers. Custom types are
-  // supported through the MSGPACK_DEFINE macro
+  /** Short name for default-serialised maps, using msgpack serialisers. Support
+   * for custom types can be added through the MSGPACK_DEFINE macro
+   */
   template <typename K, typename V>
   using Map = MsgPackSerialisedMap<K, V>;
 }

--- a/src/kv/test/kv_serialisation.cpp
+++ b/src/kv/test/kv_serialisation.cpp
@@ -341,7 +341,7 @@ struct CustomVerboseDumbSerialiser
 
 using DefaultSerialisedMap = kv::Map<CustomClass, CustomClass>;
 
-// SNIPPET_END: CustomSerialisedMap definition
+// SNIPPET_START: CustomSerialisedMap definition
 using CustomSerialisedMap =
   kv::TypedMap<CustomClass, CustomClass, CustomSerialiser, CustomSerialiser>;
 // SNIPPET_END: CustomSerialisedMap definition


### PR DESCRIPTION
Moved from `kv_how_to` to `kv_serialisation`, added current detail with snippets from unit test.

Fixes #531. 