### PR TITLE
Ensure that we cannot send message to an "unused" threads queue

### DIFF
--- a/src/ds/test/messaging.cpp
+++ b/src/ds/test/messaging.cpp
@@ -5,6 +5,7 @@
 #include "../non_blocking.h"
 #include "../ring_buffer.h"
 #include "../serialized.h"
+#include "../thread_messaging.h"
 
 #include <array>
 #include <doctest/doctest.h>
@@ -16,6 +17,8 @@
 
 using namespace messaging;
 using namespace ringbuffer;
+
+std::atomic<uint16_t> threading::ThreadMessaging::thread_count = 0;
 
 template <typename Ex, typename F>
 void require_throws_with(

--- a/src/ds/test/messaging.cpp
+++ b/src/ds/test/messaging.cpp
@@ -18,7 +18,7 @@
 using namespace messaging;
 using namespace ringbuffer;
 
-std::atomic<uint16_t> threading::ThreadMessaging::thread_count = 0;
+std::atomic<uint16_t> threading::ThreadMessaging::thread_count = 1;
 
 template <typename Ex, typename F>
 void require_throws_with(

--- a/src/ds/thread_messaging.h
+++ b/src/ds/thread_messaging.h
@@ -267,7 +267,7 @@ namespace threading
 
     void run()
     {
-      Task& task = tasks[get_current_thread_id()];
+      Task& task = get_task(get_current_thread_id());
 
       while (!is_finished())
       {
@@ -275,8 +275,13 @@ namespace threading
       }
     }
 
-    Task& get_task(uint16_t tid)
+    inline Task& get_task(uint16_t tid)
     {
+      CCF_ASSERT_FMT(
+        tid <= thread_count,
+        "Attempting to add task to tid > thread_count, tid:{}, thread_count:{}",
+        tid,
+        thread_count);
       return tasks[tid];
     }
 
@@ -288,7 +293,7 @@ namespace threading
     template <typename Payload>
     void add_task(uint16_t tid, std::unique_ptr<Tmsg<Payload>> msg)
     {
-      Task& task = tasks[tid];
+      Task& task = get_task(tid);
 
       task.add_task(reinterpret_cast<ThreadMsg*>(msg.release()));
     }
@@ -297,7 +302,7 @@ namespace threading
     void add_task_after(
       std::unique_ptr<Tmsg<Payload>> msg, std::chrono::milliseconds ms)
     {
-      Task& task = tasks[get_current_thread_id()];
+      Task& task = get_task(get_current_thread_id());
       task.add_task_after(std::move(msg), ms);
     }
 
@@ -321,7 +326,7 @@ namespace threading
     {
       for (auto i = 0; i < thread_count; ++i)
       {
-        auto& task = tasks[i];
+        auto& task = get_task(i);
         auto msg = std::make_unique<Tmsg<TickMsg>>(&tick_cb, elapsed, task);
         task.add_task(msg.release());
       }

--- a/src/ds/thread_messaging.h
+++ b/src/ds/thread_messaging.h
@@ -278,7 +278,7 @@ namespace threading
     inline Task& get_task(uint16_t tid)
     {
       CCF_ASSERT_FMT(
-        tid <= thread_count,
+        tid < thread_count,
         "Attempting to add task to tid > thread_count, tid:{}, thread_count:{}",
         tid,
         thread_count);


### PR DESCRIPTION
Always call get_task when getting and task queue and then have an assert in said function to ensure the queue we are returning will eventually be polled