### PR TITLE
Fix sandbox

### DIFF
--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -41,6 +41,11 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         default="/opt/openenclave/bin/",
     )
     parser.add_argument(
+        "--library-dir",
+        help="Path to CCF libraries (enclave images)",
+        default=".",
+    )
+    parser.add_argument(
         "-d",
         "--debug-nodes",
         help="List of node ids. Nodes that are specified will need to be started manually",

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -43,7 +43,7 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
     parser.add_argument(
         "--library-dir",
         help="Path to CCF libraries (enclave images)",
-        default=".",
+        default=None,
     )
     parser.add_argument(
         "-d",
@@ -228,6 +228,13 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         args, unknown_args = parser.parse_known_args()
     else:
         args = parser.parse_args()
+
+    if args.library_dir is None:
+        binary_dir = os.path.abspath(args.binary_dir)
+        if os.path.basename(binary_dir) == "bin":
+            args.library_dir = os.path.join(binary_dir, os.pardir, "lib")
+        else:
+            args.library_dir = args.binary_dir
 
     if not args.package and (args.js_app_script or args.js_app_bundle):
         args.package = "libjs_generic"

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -229,10 +229,11 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
     else:
         args = parser.parse_args()
 
+    args.binary_dir = os.path.abspath(args.binary_dir)
+
     if args.library_dir is None:
-        binary_dir = os.path.abspath(args.binary_dir)
-        if os.path.basename(binary_dir) == "bin":
-            args.library_dir = os.path.join(binary_dir, os.pardir, "lib")
+        if os.path.basename(args.binary_dir) == "bin":
+            args.library_dir = os.path.join(args.binary_dir, os.pardir, "lib")
         else:
             args.library_dir = args.binary_dir
 

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -87,6 +87,7 @@ class Network:
         self,
         hosts,
         binary_dir=".",
+        library_dir=".",
         dbg_nodes=None,
         perf_nodes=None,
         existing_network=None,
@@ -114,6 +115,7 @@ class Network:
         self.hosts = hosts
         self.status = ServiceStatus.CLOSED
         self.binary_dir = binary_dir
+        self.library_dir = library_dir
         self.common_dir = None
         self.election_duration = None
         self.key_generator = os.path.join(binary_dir, self.KEY_GEN)
@@ -160,7 +162,9 @@ class Network:
         perf = (
             (str(node_id) in self.perf_nodes) if self.perf_nodes is not None else False
         )
-        node = infra.node.Node(node_id, host, self.binary_dir, debug, perf)
+        node = infra.node.Node(
+            node_id, host, self.binary_dir, self.library_dir, debug, perf
+        )
         self.nodes.append(node)
         return node
 
@@ -762,12 +766,19 @@ class Network:
 
 @contextmanager
 def network(
-    hosts, binary_directory=".", dbg_nodes=None, perf_nodes=None, pdb=False, txs=None
+    hosts,
+    binary_directory=".",
+    library_directory=".",
+    dbg_nodes=None,
+    perf_nodes=None,
+    pdb=False,
+    txs=None,
 ):
     """
     Context manager for Network class.
     :param hosts: a list of hostnames (localhost or remote hostnames)
     :param binary_directory: the directory where CCF's binaries are located
+    :param library_directory: the directory where CCF's libraries are located
     :param dbg_nodes: default: []. List of node id's that will not start (user is prompted to start them manually)
     :param perf_nodes: default: []. List of node ids that will run under perf record
     :param pdb: default: False. Debugger.
@@ -783,6 +794,7 @@ def network(
     net = Network(
         hosts=hosts,
         binary_dir=binary_directory,
+        library_dir=library_directory,
         dbg_nodes=dbg_nodes,
         perf_nodes=perf_nodes,
         txs=txs,

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -87,11 +87,11 @@ class Network:
         self,
         hosts,
         binary_dir=".",
-        library_dir=".",
         dbg_nodes=None,
         perf_nodes=None,
         existing_network=None,
         txs=None,
+        library_dir=".",
     ):
         self.existing_network = existing_network
         if self.existing_network is None:

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -768,11 +768,11 @@ class Network:
 def network(
     hosts,
     binary_directory=".",
-    library_directory=".",
     dbg_nodes=None,
     perf_nodes=None,
     pdb=False,
     txs=None,
+    library_directory=".",
 ):
     """
     Context manager for Network class.

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -45,9 +45,12 @@ def get_snapshot_seqno(file_name):
 
 
 class Node:
-    def __init__(self, node_id, host, binary_dir=".", debug=False, perf=False):
+    def __init__(
+        self, node_id, host, binary_dir=".", library_dir=".", debug=False, perf=False
+    ):
         self.node_id = node_id
         self.binary_dir = binary_dir
+        self.library_dir = library_dir
         self.debug = debug
         self.perf = perf
         self.remote = None
@@ -152,7 +155,9 @@ class Node:
         If self.debug is set, it will not actually start up the node, but will
         prompt the user to do so manually.
         """
-        lib_path = infra.path.build_lib_path(lib_name, enclave_type)
+        lib_path = infra.path.build_lib_path(
+            lib_name, enclave_type, library_dir=self.library_dir
+        )
         self.common_dir = common_dir
         self.remote = infra.remote.CCFRemote(
             start_type,
@@ -310,18 +315,32 @@ class Node:
 
 
 @contextmanager
-def node(node_id, host, binary_directory, debug=False, perf=False, pdb=False):
+def node(
+    node_id,
+    host,
+    binary_directory,
+    library_directory,
+    debug=False,
+    perf=False,
+    pdb=False,
+):
     """
     Context manager for Node class.
     :param node_id: unique ID of node
     :param binary_directory: the directory where CCF's binaries are located
+    :param library_directory: the directory where CCF's libraries are located
     :param host: node's hostname
     :param debug: default: False. If set, node will not start (user is prompted to start them manually)
     :param perf: default: False. If set, node will run under perf record
     :return: a Node instance that can be used to build a CCF network
     """
     this_node = Node(
-        node_id=node_id, host=host, binary_dir=binary_directory, debug=debug, perf=perf
+        node_id=node_id,
+        host=host,
+        binary_dir=binary_directory,
+        library_dir=library_directory,
+        debug=debug,
+        perf=perf,
     )
     try:
         yield this_node

--- a/tests/infra/path.py
+++ b/tests/infra/path.py
@@ -18,7 +18,7 @@ def mk_new(name, contents):
         mk(name, contents)
 
 
-def build_lib_path(lib_name, enclave_type=None):
+def build_lib_path(lib_name, enclave_type=None, library_dir="."):
     if enclave_type == "virtual":
         ext = ".virtual.so"
         mode = "Virtual mode"
@@ -34,7 +34,7 @@ def build_lib_path(lib_name, enclave_type=None):
         return lib_name
     else:
         # Make sure relative paths include current directory. Absolute paths will be unaffected
-        return os.path.join(".", os.path.normpath(f"{lib_name}{ext}"))
+        return os.path.join(library_dir, os.path.normpath(f"{lib_name}{ext}"))
 
 
 def build_bin_path(bin_name, enclave_type=None, binary_dir="."):

--- a/tests/sandbox/sandbox.sh
+++ b/tests/sandbox/sandbox.sh
@@ -21,15 +21,13 @@ source "${VENV_DIR}"/bin/activate
 if [ -f "${VERSION_FILE}" ]; then
     # install tree
     BINARY_DIR=${PATH_HERE}
-    LIBRARY_DIR="${PATH_HERE}"/../lib
     START_NETWORK_SCRIPT="${PATH_HERE}"/start_network.py
     VERSION=$(<"${VERSION_FILE}")
     pip install --disable-pip-version-check -q -U ccf=="$VERSION"
     pip install --disable-pip-version-check -q -U -r "${PATH_HERE}"/requirements.txt
 else
     # source tree
-    BINARY_DIR="${PATH_HERE}"/../../build
-    LIBRARY_DIR=${BINARY_DIR}
+    BINARY_DIR=.
     START_NETWORK_SCRIPT="${PATH_HERE}"/../start_network.py
     pip install --disable-pip-version-check -q -U -e "${PATH_HERE}"/../../python/
     pip install --disable-pip-version-check -q -U -r "${PATH_HERE}"/../requirements.txt
@@ -40,7 +38,6 @@ echo "Python environment successfully setup"
 export CURL_CLIENT=ON
 exec python "${START_NETWORK_SCRIPT}" \
     --binary-dir "${BINARY_DIR}" \
-    --library-dir "${LIBRARY_DIR}" \
     --enclave-type virtual \
     --initial-member-count 1 \
     --initial-user-count 1 \

--- a/tests/sandbox/sandbox.sh
+++ b/tests/sandbox/sandbox.sh
@@ -20,12 +20,16 @@ source "${VENV_DIR}"/bin/activate
 
 if [ -f "${VERSION_FILE}" ]; then
     # install tree
+    BINARY_DIR=${PATH_HERE}
+    LIBRARY_DIR="${PATH_HERE}"/../lib
     START_NETWORK_SCRIPT="${PATH_HERE}"/start_network.py
     VERSION=$(<"${VERSION_FILE}")
     pip install --disable-pip-version-check -q -U ccf=="$VERSION"
     pip install --disable-pip-version-check -q -U -r "${PATH_HERE}"/requirements.txt
 else
     # source tree
+    BINARY_DIR="${PATH_HERE}"/../../build
+    LIBRARY_DIR=${BINARY_DIR}
     START_NETWORK_SCRIPT="${PATH_HERE}"/../start_network.py
     pip install --disable-pip-version-check -q -U -e "${PATH_HERE}"/../../python/
     pip install --disable-pip-version-check -q -U -r "${PATH_HERE}"/../requirements.txt
@@ -35,6 +39,8 @@ echo "Python environment successfully setup"
 
 CURL_CLIENT=ON \
     python "${START_NETWORK_SCRIPT}" \
+    --binary-dir "${BINARY_DIR}" \
+    --library-dir "${LIBRARY_DIR}" \
     --enclave-type virtual \
     --initial-member-count 1 \
     --initial-user-count 1 \

--- a/tests/sandbox/sandbox.sh
+++ b/tests/sandbox/sandbox.sh
@@ -37,8 +37,8 @@ fi
 
 echo "Python environment successfully setup"
 
-CURL_CLIENT=ON \
-    python "${START_NETWORK_SCRIPT}" \
+export CURL_CLIENT=ON
+exec python "${START_NETWORK_SCRIPT}" \
     --binary-dir "${BINARY_DIR}" \
     --library-dir "${LIBRARY_DIR}" \
     --enclave-type virtual \

--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -42,7 +42,10 @@ def run(args):
         LOG.warning("Virtual mode enabled")
 
     with infra.network.network(
-        hosts=hosts, binary_directory=args.binary_dir, dbg_nodes=args.debug_nodes
+        hosts=hosts,
+        binary_directory=args.binary_dir,
+        library_directory=args.library_dir,
+        dbg_nodes=args.debug_nodes,
     ) as network:
         if args.recover:
             args.label = args.label + "_recover"


### PR DESCRIPTION
Backwards compatible changes to the infra code to fix an issue with launching sandbox.sh from arbitrary folders.
This also uses `exec` to launch python so that signals are forwarded when using the script programmatically.