### PR TITLE
Primary endpoint

### DIFF
--- a/python/ccf/clients.py
+++ b/python/ccf/clients.py
@@ -341,7 +341,7 @@ class RequestClient:
             "url": f"https://{self.host}:{self.port}{request.path}",
             "auth": auth_value,
             "headers": extra_headers,
-            "allow_redirects": False
+            "allow_redirects": False,
         }
 
         if request.params is not None:

--- a/python/ccf/clients.py
+++ b/python/ccf/clients.py
@@ -341,6 +341,7 @@ class RequestClient:
             "url": f"https://{self.host}:{self.port}{request.path}",
             "auth": auth_value,
             "headers": extra_headers,
+            "allow_redirects": False
         }
 
         if request.params is not None:
@@ -490,6 +491,9 @@ class CCFClient:
 
     def delete(self, *args, **kwargs):
         return self.call(*args, http_verb="DELETE", **kwargs)
+
+    def head(self, *args, **kwargs):
+        return self.call(*args, http_verb="HEAD", **kwargs)
 
 
 @contextlib.contextmanager

--- a/src/node/rpc/endpoint_registry.h
+++ b/src/node/rpc/endpoint_registry.h
@@ -56,6 +56,7 @@ namespace ccf
   {
     Sometimes,
     Always,
+    Never
   };
 
   /** The EndpointRegistry records the user-defined endpoints for a given

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -335,6 +335,11 @@ namespace ccf
       {
         switch (endpoint->forwarding_required)
         {
+          case ForwardingRequired::Never:
+          {
+            break;
+          }
+
           case ForwardingRequired::Sometimes:
           {
             if (ctx->session->is_forwarding)

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -317,6 +317,18 @@ namespace ccf
       make_read_only_endpoint(
         "network", HTTP_GET, json_read_only_adapter(network_status))
         .install();
+
+      auto is_primary = [this](CommandEndpointContext& args) {
+        if (this->node.is_primary())
+        {
+          args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+        }
+        else
+        {
+          args.rpc_ctx->set_response_status(HTTP_STATUS_PERMANENT_REDIRECT);
+        }
+      };
+      make_command_endpoint("primary", HTTP_GET, is_primary).install();
     }
   };
 

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -341,7 +341,9 @@ namespace ccf
           }
         }
       };
-      make_read_only_endpoint("primary", HTTP_GET, is_primary).install();
+      make_read_only_endpoint("primary", HTTP_HEAD, is_primary)
+        .set_forwarding_required(ForwardingRequired::Never)
+        .install();
     }
   };
 

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -542,14 +542,17 @@ def test_tx_statuses(network, args):
 @reqs.description("Primary and redirection")
 @reqs.at_least_n_nodes(2)
 def test_primary(network, args, notifications_queue=None, verify=True):
+    LOG.error(network.nodes)
     primary, _ = network.find_primary()
+    LOG.error(f"PRIMARY {primary.pubhost}")
     with primary.client() as c:
-        r = c.get("/node/primary")
+        r = c.head("/node/primary")
         assert r.status == http.HTTPStatus.OK.value
 
     backup = network.find_any_backup()
+    LOG.error(f"BACKUP {backup.pubhost}")
     with backup.client() as c:
-        r = c.get("/node/primary")
+        r = c.head("/node/primary")
         assert r.status == http.HTTPStatus.PERMANENT_REDIRECT.value
         assert (
             r.headers["location"]


### PR DESCRIPTION
As requested by @syhamza, for load balancing purposes, this adds a `/node/primary` which will either return 200 if the node is primary, or 308 and attempt to redirect to the primary if possible.