### PR TITLE
Fix Raft term history on backup

### DIFF
--- a/src/consensus/raft/raft.h
+++ b/src/consensus/raft/raft.h
@@ -693,7 +693,6 @@ namespace raft
 
           case kv::DeserialiseSuccess::PASS_SIGNATURE:
           {
-            LOG_DEBUG_FMT("Commit idx: {}", commit_idx);
             LOG_DEBUG_FMT("Deserialising signature at {}", i);
             committable_indices.push_back(i);
 

--- a/src/consensus/raft/raft.h
+++ b/src/consensus/raft/raft.h
@@ -546,6 +546,7 @@ namespace raft
         LOG_FAIL_FMT(err.what());
         return;
       }
+
       LOG_DEBUG_FMT(
         "Received pt: {} pi: {} t: {} i: {}",
         r.prev_term,
@@ -618,7 +619,7 @@ namespace raft
       if (r.prev_idx < commit_idx)
       {
         LOG_DEBUG_FMT(
-          "Recv append entries to {} from {} but prev_idex ({}) < commit_idx "
+          "Recv append entries to {} from {} but prev_idx ({}) < commit_idx "
           "({})",
           local_id,
           r.from_node,
@@ -684,22 +685,35 @@ namespace raft
         switch (deserialise_success)
         {
           case kv::DeserialiseSuccess::FAILED:
+          {
             throw std::logic_error(
               "Follower failed to apply log entry " + std::to_string(i));
             break;
+          }
 
           case kv::DeserialiseSuccess::PASS_SIGNATURE:
+          {
+            LOG_DEBUG_FMT("Commit idx: {}", commit_idx);
             LOG_DEBUG_FMT("Deserialising signature at {}", i);
             committable_indices.push_back(i);
+
             if (sig_term)
+            {
               term_history.update(commit_idx + 1, sig_term);
+              commit_if_possible(r.leader_commit_idx);
+            }
             break;
+          }
 
           case kv::DeserialiseSuccess::PASS:
+          {
             break;
+          }
 
           default:
+          {
             throw std::logic_error("Unknown DeserialiseSuccess value");
+          }
         }
       }
 

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -446,7 +446,7 @@ def test_view_history(network, args):
     check = infra.checker.Checker()
 
     previous_node = None
-    previous_tx_ids = None
+    previous_tx_ids = ""
     for node in network.get_joined_nodes():
         with node.client("user0") as c:
             r = c.get("/node/commit")
@@ -494,7 +494,7 @@ def test_view_history(network, args):
                 )
 
             # Compare view history between nodes
-            if previous_tx_ids is not None:
+            if len(previous_tx_ids):
                 # Some nodes may have a slightly longer view history so only compare the common prefix
                 min_tx_ids_len = min(len(previous_tx_ids), len(tx_ids_condensed))
                 assert (

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -494,7 +494,7 @@ def test_view_history(network, args):
                 )
 
             # Compare view history between nodes
-            if len(previous_tx_ids):
+            if previous_tx_ids:
                 # Some nodes may have a slightly longer view history so only compare the common prefix
                 min_tx_ids_len = min(len(previous_tx_ids), len(tx_ids_condensed))
                 assert (

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -445,6 +445,8 @@ def test_view_history(network, args):
 
     check = infra.checker.Checker()
 
+    previous_node = None
+    previous_tx_ids = None
     for node in network.get_joined_nodes():
         with node.client("user0") as c:
             r = c.get("/node/commit")
@@ -490,6 +492,18 @@ def test_view_history(network, args):
                 raise RuntimeError(
                     f"Node {node.node_id}: Incomplete or inconsistent view history"
                 )
+
+            # Compare view history between nodes
+            if previous_tx_ids is not None:
+                # Some nodes may have a slightly longer view history so only compare the common prefix
+                min_tx_ids_len = min(len(previous_tx_ids), len(tx_ids_condensed))
+                assert (
+                    tx_ids_condensed[:min_tx_ids_len]
+                    == previous_tx_ids[:min_tx_ids_len]
+                ), f"Tx IDs don't match between node {node.node_id} and node {previous_node.node_id}: {tx_ids_condensed[:min_tx_ids_len]} and {previous_tx_ids[:min_tx_ids_len]}"
+
+            previous_tx_ids = tx_ids_condensed
+            previous_node = node
 
     return network
 


### PR DESCRIPTION
The way we used to build the term history on backup was buggy when we had signatures _across different terms_ in the same append entries batch. As we didn't have any tests that compared the term history between nodes, we didn't see that small difference. This is now fixed and the `test_view_history` end-to-end test now compares the view history between all nodes active in the network.

**Details:**

The fix is to call `commit_if_possible(r.leader_commit_idx)` early after we've passed a signature in the append entries batch (which will update `commit_idx` to the index of that first signature). That way, the call to `term_history.update(commit_idx + 1, sig_term)` after the next signature (in the new term) will create a new term in the term history, starting at the index right after the previous signature, which is correct.