### PR TITLE
Redirect cmake-format --check output to /dev/null

### DIFF
--- a/scripts/check-cmake-format.sh
+++ b/scripts/check-cmake-format.sh
@@ -38,7 +38,7 @@ pip install --disable-pip-version-check cmake_format 1>/dev/null
 
 unformatted_files=""
 for file in $(find "$@" -name "*.cmake" -o -name "CMakeLists.txt"); do
-  cmake-format --check "$file"
+  cmake-format --check "$file" > /dev/null
   d=$?
   if $fix ; then
     cmake-format -i "$file"


### PR DESCRIPTION
Since the last release (0.6.11) of `cmake-format`, it dumps the contents of correctly formatted files to std out in `--check` mode. This fills our CI `Checks` output [with CMake](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=11520&view=logs&j=435ca956-9126-505f-566f-fff31072e2ba&t=fd2f8e8e-b3a5-5d78-5a6a-df40f62a292a).

For now we pipe the results to `/dev/null` to ignore them.