### PR TITLE
Wait longer in committable_suffix_test

### DIFF
--- a/tests/committable.py
+++ b/tests/committable.py
@@ -37,7 +37,9 @@ def run(args):
         primary.stop()
         backups[1].resume()
         backups[2].resume()
-        new_primary, new_term = network.wait_for_new_primary(primary.node_id, timeout_multiplier=6)
+        new_primary, new_term = network.wait_for_new_primary(
+            primary.node_id, timeout_multiplier=6
+        )
         LOG.debug(f"New primary is {new_primary.node_id} in term {new_term}")
         assert new_primary.node_id == backups[0].node_id
 

--- a/tests/committable.py
+++ b/tests/committable.py
@@ -37,7 +37,7 @@ def run(args):
         primary.stop()
         backups[1].resume()
         backups[2].resume()
-        new_primary, new_term = network.wait_for_new_primary(primary.node_id)
+        new_primary, new_term = network.wait_for_new_primary(primary.node_id, timeout_multiplier=6)
         LOG.debug(f"New primary is {new_primary.node_id} in term {new_term}")
         assert new_primary.node_id == backups[0].node_id
 

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -689,10 +689,10 @@ class Network:
         expected = [commits[0]] * len(commits)
         assert expected == commits, f"{commits} != {expected}"
 
-    def wait_for_new_primary(self, old_primary_id):
+    def wait_for_new_primary(self, old_primary_id, timeout_multiplier=2):
         # We arbitrarily pick twice the election duration to protect ourselves against the somewhat
         # but not that rare cases when the first round of election fails (short timeout are particularly susceptible to this)
-        timeout = self.election_duration * 2
+        timeout = self.election_duration * timeout_multiplier
         LOG.info(
             f"Waiting up to {timeout}s for a new primary (different from {old_primary_id}) to be elected..."
         )


### PR DESCRIPTION
Quick fix: `committable_suffix_test` is failing sporadically in the CI. It looks like we don't wait long enough for a new primary when the nodes are coming out of suspension. So in this special case, we wait longer.