### PR TITLE
PyPi releases

### DIFF
--- a/.azure-pipelines-templates/release.yml
+++ b/.azure-pipelines-templates/release.yml
@@ -28,12 +28,11 @@ jobs:
         addChangeLog: false
       displayName: 'GitHub release (create)'
 
-    # For now, push to test PyPi
     - script: |
         python3.7 -m venv env
         source ./env/bin/activate
         python setup.py sdist
-        python -m pip install twine
-        twine upload -u __token__ -p $(pypi_test_token) --repository testpypi dist/*
+        pip install twine
+        twine upload -u __token__ -p $(pypi_token) dist/*
       workingDirectory: python
-      displayName: PyPi https://test.pypi.org/project/ccf/
+      displayName: PyPi https://pypi.org/project/ccf/

--- a/python/README.md
+++ b/python/README.md
@@ -5,7 +5,3 @@ Suite of Python tools for the Confidential Consortium Framework (CCF).
 For more information, please find the the CCF documentation at https://microsoft.github.io/CCF.
 
 Package sources are available at https://github.com/microsoft/CCF/tree/master/python.
-
-
-
-

--- a/python/README.md
+++ b/python/README.md
@@ -1,3 +1,11 @@
 # CCF Python
 
-Suite of Python tools for the Confidential Consortium Framework (CCF). For more information, please visit https://github.com/microsoft/CCF/tree/master/python.
+Suite of Python tools for the Confidential Consortium Framework (CCF).
+
+For more information, please find the the CCF documentation at https://microsoft.github.io/CCF.
+
+Package sources are available at https://github.com/microsoft/CCF/tree/master/python.
+
+
+
+

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,14 +14,13 @@ with open(path.join(path_here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name=PACKAGE_NAME,
-    version="0.11.7",
+    version="0.12",
     description="Set of tools and utilities for the Confidential Consortium Framework (CCF)",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/microsoft/CCF/python/ccf",
     license="Apache License 2.0",
     author="CCF Team",
-    author_email="ccfeng@microsoft.com",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,11 @@
 wheel
 paramiko
+msgpack
 loguru
 coincurve
 psutil
 cimetrics>=0.2.1
+requests-http-signature
+flatbuffers
+websocket-client
 pynacl

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,11 +1,7 @@
 wheel
 paramiko
-msgpack
 loguru
 coincurve
 psutil
 cimetrics>=0.2.1
-requests-http-signature
-flatbuffers
-websocket-client
 pynacl


### PR DESCRIPTION
Automated PyPi releases (this time, to the real PyPi!)

The version number is hardcoded to `0.12` for now. A further PR will address that so that it is derived from the git tag/cmake version.