### PR TITLE
Add inspected types to proposal_generator CLI args

### DIFF
--- a/python/ccf/proposal_generator.py
+++ b/python/ccf/proposal_generator.py
@@ -268,7 +268,7 @@ def set_js_app(app_script_path: str, **kwargs):
 
 
 @cli_proposal
-def set_module(module_name, module_path, **kwargs):
+def set_module(module_name: str, module_path: str, **kwargs):
     module_name_ = PurePosixPath(module_name)
     if not module_name_.is_absolute():
         raise ValueError("module name must be an absolute path")
@@ -284,7 +284,7 @@ def set_module(module_name, module_path, **kwargs):
 
 
 @cli_proposal
-def remove_module(module_name, **kwargs):
+def remove_module(module_name: str, **kwargs):
     return build_proposal("remove_module", module_name, **kwargs)
 
 
@@ -299,16 +299,14 @@ def retire_node(node_id: int, **kwargs):
 
 
 @cli_proposal
-def new_node_code(code_digest: Union[str, list], **kwargs):
-    if isinstance(code_digest, str):
-        code_digest = list(bytearray.fromhex(code_digest))
+def new_node_code(code_digest: str, **kwargs):
+    code_digest = list(bytearray.fromhex(code_digest))
     return build_proposal("new_node_code", code_digest, **kwargs)
 
 
 @cli_proposal
-def new_user_code(code_digest: Union[str, list], **kwargs):
-    if isinstance(code_digest, str):
-        code_digest = list(bytearray.fromhex(code_digest))
+def new_user_code(code_digest: str, **kwargs):
+    code_digest = list(bytearray.fromhex(code_digest))
     return build_proposal("new_user_code", code_digest, **kwargs)
 
 
@@ -439,7 +437,13 @@ if __name__ == "__main__":
         for param_name, param in parameters.items():
             if param.kind == param.VAR_POSITIONAL or param.kind == param.VAR_KEYWORD:
                 continue
-            subparser.add_argument(param_name)
+            if param.annotation == param.empty:
+                param_type = None
+            elif param.annotation == dict:
+                param_type = json.loads
+            else:
+                param_type = param.annotation
+            subparser.add_argument(param_name, type=param_type)
             func_param_names.append(param_name)
         subparser.set_defaults(func=func, param_names=func_param_names)
 

--- a/python/ccf/proposal_generator.py
+++ b/python/ccf/proposal_generator.py
@@ -300,14 +300,14 @@ def retire_node(node_id: int, **kwargs):
 
 @cli_proposal
 def new_node_code(code_digest: str, **kwargs):
-    code_digest = list(bytearray.fromhex(code_digest))
-    return build_proposal("new_node_code", code_digest, **kwargs)
+    code_digest_bytes = list(bytearray.fromhex(code_digest))
+    return build_proposal("new_node_code", code_digest_bytes, **kwargs)
 
 
 @cli_proposal
 def new_user_code(code_digest: str, **kwargs):
-    code_digest = list(bytearray.fromhex(code_digest))
-    return build_proposal("new_user_code", code_digest, **kwargs)
+    code_digest_bytes = list(bytearray.fromhex(code_digest))
+    return build_proposal("new_user_code", code_digest_bytes, **kwargs)
 
 
 @cli_proposal
@@ -443,7 +443,7 @@ if __name__ == "__main__":
                 param_type = json.loads
             else:
                 param_type = param.annotation
-            subparser.add_argument(param_name, type=param_type)
+            subparser.add_argument(param_name, type=param_type)  # type: ignore
             func_param_names.append(param_name)
         subparser.set_defaults(func=func, param_names=func_param_names)
 


### PR DESCRIPTION
I noticed that `trust_node` and `retire_node` proposals generated by `proposal_generator` weren't actually useable, because they placed strings into the proposals rather than the int we require. Luckily we now have type annotations, so we can pass them to `argparse` and get the correct result (with an extra hack to load json dicts).