### PR TITLE
Respect relative path in LocalRemote.get

### DIFF
--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -445,7 +445,7 @@ class LocalRemote(CmdMixin):
         else:
             raise ValueError(path)
         target_name = target_name or file_name
-        self._cp(path, dst_path)
+        self._cp(path, os.path.join(dst_path, target_name))
 
     def list_files(self):
         return os.listdir(self.root)

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -435,8 +435,8 @@ class LocalRemote(CmdMixin):
             dst_path = os.path.join(self.root, os.path.basename(path))
             self._cp(path, dst_path)
 
-    def get(self, file_name, dst_path, timeout=FILE_TIMEOUT, target_name=None):
-        path = os.path.join(self.root, file_name)
+    def get(self, src_path, dst_path, timeout=FILE_TIMEOUT, target_name=None):
+        path = os.path.join(self.root, src_path)
         end_time = time.time() + timeout
         while time.time() < end_time:
             if os.path.exists(path):
@@ -444,8 +444,10 @@ class LocalRemote(CmdMixin):
             time.sleep(0.1)
         else:
             raise ValueError(path)
-        target_name = target_name or file_name
-        self._cp(path, os.path.join(dst_path, target_name))
+        if target_name is not None:
+            self._cp(path, os.path.join(dst_path, target_name))
+        else:
+            self._cp(path, dst_path)
 
     def list_files(self):
         return os.listdir(self.root)

--- a/tests/infra/remote_client.py
+++ b/tests/infra/remote_client.py
@@ -72,24 +72,18 @@ class CCFRemoteClient(object):
         return self.remote.debug_node_cmd()
 
     def stop(self):
-        try:
-            self.remote.stop()
-            remote_files = self.remote.list_files()
-            remote_csvs = [f for f in remote_files if f.endswith(".csv")]
+        self.remote.stop()
+        remote_files = self.remote.list_files()
+        remote_csvs = [f for f in remote_files if f.endswith(".csv")]
 
-            for csv in remote_csvs:
-                remote_file_dst = f"{self.name}_{csv}"
-                self.remote.get(csv, self.common_dir, 1, remote_file_dst)
-                if csv == "perf_summary.csv":
-                    with open("perf_summary.csv", "a") as l:
-                        with open(
-                            os.path.join(self.common_dir, remote_file_dst), "r"
-                        ) as r:
-                            for line in r.readlines():
-                                l.write(line)
-
-        except Exception:
-            LOG.exception("Failed to shut down {} cleanly".format(self.name))
+        for csv in remote_csvs:
+            remote_file_dst = f"{self.name}_{csv}"
+            self.remote.get(csv, self.common_dir, 1, remote_file_dst)
+            if csv == "perf_summary.csv":
+                with open("perf_summary.csv", "a") as l:
+                    with open(os.path.join(self.common_dir, remote_file_dst), "r") as r:
+                        for line in r.readlines():
+                            l.write(line)
 
     def check_done(self):
         return self.remote.check_done()

--- a/tests/infra/remote_client.py
+++ b/tests/infra/remote_client.py
@@ -82,8 +82,7 @@ class CCFRemoteClient(object):
             if csv == "perf_summary.csv":
                 with open("perf_summary.csv", "a") as l:
                     with open(os.path.join(self.common_dir, remote_file_dst), "r") as r:
-                        for line in r.readlines():
-                            l.write(line)
+                        l.write(r.read())
 
     def check_done(self):
         return self.remote.check_done()


### PR DESCRIPTION
For some time our perf runs have been failing to retrieve `perf_summary.csv`. This fixes that.