### PR TITLE
Issue signatures from history

### DIFF
--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -48,4 +48,3 @@ jobs:
       suffix: 'Release'
       artifact_name: 'SGX_Release'
       ctest_filter: '-LE "benchmark|perf"'
-

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -93,7 +93,7 @@ if(BUILD_TESTS)
       --transactions
       ${SMALL_BANK_SIGNED_ITERATIONS}
       --max-writes-ahead
-      500
+      250
       --sign
       --participants-curve
       "secp256k1"

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -60,7 +60,7 @@ if(BUILD_TESTS)
       LABEL SB
       CONSENSUS ${CONSENSUS}
       ADDITIONAL_ARGS
-        --transactions ${SMALL_BANK_ITERATIONS} --max-writes-ahead 500
+        --transactions ${SMALL_BANK_ITERATIONS} --max-writes-ahead 1000
         --metrics-file small_bank_cft_metrics.json
     )
   endforeach()
@@ -76,7 +76,7 @@ if(BUILD_TESTS)
       --transactions
       ${SMALL_BANK_ITERATIONS}
       --max-writes-ahead
-      500
+      1000
       --metrics-file
       small_bank_cft_metrics.json
       --use-websockets

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -60,7 +60,7 @@ if(BUILD_TESTS)
       LABEL SB
       CONSENSUS ${CONSENSUS}
       ADDITIONAL_ARGS
-        --transactions ${SMALL_BANK_ITERATIONS} --max-writes-ahead 1000
+        --transactions ${SMALL_BANK_ITERATIONS} --max-writes-ahead 500
         --metrics-file small_bank_cft_metrics.json
     )
   endforeach()

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -60,7 +60,7 @@ if(BUILD_TESTS)
       LABEL SB
       CONSENSUS ${CONSENSUS}
       ADDITIONAL_ARGS
-        --transactions ${SMALL_BANK_ITERATIONS} --max-writes-ahead 500
+        --transactions ${SMALL_BANK_ITERATIONS} --max-writes-ahead 250
         --metrics-file small_bank_cft_metrics.json
     )
   endforeach()
@@ -76,7 +76,7 @@ if(BUILD_TESTS)
       --transactions
       ${SMALL_BANK_ITERATIONS}
       --max-writes-ahead
-      500
+      250
       --metrics-file
       small_bank_cft_metrics.json
       --use-websockets
@@ -93,7 +93,7 @@ if(BUILD_TESTS)
       --transactions
       ${SMALL_BANK_SIGNED_ITERATIONS}
       --max-writes-ahead
-      250
+      1000
       --sign
       --participants-curve
       "secp256k1"

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -93,7 +93,7 @@ if(BUILD_TESTS)
       --transactions
       ${SMALL_BANK_SIGNED_ITERATIONS}
       --max-writes-ahead
-      1000
+      500
       --sign
       --participants-curve
       "secp256k1"

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -60,7 +60,7 @@ if(BUILD_TESTS)
       LABEL SB
       CONSENSUS ${CONSENSUS}
       ADDITIONAL_ARGS
-        --transactions ${SMALL_BANK_ITERATIONS} --max-writes-ahead 1000
+        --transactions ${SMALL_BANK_ITERATIONS} --max-writes-ahead 500
         --metrics-file small_bank_cft_metrics.json
     )
   endforeach()
@@ -76,7 +76,7 @@ if(BUILD_TESTS)
       --transactions
       ${SMALL_BANK_ITERATIONS}
       --max-writes-ahead
-      1000
+      500
       --metrics-file
       small_bank_cft_metrics.json
       --use-websockets

--- a/samples/apps/smallbank/smallbank.cmake
+++ b/samples/apps/smallbank/smallbank.cmake
@@ -76,7 +76,7 @@ if(BUILD_TESTS)
       --transactions
       ${SMALL_BANK_ITERATIONS}
       --max-writes-ahead
-      1000
+      500
       --metrics-file
       small_bank_cft_metrics.json
       --use-websockets

--- a/src/ds/spin_lock.h
+++ b/src/ds/spin_lock.h
@@ -5,6 +5,9 @@
 #ifdef INSIDE_ENCLAVE
 #  include <pthread.h>
 
+// OpenEnclave, at this time, does not provide pthread_spin_trylock. There is
+// currently a PR that will introduce said function and this should be removed
+// when said function is in OpenEnclave.
 #  ifndef VIRTUAL_ENCLAVE
 static unsigned int _spin_set_locked(pthread_spinlock_t* spinlock)
 {

--- a/src/ds/spin_lock.h
+++ b/src/ds/spin_lock.h
@@ -4,6 +4,18 @@
 
 #ifdef INSIDE_ENCLAVE
 #  include <pthread.h>
+   static unsigned int _spin_set_locked(pthread_spinlock_t* spinlock)
+{
+    unsigned int value = 1;
+
+    asm volatile("lock xchg %0, %1;"
+                 : "=r"(value)     /* %0 */
+                 : "m"(*spinlock), /* %1 */
+                   "0"(value)      /* also %2 */
+                 : "memory");
+
+    return value;
+}
 
 class SpinLock
 {
@@ -24,6 +36,11 @@ public:
   void lock()
   {
     pthread_spin_lock(&sl);
+  }
+
+  bool try_lock()
+  {
+    return (_spin_set_locked(&sl) == 0);
   }
 
   void unlock()

--- a/src/ds/spin_lock.h
+++ b/src/ds/spin_lock.h
@@ -8,6 +8,7 @@
 // OpenEnclave, at this time, does not provide pthread_spin_trylock. There is
 // currently a PR that will introduce said function and this should be removed
 // when said function is in OpenEnclave.
+// https://github.com/openenclave/openenclave/pull/3641
 #  ifndef VIRTUAL_ENCLAVE
 static unsigned int _spin_set_locked(pthread_spinlock_t* spinlock)
 {

--- a/src/ds/thread_messaging.h
+++ b/src/ds/thread_messaging.h
@@ -78,6 +78,11 @@ namespace threading
 
     struct TimerEntry
     {
+      TimerEntry() : time_offset(0), counter(0) {}
+      TimerEntry(std::chrono::milliseconds time_offset_, uint64_t counter_) :
+        time_offset(time_offset_), counter(counter_)
+      {}
+
       std::chrono::milliseconds time_offset;
       uint64_t counter;
     };
@@ -108,19 +113,6 @@ namespace threading
       auto num_erased = timer_map.erase(timer_entry);
       CCF_ASSERT(num_erased <= 1, "Too many items erased");
       return num_erased != 0;
-    }
-
-    TimerEntry reset(TimerEntry timer_entry, std::chrono::milliseconds ms)
-    {
-      auto it = timer_map.find(timer_entry);
-      if (it == timer_map.end())
-      {
-        return {std::chrono::milliseconds(0), 0};
-      }
-
-      auto tmsg = std::move(it->second);
-      timer_map.erase(it);
-      return add_task_after(std::move(tmsg), ms);
     }
 
     void tick(std::chrono::milliseconds elapsed)
@@ -273,12 +265,6 @@ namespace threading
       return task.cancel_timer_task(timer_entry);
     }
 
-    Task::TimerEntry reset(
-      Task::TimerEntry timer_entry, std::chrono::milliseconds ms)
-    {
-      Task& task = get_task(get_current_thread_id());
-      return task.reset(timer_entry, ms);
-    }
     std::chrono::milliseconds get_current_time_offset()
     {
       Task& task = get_task(get_current_thread_id());

--- a/src/ds/thread_messaging.h
+++ b/src/ds/thread_messaging.h
@@ -290,7 +290,6 @@ namespace threading
 
     void tick(std::chrono::milliseconds elapsed)
     {
-      LOG_INFO_FMT("CCCCC - tick - elapsed {}", elapsed.count());
       for (auto i = 0; i < thread_count; ++i)
       {
         auto& task = get_task(i);

--- a/src/ds/thread_messaging.h
+++ b/src/ds/thread_messaging.h
@@ -138,7 +138,7 @@ namespace threading
     }
 
   private:
-    std::chrono::milliseconds time_offset;
+    std::chrono::milliseconds time_offset = std::chrono::milliseconds(0);
     uint64_t time_entry_counter = 0;
     std::map<TimerEntry, std::unique_ptr<ThreadMsg>, TimerEntryCompare>
       timer_map;
@@ -290,6 +290,7 @@ namespace threading
 
     void tick(std::chrono::milliseconds elapsed)
     {
+      LOG_INFO_FMT("CCCCC - tick - elapsed {}", elapsed.count());
       for (auto i = 0; i < thread_count; ++i)
       {
         auto& task = get_task(i);

--- a/src/ds/thread_messaging.h
+++ b/src/ds/thread_messaging.h
@@ -80,7 +80,8 @@ namespace threading
     {
       TimerEntry() : time_offset(0), counter(0) {}
       TimerEntry(std::chrono::milliseconds time_offset_, uint64_t counter_) :
-        time_offset(time_offset_), counter(counter_)
+        time_offset(time_offset_),
+        counter(counter_)
       {}
 
       std::chrono::milliseconds time_offset;

--- a/src/ds/thread_messaging.h
+++ b/src/ds/thread_messaging.h
@@ -143,7 +143,7 @@ namespace threading
         cb(std::move(msg));
       }
 
-      if (!timer_map.empty() && updated)
+      if (updated)
       {
         next_time_offset = timer_map.begin()->first.time_offset;
       }

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -208,6 +208,7 @@ namespace enclave
             auto [ms_count] =
               ringbuffer::read_message<AdminMessage::tick>(data, size);
 
+            LOG_INFO_FMT("CCCCC - 1 - tick - ms_count {}", ms_count);
             if (ms_count > 0)
             {
               const auto message_counts =

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -208,7 +208,6 @@ namespace enclave
             auto [ms_count] =
               ringbuffer::read_message<AdminMessage::tick>(data, size);
 
-            LOG_INFO_FMT("CCCCC - 1 - tick - ms_count {}", ms_count);
             if (ms_count > 0)
             {
               const auto message_counts =

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -102,7 +102,10 @@ namespace enclave
         fe->set_cmd_forwarder(cmd_forwarder);
       }
 
-      node->initialize(consensus_config, n2n_channels, rpc_map, cmd_forwarder);
+      node->initialize(consensus_config, n2n_channels, rpc_map, cmd_forwarder,
+          signature_intervals.sig_tx_interval,
+          signature_intervals.sig_ms_interval
+      );
     }
 
     bool create_new_node(

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -102,10 +102,13 @@ namespace enclave
         fe->set_cmd_forwarder(cmd_forwarder);
       }
 
-      node->initialize(consensus_config, n2n_channels, rpc_map, cmd_forwarder,
-          signature_intervals.sig_tx_interval,
-          signature_intervals.sig_ms_interval
-      );
+      node->initialize(
+        consensus_config,
+        n2n_channels,
+        rpc_map,
+        cmd_forwarder,
+        signature_intervals.sig_tx_interval,
+        signature_intervals.sig_ms_interval);
     }
 
     bool create_new_node(

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -210,7 +210,7 @@ namespace kv
     virtual bool verify(
       Term* term = nullptr, ccf::PrimarySignature* sig = nullptr) = 0;
     virtual void try_emit_signature() = 0;
-    virtual void emit_signature(uint32_t) = 0;
+    virtual void emit_signature() = 0;
     virtual crypto::Sha256Hash get_replicated_state_root() = 0;
     virtual std::vector<uint8_t> get_receipt(Version v) = 0;
     virtual bool verify_receipt(const std::vector<uint8_t>& receipt) = 0;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -210,7 +210,7 @@ namespace kv
     virtual bool verify(
       Term* term = nullptr, ccf::PrimarySignature* sig = nullptr) = 0;
     virtual void try_emit_signature() = 0;
-    virtual void emit_signature() = 0;
+    virtual void emit_signature(uint32_t) = 0;
     virtual crypto::Sha256Hash get_replicated_state_root() = 0;
     virtual std::vector<uint8_t> get_receipt(Version v) = 0;
     virtual bool verify_receipt(const std::vector<uint8_t>& receipt) = 0;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -209,6 +209,7 @@ namespace kv
       ccf::PrimarySignature& signature, Term* term = nullptr) = 0;
     virtual bool verify(
       Term* term = nullptr, ccf::PrimarySignature* sig = nullptr) = 0;
+    virtual void try_emit_signature(kv::Version commit_version) = 0;
     virtual void emit_signature() = 0;
     virtual crypto::Sha256Hash get_replicated_state_root() = 0;
     virtual std::vector<uint8_t> get_receipt(Version v) = 0;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -217,8 +217,6 @@ namespace kv
     virtual bool init_from_snapshot(
       const std::vector<uint8_t>& hash_at_snapshot) = 0;
     virtual std::vector<uint8_t> get_raw_leaf(uint64_t index) = 0;
-    
-    virtual void StopCallbacks() = 0;
 
     virtual bool add_request(
       kv::TxHistory::RequestID id,

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -217,6 +217,8 @@ namespace kv
     virtual bool init_from_snapshot(
       const std::vector<uint8_t>& hash_at_snapshot) = 0;
     virtual std::vector<uint8_t> get_raw_leaf(uint64_t index) = 0;
+    
+    virtual void StopCallbacks() = 0;
 
     virtual bool add_request(
       kv::TxHistory::RequestID id,

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -209,7 +209,7 @@ namespace kv
       ccf::PrimarySignature& signature, Term* term = nullptr) = 0;
     virtual bool verify(
       Term* term = nullptr, ccf::PrimarySignature* sig = nullptr) = 0;
-    virtual void try_emit_signature(kv::Version commit_version) = 0;
+    virtual void try_emit_signature() = 0;
     virtual void emit_signature() = 0;
     virtual crypto::Sha256Hash get_replicated_state_root() = 0;
     virtual std::vector<uint8_t> get_receipt(Version v) = 0;

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -110,6 +110,10 @@ namespace kv
 
     Store(const Store& that) = delete;
 
+    ~Store() {
+      LOG_INFO_FMT("BBBBBB deleting store");
+    }
+
     std::shared_ptr<Consensus> get_consensus() override
     {
       return consensus;

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -110,10 +110,6 @@ namespace kv
 
     Store(const Store& that) = delete;
 
-    ~Store() {
-      LOG_INFO_FMT("BBBBBB deleting store");
-    }
-
     std::shared_ptr<Consensus> get_consensus() override
     {
       return consensus;

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -751,7 +751,7 @@ namespace ccf
 
     void try_emit_signature() override
     {
-      if ((store.commit_gap()) != sig_tx_interval / 2)
+      if ((store.commit_gap()) < sig_tx_interval)
       {
         return;
       }

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -547,6 +547,25 @@ namespace ccf
                 sig_ms_interval)
             {
               msg->data.self->emit_signature();
+              /*
+              LOG_INFO_FMT(
+                "AAAAA - sign, is_primary:{}, commit_gap:{}, time:{},
+              time_of_last:{}", consensus->is_primary(),
+                self->store.commit_gap(),
+                time.count(),
+                self->time_of_last_signature.count());
+              */
+            }
+            else
+            {
+              /*
+              LOG_INFO_FMT(
+                "AAAAA - not sign, is_primary:{}, commit_gap:{}, time:{},
+              time_of_last:{}", consensus->is_primary(),
+                self->store.commit_gap(),
+                time.count(),
+                self->time_of_last_signature.count());
+              */
             }
 
             time_since_last_sig =
@@ -755,7 +774,7 @@ namespace ccf
         return;
       }
 
-      if ((commit_version - last_signed_tx) != sig_tx_interval / 2)
+      if ((commit_version - last_signed_tx) == sig_tx_interval / 2)
       {
         emit_signature();
       }
@@ -786,7 +805,7 @@ namespace ccf
         threading::ThreadMessaging::thread_messaging.get_current_time_offset();
 
       LOG_DEBUG_FMT(
-        "Signed at {} in view: {} commit was: {}.{}",
+        "AAAAA Signed at {} in view: {} commit was: {}.{}",
         txid.version,
         txid.term,
         commit_txid.first,

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -756,7 +756,7 @@ namespace ccf
       }
 
       std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
-      if (!mguard.try_lock())
+      if (mguard.try_lock())
       {
         emit_signature();
       }

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -134,7 +134,7 @@ namespace ccf
       return {};
     }
 
-    void emit_signature(uint32_t) override
+    void emit_signature() override
     {
       auto txid = store.next_txid();
       LOG_INFO_FMT("Issuing signature at {}.{}", txid.term, txid.version);

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -537,18 +537,18 @@ namespace ccf
             self->store.commit_gap() > 0 &&
             time.count() > self->time_of_last_signature.load().count() &&
             (time.count() - self->time_of_last_signature.load().count())
-                 > 200)
+                 > 1000)
           {
             LOG_INFO_FMT("AAAAAAA - time based - calling emit_signature");
             msg->data.self->emit_signature();
           }
 
           auto time_since_last_sig =
-            200 - (time - self->time_of_last_signature.load()).count();
+            1000 - (time - self->time_of_last_signature.load()).count();
 
           if (time_since_last_sig <= 0)
           {
-            time_since_last_sig = 200;
+            time_since_last_sig = 1000;
           }
 
           LOG_INFO_FMT("AAAAAAA - scheduling time:{}", time_since_last_sig);
@@ -562,7 +562,7 @@ namespace ccf
 
       emit_signature_timer_entry =
         threading::ThreadMessaging::thread_messaging.add_task_after(
-          std::move(emit_sig_msg), std::chrono::milliseconds(200));
+          std::move(emit_sig_msg), std::chrono::milliseconds(1000));
     }
 
     ~HashedTxHistory()

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -526,8 +526,8 @@ namespace ccf
         [](std::unique_ptr<threading::Tmsg<EmitSigMsg>> msg) {
           auto self = msg->data.self;
 
-          //std::unique_lock<SpinLock> mguard(
-          //  self->signature_lock, std::defer_lock);
+          std::unique_lock<SpinLock> mguard(
+            self->signature_lock, std::defer_lock);
 
           const int64_t sig_ms_interval = self->sig_ms_interval;
           int64_t time_since_last_sig = sig_ms_interval;
@@ -751,8 +751,8 @@ namespace ccf
 
     void try_emit_signature() override
     {
-      //std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
-      //if (!mguard.try_lock())
+      std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
+      if (store.commit_gap()) < sig_tx_interval || !mguard.try_lock())
       {
         return;
       }

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -511,10 +511,13 @@ namespace ccf
       nodes(nodes_),
       sig_tx_interval(sig_tx_interval_),
       sig_ms_interval(sig_ms_interval_)
-    {}
+    {
+      LOG_INFO_FMT("BBBBBBB 1 starting timer");
+    }
 
     void start_signature_emit_timer(std::shared_ptr<HashedTxHistory<T>> self)
     {
+      LOG_INFO_FMT("BBBBBBB 2 starting timer");
       struct EmitSigMsg
       {
         EmitSigMsg(std::shared_ptr<HashedTxHistory<T>> self_) : self(self_) {}
@@ -546,26 +549,26 @@ namespace ccf
               (time.count() - self->time_of_last_signature.count()) >
                 sig_ms_interval)
             {
+
               msg->data.self->emit_signature();
-              /*
               LOG_INFO_FMT(
-                "AAAAA - sign, is_primary:{}, commit_gap:{}, time:{},
-              time_of_last:{}", consensus->is_primary(),
+                "AAAAA - sign, is_primary:{}, commit_gap:{}, time:{}, time_of_last:{}",
+              consensus->is_primary(),
                 self->store.commit_gap(),
                 time.count(),
                 self->time_of_last_signature.count());
-              */
             }
             else
             {
-              /*
+              auto txid = self->store.current_version();
               LOG_INFO_FMT(
-                "AAAAA - not sign, is_primary:{}, commit_gap:{}, time:{},
-              time_of_last:{}", consensus->is_primary(),
+                "AAAAA - not sign, is_primary:{}, commit_gap:{}, time:{}, "
+                "time_of_last:{}, current_version:{}",
+                consensus->is_primary(),
                 self->store.commit_gap(),
                 time.count(),
-                self->time_of_last_signature.count());
-              */
+                self->time_of_last_signature.count(),
+                txid);
             }
 
             time_since_last_sig =

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -532,7 +532,7 @@ namespace ccf
           const int64_t sig_ms_interval = self->sig_ms_interval;
           int64_t time_since_last_sig = sig_ms_interval;
 
-          //if (mguard.try_lock())
+          if (mguard.try_lock())
           {
             auto time = threading::ThreadMessaging::thread_messaging
                           .get_current_time_offset()

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -150,7 +150,7 @@ namespace ccf
         true);
     }
 
-    void try_emit_signature(kv::Version) override
+    void try_emit_signature() override
     {
       emit_signature();
     }
@@ -748,7 +748,7 @@ namespace ccf
       std::chrono::milliseconds(0);
     SpinLock signature_lock;
 
-    void try_emit_signature(kv::Version) override
+    void try_emit_signature() override
     {
       if ((store.commit_gap()) != sig_tx_interval / 2)
       {

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -545,7 +545,7 @@ namespace ccf
               self->store.commit_gap() > 0 && time > time_of_last_signature &&
               (time - time_of_last_signature) > sig_ms_interval)
             {
-              msg->data.self->emit_signature(2);
+              msg->data.self->emit_signature();
             }
 
             time_since_last_sig =
@@ -759,11 +759,11 @@ namespace ccf
 
       if (store.commit_gap() >= sig_tx_interval)
       {
-        emit_signature(3);
+        emit_signature();
       }
     }
 
-    void emit_signature(uint32_t from) override
+    void emit_signature() override
     {
       // Signatures are only emitted when there is a consensus
       auto consensus = store.get_consensus();
@@ -788,12 +788,11 @@ namespace ccf
         threading::ThreadMessaging::thread_messaging.get_current_time_offset();
 
       LOG_DEBUG_FMT(
-        "Signed at {} in view: {} commit was: {}.{}, from:{} ",
+        "Signed at {} in view: {} commit was: {}.{}",
         txid.version,
         txid.term,
         commit_txid.first,
-        commit_txid.second,
-        from);
+        commit_txid.second);
 
       store.commit(
         txid,

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -535,21 +535,21 @@ namespace ccf
           if (mguard.try_lock())
           {
             auto time = threading::ThreadMessaging::thread_messaging
-                          .get_current_time_offset();
+                          .get_current_time_offset()
+                          .count();
+            auto time_of_last_signature = self->time_of_last_signature.count();
 
             auto consensus = self->store.get_consensus();
             if (
               (consensus != nullptr) && consensus->is_primary() &&
-              self->store.commit_gap() > 0 &&
-              time.count() > self->time_of_last_signature.count() &&
-              (time.count() - self->time_of_last_signature.count()) >
-                sig_ms_interval)
+              self->store.commit_gap() > 0 && time > time_of_last_signature &&
+              (time - time_of_last_signature) > sig_ms_interval)
             {
               msg->data.self->emit_signature();
             }
 
             time_since_last_sig =
-              sig_ms_interval - (time - self->time_of_last_signature).count();
+              sig_ms_interval - (time - self->time_of_last_signature.count());
 
             if (
               time_since_last_sig <= 0 || time_since_last_sig > sig_ms_interval)

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -766,7 +766,7 @@ namespace ccf
     std::chrono::milliseconds time_of_last_signature;
     SpinLock signature_lock;
 
-    void try_emit_signature(kv::Version commit_version) override
+    void try_emit_signature(kv::Version) override
     {
       std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
       if (!mguard.try_lock())
@@ -774,7 +774,7 @@ namespace ccf
         return;
       }
 
-      if ((commit_version - last_signed_tx) == sig_tx_interval / 2)
+      if ((store.commit_gap()) == sig_tx_interval / 2)
       {
         emit_signature();
       }

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -788,7 +788,7 @@ namespace ccf
         threading::ThreadMessaging::thread_messaging.get_current_time_offset();
 
       LOG_DEBUG_FMT(
-        "Signed at {} in view: {} commit was: {}.{}, from:{}",
+        "Signed at {} in view: {} commit was: {}.{}, from:{} ",
         txid.version,
         txid.term,
         commit_txid.first,

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -752,12 +752,12 @@ namespace ccf
     void try_emit_signature() override
     {
       std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
-      if (store.commit_gap() < sig_tx_interval || !mguard.try_lock())
+      if (store.commit_gap() < (sig_tx_interval / 2) || !mguard.try_lock())
       {
         return;
       }
 
-      if (store.commit_gap() >= sig_tx_interval)
+      if (store.commit_gap() >= (sig_tx_interval / 2))
       {
         emit_signature(3);
       }

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -751,13 +751,13 @@ namespace ccf
 
     void try_emit_signature() override
     {
-      if ((store.commit_gap()) < sig_tx_interval)
+      std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
+      if (!mguard.try_lock())
       {
         return;
       }
 
-      std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
-      if (mguard.try_lock())
+      if ((store.commit_gap()) < sig_tx_interval)
       {
         emit_signature(3);
       }

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -752,12 +752,12 @@ namespace ccf
     void try_emit_signature() override
     {
       std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
-      if (store.commit_gap()) < sig_tx_interval || !mguard.try_lock())
+      if (store.commit_gap() < sig_tx_interval || !mguard.try_lock())
       {
         return;
       }
 
-      if ((store.commit_gap()) >= sig_tx_interval)
+      if (store.commit_gap() >= sig_tx_interval)
       {
         emit_signature(3);
       }

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -16,7 +16,6 @@
 
 #include <array>
 #include <deque>
-#include <mutex>
 #include <string.h>
 
 extern "C"
@@ -552,11 +551,8 @@ namespace ccf
             time_since_last_sig =
               sig_ms_interval - (time - self->time_of_last_signature).count();
 
-            if (time_since_last_sig <= 0)
-            {
-              time_since_last_sig = sig_ms_interval;
-            }
-            else if (time_since_last_sig > sig_ms_interval)
+            if (
+              time_since_last_sig <= 0 || time_since_last_sig > sig_ms_interval)
             {
               time_since_last_sig = sig_ms_interval;
             }

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -523,9 +523,7 @@ namespace ccf
       LOG_INFO_FMT("BBBBBBB 2 starting timer");
       struct EmitSigMsg
       {
-        //EmitSigMsg(std::shared_ptr<HashedTxHistory<T>> self_) : self(self_) {}
         EmitSigMsg(HashedTxHistory<T>* self_) : self(self_) {}
-        //std::shared_ptr<HashedTxHistory<T>> self;
         HashedTxHistory<T>* self;
       };
 
@@ -541,7 +539,7 @@ namespace ccf
             const int64_t sig_ms_interval = self->sig_ms_interval;
             int64_t time_since_last_sig = sig_ms_interval;
 
-            // if (mguard.try_lock())
+            if (mguard.try_lock())
             {
               auto time = threading::ThreadMessaging::thread_messaging
                             .get_current_time_offset();
@@ -807,9 +805,9 @@ namespace ccf
     void try_emit_signature(kv::Version) override
     {
       std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
-      //if (!mguard.try_lock())
+      if (!mguard.try_lock())
       {
-        //return;
+        return;
       }
 
       if ((store.commit_gap()) == sig_tx_interval / 2)

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -750,13 +750,13 @@ namespace ccf
 
     void try_emit_signature(kv::Version) override
     {
-      std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
-      if (!mguard.try_lock())
+      if ((store.commit_gap()) != sig_tx_interval / 2)
       {
         return;
       }
 
-      if ((store.commit_gap()) == sig_tx_interval / 2)
+      std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
+      if (!mguard.try_lock())
       {
         emit_signature();
       }

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -152,7 +152,7 @@ namespace ccf
 
     void try_emit_signature() override
     {
-      emit_signature(1);
+      emit_signature();
     }
 
     bool add_request(

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -746,6 +746,7 @@ namespace ccf
     kv::Version last_signed_tx = 0;
     std::chrono::milliseconds time_of_last_signature =
       std::chrono::milliseconds(0);
+
     SpinLock signature_lock;
 
     void try_emit_signature() override

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -751,7 +751,7 @@ namespace ccf
 
     void try_emit_signature() override
     {
-      if ((store.commit_gap()) != sig_tx_interval)
+      if ((store.commit_gap()) != sig_tx_interval / 2)
       {
         return;
       }

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -515,12 +515,10 @@ namespace ccf
       sig_tx_interval(sig_tx_interval_),
       sig_ms_interval(sig_ms_interval_)
     {
-      LOG_INFO_FMT("BBBBBBB 1 starting timer");
     }
 
     void start_signature_emit_timer(std::shared_ptr<HashedTxHistory<T>> self)
     {
-      LOG_INFO_FMT("BBBBBBB 2 starting timer");
       struct EmitSigMsg
       {
         EmitSigMsg(HashedTxHistory<T>* self_) : self(self_) {}
@@ -553,6 +551,7 @@ namespace ccf
                   sig_ms_interval)
               {
                 msg->data.self->emit_signature();
+                /*
                 LOG_INFO_FMT(
                   "AAAAA - sign, is_primary:{}, commit_gap:{}, time:{}, "
                   "time_of_last:{}",
@@ -560,7 +559,9 @@ namespace ccf
                   self->store.commit_gap(),
                   time.count(),
                   self->time_of_last_signature.count());
+                  */
               }
+              /*
               else if(consensus != nullptr)
               {
                 auto txid = self->store.current_version();
@@ -584,6 +585,7 @@ namespace ccf
                   self->time_of_last_signature.count(),
                   txid);
               }
+              */
 
               // time_since_last_sig =
               //  sig_ms_interval - (time -
@@ -598,7 +600,7 @@ namespace ccf
               }
             }
 
-            LOG_INFO_FMT("AAAAAAA scheduling {}", time_since_last_sig);
+            //LOG_INFO_FMT("AAAAAAA scheduling {}", time_since_last_sig);
 
             self->emit_signature_timer_entry =
               threading::ThreadMessaging::thread_messaging.add_task_after(
@@ -618,14 +620,12 @@ namespace ccf
     }
     void StopCallbacks() override
     {
-      LOG_INFO_FMT("BBBBBBB 3.1 starting timer");
       threading::ThreadMessaging::thread_messaging.cancel_timer_task(
         emit_signature_timer_entry);
     }
 
     ~HashedTxHistory()
     {
-      LOG_INFO_FMT("BBBBBBB 3 starting timer");
       threading::ThreadMessaging::thread_messaging.cancel_timer_task(
         emit_signature_timer_entry);
     }
@@ -841,7 +841,7 @@ namespace ccf
         threading::ThreadMessaging::thread_messaging.get_current_time_offset();
 
       LOG_DEBUG_FMT(
-        "AAAAA Signed at {} in view: {} commit was: {}.{}",
+        "Signed at {} in view: {} commit was: {}.{}",
         txid.version,
         txid.term,
         commit_txid.first,

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -526,7 +526,7 @@ namespace ccf
           auto& self = msg->data.self;
 
           std::unique_lock<SpinLock> mguard(
-            self->signature_lock,std::defer_lock);
+            self->signature_lock, std::defer_lock);
 
           threading::Task::TimerEntry& timer_entry =
             self->emit_signature_timer_entry;
@@ -749,7 +749,7 @@ namespace ccf
 
     void try_emit_signature(kv::Version commit_version) override
     {
-      std::unique_lock<SpinLock> mguard(signature_lock,std::defer_lock);
+      std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
       if (!mguard.try_lock())
       {
         return;

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -757,7 +757,7 @@ namespace ccf
         return;
       }
 
-      if ((store.commit_gap()) < sig_tx_interval)
+      if ((store.commit_gap()) >= sig_tx_interval)
       {
         emit_signature(3);
       }

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -475,6 +475,9 @@ namespace ccf
     std::optional<ResponseCallbackHandler> on_response;
 
     threading::Task::TimerEntry emit_signature_timer_entry;
+    
+    size_t sig_tx_interval;
+    size_t sig_ms_interval;
 
     void discard_pending(kv::Version v)
     {
@@ -498,12 +501,17 @@ namespace ccf
       NodeId id_,
       tls::KeyPair& kp_,
       Signatures& sig_,
-      Nodes& nodes_) :
+      Nodes& nodes_,
+    size_t sig_tx_interval_ = 0,
+    size_t sig_ms_interval_ = 0
+      ) :
       store(store_),
       id(id_),
       kp(kp_),
       signatures(sig_),
-      nodes(nodes_)
+      nodes(nodes_),
+      sig_tx_interval(sig_tx_interval_),
+      sig_ms_interval(sig_ms_interval_)
     {}
 
     void start_signature_emit_timer(std::shared_ptr<HashedTxHistory<T>> self)

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -752,12 +752,12 @@ namespace ccf
     void try_emit_signature() override
     {
       std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
-      if (store.commit_gap() < (sig_tx_interval / 2) || !mguard.try_lock())
+      if (store.commit_gap() < sig_tx_interval || !mguard.try_lock())
       {
         return;
       }
 
-      if (store.commit_gap() >= (sig_tx_interval / 2))
+      if (store.commit_gap() >= sig_tx_interval)
       {
         emit_signature(3);
       }

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -526,13 +526,13 @@ namespace ccf
         [](std::unique_ptr<threading::Tmsg<EmitSigMsg>> msg) {
           auto self = msg->data.self;
 
-          std::unique_lock<SpinLock> mguard(
-            self->signature_lock, std::defer_lock);
+          //std::unique_lock<SpinLock> mguard(
+          //  self->signature_lock, std::defer_lock);
 
           const int64_t sig_ms_interval = self->sig_ms_interval;
           int64_t time_since_last_sig = sig_ms_interval;
 
-          if (mguard.try_lock())
+          //if (mguard.try_lock())
           {
             auto time = threading::ThreadMessaging::thread_messaging
                           .get_current_time_offset()
@@ -751,8 +751,8 @@ namespace ccf
 
     void try_emit_signature() override
     {
-      std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
-      if (!mguard.try_lock())
+      //std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
+      //if (!mguard.try_lock())
       {
         return;
       }

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -983,7 +983,7 @@ namespace ccf
 
       // Emit signature to certify transactions that happened on public
       // network
-      history->emit_signature(0);
+      history->emit_signature();
 
       for (auto const& v : restored_versions)
       {

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -831,9 +831,15 @@ namespace ccf
           recovery_v));
       }
 
+      LOG_INFO_FMT("BBBBBB 9");
       network.tables->swap_private_maps(*recovery_store.get());
+      LOG_INFO_FMT("BBBBBB 9");
+      recovery_history->StopCallbacks();
+      LOG_INFO_FMT("BBBBBB 9");
       recovery_store.reset();
+      LOG_INFO_FMT("BBBBBB 9");
       reset_recovery_hook();
+      LOG_INFO_FMT("BBBBBB 9");
 
       // Raft should deserialise all security domains when network is opened
       consensus->enable_all_domains();
@@ -907,9 +913,11 @@ namespace ccf
         self,
         *node_sign_kp,
         *recovery_signature_map,
-        *recovery_nodes_map);
+        *recovery_nodes_map,
+        sig_tx_interval,
+        sig_ms_interval);
       m->start_signature_emit_timer(m);
-        recovery_history = m; 
+      recovery_history = m; 
 
 #ifdef USE_NULL_ENCRYPTOR
       recovery_encryptor = std::make_shared<kv::NullTxEncryptor>();

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -211,9 +211,8 @@ namespace ccf
       std::shared_ptr<NodeToNode> n2n_channels_,
       std::shared_ptr<enclave::RPCMap> rpc_map_,
       std::shared_ptr<Forwarder<NodeToNode>> cmd_forwarder_,
-    size_t sig_tx_interval_,
-    size_t sig_ms_interval_
-      )
+      size_t sig_tx_interval_,
+      size_t sig_ms_interval_)
     {
       std::lock_guard<SpinLock> guard(lock);
       sm.expect(State::uninitialized);
@@ -1727,7 +1726,7 @@ namespace ccf
     {
       // This function can be called once the node has started up and before
       // it has joined the service.
-      auto tmp = std::make_shared<MerkleTxHistory>(
+      auto h = std::make_shared<MerkleTxHistory>(
         *network.tables.get(),
         self,
         *node_sign_kp,
@@ -1735,8 +1734,8 @@ namespace ccf
         network.nodes,
         sig_tx_interval,
         sig_ms_interval);
-      tmp->start_signature_emit_timer(tmp);
-      history = tmp;
+      h->start_signature_emit_timer(h);
+      history = h;
 
       network.tables->set_history(history);
     }

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -832,7 +832,6 @@ namespace ccf
       }
 
       network.tables->swap_private_maps(*recovery_store.get());
-      //recovery_history->StopCallbacks();
       recovery_history.reset();
       recovery_store.reset();
       reset_recovery_hook();
@@ -904,7 +903,7 @@ namespace ccf
         recovery_store->get<Signatures>(Tables::SIGNATURES);
       Nodes* recovery_nodes_map = recovery_store->get<Nodes>(Tables::NODES);
 
-      auto m = std::make_shared<MerkleTxHistory>(
+      recovery_history = std::make_shared<MerkleTxHistory>(
         *recovery_store.get(),
         self,
         *node_sign_kp,
@@ -912,8 +911,6 @@ namespace ccf
         *recovery_nodes_map,
         sig_tx_interval,
         sig_ms_interval);
-      m->start_signature_emit_timer(m);
-      recovery_history = m; 
 
 #ifdef USE_NULL_ENCRYPTOR
       recovery_encryptor = std::make_shared<kv::NullTxEncryptor>();
@@ -1732,7 +1729,7 @@ namespace ccf
     {
       // This function can be called once the node has started up and before
       // it has joined the service.
-      auto h = std::make_shared<MerkleTxHistory>(
+      history = std::make_shared<MerkleTxHistory>(
         *network.tables.get(),
         self,
         *node_sign_kp,
@@ -1740,8 +1737,6 @@ namespace ccf
         network.nodes,
         sig_tx_interval,
         sig_ms_interval);
-      h->start_signature_emit_timer(h);
-      history = h;
 
       network.tables->set_history(history);
     }

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -143,6 +143,8 @@ namespace ccf
     ringbuffer::AbstractWriterFactory& writer_factory;
     ringbuffer::WriterPtr to_host;
     consensus::Config consensus_config;
+    size_t sig_tx_interval;
+    size_t sig_ms_interval;
 
     NetworkState& network;
 
@@ -208,7 +210,10 @@ namespace ccf
       const consensus::Config& consensus_config_,
       std::shared_ptr<NodeToNode> n2n_channels_,
       std::shared_ptr<enclave::RPCMap> rpc_map_,
-      std::shared_ptr<Forwarder<NodeToNode>> cmd_forwarder_)
+      std::shared_ptr<Forwarder<NodeToNode>> cmd_forwarder_,
+    size_t sig_tx_interval_,
+    size_t sig_ms_interval_
+      )
     {
       std::lock_guard<SpinLock> guard(lock);
       sm.expect(State::uninitialized);
@@ -217,6 +222,8 @@ namespace ccf
       n2n_channels = n2n_channels_;
       rpc_map = rpc_map_;
       cmd_forwarder = cmd_forwarder_;
+      sig_tx_interval = sig_tx_interval_;
+      sig_ms_interval = sig_ms_interval_;
       sm.advance(State::initialized);
     }
 
@@ -1725,7 +1732,9 @@ namespace ccf
         self,
         *node_sign_kp,
         network.signatures,
-        network.nodes);
+        network.nodes,
+        sig_tx_interval,
+        sig_ms_interval);
       tmp->start_signature_emit_timer(tmp);
       history = tmp;
 

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1720,12 +1720,14 @@ namespace ccf
     {
       // This function can be called once the node has started up and before
       // it has joined the service.
-      history = std::make_shared<MerkleTxHistory>(
+      auto tmp = std::make_shared<MerkleTxHistory>(
         *network.tables.get(),
         self,
         *node_sign_kp,
         network.signatures,
         network.nodes);
+      tmp->start_signature_emit_timer(tmp);
+      history = tmp;
 
       network.tables->set_history(history);
     }

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -902,12 +902,14 @@ namespace ccf
         recovery_store->get<Signatures>(Tables::SIGNATURES);
       Nodes* recovery_nodes_map = recovery_store->get<Nodes>(Tables::NODES);
 
-      recovery_history = std::make_shared<MerkleTxHistory>(
+      auto m = std::make_shared<MerkleTxHistory>(
         *recovery_store.get(),
         self,
         *node_sign_kp,
         *recovery_signature_map,
         *recovery_nodes_map);
+      m->start_signature_emit_timer(m);
+        recovery_history = m; 
 
 #ifdef USE_NULL_ENCRYPTOR
       recovery_encryptor = std::make_shared<kv::NullTxEncryptor>();

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -983,7 +983,7 @@ namespace ccf
 
       // Emit signature to certify transactions that happened on public
       // network
-      history->emit_signature();
+      history->emit_signature(0);
 
       for (auto const& v : restored_versions)
       {

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -832,7 +832,8 @@ namespace ccf
       }
 
       network.tables->swap_private_maps(*recovery_store.get());
-      recovery_history->StopCallbacks();
+      //recovery_history->StopCallbacks();
+      recovery_history.reset();
       recovery_store.reset();
       reset_recovery_hook();
 

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -831,15 +831,10 @@ namespace ccf
           recovery_v));
       }
 
-      LOG_INFO_FMT("BBBBBB 9");
       network.tables->swap_private_maps(*recovery_store.get());
-      LOG_INFO_FMT("BBBBBB 9");
       recovery_history->StopCallbacks();
-      LOG_INFO_FMT("BBBBBB 9");
       recovery_store.reset();
-      LOG_INFO_FMT("BBBBBB 9");
       reset_recovery_hook();
-      LOG_INFO_FMT("BBBBBB 9");
 
       // Raft should deserialise all security domains when network is opened
       consensus->enable_all_domains();

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -415,7 +415,7 @@ namespace ccf
                 // Deprecated, this will be removed in future releases
                 ctx->set_global_commit(consensus->get_committed_seqno());
 
-                if (history && consensus->is_primary())
+                if (history != nullptr && consensus->is_primary())
                 {
                   history->try_emit_signature(cv);
                 }

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -507,10 +507,6 @@ namespace ccf
       sig_tx_interval = sig_tx_interval_;
       sig_ms_interval = std::chrono::milliseconds(sig_ms_interval_);
       ms_to_sig = sig_ms_interval;
-      LOG_INFO_FMT(
-        "BBBBBBBBBBBBBBB sig_ms_interval_:{}, sig_tx_interval_:{}",
-        sig_ms_interval_,
-        sig_tx_interval_);
     }
 
     void set_cmd_forwarder(
@@ -723,23 +719,6 @@ namespace ccf
 
       // reset tx_counter for next tick interval
       tx_count = 0;
-
-      /*
-      if ((consensus != nullptr) && consensus->is_primary())
-      {
-        if (elapsed < ms_to_sig)
-        {
-          ms_to_sig -= elapsed;
-          return;
-        }
-
-        ms_to_sig = sig_ms_interval;
-        if (history && tables.commit_gap() > 0)
-        {
-          //history->emit_signature();
-        }
-      }
-      */
     }
 
     // Return false if frontend believes it should be able to look up caller

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -421,7 +421,10 @@ namespace ccf
                 {
                   //history->emit_signature();
                 }
+                if (history && consensus->is_primary())
+                {
                   history->try_emit_signature(cv);
+                }
               }
 
               update_metrics(ctx, endpoint->metrics);
@@ -510,6 +513,7 @@ namespace ccf
       sig_tx_interval = sig_tx_interval_;
       sig_ms_interval = std::chrono::milliseconds(sig_ms_interval_);
       ms_to_sig = sig_ms_interval;
+      LOG_INFO_FMT("BBBBBBBBBBBBBBB sig_ms_interval_:{}, sig_tx_interval_:{}", sig_ms_interval_, sig_tx_interval_);
     }
 
     void set_cmd_forwarder(

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -417,7 +417,7 @@ namespace ccf
 
                 if (history != nullptr && consensus->is_primary())
                 {
-                  history->try_emit_signature(cv);
+                  history->try_emit_signature();
                 }
               }
 

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -419,8 +419,9 @@ namespace ccf
                   history && consensus->is_primary() &&
                   (cv % sig_tx_interval == sig_tx_interval / 2))
                 {
-                  history->emit_signature();
+                  //history->emit_signature();
                 }
+                  history->try_emit_signature(cv);
               }
 
               update_metrics(ctx, endpoint->metrics);
@@ -722,6 +723,7 @@ namespace ccf
       // reset tx_counter for next tick interval
       tx_count = 0;
 
+      /*
       if ((consensus != nullptr) && consensus->is_primary())
       {
         if (elapsed < ms_to_sig)
@@ -733,9 +735,10 @@ namespace ccf
         ms_to_sig = sig_ms_interval;
         if (history && tables.commit_gap() > 0)
         {
-          history->emit_signature();
+          //history->emit_signature();
         }
       }
+      */
     }
 
     // Return false if frontend believes it should be able to look up caller

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -415,12 +415,6 @@ namespace ccf
                 // Deprecated, this will be removed in future releases
                 ctx->set_global_commit(consensus->get_committed_seqno());
 
-                if (
-                  history && consensus->is_primary() &&
-                  (cv % sig_tx_interval == sig_tx_interval / 2))
-                {
-                  //history->emit_signature();
-                }
                 if (history && consensus->is_primary())
                 {
                   history->try_emit_signature(cv);
@@ -513,7 +507,10 @@ namespace ccf
       sig_tx_interval = sig_tx_interval_;
       sig_ms_interval = std::chrono::milliseconds(sig_ms_interval_);
       ms_to_sig = sig_ms_interval;
-      LOG_INFO_FMT("BBBBBBBBBBBBBBB sig_ms_interval_:{}, sig_tx_interval_:{}", sig_ms_interval_, sig_tx_interval_);
+      LOG_INFO_FMT(
+        "BBBBBBBBBBBBBBB sig_ms_interval_:{}, sig_tx_interval_:{}",
+        sig_ms_interval_,
+        sig_tx_interval_);
     }
 
     void set_cmd_forwarder(

--- a/src/node/test/historical_queries.cpp
+++ b/src/node/test/historical_queries.cpp
@@ -11,6 +11,9 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 
+threading::ThreadMessaging threading::ThreadMessaging::thread_messaging;
+std::atomic<uint16_t> threading::ThreadMessaging::thread_count = 0;
+
 struct StubWriter : public ringbuffer::AbstractWriter
 {
 public:

--- a/src/node/test/historical_queries.cpp
+++ b/src/node/test/historical_queries.cpp
@@ -118,7 +118,7 @@ TEST_CASE("StateCache")
           i == low_signature_transaction - 1 ||
           i == high_signature_transaction - 1)
         {
-          history->emit_signature();
+          history->emit_signature(999);
           store.compact(store.current_version());
         }
         else

--- a/src/node/test/historical_queries.cpp
+++ b/src/node/test/historical_queries.cpp
@@ -118,7 +118,7 @@ TEST_CASE("StateCache")
           i == low_signature_transaction - 1 ||
           i == high_signature_transaction - 1)
         {
-          history->emit_signature(999);
+          history->emit_signature();
           store.compact(store.current_version());
         }
         else

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -14,6 +14,9 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 #include <doctest/doctest.h>
 
+threading::ThreadMessaging threading::ThreadMessaging::thread_messaging;
+std::atomic<uint16_t> threading::ThreadMessaging::thread_count = 0;
+
 extern "C"
 {
 #include <evercrypt/EverCrypt_AutoConfig2.h>

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -107,7 +107,7 @@ TEST_CASE("Check signature verification")
 
   INFO("Issue signature, and verify successfully on backup");
   {
-    primary_history->emit_signature(99);
+    primary_history->emit_signature();
     REQUIRE(backup_store.current_version() == 2);
   }
 
@@ -183,7 +183,7 @@ TEST_CASE("Check signing works across rollback")
 
   INFO("Issue signature, and verify successfully on backup");
   {
-    primary_history->emit_signature(9999);
+    primary_history->emit_signature();
     if (consensus->type() == ConsensusType::BFT)
     {
       REQUIRE(backup_store.current_version() == 1);

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -107,7 +107,7 @@ TEST_CASE("Check signature verification")
 
   INFO("Issue signature, and verify successfully on backup");
   {
-    primary_history->emit_signature();
+    primary_history->emit_signature(99);
     REQUIRE(backup_store.current_version() == 2);
   }
 
@@ -183,7 +183,7 @@ TEST_CASE("Check signing works across rollback")
 
   INFO("Issue signature, and verify successfully on backup");
   {
-    primary_history->emit_signature();
+    primary_history->emit_signature(9999);
     if (consensus->type() == ConsensusType::BFT)
     {
       REQUIRE(backup_store.current_version() == 1);

--- a/src/node/test/history_bench.cpp
+++ b/src/node/test/history_bench.cpp
@@ -8,6 +8,14 @@
 #define PICOBENCH_IMPLEMENT
 #include <picobench/picobench.hpp>
 
+threading::ThreadMessaging threading::ThreadMessaging::thread_messaging;
+std::atomic<uint16_t> threading::ThreadMessaging::thread_count = 0;
+
+namespace threading
+{
+  std::map<std::thread::id, uint16_t> thread_ids;
+}
+
 extern "C"
 {
 #include <evercrypt/EverCrypt_AutoConfig2.h>

--- a/src/node/test/snapshot.cpp
+++ b/src/node/test/snapshot.cpp
@@ -11,6 +11,9 @@
 #include <doctest/doctest.h>
 #include <string>
 
+threading::ThreadMessaging threading::ThreadMessaging::thread_messaging;
+std::atomic<uint16_t> threading::ThreadMessaging::thread_count = 0;
+
 TEST_CASE("Snapshot with merkle tree" * doctest::test_suite("snapshot"))
 {
   auto source_consensus = std::make_shared<kv::StubConsensus>();

--- a/src/node/test/snapshot.cpp
+++ b/src/node/test/snapshot.cpp
@@ -53,7 +53,7 @@ TEST_CASE("Snapshot with merkle tree" * doctest::test_suite("snapshot"))
 
   INFO("Emit signature");
   {
-    source_history->emit_signature(99999);
+    source_history->emit_signature();
     // Snapshot version is the version of the signature
     snapshot_version = transactions_count + 1;
   }

--- a/src/node/test/snapshot.cpp
+++ b/src/node/test/snapshot.cpp
@@ -53,7 +53,7 @@ TEST_CASE("Snapshot with merkle tree" * doctest::test_suite("snapshot"))
 
   INFO("Emit signature");
   {
-    source_history->emit_signature();
+    source_history->emit_signature(99999);
     // Snapshot version is the version of the signature
     snapshot_version = transactions_count + 1;
   }


### PR DESCRIPTION
Resolves #1736, #48
Links: #1737

There is a long held desire to move the instigation of signatures from the frontends. This change address this by moving the issuance of signatures to history. Please review this carefully, not much code changes here but this is a more fundamental change where bugs can be harder to find later.