### PR TITLE
Ensure connections_test actually creates and exhausts fds

### DIFF
--- a/tests/connections.py
+++ b/tests/connections.py
@@ -8,7 +8,6 @@ import infra.checker
 import contextlib
 import resource
 import psutil
-import random
 
 from loguru import logger as LOG
 
@@ -53,7 +52,7 @@ def run(args):
 
             try:
                 clients[-1].post("/app/log/private", {"id": 42, "msg": "foo"})
-            except Exception as e:
+            except Exception:
                 pass
             else:
                 assert False, "Expected error due to fd limit"
@@ -83,7 +82,7 @@ def run(args):
 
             try:
                 clients[-1].post("/app/log/private", {"id": 42, "msg": "foo"})
-            except Exception as e:
+            except Exception:
                 pass
             else:
                 assert False, "Expected error due to fd limit"


### PR DESCRIPTION
Our `connections_test` e2e test is intended to test the behaviour of a CCF node when the file descriptor cap is reached. It does this by setting a low cap, and then creating many connections to the CCF node. However, creating our Python client connection doesn't necessarily claim a fd - this is only done lazily, at the first message on that connection.

This PR updates the test to send logging messages from the create connections, and asserts that once the cap is reached any future connections will receive errors.