### PR TITLE
Remove --no-undefined in SAN builds

### DIFF
--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -257,8 +257,6 @@ function(add_ccf_app name)
       ${virt_name} PRIVATE ${PARSED_ARGS_LINK_LIBS_VIRTUAL} ccf.virtual
     )
 
-    target_link_options(${virt_name} PRIVATE LINKER:--no-undefined)
-
     set_property(TARGET ${virt_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
     enable_coverage(${virt_name})

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -257,6 +257,10 @@ function(add_ccf_app name)
       ${virt_name} PRIVATE ${PARSED_ARGS_LINK_LIBS_VIRTUAL} ccf.virtual
     )
 
+    if(NOT SAN)
+      target_link_options(${virt_name} PRIVATE LINKER:--no-undefined)
+    endif()
+
     set_property(TARGET ${virt_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
     enable_coverage(${virt_name})

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -79,6 +79,13 @@ set(CLIENT_MBEDTLS_LIBRARIES "${MBEDTLS_LIBRARIES}")
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ccf_app.cmake)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ccf_app.cmake DESTINATION cmake)
 
+if(SAN AND LVI_MITIGATIONS)
+  message(
+    FATAL_ERROR
+      "Building with both SAN and LVI mitigations is unsafe and deadlocks - choose one"
+  )
+endif()
+
 add_custom_command(
   COMMAND
     openenclave::oeedger8r ${CCF_DIR}/edl/ccf.edl --search-path ${OE_INCLUDEDIR}


### PR DESCRIPTION
This option doesn't play nicely with the SAN builds. I got a lucky combination on a local build that gave a huge amount of errors:

```
/data/src/CCF/build.san/../src/enclave/thread_local.cpp:(.text.startup+0x2d): undefined reference to `__asan_before_dynamic_init'
/data/src/CCF/build.san/../src/enclave/thread_local.cpp:(.text.startup+0x34): undefined reference to `__asan_option_detect_stack_use_after_return'
/data/src/CCF/build.san/../src/enclave/thread_local.cpp:(.text.startup+0x43): undefined reference to `__asan_stack_malloc_0'
/data/src/CCF/build.san/../src/enclave/thread_local.cpp:(.text.startup+0x10e): undefined reference to `__asan_after_dynamic_init'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

It seems to mostly cause builds to deadlock/time-out, as it has been in our Daily CI. No idea why.