### PR TITLE
Fix perf regression: Restore old read_block_size

### DIFF
--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -77,7 +77,7 @@ namespace http
       }
       else
       {
-        constexpr auto read_block_size = 16384;
+        constexpr auto read_block_size = 4096;
         auto buf = read(read_block_size, false);
         auto data = buf.data();
         auto size = buf.size();


### PR DESCRIPTION
#1783 introduced a significant perf regression.

While exploring the `modules_test` failures I'd fiddled with some hardcoded limits to see if I could reduce queuing on large requests. I thought I'd reverted all of these but I missed this one, which makes a significantly larger allocation than it used to. I believe this is the cause of the perf regression - opening as a draft to confirm. If this _is_ responsible for such a significant slowdown, its worth seeing if we can reduce the allocation/copying here, and actually get a speed-up.