### PR TITLE
Give the C++ e2e logging test a uniquely regexable name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -554,7 +554,7 @@ if(BUILD_TESTS)
   )
 
   add_e2e_test(
-    NAME lua_end_to_end_batched
+    NAME lua_e2e_batched
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_batched.py
     CONSENSUS raft
     ADDITIONAL_ARGS --app-script
@@ -627,7 +627,7 @@ if(BUILD_TESTS)
     )
 
     add_e2e_test(
-      NAME js_end_to_end_logging_${CONSENSUS}
+      NAME js_e2e_logging_${CONSENSUS}
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py
       CONSENSUS ${CONSENSUS}
       ADDITIONAL_ARGS --js-app-script
@@ -635,7 +635,7 @@ if(BUILD_TESTS)
     )
 
     add_e2e_test(
-      NAME end_to_end_scenario_${CONSENSUS}
+      NAME e2e_scenario_${CONSENSUS}
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_scenarios.py
       CONSENSUS ${CONSENSUS}
       ADDITIONAL_ARGS --scenario
@@ -649,7 +649,7 @@ if(BUILD_TESTS)
     )
 
     add_e2e_test(
-      NAME lua_end_to_end_logging_${CONSENSUS}
+      NAME lua_e2e_logging_${CONSENSUS}
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py
       CONSENSUS ${CONSENSUS}
       ADDITIONAL_ARGS --app-script
@@ -694,7 +694,7 @@ if(BUILD_TESTS)
     )
 
     add_e2e_test(
-      NAME cpp_end_to_end_logging_${CONSENSUS}
+      NAME cpp_e2e_logging_${CONSENSUS}
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py
       CURL_CLIENT TRUE
       CONSENSUS ${CONSENSUS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -694,7 +694,7 @@ if(BUILD_TESTS)
     )
 
     add_e2e_test(
-      NAME end_to_end_logging_${CONSENSUS}
+      NAME cpp_end_to_end_logging_${CONSENSUS}
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py
       CURL_CLIENT TRUE
       CONSENSUS ${CONSENSUS}

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -386,7 +386,7 @@ function(add_e2e_test)
       )
     endif()
 
-    set_property(TEST ${PARSED_ARGS_NAME} APPEND PROPERTY LABELS end_to_end)
+    set_property(TEST ${PARSED_ARGS_NAME} APPEND PROPERTY LABELS e2e)
     set_property(
       TEST ${PARSED_ARGS_NAME} APPEND PROPERTY LABELS ${PARSED_ARGS_LABEL}
     )

--- a/doc/developers/demo.rst
+++ b/doc/developers/demo.rst
@@ -13,10 +13,10 @@ To see how this is run in the main test suite, look at the `Test command` used b
 .. code-block:: bash
 
     $ cd build
-    $ ctest -VV -R end_to_end_scenario -N
+    $ ctest -VV -R e2e_scenario -N
 
     ...
-    42: Test command: /usr/bin/unbuffer "python3" "/data/src/CCF/tests/e2e_scenarios.py" "-b" "." "--label" "end_to_end_scenario" "-l" "info" "-g" "/data/src/CCF/src/runtime_config/gov.lua" "--scenario" "/data/src/CCF/tests/simple_logging_scenario.json"
+    42: Test command: /usr/bin/unbuffer "python3" "/data/src/CCF/tests/e2e_scenarios.py" "-b" "." "--label" "e2e_scenario" "-l" "info" "-g" "/data/src/CCF/src/runtime_config/gov.lua" "--scenario" "/data/src/CCF/tests/simple_logging_scenario.json"
     42: Environment variables:
     42:  PYTHONPATH=/data/src/CCF/tests
 
@@ -72,5 +72,5 @@ The ``e2e`` test script takes several additional parameters, documented by passi
 
 .. rubric:: Footnotes
 
-.. [#log_location] The log location should be visible in the Python output. By default, node ``N`` will log to files ``out`` and ``err`` in ``CCF/build/workspace/end_to_end_scenario_{N}``
+.. [#log_location] The log location should be visible in the Python output. By default, node ``N`` will log to files ``out`` and ``err`` in ``CCF/build/workspace/e2e_scenario_{N}``
 


### PR DESCRIPTION
One of our most thorough tests is `end_to_end_logging_`. This often picks things up in the CI that other tests miss, as it tests all the obscure variants of our endpoints.

However, it is also one of the most difficult to run in isolation, because `ctest` is useless. The usual way to run a single `ctest` is with a regex, but:

```
$ ctest -N -R end_to_end_logging_raft
Test project /data/src/2.CCF/build
  Test #58: js_end_to_end_logging_raft
  Test #61: lua_end_to_end_logging_raft
  Test #66: end_to_end_logging_raft

Total Tests: 3
```

I don't want the `js_` and `lua_` variants which do a subset of the work. So previously I needed to run some `-N` that would include this good test, then the devil-summoning `ctest -VV -I 66,66`. (NB: You can't add `-I 66,66` to the previous command, because even though it still says `Test #66` its now `-I 3,3`. ctest!)

Now the good test has a unique name, so we can easily run it by itself.

I'm tempted to go with `end_to_end_logging_cpp_raft`, `end_to_end_logging_js_pbft` etc, so the unique bit for each test is shorter, but we already have a _bunch_ with `lua_` as a prefix.