### PR TITLE
Do not drop client signature if transaction conflict

### DIFF
--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -282,6 +282,7 @@ namespace ccf
 
       // By default, signed requests are verified and recorded, even on
       // endpoints that do not require client signatures
+      bool should_record_client_signature = false;
       if (signed_request.has_value())
       {
         // For forwarded requests (raft only), skip verification as it is
@@ -300,7 +301,7 @@ namespace ccf
 
         if (is_primary)
         {
-          record_client_signature(tx, caller_id, signed_request.value());
+          should_record_client_signature = true;
         }
       }
 
@@ -340,6 +341,12 @@ namespace ccf
           {
             pre_exec(tx, *ctx.get(), *this);
           }
+
+          if (should_record_client_signature)
+          {
+            record_client_signature(tx, caller_id, signed_request.value());
+          }
+
           func(args);
 
           if (!ctx->should_apply_writes())

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -1464,7 +1464,7 @@ public:
 
   TestConflictFrontend(kv::Store& tables) :
     SimpleUserRpcFrontend(tables),
-    values(tables.create<size_t, size_t>("test_values"))
+    values(tables.create<size_t, size_t>("test_values_conflict"))
   {
     open();
 


### PR DESCRIPTION
Now that we drop all views when a transaction conflicts (rightly so!), we need to make sure that the client signature is not dropped if the execution of our RPC endpoint conflicts. 

