### PR TITLE
Make foreach iteration over TxViews operate over a copy, to avoid invalidated iterators caused by modifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - `node/quote` endpoint now returns a single JSON object containing the node's quote (#1761).
+- Calling `foreach` on a `TxView` now iterates over the entries which previously existed, ignoring any modifications made by the functor while iterating.
 
 ## [0.14.1]
 ### Added

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -395,26 +395,26 @@ TEST_CASE("Modifications during foreach iteration")
   auto view = tx.get_view(map);
 
   // 5 types of key:
-  // - Some were previously committed and are unmodified
+  // 1) previously committed and unmodified
   const auto initial_keys_size = keys.size();
   const auto keys_per_category = keys.size() / 3;
   // We do nothing to the first keys_per_category keys
 
-  // - Some were previously committed and had their values changed
+  // 2) previously committed and had their values changed
   for (size_t i = keys_per_category; i < 2 * keys_per_category; ++i)
   {
     keys.insert(i);
     view->put(i, value2);
   }
 
-  // - Some were previously committed and now removed
+  // 3) previously committed and now removed
   for (size_t i = 2 * keys_per_category; i < initial_keys_size; ++i)
   {
     keys.erase(i);
     view->remove(i);
   }
 
-  // - Some are newly written
+  // 4) newly written
   for (size_t i = initial_keys_size; i < initial_keys_size + keys_per_category;
        ++i)
   {
@@ -422,7 +422,7 @@ TEST_CASE("Modifications during foreach iteration")
     view->put(i, value2);
   }
 
-  // - Some are newly written and then removed
+  // 5) newly written and then removed
   for (size_t i = initial_keys_size + keys_per_category;
        i < initial_keys_size + 2 * keys_per_category;
        ++i)


### PR DESCRIPTION
Opening this as a draft as there's still discussion around whether these are the semantics we want.

We want to avoid errors when the functor in a `foreach` calls `put` or `remove`.

ie, if we have a map:

```
{
  1: 'a',
  2: 'b'
}
```

and we call:

```
view->foreach([&view](const auto& key, const auto& value)
  {
    LOG_INFO_FMT("{} {};", key, value);
    view->remove(2);
  }
);
```

Since iteration order is undefined, we may be removing 2 before we've called the functor. We _could_ try and get to a point where this example may print _either_ `2 b; 1 a;` _or_ `1 a;`, and does so safely, but I don't think this 'randomness' is useful behaviour.

We could guide users towards only `foreach`ing on `ReadOnly` views, and building their own collection of keys to iterate over. This is slower and hard to enforce (I think we still need to change how we iterate over the `std::map` for safety when they _don't_ do this), but maybe cleaner.

This PR proposes that we define some firm "we iterate over the initial set" semantics, by taking a copy of the write set before iteration. This is perhaps non-obvious at the calling point, but I think provides what users will _expect_ in most cases, and seems a sensible compromise given the undefined iteration order.