### PR TITLE
Document nlohmann's tuple maps as oneOf, rather than a tuple

### DIFF
--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -527,14 +527,18 @@
       },
       "uint64_to_Script": {
         "items": {
-          "items": [
-            {
-              "$ref": "#/components/schemas/uint64"
-            },
-            {
-              "$ref": "#/components/schemas/Script"
-            }
-          ],
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/uint64"
+              },
+              {
+                "$ref": "#/components/schemas/Script"
+              }
+            ]
+          },
+          "maxItems": 2,
+          "minItems": 2,
           "type": "array"
         },
         "type": "array"

--- a/src/ds/openapi.h
+++ b/src/ds/openapi.h
@@ -236,9 +236,6 @@ namespace ds
               items["type"] = "array";
 
               auto sub_items = nlohmann::json::array();
-              // NB: OpenAPI doesn't like this tuple for "items", even though
-              // its valid JSON schema. May need to switch this to oneOf to
-              // satisfy some validators
               sub_items.push_back(add_schema_component<typename T::key_type>());
               sub_items.push_back(
                 add_schema_component<typename T::mapped_type>());

--- a/src/ds/openapi.h
+++ b/src/ds/openapi.h
@@ -242,7 +242,10 @@ namespace ds
               sub_items.push_back(add_schema_component<typename T::key_type>());
               sub_items.push_back(
                 add_schema_component<typename T::mapped_type>());
-              items["items"] = sub_items;
+
+              items["items"]["oneOf"] = sub_items;
+              items["minItems"] = 2;
+              items["maxItems"] = 2;
             }
             schema["items"] = items;
           }


### PR DESCRIPTION
As discussed in recent PRs:

```
[
  { ... Schema A ... },
  { ... Schema B ... }
]
```

is valid JSON schema, describing a 2-element tuple (which is how nlohmann converts entries in a non-string-keyed `std::map`). However it is not valid in OpenAPI 3.0. So we replace this with:

```
"oneOf":
[
  { ... Schema A ... },
  { ... Schema B ... }
],
"minItems": 2,
"maxItems": 2
```

This is _slightly_ less precise (it accepts `[B, A]` when we really only want `[A, B]`). But it looks close-enough, and gives us compliant OAPI 3.0. Hopefully we can revert this when we have OAPI 3.1 support.