### PR TITLE
Install utils in bin, not BIN

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -97,7 +97,7 @@ foreach(UTILITY ${CCF_UTILITIES})
   configure_file(
     ${CCF_DIR}/python/utils/${UTILITY} ${CMAKE_CURRENT_BINARY_DIR} COPYONLY
   )
-  install(PROGRAMS ${CCF_DIR}/python/utils/${UTILITY} DESTINATION BIN)
+  install(PROGRAMS ${CCF_DIR}/python/utils/${UTILITY} DESTINATION bin)
 endforeach()
 
 # Copy utilities from tests directory

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -109,9 +109,7 @@ foreach(UTILITY ${CCF_TEST_UTILITIES})
 endforeach()
 
 # Install additional utilities
-install(
-  PROGRAMS ${CCF_DIR}/tests/sgxinfo.sh DESTINATION bin
-)
+install(PROGRAMS ${CCF_DIR}/tests/sgxinfo.sh DESTINATION bin)
 
 # Install getting_started scripts for VM creation and setup
 install(DIRECTORY ${CCF_DIR}/getting_started/ DESTINATION getting_started)

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -108,11 +108,9 @@ foreach(UTILITY ${CCF_TEST_UTILITIES})
   )
 endforeach()
 
-# Install specific utilities
+# Install additional utilities
 install(
-  PROGRAMS ${CCF_DIR}/python/utils/scurl.sh
-           ${CCF_DIR}/python/utils/keygenerator.sh ${CCF_DIR}/tests/sgxinfo.sh
-           ${CCF_DIR}/python/utils/submit_recovery_share.sh DESTINATION bin
+  PROGRAMS ${CCF_DIR}/tests/sgxinfo.sh DESTINATION bin
 )
 
 # Install getting_started scripts for VM creation and setup


### PR DESCRIPTION
Before:
```
$ find /opt/ccf-0.11.7-31-g89ccf662/ -type f -regex ".*\.sh$"
/opt/ccf-0.11.7-31-g89ccf662/BIN/keygenerator.sh
/opt/ccf-0.11.7-31-g89ccf662/BIN/submit_recovery_share.sh
/opt/ccf-0.11.7-31-g89ccf662/BIN/scurl.sh
/opt/ccf-0.11.7-31-g89ccf662/getting_started/setup_vm/run.sh
/opt/ccf-0.11.7-31-g89ccf662/getting_started/create_vm/destroy_vm.sh
/opt/ccf-0.11.7-31-g89ccf662/getting_started/create_vm/pre_make_vm.sh
/opt/ccf-0.11.7-31-g89ccf662/getting_started/create_vm/make_vm.sh
/opt/ccf-0.11.7-31-g89ccf662/bin/keygenerator.sh
/opt/ccf-0.11.7-31-g89ccf662/bin/submit_recovery_share.sh
/opt/ccf-0.11.7-31-g89ccf662/bin/scurl.sh
/opt/ccf-0.11.7-31-g89ccf662/bin/sgxinfo.sh
```

After:
```
$ find /opt/ccf-0.11.7-33-g3baa6444/ -type f -regex ".*\.sh$"
/opt/ccf-0.11.7-33-g3baa6444/getting_started/setup_vm/run.sh
/opt/ccf-0.11.7-33-g3baa6444/getting_started/create_vm/destroy_vm.sh
/opt/ccf-0.11.7-33-g3baa6444/getting_started/create_vm/pre_make_vm.sh
/opt/ccf-0.11.7-33-g3baa6444/getting_started/create_vm/make_vm.sh
/opt/ccf-0.11.7-33-g3baa6444/bin/keygenerator.sh
/opt/ccf-0.11.7-33-g3baa6444/bin/submit_recovery_share.sh
/opt/ccf-0.11.7-33-g3baa6444/bin/scurl.sh
/opt/ccf-0.11.7-33-g3baa6444/bin/sgxinfo.sh