### PR TITLE
Add link to remote SSH tutorial

### DIFF
--- a/doc/quickstart/index.rst
+++ b/doc/quickstart/index.rst
@@ -33,6 +33,10 @@ SGX-enabled VM
 The install directory contains (under ``getting_started/``) the Azure and Ansible scripts required to create and set up
 an SGX-enabled dev VM in Azure, with all necessary dependencies to build CCF itself or CCF applications.
 
+If you use `Visual Studio Code`_ you can install and set up the `Remote - SSH`_ extension to connect to your SGX-enabled VM.
+
+.. _`Remote - SSH`: https://code.visualstudio.com/docs/remote/ssh-tutorial
+
 Creation
 ~~~~~~~~
 
@@ -63,7 +67,7 @@ After signing in to your Azure account, the script will create a default ``ccf``
 Setup
 ~~~~~
 
-CCF dependencies include OpenEnclave_, mbedtls_, libuv_ and libcurl_.
+CCF dependencies include `Open Enclave`_, mbedtls_, libuv_ and libcurl_.
 
 To quickly set up the dependencies necessary to build CCF, simply run:
 
@@ -81,7 +85,7 @@ On a machine without SGX, you can instead run:
     $ cd CCF/getting_started/setup_vm
     $ ./run.sh ccf-dev.yml
 
-.. _OpenEnclave: https://github.com/openenclave/openenclave
+.. _`Open Enclave`: https://github.com/openenclave/openenclave
 .. _mbedtls: https://tls.mbed.org/
 .. _libuv: https://github.com/libuv/libuv
 .. _libcurl: https://curl.haxx.se/libcurl/


### PR DESCRIPTION
VS Code has added a new and excellent tutorial page for the SSH extension.