### PR TITLE
Remove misalignment UB

### DIFF
--- a/src/ds/serialized.h
+++ b/src/ds/serialized.h
@@ -22,15 +22,15 @@ namespace serialized
   }
 
   template <class T>
-  __attribute__((no_sanitize("undefined"))) T read(
-    const uint8_t*& data, size_t& size)
+  T read(const uint8_t*& data, size_t& size)
   {
     if (size < sizeof(T))
       throw std::logic_error(
         "Insufficient space (read<T>: " + std::to_string(size) + " < " +
         std::to_string(sizeof(T)) + ")");
 
-    T v = *(T*)data;
+    T v;
+    std::memcpy(reinterpret_cast<uint8_t*>(&v), data, sizeof(T));
     data += sizeof(T);
     size -= sizeof(T);
     return v;
@@ -75,15 +75,15 @@ namespace serialized
   };
 
   template <class T>
-  __attribute__((no_sanitize("undefined"))) void write(
-    uint8_t*& data, size_t& size, T v)
+  void write(uint8_t*& data, size_t& size, const T& v)
   {
     if (size < sizeof(T))
       throw std::logic_error(
         "Insufficient space (write<T>: " + std::to_string(size) + " < " +
         std::to_string(sizeof(T)) + ")");
 
-    *reinterpret_cast<T*>(data) = v;
+    const auto src = reinterpret_cast<const uint8_t*>(&v);
+    std::memcpy(data, src, sizeof(T));
     data += sizeof(T);
     size -= sizeof(T);
   }

--- a/src/ds/test/ring_buffer.cpp
+++ b/src/ds/test/ring_buffer.cpp
@@ -155,37 +155,43 @@ TEST_CASE("Variadic write" * doctest::test_suite("ringbuffer"))
   r.read(1, [&](Message m, const uint8_t* data, size_t size) {
     REQUIRE(Const::msg_min == m);
 
-    auto r0 = serialized::read<decltype(v0)>(data, size);
+    auto r0 = serialized::read<std::remove_const_t<decltype(v0)>>(data, size);
     REQUIRE(v0 == r0);
 
-    auto r1 = serialized::read<decltype(v1)>(data, size);
+    auto r1 = serialized::read<std::remove_const_t<decltype(v1)>>(data, size);
     REQUIRE(v1 == r1);
 
-    auto r2 = serialized::read<decltype(v2)>(data, size);
+    auto r2 = serialized::read<std::remove_const_t<decltype(v2)>>(data, size);
     REQUIRE(v2 == r2);
 
-    auto r3 = serialized::read<decltype(v3)>(data, size);
+    auto r3 = serialized::read<std::remove_const_t<decltype(v3)>>(data, size);
     REQUIRE(v3 == r3);
 
-    auto s4 = serialized::read<decltype(v4.size())>(data, size);
+    auto s4 =
+      serialized::read<std::remove_const_t<decltype(v4.size())>>(data, size);
     REQUIRE(v4.size() == s4);
 
     for (size_t i = 0; i < s4; ++i)
     {
-      auto r4i = serialized::read<decltype(v4)::value_type>(data, size);
+      auto r4i =
+        serialized::read<std::remove_const_t<decltype(v4)>::value_type>(
+          data, size);
       REQUIRE(v4[i] == r4i);
     }
 
-    auto s5 = serialized::read<decltype(v5_limit)>(data, size);
+    auto s5 =
+      serialized::read<std::remove_const_t<decltype(v5_limit)>>(data, size);
     REQUIRE(v5_limit == s5);
 
     for (size_t i = 0; i < s5; ++i)
     {
-      auto r5i = serialized::read<decltype(v4)::value_type>(data, size);
+      auto r5i =
+        serialized::read<std::remove_const_t<decltype(v4)>::value_type>(
+          data, size);
       REQUIRE(v4[i] == r5i);
     }
 
-    auto r6 = serialized::read<decltype(v6)>(data, size);
+    auto r6 = serialized::read<std::remove_const_t<decltype(v6)>>(data, size);
     REQUIRE(v6 == r6);
 
     REQUIRE(size == 0);


### PR DESCRIPTION
Fixes #799.

The assignments in the generic templates of `serialized::read` and `serialized::write` are technically UB, since they can (and do!) result in misaligned loads/stores. All the platforms and compilers we care about will do the correct thing here, but to be safe I've replaced the problematic lines with explicit `memcpy`s. I believe these should compile to the same things, and a quick [godbolt experiment](https://godbolt.org/z/KhdfjG) seems to back that up.