### PR TITLE
Require / prefix on URL paths in Python

### DIFF
--- a/python/ccf/clients.py
+++ b/python/ccf/clients.py
@@ -491,7 +491,7 @@ class CCFClient:
         """
         Issues one request, synchronously, and returns the response.
 
-        :param str path: URI of the targeted resource.
+        :param str path: URI of the targeted resource. Must begin with '/'
         :param dict body: Request body (optional).
         :param http_verb: HTTP verb (e.g. "POST" or "GET").
         :param headers: HTTP request headers (optional).
@@ -500,6 +500,9 @@ class CCFClient:
 
         :return: :py:class:`ccf.clients.Response`
         """
+        if not path.startswith("/"):
+            raise ValueError(f"URL path '{path}' is invalid, must start with /")
+
         end_time = time.time() + self.connection_timeout
         while True:
             try:

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -92,7 +92,7 @@ def can_kill_n_nodes(nodes_to_kill_count):
         primary, _ = network.find_primary()
         with primary.client("member0") as c:
             r = c.post(
-                "gov/query",
+                "/gov/query",
                 {
                     "text": """tables = ...
                         trusted_nodes_count = 0


### PR DESCRIPTION
While trying to repro a failure in `full_test_suite`, I noticed we've been silently skipping one of the tests for a while:

```
2020-07-29 10:14:06.413 | WARNING  | __main__:run:141 - Test #25:
{
    "name": "election.test_kill_primary",
    "status": "skipped",
    "elapsed (s)": 0.07,
    "reason": "Could not check if test requirements were met: Request client failed with unexpected error"
}
```

The error is trivial, a missing `/` prefix when constructing a requirement-checking request. Now we enforce that all request paths include this prefix. Open to suggestions if anyone sees a neater way to handle requirement failures to ensure these skips are louder in future.