### PR TITLE
Aft: In BFT mode propagate backup signatures and backups to signatures 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,6 +320,16 @@ if(BUILD_TESTS)
     )
 
     add_unit_test(
+      progress_tracker_test
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/node/test/progress_tracker.cpp
+    )
+    target_include_directories(progress_tracker_test PRIVATE ${EVERCRYPT_INC})
+    target_link_libraries(
+      progress_tracker_test PRIVATE ${CRYPTO_LIBRARY} evercrypt.host
+                                    secp256k1.host
+    )
+
+    add_unit_test(
       secret_sharing_test
       ${CMAKE_CURRENT_SOURCE_DIR}/src/node/test/secret_share.cpp
     )

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -871,7 +871,7 @@ namespace aft
       auto h = progress_tracker->get_my_hashed_nonce(
         state->current_view, state->last_idx);
 
-      std::array<uint8_t, 32> hashed_nonce;
+      Nonce hashed_nonce;
       std::copy(h.begin(), h.end(), hashed_nonce.begin());
 
       SignedAppendEntriesResponse r = {
@@ -898,7 +898,8 @@ namespace aft
         auto send_to = it->first;
         if (send_to != state->my_node_id)
         {
-          channels->send_authenticated(ccf::NodeMsgType::consensus_msg, send_to, r);
+          channels->send_authenticated(
+            ccf::NodeMsgType::consensus_msg, send_to, r);
         }
       }
     }
@@ -934,12 +935,21 @@ namespace aft
       if (progress_tracker != nullptr)
       {
         auto result = progress_tracker->add_signature(
-          r.term, r.last_log_idx, r.from_node, r.signature_size, r.sig, r.hashed_nonce, nodes.size());
+          r.term,
+          r.last_log_idx,
+          r.from_node,
+          r.signature_size,
+          r.sig,
+          r.hashed_nonce,
+          nodes.size());
         try_send_sig_ack(r.term, r.last_log_idx, result);
       }
     }
 
-    void try_send_sig_ack(kv::Consensus::View view, kv::Consensus::SeqNo seqno, kv::TxHistory::Result r)
+    void try_send_sig_ack(
+      kv::Consensus::View view,
+      kv::Consensus::SeqNo seqno,
+      kv::TxHistory::Result r)
     {
       switch (r)
       {
@@ -990,7 +1000,8 @@ namespace aft
       catch (const std::logic_error& err)
       {
         LOG_FAIL_FMT("Error in recv_signature_received_ack message");
-        LOG_DEBUG_FMT("Error in recv_signature_received_ack message: {}", err.what());
+        LOG_DEBUG_FMT(
+          "Error in recv_signature_received_ack message: {}", err.what());
         return;
       }
 
@@ -1033,7 +1044,7 @@ namespace aft
         }
         case kv::TxHistory::Result::SEND_REPLY_AND_NONCE:
         {
-          std::array<uint8_t, 32> nonce;
+          Nonce nonce;
           auto progress_tracker = store->get_progress_tracker();
           if (progress_tracker != nullptr)
           {
@@ -1071,17 +1082,15 @@ namespace aft
 
       try
       {
-        r = channels->template recv_authenticated<NonceRevealMsg>(
-          data, size);
+        r = channels->template recv_authenticated<NonceRevealMsg>(data, size);
       }
       catch (const std::logic_error& err)
       {
         LOG_FAIL_FMT("Error in recv_signature_received_ack message");
-        LOG_DEBUG_FMT("Error in recv_signature_received_ack message: {}", err.what());
+        LOG_DEBUG_FMT(
+          "Error in recv_signature_received_ack message: {}", err.what());
         return;
       }
-
-      LOG_INFO_FMT("AAAAAA got a nonce, from:{}, seqno:{}, nonce:{}", r.from_node, r.idx, r.nonce);
 
       auto node = nodes.find(r.from_node);
       if (node == nodes.end())

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -789,7 +789,6 @@ namespace aft
             break;
           }
 
-          case kv::DeserialiseSuccess::PASS_SIGNATURE_SEND_ACK:
           case kv::DeserialiseSuccess::PASS_SIGNATURE:
           {
             LOG_DEBUG_FMT("Deserialising signature at {}", i);
@@ -804,14 +803,6 @@ namespace aft
             {
               send_append_entries_signed_response(r.from_node, sig);
             }
-
-            try_send_sig_ack(
-              sig.view,
-              sig.seqno,
-              deserialise_success ==
-                  kv::DeserialiseSuccess::PASS_SIGNATURE_SEND_ACK ?
-                kv::TxHistory::Result::SEND_SIG_RECEIPT_ACK :
-                kv::TxHistory::Result::OK);
             break;
           }
 
@@ -1065,7 +1056,7 @@ namespace aft
           if (progress_tracker != nullptr)
           {
             progress_tracker->add_nonce_reveal(
-              view, seqno, nonce, state->my_node_id, nodes.size());
+              view, seqno, nonce, state->my_node_id);
           }
           break;
         }
@@ -1112,7 +1103,7 @@ namespace aft
           r.term,
           r.idx);
         progress_tracker->add_nonce_reveal(
-          r.term, r.idx, r.nonce, r.from_node, nodes.size());
+          r.term, r.idx, r.nonce, r.from_node);
       }
     }
 

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -882,8 +882,6 @@ namespace aft
         r.sig,
         hashed_nonce,
         nodes.size());
-      try_send_sig_ack(r.term, r.last_log_idx, result);
-
       for (auto it = nodes.begin(); it != nodes.end(); ++it)
       {
         auto send_to = it->first;
@@ -893,6 +891,8 @@ namespace aft
             ccf::NodeMsgType::consensus_msg, send_to, r);
         }
       }
+
+      try_send_sig_ack(r.term, r.last_log_idx, result);
     }
 
     void recv_append_entries_signed_response(const uint8_t* data, size_t size)
@@ -1102,8 +1102,7 @@ namespace aft
           r.from_node,
           r.term,
           r.idx);
-        progress_tracker->add_nonce_reveal(
-          r.term, r.idx, r.nonce, r.from_node);
+        progress_tracker->add_nonce_reveal(r.term, r.idx, r.nonce, r.from_node);
       }
     }
 

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -868,8 +868,8 @@ namespace aft
         state->last_idx);
 
       auto progress_tracker = store->get_progress_tracker();
-      // TODO: Should hash the nonce
-      uint64_t hashed_nonce = progress_tracker->get_my_nonce(state->current_view, state->last_idx);
+      uint64_t hashed_nonce = progress_tracker->get_my_hashed_nonce(
+        state->current_view, state->last_idx);
 
       SignedAppendEntriesResponse r = {
         {raft_append_entries_signed_response, state->my_node_id},

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -864,8 +864,9 @@ namespace aft
       auto progress_tracker = store->get_progress_tracker();
       if (progress_tracker != nullptr)
       {
-        progress_tracker->add_signature(
+        auto result = progress_tracker->add_signature(
           r.term, r.last_log_idx, r.from_node, r.signature_size, r.sig, nodes.size());
+        try_send_sig_ack(r.term, r.last_log_idx, result);
       }
 
       for (auto it = nodes.begin(); it != nodes.end(); ++it)
@@ -914,16 +915,16 @@ namespace aft
       }
     }
 
-    void try_send_sig_ack(kv::Consensus::View view, kv::Consensus::SeqNo seqno, ccf::ProgressTracker::Result r)
+    void try_send_sig_ack(kv::Consensus::View view, kv::Consensus::SeqNo seqno, kv::TxHistory::Result r)
     {
       switch (r)
       {
-        case ccf::ProgressTracker::Result::OK:
-        case ccf::ProgressTracker::Result::FAIL:
+        case kv::TxHistory::Result::OK:
+        case kv::TxHistory::Result::FAIL:
         {
           break;
         }
-        case ccf::ProgressTracker::Result::SEND_SIG_RECEIPT_ACK:
+        case kv::TxHistory::Result::SEND_SIG_RECEIPT_ACK:
         {
           SignaturesReceivedAck r = {
             {bft_signature_received_ack, state->my_node_id}, view, seqno};

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1033,7 +1033,7 @@ namespace aft
         }
         case kv::TxHistory::Result::SEND_REPLY_AND_NONCE:
         {
-          uint64_t nonce = 0;
+          std::array<uint8_t, 32> nonce;
           auto progress_tracker = store->get_progress_tracker();
           if (progress_tracker != nullptr)
           {

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -868,8 +868,11 @@ namespace aft
         state->last_idx);
 
       auto progress_tracker = store->get_progress_tracker();
-      uint64_t hashed_nonce = progress_tracker->get_my_hashed_nonce(
+      auto h = progress_tracker->get_my_hashed_nonce(
         state->current_view, state->last_idx);
+
+      std::array<uint8_t, 32> hashed_nonce;
+      std::copy(h.begin(), h.end(), hashed_nonce.begin());
 
       SignedAppendEntriesResponse r = {
         {raft_append_entries_signed_response, state->my_node_id},

--- a/src/consensus/aft/raft_consensus.h
+++ b/src/consensus/aft/raft_consensus.h
@@ -126,6 +126,11 @@ namespace aft
       aft->enable_all_domains();
     }
 
+    uint32_t node_count() override
+    {
+      return aft->node_count();
+    }
+
     void open_network() override
     {
       is_open = true;

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -164,6 +164,7 @@ namespace aft
   {
     Term term;
     Index last_log_idx;
+    uint64_t hashed_nonce;
     uint32_t signature_size;
     std::array<uint8_t, MBEDTLS_ECDSA_MAX_LEN> sig;
   };

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -164,7 +164,7 @@ namespace aft
   {
     Term term;
     Index last_log_idx;
-    uint64_t hashed_nonce;
+    std::array<uint8_t, 32> hashed_nonce;
     uint32_t signature_size;
     std::array<uint8_t, MBEDTLS_ECDSA_MAX_LEN> sig;
   };

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -21,6 +21,7 @@ namespace aft
   using Term = int64_t;
   using NodeId = uint64_t;
   using Node2NodeMsg = uint64_t;
+  using Nonce = std::array<uint8_t, 32>;
 
   using ReplyCallback = std::function<bool(
     void* owner,
@@ -164,7 +165,7 @@ namespace aft
   {
     Term term;
     Index last_log_idx;
-    std::array<uint8_t, 32> hashed_nonce;
+    Nonce hashed_nonce;
     uint32_t signature_size;
     std::array<uint8_t, MBEDTLS_ECDSA_MAX_LEN> sig;
   };
@@ -179,7 +180,7 @@ namespace aft
   {
     Term term;
     Index idx;
-    std::array<uint8_t, 32> nonce;
+    Nonce nonce;
   };
 
   struct RequestVote : RaftHeader

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -179,7 +179,7 @@ namespace aft
   {
     Term term;
     Index idx;
-    uint64_t nonce;
+    std::array<uint8_t, 32> nonce;
   };
 
   struct RequestVote : RaftHeader

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -133,7 +133,8 @@ namespace aft
     raft_request_vote_response,
 
     bft_request,
-    bft_signature_received_ack
+    bft_signature_received_ack,
+    bft_nonce_reveal
   };
 
 #pragma pack(push, 1)
@@ -171,6 +172,13 @@ namespace aft
   {
     Term term;
     Index idx;
+  };
+
+  struct NonceRevealMsg : RaftHeader
+  {
+    Term term;
+    Index idx;
+    uint64_t nonce;
   };
 
   struct RequestVote : RaftHeader

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -133,6 +133,7 @@ namespace aft
     raft_request_vote_response,
 
     bft_request,
+    bft_signature_received_ack
   };
 
 #pragma pack(push, 1)
@@ -164,6 +165,12 @@ namespace aft
     Index last_log_idx;
     uint32_t signature_size;
     std::array<uint8_t, MBEDTLS_ECDSA_MAX_LEN> sig;
+  };
+
+  struct SignaturesReceivedAck : RaftHeader
+  {
+    Term term;
+    Index idx;
   };
 
   struct RequestVote : RaftHeader

--- a/src/ds/logger.h
+++ b/src/ds/logger.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
-#include "ring_buffer.h"
 #include "logger_formatters.h"
+#include "ring_buffer.h"
 #include "thread_ids.h"
 
 #include <chrono>

--- a/src/ds/logger.h
+++ b/src/ds/logger.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ring_buffer.h"
+#include "logger_formatters.h"
 #include "thread_ids.h"
 
 #include <chrono>

--- a/src/ds/logger_formatters.h
+++ b/src/ds/logger_formatters.h
@@ -12,12 +12,9 @@ namespace fmt
   inline std::string uint8_vector_to_hex_string(const std::vector<uint8_t>& v)
   {
     std::stringstream ss;
-    ss << std::hex << std::setfill('0');
-    std::vector<uint8_t>::const_iterator it;
-
-    for (it = v.begin(); it != v.end(); it++)
+    for (auto it = v.begin(); it != v.end(); it++)
     {
-      ss << std::hex << std::setw(2) << static_cast<unsigned>(*it);
+      ss << std::hex << static_cast<unsigned>(*it);
     }
 
     return ss.str();

--- a/src/ds/logger_formatters.h
+++ b/src/ds/logger_formatters.h
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#define FMT_HEADER_ONLY
+#include <fmt/format.h>
+#include <msgpack/msgpack.hpp>
+#include <sstream>
+
+namespace fmt
+{
+  inline std::string uint8_vector_to_hex_string(const std::vector<uint8_t>& v)
+  {
+    std::stringstream ss;
+    ss << std::hex << std::setfill('0');
+    std::vector<uint8_t>::const_iterator it;
+
+    for (it = v.begin(); it != v.end(); it++)
+    {
+      ss << std::hex << std::setw(2) << static_cast<unsigned>(*it);
+    }
+
+    return ss.str();
+  }
+
+  template <>
+  struct formatter<std::vector<uint8_t>>
+  {
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+      return ctx.begin();
+    }
+
+    template <typename FormatContext>
+    auto format(const std::vector<uint8_t>& p, FormatContext& ctx)
+    {
+      return format_to(ctx.out(), uint8_vector_to_hex_string(p));
+    }
+  };
+
+  template <>
+  struct formatter<std::array<uint8_t, 32>>
+  {
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+      return ctx.begin();
+    }
+
+    template <typename FormatContext>
+    auto format(const std::array<uint8_t, 32>& p, FormatContext& ctx)
+    {
+      return format_to(
+        ctx.out(), uint8_vector_to_hex_string({p.begin(), p.end()}));
+    }
+  };
+}

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -314,6 +314,7 @@ namespace kv
     }
     virtual void enable_all_domains() {}
 
+    virtual uint32_t node_count() = 0;
     virtual void open_network() = 0;
     virtual void emit_signature() = 0;
     virtual ConsensusType type() = 0;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -149,9 +149,10 @@ namespace kv
 
     enum class Result
     {
-      OK,
+      OK = 0,
       FAIL,
-      SEND_SIG_RECEIPT_ACK
+      SEND_SIG_RECEIPT_ACK,
+      SEND_REPLY_AND_NONCE
     };
 
     using ResultCallbackHandler = std::function<bool(ResultCallbackArgs)>;
@@ -162,7 +163,7 @@ namespace kv
     virtual void append(const uint8_t* replicated, size_t replicated_size) = 0;
     virtual Result verify_and_sign(
       ccf::PrimarySignature& signature, Term* term = nullptr) = 0;
-    virtual bool verify(Term* term = nullptr) = 0;
+    virtual bool verify(Term* term = nullptr, ccf::PrimarySignature* sig = nullptr) = 0;
     virtual void emit_signature() = 0;
     virtual crypto::Sha256Hash get_replicated_state_root() = 0;
     virtual std::vector<uint8_t> get_receipt(Version v) = 0;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -149,10 +149,10 @@ namespace kv
 
     enum class Result
     {
-      OK = 0,
-      FAIL,
-      SEND_SIG_RECEIPT_ACK,
-      SEND_REPLY_AND_NONCE
+      FAIL = 0,
+      OK = 1,
+      SEND_SIG_RECEIPT_ACK = 2,
+      SEND_REPLY_AND_NONCE = 4
     };
 
     using ResultCallbackHandler = std::function<bool(ResultCallbackArgs)>;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -84,7 +84,6 @@ namespace kv
     FAILED = 0,
     PASS = 1,
     PASS_SIGNATURE = 2,
-    PASS_SIGNATURE_SEND_ACK = 3,
     PASS_PRE_PREPARE = 4,
     PASS_NEW_VIEW = 5
   };

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -84,8 +84,8 @@ namespace kv
     FAILED = 0,
     PASS = 1,
     PASS_SIGNATURE = 2,
-    PASS_PRE_PREPARE = 4,
-    PASS_NEW_VIEW = 5
+    PASS_PRE_PREPARE = 3,
+    PASS_NEW_VIEW = 4
   };
 
   enum ReplicateType
@@ -149,9 +149,9 @@ namespace kv
     enum class Result
     {
       FAIL = 0,
-      OK = 1,
-      SEND_SIG_RECEIPT_ACK = 2,
-      SEND_REPLY_AND_NONCE = 3
+      OK,
+      SEND_SIG_RECEIPT_ACK,
+      SEND_REPLY_AND_NONCE
     };
 
     using ResultCallbackHandler = std::function<bool(ResultCallbackArgs)>;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -163,7 +163,8 @@ namespace kv
     virtual void append(const uint8_t* replicated, size_t replicated_size) = 0;
     virtual Result verify_and_sign(
       ccf::PrimarySignature& signature, Term* term = nullptr) = 0;
-    virtual bool verify(Term* term = nullptr, ccf::PrimarySignature* sig = nullptr) = 0;
+    virtual bool verify(
+      Term* term = nullptr, ccf::PrimarySignature* sig = nullptr) = 0;
     virtual void emit_signature() = 0;
     virtual crypto::Sha256Hash get_replicated_state_root() = 0;
     virtual std::vector<uint8_t> get_receipt(Version v) = 0;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -152,7 +152,7 @@ namespace kv
       FAIL = 0,
       OK = 1,
       SEND_SIG_RECEIPT_ACK = 2,
-      SEND_REPLY_AND_NONCE = 4
+      SEND_REPLY_AND_NONCE = 3
     };
 
     using ResultCallbackHandler = std::function<bool(ResultCallbackArgs)>;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -84,8 +84,9 @@ namespace kv
     FAILED = 0,
     PASS = 1,
     PASS_SIGNATURE = 2,
-    PASS_PRE_PREPARE = 3,
-    PASS_NEW_VIEW = 4
+    PASS_SIGNATURE_SEND_ACK = 3,
+    PASS_PRE_PREPARE = 4,
+    PASS_NEW_VIEW = 5
   };
 
   enum ReplicateType
@@ -146,13 +147,20 @@ namespace kv
       std::vector<uint8_t> response;
     };
 
+    enum class Result
+    {
+      OK,
+      FAIL,
+      SEND_SIG_RECEIPT_ACK
+    };
+
     using ResultCallbackHandler = std::function<bool(ResultCallbackArgs)>;
     using ResponseCallbackHandler = std::function<bool(ResponseCallbackArgs)>;
 
     virtual ~TxHistory() {}
     virtual void append(const std::vector<uint8_t>& replicated) = 0;
     virtual void append(const uint8_t* replicated, size_t replicated_size) = 0;
-    virtual bool verify_and_sign(
+    virtual Result verify_and_sign(
       ccf::PrimarySignature& signature, Term* term = nullptr) = 0;
     virtual bool verify(Term* term = nullptr) = 0;
     virtual void emit_signature() = 0;

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -792,7 +792,6 @@ namespace kv
             auto r = h->verify_and_sign(*sig, term_);
             if (r == kv::TxHistory::Result::SEND_SIG_RECEIPT_ACK)
             {
-              // TODO: consume this in raft.h
               success = DeserialiseSuccess::PASS_SIGNATURE_SEND_ACK;
             }
             else if (r != kv::TxHistory::Result::OK)

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -790,11 +790,9 @@ namespace kv
           if (sig != nullptr)
           {
             auto r = h->verify_and_sign(*sig, term_);
-            if (r == kv::TxHistory::Result::SEND_SIG_RECEIPT_ACK)
-            {
-              success = DeserialiseSuccess::PASS_SIGNATURE_SEND_ACK;
-            }
-            else if (r != kv::TxHistory::Result::OK)
+            if (
+              r != kv::TxHistory::Result::OK &&
+              r != kv::TxHistory::Result::SEND_SIG_RECEIPT_ACK)
             {
               result = false;
             }

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -783,7 +783,6 @@ namespace kv
           {
             return success;
           }
-          success = DeserialiseSuccess::PASS_SIGNATURE;
 
           auto h = get_history();
           bool result = true;
@@ -811,6 +810,7 @@ namespace kv
             return DeserialiseSuccess::FAILED;
           }
           h->append(data.data(), data.size());
+          success = DeserialiseSuccess::PASS_SIGNATURE;
         }
         else if (views.find(ccf::Tables::AFT_REQUESTS) == views.end())
         {

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -708,7 +708,7 @@ TEST_CASE("Deserialise return status")
   {
     kv::Tx tx(store.next_version());
     auto sig_view = tx.get_view(signatures);
-    ccf::PrimarySignature sigv(0, 2);
+    ccf::PrimarySignature sigv(0, 2, 0);
     sig_view->put(0, sigv);
     auto [success, reqid, data] = tx.commit_reserved();
     REQUIRE(success == kv::CommitSuccess::OK);
@@ -720,7 +720,7 @@ TEST_CASE("Deserialise return status")
   {
     kv::Tx tx(store.next_version());
     auto [sig_view, data_view] = tx.get_view(signatures, data);
-    ccf::PrimarySignature sigv(0, 2);
+    ccf::PrimarySignature sigv(0, 2, 0);
     sig_view->put(0, sigv);
     data_view->put(43, 43);
     auto [success, reqid, data] = tx.commit_reserved();

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -708,7 +708,7 @@ TEST_CASE("Deserialise return status")
   {
     kv::Tx tx(store.next_version());
     auto sig_view = tx.get_view(signatures);
-    ccf::PrimarySignature sigv(0, 2, 0);
+    ccf::PrimarySignature sigv(0, 2, {0});
     sig_view->put(0, sigv);
     auto [success, reqid, data] = tx.commit_reserved();
     REQUIRE(success == kv::CommitSuccess::OK);
@@ -720,7 +720,7 @@ TEST_CASE("Deserialise return status")
   {
     kv::Tx tx(store.next_version());
     auto [sig_view, data_view] = tx.get_view(signatures, data);
-    ccf::PrimarySignature sigv(0, 2, 0);
+    ccf::PrimarySignature sigv(0, 2, {0});
     sig_view->put(0, sigv);
     data_view->put(43, 43);
     auto [success, reqid, data] = tx.commit_reserved();

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -145,6 +145,11 @@ namespace kv
       return;
     }
 
+    uint32_t node_count() override
+    {
+      return 0;
+    }
+
     void emit_signature() override
     {
       return;

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -591,10 +591,14 @@ namespace ccf
       auto progress_tracker = store.get_progress_tracker();
       if (progress_tracker)
       {
+        // TODO: set the nonce correctly
+        uint64_t hashed_nonce = 0;
         result = progress_tracker->record_primary(
           sig.view,
           sig.seqno,
+          sig.node,
           sig.root,
+          hashed_nonce,
           store.get_consensus()->node_count());
       }
 
@@ -694,10 +698,14 @@ namespace ccf
           auto progress_tracker = store.get_progress_tracker();
           if (progress_tracker)
           {
+            // TODO: set the nonce correctly
+            uint64_t hashed_nonce = 0;
             auto r = progress_tracker->record_primary(
               txid.term,
               txid.version,
-              root);
+              id,
+              root,
+              hashed_nonce);
             CCF_ASSERT_FMT(
               r == kv::TxHistory::Result::OK,
               "Expected success when primary added signature to the progress "

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -694,13 +694,12 @@ namespace ccf
           crypto::Sha256Hash root = replicated_state_tree.get_root();
 
           Nonce hashed_nonce;
-          auto progress_tracker = store.get_progress_tracker();
-          CCF_ASSERT(
-            progress_tracker != nullptr, "progress_tracker is not set");
           auto consensus = store.get_consensus();
-
           if (consensus != nullptr && consensus->type() == ConsensusType::BFT)
           {
+            auto progress_tracker = store.get_progress_tracker();
+            CCF_ASSERT(
+              progress_tracker != nullptr, "progress_tracker is not set");
             auto r = progress_tracker->record_primary(
               txid.term, txid.version, id, root, hashed_nonce);
             if (r != kv::TxHistory::Result::OK)

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -604,7 +604,8 @@ namespace ccf
       return result;
     }
 
-    bool verify(kv::Term* term = nullptr, PrimarySignature* signature = nullptr) override
+    bool verify(
+      kv::Term* term = nullptr, PrimarySignature* signature = nullptr) override
     {
       kv::Tx tx;
       auto [sig_tv, ni_tv] = tx.get_view(signatures, nodes);
@@ -620,7 +621,7 @@ namespace ccf
         *term = sig_value.view;
       }
 
-      if  (signature)
+      if (signature)
       {
         *signature = sig_value;
       }
@@ -694,16 +695,12 @@ namespace ccf
           auto sig_view = sig.get_view(signatures);
           crypto::Sha256Hash root = replicated_state_tree.get_root();
 
-          std::array<uint8_t, 32> hashed_nonce;
+          Nonce hashed_nonce;
           auto progress_tracker = store.get_progress_tracker();
           if (progress_tracker)
           {
             auto r = progress_tracker->record_primary(
-              txid.term,
-              txid.version,
-              id,
-              root,
-              hashed_nonce);
+              txid.term, txid.version, id, root, hashed_nonce);
             CCF_ASSERT_FMT(
               r == kv::TxHistory::Result::OK,
               "Expected success when primary added signature to the progress "

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -701,13 +701,16 @@ namespace ccf
           {
             auto r = progress_tracker->record_primary(
               txid.term, txid.version, id, root, hashed_nonce);
-            CCF_ASSERT_FMT(
-              r == kv::TxHistory::Result::OK,
-              "Expected success when primary added signature to the progress "
-              "tracker. r:{}, view:{}, seqno:{}",
-              r,
-              txid.term,
-              txid.version);
+            if (r != kv::TxHistory::Result::OK)
+            {
+              throw ccf::ccf_logic_error(fmt::format(
+                "Expected success when primary added signature to the "
+                "progress "
+                "tracker. r:{}, view:{}, seqno:{}",
+                r,
+                txid.term,
+                txid.version));
+            }
 
             auto h =
               progress_tracker->get_my_hashed_nonce(txid.term, txid.version);

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -711,8 +711,7 @@ namespace ccf
               txid.term,
               txid.version);
 
-            // TODO: Should hash the nonce
-            hashed_nonce = progress_tracker->get_my_nonce(txid.term, txid.version);
+            hashed_nonce = progress_tracker->get_my_hashed_nonce(txid.term, txid.version);
           }
 
           PrimarySignature sig_value(

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -631,7 +631,11 @@ namespace ccf
       auto progress_tracker = store.get_progress_tracker();
       if (progress_tracker)
       {
-        progress_tracker->record_primary(sig_value.view, sig_value.seqno, root);
+        progress_tracker->record_primary(
+          sig_value.view,
+          sig_value.seqno,
+          root,
+          store.get_consensus()->node_count());
       }
 
       return true;
@@ -685,7 +689,11 @@ namespace ccf
           auto progress_tracker = store.get_progress_tracker();
           if (progress_tracker)
           {
-            progress_tracker->record_primary(txid.term, txid.version, root);
+            progress_tracker->record_primary(
+              txid.term,
+              txid.version,
+              root,
+              store.get_consensus()->node_count());
           }
 
           PrimarySignature sig_value(

--- a/src/node/node_signature.h
+++ b/src/node/node_signature.h
@@ -31,7 +31,7 @@ namespace ccf
 
     bool operator==(const NodeSignature& o) const
     {
-      return sig == o.sig && node == o.node && hashed_nonce == o.hashed_nonce;
+      return sig == o.sig && hashed_nonce == o.hashed_nonce;
     }
 
     MSGPACK_DEFINE(sig, node, hashed_nonce);

--- a/src/node/node_signature.h
+++ b/src/node/node_signature.h
@@ -3,6 +3,7 @@
 #pragma once
 #include "ds/json.h"
 #include "entities.h"
+#include "tls/hash.h"
 
 #include <vector>
 
@@ -12,13 +13,13 @@ namespace ccf
   {
     std::vector<uint8_t> sig;
     ccf::NodeId node;
-    uint64_t hashed_nonce = 0;
+    std::array<uint8_t, 32> hashed_nonce;
 
     NodeSignature(
-      const std::vector<uint8_t>& sig_, NodeId node_, uint64_t hashed_nonce_) :
+      const std::vector<uint8_t>& sig_, NodeId node_, std::array<uint8_t, 32> hashed_nonce_) :
       sig(sig_), node(node_), hashed_nonce(hashed_nonce_)
     {}
-    NodeSignature(ccf::NodeId node_, uint64_t hashed_nonce_) : node(node_), hashed_nonce(hashed_nonce_) {}
+    NodeSignature(ccf::NodeId node_, std::array<uint8_t, 32> hashed_nonce_) : node(node_), hashed_nonce(hashed_nonce_) {}
     NodeSignature() = default;
 
     bool operator==(const NodeSignature& o) const

--- a/src/node/node_signature.h
+++ b/src/node/node_signature.h
@@ -9,17 +9,24 @@
 
 namespace ccf
 {
+  using Nonce = std::array<uint8_t, 32>;
+
   struct NodeSignature
   {
     std::vector<uint8_t> sig;
     ccf::NodeId node;
-    std::array<uint8_t, 32> hashed_nonce;
+    Nonce hashed_nonce;
 
     NodeSignature(
-      const std::vector<uint8_t>& sig_, NodeId node_, std::array<uint8_t, 32> hashed_nonce_) :
-      sig(sig_), node(node_), hashed_nonce(hashed_nonce_)
+      const std::vector<uint8_t>& sig_, NodeId node_, Nonce hashed_nonce_) :
+      sig(sig_),
+      node(node_),
+      hashed_nonce(hashed_nonce_)
     {}
-    NodeSignature(ccf::NodeId node_, std::array<uint8_t, 32> hashed_nonce_) : node(node_), hashed_nonce(hashed_nonce_) {}
+    NodeSignature(ccf::NodeId node_, Nonce hashed_nonce_) :
+      node(node_),
+      hashed_nonce(hashed_nonce_)
+    {}
     NodeSignature() = default;
 
     bool operator==(const NodeSignature& o) const

--- a/src/node/node_signature.h
+++ b/src/node/node_signature.h
@@ -12,21 +12,22 @@ namespace ccf
   {
     std::vector<uint8_t> sig;
     ccf::NodeId node;
+    uint64_t hashed_nonce = 0;
 
-    NodeSignature(const std::vector<uint8_t>& sig_, NodeId node_) :
-      sig(sig_),
-      node(node_)
+    NodeSignature(
+      const std::vector<uint8_t>& sig_, NodeId node_, uint64_t hashed_nonce_) :
+      sig(sig_), node(node_), hashed_nonce(hashed_nonce_)
     {}
-    NodeSignature(ccf::NodeId node_) : node(node_) {}
+    NodeSignature(ccf::NodeId node_, uint64_t hashed_nonce_) : node(node_), hashed_nonce(hashed_nonce_) {}
     NodeSignature() = default;
 
     bool operator==(const NodeSignature& o) const
     {
-      return sig == o.sig;
+      return sig == o.sig && node == o.node && hashed_nonce == o.hashed_nonce;
     }
 
-    MSGPACK_DEFINE(sig, node);
+    MSGPACK_DEFINE(sig, node, hashed_nonce);
   };
   DECLARE_JSON_TYPE(NodeSignature);
-  DECLARE_JSON_REQUIRED_FIELDS(NodeSignature, sig, node);
+  DECLARE_JSON_REQUIRED_FIELDS(NodeSignature, sig, node, hashed_nonce);
 }

--- a/src/node/progress_tracker.h
+++ b/src/node/progress_tracker.h
@@ -380,12 +380,11 @@ namespace ccf
     std::vector<uint8_t> hash_data(Nonce data)
     {
       tls::HashBytes hash;
-      int r = tls::do_hash(
+      tls::do_hash(
         reinterpret_cast<const uint8_t*>(&data),
         data.size(),
         hash,
         MBEDTLS_MD_SHA256);
-      CCF_ASSERT_FMT(r == 0, "Failed to hash, r:{}", r);
       return hash;
     }
 

--- a/src/node/progress_tracker.h
+++ b/src/node/progress_tracker.h
@@ -12,7 +12,6 @@
 #include "tls/tls.h"
 #include "tls/verifier.h"
 
-#define FMT_HEADER_ONLY
 #include <array>
 #include <vector>
 

--- a/src/node/signatures.h
+++ b/src/node/signatures.h
@@ -31,8 +31,8 @@ namespace ccf
 
     PrimarySignature() {}
 
-    PrimarySignature(ccf::NodeId node_, ObjectId seqno_) :
-      NodeSignature(node_),
+    PrimarySignature(ccf::NodeId node_, ObjectId seqno_, uint64_t hashed_nonce) :
+      NodeSignature(node_, hashed_nonce),
       seqno(seqno_)
     {}
 
@@ -45,9 +45,10 @@ namespace ccf
       ObjectId commit_seqno_,
       ObjectId commit_view_,
       const crypto::Sha256Hash root_,
+      uint64_t hashed_nonce_,
       const std::vector<uint8_t>& sig_,
       const std::vector<uint8_t>& tree_) :
-      NodeSignature(sig_, node_),
+      NodeSignature(sig_, node_, hashed_nonce_),
       seqno(seqno_),
       view(view_),
       commit_seqno(commit_seqno_),

--- a/src/node/signatures.h
+++ b/src/node/signatures.h
@@ -31,7 +31,7 @@ namespace ccf
 
     PrimarySignature() {}
 
-    PrimarySignature(ccf::NodeId node_, ObjectId seqno_, uint64_t hashed_nonce) :
+    PrimarySignature(ccf::NodeId node_, ObjectId seqno_, std::array<uint8_t, 32> hashed_nonce) :
       NodeSignature(node_, hashed_nonce),
       seqno(seqno_)
     {}
@@ -45,7 +45,7 @@ namespace ccf
       ObjectId commit_seqno_,
       ObjectId commit_view_,
       const crypto::Sha256Hash root_,
-      uint64_t hashed_nonce_,
+      std::array<uint8_t, 32> hashed_nonce_,
       const std::vector<uint8_t>& sig_,
       const std::vector<uint8_t>& tree_) :
       NodeSignature(sig_, node_, hashed_nonce_),

--- a/src/node/signatures.h
+++ b/src/node/signatures.h
@@ -31,7 +31,7 @@ namespace ccf
 
     PrimarySignature() {}
 
-    PrimarySignature(ccf::NodeId node_, ObjectId seqno_, std::array<uint8_t, 32> hashed_nonce) :
+    PrimarySignature(ccf::NodeId node_, ObjectId seqno_, Nonce hashed_nonce) :
       NodeSignature(node_, hashed_nonce),
       seqno(seqno_)
     {}
@@ -45,7 +45,7 @@ namespace ccf
       ObjectId commit_seqno_,
       ObjectId commit_view_,
       const crypto::Sha256Hash root_,
-      std::array<uint8_t, 32> hashed_nonce_,
+      Nonce hashed_nonce_,
       const std::vector<uint8_t>& sig_,
       const std::vector<uint8_t>& tree_) :
       NodeSignature(sig_, node_, hashed_nonce_),

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -113,7 +113,7 @@ TEST_CASE("Check signature verification")
   {
     kv::Tx txs;
     auto tx = txs.get_view(primary_signatures);
-    ccf::PrimarySignature bogus(0, 0);
+    ccf::PrimarySignature bogus(0, 0, 0);
     bogus.sig = std::vector<uint8_t>(MBEDTLS_ECDSA_MAX_LEN, 1);
     tx->put(0, bogus);
     REQUIRE(txs.commit() == kv::CommitSuccess::NO_REPLICATE);

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -113,7 +113,7 @@ TEST_CASE("Check signature verification")
   {
     kv::Tx txs;
     auto tx = txs.get_view(primary_signatures);
-    ccf::PrimarySignature bogus(0, 0, 0);
+    ccf::PrimarySignature bogus(0, 0, {0});
     bogus.sig = std::vector<uint8_t>(MBEDTLS_ECDSA_MAX_LEN, 1);
     tx->put(0, bogus);
     REQUIRE(txs.commit() == kv::CommitSuccess::NO_REPLICATE);

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -61,6 +61,7 @@ TEST_CASE("Check signature verification")
 {
   auto encryptor = std::make_shared<kv::NullTxEncryptor>();
   kv::Store primary_store;
+
   primary_store.set_encryptor(encryptor);
   auto& primary_nodes = primary_store.create<ccf::Nodes>(
     ccf::Tables::NODES, kv::SecurityDomain::PUBLIC);

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+
+#include "node/progress_tracker.h"
+
+#include "kv/store.h"
+#include "node/nodes.h"
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+#include <string>
+
+TEST_CASE("Ordered Execution")
+{
+  kv::Store store;
+  auto& nodes =
+    store.create<ccf::Nodes>(ccf::Tables::NODES, kv::SecurityDomain::PUBLIC);
+
+  kv::Consensus::View view = 0;
+  kv::Consensus::SeqNo seqno = 0;
+  uint32_t node_count = 4;
+
+  crypto::Sha256Hash root;
+  std::array<uint8_t, MBEDTLS_ECDSA_MAX_LEN> sig;
+  ccf::Nonce nonce;
+
+  INFO("Adding signature");
+  {
+    auto pt = std::make_unique<ccf::ProgressTracker>(0, nodes);
+    auto result = pt->add_signature(
+      view, seqno, 1, MBEDTLS_ECDSA_MAX_LEN, sig, nonce, node_count);
+    REQUIRE(result == kv::TxHistory::Result::OK);
+    REQUIRE_THROWS(pt->record_primary(view, seqno, 0, root, nonce, node_count));
+  }
+
+  INFO("Waits for signature tx");
+  {
+    auto pt = std::make_unique<ccf::ProgressTracker>(0, nodes);
+    for (size_t i = 0; i < node_count; ++i)
+    {
+      auto result = pt->add_signature_ack(view, seqno, i, node_count);
+      REQUIRE(result == kv::TxHistory::Result::OK);
+    }
+  }
+}


### PR DESCRIPTION
Part of #1655, #1627

In this PR AFT backup nodes will send their signatures of the primary signed merkle root to the other replicas and propagate their their acks of receiving said signatures.
The next PR will involve writing this info to the ledger. This should allow for a node to catchup that is behind the 2f+1 up to date bft nodes.