### PR TITLE
Implement has(k) on TxView

### DIFF
--- a/src/apps/js_generic/js_generic.cpp
+++ b/src/apps/js_generic/js_generic.cpp
@@ -395,9 +395,9 @@ namespace ccfapp
     if (!key)
       return JS_ThrowTypeError(ctx, "Argument must be an ArrayBuffer");
 
-    auto val = map_view->get({key, key + key_size});
+    auto has = map_view->has({key, key + key_size});
 
-    return JS_NewBool(ctx, val.has_value());
+    return JS_NewBool(ctx, has);
   }
 
   static JSValue js_kv_map_get(

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -1061,7 +1061,8 @@ TEST_CASE("Conflict resolution")
   REQUIRE(res1 == kv::CommitSuccess::OK);
   confirm_state({"baz", "buzz"}, {"bar"});
 
-  // Third transaction completes later, has no conflicts but reports the earlier version it read
+  // Third transaction completes later, has no conflicts but reports the earlier
+  // version it read
   auto res3 = tx3.commit();
   REQUIRE(res3 == kv::CommitSuccess::OK);
 

--- a/src/kv/tx_view.h
+++ b/src/kv/tx_view.h
@@ -54,6 +54,11 @@ namespace kv
       return std::nullopt;
     }
 
+    bool has(const K& key)
+    {
+      return untyped_view.has(KSerialiser::to_serialised(key));
+    }
+
     template <class F>
     void foreach(F&& f)
     {

--- a/src/kv/untyped_tx_view.h
+++ b/src/kv/untyped_tx_view.h
@@ -23,15 +23,61 @@ namespace kv::untyped
 
   class TxView
   {
-  protected:
-    ChangeSet& tx_changes;
-
   public:
     // Expose these types so that other code can use them as MyTx::KeyType or
     // MyMap::TxView::KeyType, templated on the TxView or Map type
     using KeyType = SerialisedEntry;
     using ValueType = SerialisedEntry;
 
+  protected:
+    ChangeSet& tx_changes;
+
+    /** Get pointer to current value if this key exists, else nullptr if it does
+     * not exist or has been deleted. If non-null, points to something owned by
+     * tx_changes - expect this is used/dereferenced immediately, and there is
+     * no concurrent access which could invalidate it. Modifies read set if
+     * appropriate to record read dependency on this key, at the version of the
+     * returned data.
+     */
+    const ValueType* read_key(const KeyType& key) {
+      // A write followed by a read doesn't introduce a read dependency.
+      // If we have written, return the value without updating the read set.
+      auto write = tx_changes.writes.find(key);
+      if (write != tx_changes.writes.end())
+      {
+        if (write->second.has_value())
+        {
+          return &write->second.value();
+        }
+        else
+        {
+          return nullptr;
+        }
+      }
+
+      // If the key doesn't exist, return empty and record that we depend on
+      // the key not existing.
+      const auto search = tx_changes.state.getp(key);
+      if (search == nullptr)
+      {
+        tx_changes.reads.insert(std::make_pair(key, NoVersion));
+        return nullptr;
+      }
+
+      // Record the version that we depend on.
+      tx_changes.reads.insert(std::make_pair(key, search->version));
+
+      // If the key has been deleted, return empty.
+      if (is_deleted(search->version))
+      {
+        return nullptr;
+      }
+
+      // Return the value.
+      return &search->value;
+    }
+
+  public:
     TxView(ChangeSet& cs) : tx_changes(cs) {}
 
     /** Get value for key
@@ -46,37 +92,13 @@ namespace kv::untyped
      */
     std::optional<ValueType> get(const KeyType& key)
     {
-      // A write followed by a read doesn't introduce a read dependency.
-      // If we have written, return the value without updating the read set.
-      auto write = tx_changes.writes.find(key);
-      if (write != tx_changes.writes.end())
-      {
-        // May be empty, for a key that has been removed. This matches the
-        // return semantics
-        return write->second;
-      }
-
-      // If the key doesn't exist, return empty and record that we depend on
-      // the key not existing.
-      auto search = tx_changes.state.get(key);
-      if (!search.has_value())
-      {
-        tx_changes.reads.insert(std::make_pair(key, NoVersion));
-        return std::nullopt;
-      }
-
-      // Record the version that we depend on.
-      auto& found = search.value();
-      tx_changes.reads.insert(std::make_pair(key, found.version));
-
-      // If the key has been deleted, return empty.
-      if (is_deleted(found.version))
+      auto value_p = read_key(key);
+      if (value_p == nullptr)
       {
         return std::nullopt;
       }
 
-      // Return the value.
-      return found.value;
+      return *value_p;
     }
 
     /** Get globally committed value for key
@@ -124,38 +146,8 @@ namespace kv::untyped
      */
     bool has(const KeyType& key)
     {
-      // NB: In terms of dependencies, this is a read equivalent to a get
-
-      // A write followed by a read doesn't introduce a read dependency.
-      // If this is tracked in our write set, return its status there without
-      // updating the read set.
-      auto write = tx_changes.writes.find(key);
-      if (write != tx_changes.writes.end())
-      {
-        return write->second.has_value();
-      }
-
-      // If the key doesn't exist, return false and record that we depend on
-      // the key not existing.
-      auto search = tx_changes.state.get(key);
-      if (!search.has_value())
-      {
-        tx_changes.reads.insert(std::make_pair(key, NoVersion));
-        return false;
-      }
-
-      // Record the version that we depend on.
-      auto& found = search.value();
-      tx_changes.reads.insert(std::make_pair(key, found.version));
-
-      // If the key has been deleted, return false.
-      if (is_deleted(found.version))
-      {
-        return false;
-      }
-
-      // This key exists and is not deleted, return true.
-      return true;
+      auto value_p = read_key(key);
+      return value_p != nullptr;
     }
 
     /** Write value at key

--- a/src/kv/untyped_tx_view.h
+++ b/src/kv/untyped_tx_view.h
@@ -39,7 +39,8 @@ namespace kv::untyped
      * appropriate to record read dependency on this key, at the version of the
      * returned data.
      */
-    const ValueType* read_key(const KeyType& key) {
+    const ValueType* read_key(const KeyType& key)
+    {
       // A write followed by a read doesn't introduce a read dependency.
       // If we have written, return the value without updating the read set.
       auto write = tx_changes.writes.find(key);


### PR DESCRIPTION
Adds a native `.has()` method. This is more efficient than `.get()` as it doesn't deserialise/copy the value.