### PR TITLE
Don't double-prefix the install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ message(STATUS "CCF release version=${CCF_RELEASE_VERSION}")
 #
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX
-      "/opt/ccf/ccf-${CCF_RELEASE_VERSION}"
+      "/opt/ccf/${CCF_VERSION}"
       CACHE PATH "Default install prefix" FORCE
   )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ message(STATUS "CCF release version=${CCF_RELEASE_VERSION}")
 #
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX
-      "/opt/ccf/ccf-${CCF_VERSION}"
+      "/opt/ccf/ccf-${CCF_RELEASE_VERSION}"
       CACHE PATH "Default install prefix" FORCE
   )
 endif()

--- a/doc/developers/ledger.rst
+++ b/doc/developers/ledger.rst
@@ -71,7 +71,7 @@ The following diagram describes how deltas committed by the leader are written t
 Reading and Verifing Ledger
 ---------------------------
 
-A Python implementation for parsing the ledger can be found in `ledger.py <https://github.com/microsoft/CCF/blob/master/tests/ledger.py>`_.
+A Python implementation for parsing the ledger can be found in `ledger.py <https://github.com/microsoft/CCF/blob/master/tests/infra/ledger.py>`_.
 
 The ``Ledger`` class is constructed using the path of the ledger. It then exposes an iterator for transaction data structures, where each transaction is composed of the following:
 


### PR DESCRIPTION
Before:
```
$ cmake .. -UCMAKE_INSTALL_PREFIX
-- CCF version=ccf-0.11.1
-- CCF release version=0.11.1
-- CMAKE_INSTALL_PREFIX is '/opt/ccf/ccf-ccf-0.11.1'
```

After:
```
$ cmake .. -UCMAKE_INSTALL_PREFIX
-- CCF version=ccf-0.11.1-3-g99e8c55a
-- CCF release version=0.11.1
-- CMAKE_INSTALL_PREFIX is '/opt/ccf/ccf-0.11.1'
```