### PR TITLE
Fix tsoa route handling

### DIFF
--- a/tests/npm-tsoa-app/tsoa-support/routes.ts.tmpl
+++ b/tests/npm-tsoa-app/tsoa-support/routes.ts.tmpl
@@ -120,18 +120,23 @@ export function getValidatedArgs(args: any, request: any, response: any): any[] 
 
 // CCF:METADATA-START
 {
-    "endpoints": {
-    {{#each controllers}}
-        "{{path}}": {
-        {{#each actions}}
-            "{{method}}": {
-                "js_module": "build/{{../name}}Proxy.js",
+    "controllers": [
+        {{#each controllers}}
+        {
+          "path": "{{path}}",
+          "js_module": "build/{{name}}Proxy.js",
+          "actions": [
+              {{#each actions}}
+              {
+                "full_path": "{{fullPath}}",
+                "method": "{{method}}",
                 "js_function": "{{name}}"
-            }{{#unless @last}},{{/unless}}
-        {{/each}}
+              }{{#unless @last}},{{/unless}}
+              {{/each}}
+          ]
         }{{#unless @last}},{{/unless}}
-    {{/each}}
-    }
+        {{/each}}
+    ]
 }
 // CCF:METADATA-END
 


### PR DESCRIPTION
In tsoa, there are controllers and actions. A controller has a route "users" and an action may have an appended route as well, e.g. "{id}". Previously, the helper code didn't handle the extra route of actions. This PR fixes that.