### PR TITLE
Vegeta CLI target generator

### DIFF
--- a/tests/generate_vegeta_targets.py
+++ b/tests/generate_vegeta_targets.py
@@ -94,7 +94,6 @@ if __name__ == "__main__":
             end_index = len(remaining_args)
 
         parse_slice = remaining_args[start_index:end_index]
-        LOG.info(f"Parsing: {parse_slice}")
         args, rest = targets_parser.parse_known_args(parse_slice)
         steps += [args]
         remaining_args = remaining_args[end_index:]

--- a/tests/generate_vegeta_targets.py
+++ b/tests/generate_vegeta_targets.py
@@ -1,0 +1,103 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+import argparse
+import json
+import base64
+import sys
+import urllib.parse
+from collections import abc
+from loguru import logger as LOG
+
+
+def build_vegeta_target(hostname, path, body=None, method="POST"):
+    target = {}
+    target["method"] = method
+    target["url"] = urllib.parse.urljoin(f"https://{hostname}", path)
+    target["header"] = {"Content-Type": ["application/json"]}
+    if body is not None:
+        # Bodies must be base64 encoded strings
+        target["body"] = base64.b64encode(json.dumps(body).encode()).decode()
+        target["body"] = body
+    return target
+
+
+def write_vegeta_target_line(f, *args, **kwargs):
+    target = build_vegeta_target(*args, **kwargs)
+    f.write(json.dumps(target))
+    f.write("\n")
+
+
+# Quick and dirty solution for building request bodies that vary
+def recursive_format(obj, i):
+    if isinstance(obj, str):
+        return obj.format(i=i)
+    elif isinstance(obj, int) and obj == 0:
+        return i
+    elif isinstance(obj, abc.Sequence):
+        return [recursive_format(e, i) for e in obj]
+    elif isinstance(obj, abc.Mapping):
+        return {recursive_format(k, i): recursive_format(v, i) for k, v in obj.items()}
+    else:
+        return obj
+
+
+def append_targets(file, args):
+    for i in range(args.range_start, args.range_end):
+        format_args = {"i": i}
+        path = args.uri_path.format(**format_args)
+        if args.body is not None:
+            body = recursive_format(json.loads(args.body), **format_args)
+        else:
+            body = None
+        write_vegeta_target_line(
+            file,
+            hostname=args.hostname,
+            path=path,
+            method=args.method,
+            body=body,
+        )
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    subparsers = parser.add_subparsers(
+        title="targets",
+        description="Instructions to generate a list of targets. Can be repeated multiple times",
+    )
+    targets_s = "targets"
+    targets_parser = subparsers.add_parser(targets_s)
+
+    targets_parser.add_argument("--uri-path", type=str)
+    targets_parser.add_argument("--range-start", type=int, default=0)
+    targets_parser.add_argument("--range-end", type=int, default=1)
+    targets_parser.add_argument("--method", type=str, default="POST")
+    targets_parser.add_argument("--hostname", type=str, default="127.0.0.1:8000")
+    targets_parser.add_argument("--body", default=None)
+
+    remaining_args = sys.argv[1:]
+    steps = []
+    while remaining_args:
+        try:
+            start_index = remaining_args.index(targets_s)
+        except ValueError:
+            start_index = None
+        if start_index != 0:
+            raise RuntimeError(
+                f"Unable to parse args - next section doesn't begin with '{targets_s}'"
+            )
+
+        try:
+            end_index = remaining_args.index(targets_s, start_index + 1)
+        except ValueError:
+            end_index = len(remaining_args)
+
+        parse_slice = remaining_args[start_index:end_index]
+        LOG.info(f"Parsing: {parse_slice}")
+        args, rest = targets_parser.parse_known_args(parse_slice)
+        steps += [args]
+        remaining_args = remaining_args[end_index:]
+
+    for step in steps:
+        append_targets(sys.stdout, step)

--- a/tests/generate_vegeta_targets.py
+++ b/tests/generate_vegeta_targets.py
@@ -17,7 +17,6 @@ def build_vegeta_target(hostname, path, body=None, method="POST"):
     if body is not None:
         # Bodies must be base64 encoded strings
         target["body"] = base64.b64encode(json.dumps(body).encode()).decode()
-        target["body"] = body
     return target
 
 

--- a/tests/generate_vegeta_targets.py
+++ b/tests/generate_vegeta_targets.py
@@ -30,8 +30,6 @@ def write_vegeta_target_line(f, *args, **kwargs):
 def recursive_format(obj, i):
     if isinstance(obj, str):
         return obj.format(i=i)
-    elif isinstance(obj, int) and obj == 0:
-        return i
     elif isinstance(obj, abc.Sequence):
         return [recursive_format(e, i) for e in obj]
     elif isinstance(obj, abc.Mapping):
@@ -39,13 +37,21 @@ def recursive_format(obj, i):
     else:
         return obj
 
+def nan_replacer(i):
+    def fun(s):
+        if s == "NaN":
+            return i
+        return float(s)
+    return fun
 
 def append_targets(file, args):
     for i in range(args.range_start, args.range_end):
         format_args = {"i": i}
         path = args.uri_path.format(**format_args)
         if args.body is not None:
-            body = recursive_format(json.loads(args.body), **format_args)
+            body = recursive_format(
+                json.loads(args.body, parse_constant=nan_replacer(i)), **format_args
+            )
         else:
             body = None
         write_vegeta_target_line(

--- a/tests/generate_vegeta_targets.py
+++ b/tests/generate_vegeta_targets.py
@@ -6,7 +6,6 @@ import base64
 import sys
 import urllib.parse
 from collections import abc
-from loguru import logger as LOG
 
 
 def build_vegeta_target(hostname, path, body=None, method="POST"):
@@ -37,12 +36,15 @@ def recursive_format(obj, i):
     else:
         return obj
 
+
 def nan_replacer(i):
     def fun(s):
         if s == "NaN":
             return i
         return float(s)
+
     return fun
+
 
 def append_targets(file, args):
     for i in range(args.range_start, args.range_end):

--- a/tests/generate_vegeta_targets.py
+++ b/tests/generate_vegeta_targets.py
@@ -59,21 +59,36 @@ def append_targets(file, args):
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
 
     subparsers = parser.add_subparsers(
         title="targets",
         description="Instructions to generate a list of targets. Can be repeated multiple times",
     )
     targets_s = "targets"
-    targets_parser = subparsers.add_parser(targets_s)
+    targets_parser = subparsers.add_parser(
+        targets_s, formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
 
-    targets_parser.add_argument("--uri-path", type=str)
-    targets_parser.add_argument("--range-start", type=int, default=0)
-    targets_parser.add_argument("--range-end", type=int, default=1)
-    targets_parser.add_argument("--method", type=str, default="POST")
-    targets_parser.add_argument("--hostname", type=str, default="127.0.0.1:8000")
-    targets_parser.add_argument("--body", default=None)
+    targets_parser.add_argument("--uri-path", type=str, help="Path to desired endpoint")
+    targets_parser.add_argument(
+        "--range-start", type=int, default=0, help="First index for range of targets"
+    )
+    targets_parser.add_argument(
+        "--range-end", type=int, default=1, help="End index for range of targets"
+    )
+    targets_parser.add_argument(
+        "--method", type=str, default="POST", help="HTTP method to be called"
+    )
+    targets_parser.add_argument(
+        "--hostname",
+        type=str,
+        default="127.0.0.1:8000",
+        help="Base hostname to submit target to",
+    )
+    targets_parser.add_argument("--body", default=None, help="JSON body of request")
 
     remaining_args = sys.argv[1:]
     steps = []

--- a/tests/vegeta_stress.py
+++ b/tests/vegeta_stress.py
@@ -3,8 +3,6 @@
 import infra.network
 import infra.e2e_args
 import subprocess
-import json
-import base64
 import threading
 import time
 import generate_vegeta_targets as TargetGenerator


### PR DESCRIPTION
Followup to #1763.

I had a bash script for generating Vegeta target streams, but that was rewritten in Python. I've now pulled that generation logic into a separate Python file so we can use it as a CLI tool for manually stressing a network. Its ugly, but removes some of the grunt work, and should be easy to extend if we start using this more often.

Example (command formatted for readability):
```
$ python ../tests/generate_vegeta_targets.py
  targets
    --uri-path /app/hello
  targets
    --uri-path '/app/foo/{i}/bar'
    --range-start 5
    --range-end 9
    --method "GET"
    --hostname 127.1.2.3:1234
    --body '{"Key {i}": ["A message about {i}", NaN]}'
{"method": "POST", "url": "https://127.0.0.1:8000/app/hello", "header": {"Content-Type": ["application/json"]}}
{"method": "GET", "url": "https://127.1.2.3:1234/app/foo/5/bar", "header": {"Content-Type": ["application/json"]}, "body": "eyJLZXkgNSI6IFsiQSBtZXNzYWdlIGFib3V0IDUiLCA1XX0="}
{"method": "GET", "url": "https://127.1.2.3:1234/app/foo/6/bar", "header": {"Content-Type": ["application/json"]}, "body": "eyJLZXkgNiI6IFsiQSBtZXNzYWdlIGFib3V0IDYiLCA2XX0="}
{"method": "GET", "url": "https://127.1.2.3:1234/app/foo/7/bar", "header": {"Content-Type": ["application/json"]}, "body": "eyJLZXkgNyI6IFsiQSBtZXNzYWdlIGFib3V0IDciLCA3XX0="}
{"method": "GET", "url": "https://127.1.2.3:1234/app/foo/8/bar", "header": {"Content-Type": ["application/json"]}, "body": "eyJLZXkgOCI6IFsiQSBtZXNzYWdlIGFib3V0IDgiLCA4XX0="}
```

It does some formatting/interpolation of the inputs, so the base64-decoded bodies on those requests are actually:
```
{"Key 5": ["A message about 5", 5]}
{"Key 6": ["A message about 6", 6]}
{"Key 7": ["A message about 7", 7]}
{"Key 8": ["A message about 8", 8]}
```