### PR TITLE
Test and document set_user_data

### DIFF
--- a/doc/members/open_network.rst
+++ b/doc/members/open_network.rst
@@ -26,7 +26,7 @@ Then, the certificates of trusted users should be registered in CCF via the memb
         "state": "OPEN"
     }
 
-Other members are then allowed to vote for the proposal, using the proposal id returned to the proposer member (here ``5``). They may submit an unconditional approval, or their vote may query the current state and the proposed calls. These votes `must` be signed.
+Other members are then allowed to vote for the proposal, using the proposal id returned to the proposer member (here ``5``). They may submit an unconditional approval, or their vote may query the current state and the proposed actions. These votes `must` be signed.
 
 .. code-block:: bash
 
@@ -69,7 +69,53 @@ The user can then make user RPCs, for example ``user_id`` to retrieve the unique
         "caller_id": 4
     }
 
-For each user CCF also stores arbitrary user-data in a JSON object, which can only be written to by members, subject to the standard proposal-vote governance mechanism. This lets members define initial metadata for certain users; for example to grant specific privileges, associate a human-readable name, or categorise the users. This user-data can then be read (but not written) by user-facing apps.
+User Data
+---------
+
+For each user, CCF also stores arbitrary user-data in a JSON object. This can only be written to by members, subject to the standard proposal-vote governance mechanism, via the ``set_user_data`` action. This lets members define initial metadata for certain users; for example to grant specific privileges, associate a human-readable name, or categorise the users. This user-data can then be read (but not written) by user-facing endpoints.
+
+For example, the C++ logging sample app has an endpoint (``/log/private/admin_only``) which uses user-data to restrict who is permitted to call it:
+
+.. literalinclude:: ../../src/apps/logging/logging.cpp
+    :language: cpp
+    :start-after: SNIPPET_START: user_data_check
+    :end-before: SNIPPET_END: user_data_check
+    :dedent: 12
+
+Members configure this permission with ``set_user_data`` proposals:
+
+.. code-block:: bash
+
+    $ cat set_user_data_proposal.json 
+    {
+        "script": {
+            "text": "tables, args = ...; return Calls:call(\"set_user_data\", args)"
+        },
+        "parameter": {
+            "user_id": 0,
+            "user_data": {
+                "isAdmin": true
+            }
+        }
+    }
+
+Once this proposal is accepted, user 0 is able to use this endpoint:
+
+.. code-block:: bash
+
+    $ curl https://<ccf-node-address>/app/log/private/admin_only --key user0_privk.pem --cert user0_cert.pem --cacert networkcert.pem -X POST --data-binary '{"id": 42, "msg": "hello world"}' -H "Content-type: application/json" -i
+    HTTP/1.1 200 OK
+
+    true
+
+All other users have empty or non-matching user-data, so will receive a HTTP error if they attempt to access it:
+
+.. code-block:: bash
+
+    $ curl https://<ccf-node-address>/app/log/private/admin_only --key user1_privk.pem --cert user1_cert.pem --cacert networkcert.pem -X POST --data-binary '{"id": 42, "msg": "hello world"}' -H "Content-type: application/json" -i
+    HTTP/1.1 403 Forbidden
+
+    Only admins may access this endpoint
 
 Registering the Lua Application
 -------------------------------

--- a/doc/members/open_network.rst
+++ b/doc/members/open_network.rst
@@ -74,7 +74,7 @@ User Data
 
 For each user, CCF also stores arbitrary user-data in a JSON object. This can only be written to by members, subject to the standard proposal-vote governance mechanism, via the ``set_user_data`` action. This lets members define initial metadata for certain users; for example to grant specific privileges, associate a human-readable name, or categorise the users. This user-data can then be read (but not written) by user-facing endpoints.
 
-For example, the C++ logging sample app has an endpoint (``/log/private/admin_only``) which uses user-data to restrict who is permitted to call it:
+For example, the ``/log/private/admin_only`` endpoint in the C++ logging sample app uses user-data to restrict who is permitted to call it:
 
 .. literalinclude:: ../../src/apps/logging/logging.cpp
     :language: cpp

--- a/doc/members/proposals.rst
+++ b/doc/members/proposals.rst
@@ -3,7 +3,7 @@ Proposing and Voting for a Proposal
 
 This page explains how members can submit and vote for proposals.
 
-Proposals and vote ballots are submitted as Lua scripts. These scripts are executed transactionally, able to read from the current KV state but not write directly to it. Proposals return a list of proposed actions which can make writes, but are only applied when the proposal is accepted. Each vote script is given this list of proposed calls, and also able to read from the KV, and returns a boolean indicating whether it supports or rejects the proposed actions.
+Proposals and vote ballots are submitted as Lua scripts. These scripts are executed transactionally, able to read from the current KV state but not write directly to it. Proposals return a list of proposed actions which can make writes, but are only applied when the proposal is accepted. Each vote script is given this list of proposed actions, and also able to read from the KV, and returns a boolean indicating whether it supports or rejects the proposed actions.
 
 Any member can submit a new proposal. All members can then vote on this proposal using its unique proposal id. Each member may alter their vote (by submitting a new vote) any number of times while the proposal is open. The member who originally submitted the proposal (the `proposer`) votes for the proposal by default, but has the option to include a negative or conditional vote like any other member. Additionally, the proposer has the ability to `withdraw` a proposal while it is open.
 

--- a/doc/schemas/log/private/admin_only_POST_params.json
+++ b/doc/schemas/log/private/admin_only_POST_params.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "id": {
+      "maximum": 18446744073709551615,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "msg": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "msg"
+  ],
+  "title": "log/private/admin_only/params",
+  "type": "object"
+}

--- a/doc/schemas/log/private/admin_only_POST_result.json
+++ b/doc/schemas/log/private/admin_only_POST_result.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "log/private/admin_only/result",
+  "type": "boolean"
+}

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -387,6 +387,48 @@ def test_update_lua(network, args):
 
     return network
 
+@reqs.description("Test user-data used for access permissions")
+@reqs.supports_methods("log/private/admin_only")
+def test_user_data_ACL(network, args):
+    primary, _ = network.find_primary()
+
+    proposing_member = network.consortium.get_any_active_member()
+    user_id = 0
+
+    # Give isAdmin permissions to a single user
+    proposal_body, careful_vote = ccf.proposal_generator.set_user_data(
+        user_id,
+        {"isAdmin": True},
+    )
+    proposal = proposing_member.propose(
+        primary, proposal_body
+    )
+    proposal.vote_for = careful_vote
+    network.consortium.vote_using_majority(primary, proposal)
+
+    # Confirm that user can now use this endpoint
+    with primary.client(f"user{user_id}") as c:
+        r = c.post("/app/log/private/admin_only", {"id": 42, "msg": "hello world"})
+        assert r.status_code == http.HTTPStatus.OK.value, r.status_code
+
+    # Remove permission
+    proposal_body, careful_vote = ccf.proposal_generator.set_user_data(
+        user_id,
+        {"isAdmin": False},
+    )
+    proposal = proposing_member.propose(
+        primary, proposal_body
+    )
+    proposal.vote_for = careful_vote
+    network.consortium.vote_using_majority(primary, proposal)
+
+    # Confirm that user is now forbidden on this endpoint
+    with primary.client(f"user{user_id}") as c:
+        r = c.post("/app/log/private/admin_only", {"id": 42, "msg": "hello world"})
+        assert r.status_code == http.HTTPStatus.FORBIDDEN.value, r.status_code
+
+    return network
+
 
 @reqs.description("Check for commit of every prior transaction")
 @reqs.supports_methods("/node/commit")
@@ -586,6 +628,7 @@ def run(args):
             network = test_remove(network, args)
             network = test_forwarding_frontends(network, args)
             network = test_update_lua(network, args)
+            network = test_user_data_ACL(network, args)
             network = test_cert_prefix(network, args)
             network = test_anonymous_caller(network, args)
             network = test_raw_text(network, args)

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -431,7 +431,7 @@ def test_user_data_ACL(network, args):
 
 
 @reqs.description("Check for commit of every prior transaction")
-@reqs.supports_methods("/node/commit")
+@reqs.supports_methods("commit")
 def test_view_history(network, args):
     if args.consensus == "pbft":
         # This appears to work in PBFT, but it is unacceptably slow:

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -387,6 +387,7 @@ def test_update_lua(network, args):
 
     return network
 
+
 @reqs.description("Test user-data used for access permissions")
 @reqs.supports_methods("log/private/admin_only")
 def test_user_data_ACL(network, args):
@@ -397,12 +398,9 @@ def test_user_data_ACL(network, args):
 
     # Give isAdmin permissions to a single user
     proposal_body, careful_vote = ccf.proposal_generator.set_user_data(
-        user_id,
-        {"isAdmin": True},
+        user_id, {"isAdmin": True},
     )
-    proposal = proposing_member.propose(
-        primary, proposal_body
-    )
+    proposal = proposing_member.propose(primary, proposal_body)
     proposal.vote_for = careful_vote
     network.consortium.vote_using_majority(primary, proposal)
 
@@ -413,12 +411,9 @@ def test_user_data_ACL(network, args):
 
     # Remove permission
     proposal_body, careful_vote = ccf.proposal_generator.set_user_data(
-        user_id,
-        {"isAdmin": False},
+        user_id, {"isAdmin": False},
     )
-    proposal = proposing_member.propose(
-        primary, proposal_body
-    )
+    proposal = proposing_member.propose(primary, proposal_body)
     proposal.vote_for = careful_vote
     network.consortium.vote_using_majority(primary, proposal)
 

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -426,7 +426,6 @@ def test_user_data_ACL(network, args):
 
 
 @reqs.description("Check for commit of every prior transaction")
-@reqs.supports_methods("commit")
 def test_view_history(network, args):
     if args.consensus == "pbft":
         # This appears to work in PBFT, but it is unacceptably slow:

--- a/tests/suite/test_suite.py
+++ b/tests/suite/test_suite.py
@@ -62,6 +62,7 @@ all_tests_suite = [
     e2e_logging.test_raw_text,
     e2e_logging.test_forwarding_frontends,
     e2e_logging.test_update_lua,
+    e2e_logging.test_user_data_ACL,
     e2e_logging.test_view_history,
     e2e_logging.test_tx_statuses,
     # memberclient:

--- a/tests/ws_scaffold.py
+++ b/tests/ws_scaffold.py
@@ -12,7 +12,7 @@ from loguru import logger as LOG
 
 
 @reqs.description("Running transactions against logging app")
-@reqs.supports_methods("/app/log/private")
+@reqs.supports_methods("log/private")
 @reqs.at_least_n_nodes(2)
 def test(network, args, notifications_queue=None):
     primary, other = network.find_primary_and_any_backup()


### PR DESCRIPTION
Fixes #1397.

- Adds `/app/log/private/admin_only` to the C++ logging app, using user-data as a very primitive ACL
- Expands documentation on `set_user_data` proposals
- Adds test case in `e2e_logging.py`
