### PR TITLE
Add retire_node_code proposal

### DIFF
--- a/python/ccf/proposal_generator.py
+++ b/python/ccf/proposal_generator.py
@@ -311,6 +311,12 @@ def new_node_code(code_digest: str, **kwargs):
 
 
 @cli_proposal
+def retire_node_code(code_digest: str, **kwargs):
+    code_digest_bytes = list(bytearray.fromhex(code_digest))
+    return build_proposal("retire_node_code", code_digest_bytes, **kwargs)
+
+
+@cli_proposal
 def new_user_code(code_digest: str, **kwargs):
     code_digest_bytes = list(bytearray.fromhex(code_digest))
     return build_proposal("new_user_code", code_digest_bytes, **kwargs)

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -355,6 +355,12 @@ class Consortium:
         proposal.vote_for = careful_vote
         return self.vote_using_majority(remote_node, proposal)
 
+    def retire_code(self, remote_node, code_id):
+        proposal_body, careful_vote = self.make_proposal("retire_node_code", code_id)
+        proposal = self.get_any_active_member().propose(remote_node, proposal_body)
+        proposal.vote_for = careful_vote
+        return self.vote_using_majority(remote_node, proposal)
+
     def add_new_user_code(self, remote_node, new_code_id):
         proposal_body, careful_vote = self.make_proposal("new_user_code", new_code_id)
         proposal = self.get_any_active_member().propose(remote_node, proposal_body)

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -47,6 +47,10 @@ class CodeIdNotFound(Exception):
     pass
 
 
+class CodeIdRetired(Exception):
+    pass
+
+
 class NodeShutdownError(Exception):
     pass
 
@@ -473,6 +477,8 @@ class Network:
                 for error in errors:
                     if "CODE_ID_NOT_FOUND" in error:
                         raise CodeIdNotFound from e
+                    if "CODE_ID_RETIRED" in error:
+                        raise CodeIdRetired from e
             raise
 
         return new_node


### PR DESCRIPTION
It is currently possible to retire code with a `raw_puts` proposal, but this is slightly more obvious. We were also missing a test for this.