### PR TITLE
lfence after memory validation

### DIFF
--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -71,7 +71,7 @@ extern "C"
     }
 
     // Check that where we expect arguments to be in host-memory, they really
-    // are
+    // are. lfence after these checks to prevent speculative execution
     if (oe_is_within_enclave(time_location, sizeof(enclave::host_time)))
     {
       return false;
@@ -93,6 +93,8 @@ extern "C"
         return false;
       }
 
+      oe_lfence();
+
       const auto& reader = ec.circuit->read_from_outside();
       auto [data, size] = reader.get_memory_range();
       if (oe_is_within_enclave(data, size))
@@ -105,6 +107,8 @@ extern "C"
     {
       return false;
     }
+
+    oe_lfence();
 
     msgpack::object_handle oh = msgpack::unpack(ccf_config, ccf_config_size);
     msgpack::object obj = oh.get();

--- a/src/enclave/oe_shim.h
+++ b/src/enclave/oe_shim.h
@@ -11,6 +11,7 @@
 
 #ifndef VIRTUAL_ENCLAVE
 
+#  include <openenclave/edger8r/enclave.h> // For oe_lfence
 #  include <openenclave/enclave.h>
 
 #else
@@ -40,5 +41,7 @@ OE_EXTERNC bool oe_is_outside_enclave(const void* p, std::size_t n)
 {
   return !oe_is_within_enclave(p, n);
 }
+
+#  define oe_lfence() // nop
 
 #endif


### PR DESCRIPTION
When our `oe_is_within_enclave` checks fail, it is possible for speculative execution to reveal enclave data past the execution point. While we run these checks at initialisation and are unlikely to have any interesting secrets at this time, its best to be sure. So I'm adding lfences to prevent speculative execution over these boundaries.