### PR TITLE
Document all endpoints, even those with no schema

### DIFF
--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -605,8 +605,27 @@
     },
     "/log/private/historical": {
       "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "maximum": 18446744073709551615,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoggingGet__Out"
+                }
+              }
+            },
             "description": "Default response description"
           }
         }
@@ -614,8 +633,25 @@
     },
     "/log/private/prefix_cert": {
       "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoggingRecord__In"
+              }
+            }
+          },
+          "description": "Auto-generated request body schema"
+        },
         "responses": {
           "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/boolean"
+                }
+              }
+            },
             "description": "Default response description"
           }
         }

--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -603,6 +603,24 @@
         }
       }
     },
+    "/log/private/historical": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default response description"
+          }
+        }
+      }
+    },
+    "/log/private/prefix_cert": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Default response description"
+          }
+        }
+      }
+    },
     "/log/private/raw_text/{id}": {
       "parameters": [
         {
@@ -613,7 +631,14 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Default response description"
+          }
+        }
+      }
     },
     "/log/public": {
       "delete": {

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -635,6 +635,15 @@
         }
       }
     },
+    "/create": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Default response description"
+          }
+        }
+      }
+    },
     "/endpoint_metrics": {
       "get": {
         "responses": {

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -456,6 +456,15 @@
         }
       }
     },
+    "/config": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default response description"
+          }
+        }
+      }
+    },
     "/endpoint_metrics": {
       "get": {
         "responses": {
@@ -467,6 +476,15 @@
                 }
               }
             },
+            "description": "Default response description"
+          }
+        }
+      }
+    },
+    "/join": {
+      "post": {
+        "responses": {
+          "200": {
             "description": "Default response description"
           }
         }
@@ -526,6 +544,15 @@
         }
       }
     },
+    "/network": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default response description"
+          }
+        }
+      }
+    },
     "/network_info": {
       "get": {
         "responses": {
@@ -571,6 +598,15 @@
                 }
               }
             },
+            "description": "Default response description"
+          }
+        }
+      }
+    },
+    "/primary": {
+      "head": {
+        "responses": {
+          "200": {
             "description": "Default response description"
           }
         }

--- a/python/ccf/proposal_generator.py
+++ b/python/ccf/proposal_generator.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache 2.0 License.
 
 import argparse
-import collections
+from collections import abc
 import inspect
 import json
 import glob
@@ -35,9 +35,9 @@ def as_lua_literal(arg):
         return f"[====[\n{arg}]====]"
     elif isinstance(arg, bool):
         return str(arg).lower()
-    elif isinstance(arg, collections.abc.Sequence):
+    elif isinstance(arg, abc.Sequence):
         return f"{{ {', '.join(as_lua_literal(e) for e in arg)} }}"
-    elif isinstance(arg, collections.abc.Mapping):
+    elif isinstance(arg, abc.Mapping):
         inner = ", ".join(
             f"[ {as_lua_literal(k)} ] = {as_lua_literal(v)}" for k, v in arg.items()
         )
@@ -105,7 +105,7 @@ def complete_vote_output_path(
 
 def add_arg_construction(
     lines: list,
-    arg: Union[str, collections.abc.Sequence, collections.abc.Mapping],
+    arg: Union[str, abc.Sequence, abc.Mapping],
     arg_name: str = "args",
 ):
     lines.append(f"{arg_name} = {as_lua_literal(arg)}")
@@ -113,7 +113,7 @@ def add_arg_construction(
 
 def add_arg_checks(
     lines: list,
-    arg: Union[str, collections.abc.Sequence, collections.abc.Mapping],
+    arg: Union[str, abc.Sequence, abc.Mapping],
     arg_name: str = "args",
     added_equal_tables_fn: bool = False,
 ):
@@ -122,8 +122,8 @@ def add_arg_checks(
         lines.append(
             f"if not {arg_name} == {as_lua_literal(arg)} then return false end"
         )
-    elif isinstance(arg, collections.abc.Sequence) or isinstance(
-        arg, collections.abc.Mapping
+    elif isinstance(arg, abc.Sequence) or isinstance(
+        arg, abc.Mapping
     ):
         if not added_equal_tables_fn:
             lines.extend(

--- a/src/node/rpc/endpoint_registry.h
+++ b/src/node/rpc/endpoint_registry.h
@@ -581,9 +581,28 @@ namespace ccf
     static void add_endpoint_to_api_document(
       nlohmann::json& document, const Endpoint& endpoint)
     {
-      for (const auto& builder_fn : endpoint.schema_builders)
+      if (endpoint.schema_builders.empty())
       {
-        builder_fn(document, endpoint);
+        // If we have no more specific schema information, make sure the
+        // endpoint is still minimally documented (NB: this claims the endpoint
+        // will sometimes return a 200 status code, which may not be true!)
+        const auto http_verb = endpoint.verb.get_http_method();
+        if (!http_verb.has_value())
+        {
+          return;
+        }
+
+        ds::openapi::response(
+          ds::openapi::path_operation(
+            ds::openapi::path(document, endpoint.method), http_verb.value()),
+          HTTP_STATUS_OK);
+      }
+      else
+      {
+        for (const auto& builder_fn : endpoint.schema_builders)
+        {
+          builder_fn(document, endpoint);
+        }
       }
     }
 


### PR DESCRIPTION
As noted in #1735, we were failing to document a few endpoints which had no schema defined. These are now included in the OpenAPI document, with the minimal fields to create a valid document. This requires a response code, so we assume they are all capable of returning a 200. To be more accurate, we could be injecting some system error codes in here that we know they may return, but we don't currently have documentation for those.