### PR TITLE
Use gitignore in notice-check.py

### DIFF
--- a/scripts/notice-check.py
+++ b/scripts/notice-check.py
@@ -55,6 +55,11 @@ def submodules():
     ]
 
 
+def gitignored(path):
+    r = subprocess.run(["git", "check-ignore", path], capture_output=True, check=False)
+    return r.returncode == 0  # Returns 0 for files which _are_ ignored
+
+
 def check_ccf():
     missing = []
     excluded = ["3rdparty", ".git", "build", "env"] + submodules()
@@ -67,8 +72,9 @@ def check_ccf():
                 continue
             if is_src(name):
                 path = os.path.join(root, name)
-                if not has_notice(path, PREFIXES_CCF):
-                    missing.append(path)
+                if not gitignored(path):
+                    if not has_notice(path, PREFIXES_CCF):
+                        missing.append(path)
     return missing
 
 


### PR DESCRIPTION
Previously if I ran `ci-checks.sh` locally, I'd get lots of failures from `notice-check.py`:

```
...
Copyright notice missing from ./build.debug/cmake_install.cmake
...
```

because I have a lot of builds in directories not called `build/`. These are listed in `.gitignore`, so I've updated `notice-check.py` to ignore anything which Git is going to ignore. I was going to add this more generally to `ci-checks.sh`, but everything else runs on specific folders (`src/` and friends) so this was only a problem with `notice-check.py`, since it does `os.walk(".")`