### PR TITLE
Move opening to after public ledger is recovered

### DIFF
--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -351,10 +351,6 @@ namespace ccf
 
           setup_recovery_hook();
 
-          // Accept members connections for members to finish recovery once
-          // the public ledger has been read
-          open_member_frontend();
-
           accept_network_tls_connections(args.config);
 
           sm.advance(State::readingPublicLedger);
@@ -672,6 +668,8 @@ namespace ccf
           "Could not commit transaction when starting recovered public "
           "network");
       }
+
+      open_member_frontend();
 
       sm.advance(State::partOfPublicNetwork);
     }


### PR DESCRIPTION
Resolves #83

Fixes a very old issue that can now be fixed trivially now that they way we manager TLS connection endorsement/opening of frontends has changed.

The member frontend is now only opened _after_ the public ledger has been recovered. The node frontend can still be used to check on the progress of the public recovery. 