### PR TITLE
Fix --gov-script requirements

### DIFF
--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -8,12 +8,11 @@ import sys
 
 
 def absolute_path_to_existing_file(arg):
-    abs_arg = os.path.abspath(arg)
-    if arg != abs_arg:
+    if not os.path.isabs(arg):
         raise argparse.ArgumentTypeError("Must provide absolute path")
-    if not os.path.isfile(abs_arg):
-        raise argparse.ArgumentTypeError(f"{abs_arg} is not a file")
-    return abs_arg
+    if not os.path.isfile(arg):
+        raise argparse.ArgumentTypeError(f"{arg} is not a file")
+    return arg
 
 
 def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
@@ -64,7 +63,6 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         "-g",
         "--gov-script",
         help="Path to governance script",
-        required=True,
         type=absolute_path_to_existing_file,
     )
     parser.add_argument("-s", "--app-script", help="Path to app script")

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -277,6 +277,9 @@ class Network:
         :param args: command line arguments to configure the CCF nodes.
         """
         self.common_dir = get_common_folder_name(args.workspace, args.label)
+
+        assert args.gov_script is not None, "--gov-script argument must be provided to start a network"
+        
         self._setup_common_folder(args.gov_script)
 
         initial_member_ids = list(range(max(1, args.initial_member_count)))

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -278,8 +278,10 @@ class Network:
         """
         self.common_dir = get_common_folder_name(args.workspace, args.label)
 
-        assert args.gov_script is not None, "--gov-script argument must be provided to start a network"
-        
+        assert (
+            args.gov_script is not None
+        ), "--gov-script argument must be provided to start a network"
+
         self._setup_common_folder(args.gov_script)
 
         initial_member_ids = list(range(max(1, args.initial_member_count)))

--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -120,4 +120,8 @@ if __name__ == "__main__":
             "Error: --recover requires --ledger, --network-enc-pubk and --common-dir arguments."
         )
         sys.exit(1)
+    else:
+        print("Error: --gov-script is required.")
+        sys.exit(2)
+
     run(args)

--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -120,8 +120,5 @@ if __name__ == "__main__":
             "Error: --recover requires --ledger, --network-enc-pubk and --common-dir arguments."
         )
         sys.exit(1)
-    else:
-        print("Error: --gov-script is required.")
-        sys.exit(2)
 
     run(args)


### PR DESCRIPTION
Fix daily build failure, caused by the code changes in [#1415](https://github.com/microsoft/CCF/pull/1415/files#diff-797fc5ba90a3fcd2d165899c4b735d24). We don't need a normalised abs path (what the previous code did), just an abs path. Additionally, we can't make it required because its actually _not_ required for the `--recover` case. ~~This sadly means it is not required for anything apart from `start_network.py`, but if its ever missing we'll get ugly errors later...~~ Instead, we assert its set just before use, at least getting a clear error.