### PR TITLE
Update documentation related to start_test_network.sh to talk about sandbox.sh instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Changed
+- The `start_test_network.sh` script has been replaced by [`sandbox.sh`](https://microsoft.github.io/CCF/master/quickstart/test_network.html). Users wishing to override the default network config (a single node on '127.0.0.1:8000') must now explicly specify if they should be started locally (eg. `-n 'local://127.4.4.5:7000'`) or on remote machine via password-less ssh (eg. `-n 'ssh://10.0.0.1:6000'`).
 - `node/quote` endpoint now returns a single JSON object containing the node's quote (#1761).
 - Calling `foreach` on a `TxView` now iterates over the entries which previously existed, ignoring any modifications made by the functor while iterating.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Changed
-- The `start_test_network.sh` script has been replaced by [`sandbox.sh`](https://microsoft.github.io/CCF/master/quickstart/test_network.html). Users wishing to override the default network config (a single node on '127.0.0.1:8000') must now explicly specify if they should be started locally (eg. `-n 'local://127.4.4.5:7000'`) or on remote machine via password-less ssh (eg. `-n 'ssh://10.0.0.1:6000'`).
+- The `start_test_network.sh` script has been replaced by [`sandbox.sh`](https://microsoft.github.io/CCF/master/quickstart/test_network.html). Users wishing to override the default network config (a single node on '127.0.0.1:8000') must now explictly specify if they should be started locally (eg. `-n 'local://127.4.4.5:7000'`) or on remote machine via password-less ssh (eg. `-n 'ssh://10.0.0.1:6000'`).
 - `node/quote` endpoint now returns a single JSON object containing the node's quote (#1761).
 - Calling `foreach` on a `TxView` now iterates over the entries which previously existed, ignoring any modifications made by the functor while iterating.
 

--- a/doc/developers/demo.rst
+++ b/doc/developers/demo.rst
@@ -6,7 +6,7 @@ This document explains how to spin up a test CCF network and submit simple comma
 Startup
 -------
 
-This uses the :ref:`example C++ logging app <developers/logging_cpp:Logging (C++)>` and the ``sandbox.sh`` helper script from the main CCF repo.
+This uses the :ref:`example C++ logging app <developers/logging_cpp:Logging (C++)>` and the ``sandbox.sh`` helper script included in CCF releases under the 'bin' directory.
 
 ``sandbox.sh`` is a thin wrapper around ``start_network.py``. It ensures the necessary Python dependencies are available and sets some sensible default values.
 There are a large number of additional configuration options, documented by passing the ``--help`` argument. You may wish to pass ``-v`` which will make the script significantly more verbose, printing the precise ``curl`` commands which were used to communicate with the test network.

--- a/doc/developers/demo.rst
+++ b/doc/developers/demo.rst
@@ -33,7 +33,7 @@ The following command will run a simple one node test network on a single machin
     [16:14:10.010] Started CCF network with the following nodes:
     [16:14:10.011]   Node [0] = https://127.0.0.1:8000
     [16:14:10.011] You can now issue business transactions to the ./liblogging.virtual.so application.
-    [16:14:10.011] Keys and certificates have been copied to the common folder: /data/amchamay/CCF/build/workspace/sandbox_common
+    [16:14:10.011] Keys and certificates have been copied to the common folder: /data/src/CCF/build/workspace/sandbox_common
     [16:14:10.011] See https://microsoft.github.io/CCF/master/users/issue_commands.html for more information.
     [16:14:10.011] Press Ctrl+C to shutdown the network.
 
@@ -125,4 +125,3 @@ Note that the paths to these handlers is arbitrary. The names of the endpoints d
     Not visible
 
 .. _curl: https://curl.haxx.se/
-

--- a/doc/developers/demo.rst
+++ b/doc/developers/demo.rst
@@ -25,7 +25,7 @@ The following command will run a simple one node test network on a single machin
 
     $ cd CCF/build
 
-    $ ../sandbox.sh -p ./liblogging.virtual.so
+    $ ../tests/sandbox.sh -p ./liblogging.virtual.so
     Setting up Python environment...
     Python environment successfully setup
     [16:14:05.294] Starting 1 CCF nodes...

--- a/doc/developers/demo.rst
+++ b/doc/developers/demo.rst
@@ -6,9 +6,10 @@ This document explains how to spin up a test CCF network and submit simple comma
 Startup
 -------
 
-This uses the :ref:`example C++ logging app <developers/logging_cpp:Logging (C++)>` and the ``start_test_network.sh`` helper script from the main CCF repo.
+This uses the :ref:`example C++ logging app <developers/logging_cpp:Logging (C++)>` and the ``sandbox.sh`` helper script from the main CCF repo.
 
-``start_test_network.sh`` is a thin wrapper around ``start_network.py``. It ensures the necessary Python dependencies are available, sets some sensible default values, and uses ``curl`` to submit CCF commands (``CURL_CLIENT=ON``). There are a large number of additional configuration options, documented by passing the ``--help`` argument. You may wish to pass ``-v`` which will make the script significantly more verbose, printing the precise ``curl`` commands which were used to communicate with the test network.
+``sandbox.sh`` is a thin wrapper around ``start_network.py``. It ensures the necessary Python dependencies are available and sets some sensible default values.
+There are a large number of additional configuration options, documented by passing the ``--help`` argument. You may wish to pass ``-v`` which will make the script significantly more verbose, printing the precise ``curl`` commands which were used to communicate with the test network.
 
 This script automates the steps described in :doc:`/operators/start_network`, in summary:
 
@@ -18,27 +19,26 @@ This script automates the steps described in :doc:`/operators/start_network`, in
 - verifying that each node has successfully joined the new service
 - proposing and passing governance votes using the generated member identities
 
-The following command will run a simple 3-node test network on a single machine:
+The following command will run a simple one node test network on a single machine:
 
 .. code-block:: bash
 
     $ cd CCF/build
 
-    $ ../start_test_network.sh --package ./liblogging.enclave.so.signed
+    $ ../sandbox.sh -p ./liblogging.virtual.signed
     Setting up Python environment...
-    ...
     Python environment successfully setup
-    [15:27:41.759] Starting 3 CCF nodes...
-    [15:27:46.643] Started CCF network with the following nodes:
-    [15:27:46.643]   Node [ 0] = 127.251.192.205:36981
-    [15:27:46.643]   Node [ 1] = 127.98.174.190:36795
-    [15:27:46.643]   Node [ 2] = 127.113.40.231:33227
-    [15:27:46.644] You can now issue business transactions to the ./liblogging.enclave.so.signed application.
-    [15:27:46.644] Keys and certificates have been copied to the common folder: /data/src/CCF/build/workspace/test_network_common
-    [15:27:46.644] See https://microsoft.github.io/CCF/master/users/issue_commands.html for more information.
-    [15:27:46.644] Press Ctrl+C to shutdown the network.
+    [16:14:05.294] Starting 1 CCF nodes...
+    [16:14:05.295] Virtual mode enabled
+    [16:14:10.010] Started CCF network with the following nodes:
+    [16:14:10.011]   Node [0] = https://127.0.0.1:8000
+    [16:14:10.011] You can now issue business transactions to the ./liblogging.virtual.so application.
+    [16:14:10.011] Keys and certificates have been copied to the common folder: /data/amchamay/CCF/build/workspace/sandbox_common
+    [16:14:10.011] See https://microsoft.github.io/CCF/master/users/issue_commands.html for more information.
+    [16:14:10.011] Press Ctrl+C to shutdown the network.
 
-The command output shows the addresses of the CCF nodes where commands may be submitted (eg, in this case, via ``curl https://127.251.192.205:36981/...``). The output and error logs of each node can be found in the node-specific directory in the workspace (eg, ``workspace/test_network_0/err`` is node 0's stderr).
+The command output shows the addresses of the CCF nodes where commands may be submitted (eg, in this case, via ``curl https://127.0.0.1:8000/...``).
+The output and error logs of each node can be found in the node-specific directory in the workspace (eg, ``workspace/sandbox_0/err`` is node 0's stderr).
 
 Authentication
 --------------

--- a/doc/developers/demo.rst
+++ b/doc/developers/demo.rst
@@ -25,7 +25,7 @@ The following command will run a simple one node test network on a single machin
 
     $ cd CCF/build
 
-    $ ../sandbox.sh -p ./liblogging.virtual.signed
+    $ ../sandbox.sh -p ./liblogging.virtual.so
     Setting up Python environment...
     Python environment successfully setup
     [16:14:05.294] Starting 1 CCF nodes...
@@ -125,5 +125,4 @@ Note that the paths to these handlers is arbitrary. The names of the endpoints d
     Not visible
 
 .. _curl: https://curl.haxx.se/
-
 

--- a/doc/quickstart/test_network.rst
+++ b/doc/quickstart/test_network.rst
@@ -29,7 +29,7 @@ For example, deploying the ``liblogging`` example application:
 
 .. note::
 
-    - `sandbox.sh` defaults to using CCF's `virtual` mode, which does not require or make use of SGX. To load debug or release enclaves and make use of SGX, `-e` must be set to the right value, for example: `./sandbox.sh -e release -p ./liblogging.enclave.so.signed`
+    - `sandbox.sh` defaults to using CCF's `virtual` mode, which does not require or make use of SGX. To load debug or release enclaves and make use of SGX, `--enclave-type` must be set to the right value, for example: `./sandbox.sh --enclave-type release -p ./liblogging.enclave.so.signed`
     - The ``--verbose`` argument can be used to display all commands issued by operators and members to start the network.
     - Snapshots can be generated at regular intervals by the primary node of the service using the ``--snapshot-tx-interval <interval>`` option.
 

--- a/doc/quickstart/test_network.rst
+++ b/doc/quickstart/test_network.rst
@@ -23,7 +23,7 @@ For example, deploying the ``liblogging`` example application:
     [16:14:10.010] Started CCF network with the following nodes:
     [16:14:10.011]   Node [0] = https://127.0.0.1:8000
     [16:14:10.011] You can now issue business transactions to the ./liblogging.virtual.so application.
-    [16:14:10.011] Keys and certificates have been copied to the common folder: /data/amchamay/CCF/build/workspace/sandbox_common
+    [16:14:10.011] Keys and certificates have been copied to the common folder: /data/src/CCF/build/workspace/sandbox_common
     [16:14:10.011] See https://microsoft.github.io/CCF/master/users/issue_commands.html for more information.
     [16:14:10.011] Press Ctrl+C to shutdown the network.
 

--- a/doc/quickstart/test_network.rst
+++ b/doc/quickstart/test_network.rst
@@ -6,67 +6,67 @@ Starting a Test Network
     - The CCF runtime environment has successfully been setup (see :ref:`environment setup instructions <quickstart/run_setup:Setup CCF Runtime Environment>`).
     - CCF is installed (see :ref:`installation steps <quickstart/install:Install>`)
 
-The quickest way to start a CCF test network is to use the `start_test_network.sh <https://github.com/microsoft/CCF/blob/master/start_test_network.sh>`_ test script, specifying the :doc:`enclave image </developers/index>` to run.
+The quickest way to start a CCF test network is to use the `sandbox.sh <https://github.com/microsoft/CCF/blob/master/tests/sandbox/sandbox.sh>`_ test script, specifying the :doc:`enclave image </developers/index>` to run.
 
-The script creates a new test CCF network composed of 3 nodes running locally. All the governance requests required to open the network to users are automatically issued.
+The script creates a new one node test CCF network running locally. All the governance requests required to open the network to users are automatically issued.
 
 For example, deploying the ``liblogging`` example application:
 
 .. code-block:: bash
 
     $ cd CCF/build
-    $ ../start_test_network.sh --package ./liblogging.enclave.so.signed
+    $ ../sandbox.sh --package ./liblogging.virtual.so
     Setting up Python environment...
     Python environment successfully setup
-    [14:47:41.562] Starting 3 CCF nodes...
-    [14:48:12.138] Started CCF network with the following nodes:
-    [14:48:12.138]   Node [ 0] = 127.177.10.108:37765
-    [14:48:12.138]   Node [ 1] = 127.169.74.37:58343
-    [14:48:12.138]   Node [ 2] = 127.131.108.179:50532
-    [14:48:12.138] You can now issue business transactions to the ./liblogging.enclave.so.signed application.
-    [14:48:12.138] Keys and certificates have been copied to the common folder: /path/to/test_network_common
-    [14:48:12.138] See https://microsoft.github.io/CCF/master/users/issue_commands.html for more information.
-    [14:48:12.138] Press Ctrl+C to shutdown the network.
+    [16:14:05.294] Starting 1 CCF nodes...
+    [16:14:05.295] Virtual mode enabled
+    [16:14:10.010] Started CCF network with the following nodes:
+    [16:14:10.011]   Node [0] = https://127.0.0.1:8000
+    [16:14:10.011] You can now issue business transactions to the ./liblogging.virtual.so application.
+    [16:14:10.011] Keys and certificates have been copied to the common folder: /data/amchamay/CCF/build/workspace/sandbox_common
+    [16:14:10.011] See https://microsoft.github.io/CCF/master/users/issue_commands.html for more information.
+    [16:14:10.011] Press Ctrl+C to shutdown the network.
 
 .. note::
 
-    - To use CCF `virtual` mode, the same command can be run with ``TEST_ENCLAVE=virtual`` set as environment variable and the virtual version of the enclave application passed to the script. For example ``$ TEST_ENCLAVE=virtual ../start_test_network.sh --package ./liblogging.virtual.so``.
+    - `sandbox.sh` defaults to using CCF's `virtual` mode, which does not require or make use of SGX. To load debug or release enclaves and make use of SGX, `-e` must be set to the right value, for example: `./sandbox.sh -e release -p ./liblogging.enclave.so.signed`
     - The ``--verbose`` argument can be used to display all commands issued by operators and members to start the network.
     - Snapshots can be generated at regular intervals by the primary node of the service using the ``--snapshot-tx-interval <interval>`` option.
 
 The log files (``out`` and ``err``) and ledger directory (``<node_id>.ledger``) for each CCF node can be found under ``./workspace/test_network_<node_id>``.
 
-.. note:: The first time the command is run, a Python virtual environment will be created. This may take a few seconds. It will not be run the next time the ``start_test_network.sh`` script is started.
+.. note:: The first time the command is run, a Python virtual environment will be created. This may take a few seconds. It will not be run the next time the ``sandbox.sh`` script is started.
 
-In a different terminal, using the local IP address and port of the CCF nodes displayed by the command (e.g. ``https://127.177.10.108:37765`` for node ``0``), it is then possible for users to :ref:`issue business requests <users/issue_commands:Issuing Commands>`.
+In a different terminal, using the local IP address and port of the CCF nodes displayed by the command (e.g. ``https://127.0.0.1:8000`` for node ``0``), it is then possible for users to :ref:`issue business requests <users/issue_commands:Issuing Commands>`.
 
 Recovering a Service
 --------------------
 
-The ``start_test_network.sh`` script can also be used to automatically recover a defunct network, as per the steps described :ref:`here <members/accept_recovery:Accepting Recovery and Submitting Shares>`. The ledger to be recovered (``--ledger-dir``) , the defunct network encryption public key (``--network-enc-pubk``) and the directory containing the members and users identities and the network encryption public key (``--common-dir``) should be passed as arguments to the script.
+The ``sandbox.sh`` script can also be used to automatically recover a defunct network, as per the steps described :ref:`here <members/accept_recovery:Accepting Recovery and Submitting Shares>`. The ledger to be recovered (``--ledger-dir``) , the defunct network encryption public key (``--network-enc-pubk``) and the directory containing the members and users identities and the network encryption public key (``--common-dir``) should be passed as arguments to the script.
 
 Additionally, if snapshots were generated by the defunct service (using the ``--snapshot-tx-interval <interval>`` option), the recovery procedure can be significantly speeded up by re-starting from the latest available snapshot (``--snapshot-dir``).
 
 .. code-block:: bash
 
     $ cd CCF/build
-    $ cp -r ./workspace/test_network_0/0.ledger .
-    $ cp -r ./workspace/test_network_0/snapshots . # Optional, only if snapshots are available
-    $ cp ./workspace/test_network_0/network_enc_pubk.pem .
-    $ ../start_test_network.sh -p liblogging.enclave.so.signed --recover --ledger-dir 0.ledger --network-enc-pubk network_enc_pubk.pem --common-dir ./workspace/test_network_common/ [--snapshot-dir snapshots]
-    [14:50:19.746] Starting 3 CCF nodes...
-    [14:50:19.746] Recovering network from:
-    [14:50:19.746]  - Defunct network public encryption key: network_enc_pubk.pem
-    [14:50:19.746]  - Common directory: ./workspace/test_network_common/
-    [14:50:19.746]  - Ledger: 0.ledger
-    [14:50:24.388] Started CCF network with the following nodes:
-    [14:50:24.388]   Node [ 3] = 127.191.152.111:40371
-    [14:50:24.388]   Node [ 4] = 127.184.250.157:35113
-    [14:50:24.388]   Node [ 5] = 127.175.51.36:34699
-    [14:50:24.388] You can now issue business transactions to the liblogging.enclave.so.signed application.
-    [14:50:24.388] Keys and certificates have been copied to the common folder: /path/to/test_network_common
-    [14:50:24.388] See https://microsoft.github.io/CCF/master/users/issue_commands.html for more information.
-    [14:50:24.388] Press Ctrl+C to shutdown the network.
+    $ cp -r ./workspace/sandbox_0/0.ledger .
+    $ cp -r ./workspace/sanbox_0/snapshots . # Optional, only if snapshots are available
+    $ cp ./workspace/sandbox_0/network_enc_pubk.pem .
+    $ ./sandbox.sh -e release -p liblogging.enclave.so.signed --recover --ledger-dir 0.ledger --network-enc-pubk network_enc_pubk.pem --common-dir ./workspace/sandbox_common/ [--snapshot-dir snapshots]
+    Setting up Python environment...
+    Python environment successfully setup
+    [16:24:29.563] Starting 1 CCF nodes...
+    [16:24:29.563] Recovering network from:
+    [16:24:29.563]  - Defunct network public encryption key: network_enc_pubk.pem
+    [16:24:29.563]  - Common directory: ./workspace/sandbox_common/
+    [16:24:29.563]  - Ledger: 0.ledger
+    [16:24:29.563] No available snapshot to recover from. Entire transaction history will be replayed.
+    [16:24:32.885] Started CCF network with the following nodes:
+    [16:24:32.885]   Node [1] = https://127.0.0.1:8000
+    [16:24:32.885] You can now issue business transactions to the liblogging.enclave.so.signed application.
+    [16:24:32.885] Keys and certificates have been copied to the common folder: ./workspace/sandbox_common/
+    [16:24:32.885] See https://microsoft.github.io/CCF/master/users/issue_commands.html for more information.
+    [16:24:32.885] Press Ctrl+C to shutdown the network.
 
 The effects of transactions committed by the defunct network should then be recovered. Users can also :ref:`issue new business requests <users/issue_commands:Issuing Commands>`.
 


### PR DESCRIPTION
Helps with #1700, but isn't complete. We should talk about JS app bundles, and we will once 0.14.2 is out of the door.