### PR TITLE
AFT: verify signature on the backups

### DIFF
--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -699,7 +699,7 @@ namespace kv
 
         auto h = get_history();
 
-        auto search = views.find("ccf.signatures");
+        auto search = views.find(ccf::Tables::SIGNATURES);
         if (search != views.end())
         {
           // Transactions containing a signature must only contain
@@ -749,6 +749,14 @@ namespace kv
             return success;
           }
           auto h = get_history();
+          if (!h->verify(term_))
+          {
+            LOG_FAIL_FMT("Failed to deserialise");
+            LOG_DEBUG_FMT("Signature in transaction {} failed to verify", v);
+            throw std::logic_error(
+              "Failed to verify signature, view-changes not implemented");
+            return DeserialiseSuccess::FAILED;
+          }
           h->append(data.data(), data.size());
           success = DeserialiseSuccess::PASS_SIGNATURE;
         }

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -726,16 +726,7 @@ namespace ccf
       kv::Version version,
       std::shared_ptr<std::vector<uint8_t>> replicated) override
     {
-      auto consensus = store.get_consensus();
-      if (consensus->type() == ConsensusType::CFT)
-      {
-        add_result(id, version, replicated->data(), replicated->size());
-      }
-      else
-      {
-        std::lock_guard<SpinLock> vguard(version_lock);
-        pending_inserts.insert_back(new PendingInsert(id, version, replicated));
-      }
+      add_result(id, version, replicated->data(), replicated->size());
     }
 
     void flush_pending() override


### PR DESCRIPTION
When a BFT backup receives a signature append entry it will validate the signature and compare it to its own merkle root (same as with cft).