### PR TITLE
Support optional arguments when creating proposals via the CLI

### DIFF
--- a/python/ccf/proposal_generator.py
+++ b/python/ccf/proposal_generator.py
@@ -464,11 +464,15 @@ if __name__ == "__main__":
                 continue
             if param.annotation == param.empty:
                 param_type = None
-            elif param.annotation == dict:
+            elif param.annotation == dict or param.annotation == Any:
                 param_type = json.loads
             else:
                 param_type = param.annotation
-            subparser.add_argument(param_name, type=param_type)  # type: ignore
+            add_argument_extras = {}
+            if param.default is None:
+                add_argument_extras["nargs"] = "?"
+                add_argument_extras["default"] = param.default
+            subparser.add_argument(param_name, type=param_type, **add_argument_extras)  # type: ignore
             func_param_names.append(param_name)
         subparser.set_defaults(func=func, param_names=func_param_names)
 

--- a/python/ccf/proposal_generator.py
+++ b/python/ccf/proposal_generator.py
@@ -471,7 +471,7 @@ if __name__ == "__main__":
             add_argument_extras = {}
             if param.default is None:
                 add_argument_extras["nargs"] = "?"
-                add_argument_extras["default"] = param.default
+                add_argument_extras["default"] = param.default  # type: ignore
             subparser.add_argument(param_name, type=param_type, **add_argument_extras)  # type: ignore
             func_param_names.append(param_name)
         subparser.set_defaults(func=func, param_names=func_param_names)


### PR DESCRIPTION
When we made it possible to specify the user data at creation (ie - in the `new_user` proposal), we broke the CLI as this `user_data` argument was required (but unparseable) on the CLI.

Before:

```
$ python -m ccf.proposal_generator new_user --help
usage: proposal_generator.py new_user [-h] user_cert_path user_data

$ python -m ccf.proposal_generator new_user bob_cert.pem 
usage: proposal_generator.py new_user [-h] user_cert_path user_data
proposal_generator.py new_user: error: the following arguments are required: user_data
```

After
```
$ python -m ccf.proposal_generator new_user --help
usage: proposal_generator.py new_user [-h] user_cert_path [user_data]

# Can call without specifying any user data
$ python -m ccf.proposal_generator new_user bob_cert.pem
[2020-09-10 16:25:08.973] SUCCESS | Writing proposal to ./new_user_proposal.json
[2020-09-10 16:25:08.973] SUCCESS | Wrote vote to ./new_user_vote_for.json

# Or can specify user data as JSON on the CLI
$ python -m ccf.proposal_generator --pretty-print new_user bob_cert.pem '{"friendly_name": "Bob"}'
[2020-09-10 16:25:40.841] SUCCESS | Writing proposal to ./new_user_proposal.json
[2020-09-10 16:25:40.841] SUCCESS | Wrote vote to ./new_user_vote_for.json

$ cat new_user_proposal.json 
{
  "script": {
    "text": "tables, args = ...; return Calls:call(\"new_user\", args)"
  },
  "parameter": {
    "cert": "-----BEGIN CERTIFICATE----- [SNIP] -----END CERTIFICATE-----\n",
    "user_data": {
      "friendly_name": "Bob"
    }
  }
}
```