### PR TITLE
Update curl sample line so quotes aren't swallowed by terminal

### DIFF
--- a/doc/users/rpc_api.rst
+++ b/doc/users/rpc_api.rst
@@ -29,7 +29,7 @@ The API can also be retrieved from a running service using the `api`_ and `api/s
       ]
     }
 
-    $ curl https://<ccf-node-address>/node/api/schema?method="tx" -X GET --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem -H "Content-Type: application/json"
+    $ curl 'https://<ccf-node-address>/node/api/schema?method="tx"' -X GET --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem -H "Content-Type: application/json"
     {
       "params_schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
As noted in #1375, if users try to use this sample command from our docs they'll get a non-obvious error message. The quotes around `"tx"` are actually being swallowed by the terminal so we send a query string `?method=tx`, and then we try to parse the right-hand side as JSON and fail.

This is an unfortunate knock-on of trying to retain our JSON parsers for query-string arguments, which we actually use in very few places. I plan to remove this, so endpoints can accept the more obvious `method=tx` if they wish. A slight extension to this is that we're discussing removing `json_handler` from the public API entirely, since it introduces obscure requirements like this which only complicate app development.