### PR TITLE
Add ms units to Timer repeat argument

### DIFF
--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -511,7 +511,8 @@ int main(int argc, char** argv)
   oversized::FragmentReconstructor fr(bp.get_dispatcher());
 
   // provide regular ticks to the enclave
-  asynchost::Ticker ticker(tick_period_ms, writer_factory, [](auto s) {
+  const std::chrono::milliseconds tick_period(tick_period_ms);
+  asynchost::Ticker ticker(tick_period, writer_factory, [](auto s) {
     logger::config::set_start(s);
   });
 
@@ -519,10 +520,10 @@ int main(int argc, char** argv)
   asynchost::ResetTCPReadQuota reset_tcp_quota;
 
   // regularly update the time given to the enclave
-  asynchost::TimeUpdater time_updater(1);
+  asynchost::TimeUpdater time_updater(1ms);
 
   // regularly record some load statistics
-  asynchost::LoadMonitor load_monitor(500, bp);
+  asynchost::LoadMonitor load_monitor(500ms, bp);
 
   // handle outbound messages from the enclave
   asynchost::HandleRingbuffer handle_ringbuffer(
@@ -539,7 +540,7 @@ int main(int argc, char** argv)
   // requesting port 0). The hostname and port may be modified - after calling
   // it holds the final assigned values.
   asynchost::NodeConnectionsTickingReconnect node(
-    20, //< Flush reconnections every 20ms
+    20ms, //< Flush reconnections every 20ms
     bp.get_dispatcher(),
     ledger,
     writer_factory,

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -512,9 +512,8 @@ int main(int argc, char** argv)
 
   // provide regular ticks to the enclave
   const std::chrono::milliseconds tick_period(tick_period_ms);
-  asynchost::Ticker ticker(tick_period, writer_factory, [](auto s) {
-    logger::config::set_start(s);
-  });
+  asynchost::Ticker ticker(
+    tick_period, writer_factory, [](auto s) { logger::config::set_start(s); });
 
   // reset the inbound-TCP processing quota each iteration
   asynchost::ResetTCPReadQuota reset_tcp_quota;

--- a/src/host/timer.h
+++ b/src/host/timer.h
@@ -18,7 +18,7 @@ namespace asynchost
     friend class close_ptr<Timer<Behaviour>>;
 
     template <typename... Args>
-    Timer(uint64_t repeat_ms, Args&&... args) :
+    Timer(std::chrono::milliseconds repeat_ms, Args&&... args) :
       behaviour(std::forward<Args>(args)...)
     {
       int rc;
@@ -31,7 +31,7 @@ namespace asynchost
 
       uv_handle.data = this;
 
-      if ((rc = uv_timer_start(&uv_handle, on_timer, 0, repeat_ms)) < 0)
+      if ((rc = uv_timer_start(&uv_handle, on_timer, 0, repeat_ms.count())) < 0)
       {
         LOG_FAIL_FMT("uv_timer_start failed: {}", uv_strerror(rc));
         throw std::logic_error("uv_timer_start failed");


### PR DESCRIPTION
Suggestion from @achamayou to make the times specified in `host/main.cpp` more readable.