### PR TITLE
test_retire_primary requires at least 1 killable node

### DIFF
--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -100,7 +100,7 @@ def test_retire_backup(network, args):
 
 
 @reqs.description("Retiring the primary")
-@reqs.at_least_n_nodes(3)
+@reqs.can_kill_n_nodes(1)
 def test_retire_primary(network, args):
     primary, backup = network.find_primary_and_any_backup()
     network.consortium.retire_node(primary, primary)


### PR DESCRIPTION
When running the full suite, we would run the `test_retire_primary` test case with as few as 3 nodes. This is insufficient - with 3 nodes, if we retire the primary, we don't have quorum to find a new primary and we're stuck. Instead the requirement is that we have at least 1 killable node.

This should fix some of the recent instability in our daily CI.

There's a followup task to find something I'm missing - if we run the reconfiguration suite as written, we're actually skipping this test:
```
42: 2020-09-04 17:03:49.316 | SUCCESS  | __main__:run:126 - Full suite passed. Ran 9/9
42: 2020-09-04 17:03:49.316 | SUCCESS  | __main__:run:141 - Test #0:
42: {
42:     "name": "reconfiguration.test_add_node",
42:     "status": "success",
42:     "elapsed (s)": 5.12
42: }
42: 2020-09-04 17:03:49.316 | SUCCESS  | __main__:run:141 - Test #1:
42: {
42:     "name": "reconfiguration.test_retire_primary",
42:     "status": "success",
42:     "elapsed (s)": 10.08
42: }
42: 2020-09-04 17:03:49.316 | SUCCESS  | __main__:run:141 - Test #2:
42: {
42:     "name": "reconfiguration.test_add_node",
42:     "status": "success",
42:     "elapsed (s)": 5.26
42: }
42: 2020-09-04 17:03:49.316 | WARNING  | __main__:run:141 - Test #3:
42: {
42:     "name": "election.test_kill_primary",
42:     "status": "skipped",
42:     "elapsed (s)": 0.05,
42:     "reason": "Cannot kill 1 node(s) as the network would not be able to make progress (would leave 2 nodes but requires 3 nodes to make progress) "
42: }

...

1/1 Test #42: reconfiguration_test_suite .......   Passed   48.43 sec
```

I don't understand why `2 + 1 = 3` nodes is enough to retire a primary, but then straight afterwards `2 + 1 = 3` is not enough to kill a new primary? There's likely some issue with how we count nodes inside `can_kill_n_nodes` - I'll take a look at that on Monday.