### PR TITLE
Libcurl is not needed anymore now that the notification server is gone

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -179,8 +179,6 @@ include(${CCF_DIR}/cmake/secp256k1.cmake)
 include(${CCF_DIR}/cmake/quickjs.cmake)
 include(${CCF_DIR}/cmake/sss.cmake)
 
-find_package(CURL REQUIRED)
-
 list(APPEND LINK_LIBCXX -lc++ -lc++abi -lc++fs -stdlib=libc++)
 
 # Unit test wrapper
@@ -237,7 +235,6 @@ if("sgx" IN_LIST COMPILE_TARGETS)
             openenclave::oehost
             ccfcrypto.host
             evercrypt.host
-            CURL::libcurl
   )
   enable_quote_code(cchost)
 
@@ -279,7 +276,6 @@ if("virtual" IN_LIST COMPILE_TARGETS)
             ${LINK_LIBCXX}
             ccfcrypto.host
             evercrypt.host
-            CURL::libcurl
   )
 
   install(TARGETS cchost.virtual DESTINATION bin)

--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -11,7 +11,7 @@ set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 
 # CPack variables for Debian packages
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-    "open-enclave (>=0.12.0), libuv1 (>= 1.18.0), libc++1-8, libc++abi1-8, libcurl4"
+    "open-enclave (>=0.12.0), libuv1 (>= 1.18.0), libc++1-8, libc++abi1-8"
 )
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 

--- a/getting_started/setup_vm/roles/ccf_build/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_build/vars/common.yml
@@ -13,7 +13,6 @@ debs:
   - clang-tools-8
   - expect
   - git
-  - libcurl4-openssl-dev
   - ccache
   - doxygen
   - kmod

--- a/getting_started/setup_vm/roles/ccf_run/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_run/vars/common.yml
@@ -3,4 +3,3 @@ debs:
   - libc++abi1
   - libc++1
   - libuv1
-  - libcurl4


### PR DESCRIPTION
Spotted by @jumaffre, this dramatically shortens the size of `ldd cchost.virtual` :)