### PR TITLE
Python infra support for read-only ledger

### DIFF
--- a/src/apps/logging/logging.cpp
+++ b/src/apps/logging/logging.cpp
@@ -342,6 +342,7 @@ namespace loggingapp
         ccf::historical::adapter(
           get_historical, context.get_historical_state(), is_tx_committed))
         .set_auto_schema<LoggingGetHistorical>()
+        .set_forwarding_required(ccf::ForwardingRequired::Never)
         .install();
 
       auto record_admin_only =

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -32,7 +32,7 @@ def test(network, args, verify=True):
         on_backup=True,
     )
     if verify:
-        network.txs.verify(network)
+        network.txs.verify()
     else:
         LOG.warning("Skipping log messages verification")
 
@@ -70,7 +70,7 @@ def test_illegal(network, args, verify=True):
         on_backup=True,
     )
     if verify:
-        network.txs.verify(network)
+        network.txs.verify()
     else:
         LOG.warning("Skipping log messages verification")
 
@@ -265,7 +265,7 @@ def test_historical_query(network, args):
     if args.package == "liblogging":
         network.txs.issue(network, number_txs=2)
         network.txs.issue(network, number_txs=2, repeat=True)
-        network.txs.verify(network)
+        network.txs.verify()
     else:
         LOG.warning(
             f"Skipping {inspect.currentframe().f_code.co_name} as application is not C++"

--- a/tests/governance.py
+++ b/tests/governance.py
@@ -74,7 +74,7 @@ def test_user(network, args, verify=True):
         number_txs=1,
     )
     if verify:
-        txs.verify(network)
+        txs.verify()
     network.consortium.remove_user(primary, new_user_id)
     with primary.client(f"user{new_user_id}") as c:
         r = c.get("/app/log/private")

--- a/tests/infra/logging_app.py
+++ b/tests/infra/logging_app.py
@@ -23,6 +23,7 @@ class LoggingTxs:
         self.priv = defaultdict(list)
         self.idx = 0
         self.user = f"user{user_id}"
+        self.network = None
 
     def get_last_tx(self, priv=True):
         txs = self.priv if priv else self.pub
@@ -36,6 +37,7 @@ class LoggingTxs:
         on_backup=False,
         repeat=False,
     ):
+        self.network = network
         remote_node, _ = network.find_primary()
         if on_backup:
             remote_node = network.find_any_backup()
@@ -81,9 +83,11 @@ class LoggingTxs:
 
         network.wait_for_node_commit_sync()
 
-    def verify(self, network, node=None, timeout=3):
+    def verify(self, network=None, node=None, timeout=3):
         LOG.info("Verifying all logging txs")
-        nodes = network.get_joined_nodes() if node is None else [node]
+        if network is not None:
+            self.network = network
+        nodes = self.network.get_joined_nodes() if node is None else [node]
         for node in nodes:
             for pub_idx, pub_value in self.pub.items():
                 # As public records do not yet handle historical queries,

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -190,7 +190,7 @@ class Network:
         # Only retrieve snapshot from target node if the snapshot directory is not
         # specified
         if from_snapshot and snapshot_dir is None:
-            snapshot_dir = target_node.get_snapshots()
+            snapshot_dir = target_node.get_committed_snapshots()
             assert (
                 len(os.listdir(snapshot_dir)) > 0
             ), f"There are no snapshots to resume from in directory {snapshot_dir}"
@@ -742,6 +742,16 @@ class Network:
             time.sleep(0.1)
         flush_info(logs, None)
         raise error(f"A new primary was not elected after {timeout} seconds")
+
+    def is_snapshot_committed_for(self, seqno):
+        primary, _ = self.find_primary()
+
+        snapshots = primary.get_committed_snapshots()
+        for s in os.listdir(snapshots):
+            if infra.node.get_snapshot_seqno(s) > seqno:
+                LOG.error(f"Snapshot committed for {seqno}: {s}")
+                return True
+        return False
 
 
 @contextmanager

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -199,7 +199,9 @@ class Network:
         if snapshot_dir is not None:
             LOG.info(f"Joining from snapshot: {snapshot_dir}")
             if copy_ledger_read_only:
-                LOG.info(f"Copying target node to read-only ledger directory")
+                LOG.info(
+                    f"Copying target node ledger to read-only ledger directory {read_only_ledger_dir}"
+                )
                 read_only_ledger_dir = target_node.get_ledger()
 
         node.join(

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -106,7 +106,7 @@ class Node:
         common_dir,
         target_rpc_address,
         snapshot_dir,
-        read_ledger_dir=None,
+        read_only_ledger_dir=None,
         **kwargs,
     ):
         self._start(
@@ -118,7 +118,7 @@ class Node:
             common_dir,
             target_rpc_address=target_rpc_address,
             snapshot_dir=snapshot_dir,
-            read_ledger_dir=read_ledger_dir,
+            read_only_ledger_dir=read_only_ledger_dir,
             **kwargs,
         )
 
@@ -145,7 +145,7 @@ class Node:
         target_rpc_address=None,
         snapshot_dir=None,
         members_info=None,
-        read_ledger_dir=None,
+        read_only_ledger_dir=None,
         **kwargs,
     ):
         """
@@ -173,7 +173,7 @@ class Node:
             target_rpc_address=target_rpc_address,
             members_info=members_info,
             snapshot_dir=snapshot_dir,
-            read_ledger_dir=read_ledger_dir,
+            read_only_ledger_dir=read_only_ledger_dir,
             binary_dir=self.binary_dir,
             **kwargs,
         )

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -97,6 +97,7 @@ class Node:
         common_dir,
         target_rpc_address,
         snapshot_dir,
+        read_ledger_dir=None,
         **kwargs,
     ):
         self._start(
@@ -108,6 +109,7 @@ class Node:
             common_dir,
             target_rpc_address=target_rpc_address,
             snapshot_dir=snapshot_dir,
+            read_ledger_dir=read_ledger_dir,
             **kwargs,
         )
 
@@ -134,18 +136,15 @@ class Node:
         target_rpc_address=None,
         snapshot_dir=None,
         members_info=None,
+        read_ledger_dir=None,
         **kwargs,
     ):
         """
-        Creates a CCFRemote instance, sets it up (connects, creates the directory and ships over the files), and
-        (optionally) starts the node by executing the appropriate command.
-        If self.debug is set to True, it will not actually start up the node, but will prompt the user to do so manually
-        Raises exception if failed to prepare or start the node
-        :param lib_name: the enclave package to load
-        :param enclave_type: default: release. Choices: 'release', 'debug', 'virtual'
-        :param workspace: directory where node is started
-        :param label: label for this node (to differentiate nodes from different test runs)
-        :return: void
+        Creates a CCFRemote instance, sets it up (connects, creates the directory
+        and ships over the files), and (optionally) starts the node by executing
+        the appropriate command.
+        If self.debug is set, it will not actually start up the node, but will
+        prompt the user to do so manually.
         """
         lib_path = infra.path.build_lib_path(lib_name, enclave_type)
         self.common_dir = common_dir
@@ -162,9 +161,10 @@ class Node:
             workspace,
             label,
             common_dir,
-            target_rpc_address,
-            members_info,
-            snapshot_dir,
+            target_rpc_address=target_rpc_address,
+            members_info=members_info,
+            snapshot_dir=snapshot_dir,
+            read_ledger_dir=read_ledger_dir,
             binary_dir=self.binary_dir,
             **kwargs,
         )

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -583,6 +583,7 @@ class CCFRemote(object):
         memory_reserve_startup=0,
         gov_script=None,
         ledger_dir=None,
+        read_ledger_dir=None,
         log_format_json=None,
         binary_dir=".",
         ledger_chunk_bytes=(5 * 1000 * 1000),
@@ -600,6 +601,7 @@ class CCFRemote(object):
         self.BIN = infra.path.build_bin_path(
             self.BIN, enclave_type, binary_dir=binary_dir
         )
+        self.common_dir = common_dir
 
         self.ledger_dir = os.path.normpath(ledger_dir) if ledger_dir else None
         self.ledger_dir_name = (
@@ -611,8 +613,12 @@ class CCFRemote(object):
         self.snapshot_dir_name = (
             os.path.basename(self.snapshot_dir) if self.snapshot_dir else "snapshots"
         )
-
-        self.common_dir = common_dir
+        self.read_ledger_dir = (
+            os.path.normpath(read_ledger_dir) if read_ledger_dir else None
+        )
+        self.read_ledger_dir_name = (
+            os.path.basename(read_ledger_dir) if read_ledger_dir else None
+        )
 
         exe_files = [self.BIN, lib_path] + self.DEPS
         data_files = [self.ledger_dir] if self.ledger_dir else []
@@ -667,6 +673,10 @@ class CCFRemote(object):
 
         if snapshot_tx_interval:
             cmd += [f"--snapshot-tx-interval={snapshot_tx_interval}"]
+
+        if read_ledger_dir:
+            cmd += [f"--read-only-ledger-dir={self.read_ledger_dir_name}"]
+            data_files += [os.path.join(self.common_dir, read_ledger_dir)]
 
         if start_type == StartType.new:
             cmd += [

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -583,7 +583,7 @@ class CCFRemote(object):
         memory_reserve_startup=0,
         gov_script=None,
         ledger_dir=None,
-        read_ledger_dir=None,
+        read_only_ledger_dir=None,
         log_format_json=None,
         binary_dir=".",
         ledger_chunk_bytes=(5 * 1000 * 1000),
@@ -613,11 +613,8 @@ class CCFRemote(object):
         self.snapshot_dir_name = (
             os.path.basename(self.snapshot_dir) if self.snapshot_dir else "snapshots"
         )
-        self.read_ledger_dir = (
-            os.path.normpath(read_ledger_dir) if read_ledger_dir else None
-        )
         self.read_ledger_dir_name = (
-            os.path.basename(read_ledger_dir) if read_ledger_dir else None
+            os.path.basename(read_only_ledger_dir) if read_only_ledger_dir else None
         )
 
         exe_files = [self.BIN, lib_path] + self.DEPS
@@ -674,9 +671,9 @@ class CCFRemote(object):
         if snapshot_tx_interval:
             cmd += [f"--snapshot-tx-interval={snapshot_tx_interval}"]
 
-        if read_ledger_dir:
+        if read_only_ledger_dir:
             cmd += [f"--read-only-ledger-dir={self.read_ledger_dir_name}"]
-            data_files += [os.path.join(self.common_dir, read_ledger_dir)]
+            data_files += [os.path.join(self.common_dir, read_only_ledger_dir)]
 
         if start_type == StartType.new:
             cmd += [

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -779,7 +779,7 @@ class CCFRemote(object):
         self.remote.get(self.ledger_dir_name, self.common_dir)
         return os.path.join(self.common_dir, self.ledger_dir_name)
 
-    def get_snapshots(self, pre_condition_func=lambda src_dir, _: True):
+    def get_committed_snapshots(self, pre_condition_func=lambda src_dir, _: True):
         self.remote.get(
             self.snapshot_dir_name,
             self.common_dir,

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -65,9 +65,10 @@ def test_add_node_from_backup(network, args):
 
 @reqs.description("Adding a valid node from snapshot")
 @reqs.at_least_n_nodes(2)
-def test_add_node_from_snapshot(network, args):
+# @reqs.verify_txs # TODO: Implement this to verify all txs so far
+def test_add_node_from_snapshot(network, args, copy_ledger=True):
     new_node = network.create_and_trust_node(
-        args.package, "localhost", args, from_snapshot=True
+        args.package, "localhost", args, from_snapshot=True, copy_ledger=copy_ledger
     )
     assert new_node
     return network
@@ -146,13 +147,13 @@ def run(args):
         if args.snapshot_tx_interval is not None:
             test_add_node_from_snapshot(network, args)
 
-        test_add_node_from_backup(network, args)
-        test_add_node(network, args)
-        test_add_node_untrusted_code(network, args)
-        test_retire_backup(network, args)
-        test_add_as_many_pending_nodes(network, args)
-        test_add_node(network, args)
-        test_retire_primary(network, args)
+        # test_add_node_from_backup(network, args)
+        # test_add_node(network, args)
+        # test_add_node_untrusted_code(network, args)
+        # test_retire_backup(network, args)
+        # test_add_as_many_pending_nodes(network, args)
+        # test_add_node(network, args)
+        # test_retire_primary(network, args)
 
 
 if __name__ == "__main__":

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -3,6 +3,7 @@
 import infra.e2e_args
 import infra.network
 import infra.proc
+import infra.logging_app as app
 import suite.test_requirements as reqs
 import time
 
@@ -65,7 +66,7 @@ def test_add_node_from_backup(network, args):
 
 @reqs.description("Adding a valid node from snapshot")
 @reqs.at_least_n_nodes(2)
-# @reqs.verify_txs # TODO: Implement this to verify all txs so far
+@reqs.start_from_snapshot()  # TODO: Implement this to verify all txs so far
 def test_add_node_from_snapshot(network, args, copy_ledger=True):
     new_node = network.create_and_trust_node(
         args.package, "localhost", args, from_snapshot=True, copy_ledger=copy_ledger
@@ -140,10 +141,12 @@ def test_retire_primary(network, args):
 def run(args):
     hosts = ["localhost", "localhost"]
 
+    txs = app.LoggingTxs()
     with infra.network.network(
-        hosts, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
+        hosts, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb, txs=txs
     ) as network:
         network.start_and_join(args)
+
         if args.snapshot_tx_interval is not None:
             test_add_node_from_snapshot(network, args)
 

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -66,10 +66,14 @@ def test_add_node_from_backup(network, args):
 
 @reqs.description("Adding a valid node from snapshot")
 @reqs.at_least_n_nodes(2)
-@reqs.start_from_snapshot()  # TODO: Implement this to verify all txs so far
-def test_add_node_from_snapshot(network, args, copy_ledger=True):
+@reqs.add_from_snapshot()
+def test_add_node_from_snapshot(network, args, copy_ledger_read_only=True):
     new_node = network.create_and_trust_node(
-        args.package, "localhost", args, from_snapshot=True, copy_ledger=copy_ledger
+        args.package,
+        "localhost",
+        args,
+        from_snapshot=True,
+        copy_ledger_read_only=copy_ledger_read_only,
     )
     assert new_node
     return network
@@ -147,16 +151,24 @@ def run(args):
     ) as network:
         network.start_and_join(args)
 
-        if args.snapshot_tx_interval is not None:
-            test_add_node_from_snapshot(network, args)
+        test_add_node_from_backup(network, args)
+        test_add_node(network, args)
+        test_add_node_untrusted_code(network, args)
+        test_retire_backup(network, args)
+        test_add_as_many_pending_nodes(network, args)
+        test_add_node(network, args)
+        test_retire_primary(network, args)
 
-        # test_add_node_from_backup(network, args)
-        # test_add_node(network, args)
-        # test_add_node_untrusted_code(network, args)
-        # test_retire_backup(network, args)
-        # test_add_as_many_pending_nodes(network, args)
-        # test_add_node(network, args)
-        # test_retire_primary(network, args)
+        if args.snapshot_tx_interval is not None:
+            test_add_node_from_snapshot(network, args, copy_ledger_read_only=True)
+
+            try:
+                test_add_node_from_snapshot(network, args, copy_ledger_read_only=False)
+                assert (
+                    False
+                ), "Node added from snapshot without ledger should not be able to verify historical entries"
+            except app.LoggingTxsVerifyException:
+                pass
 
 
 if __name__ == "__main__":

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -18,7 +18,7 @@ def test(network, args, from_snapshot=False):
     # Retrieve ledger and snapshots
     snapshot_dir = None
     if from_snapshot:
-        snapshot_dir = old_primary.get_snapshots()
+        snapshot_dir = old_primary.get_committed_snapshots()
         if not os.listdir(snapshot_dir):
             raise RuntimeError(f"No snapshot found in {snapshot_dir}")
     ledger_dir = old_primary.get_ledger()
@@ -43,7 +43,7 @@ def test_share_resilience(network, args, from_snapshot=False):
 
     snapshot_dir = None
     if from_snapshot:
-        snapshot_dir = old_primary.get_snapshots()
+        snapshot_dir = old_primary.get_committed_snapshots()
         if not os.listdir(snapshot_dir):
             raise RuntimeError(f"No snapshot found in {snapshot_dir}")
     ledger_dir = old_primary.get_ledger()

--- a/tests/rekey.py
+++ b/tests/rekey.py
@@ -32,7 +32,7 @@ def run(args):
             network=network,
             number_txs=3,
         )
-        txs.verify(network=network)
+        txs.verify()
 
         network = test(network, args)
 
@@ -40,7 +40,7 @@ def run(args):
             network=network,
             number_txs=3,
         )
-        txs.verify(network=network)
+        txs.verify()
 
 
 if __name__ == "__main__":

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -196,7 +196,7 @@ def add_from_snapshot():
                 )
             network = func(*args, **kwargs)
             # Only verify entries on node just added
-            network.txs.verify(network=network, node=network.get_joined_nodes()[-1])
+            network.txs.verify(node=network.get_joined_nodes()[-1])
 
             return network
 


### PR DESCRIPTION
Resolves https://github.com/microsoft/CCF/issues/1527

Now that a node can use the `--read-only-ledger-dir` option to specify a read-only ledger directory (see #1725), this PR adds end-to-end testing for this feature. 

To do so, the `test_add_node_from_snapshot` test in `reconfiguration.py` now takes an extra `copy_ledger_read_only` argument to copy the target node's ledger to the new node's read-only ledger directory. 

The new `@req.add_from_snapshot` decorator also guarantees that there are some historical entries followed by a committed snapshot before the new node joins. The decorator also make sure that the historical entries are verified on the new node after it has joined. Using this decorator will allow us to test this easily in the test suite. Note that the `test_add_node_from_snapshot` test fails if `copy_ledger_read_only` is `False`, which we test for in the `reconfiguration.py` test.