### PR TITLE
Fix memory range check on ecall

### DIFF
--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -72,7 +72,7 @@ extern "C"
 
     // Check that where we expect arguments to be in host-memory, they really
     // are. lfence after these checks to prevent speculative execution
-    if (oe_is_within_enclave(time_location, sizeof(enclave::host_time)))
+    if (!oe_is_outside_enclave(time_location, sizeof(enclave::host_time)))
     {
       return false;
     }
@@ -80,7 +80,7 @@ extern "C"
     enclave::host_time =
       static_cast<decltype(enclave::host_time)>(time_location);
 
-    if (oe_is_within_enclave(enclave_config, sizeof(EnclaveConfig)))
+    if (!oe_is_outside_enclave(enclave_config, sizeof(EnclaveConfig)))
     {
       return false;
     }
@@ -88,7 +88,7 @@ extern "C"
     EnclaveConfig ec = *static_cast<EnclaveConfig*>(enclave_config);
 
     {
-      if (oe_is_within_enclave(ec.circuit, sizeof(ringbuffer::Circuit)))
+      if (!oe_is_outside_enclave(ec.circuit, sizeof(ringbuffer::Circuit)))
       {
         return false;
       }
@@ -97,13 +97,13 @@ extern "C"
 
       const auto& reader = ec.circuit->read_from_outside();
       auto [data, size] = reader.get_memory_range();
-      if (oe_is_within_enclave(data, size))
+      if (!oe_is_outside_enclave(data, size))
       {
         return false;
       }
     }
 
-    if (oe_is_within_enclave(ccf_config, ccf_config_size))
+    if (!oe_is_outside_enclave(ccf_config, ccf_config_size))
     {
       return false;
     }

--- a/src/enclave/oe_shim.h
+++ b/src/enclave/oe_shim.h
@@ -37,9 +37,9 @@ OE_EXTERNC bool oe_is_within_enclave(const void*, std::size_t)
   return false;
 }
 
-OE_EXTERNC bool oe_is_outside_enclave(const void* p, std::size_t n)
+OE_EXTERNC bool oe_is_outside_enclave(const void*, std::size_t)
 {
-  return !oe_is_within_enclave(p, n);
+  return true;
 }
 
 #  define oe_lfence() // nop


### PR DESCRIPTION
Adjustment to #1492, which introduced range checks that weren't quite right. We want to check that the entire buffer subject to user_check is strictly outside enclave memory (https://github.com/openenclave/openenclave/blob/b9ae53c1e580fd1af4760f914d53cba1650068ae/include/openenclave/enclave.h#L105) and fail if it's not.

Current code instead checks for strictly in-enclave buffers, and would therefore be satisfied by a partially in-enclave buffer.