### PR TITLE
Workaround for lifetime mismatch between thread messaging and ringbuffers/enclave

### DIFF
--- a/src/enclave/tls_endpoint.h
+++ b/src/enclave/tls_endpoint.h
@@ -220,13 +220,14 @@ namespace enclave
     struct SendRecvMsg
     {
       std::vector<uint8_t> data;
-      std::shared_ptr<Endpoint> self;
+      std::weak_ptr<Endpoint> self;
     };
 
     static void send_raw_cb(std::unique_ptr<threading::Tmsg<SendRecvMsg>> msg)
     {
-      reinterpret_cast<TLSEndpoint*>(msg->data.self.get())
-        ->send_raw_thread(msg->data.data);
+      auto ptr = msg->data.self.lock();
+      reinterpret_cast<TLSEndpoint*>(ptr.get())->send_raw_thread(
+        msg->data.data);
     }
 
     void send_raw(const std::vector<uint8_t>& data)

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -35,8 +35,9 @@ namespace http
   public:
     static void recv_cb(std::unique_ptr<threading::Tmsg<SendRecvMsg>> msg)
     {
-      reinterpret_cast<HTTPEndpoint*>(msg->data.self.get())
-        ->recv_(msg->data.data.data(), msg->data.data.size());
+      auto ptr = msg->data.self.lock();
+      reinterpret_cast<TLSEndpoint*>(ptr.get())->send_raw_thread(
+        msg->data.data);
     }
 
     void recv(const uint8_t* data, size_t size) override

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -36,7 +36,7 @@ namespace http
     static void recv_cb(std::unique_ptr<threading::Tmsg<SendRecvMsg>> msg)
     {
       auto ptr = msg->data.self.lock();
-      reinterpret_cast<TLSEndpoint*>(ptr.get())->send_raw_thread(
+      reinterpret_cast<HTTPEndpoint*>(ptr.get())->send_raw_thread(
         msg->data.data);
     }
 


### PR DESCRIPTION
Follow up to #1442, which revealed in some Daily build runs that ownership of Endpoints by the Tasks can cause them to be destroyed after the ringbuffers (which is problematic because the TLSEndpoint destructor uses the ringbuffer to send a session close).

The right long term solution is probably to change the lifetime of thread_messaging so it isn't static and so it's scoped to be shut down before the ringbuffers/while the enclave/node is still effectively in scope. This is a bigger change than we want to squeeze in just before a release though.