### PR TITLE
Fix ci-checks scripts

### DIFF
--- a/scripts/check-format.sh
+++ b/scripts/check-format.sh
@@ -34,11 +34,11 @@ badly_named_files=""
 for file in $(find "$@" -name "*.h" -or -name "*.hpp" -or -name "*.cpp" -or -name "*.c"); do
   # Workaround for https://bugs.llvm.org/show_bug.cgi?id=39216
   d=$(cat "$file" | clang-format-8 -style=file --assume-filename "${file%.*}".cpp | diff "$file" -)
-  if $fix ; then
-    cat "$file" | clang-format-8 -style=file --assume-filename "${file%.*}".cpp > "$file".tmp
-    mv "$file".tmp "$file"
-  fi
   if [ "$d" != "" ]; then
+    if $fix ; then
+      cat "$file" | clang-format-8 -style=file --assume-filename "${file%.*}".cpp > "$file".tmp
+      mv "$file".tmp "$file"
+    fi
     if [ "$unformatted_files" != "" ]; then
       unformatted_files+=$'\n'
     fi
@@ -54,9 +54,15 @@ for file in $(find "$@" -name "*.h" -or -name "*.hpp" -or -name "*.cpp" -or -nam
 done
 
 if [ "$unformatted_files" != "" ]; then
-  echo "Fix formatting:"
+  if $fix ; then
+    echo "Fixed formatting:"
+  else
+    echo "Fix formatting:"
+  fi
   echo "$unformatted_files"
-  exit 1
+  if ! $fix ; then
+    exit 1
+  fi
 else
   echo "All files formatted correctly!"
 fi

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -19,9 +19,10 @@ echo "TODOs"
 "$SCRIPT_DIR"/check-todo.sh src
 
 echo "C/C++ format"
-"$SCRIPT_DIR"/check-format.sh src samples
-if [ $FIX -ne 0 ] && [ $? -ne 0 ]; then
-    "$SCRIPT_DIR"/check-format.sh -f src samples
+if [ $FIX -ne 0 ]; then
+  "$SCRIPT_DIR"/check-format.sh -f src samples
+else
+  "$SCRIPT_DIR"/check-format.sh src samples
 fi
 
 echo "Copyright notice headers"
@@ -41,7 +42,7 @@ if [ ! -f "scripts/env/bin/activate" ]
 fi
 
 source scripts/env/bin/activate
-pip --disable-pip-version-check install black pylint mypy 1>/dev/null
+pip --disable-pip-version-check install -U black pylint mypy 1>/dev/null
 
 echo "Python format"
 if [ $FIX -ne 0 ]; then


### PR DESCRIPTION
`-f` was broken for clang-format.
This also adds `-U` to `pip install` to avoid using old dependency versions and potentially formatting/linting files differently than in CI.