### PR TITLE
Run cmake before release

### DIFF
--- a/.azure-pipelines-templates/release.yml
+++ b/.azure-pipelines-templates/release.yml
@@ -28,6 +28,11 @@ jobs:
         addChangeLog: false
       displayName: 'GitHub release (create)'
 
+    # Used to generate setup.py
+    - template: cmake.yml
+      parameters:
+        cmake_args: ''
+
     - script: |
         python3.7 -m venv env
         source ./env/bin/activate


### PR DESCRIPTION
Otherwise, `setup.py` will not be generated (cmake generates `setup.py` with the right version from `setup.py.in`).