### PR TITLE
Rename submit recovery share endpoint

### DIFF
--- a/doc/members/accept_recovery.rst
+++ b/doc/members/accept_recovery.rst
@@ -71,7 +71,7 @@ The recovery share retrieval, decryption and submission steps are conveniently p
     x-ccf-tx-view: 4
     2/2 recovery shares successfully submitted. End of recovery procedure initiated.
 
-When the recovery threshold is reached, the ``recovery_share/submit`` RPC returns that the end of the recovery procedure is initiated and the private ledger is now being recovered.
+When the recovery threshold is reached, the ``POST recovery_share`` RPC returns that the end of the recovery procedure is initiated and the private ledger is now being recovered.
 
 .. note:: While all nodes are recovering the private ledger, no new transaction can be executed by the network.
 
@@ -102,13 +102,13 @@ Summary Diagram
         Member 0->>+Node 2: GET recovery_share
         Node 2-->>Member 0: Encrypted recovery share for Member 0
         Note over Member 0: Decrypts recovery share
-        Member 0->>+Node 2: POST recovery_share/submit: {"recovery_share": ...}
+        Member 0->>+Node 2: POST recovery_share: "<recovery_share_0>"
         Node 2-->>Member 0: False
 
         Member 1->>+Node 2: GET recovery_share
         Node 2-->>Member 1: Encrypted recovery share for Member 1
         Note over Member 1: Decrypts recovery share
-        Member 1->>+Node 2: POST recovery_share/submit: {"recovery_share": ...}
+        Member 1->>+Node 2: POST recovery_share: "<recovery_share_1>"
         Node 2-->>Member 1: True
 
         Note over Node 2, Node 3: Reading Private Ledger...

--- a/doc/members/member_rpc_api.rst
+++ b/doc/members/member_rpc_api.rst
@@ -44,7 +44,7 @@ Get an existing proposal
 
 .. literalinclude:: ../schemas/proposals/{proposal_id}_GET_result.json
     :language: json
-    
+
 POST /gov/proposals/{proposal_id}/withdraw
 ------------------------------------------
 
@@ -99,12 +99,12 @@ Retrieve encrypted recovery share of current member
 .. literalinclude:: ../schemas/recovery_share_GET_result.json
     :language: json
 
-POST /gov/recovery_share/submit
+POST /gov/recovery_share
 -------------------------------
 
 Submit recovery share of current member
 
-.. literalinclude:: ../schemas/recovery_share/submit_POST_params.json
+.. literalinclude:: ../schemas/recovery_share_POST_params.json
     :language: json
-.. literalinclude:: ../schemas/recovery_share/submit_POST_result.json
+.. literalinclude:: ../schemas/recovery_share_POST_result.json
     :language: json

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -1105,9 +1105,7 @@
             "description": "Default response description"
           }
         }
-      }
-    },
-    "/recovery_share/submit": {
+      },
       "post": {
         "requestBody": {
           "content": {

--- a/doc/schemas/recovery_share/submit_POST_params.json
+++ b/doc/schemas/recovery_share/submit_POST_params.json
@@ -1,4 +1,0 @@
-{
-  "title": "recovery_share/submit/params",
-  "type": "string"
-}

--- a/doc/schemas/recovery_share/submit_POST_result.json
+++ b/doc/schemas/recovery_share/submit_POST_result.json
@@ -1,4 +1,0 @@
-{
-  "title": "recovery_share/submit/result",
-  "type": "string"
-}

--- a/doc/schemas/recovery_share_POST_params.json
+++ b/doc/schemas/recovery_share_POST_params.json
@@ -1,0 +1,4 @@
+{
+  "title": "recovery_share/params",
+  "type": "string"
+}

--- a/doc/schemas/recovery_share_POST_result.json
+++ b/doc/schemas/recovery_share_POST_result.json
@@ -1,0 +1,4 @@
+{
+  "title": "recovery_share/result",
+  "type": "string"
+}

--- a/python/utils/submit_recovery_share.sh
+++ b/python/utils/submit_recovery_share.sh
@@ -82,4 +82,4 @@ encrypted_share_b64_url=$(echo "${encrypted_share}" | sed 's/+/-/g; s/\//_/g')
 
 # Decrypt encrypted share with nonce, member private key and defunct network public key and submit share
 # All in one line so that the recovery share is not exposed
-echo "${encrypted_share_b64_url}" | step crypto nacl box open base64:"${nonce}" "${tmp_dir}/network_enc_pubk.raw" "${tmp_dir}/member_enc_privk.raw" | openssl base64 -A | curl -i -sS --fail https://"${node_rpc_address}"/gov/recovery_share/submit "${@}" -d @-
+echo "${encrypted_share_b64_url}" | step crypto nacl box open base64:"${nonce}" "${tmp_dir}/network_enc_pubk.raw" "${tmp_dir}/member_enc_privk.raw" | openssl base64 -A | curl -i -sS --fail https://"${node_rpc_address}"/gov/recovery_share "${@}" -d @-

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -1417,7 +1417,7 @@ namespace ccf
           submitted_shares_count,
           g.get_recovery_threshold()));
       };
-      make_endpoint("recovery_share/submit", HTTP_POST, submit_recovery_share)
+      make_endpoint("recovery_share", HTTP_POST, submit_recovery_share)
         .set_auto_schema<std::string, std::string>()
         .install();
 

--- a/src/node/rpc/test/member_voting_test.cpp
+++ b/src/node/rpc/test/member_voting_test.cpp
@@ -1774,7 +1774,7 @@ DOCTEST_TEST_CASE("Submit recovery shares")
   {
     MemberId member_id = 0;
     const auto submit_recovery_share = create_text_request(
-      tls::b64_from_raw(retrieved_shares[member_id]), "recovery_share/submit");
+      tls::b64_from_raw(retrieved_shares[member_id]), "recovery_share");
 
     check_error(
       frontend_process(
@@ -1806,7 +1806,7 @@ DOCTEST_TEST_CASE("Submit recovery shares")
       auto bogus_recovery_share = retrieved_shares[m.first];
       bogus_recovery_share[0] = bogus_recovery_share[0] + 1;
       const auto submit_recovery_share = create_text_request(
-        tls::b64_from_raw(bogus_recovery_share), "recovery_share/submit");
+        tls::b64_from_raw(bogus_recovery_share), "recovery_share");
 
       auto rep =
         frontend_process(frontend, submit_recovery_share, m.second.first);
@@ -1832,7 +1832,7 @@ DOCTEST_TEST_CASE("Submit recovery shares")
     for (auto const& m : members)
     {
       const auto submit_recovery_share = create_text_request(
-        tls::b64_from_raw(retrieved_shares[m.first]), "recovery_share/submit");
+        tls::b64_from_raw(retrieved_shares[m.first]), "recovery_share");
 
       auto rep =
         frontend_process(frontend, submit_recovery_share, m.second.first);


### PR DESCRIPTION
Rename `POST gov/recovery_share/submit` to `POST gov/recovery_share` to be more RESTful.