### PR TITLE
Enable sleep OCall and tweak default sleep

### DIFF
--- a/edl/ccf.edl
+++ b/edl/ccf.edl
@@ -3,6 +3,7 @@
 
 enclave {
     from "openenclave/edl/sgx/platform.edl" import *;
+    from "openenclave/edl/time.edl" import *;
 
     include "enclave/start_type.h"
     include "enclave/consensus_type.h"

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -338,7 +338,7 @@ namespace enclave
 
           if ((time_now - idling_start_time) > timeout)
           {
-            std::this_thread::sleep_for(timeout);
+            std::this_thread::sleep_for(timeout * 10);
           }
           else
           {


### PR DESCRIPTION
#1100 previously enabled backoff in enclave after an interval to avoid spinning for extended periods of time.

Unfortunately the migration of internal Open Enclave OCalls to EDL caused this to break inadvertently, because we did not explicitly enable the nanosleep ocall. After testing with the existing value, CPU usage is still near 100%, so this is bumping it up to 50ms, which makes usage about 16% when idle.

The right solution here likely involves a CCF OCall with a condition variable on the host side, or something similar, to strike a better tradeoff between usage and latency on resume. This is a short term improvement over the current situation though.