### PR TITLE
AFT: Send request hash when forwarding request

### DIFF
--- a/src/consensus/aft/impl/execution.cpp
+++ b/src/consensus/aft/impl/execution.cpp
@@ -50,7 +50,9 @@ namespace aft
   }
 
   kv::Version ExecutorImpl::execute_request(
-    std::unique_ptr<RequestMessage> request, bool is_create_request)
+    std::unique_ptr<RequestMessage> request,
+    bool is_create_request,
+    std::shared_ptr<aft::RequestTracker> request_tracker)
   {
     std::shared_ptr<enclave::RpcContext>& ctx = request->get_request_ctx().ctx;
     std::shared_ptr<enclave::RpcHandler>& frontend =
@@ -59,6 +61,26 @@ namespace aft
     ctx->pbft_raw.resize(request->size());
     request->serialize_message(
       NoNode, ctx->pbft_raw.data(), ctx->pbft_raw.size());
+
+    if (request_tracker != nullptr)
+    {
+      const auto& raw_request = ctx->get_serialised_request();
+      auto data_ = raw_request.data();
+      auto size_ = raw_request.size();
+
+      std::array<uint8_t, 32> hash;
+      tls::do_hash(data_, size_, hash, MBEDTLS_MD_SHA256);
+
+      if (!request_tracker->remove(hash))
+      {
+        request_tracker->insert_deleted(
+          hash,
+          threading::ThreadMessaging::thread_messaging
+            .get_current_time_offset());
+      }
+
+      LOG_INFO_FMT("AAAAAAA executing hash:{}", hash);
+    }
 
     ctx->is_create_request = is_create_request;
     ctx->execute_on_node = true;
@@ -99,7 +121,7 @@ namespace aft
       std::move(serialized_req), args.rid, std::move(ctx), rep_cb);
   }
 
-  kv::Version ExecutorImpl::commit_replayed_request(kv::Tx& tx)
+  kv::Version ExecutorImpl::commit_replayed_request(kv::Tx& tx, std::shared_ptr<aft::RequestTracker> request_tracker)
   {
     auto tx_view = tx.get_view(bft_requests_map);
     auto req_v = tx_view->get(0);
@@ -113,6 +135,6 @@ namespace aft
     auto request_message = RequestMessage::deserialize(
       std::move(request.raw), request.rid, std::move(ctx), nullptr);
 
-    return execute_request(std::move(request_message), state->commit_idx == 0);
+    return execute_request(std::move(request_message), state->commit_idx == 0, request_tracker);
   }
 }

--- a/src/consensus/aft/impl/execution.cpp
+++ b/src/consensus/aft/impl/execution.cpp
@@ -78,8 +78,6 @@ namespace aft
           threading::ThreadMessaging::thread_messaging
             .get_current_time_offset());
       }
-
-      LOG_INFO_FMT("AAAAAAA executing hash:{}", hash);
     }
 
     ctx->is_create_request = is_create_request;
@@ -121,7 +119,8 @@ namespace aft
       std::move(serialized_req), args.rid, std::move(ctx), rep_cb);
   }
 
-  kv::Version ExecutorImpl::commit_replayed_request(kv::Tx& tx, std::shared_ptr<aft::RequestTracker> request_tracker)
+  kv::Version ExecutorImpl::commit_replayed_request(
+    kv::Tx& tx, std::shared_ptr<aft::RequestTracker> request_tracker)
   {
     auto tx_view = tx.get_view(bft_requests_map);
     auto req_v = tx_view->get(0);
@@ -135,6 +134,7 @@ namespace aft
     auto request_message = RequestMessage::deserialize(
       std::move(request.raw), request.rid, std::move(ctx), nullptr);
 
-    return execute_request(std::move(request_message), state->commit_idx == 0, request_tracker);
+    return execute_request(
+      std::move(request_message), state->commit_idx == 0, request_tracker);
   }
 }

--- a/src/consensus/aft/impl/execution.h
+++ b/src/consensus/aft/impl/execution.h
@@ -5,7 +5,7 @@
 #include "consensus/aft/raft_types.h"
 #include "consensus/aft/request.h"
 #include "enclave/rpc_map.h"
-#include "request_tracker.h"
+#include "node/request_tracker.h"
 #include "state.h"
 
 namespace enclave
@@ -73,7 +73,9 @@ namespace aft
     std::unique_ptr<aft::RequestMessage> create_request_message(
       const kv::TxHistory::RequestCallbackArgs& args) override;
 
-    kv::Version commit_replayed_request(kv::Tx& tx, std::shared_ptr<aft::RequestTracker> request_tracker) override;
+    kv::Version commit_replayed_request(
+      kv::Tx& tx,
+      std::shared_ptr<aft::RequestTracker> request_tracker) override;
 
   private:
     RequestsMap& bft_requests_map;

--- a/src/consensus/aft/impl/execution.h
+++ b/src/consensus/aft/impl/execution.h
@@ -5,6 +5,7 @@
 #include "consensus/aft/raft_types.h"
 #include "consensus/aft/request.h"
 #include "enclave/rpc_map.h"
+#include "request_tracker.h"
 #include "state.h"
 
 namespace enclave
@@ -34,12 +35,15 @@ namespace aft
       Request& request) = 0;
 
     virtual kv::Version execute_request(
-      std::unique_ptr<RequestMessage> request, bool is_create_request) = 0;
+      std::unique_ptr<RequestMessage> request,
+      bool is_create_request,
+      std::shared_ptr<aft::RequestTracker> request_tracker = nullptr) = 0;
 
     virtual std::unique_ptr<aft::RequestMessage> create_request_message(
       const kv::TxHistory::RequestCallbackArgs& args) = 0;
 
-    virtual kv::Version commit_replayed_request(kv::Tx& tx) = 0;
+    virtual kv::Version commit_replayed_request(
+      kv::Tx& tx, std::shared_ptr<aft::RequestTracker> request_tracker) = 0;
   };
 
   class ExecutorImpl : public Executor
@@ -62,12 +66,14 @@ namespace aft
     std::unique_ptr<RequestCtx> create_request_ctx(Request& request) override;
 
     kv::Version execute_request(
-      std::unique_ptr<RequestMessage> request, bool is_create_request) override;
+      std::unique_ptr<RequestMessage> request,
+      bool is_create_request,
+      std::shared_ptr<aft::RequestTracker> request_tracker = nullptr) override;
 
     std::unique_ptr<aft::RequestMessage> create_request_message(
       const kv::TxHistory::RequestCallbackArgs& args) override;
 
-    kv::Version commit_replayed_request(kv::Tx& tx) override;
+    kv::Version commit_replayed_request(kv::Tx& tx, std::shared_ptr<aft::RequestTracker> request_tracker) override;
 
   private:
     RequestsMap& bft_requests_map;

--- a/src/consensus/aft/impl/request_tracker.h
+++ b/src/consensus/aft/impl/request_tracker.h
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+#include "ds/ccf_assert.h"
+#include "ds/dl_list.h"
+
+#include <array>
+#include <chrono>
+#include <optional>
+#include <set>
+
+namespace aft
+{
+  class RequestTracker
+  {
+    struct Request
+    {
+      Request(
+        const std::array<uint8_t, 32>& hash_, std::chrono::milliseconds time_) :
+        hash(hash_), time(time_)
+      {}
+
+      Request(const std::array<uint8_t, 32>& hash_) : hash(hash_) {}
+
+      std::array<uint8_t, 32> hash;
+      std::chrono::milliseconds time;
+
+      Request* next = nullptr;
+      Request* prev = nullptr;
+    };
+
+    struct RequestComp
+    {
+      bool operator()(const Request* lhs, const Request* rhs) const
+      {
+        const std::array<uint64_t, 4>& lhs_hash =
+          (std::array<uint64_t, 4>&)lhs->hash;
+        const std::array<uint64_t, 4>& rhs_hash =
+          (std::array<uint64_t, 4>&)rhs->hash;
+
+        for (uint32_t i = 0; i < 4; ++i)
+        {
+          if (lhs_hash[i] == rhs_hash[i])
+          {
+            continue;
+          }
+          return lhs_hash[i] > rhs_hash[i];
+        }
+        return false;
+      }
+    };
+
+    static constexpr std::chrono::minutes retail_unmatched_deleted_hashes =
+      std::chrono::minutes(1);
+
+  public:
+    void insert(
+      const std::array<uint8_t, 32>& hash, std::chrono::milliseconds time)
+    {
+      if (remove(hash, deleted_requests, deleted_requests_list))
+      {
+        return;
+      }
+      insert(hash, time, requests, requests_list);
+    }
+
+    void insert_deleted(
+      const std::array<uint8_t, 32>& hash, std::chrono::milliseconds time)
+    {
+#ifndef NDEBUG
+      Request r(hash);
+      CCF_ASSERT_FMT(
+        requests.find(&r) == requests.end(),
+        "cannot add deleted request that is a known request, hash:{}",
+        hash);
+#endif
+      insert(hash, time, deleted_requests, deleted_requests_list);
+    }
+
+    bool remove(
+      const std::array<uint8_t, 32>& hash)
+    {
+      return remove(hash, requests, requests_list);
+    }
+
+    void tick(std::chrono::milliseconds current_time)
+    {
+      if (current_time < retail_unmatched_deleted_hashes)
+      {
+        return;
+      }
+      current_time += retail_unmatched_deleted_hashes;
+
+      while (!deleted_requests_list.is_empty() &&
+             deleted_requests_list.get_head()->time < current_time)
+      {
+        Request* req = deleted_requests_list.get_head();
+        auto it = deleted_requests.find(req);
+        CCF_ASSERT_FMT(
+          it != deleted_requests.end(),
+          "Could not find hash:{} in map",
+          req->hash);
+        deleted_requests.erase(req);
+        delete deleted_requests_list.pop();
+      }
+    }
+
+    std::optional<std::chrono::milliseconds> oldest_entry()
+    {
+      if (requests_list.is_empty())
+      {
+        return std::nullopt;
+      }
+      return requests_list.get_head()->time;
+    }
+
+  private:
+    std::set<Request*, RequestComp> requests;
+    snmalloc::DLList<Request, std::nullptr_t, true> requests_list;
+
+    std::set<Request*, RequestComp> deleted_requests;
+    snmalloc::DLList<Request, std::nullptr_t, true> deleted_requests_list;
+
+    void insert(
+      const std::array<uint8_t, 32>& hash,
+      std::chrono::milliseconds time,
+      std::set<Request*, RequestComp>& requests_,
+      snmalloc::DLList<Request, std::nullptr_t, true>& requests_list_)
+    {
+      CCF_ASSERT_FMT(
+        requests_list_.get_tail() == nullptr ||
+          requests_list_.get_tail()->time <= time,
+        "items not entred in the correct order. last:{}, time:{}",
+        requests_list_.get_tail()->time,
+        time);
+      auto r = std::make_unique<Request>(hash, time);
+      requests_.insert(r.get());
+      requests_list_.insert_back(r.release());
+    }
+
+    bool remove(
+      const std::array<uint8_t, 32>& hash,
+      std::set<Request*, RequestComp>& requests_,
+      snmalloc::DLList<Request, std::nullptr_t, true>& requests_list_)
+    {
+      Request r(hash);
+      auto it = requests_.find(&r);
+      if (it == requests_.end())
+      {
+        return false;
+      }
+      std::unique_ptr<Request> req(*it);
+      requests_.erase(it);
+      requests_list_.remove(req.get());
+      return true;
+    }
+  };
+}

--- a/src/consensus/aft/impl/request_tracker.h
+++ b/src/consensus/aft/impl/request_tracker.h
@@ -57,6 +57,7 @@ namespace aft
     void insert(
       const std::array<uint8_t, 32>& hash, std::chrono::milliseconds time)
     {
+      LOG_INFO_FMT("AAAAA inserting hash size:{}, size:{}", hash, requests.size());
       if (remove(hash, deleted_requests, deleted_requests_list))
       {
         return;
@@ -80,6 +81,7 @@ namespace aft
     bool remove(
       const std::array<uint8_t, 32>& hash)
     {
+      LOG_INFO_FMT("AAAAA removing hash:{}", hash);
       return remove(hash, requests, requests_list);
     }
 
@@ -115,10 +117,10 @@ namespace aft
     }
 
   private:
-    std::set<Request*, RequestComp> requests;
+    std::multiset<Request*, RequestComp> requests;
     snmalloc::DLList<Request, std::nullptr_t, true> requests_list;
 
-    std::set<Request*, RequestComp> deleted_requests;
+    std::multiset<Request*, RequestComp> deleted_requests;
     snmalloc::DLList<Request, std::nullptr_t, true> deleted_requests_list;
 
     void insert(

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -184,15 +184,18 @@ namespace aft
       return leader_id;
     }
 
-    std::set<NodeId> backups()
+    std::set<NodeId> active_nodes()
     {
+      // Find all nodes present in any active configuration.
       if (backup_nodes.empty())
       {
-        for (auto it : get_latest_configuration())
+        Configuration::Nodes active_nodes;
+
+        for (auto& conf : configurations)
         {
-          if (it.first != leader())
+          for (auto node : conf.nodes)
           {
-            backup_nodes.insert(it.first);
+            backup_nodes.insert(node.first);
           }
         }
       }

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -176,6 +176,20 @@ namespace aft
       return leader_id;
     }
 
+    std::set<NodeId> backups()
+    {
+      std::set<NodeId> backups;
+      for (auto it : get_latest_configuration())
+      {
+        if (it.first != leader())
+        {
+          backups.insert(it.first);
+        }
+      }
+
+      return backups;
+    }
+
     NodeId id()
     {
       return state->my_node_id;

--- a/src/consensus/aft/raft_consensus.h
+++ b/src/consensus/aft/raft_consensus.h
@@ -108,6 +108,11 @@ namespace aft
       return aft->leader();
     }
 
+    std::set<NodeId> backups() override
+    {
+      return aft->backups();
+    }
+
     void recv_message(OArray&& data) override
     {
       return aft->recv_message(std::move(data));

--- a/src/consensus/aft/raft_consensus.h
+++ b/src/consensus/aft/raft_consensus.h
@@ -108,9 +108,9 @@ namespace aft
       return aft->leader();
     }
 
-    std::set<NodeId> backups() override
+    std::set<NodeId> active_nodes() override
     {
-      return aft->backups();
+      return aft->active_nodes();
     }
 
     void recv_message(OArray&& data) override

--- a/src/consensus/aft/test/driver.cpp
+++ b/src/consensus/aft/test/driver.cpp
@@ -11,6 +11,14 @@
 
 using namespace std;
 
+threading::ThreadMessaging threading::ThreadMessaging::thread_messaging;
+std::atomic<uint16_t> threading::ThreadMessaging::thread_count = 0;
+
+namespace threading
+{
+  std::map<std::thread::id, uint16_t> thread_ids;
+}
+
 constexpr auto shash = ds::fnv_1a<size_t>;
 
 int main(int argc, char** argv)

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -61,6 +61,7 @@ public:
         nullptr,
         std::make_shared<aft::RequestTracker>(),
         ms(10),
+        ms(i * 100),
         ms(i * 100));
 
       _nodes.emplace(node_id, NodeDriver{kv, raft});

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -59,6 +59,7 @@ public:
         request_map,
         std::make_shared<aft::State>(node_id),
         nullptr,
+        std::make_shared<aft::RequestTracker>(),
         ms(10),
         ms(i * 100));
 

--- a/src/consensus/aft/test/main.cpp
+++ b/src/consensus/aft/test/main.cpp
@@ -42,6 +42,7 @@ DOCTEST_TEST_CASE("Single node startup" * doctest::test_suite("single"))
     request_map,
     std::make_shared<aft::State>(node_id),
     nullptr,
+    nullptr,
     ms(10),
     election_timeout);
 
@@ -84,6 +85,7 @@ DOCTEST_TEST_CASE("Single node commit" * doctest::test_suite("single"))
     cert,
     request_map,
     std::make_shared<aft::State>(node_id),
+    nullptr,
     nullptr,
     ms(10),
     election_timeout);
@@ -137,6 +139,7 @@ DOCTEST_TEST_CASE(
     request_map,
     std::make_shared<aft::State>(node_id0),
     nullptr,
+    nullptr,
     request_timeout,
     ms(20));
   TRaft r1(
@@ -151,6 +154,7 @@ DOCTEST_TEST_CASE(
     request_map,
     std::make_shared<aft::State>(node_id1),
     nullptr,
+    nullptr,
     request_timeout,
     ms(100));
   TRaft r2(
@@ -164,6 +168,7 @@ DOCTEST_TEST_CASE(
     cert,
     request_map,
     std::make_shared<aft::State>(node_id2),
+    nullptr,
     nullptr,
     request_timeout,
     ms(50));
@@ -340,6 +345,7 @@ DOCTEST_TEST_CASE(
     request_map,
     std::make_shared<aft::State>(node_id0),
     nullptr,
+    nullptr,
     request_timeout,
     ms(20));
   TRaft r1(
@@ -354,6 +360,7 @@ DOCTEST_TEST_CASE(
     request_map,
     std::make_shared<aft::State>(node_id1),
     nullptr,
+    nullptr,
     request_timeout,
     ms(100));
   TRaft r2(
@@ -367,6 +374,7 @@ DOCTEST_TEST_CASE(
     cert,
     request_map,
     std::make_shared<aft::State>(node_id2),
+    nullptr,
     nullptr,
     request_timeout,
     ms(50));
@@ -512,6 +520,7 @@ DOCTEST_TEST_CASE("Multiple nodes late join" * doctest::test_suite("multiple"))
     request_map,
     std::make_shared<aft::State>(node_id0),
     nullptr,
+    nullptr,
     request_timeout,
     ms(20));
   TRaft r1(
@@ -526,6 +535,7 @@ DOCTEST_TEST_CASE("Multiple nodes late join" * doctest::test_suite("multiple"))
     request_map,
     std::make_shared<aft::State>(node_id1),
     nullptr,
+    nullptr,
     request_timeout,
     ms(100));
   TRaft r2(
@@ -539,6 +549,7 @@ DOCTEST_TEST_CASE("Multiple nodes late join" * doctest::test_suite("multiple"))
     cert,
     request_map,
     std::make_shared<aft::State>(node_id2),
+    nullptr,
     nullptr,
     request_timeout,
     ms(50));
@@ -666,6 +677,7 @@ DOCTEST_TEST_CASE("Recv append entries logic" * doctest::test_suite("multiple"))
     request_map,
     std::make_shared<aft::State>(node_id0),
     nullptr,
+    nullptr,
     request_timeout,
     ms(20));
   TRaft r1(
@@ -679,6 +691,7 @@ DOCTEST_TEST_CASE("Recv append entries logic" * doctest::test_suite("multiple"))
     cert,
     request_map,
     std::make_shared<aft::State>(node_id1),
+    nullptr,
     nullptr,
     request_timeout,
     ms(100));
@@ -878,6 +891,7 @@ DOCTEST_TEST_CASE("Exceed append entries limit")
     request_map,
     std::make_shared<aft::State>(node_id0),
     nullptr,
+    nullptr,
     request_timeout,
     ms(20));
   TRaft r1(
@@ -892,6 +906,7 @@ DOCTEST_TEST_CASE("Exceed append entries limit")
     request_map,
     std::make_shared<aft::State>(node_id1),
     nullptr,
+    nullptr,
     request_timeout,
     ms(100));
   TRaft r2(
@@ -905,6 +920,7 @@ DOCTEST_TEST_CASE("Exceed append entries limit")
     cert,
     request_map,
     std::make_shared<aft::State>(node_id2),
+    nullptr,
     nullptr,
     request_timeout,
     ms(50));

--- a/src/consensus/aft/test/main.cpp
+++ b/src/consensus/aft/test/main.cpp
@@ -20,6 +20,9 @@ using Store = aft::LoggingStubStore;
 using StoreSig = aft::LoggingStubStoreSig;
 using Adaptor = aft::Adaptor<Store, kv::DeserialiseSuccess>;
 
+threading::ThreadMessaging threading::ThreadMessaging::thread_messaging;
+std::atomic<uint16_t> threading::ThreadMessaging::thread_count = 0;
+
 std::vector<uint8_t> cert;
 kv::Map<size_t, aft::Request> request_map(
   nullptr, "test", kv::SecurityDomain::PUBLIC, true);
@@ -44,7 +47,8 @@ DOCTEST_TEST_CASE("Single node startup" * doctest::test_suite("single"))
     nullptr,
     nullptr,
     ms(10),
-    election_timeout);
+    election_timeout,
+    ms(1000));
 
   kv::Consensus::Configuration::Nodes config;
   config.try_emplace(node_id);
@@ -88,7 +92,8 @@ DOCTEST_TEST_CASE("Single node commit" * doctest::test_suite("single"))
     nullptr,
     nullptr,
     ms(10),
-    election_timeout);
+    election_timeout,
+    ms(1000));
 
   aft::Configuration::Nodes config;
   config[node_id] = {};
@@ -141,7 +146,8 @@ DOCTEST_TEST_CASE(
     nullptr,
     nullptr,
     request_timeout,
-    ms(20));
+    ms(20),
+    ms(1000));
   TRaft r1(
     ConsensusType::CFT,
     std::make_unique<Adaptor>(kv_store1),
@@ -156,7 +162,8 @@ DOCTEST_TEST_CASE(
     nullptr,
     nullptr,
     request_timeout,
-    ms(100));
+    ms(100),
+    ms(1000));
   TRaft r2(
     ConsensusType::CFT,
     std::make_unique<Adaptor>(kv_store2),
@@ -171,7 +178,8 @@ DOCTEST_TEST_CASE(
     nullptr,
     nullptr,
     request_timeout,
-    ms(50));
+    ms(50),
+    ms(1000));
 
   aft::Configuration::Nodes config;
   config[node_id0] = {};
@@ -347,7 +355,8 @@ DOCTEST_TEST_CASE(
     nullptr,
     nullptr,
     request_timeout,
-    ms(20));
+    ms(20),
+    ms(1000));
   TRaft r1(
     ConsensusType::CFT,
     std::make_unique<Adaptor>(kv_store1),
@@ -362,7 +371,8 @@ DOCTEST_TEST_CASE(
     nullptr,
     nullptr,
     request_timeout,
-    ms(100));
+    ms(100),
+    ms(1000));
   TRaft r2(
     ConsensusType::CFT,
     std::make_unique<Adaptor>(kv_store2),
@@ -377,7 +387,8 @@ DOCTEST_TEST_CASE(
     nullptr,
     nullptr,
     request_timeout,
-    ms(50));
+    ms(50),
+    ms(1000));
 
   aft::Configuration::Nodes config;
   config[node_id0] = {};
@@ -522,7 +533,8 @@ DOCTEST_TEST_CASE("Multiple nodes late join" * doctest::test_suite("multiple"))
     nullptr,
     nullptr,
     request_timeout,
-    ms(20));
+    ms(20),
+    ms(1000));
   TRaft r1(
     ConsensusType::CFT,
     std::make_unique<Adaptor>(kv_store1),
@@ -537,7 +549,8 @@ DOCTEST_TEST_CASE("Multiple nodes late join" * doctest::test_suite("multiple"))
     nullptr,
     nullptr,
     request_timeout,
-    ms(100));
+    ms(100),
+    ms(1000));
   TRaft r2(
     ConsensusType::CFT,
     std::make_unique<Adaptor>(kv_store2),
@@ -552,7 +565,8 @@ DOCTEST_TEST_CASE("Multiple nodes late join" * doctest::test_suite("multiple"))
     nullptr,
     nullptr,
     request_timeout,
-    ms(50));
+    ms(50),
+    ms(1000));
 
   aft::Configuration::Nodes config;
   config[node_id0] = {};
@@ -679,7 +693,8 @@ DOCTEST_TEST_CASE("Recv append entries logic" * doctest::test_suite("multiple"))
     nullptr,
     nullptr,
     request_timeout,
-    ms(20));
+    ms(20),
+    ms(1000));
   TRaft r1(
     ConsensusType::CFT,
     std::make_unique<Adaptor>(kv_store1),
@@ -694,7 +709,8 @@ DOCTEST_TEST_CASE("Recv append entries logic" * doctest::test_suite("multiple"))
     nullptr,
     nullptr,
     request_timeout,
-    ms(100));
+    ms(100),
+    ms(1000));
 
   aft::Configuration::Nodes config0;
   config0[node_id0] = {};
@@ -893,7 +909,8 @@ DOCTEST_TEST_CASE("Exceed append entries limit")
     nullptr,
     nullptr,
     request_timeout,
-    ms(20));
+    ms(20),
+    ms(1000));
   TRaft r1(
     ConsensusType::CFT,
     std::make_unique<Adaptor>(kv_store1),
@@ -908,7 +925,8 @@ DOCTEST_TEST_CASE("Exceed append entries limit")
     nullptr,
     nullptr,
     request_timeout,
-    ms(100));
+    ms(100),
+    ms(1000));
   TRaft r2(
     ConsensusType::CFT,
     std::make_unique<Adaptor>(kv_store2),
@@ -923,7 +941,8 @@ DOCTEST_TEST_CASE("Exceed append entries limit")
     nullptr,
     nullptr,
     request_timeout,
-    ms(50));
+    ms(50),
+    ms(1000));
 
   aft::Configuration::Nodes config0;
   config0[node_id0] = {};

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -72,7 +72,7 @@ namespace enclave
       rpc_map(std::make_shared<RPCMap>()),
       rpcsessions(std::make_shared<RPCSessions>(writer_factory, rpc_map)),
       cmd_forwarder(std::make_shared<ccf::Forwarder<ccf::NodeToNode>>(
-        rpcsessions, n2n_channels, rpc_map)),
+        rpcsessions, n2n_channels, rpc_map, consensus_type_)),
       context(ccf::historical::StateCache(
         *network.tables, writer_factory.create_writer_to_outside()))
     {

--- a/src/enclave/forwarder_types.h
+++ b/src/enclave/forwarder_types.h
@@ -23,10 +23,13 @@ namespace enclave
     virtual bool forward_command(
       std::shared_ptr<enclave::RpcContext> rpc_ctx,
       ccf::NodeId to,
+      std::set<ccf::NodeId> nodes,
       ccf::CallerId caller_id,
       const std::vector<uint8_t>& caller_cert) = 0;
 
     virtual void send_request_hash_to_nodes(
-      std::shared_ptr<enclave::RpcContext> rpc_ctx, std::set<ccf::NodeId> nodes) = 0;
+      std::shared_ptr<enclave::RpcContext> rpc_ctx,
+      std::set<ccf::NodeId> nodes,
+      ccf::NodeId skip_node) = 0;
   };
 }

--- a/src/enclave/forwarder_types.h
+++ b/src/enclave/forwarder_types.h
@@ -25,5 +25,8 @@ namespace enclave
       ccf::NodeId to,
       ccf::CallerId caller_id,
       const std::vector<uint8_t>& caller_cert) = 0;
+
+    virtual void send_request_hash_to_nodes(
+      std::shared_ptr<enclave::RpcContext> rpc_ctx, std::set<ccf::NodeId> nodes) = 0;
   };
 }

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -338,7 +338,7 @@ namespace kv
     virtual void initialise_view_history(const std::vector<SeqNo>&) = 0;
     virtual SeqNo get_committed_seqno() = 0;
     virtual NodeId primary() = 0;
-    virtual std::set<NodeId> backups() = 0;
+    virtual std::set<NodeId> active_nodes() = 0;
 
     virtual void recv_message(OArray&& oa) = 0;
     virtual void add_configuration(

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -338,6 +338,7 @@ namespace kv
     virtual void initialise_view_history(const std::vector<SeqNo>&) = 0;
     virtual SeqNo get_committed_seqno() = 0;
     virtual NodeId primary() = 0;
+    virtual std::set<NodeId> backups() = 0;
 
     virtual void recv_message(OArray&& oa) = 0;
     virtual void add_configuration(

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -108,7 +108,7 @@ namespace kv
       return 1;
     }
 
-    std::set<NodeId> backups() override
+    std::set<NodeId> active_nodes() override
     {
       return {};
     }

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -108,6 +108,11 @@ namespace kv
       return 1;
     }
 
+    std::set<NodeId> backups() override
+    {
+      return {};
+    }
+
     NodeId id() override
     {
       return 0;

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1650,6 +1650,7 @@ namespace ccf
       setup_n2n_channels();
       setup_cmd_forwarder();
 
+      auto request_tracker = std::make_shared<aft::RequestTracker>();
       auto shared_state = std::make_shared<aft::State>(self);
       auto raft = std::make_unique<RaftType>(
         network.consensus_type,
@@ -1665,6 +1666,7 @@ namespace ccf
         shared_state,
         std::make_shared<aft::ExecutorImpl>(
           network.bft_requests_map, shared_state, rpc_map, rpcsessions),
+        request_tracker,
         std::chrono::milliseconds(consensus_config.raft_request_timeout),
         std::chrono::milliseconds(consensus_config.raft_election_timeout),
         public_only);
@@ -1673,6 +1675,7 @@ namespace ccf
         std::move(raft), network.consensus_type);
 
       network.tables->set_consensus(consensus);
+      cmd_forwarder->set_request_tracker(request_tracker);
 
       // When a node is added, even locally, inform raft so that it
       // can add a new active configuration.

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1669,6 +1669,7 @@ namespace ccf
         request_tracker,
         std::chrono::milliseconds(consensus_config.raft_request_timeout),
         std::chrono::milliseconds(consensus_config.raft_election_timeout),
+        std::chrono::milliseconds(consensus_config.pbft_view_change_timeout),
         public_only);
 
       consensus = std::make_shared<RaftConsensusType>(

--- a/src/node/node_types.h
+++ b/src/node/node_types.h
@@ -65,7 +65,8 @@ namespace ccf
   {
     MessageHash() = default;
     MessageHash(ForwardedMsg msg_, NodeId from_node_) :
-      msg(msg_), from_node(from_node_)
+      msg(msg_),
+      from_node(from_node_)
     {}
 
     ForwardedMsg msg;

--- a/src/node/node_types.h
+++ b/src/node/node_types.h
@@ -64,12 +64,9 @@ namespace ccf
   struct MessageHash
   {
     MessageHash() = default;
-    MessageHash(
-      ForwardedMsg msg_, NodeId from_node_, std::vector<uint8_t> hash_) :
+    MessageHash(ForwardedMsg msg_, NodeId from_node_) :
       msg(msg_), from_node(from_node_)
-    {
-      std::copy(hash_.begin(), hash_.end(), hash.begin());
-    }
+    {}
 
     ForwardedMsg msg;
     NodeId from_node;

--- a/src/node/node_types.h
+++ b/src/node/node_types.h
@@ -34,7 +34,8 @@ namespace ccf
   enum ForwardedMsg : Node2NodeMsg
   {
     forwarded_cmd = 0,
-    forwarded_response
+    forwarded_response,
+    request_hash
   };
 
 #pragma pack(push, 1)
@@ -58,6 +59,21 @@ namespace ccf
     ForwardedMsg msg;
     NodeId from_node;
     enclave::FrameFormat frame_format = enclave::FrameFormat::http;
+  };
+
+  struct MessageHash
+  {
+    MessageHash() = default;
+    MessageHash(
+      ForwardedMsg msg_, NodeId from_node_, std::vector<uint8_t> hash_) :
+      msg(msg_), from_node(from_node_)
+    {
+      std::copy(hash_.begin(), hash_.end(), hash.begin());
+    }
+
+    ForwardedMsg msg;
+    NodeId from_node;
+    std::array<uint8_t, 32> hash;
   };
 #pragma pack(pop)
 

--- a/src/node/request_tracker.h
+++ b/src/node/request_tracker.h
@@ -95,7 +95,8 @@ namespace aft
              hashes_without_requests_list.get_head()->time < current_time)
       {
         Request* req = hashes_without_requests_list.get_head();
-        remove(req->hash, hashes_without_requests, hashes_without_requests_list);
+        remove(
+          req->hash, hashes_without_requests, hashes_without_requests_list);
       }
     }
 
@@ -111,7 +112,8 @@ namespace aft
     bool is_empty()
     {
       return requests.empty() && requests_list.is_empty() &&
-        hashes_without_requests.empty() && hashes_without_requests_list.is_empty();
+        hashes_without_requests.empty() &&
+        hashes_without_requests_list.is_empty();
     }
 
   private:
@@ -119,7 +121,8 @@ namespace aft
     snmalloc::DLList<Request, std::nullptr_t, true> requests_list;
 
     std::multiset<Request*, RequestComp> hashes_without_requests;
-    snmalloc::DLList<Request, std::nullptr_t, true> hashes_without_requests_list;
+    snmalloc::DLList<Request, std::nullptr_t, true>
+      hashes_without_requests_list;
 
     void insert(
       const std::array<uint8_t, 32>& hash,

--- a/src/node/request_tracker.h
+++ b/src/node/request_tracker.h
@@ -51,8 +51,8 @@ namespace aft
       }
     };
 
-    static constexpr std::chrono::minutes retail_unmatched_deleted_hashes =
-      std::chrono::minutes(1);
+    static constexpr std::chrono::seconds retail_unmatched_deleted_hashes =
+      std::chrono::seconds(1);
 
   public:
     void insert(

--- a/src/node/request_tracker.h
+++ b/src/node/request_tracker.h
@@ -17,7 +17,8 @@ namespace aft
     {
       Request(
         const std::array<uint8_t, 32>& hash_, std::chrono::milliseconds time_) :
-        hash(hash_), time(time_)
+        hash(hash_),
+        time(time_)
       {}
 
       Request(const std::array<uint8_t, 32>& hash_) : hash(hash_) {}
@@ -57,7 +58,6 @@ namespace aft
     void insert(
       const std::array<uint8_t, 32>& hash, std::chrono::milliseconds time)
     {
-      LOG_INFO_FMT("AAAAA inserting hash size:{}, size:{}", hash, requests.size());
       if (remove(hash, deleted_requests, deleted_requests_list))
       {
         return;
@@ -78,10 +78,8 @@ namespace aft
       insert(hash, time, deleted_requests, deleted_requests_list);
     }
 
-    bool remove(
-      const std::array<uint8_t, 32>& hash)
+    bool remove(const std::array<uint8_t, 32>& hash)
     {
-      LOG_INFO_FMT("AAAAA removing hash:{}", hash);
       return remove(hash, requests, requests_list);
     }
 
@@ -97,13 +95,7 @@ namespace aft
              deleted_requests_list.get_head()->time < current_time)
       {
         Request* req = deleted_requests_list.get_head();
-        auto it = deleted_requests.find(req);
-        CCF_ASSERT_FMT(
-          it != deleted_requests.end(),
-          "Could not find hash:{} in map",
-          req->hash);
-        deleted_requests.erase(req);
-        delete deleted_requests_list.pop();
+        remove(req->hash, deleted_requests, deleted_requests_list);
       }
     }
 
@@ -114,6 +106,12 @@ namespace aft
         return std::nullopt;
       }
       return requests_list.get_head()->time;
+    }
+
+    bool is_empty()
+    {
+      return requests.empty() && requests_list.is_empty() &&
+        deleted_requests.empty() && deleted_requests_list.is_empty();
     }
 
   private:
@@ -153,7 +151,7 @@ namespace aft
       }
 
       auto it = ret.first;
-      for(auto c = ret.first; c != ret.second; ++c)
+      for (auto c = ret.first; c != ret.second; ++c)
       {
         if ((*it)->time > (*c)->time)
         {

--- a/src/node/request_tracker.h
+++ b/src/node/request_tracker.h
@@ -58,7 +58,7 @@ namespace aft
     void insert(
       const std::array<uint8_t, 32>& hash, std::chrono::milliseconds time)
     {
-      if (remove(hash, deleted_requests, deleted_requests_list))
+      if (remove(hash, hashes_without_requests, hashes_without_requests_list))
       {
         return;
       }
@@ -75,7 +75,7 @@ namespace aft
         "cannot add deleted request that is a known request, hash:{}",
         hash);
 #endif
-      insert(hash, time, deleted_requests, deleted_requests_list);
+      insert(hash, time, hashes_without_requests, hashes_without_requests_list);
     }
 
     bool remove(const std::array<uint8_t, 32>& hash)
@@ -91,11 +91,11 @@ namespace aft
       }
       current_time += retail_unmatched_deleted_hashes;
 
-      while (!deleted_requests_list.is_empty() &&
-             deleted_requests_list.get_head()->time < current_time)
+      while (!hashes_without_requests_list.is_empty() &&
+             hashes_without_requests_list.get_head()->time < current_time)
       {
-        Request* req = deleted_requests_list.get_head();
-        remove(req->hash, deleted_requests, deleted_requests_list);
+        Request* req = hashes_without_requests_list.get_head();
+        remove(req->hash, hashes_without_requests, hashes_without_requests_list);
       }
     }
 
@@ -111,15 +111,15 @@ namespace aft
     bool is_empty()
     {
       return requests.empty() && requests_list.is_empty() &&
-        deleted_requests.empty() && deleted_requests_list.is_empty();
+        hashes_without_requests.empty() && hashes_without_requests_list.is_empty();
     }
 
   private:
     std::multiset<Request*, RequestComp> requests;
     snmalloc::DLList<Request, std::nullptr_t, true> requests_list;
 
-    std::multiset<Request*, RequestComp> deleted_requests;
-    snmalloc::DLList<Request, std::nullptr_t, true> deleted_requests_list;
+    std::multiset<Request*, RequestComp> hashes_without_requests;
+    snmalloc::DLList<Request, std::nullptr_t, true> hashes_without_requests_list;
 
     void insert(
       const std::array<uint8_t, 32>& hash,
@@ -130,7 +130,7 @@ namespace aft
       CCF_ASSERT_FMT(
         requests_list_.get_tail() == nullptr ||
           requests_list_.get_tail()->time <= time,
-        "items not entred in the correct order. last:{}, time:{}",
+        "items not entered in the correct order. last:{}, time:{}",
         requests_list_.get_tail()->time,
         time);
       auto r = std::make_unique<Request>(hash, time);

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -125,7 +125,11 @@ namespace ccf
           if (
             primary_id != NoNode &&
             cmd_forwarder->forward_command(
-              ctx, primary_id, caller_id, get_cert_to_forward(ctx, endpoint)))
+              ctx,
+              primary_id,
+              consensus->backups(),
+              caller_id,
+              get_cert_to_forward(ctx, endpoint)))
           {
             // Indicate that the RPC has been forwarded to primary
             LOG_TRACE_FMT("RPC forwarded to primary {}", primary_id);
@@ -134,7 +138,7 @@ namespace ccf
 
           if (consensus->type() == ConsensusType::BFT)
           {
-            send_request_hash_to_nodes(ctx);
+            //send_request_hash_to_nodes(ctx);
           }
         }
         ctx->set_response_status(HTTP_STATUS_INTERNAL_SERVER_ERROR);
@@ -168,9 +172,10 @@ namespace ccf
       }
     }
 
+    /*
     void send_request_hash_to_nodes(std::shared_ptr<enclave::RpcContext> ctx)
     {
-      if (consensus == nullptr)
+      if (consensus == nullptr || cmd_forwarder == nullptr)
       {
         return;
       }
@@ -178,6 +183,7 @@ namespace ccf
       cmd_forwarder->send_request_hash_to_nodes(ctx, backups);
 
     }
+    */
 
     void record_client_signature(
       kv::Tx& tx, CallerId caller_id, const SignedReq& signed_request)
@@ -379,9 +385,9 @@ namespace ccf
 
       if (
         endpoint->properties.forwarding_required != ForwardingRequired::Never &&
-        consensus->type() != ConsensusType::CFT)
+        consensus != nullptr && consensus->type() != ConsensusType::CFT)
       {
-        send_request_hash_to_nodes(ctx);
+        //send_request_hash_to_nodes(ctx);
       }
 
       auto args = EndpointContext{ctx, tx, caller_id};

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -127,7 +127,7 @@ namespace ccf
             cmd_forwarder->forward_command(
               ctx,
               primary_id,
-              consensus->backups(),
+              consensus->active_nodes(),
               caller_id,
               get_cert_to_forward(ctx, endpoint)))
           {

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -135,11 +135,6 @@ namespace ccf
             LOG_TRACE_FMT("RPC forwarded to primary {}", primary_id);
             return std::nullopt;
           }
-
-          if (consensus->type() == ConsensusType::BFT)
-          {
-            //send_request_hash_to_nodes(ctx);
-          }
         }
         ctx->set_response_status(HTTP_STATUS_INTERNAL_SERVER_ERROR);
         ctx->set_response_body(
@@ -171,19 +166,6 @@ namespace ccf
         return ctx->serialise_response();
       }
     }
-
-    /*
-    void send_request_hash_to_nodes(std::shared_ptr<enclave::RpcContext> ctx)
-    {
-      if (consensus == nullptr || cmd_forwarder == nullptr)
-      {
-        return;
-      }
-      auto backups = consensus->backups();
-      cmd_forwarder->send_request_hash_to_nodes(ctx, backups);
-
-    }
-    */
 
     void record_client_signature(
       kv::Tx& tx, CallerId caller_id, const SignedReq& signed_request)
@@ -381,13 +363,6 @@ namespace ccf
             return forward_or_redirect_json(ctx, endpoint, caller_id);
           }
         }
-      }
-
-      if (
-        endpoint->properties.forwarding_required != ForwardingRequired::Never &&
-        consensus != nullptr && consensus->type() != ConsensusType::CFT)
-      {
-        //send_request_hash_to_nodes(ctx);
       }
 
       auto args = EndpointContext{ctx, tx, caller_id};

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -29,6 +29,9 @@ extern "C"
 #include <evercrypt/EverCrypt_AutoConfig2.h>
 }
 
+threading::ThreadMessaging threading::ThreadMessaging::thread_messaging;
+std::atomic<uint16_t> threading::ThreadMessaging::thread_count = 0;
+
 using namespace ccfapp;
 using namespace ccf;
 using namespace std;

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -1192,7 +1192,7 @@ TEST_CASE("Forwarding" * doctest::test_suite("forwarding"))
 
   auto channel_stub = std::make_shared<ChannelStubProxy>();
   auto backup_forwarder = std::make_shared<Forwarder<ChannelStubProxy>>(
-    nullptr, channel_stub, nullptr);
+    nullptr, channel_stub, nullptr, ConsensusType::CFT);
   auto backup_consensus = std::make_shared<kv::BackupStubConsensus>();
   network_backup.tables->set_consensus(backup_consensus);
 
@@ -1414,7 +1414,7 @@ TEST_CASE("Nodefrontend forwarding" * doctest::test_suite("forwarding"))
   network_primary.tables->set_consensus(primary_consensus);
 
   auto backup_forwarder = std::make_shared<Forwarder<ChannelStubProxy>>(
-    nullptr, channel_stub, nullptr);
+    nullptr, channel_stub, nullptr, ConsensusType::CFT);
   node_frontend_backup.set_cmd_forwarder(backup_forwarder);
   auto backup_consensus = std::make_shared<kv::BackupStubConsensus>();
   network_backup.tables->set_consensus(backup_consensus);
@@ -1460,7 +1460,7 @@ TEST_CASE("Userfrontend forwarding" * doctest::test_suite("forwarding"))
   network_primary.tables->set_consensus(primary_consensus);
 
   auto backup_forwarder = std::make_shared<Forwarder<ChannelStubProxy>>(
-    nullptr, channel_stub, nullptr);
+    nullptr, channel_stub, nullptr, ConsensusType::CFT);
   user_frontend_backup.set_cmd_forwarder(backup_forwarder);
   auto backup_consensus = std::make_shared<kv::BackupStubConsensus>();
   network_backup.tables->set_consensus(backup_consensus);
@@ -1508,7 +1508,7 @@ TEST_CASE("Memberfrontend forwarding" * doctest::test_suite("forwarding"))
   network_primary.tables->set_consensus(primary_consensus);
 
   auto backup_forwarder = std::make_shared<Forwarder<ChannelStubProxy>>(
-    nullptr, channel_stub, nullptr);
+    nullptr, channel_stub, nullptr, ConsensusType::CFT);
   member_frontend_backup.set_cmd_forwarder(backup_forwarder);
   auto backup_consensus = std::make_shared<kv::BackupStubConsensus>();
   network_backup.tables->set_consensus(backup_consensus);

--- a/src/node/test/channel_stub.h
+++ b/src/node/test/channel_stub.h
@@ -28,6 +28,17 @@ namespace ccf
     }
 
     template <class T>
+    bool send_authenticated(
+      const ccf::NodeMsgType& msg_type, NodeId to, const T& data)
+    {
+      return true;
+    }
+
+    void send_request_hash_to_nodes(
+      std::shared_ptr<enclave::RpcContext> rpc_ctx, std::set<ccf::NodeId> nodes)
+    {}
+
+    template <class T>
     std::pair<T, std::vector<uint8_t>> recv_encrypted(
       const uint8_t* data, size_t size)
     {

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -202,7 +202,6 @@ TEST_CASE("Request tracker")
     t.insert(h, std::chrono::milliseconds(0));
     REQUIRE(t.oldest_entry().has_value() == false);
 
-
     h[1] = 1;
     REQUIRE(t.remove(h) == false);
     t.insert_deleted(h, std::chrono::milliseconds(100));
@@ -216,5 +215,38 @@ TEST_CASE("Request tracker")
     t.tick(std::chrono::minutes(3));
     t.insert(h, std::chrono::milliseconds(0));
     REQUIRE(t.oldest_entry().has_value());
+  }
+
+  INFO("Can enter multiple items");
+  {
+    aft::RequestTracker t;
+    std::array<uint8_t, 32> h;
+    h.fill(0);
+
+    t.insert(h, std::chrono::milliseconds(0));
+
+    for (uint32_t i = 1; i < 4; ++i)
+    {
+      h[0] = 1;
+      t.insert(h, std::chrono::milliseconds(i));
+    }
+
+    h[0] = 2;
+    t.insert(h, std::chrono::milliseconds(4));
+    REQUIRE(t.oldest_entry() == std::chrono::milliseconds(0));
+
+    h[0] = 1;
+    REQUIRE(t.remove(h));
+    REQUIRE(t.oldest_entry() == std::chrono::milliseconds(0));
+
+    h[0] = 0;
+    t.remove(h);
+    REQUIRE(t.oldest_entry() == std::chrono::milliseconds(2));
+
+    h[0] = 1;
+    t.remove(h);
+    REQUIRE(t.oldest_entry() == std::chrono::milliseconds(3));
+    t.remove(h);
+    REQUIRE(t.oldest_entry() == std::chrono::milliseconds(4));
   }
 }

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -5,6 +5,7 @@
 
 #include "kv/store.h"
 #include "node/nodes.h"
+#include "consensus/aft/impl/request_tracker.h"
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
@@ -158,5 +159,62 @@ TEST_CASE("Ordered Execution")
   for (uint32_t i = 0; i < 4; ++i)
   {
     run_ordered_execution(i);
+  }
+}
+
+TEST_CASE("Request tracker")
+{
+  INFO("Can add and remove from progress tracker");
+  {
+    aft::RequestTracker t;
+    std::array<uint8_t, 32> h;
+    h.fill(0);
+    for (uint32_t i = 0; i < 10; ++i)
+    {
+      h[0] = i;
+      t.insert(h, std::chrono::milliseconds(i));
+      REQUIRE(t.oldest_entry() == std::chrono::milliseconds(0));
+    }
+
+    h[0] = 2;
+    REQUIRE(t.remove(h));
+    REQUIRE(t.oldest_entry() == std::chrono::milliseconds(0));
+
+    h[0] = 0;
+    REQUIRE(t.remove(h));
+    REQUIRE(t.oldest_entry() == std::chrono::milliseconds(1));
+
+    h[0] = 99;
+    REQUIRE(t.remove(h) == false);
+    REQUIRE(t.oldest_entry() == std::chrono::milliseconds(1));
+  }
+
+  INFO("Entry that was deleted is not tracked after it is added");
+  {
+    aft::RequestTracker t;
+    std::array<uint8_t, 32> h;
+    h.fill(0);
+    REQUIRE(t.oldest_entry().has_value() == false);
+
+    h[0] = 0;
+    REQUIRE(t.remove(h) == false);
+    t.insert_deleted(h, std::chrono::milliseconds(100));
+    t.insert(h, std::chrono::milliseconds(0));
+    REQUIRE(t.oldest_entry().has_value() == false);
+
+
+    h[1] = 1;
+    REQUIRE(t.remove(h) == false);
+    t.insert_deleted(h, std::chrono::milliseconds(100));
+    t.tick(std::chrono::milliseconds(120));
+    t.insert(h, std::chrono::milliseconds(0));
+    REQUIRE(t.oldest_entry().has_value() == false);
+
+    h[2] = 2;
+    REQUIRE(t.remove(h) == false);
+    t.insert_deleted(h, std::chrono::milliseconds(100));
+    t.tick(std::chrono::minutes(3));
+    t.insert(h, std::chrono::milliseconds(0));
+    REQUIRE(t.oldest_entry().has_value());
   }
 }

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -5,7 +5,7 @@
 
 #include "kv/store.h"
 #include "node/nodes.h"
-#include "consensus/aft/impl/request_tracker.h"
+#include "node/request_tracker.h"
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
@@ -213,6 +213,7 @@ TEST_CASE("Request tracker")
     REQUIRE(t.remove(h) == false);
     t.insert_deleted(h, std::chrono::milliseconds(100));
     t.tick(std::chrono::minutes(3));
+    REQUIRE(t.is_empty());
     t.insert(h, std::chrono::milliseconds(0));
     REQUIRE(t.oldest_entry().has_value());
   }
@@ -248,5 +249,11 @@ TEST_CASE("Request tracker")
     REQUIRE(t.oldest_entry() == std::chrono::milliseconds(3));
     t.remove(h);
     REQUIRE(t.oldest_entry() == std::chrono::milliseconds(4));
+    t.remove(h);
+    REQUIRE(!t.is_empty());
+
+    h[0] = 2;
+    t.remove(h);
+    REQUIRE(t.is_empty());
   }
 }

--- a/src/tls/hash.h
+++ b/src/tls/hash.h
@@ -10,6 +10,9 @@ namespace tls
 {
   using HashBytes = std::vector<uint8_t>;
 
+  template <size_t T>
+  using HashFixedSize = std::array<uint8_t, T>;
+
   /**
    * Hash the given data, with the specified digest algorithm
    *
@@ -27,6 +30,29 @@ namespace tls
     if (o_hash.size() < hash_size)
     {
       o_hash.resize(hash_size);
+    }
+
+    return mbedtls_md(md_info, data_ptr, data_size, o_hash.data());
+  }
+
+  /**
+   * Hash the given data, with the specified digest algorithm
+   *
+   * @return 0 on success
+   */
+  template<size_t T>
+  inline int do_hash(
+    const uint8_t* data_ptr,
+    size_t data_size,
+    HashFixedSize<T>& o_hash,
+    mbedtls_md_type_t md_type)
+  {
+    const auto md_info = mbedtls_md_info_from_type(md_type);
+    const auto hash_size = mbedtls_md_get_size(md_info);
+
+    if (o_hash.size() != hash_size)
+    {
+      return -1;
     }
 
     return mbedtls_md(md_info, data_ptr, data_size, o_hash.data());

--- a/src/tls/hash.h
+++ b/src/tls/hash.h
@@ -40,7 +40,7 @@ namespace tls
    *
    * @return 0 on success
    */
-  template<size_t T>
+  template <size_t T>
   inline int do_hash(
     const uint8_t* data_ptr,
     size_t data_size,


### PR DESCRIPTION
Part of #1709

When a replica forwards a request it will send a hash of the forwarded request to all the other backup nodes. If said request is not executed within a specific period if time we will issue a view-change. This PR introduces the RequestTracker class which is responsible for matching up the hashes which are sent to the requests that are seen by the backups.