### PR TITLE
Return 404s from js_generic

### DIFF
--- a/src/apps/js_generic/js_generic.cpp
+++ b/src/apps/js_generic/js_generic.cpp
@@ -1068,7 +1068,7 @@ namespace ccfapp
           args.rpc_ctx->get_method(), args.rpc_ctx->get_request_verb(), args);
       };
 
-      set_default(default_handler);
+      set_default(default_handler).set_require_client_identity(false);
     }
 
     EndpointDefinitionPtr find_endpoint(

--- a/tests/content_types.py
+++ b/tests/content_types.py
@@ -92,6 +92,40 @@ def test_content_types(network, args):
     return network
 
 
+@reqs.description("Test unknown path")
+def test_unknown_path(network, args):
+    primary, _ = network.find_nodes()
+
+    with tempfile.NamedTemporaryFile("w") as f:
+        f.write(APP_SCRIPT)
+        f.flush()
+        network.consortium.set_js_app(remote_node=primary, app_script_path=f.name)
+
+    with primary.client("user0") as c:
+        r = c.get("/app/not/a/real/path")
+        assert r.status_code == http.HTTPStatus.NOT_FOUND, r.status_code
+        r = c.post("/app/not/a/real/path")
+        assert r.status_code == http.HTTPStatus.NOT_FOUND, r.status_code
+        r = c.delete("/app/not/a/real/path")
+        assert r.status_code == http.HTTPStatus.NOT_FOUND, r.status_code
+
+        r = c.post("/app/unknown")
+        assert r.status_code == http.HTTPStatus.NOT_FOUND, r.status_code
+
+    with primary.client() as c:
+        r = c.get("/app/not/a/real/path")
+        assert r.status_code == http.HTTPStatus.NOT_FOUND, r.status_code
+        r = c.post("/app/not/a/real/path")
+        assert r.status_code == http.HTTPStatus.NOT_FOUND, r.status_code
+        r = c.delete("/app/not/a/real/path")
+        assert r.status_code == http.HTTPStatus.NOT_FOUND, r.status_code
+
+        r = c.post("/app/unknown")
+        assert r.status_code == http.HTTPStatus.NOT_FOUND, r.status_code
+
+    return network
+
+
 def run(args):
     hosts = ["localhost"] * (3 if args.consensus == "pbft" else 2)
 
@@ -100,6 +134,7 @@ def run(args):
     ) as network:
         network.start_and_join(args)
         network = test_content_types(network, args)
+        network = test_unknown_path(network, args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As noted in #1772, we are sometimes returning `403` from JS apps when we should really be returning `404`. This happens if we send an anonymous request to a non-existent path, because the default handler is selected and has all of the normal endpoint properties including a `require_client_identity = true`.

I'd like to remove the default_handler entirely in favour of the dynamic dispatch, but this is slightly more involved (we have multiple proposals for creating JS apps, but only `deploy_js_app` sidesteps the default_handler - I think we should remove the others) so I'll leave it for a future PR.