### PR TITLE
Update container dependencies

### DIFF
--- a/getting_started/setup_vm/app-dev.yml
+++ b/getting_started/setup_vm/app-dev.yml
@@ -12,6 +12,9 @@
         name: az_dcap
         tasks_from: install.yml
     - import_role:
+        name: llvm_repo
+        tasks_from: install.yml
+    - import_role:
         name: ccf_run
         tasks_from: install.yml
     - import_role:

--- a/getting_started/setup_vm/app-run.yml
+++ b/getting_started/setup_vm/app-run.yml
@@ -9,6 +9,9 @@
         name: az_dcap
         tasks_from: install.yml
     - import_role:
+        name: llvm_repo
+        tasks_from: install.yml
+    - import_role:
         name: ccf_run
         tasks_from: install.yml
     - import_role:

--- a/getting_started/setup_vm/ccf-dev.yml
+++ b/getting_started/setup_vm/ccf-dev.yml
@@ -13,6 +13,9 @@
         name: openenclave
         tasks_from: install.yml
     - import_role:
+        name: llvm_repo
+        tasks_from: install.yml
+    - import_role:
         name: ccf_run
         tasks_from: install.yml
     - import_role:

--- a/getting_started/setup_vm/roles/ccf_build/tasks/install.yml
+++ b/getting_started/setup_vm/roles/ccf_build/tasks/install.yml
@@ -6,19 +6,6 @@
     repo: ppa:deadsnakes/ppa
   become: true
 
-- name: Add LLVM repository key
-  apt_key:
-    url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
-    state: present
-  become: yes
-
-- name: Add LLVM repository
-  apt_repository:
-    repo: "deb http://apt.llvm.org/{{ ansible_distribution_release }} llvm-toolchain-{{ ansible_distribution_release }}-8 main"
-    state: present
-    update_cache: yes
-  become: yes
-
 - name: Add CMake repository key
   apt_key:
     url: "https://apt.kitware.com/keys/kitware-archive-latest.asc"

--- a/getting_started/setup_vm/roles/ccf_build/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_build/vars/common.yml
@@ -9,6 +9,7 @@ debs:
   - python3.7-venv
   - llvm-8
   - clang-8
+  - clang-format8
   - expect
   - xsltproc
   - git

--- a/getting_started/setup_vm/roles/ccf_build/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_build/vars/common.yml
@@ -9,7 +9,7 @@ debs:
   - python3.7-venv
   - llvm-8
   - clang-8
-  - clang-format8
+  - clang-format-8
   - expect
   - xsltproc
   - git

--- a/getting_started/setup_vm/roles/ccf_run/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_run/vars/common.yml
@@ -1,4 +1,6 @@
 workspace: "/tmp/"
 debs:
+  - libc++abi1
+  - libc++1
   - libuv1
   - libcurl4

--- a/getting_started/setup_vm/roles/llvm_repo/tasks/install.yml
+++ b/getting_started/setup_vm/roles/llvm_repo/tasks/install.yml
@@ -1,0 +1,15 @@
+- name: Include vars
+  include_vars: common.yml
+
+- name: Add LLVM repository key
+  apt_key:
+    url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
+    state: present
+  become: yes
+
+- name: Add LLVM repository
+  apt_repository:
+    repo: "deb http://apt.llvm.org/{{ ansible_distribution_release }} llvm-toolchain-{{ ansible_distribution_release }}-{{ llvm_version }} main"
+    state: present
+    update_cache: yes
+  become: yes

--- a/getting_started/setup_vm/roles/llvm_repo/vars/common.yml
+++ b/getting_started/setup_vm/roles/llvm_repo/vars/common.yml
@@ -1,0 +1,1 @@
+llvm_version: 8


### PR DESCRIPTION
Recent run containers are missing libc++ and libc++abi, this is adding them explicitly.

Also adding clang-format as a convenience in ccf_build/ccf-app-ci, not strictly required but quite useful when building native apps, and consistent with our inclusion of tools serving similar purposes such as doxygen.

```
root@c4a0ab881a02:/# /usr/bin/cchost -v
CCF host: ccf-0.11.1
root@c4a0ab881a02:/# ldd /usr/bin/cchost | grep libc++
        libc++.so.1 => /usr/lib/x86_64-linux-gnu/libc++.so.1 (0x00007fa01ba8c000)
        libc++abi.so.1 => /usr/lib/x86_64-linux-gnu/libc++abi.so.1 (0x00007fa01b85c000)
```

Edit: I intend to cut 0.11.2, to avoid leaving the app_run container broken.