### PR TITLE
Dynamic map swaps

### DIFF
--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -225,6 +225,8 @@ namespace kv
       return *result;
     }
 
+    // EXPERIMENTAL - DO NOT USE
+    // This API is for internal testing only, and may change or be removed
     std::shared_ptr<AbstractMap> get_map(
       kv::Version v, const std::string& map_name) override
     {
@@ -241,6 +243,8 @@ namespace kv
       return nullptr;
     }
 
+    // EXPERIMENTAL - DO NOT USE
+    // This API is for internal testing only, and may change or be removed
     void add_dynamic_map(
       kv::Version v, const std::shared_ptr<AbstractMap>& map) override
     {

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -802,35 +802,6 @@ TEST_CASE("Map swap between stores")
   }
 }
 
-TEST_CASE("Invalid map swaps")
-{
-  {
-    kv::Store s1;
-    s1.create<MapTypes::NumNum>("one");
-
-    kv::Store s2;
-    s2.create<MapTypes::NumNum>("one");
-    s2.create<MapTypes::NumNum>("two");
-
-    REQUIRE_THROWS_WITH(
-      s2.swap_private_maps(s1),
-      "Private map list mismatch during swap, missing at least two");
-  }
-
-  {
-    kv::Store s1;
-    s1.create<MapTypes::NumNum>("one");
-    s1.create<MapTypes::NumNum>("two");
-
-    kv::Store s2;
-    s2.create<MapTypes::NumNum>("one");
-
-    REQUIRE_THROWS_WITH(
-      s2.swap_private_maps(s1),
-      "Private map list mismatch during swap, two not found");
-  }
-}
-
 TEST_CASE("Private recovery map swap")
 {
   auto encryptor = std::make_shared<kv::NullTxEncryptor>();

--- a/src/kv/tx.h
+++ b/src/kv/tx.h
@@ -480,6 +480,8 @@ namespace kv
       return std::get<0>(get_tuple(m));
     }
 
+    // EXPERIMENTAL - DO NOT USE
+    // This API is for internal testing only, and may change or be removed
     template <class M>
     typename M::TxView* get_view2(const std::string& map_name)
     {
@@ -498,6 +500,8 @@ namespace kv
       return std::tuple_cat(get_tuple(m), get_tuple(ms...));
     }
 
+    // EXPERIMENTAL - DO NOT USE
+    // This API is for internal testing only, and may change or be removed
     template <class M, class... Ms, class... Ts>
     std::tuple<typename M::TxView*, typename Ms::TxView*...> get_view2(
       const std::string& map_name, const Ts&... names)

--- a/src/kv/tx.h
+++ b/src/kv/tx.h
@@ -187,7 +187,7 @@ namespace kv
       const std::string& map_names, const Ts&... names)
     {
       return std::tuple_cat(
-        get_tuple2<M>(map_names), get_tuple<Ms...>(names...));
+        get_tuple2<M>(map_names), get_tuple2<Ms...>(names...));
     }
 
     void reset()


### PR DESCRIPTION
Follow up to #1507 implementing 2 suggestions:

- Indicate that the new KV APIs are experimental, unstable, and should not be used.
- Test `swap_private_maps` with dynamically created tables (and partially rewrites to support this). This actually removes an existing test of `Invalid map swaps` - it is now perfectly valid to have additional or missing tables in the target store, all we do is copy in those from the source store. 