### PR TITLE
Allow user_data to be set during new_user proposal

### DIFF
--- a/python/ccf/proposal_generator.py
+++ b/python/ccf/proposal_generator.py
@@ -237,9 +237,11 @@ def retire_member(member_id: int, **kwargs):
 
 
 @cli_proposal
-def new_user(user_cert_path: str, **kwargs):
-    user_cert = open(user_cert_path).read()
-    return build_proposal("new_user", user_cert, **kwargs)
+def new_user(user_cert_path: str, user_data: dict = None, **kwargs):
+    user_info = {"cert": open(user_cert_path).read()}
+    if user_data is not None:
+        user_info["user_data"] = user_data
+    return build_proposal("new_user", user_info, **kwargs)
 
 
 @cli_proposal

--- a/python/ccf/proposal_generator.py
+++ b/python/ccf/proposal_generator.py
@@ -237,7 +237,7 @@ def retire_member(member_id: int, **kwargs):
 
 
 @cli_proposal
-def new_user(user_cert_path: str, user_data: dict = None, **kwargs):
+def new_user(user_cert_path: str, user_data: Any = None, **kwargs):
     user_info = {"cert": open(user_cert_path).read()}
     if user_data is not None:
         user_info["user_data"] = user_data
@@ -250,7 +250,7 @@ def remove_user(user_id: int, **kwargs):
 
 
 @cli_proposal
-def set_user_data(user_id: int, user_data: dict, **kwargs):
+def set_user_data(user_id: int, user_data: Any, **kwargs):
     proposal_args = {"user_id": user_id, "user_data": user_data}
     return build_proposal("set_user_data", proposal_args, **kwargs)
 

--- a/src/apps/lua_generic/test/lua_generic_test.cpp
+++ b/src/apps/lua_generic/test/lua_generic_test.cpp
@@ -123,7 +123,7 @@ auto init_frontend(
   std::vector<tls::Pem>* created_members = nullptr)
 {
   for (uint8_t i = 0; i < n_users; i++)
-    gen.add_user(user_caller);
+    gen.add_user({user_caller});
 
   std::vector<tls::Pem> member_certs;
   for (uint8_t i = 0; i < n_members; i++)

--- a/src/node/genesis_gen.h
+++ b/src/node/genesis_gen.h
@@ -195,12 +195,12 @@ namespace ccf
       return member.value();
     }
 
-    auto add_user(const tls::Pem& user_cert)
+    auto add_user(const ccf::UserInfo& user_info)
     {
       auto [u, uc, v] =
         tx.get_view(tables.users, tables.user_certs, tables.values);
 
-      auto user_cert_der = tls::make_verifier(user_cert)->der_cert_data();
+      auto user_cert_der = tls::make_verifier(user_info.cert)->der_cert_data();
 
       // Cert should be unique
       auto user_id = uc->get(user_cert_der);
@@ -211,7 +211,7 @@ namespace ccf
       }
 
       const auto id = get_next_id(v, ValueIds::NEXT_USER_ID);
-      u->put(id, {user_cert});
+      u->put(id, user_info);
       uc->put(user_cert_der, id);
       return id;
     }

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -217,10 +217,10 @@ namespace ccf
          }},
         {"new_user",
          [this](ObjectId, kv::Tx& tx, const nlohmann::json& args) {
-           const auto pem_cert = args.get<tls::Pem>();
+           const auto user_info = args.get<ccf::UserInfo>();
 
            GenesisGenerator g(this->network, tx);
-           g.add_user(pem_cert);
+           g.add_user(user_info);
 
            return true;
          }},

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -472,8 +472,8 @@ void prepare_callers()
   GenesisGenerator g(network, tx);
   g.init_values();
   g.create_service({});
-  user_id = g.add_user(user_caller);
-  nos_id = g.add_user(nos_caller);
+  user_id = g.add_user({user_caller});
+  nos_id = g.add_user({nos_caller});
   member_id = g.add_member(member_caller, dummy_key_share);
   invalid_member_id = g.add_member(invalid_caller, dummy_key_share);
   CHECK(g.finalize() == kv::CommitSuccess::OK);
@@ -486,7 +486,7 @@ void add_callers_primary_store()
   GenesisGenerator g(network2, gen_tx);
   g.init_values();
   g.create_service({});
-  user_id = g.add_user(user_caller);
+  user_id = g.add_user({user_caller});
   member_id = g.add_member(member_caller, dummy_key_share);
   CHECK(g.finalize() == kv::CommitSuccess::OK);
 }
@@ -504,7 +504,7 @@ void add_callers_pbft_store()
   GenesisGenerator g(pbft_network, gen_tx);
   g.init_values();
   g.create_service({});
-  user_id = g.add_user(user_caller);
+  user_id = g.add_user({user_caller});
   CHECK(g.finalize() == kv::CommitSuccess::OK);
 }
 

--- a/src/node/rpc/test/member_voting_test.cpp
+++ b/src/node/rpc/test/member_voting_test.cpp
@@ -1597,6 +1597,8 @@ DOCTEST_TEST_CASE("Members passing an operator vote")
   }
 }
 
+// TODO: Modify this test to also test initial user data
+
 DOCTEST_TEST_CASE("User data")
 {
   NetworkState network;
@@ -1607,7 +1609,7 @@ DOCTEST_TEST_CASE("User data")
   gen.create_service({});
   const auto member_id = gen.add_member(member_cert, {});
   gen.activate_member(member_id);
-  const auto user_id = gen.add_user(user_cert);
+  const auto user_id = gen.add_user({user_cert});
   set_whitelists(gen);
   gen.set_gov_scripts(lua::Interpreter().invoke<json>(gov_script_file));
   gen.finalize();

--- a/tests/governance.py
+++ b/tests/governance.py
@@ -59,13 +59,14 @@ def test_quote(network, args, notifications_queue=None, verify=True):
     return network
 
 
-@reqs.description("Add user, remove user, add user back")
+@reqs.description("Add user, remove user")
 @reqs.supports_methods("log/private")
 def test_user(network, args, notifications_queue=None, verify=True):
     primary, _ = network.find_nodes()
     new_user_id = 3
     network.create_users([new_user_id], args.participants_curve)
-    network.consortium.add_user(primary, new_user_id)
+    user_data = {"lifetime": "temporary"}
+    network.consortium.add_user(primary, new_user_id, user_data)
     txs = app.LoggingTxs(notifications_queue=notifications_queue, user_id=3)
     txs.issue(
         network=network, number_txs=1, consensus=args.consensus,

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -258,9 +258,9 @@ class Consortium:
         proposal.vote_for = careful_vote
         return self.vote_using_majority(remote_node, proposal)
 
-    def add_user(self, remote_node, user_id):
+    def add_user(self, remote_node, user_id, user_data=None):
         proposal, careful_vote = self.proposal_generator.new_user(
-            os.path.join(self.common_dir, f"user{user_id}_cert.pem")
+            os.path.join(self.common_dir, f"user{user_id}_cert.pem"), user_data
         )
 
         proposal = self.get_any_active_member().propose(remote_node, proposal)


### PR DESCRIPTION
Previously users needed to be added by a `"new_user"` proposal, and then could have user data set by `"set_user_data"`. This requires finding the assigned user ID (which is hard to do, and should be easier!), and enforces a period of time where the user has no user data.

This changes the expected data for `"new_user"`s from just a cert to a full `UserInfo` object, potentially including an initial `user_data` value.