### PR TITLE
Expose AES key generation to JS

### DIFF
--- a/src/apps/js_generic/js_generic.cpp
+++ b/src/apps/js_generic/js_generic.cpp
@@ -94,6 +94,7 @@ namespace ccfapp
       js_dump_error(ctx);
       return JS_EXCEPTION;
     }
+    // Supported key sizes for AES.
     if (key_size != 128 && key_size != 192 && key_size != 256)
     {
       JS_ThrowRangeError(ctx, "invalid key size");

--- a/tests/modules.py
+++ b/tests/modules.py
@@ -206,6 +206,12 @@ def test_npm_app(network, args):
         assert r.status_code == http.HTTPStatus.OK, r.status_code
         assert r.body.json()["available"], r.body
 
+        key_size = 256
+        r = c.post("/app/generateAesKey", {"size": key_size})
+        assert r.status_code == http.HTTPStatus.OK, r.status_code
+        assert len(r.body.data()) == key_size // 8
+        assert r.body.data() != b"\x00" * (key_size // 8)
+
         r = c.post("/app/log?id=42", {"msg": "Hello!"})
         assert r.status_code == http.HTTPStatus.OK, r.status_code
 

--- a/tests/npm-app/app.json
+++ b/tests/npm-app/app.json
@@ -36,6 +36,42 @@
           }
         }
       },
+      "/generateAesKey": {
+        "post": {
+          "js_module": "src/endpoints/crypto.js",
+          "js_function": "generateAesKey",
+          "forwarding_required": "always",
+          "execute_locally": false,
+          "require_client_signature": false,
+          "require_client_identity": true,
+          "readonly": true,
+          "openapi": {
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "properties": {
+                      "size": {
+                        "type": "number"
+                      }
+                    },
+                    "type": "object"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "content": {
+                  "application/octet-stream": {
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "/partition": {
         "post": {
           "js_module": "src/endpoints/partition.js",

--- a/tests/npm-app/src/endpoints/crypto.ts
+++ b/tests/npm-app/src/endpoints/crypto.ts
@@ -13,3 +13,12 @@ export function crypto(request: ccf.Request): ccf.Response<CryptoResponse> {
     let available = rs.KEYUTIL.generateKeypair ? true : false;
     return { body: { available: available } };
 }
+
+interface GenerateAesKeyRequest {
+    size: number
+}
+
+export function generateAesKey(request: ccf.Request<GenerateAesKeyRequest>): ccf.Response<ArrayBuffer> {
+    console.log(ccf.ccf)
+    return { body: ccf.ccf.generateAesKey(request.body.json().size) }
+}

--- a/tests/npm-app/src/types/ccf.ts
+++ b/tests/npm-app/src/types/ccf.ts
@@ -49,11 +49,12 @@ export interface CCF {
     bufToStr(v: ArrayBuffer): string
     jsonCompatibleToBuf<T extends JsonCompatible<T>>(v: T): ArrayBuffer
     bufToJsonCompatible<T extends JsonCompatible<T>>(v: ArrayBuffer): T
+    generateAesKey(size: number): ArrayBuffer
 
     kv: KVMaps
 }
 
-export declare const ccf: CCF
+export const ccf = globalThis.ccf as CCF
 
 // Additional functionality on top of C++:
 export const kv = ccf.kv

--- a/tests/npm-tsoa-app/src/types/ccf.ts
+++ b/tests/npm-tsoa-app/src/types/ccf.ts
@@ -49,11 +49,12 @@ export interface CCF {
     bufToStr(v: ArrayBuffer): string
     jsonCompatibleToBuf<T extends JsonCompatible<T>>(v: T): ArrayBuffer
     bufToJsonCompatible<T extends JsonCompatible<T>>(v: ArrayBuffer): T
+    generateAesKey(size: number): ArrayBuffer
 
     kv: KVMaps
 }
 
-export declare const ccf: CCF
+export const ccf = globalThis.ccf as CCF
 
 // Additional functionality on top of C++:
 export const kv = ccf.kv


### PR DESCRIPTION
Later on this may be exposed as [SubtleCrypto.generateKey](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/generateKey) using the same underlying C++ function.