### PR TITLE
Support LVI when building from installed CCF

### DIFF
--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -66,10 +66,17 @@ function(add_lvi_mitigations name)
 endfunction()
 
 if(LVI_MITIGATIONS)
-  install(FILES ${CMAKE_CURRENT_LIST_DIR}/lvi/lvi_mitigation_config.cmake DESTINATION cmake/lvi)
-  install(FILES ${CMAKE_CURRENT_LIST_DIR}/lvi/configure_lvi_mitigation_build.cmake DESTINATION cmake/lvi)
-  install(FILES ${CMAKE_CURRENT_LIST_DIR}/lvi/apply_lvi_mitigation.cmake DESTINATION cmake/lvi)
-  
+  install(FILES ${CMAKE_CURRENT_LIST_DIR}/lvi/lvi_mitigation_config.cmake
+          DESTINATION cmake/lvi
+  )
+  install(
+    FILES ${CMAKE_CURRENT_LIST_DIR}/lvi/configure_lvi_mitigation_build.cmake
+    DESTINATION cmake/lvi
+  )
+  install(FILES ${CMAKE_CURRENT_LIST_DIR}/lvi/apply_lvi_mitigation.cmake
+          DESTINATION cmake/lvi
+  )
+
   # Also pull in the LVI mitigation wrappers
   include(${CMAKE_CURRENT_LIST_DIR}/lvi/lvi_mitigation_config.cmake)
 endif()
@@ -88,8 +95,17 @@ function(sign_app_library name app_oe_conf_path enclave_sign_key_path)
     set(TMP_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/${name}_tmp)
     add_custom_command(
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so.debuggable
-      COMMAND cp ${app_oe_conf_path} ${DEBUG_CONF_NAME}
-      COMMAND echo "Debug=1" >> ${DEBUG_CONF_NAME}
+      COMMAND
+        cp ${app_oe_conf_path} ${DEBUG_CONF_NAME} && (grep
+                                                      "Debug\=.*"
+                                                      ${DEBUG_CONF_NAME}
+                                                      &&
+                                                      (sed -i
+                                                       "s/Debug=\.*/Debug=1/"
+                                                       ${DEBUG_CONF_NAME})
+                                                      ||
+                                                      (echo "Debug=1" >>
+                                                       ${DEBUG_CONF_NAME}))
       COMMAND mkdir -p ${TMP_FOLDER}
       COMMAND ln -s ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so
               ${TMP_FOLDER}/lib${name}.so
@@ -111,8 +127,17 @@ function(sign_app_library name app_oe_conf_path enclave_sign_key_path)
     set(SIGNED_CONF_NAME ${CMAKE_CURRENT_BINARY_DIR}/${name}.signed.conf)
     add_custom_command(
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so.signed
-      COMMAND cp ${app_oe_conf_path} ${SIGNED_CONF_NAME}
-      COMMAND echo "Debug=0" >> ${SIGNED_CONF_NAME}
+      COMMAND
+        cp ${app_oe_conf_path} ${SIGNED_CONF_NAME} && (grep
+                                                       "Debug\=.*"
+                                                       ${SIGNED_CONF_NAME}
+                                                       &&
+                                                       (sed -i
+                                                        "s/Debug=\.*/Debug=0/"
+                                                        ${SIGNED_CONF_NAME})
+                                                       ||
+                                                       (echo "Debug=0" >>
+                                                        ${SIGNED_CONF_NAME}))
       COMMAND
         openenclave::oesign sign -e ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so -c
         ${SIGNED_CONF_NAME} -k ${enclave_sign_key_path}

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -66,8 +66,12 @@ function(add_lvi_mitigations name)
 endfunction()
 
 if(LVI_MITIGATIONS)
+  install(FILES ${CMAKE_CURRENT_LIST_DIR}/lvi/lvi_mitigation_config.cmake DESTINATION cmake/lvi)
+  install(FILES ${CMAKE_CURRENT_LIST_DIR}/lvi/configure_lvi_mitigation_build.cmake DESTINATION cmake/lvi)
+  install(FILES ${CMAKE_CURRENT_LIST_DIR}/lvi/apply_lvi_mitigation.cmake DESTINATION cmake/lvi)
+  
   # Also pull in the LVI mitigation wrappers
-  include(${CCF_DIR}/cmake/lvi/lvi_mitigation_config.cmake)
+  include(${CMAKE_CURRENT_LIST_DIR}/lvi/lvi_mitigation_config.cmake)
 endif()
 
 # Sign a built enclave library with oesign

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -36,6 +36,35 @@ find_package(OpenEnclave 0.10 CONFIG REQUIRED)
 # standard naming patterns, for example use OE_INCLUDEDIR rather than
 # OpenEnclave_INCLUDE_DIRS
 
+option(LVI_MITIGATIONS "Enable LVI mitigations" ON)
+if(LVI_MITIGATIONS)
+  set(OE_TARGET_LIBC openenclave::oelibc-lvi-cfg)
+  set(OE_TARGET_ENCLAVE_AND_STD
+      openenclave::oeenclave-lvi-cfg openenclave::oelibcxx-lvi-cfg
+      openenclave::oelibc-lvi-cfg
+  )
+  set(OE_TARGET_ENCLAVE_CORE_LIBS
+      openenclave::oeenclave-lvi-cfg openenclave::oesnmalloc-lvi-cfg
+      openenclave::oecore-lvi-cfg openenclave::oesyscall-lvi-cfg
+  )
+else()
+  set(OE_TARGET_LIBC openenclave::oelibc)
+  set(OE_TARGET_ENCLAVE_AND_STD openenclave::oeenclave openenclave::oelibcxx
+                                openenclave::oelibc
+  )
+  # These oe libraries must be linked in specific order
+  set(OE_TARGET_ENCLAVE_CORE_LIBS
+      openenclave::oeenclave openenclave::oesnmalloc openenclave::oecore
+      openenclave::oesyscall
+  )
+endif()
+
+function(add_lvi_mitigations name)
+  if(LVI_MITIGATIONS)
+    apply_lvi_mitigation(${name})
+  endif()
+endfunction()
+
 if(LVI_MITIGATIONS)
   # Also pull in the LVI mitigation wrappers
   include(${CCF_DIR}/cmake/lvi/lvi_mitigation_config.cmake)

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -29,35 +29,6 @@ if(VERBOSE_LOGGING)
   set(TEST_HOST_LOGGING_LEVEL "debug")
 endif()
 
-option(LVI_MITIGATIONS "Enable LVI mitigations" ON)
-if(LVI_MITIGATIONS)
-  set(OE_TARGET_LIBC openenclave::oelibc-lvi-cfg)
-  set(OE_TARGET_ENCLAVE_AND_STD
-      openenclave::oeenclave-lvi-cfg openenclave::oelibcxx-lvi-cfg
-      openenclave::oelibc-lvi-cfg
-  )
-  set(OE_TARGET_ENCLAVE_CORE_LIBS
-      openenclave::oeenclave-lvi-cfg openenclave::oesnmalloc-lvi-cfg
-      openenclave::oecore-lvi-cfg openenclave::oesyscall-lvi-cfg
-  )
-else()
-  set(OE_TARGET_LIBC openenclave::oelibc)
-  set(OE_TARGET_ENCLAVE_AND_STD openenclave::oeenclave openenclave::oelibcxx
-                                openenclave::oelibc
-  )
-  # These oe libraries must be linked in specific order
-  set(OE_TARGET_ENCLAVE_CORE_LIBS
-      openenclave::oeenclave openenclave::oesnmalloc openenclave::oecore
-      openenclave::oesyscall
-  )
-endif()
-
-function(add_lvi_mitigations name)
-  if(LVI_MITIGATIONS)
-    apply_lvi_mitigation(${name})
-  endif()
-endfunction()
-
 option(NO_STRICT_TLS_CIPHERSUITES
        "Disable strict list of valid TLS ciphersuites" OFF
 )

--- a/src/apps/js_generic/oe_sign.conf
+++ b/src/apps/js_generic/oe_sign.conf
@@ -4,3 +4,4 @@ NumStackPages=1024
 NumTCS=8
 ProductID=1
 SecurityVersion=1
+Debug=0

--- a/src/apps/logging/oe_sign.conf
+++ b/src/apps/logging/oe_sign.conf
@@ -4,3 +4,4 @@ NumStackPages=1024
 NumTCS=8
 ProductID=1
 SecurityVersion=1
+Debug=1


### PR DESCRIPTION
Fixed #1466 

Mostly moving LVI CMake machinery from `common.cmake` to `ccf_app.cmake`. Also installing the LVI cmake files.

While testing I noticed something else:
`oesign` now throws an error if it sees multiple `Debug=X` entries in an `oe_sign.conf` (previously it happily used the latter). This means our old approach of appending `Debug=1` or `Debug=0` for `.debuggable`/`.signed` builds no longer works if apps have an explicit `Debug=X` in their `.conf`. So now the CMake trickery says "sed replace if its already there, else append". Getting this ternary command through CMake's command mangling was surprisingly awkward, so the resulting (formatted) CMake is _ugly_.