### PR TITLE
Generate setup.py before installing docs

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -22,6 +22,11 @@ jobs:
         git checkout -b master $(git rev-parse HEAD)
       displayName: Prepare repo
 
+    # Used to generate setup.py
+    - template: .azure-pipelines-templates/cmake.yml
+      parameters:
+        cmake_args: ''
+
     - script: |
         python3.7 -m venv env
         source env/bin/activate

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -21,7 +21,7 @@ setup(
     description="Set of tools and utilities for the Confidential Consortium Framework (CCF)",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/microsoft/CCF/python/ccf",
+    url="https://github.com/microsoft/CCF/tree/master/python",
     license="Apache License 2.0",
     author="CCF Team",
     classifiers=[


### PR DESCRIPTION
Looks like I broke the generation of Python docs in https://github.com/microsoft/CCF/pull/1474 as `setup.py` is only generated after cmake is run (for automated versioning).