### PR TITLE
Snapshot size calculation fix

### DIFF
--- a/src/ds/champ_map.h
+++ b/src/ds/champ_map.h
@@ -243,7 +243,8 @@ namespace champ
       const auto& entry0 = node_as<Entry<K, V>>(c_idx);
       if (k == entry0->key)
       {
-        auto current_size = get_size_with_padding<K, V>(entry0->key, entry0->value);
+        auto current_size =
+          get_size_with_padding<K, V>(entry0->key, entry0->value);
         nodes[c_idx] = std::make_shared<Entry<K, V>>(k, v);
         return current_size;
       }
@@ -411,7 +412,7 @@ namespace champ
         size_++;
       }
 
-      int64_t size_change = get_size_with_padding<K, V>(key, value) - r.second; // r.second - serialized_size
+      int64_t size_change = get_size_with_padding<K, V>(key, value) - r.second;
       return Map(std::move(r.first), size_, size_change + serialized_size);
     }
 

--- a/src/ds/champ_map.h
+++ b/src/ds/champ_map.h
@@ -334,7 +334,7 @@ namespace champ
   {
   private:
     std::shared_ptr<SubNodes<K, V, H>> root;
-    size_t size = 0;
+    size_t map_size = 0;
     size_t serialized_size = 0;
 
     Map(
@@ -342,7 +342,7 @@ namespace champ
       size_t size_,
       size_t serialized_size_) :
       root(std::move(root_)),
-      size(size_),
+      map_size(size_),
       serialized_size(serialized_size_)
     {}
 
@@ -373,9 +373,9 @@ namespace champ
       return map;
     }
 
-    size_t get_size() const
+    size_t size() const
     {
-      return size;
+      return map_size;
     }
 
     size_t get_serialized_size() const
@@ -385,7 +385,7 @@ namespace champ
 
     bool empty() const
     {
-      return size == 0;
+      return map_size == 0;
     }
 
     std::optional<V> get(const K& key) const
@@ -406,7 +406,7 @@ namespace champ
     const Map<K, V, H> put(const K& key, const V& value) const
     {
       auto r = root->put(0, H()(key), key, value);
-      auto size_ = size;
+      auto size_ = map_size;
       if (r.second == 0)
       {
         size_++;
@@ -470,7 +470,7 @@ namespace champ
     void serialize(uint8_t* data)
     {
       std::vector<KVTuple> ordered_state;
-      ordered_state.reserve(map.get_size());
+      ordered_state.reserve(map.size());
       size_t size = 0;
 
       map.foreach([&](auto& key, auto& value) {
@@ -500,7 +500,7 @@ namespace champ
         "size:{}, map->size:{} ==> count:{}, vect:{}",
         size,
         map.get_serialized_size(),
-        map.get_size(),
+        map.size(),
         ordered_state.size());
 
       serialized_buffer = CBuffer(data, map.get_serialized_size());

--- a/src/ds/test/map_test.cpp
+++ b/src/ds/test/map_test.cpp
@@ -140,91 +140,108 @@ TEST_CASE("persistent map operations")
 static const champ::Map<K, V, H> gen_map(size_t size)
 {
   champ::Map<K, V, H> map;
-  for (uint32_t j = 0; j < 2; ++j)
+  for (uint64_t i = 0; i < size; ++i)
   {
-    for (uint64_t i = 0; i < size; ++i)
-    {
-      map = map.put(i, i);
-    }
+    map = map.put(i, i);
   }
   return map;
 }
 
 TEST_CASE("serialize map")
 {
-  struct pair
-  {
-    K k;
-    V v;
-  };
+  //   struct pair
+  //   {
+  //     K k;
+  //     V v;
+  //   };
 
-  std::vector<pair> results;
-  uint32_t num_elements = 100;
-  auto map = gen_map(num_elements);
-  INFO("make sure we can serialize a map");
-  {
-    map.foreach([&results](const auto& key, const auto& value) {
-      results.push_back({key, value});
-      return true;
-    });
-    REQUIRE_EQ(num_elements, results.size());
-  }
+  //   std::vector<pair> results;
+  //   uint32_t num_elements = 100;
+  //   auto map = gen_map(num_elements);
 
-  INFO("make sure we can deserialize a map");
-  {
-    std::set<K> keys;
-    champ::Map<K, V, H> new_map;
-    for (const auto& p : results)
-    {
-      REQUIRE_LT(p.k, num_elements);
-      keys.insert(p.k);
-      new_map = new_map.put(p.k, p.v);
-    }
-    REQUIRE_EQ(num_elements, new_map.size());
-    REQUIRE_EQ(num_elements, keys.size());
-  }
+  //   INFO("make sure we can serialize a map");
+  //   {
+  //     map.foreach([&results](const auto& key, const auto& value) {
+  //       results.push_back({key, value});
+  //       return true;
+  //     });
+  //     REQUIRE_EQ(num_elements, results.size());
+  //   }
 
-  INFO("Serialize map to array");
+  //   INFO("make sure we can deserialize a map");
+  //   {
+  //     std::set<K> keys;
+  //     champ::Map<K, V, H> new_map;
+  //     for (const auto& p : results)
+  //     {
+  //       REQUIRE_LT(p.k, num_elements);
+  //       keys.insert(p.k);
+  //       new_map = new_map.put(p.k, p.v);
+  //     }
+  //     REQUIRE_EQ(num_elements, new_map.size());
+  //     REQUIRE_EQ(num_elements, keys.size());
+  //   }
+
+  //   INFO("Serialize map to array");
+  //   {
+  //     champ::Snapshot<K, V, H> snapshot(map);
+  //     std::vector<uint8_t> s(map.get_serialized_size());
+  //     snapshot.serialize(s.data());
+
+  //     champ::Map<K, V, H> new_map = champ::Map<K, V, H>::deserialize_map(s);
+
+  //     std::set<K> keys;
+  //     new_map.foreach([&keys](const auto& key, const auto& value) {
+  //       keys.insert(key);
+  //       REQUIRE_EQ(key, value);
+  //       return true;
+  //     });
+  //     REQUIRE_EQ(map.size(), new_map.size());
+  //     REQUIRE_EQ(map.size(), keys.size());
+
+  //     uint32_t offset = 1000;
+  //     for (uint32_t i = offset; i < offset + num_elements; ++i)
+  //     {
+  //       new_map = new_map.put(i, i);
+  //     }
+  //     REQUIRE_EQ(new_map.size(), map.size() + num_elements);
+  //     for (uint32_t i = offset; i < offset + num_elements; ++i)
+  //     {
+  //       auto p = new_map.get(i);
+  //       REQUIRE(p.has_value());
+  //       REQUIRE(p.value() == i);
+  //     }
+  //   }
+
+  //   INFO("Ensure serialized state is byte identical");
+  //   {
+  //     champ::Snapshot<K, V, H> snapshot_1(map);
+  //     std::vector<uint8_t> s_1(map.get_serialized_size());
+  //     snapshot_1.serialize(s_1.data());
+
+  //     champ::Snapshot<K, V, H> snapshot_2(map);
+  //     std::vector<uint8_t> s_2(map.get_serialized_size());
+  //     snapshot_2.serialize(s_2.data());
+
+  //     REQUIRE_EQ(s_1, s_2);
+  //   }
+
+  INFO("Serialize map with different key sizes");
   {
-    champ::Snapshot<K, V, H> snapshot(map);
+    using SerialisedKey = champ::serialisers::SerialisedEntry;
+    using SerialisedValue = champ::serialisers::SerialisedEntry;
+
+    uint32_t num_elements = 100;
+    champ::Map<SerialisedKey, SerialisedValue> map;
+    SerialisedKey key(16);
+    SerialisedValue value(8);
+    SerialisedValue long_value(256);
+
+    map = map.put(key, value);
+    map = map.put(key, long_value);
+
+    champ::Snapshot<SerialisedKey, SerialisedValue> snapshot(map);
     std::vector<uint8_t> s(map.get_serialized_size());
     snapshot.serialize(s.data());
-
-    champ::Map<K, V, H> new_map = champ::Map<K, V, H>::deserialize_map(s);
-
-    std::set<K> keys;
-    new_map.foreach([&keys](const auto& key, const auto& value) {
-      keys.insert(key);
-      REQUIRE_EQ(key, value);
-      return true;
-    });
-    REQUIRE_EQ(map.size(), new_map.size());
-    REQUIRE_EQ(map.size(), keys.size());
-
-    uint32_t offset = 1000;
-    for (uint32_t i = offset; i < offset + num_elements; ++i)
-    {
-      new_map = new_map.put(i, i);
-    }
-    REQUIRE_EQ(new_map.size(), map.size() + num_elements);
-    for (uint32_t i = offset; i < offset + num_elements; ++i)
-    {
-      auto p = new_map.get(i);
-      REQUIRE(p.has_value());
-      REQUIRE(p.value() == i);
-    }
-  }
-
-  INFO("Ensure serialized state is byte identical");
-  {
-    champ::Snapshot<K, V, H> snapshot_1(map);
-    std::vector<uint8_t> s_1(map.get_serialized_size());
-    snapshot_1.serialize(s_1.data());
-
-    champ::Snapshot<K, V, H> snapshot_2(map);
-    std::vector<uint8_t> s_2(map.get_serialized_size());
-    snapshot_2.serialize(s_2.data());
-
-    REQUIRE_EQ(s_1, s_2);
   }
 }

--- a/src/ds/test/map_test.cpp
+++ b/src/ds/test/map_test.cpp
@@ -149,82 +149,82 @@ static const champ::Map<K, V, H> gen_map(size_t size)
 
 TEST_CASE("serialize map")
 {
-  //   struct pair
-  //   {
-  //     K k;
-  //     V v;
-  //   };
+    struct pair
+    {
+      K k;
+      V v;
+    };
 
-  //   std::vector<pair> results;
-  //   uint32_t num_elements = 100;
-  //   auto map = gen_map(num_elements);
+    std::vector<pair> results;
+    uint32_t num_elements = 100;
+    auto map = gen_map(num_elements);
 
-  //   INFO("make sure we can serialize a map");
-  //   {
-  //     map.foreach([&results](const auto& key, const auto& value) {
-  //       results.push_back({key, value});
-  //       return true;
-  //     });
-  //     REQUIRE_EQ(num_elements, results.size());
-  //   }
+    INFO("make sure we can serialize a map");
+    {
+      map.foreach([&results](const auto& key, const auto& value) {
+        results.push_back({key, value});
+        return true;
+      });
+      REQUIRE_EQ(num_elements, results.size());
+    }
 
-  //   INFO("make sure we can deserialize a map");
-  //   {
-  //     std::set<K> keys;
-  //     champ::Map<K, V, H> new_map;
-  //     for (const auto& p : results)
-  //     {
-  //       REQUIRE_LT(p.k, num_elements);
-  //       keys.insert(p.k);
-  //       new_map = new_map.put(p.k, p.v);
-  //     }
-  //     REQUIRE_EQ(num_elements, new_map.size());
-  //     REQUIRE_EQ(num_elements, keys.size());
-  //   }
+    INFO("make sure we can deserialize a map");
+    {
+      std::set<K> keys;
+      champ::Map<K, V, H> new_map;
+      for (const auto& p : results)
+      {
+        REQUIRE_LT(p.k, num_elements);
+        keys.insert(p.k);
+        new_map = new_map.put(p.k, p.v);
+      }
+      REQUIRE_EQ(num_elements, new_map.size());
+      REQUIRE_EQ(num_elements, keys.size());
+    }
 
-  //   INFO("Serialize map to array");
-  //   {
-  //     champ::Snapshot<K, V, H> snapshot(map);
-  //     std::vector<uint8_t> s(map.get_serialized_size());
-  //     snapshot.serialize(s.data());
+    INFO("Serialize map to array");
+    {
+      champ::Snapshot<K, V, H> snapshot(map);
+      std::vector<uint8_t> s(map.get_serialized_size());
+      snapshot.serialize(s.data());
 
-  //     champ::Map<K, V, H> new_map = champ::Map<K, V, H>::deserialize_map(s);
+      champ::Map<K, V, H> new_map = champ::Map<K, V, H>::deserialize_map(s);
 
-  //     std::set<K> keys;
-  //     new_map.foreach([&keys](const auto& key, const auto& value) {
-  //       keys.insert(key);
-  //       REQUIRE_EQ(key, value);
-  //       return true;
-  //     });
-  //     REQUIRE_EQ(map.size(), new_map.size());
-  //     REQUIRE_EQ(map.size(), keys.size());
+      std::set<K> keys;
+      new_map.foreach([&keys](const auto& key, const auto& value) {
+        keys.insert(key);
+        REQUIRE_EQ(key, value);
+        return true;
+      });
+      REQUIRE_EQ(map.size(), new_map.size());
+      REQUIRE_EQ(map.size(), keys.size());
 
-  //     uint32_t offset = 1000;
-  //     for (uint32_t i = offset; i < offset + num_elements; ++i)
-  //     {
-  //       new_map = new_map.put(i, i);
-  //     }
-  //     REQUIRE_EQ(new_map.size(), map.size() + num_elements);
-  //     for (uint32_t i = offset; i < offset + num_elements; ++i)
-  //     {
-  //       auto p = new_map.get(i);
-  //       REQUIRE(p.has_value());
-  //       REQUIRE(p.value() == i);
-  //     }
-  //   }
+      uint32_t offset = 1000;
+      for (uint32_t i = offset; i < offset + num_elements; ++i)
+      {
+        new_map = new_map.put(i, i);
+      }
+      REQUIRE_EQ(new_map.size(), map.size() + num_elements);
+      for (uint32_t i = offset; i < offset + num_elements; ++i)
+      {
+        auto p = new_map.get(i);
+        REQUIRE(p.has_value());
+        REQUIRE(p.value() == i);
+      }
+    }
 
-  //   INFO("Ensure serialized state is byte identical");
-  //   {
-  //     champ::Snapshot<K, V, H> snapshot_1(map);
-  //     std::vector<uint8_t> s_1(map.get_serialized_size());
-  //     snapshot_1.serialize(s_1.data());
+    INFO("Ensure serialized state is byte identical");
+    {
+      champ::Snapshot<K, V, H> snapshot_1(map);
+      std::vector<uint8_t> s_1(map.get_serialized_size());
+      snapshot_1.serialize(s_1.data());
 
-  //     champ::Snapshot<K, V, H> snapshot_2(map);
-  //     std::vector<uint8_t> s_2(map.get_serialized_size());
-  //     snapshot_2.serialize(s_2.data());
+      champ::Snapshot<K, V, H> snapshot_2(map);
+      std::vector<uint8_t> s_2(map.get_serialized_size());
+      snapshot_2.serialize(s_2.data());
 
-  //     REQUIRE_EQ(s_1, s_2);
-  //   }
+      REQUIRE_EQ(s_1, s_2);
+    }
 
   INFO("Serialize map with different key sizes");
   {

--- a/src/ds/test/map_test.cpp
+++ b/src/ds/test/map_test.cpp
@@ -140,7 +140,7 @@ TEST_CASE("persistent map operations")
 static const champ::Map<K, V, H> gen_map(size_t size)
 {
   champ::Map<K, V, H> map;
-  for (uint64_t i = 0; i < size; ++i)
+  for (size_t i = 0; i < size; ++i)
   {
     map = map.put(i, i);
   }

--- a/src/ds/test/map_test.cpp
+++ b/src/ds/test/map_test.cpp
@@ -149,82 +149,82 @@ static const champ::Map<K, V, H> gen_map(size_t size)
 
 TEST_CASE("serialize map")
 {
-    struct pair
-    {
-      K k;
-      V v;
-    };
+  struct pair
+  {
+    K k;
+    V v;
+  };
 
-    std::vector<pair> results;
-    uint32_t num_elements = 100;
-    auto map = gen_map(num_elements);
+  std::vector<pair> results;
+  uint32_t num_elements = 100;
+  auto map = gen_map(num_elements);
 
-    INFO("make sure we can serialize a map");
+  INFO("make sure we can serialize a map");
+  {
+    map.foreach([&results](const auto& key, const auto& value) {
+      results.push_back({key, value});
+      return true;
+    });
+    REQUIRE_EQ(num_elements, results.size());
+  }
+
+  INFO("make sure we can deserialize a map");
+  {
+    std::set<K> keys;
+    champ::Map<K, V, H> new_map;
+    for (const auto& p : results)
     {
-      map.foreach([&results](const auto& key, const auto& value) {
-        results.push_back({key, value});
-        return true;
-      });
-      REQUIRE_EQ(num_elements, results.size());
+      REQUIRE_LT(p.k, num_elements);
+      keys.insert(p.k);
+      new_map = new_map.put(p.k, p.v);
     }
+    REQUIRE_EQ(num_elements, new_map.size());
+    REQUIRE_EQ(num_elements, keys.size());
+  }
 
-    INFO("make sure we can deserialize a map");
+  INFO("Serialize map to array");
+  {
+    champ::Snapshot<K, V, H> snapshot(map);
+    std::vector<uint8_t> s(map.get_serialized_size());
+    snapshot.serialize(s.data());
+
+    champ::Map<K, V, H> new_map = champ::Map<K, V, H>::deserialize_map(s);
+
+    std::set<K> keys;
+    new_map.foreach([&keys](const auto& key, const auto& value) {
+      keys.insert(key);
+      REQUIRE_EQ(key, value);
+      return true;
+    });
+    REQUIRE_EQ(map.size(), new_map.size());
+    REQUIRE_EQ(map.size(), keys.size());
+
+    uint32_t offset = 1000;
+    for (uint32_t i = offset; i < offset + num_elements; ++i)
     {
-      std::set<K> keys;
-      champ::Map<K, V, H> new_map;
-      for (const auto& p : results)
-      {
-        REQUIRE_LT(p.k, num_elements);
-        keys.insert(p.k);
-        new_map = new_map.put(p.k, p.v);
-      }
-      REQUIRE_EQ(num_elements, new_map.size());
-      REQUIRE_EQ(num_elements, keys.size());
+      new_map = new_map.put(i, i);
     }
-
-    INFO("Serialize map to array");
+    REQUIRE_EQ(new_map.size(), map.size() + num_elements);
+    for (uint32_t i = offset; i < offset + num_elements; ++i)
     {
-      champ::Snapshot<K, V, H> snapshot(map);
-      std::vector<uint8_t> s(map.get_serialized_size());
-      snapshot.serialize(s.data());
-
-      champ::Map<K, V, H> new_map = champ::Map<K, V, H>::deserialize_map(s);
-
-      std::set<K> keys;
-      new_map.foreach([&keys](const auto& key, const auto& value) {
-        keys.insert(key);
-        REQUIRE_EQ(key, value);
-        return true;
-      });
-      REQUIRE_EQ(map.size(), new_map.size());
-      REQUIRE_EQ(map.size(), keys.size());
-
-      uint32_t offset = 1000;
-      for (uint32_t i = offset; i < offset + num_elements; ++i)
-      {
-        new_map = new_map.put(i, i);
-      }
-      REQUIRE_EQ(new_map.size(), map.size() + num_elements);
-      for (uint32_t i = offset; i < offset + num_elements; ++i)
-      {
-        auto p = new_map.get(i);
-        REQUIRE(p.has_value());
-        REQUIRE(p.value() == i);
-      }
+      auto p = new_map.get(i);
+      REQUIRE(p.has_value());
+      REQUIRE(p.value() == i);
     }
+  }
 
-    INFO("Ensure serialized state is byte identical");
-    {
-      champ::Snapshot<K, V, H> snapshot_1(map);
-      std::vector<uint8_t> s_1(map.get_serialized_size());
-      snapshot_1.serialize(s_1.data());
+  INFO("Ensure serialized state is byte identical");
+  {
+    champ::Snapshot<K, V, H> snapshot_1(map);
+    std::vector<uint8_t> s_1(map.get_serialized_size());
+    snapshot_1.serialize(s_1.data());
 
-      champ::Snapshot<K, V, H> snapshot_2(map);
-      std::vector<uint8_t> s_2(map.get_serialized_size());
-      snapshot_2.serialize(s_2.data());
+    champ::Snapshot<K, V, H> snapshot_2(map);
+    std::vector<uint8_t> s_2(map.get_serialized_size());
+    snapshot_2.serialize(s_2.data());
 
-      REQUIRE_EQ(s_1, s_2);
-    }
+    REQUIRE_EQ(s_1, s_2);
+  }
 
   INFO("Serialize map with different key sizes");
   {


### PR DESCRIPTION
Noticed this when plugging the new snapshot mechanism into the rest of CCF. The size of the pre-insertion serialised K,V pair returned by `put_mut()` was actually the size of the post-insertion serialised K,V. This worked so far in our unit tests because we use same keys and values but didn't in the case of the `ccf.member_acks` table which changes in size as members ack.