### PR TITLE
Fix python warning

### DIFF
--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -644,11 +644,9 @@ def run(args):
         network = test(
             network,
             args,
-            verify=args.package is not "libjs_generic",
+            verify=args.package != "libjs_generic",
         )
-        network = test_illegal(
-            network, args, verify=args.package is not "libjs_generic"
-        )
+        network = test_illegal(network, args, verify=args.package != "libjs_generic")
         network = test_large_messages(network, args)
         network = test_remove(network, args)
         network = test_forwarding_frontends(network, args)


### PR DESCRIPTION
Fix the following warning

SyntaxWarning: "is not" with a literal. Did you mean "!="? verify=args.package is not "libjs_generic",