### PR TITLE
Only send Tick messages to live threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed infinite memory growth issue (#1639)
     
 ## [0.13.3] - 2020-09-18
 ### Added

--- a/getting_started/setup_vm/roles/ccf_build/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_build/vars/common.yml
@@ -27,5 +27,5 @@ debs:
 mbedtls_ver: "2.16.6"
 mbedtls_dir: "mbedtls-{{ mbedtls_ver }}"
 mbedtls_src: "{{ mbedtls_dir }}.tar.gz"
-step_cli_ver: "0.14.4"
+step_cli_ver: "0.15.2"
 step_cli: "https://github.com/smallstep/cli/releases/download/v{{ step_cli_ver }}/step-cli_{{ step_cli_ver }}_amd64.deb"

--- a/src/ds/thread_messaging.h
+++ b/src/ds/thread_messaging.h
@@ -322,10 +322,7 @@ namespace threading
       for (auto i = 0; i < thread_count; ++i)
       {
         auto& task = tasks[i];
-        auto msg = std::make_unique<Tmsg<TickMsg>>(
-          &tick_cb,
-          elapsed,
-          task);
+        auto msg = std::make_unique<Tmsg<TickMsg>>(&tick_cb, elapsed, task);
         task.add_task(msg.release());
       }
     }


### PR DESCRIPTION
Fixes a memory growth issue, where messages would be queued indefinitely for inactive threads.

The real fix is to loop `< thread_count` rather than `: tasks`. The rest of the diff is from pulling the inline lambda into `tick_cb`.