### PR TITLE
The cchost ledger-chunk-max-bytes option was badly named

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,8 +485,6 @@ if(BUILD_TESTS)
     NAME governance_history_test
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/governance_history.py
     CONSENSUS raft
-    ADDITIONAL_ARGS # https://github.com/microsoft/CCF/issues/1275
-                    --ledger-chunk-max-bytes 20MB
   )
 
   add_e2e_test(

--- a/doc/operators/ledger.rst
+++ b/doc/operators/ledger.rst
@@ -15,10 +15,10 @@ Nodes can be configured to store their ledger under a particular directory with 
 File layout
 -----------
 
-The ledger directory contains a series of files. File size is controlled by the ``--ledger-chunk-max-bytes`` command line option.
+The ledger directory contains a series of files. File size is controlled by the ``--ledger-chunk-min-bytes`` command line option.
 
 Files containing only committed entries are named ``ledger_$STARTSEQNO-$ENDSEQNO.committed``. These files are closed and immutable,
-it is safe to replicate them to backup storage. They are identical across nodes, provided ``--ledger-chunk-max-bytes`` has been set to the same value.
+it is safe to replicate them to backup storage. They are identical across nodes, provided ``--ledger-chunk-min-bytes`` has been set to the same value.
 
 .. warning:: Removing files from a ledger directory may cause a node to crash.
 
@@ -32,7 +32,7 @@ a ``.committed`` file once the size threshold is met.
 The listing below is an example of what a ledger directory may look like.
 
 .. code-block:: bash
- 
+
     $ ./cchost --ledger-dir $LEDGER_DIR ...
     $ cd $LEDGER_DIR
     $ ls

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -136,11 +136,11 @@ int main(int argc, char** argv)
   app.add_option("--ledger-dir", ledger_dir, "Ledger directory")
     ->capture_default_str();
 
-  size_t ledger_chunk_threshold = 5'000'000;
+  size_t ledger_min_bytes = 5'000'000;
   app
     .add_option(
-      "--ledger-chunk-max-bytes",
-      ledger_chunk_threshold,
+      "--ledger-chunk-min-bytes",
+      ledger_min_bytes,
       "Minimum size (bytes) at which a new ledger chunk is created.")
     ->capture_default_str()
     ->transform(CLI::AsSizeValue(true)); // 1000 is kb
@@ -531,8 +531,7 @@ int main(int argc, char** argv)
   // graceful shutdown on sigterm
   asynchost::Sigterm sigterm(writer_factory);
 
-  // write to a ledger
-  asynchost::Ledger ledger(ledger_dir, writer_factory, ledger_chunk_threshold);
+  asynchost::Ledger ledger(ledger_dir, writer_factory, ledger_min_bytes);
   ledger.register_message_handlers(bp.get_dispatcher());
 
   // Begin listening for node-to-node and RPC messages.

--- a/start_test_network.sh
+++ b/start_test_network.sh
@@ -21,5 +21,5 @@ CURL_CLIENT=ON \
     python "${PATH_HERE}"/tests/start_network.py \
     --gov-script "${PATH_HERE}"/src/runtime_config/gov.lua \
     --label test_network \
-    --ledger-chunk-max-bytes 5MB \
+    --ledger-chunk-min-bytes 5MB \
     "$@"

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -166,7 +166,7 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         default=30,
     )
     parser.add_argument(
-        "--ledger-chunk-max-bytes",
+        "--ledger-chunk-min-bytes",
         help="Minimum size (bytes) at which a new ledger chunk is created.",
         default="20KB",
     )

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -73,7 +73,7 @@ class Network:
         "gov_script",
         "join_timer",
         "worker_threads",
-        "ledger_chunk_max_bytes",
+        "ledger_chunk_min_bytes",
         "domain",
     ]
 

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -562,7 +562,7 @@ class CCFRemote(object):
         ledger_dir=None,
         log_format_json=None,
         binary_dir=".",
-        ledger_chunk_max_bytes=(5 * 1024 * 1024),
+        ledger_chunk_min_bytes=(5 * 1024 * 1024),
         domain=None,
     ):
         """
@@ -629,8 +629,8 @@ class CCFRemote(object):
         if memory_reserve_startup:
             cmd += [f"--memory-reserve-startup={memory_reserve_startup}"]
 
-        if ledger_chunk_max_bytes:
-            cmd += [f"--ledger-chunk-max-bytes={ledger_chunk_max_bytes}"]
+        if ledger_chunk_min_bytes:
+            cmd += [f"--ledger-chunk-min-bytes={ledger_chunk_min_bytes}"]
 
         if notify_server:
             notify_server_host, *notify_server_port = notify_server.split(":")


### PR DESCRIPTION
The `cchost` option to specify the chunking threshold (in bytes) was named `--ledger-chunk-max-bytes` but the description was `"Minimum size (bytes) at which a new ledger chunk is created"`. The description is right: we create a new chunk only if the threshold has been passed _and_ a signature transaction has been issued so the size of a ledger chunk will always be slightly above the threshold. 

The option is now named `--ledger-chunk-min-bytes` for consistency. 