### PR TITLE
Do not serialise if length of vector is 0

### DIFF
--- a/src/kv/msgpack_serialise.h
+++ b/src/kv/msgpack_serialise.h
@@ -41,7 +41,10 @@ namespace kv
     {
       const uint64_t size = entry.size();
       sb.write(reinterpret_cast<char const*>(&size), sizeof(size));
-      sb.write(reinterpret_cast<char const*>(entry.data()), entry.size());
+      if (entry.size() > 0)
+      {
+        sb.write(reinterpret_cast<char const*>(entry.data()), entry.size());
+      }
     }
 
     void clear()


### PR DESCRIPTION
Fixes daily SAN `kv_test` failure: https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=10660&view=logs&j=383d248c-4494-5797-d98f-6cef5140601e&t=bbcdfa66-260b-5619-96df-9537b476c35e&l=195

We should not serialise a raw entry if its size is 0 - which happens in the case of snapshots when a map is empty.

Daily build run for this PR (in progress): https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=10670&view=results