### PR TITLE
Propagate errors from foreach functors called in Lua

### DIFF
--- a/src/lua_interp/lua_kv.h
+++ b/src/lua_interp/lua_kv.h
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 #pragma once
-#include "ds/logger.h"
 #include "lua_json.h"
 
 /**
@@ -138,7 +137,6 @@ namespace ccf
           lua::push_raw<nlohmann::json>(l, v);
 
           // Call the lua functor. This pops the args and functor-copy
-          LOG_INFO_FMT("Called foreach from lua, ifunc is {}", ifunc);
           const auto ret = lua_pcall(l, 2, 0, 0);
 
           if (ret != 0)

--- a/src/lua_interp/lua_kv.h
+++ b/src/lua_interp/lua_kv.h
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 #pragma once
+#include "ds/logger.h"
 #include "lua_json.h"
 
 /**
@@ -137,7 +138,15 @@ namespace ccf
           lua::push_raw<nlohmann::json>(l, v);
 
           // Call the lua functor. This pops the args and functor-copy
-          lua_pcall(l, ifunc, 0, 0);
+          LOG_INFO_FMT("Called foreach from lua, ifunc is {}", ifunc);
+          const auto ret = lua_pcall(l, 2, 0, 0);
+
+          if (ret != 0)
+          {
+            const auto err = lua::check_get<std::string>(l, -1);
+            throw lua::ex(err);
+          }
+
           return true;
         });
 

--- a/src/lua_interp/test/lua_kv.cpp
+++ b/src/lua_interp/test/lua_kv.cpp
@@ -78,6 +78,8 @@ namespace ccf
         "local n = 0;"
         "tx:foreach( function(k, v) n = n + 1 end );"
         "return n");
+      constexpr auto foreach_error(
+        "tx:foreach( function(k, v) nil = nil + nil end )");
       constexpr auto put(
         "local tx, k, v = ...;"
         "return tx:put(k, v)");
@@ -148,6 +150,11 @@ namespace ccf
         }
 
         REQUIRE(next_txs.commit() == kv::CommitSuccess::OK);
+      }
+
+      INFO("Errors caught in foreach");
+      {
+        REQUIRE_THROWS_AS(li.invoke<int>(foreach_error, tx), lua::ex);
       }
     }
   }


### PR DESCRIPTION
Spotted while debugging something else. When calling `tx:foreach( foo )` in Lua, any errors in foo would be silently ignored (they're invoked from a separate `lua_pcall`, and we were ignoring the return code from this). Errors in these functors are now raised as exceptions, the same as we do with any other lua error.