### PR TITLE
Fix Daily CI - pass absolute package path

### DIFF
--- a/.daily.yml
+++ b/.daily.yml
@@ -30,3 +30,4 @@ resources:
 
 jobs:
 - template: .azure-pipelines-templates/daily-matrix.yml
+

--- a/.daily.yml
+++ b/.daily.yml
@@ -30,5 +30,3 @@ resources:
 
 jobs:
 - template: .azure-pipelines-templates/daily-matrix.yml
-
- 

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -28,13 +28,13 @@ python -m pip install ../../../python
 # Start ephemeral network in the background
 network_info_file="network_info.txt"
 
-package="$(pwd)"/../../../build/liblogging
 
 network_live_time=30
 timeout --signal=SIGINT --kill-after=${network_live_time}s --preserve-status ${network_live_time}s \
 python "$INSTALL_PREFIX"/bin/start_network.py \
-    -p "${package}" \
+    -p liblogging \
     -b "$INSTALL_PREFIX"/bin \
+    --library-dir ../../../build \
     -g "$(pwd)"/../../../src/runtime_config/gov.lua \
     --network-info-file "$network_info_file" \
     -v &
@@ -59,8 +59,9 @@ cp ./workspace/start_network_0/network_enc_pubk.pem .
 
 timeout --signal=SIGINT --kill-after=${network_live_time}s --preserve-status ${network_live_time}s \
 python "$INSTALL_PREFIX"/bin/start_network.py \
-    -p "${package}" \
+    -p liblogging \
     -b "$INSTALL_PREFIX"/bin \
+    --library-dir ../../../build \
     -v \
     --recover \
     --ledger-dir 0.ledger \

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -12,8 +12,10 @@ echo "Install prefix is ${1}"
 
 # Setup env
 INSTALL_PREFIX="$1"
-mkdir -p nested/run
-cd nested/run
+working_dir="nested/run"
+rm -rf "$working_dir"
+mkdir -p "$working_dir"
+cd "$working_dir"
 
 python3.8 -m venv env
 source env/bin/activate
@@ -26,26 +28,38 @@ python -m pip install ../../../python
 # Start ephemeral network in the background
 network_info_file="network_info.txt"
 
-timeout --signal=SIGINT --kill-after=30s --preserve-status 30s \
+package="$(pwd)"/../../../build/liblogging
+
+network_live_time=30
+timeout --signal=SIGINT --kill-after=${network_live_time}s --preserve-status ${network_live_time}s \
 python "$INSTALL_PREFIX"/bin/start_network.py \
-    -p ../../../build/liblogging \
+    -p "${package}" \
     -b "$INSTALL_PREFIX"/bin \
     -g "$(pwd)"/../../../src/runtime_config/gov.lua \
     --network-info-file "$network_info_file" \
     -v &
 
+# Wait for network to be open and accessible
+while [ ! -f "$network_info_file" ]; do
+    sleep 1
+done
+
 # Issue tutorial transactions to ephemeral network
-sleep 20
 python ../../../python/tutorial.py "$network_info_file"
-sleep 15
+
+# Wait until original network has died
+sleep ${network_live_time}
+
+# ...and a tad longer to be sure
+sleep 5
 
 # Recover network
 cp -r ./workspace/start_network_0/0.ledger .
 cp ./workspace/start_network_0/network_enc_pubk.pem .
 
-timeout --signal=SIGINT --kill-after=30s --preserve-status 30s \
+timeout --signal=SIGINT --kill-after=${network_live_time}s --preserve-status ${network_live_time}s \
 python "$INSTALL_PREFIX"/bin/start_network.py \
-    -p ../../../build/liblogging \
+    -p "${package}" \
     -b "$INSTALL_PREFIX"/bin \
     -v \
     --recover \


### PR DESCRIPTION
The recent `--library-dir` means that relative package paths must be relative to the binary dir, not the working directory. For simplicity, the path in `test_install.sh` is now an absolute path.

Unrelated tweak in the same script - wait for `network_info.txt` to appear as a sign the network is open.