### PR TITLE
regex is not re

### DIFF
--- a/python/ccf/clients.py
+++ b/python/ccf/clients.py
@@ -17,7 +17,7 @@ from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 import struct
 import base64
-import regex  # type: ignore
+import re
 from typing import Union, Optional, List, Any
 
 import requests
@@ -29,7 +29,7 @@ import ccf.commit
 from ccf.log_capture import flush_info
 
 
-loguru_tag_regex = regex.compile(r"\\?</?((?:[fb]g\s)?[^<>\s]*)>")
+loguru_tag_regex = re.compile(r"\\?</?((?:[fb]g\s)?[^<>\s]*)>")
 
 
 def escape_loguru_tags(s):


### PR DESCRIPTION
I meant to use the standard Python `re` library, but we have a (very similar!) pip package named `regex` through some dependency. This code worked in some `venv`s but not all.