### PR TITLE
Remove old Store-less Tx constructor

### DIFF
--- a/src/consensus/aft/test/logging_stub.h
+++ b/src/consensus/aft/test/logging_stub.h
@@ -221,7 +221,7 @@ namespace aft
 
     kv::Tx create_tx()
     {
-      return kv::Tx();
+      return kv::Tx(nullptr);
     }
   };
 

--- a/src/node/progress_tracker_types.h
+++ b/src/node/progress_tracker_types.h
@@ -156,7 +156,7 @@ namespace ccf
       uint8_t* sig) override
     {
       kv::Tx tx(&store);
-      auto ni_tv = tx.get_view_old(nodes);
+      auto ni_tv = tx.get_view(nodes);
 
       auto ni = ni_tv->get(node_id);
       if (!ni.has_value())


### PR DESCRIPTION
Thanks to the recent changes to `ProgressTracker`, we no longer need the old (unsafe!) `Tx` constructor any more, so this removes it.