### PR TITLE
Allow longer for e2e_batched timeout

### DIFF
--- a/tests/e2e_batched.py
+++ b/tests/e2e_batched.py
@@ -107,15 +107,25 @@ def run_to_destruction(args):
                 network = test(network, args, batch_size=10, write_size_multiplier=wsm)
                 wsm += 5000
         except Exception as e:
-            sleep_time = 3
+            timeout = 10
+            
             LOG.info("Large write set caused an exception, as expected")
             LOG.info(f"Exception was: {e}")
-            LOG.info(f"Waiting {sleep_time}s for node to terminate")
+            LOG.info(f"Polling for {timeout}s for node to terminate")
 
-            time.sleep(sleep_time)
-            assert (
-                network.nodes[0].remote.remote.proc.poll() is not None
-            ), "Primary should have been terminated"
+            end_time = time.time() + timeout
+            while time.time() < end_time:
+                time.sleep(0.1)
+                exit_code = network.nodes[0].remote.remote.proc.poll()
+                if exit_code is not None:
+                    LOG.info(f"Node terminated with exit code {exit_code}")
+                    assert exit_code != 0
+                    break
+
+            if time.time() > end_time:
+                raise TimeoutError(
+                    f"Node took longer than {end_time}s to terminate"
+                )
 
             network.ignore_errors_on_shutdown()
 

--- a/tests/e2e_batched.py
+++ b/tests/e2e_batched.py
@@ -108,7 +108,7 @@ def run_to_destruction(args):
                 wsm += 5000
         except Exception as e:
             timeout = 10
-            
+
             LOG.info("Large write set caused an exception, as expected")
             LOG.info(f"Exception was: {e}")
             LOG.info(f"Polling for {timeout}s for node to terminate")
@@ -123,9 +123,7 @@ def run_to_destruction(args):
                     break
 
             if time.time() > end_time:
-                raise TimeoutError(
-                    f"Node took longer than {end_time}s to terminate"
-                )
+                raise TimeoutError(f"Node took longer than {end_time}s to terminate")
 
             network.ignore_errors_on_shutdown()
 


### PR DESCRIPTION
`lua_e2e_batched` is failing occasionally in the CI. Looks like the "wait 3 seconds for dying node to terminate" is not always long enough. This extends the timeout to 10s, but polls more rapidly, so we should wait _less_ time when the node actually terminates straight away.