### PR TITLE
Optimistic fix for GH Pages CI failures

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
         env
         git status
         git rev-parse HEAD
-        git checkout -b master $BUILD_SOURCEVERSION
+        git checkout -b master $(git rev-parse HEAD)
       displayName: Prepare repo
 
     - script: |


### PR DESCRIPTION
[This run](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=11041&view=logs&j=f1fd332c-cd58-5ba4-fc7d-3c1d3a3f0cd3&t=2dc3064a-1eab-55f1-840a-179a38037e58) is a failure with the debugging from #1438, and it looks like `git rev-parse HEAD` is the correct current commit hash even when `BUILD_SOURCEVERSION` is wrong.

Its possible that `git checkout -b master` is sufficient here (we're trying to create a branch from the current state, called master, to satisfy `sphinx-multiversion`), but this is hard to reproduce or verify so going with the safer option.