### PR TITLE
In non-verbose start_network, don't log request status

### DIFF
--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -75,7 +75,10 @@ def run(args):
         # To be sure, confirm that the app frontend is open on each node
         for node in [primary, *backups]:
             with node.client("user0") as c:
-                r = c.get("/app/commit")
+                if args.verbose:
+                    r = c.get("/app/commit")
+                else:
+                    r = c.get("/app/commit", log_capture=[])
                 assert r.status_code == http.HTTPStatus.OK, r.status_code
 
         def pad_node_id(nid):


### PR DESCRIPTION
Some of our request logging had leaked into `sandbox.sh`. All other requests are suppressed by `LOG.disable("ccf")`, but this is called directly from `start_network.py` so is not caught. Instead, if we're not verbose, we dump these messages to an ignored list.


Then:
```
$ ../tests/sandbox/sandbox.sh -p liblogging
Setting up Python environment...
Python environment successfully setup
[09:26:52.885] Starting 1 CCF nodes...
[09:26:52.885] Virtual mode enabled
[09:26:58.146] [0|user0] GET /app/commit
[09:26:58.146] 200 @2.8 {"seqno":8,"view":2}

[09:26:58.146] Started CCF network with the following nodes:
[09:26:58.146]   Node [0] = https://127.0.0.1:8000
```

Now:
```
$ ../tests/sandbox/sandbox.sh -p liblogging
Setting up Python environment...
Python environment successfully setup
[09:27:34.639] Starting 1 CCF nodes...
[09:27:34.639] Virtual mode enabled
[09:27:38.651] Started CCF network with the following nodes:
[09:27:38.652]   Node [0] = https://127.0.0.1:8000
```