### PR TITLE
AFT: Send view change messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -830,12 +830,12 @@ if(BUILD_TESTS)
       CONSENSUS ${CONSENSUS}
     )
 
-  add_e2e_test(
-    NAME election_test_${CONSENSUS}
-    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/election.py
-    CONSENSUS ${CONSENSUS}
-    ADDITIONAL_ARGS "--raft-election-timeout" "4000"
-  )
+    add_e2e_test(
+      NAME election_test_${CONSENSUS}
+      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/election.py
+      CONSENSUS ${CONSENSUS}
+      ADDITIONAL_ARGS "--raft-election-timeout" "4000"
+    )
 
   endforeach()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -799,13 +799,6 @@ if(BUILD_TESTS)
   )
 
   add_e2e_test(
-    NAME election_test_cft
-    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/election.py
-    CONSENSUS cft
-    ADDITIONAL_ARGS "--raft-election-timeout" "4000"
-  )
-
-  add_e2e_test(
     NAME vegeta_stress_cft
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/vegeta_stress.py
     CONSENSUS cft
@@ -836,6 +829,14 @@ if(BUILD_TESTS)
       CURL_CLIENT TRUE
       CONSENSUS ${CONSENSUS}
     )
+
+  add_e2e_test(
+    NAME election_test_${CONSENSUS}
+    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/election.py
+    CONSENSUS ${CONSENSUS}
+    ADDITIONAL_ARGS "--raft-election-timeout" "4000"
+  )
+
   endforeach()
 
   add_perf_test(

--- a/src/consensus/aft/impl/state.h
+++ b/src/consensus/aft/impl/state.h
@@ -98,8 +98,7 @@ namespace aft
       my_node_id(my_node_id_),
       current_view(0),
       last_idx(0),
-      commit_idx(0),
-      view_change_in_progress(false)
+      commit_idx(0)
     {}
 
     SpinLock lock;
@@ -109,7 +108,6 @@ namespace aft
     kv::Consensus::View current_view;
     kv::Version last_idx;
     kv::Version commit_idx;
-    bool view_change_in_progress;
 
     kv::Version cft_watermark_idx;
     kv::Version bft_watermark_idx;

--- a/src/consensus/aft/impl/state.h
+++ b/src/consensus/aft/impl/state.h
@@ -98,7 +98,8 @@ namespace aft
       my_node_id(my_node_id_),
       current_view(0),
       last_idx(0),
-      commit_idx(0)
+      commit_idx(0),
+      view_change_in_progress(false)
     {}
 
     SpinLock lock;
@@ -108,6 +109,7 @@ namespace aft
     kv::Consensus::View current_view;
     kv::Version last_idx;
     kv::Version commit_idx;
+    bool view_change_in_progress;
 
     kv::Version cft_watermark_idx;
     kv::Version bft_watermark_idx;

--- a/src/consensus/aft/impl/view_change_tracker.h
+++ b/src/consensus/aft/impl/view_change_tracker.h
@@ -34,12 +34,17 @@ namespace aft
         ViewChange vc;
         vc.received_view_changes.emplace(my_node_id);
         ++last_view_change_sent;
-        view_changes.insert(std::pair<kv::Consensus::View, ViewChange>(
-          last_view_change_sent, std::move(vc)));
+        view_changes.emplace(last_view_change_sent, std::move(vc));
         time_previous_view_change_increment = time;
         return true;
       }
       return false;
+    }
+
+    bool is_view_change_in_progress(std::chrono::milliseconds time)
+    {
+      return time <=
+        (time_between_attempts + time_previous_view_change_increment);
     }
 
     kv::Consensus::View get_target_view() const

--- a/src/consensus/aft/impl/view_change_tracker.h
+++ b/src/consensus/aft/impl/view_change_tracker.h
@@ -27,12 +27,9 @@ namespace aft
       time_between_attempts(time_between_attempts_)
     {}
 
-    bool should_send_view_change(
-      std::chrono::milliseconds time)
+    bool should_send_view_change(std::chrono::milliseconds time)
     {
-      if (
-        time > time_between_attempts +
-          time_previous_view_change_increment)
+      if (time > time_between_attempts + time_previous_view_change_increment)
       {
         ViewChange vc;
         vc.received_view_changes.emplace(my_node_id);

--- a/src/consensus/aft/impl/view_change_tracker.h
+++ b/src/consensus/aft/impl/view_change_tracker.h
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "consensus/aft/raft_types.h"
+
+#include <chrono>
+#include <map>
+#include <set>
+
+namespace aft
+{
+  class ViewChangeTracker
+  {
+    struct ViewChange
+    {
+      std::set<kv::NodeId> received_view_changes;
+    };
+
+  public:
+    ViewChangeTracker(
+      kv::NodeId my_node_id_,
+      kv::Consensus::View current_view,
+      std::chrono::milliseconds time_between_attempts_) :
+      my_node_id(my_node_id_),
+      last_view_change_sent(current_view),
+      time_between_attempts(time_between_attempts_)
+    {}
+
+    bool should_send_view_change(
+      std::chrono::milliseconds time)
+    {
+      if (
+        time > time_between_attempts +
+          time_previous_view_change_increment)
+      {
+        ViewChange vc;
+        vc.received_view_changes.emplace(my_node_id);
+        ++last_view_change_sent;
+        view_changes.insert(std::pair<kv::Consensus::View, ViewChange>(
+          last_view_change_sent, std::move(vc)));
+        time_previous_view_change_increment = time;
+        return true;
+      }
+      return false;
+    }
+
+    kv::Consensus::View get_target_view() const
+    {
+      return last_view_change_sent;
+    }
+
+    void set_current_view_change(kv::Consensus::View view)
+    {
+      view_changes.clear();
+      last_view_change_sent = view;
+    }
+
+  private:
+    kv::NodeId my_node_id;
+    std::map<kv::Consensus::View, ViewChange> view_changes;
+    std::chrono::milliseconds time_previous_view_change_increment =
+      std::chrono::milliseconds(0);
+    kv::Consensus::View last_view_change_sent = 0;
+    const std::chrono::milliseconds time_between_attempts;
+  };
+}

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -616,8 +616,9 @@ namespace aft
       RequestViewChangeMsg r;
       try
       {
-        r = channels->template recv_authenticated_with_load<RequestViewChangeMsg>(
-          data, size);
+        r =
+          channels->template recv_authenticated_with_load<RequestViewChangeMsg>(
+            data, size);
       }
       catch (const std::logic_error& err)
       {

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -559,11 +559,11 @@ namespace aft
 
           size_t vc_size = vc->get_serialized_size();
 
-          ViewChangeMsg vcm = {
+          RequestViewChangeMsg vcm = {
             {bft_view_change, state->my_node_id}, new_view, seqno, root};
 
           std::vector<uint8_t> m;
-          m.resize(sizeof(ViewChangeMsg) + vc_size);
+          m.resize(sizeof(RequestViewChangeMsg) + vc_size);
 
           uint8_t* data = m.data();
           size_t size = m.size();
@@ -613,10 +613,10 @@ namespace aft
 
     void recv_view_change(const uint8_t* data, size_t size)
     {
-      ViewChangeMsg r;
+      RequestViewChangeMsg r;
       try
       {
-        r = channels->template recv_authenticated_with_load<ViewChangeMsg>(
+        r = channels->template recv_authenticated_with_load<RequestViewChangeMsg>(
           data, size);
       }
       catch (const std::logic_error& err)

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -635,6 +635,9 @@ namespace aft
       LOG_INFO_FMT(
         "AAAAAAAAAAA got view change from:{}, view:{}", r.from_node, v.view);
 
+      auto progress_tracker = store->get_progress_tracker();
+      progress_tracker->apply_view_change_message(v, r.from_node);
+
       /*
             auto progress_tracker = store->get_progress_tracker();
             CCF_ASSERT(progress_tracker != nullptr, "progress_tracker is not

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -542,7 +542,6 @@ namespace aft
           (state->view_change_in_progress || has_bft_timeout_occurred(time)) &&
           view_change_tracker.should_send_view_change(time))
         {
-
           state->view_change_in_progress = true;
 
           // We have not seen a request executed within an expected period of
@@ -562,7 +561,8 @@ namespace aft
           uint8_t* data = m.data();
           size_t size = m.size();
 
-          serialized::write(data, size, reinterpret_cast<uint8_t*>(&vcm), sizeof(vcm));
+          serialized::write(
+            data, size, reinterpret_cast<uint8_t*>(&vcm), sizeof(vcm));
           vc->serialize(data, size);
           CCF_ASSERT_FMT(size == 0, "Did not write to everything");
 
@@ -609,13 +609,13 @@ namespace aft
       ViewChangeMsg r;
       try
       {
-        r = channels->template recv_authenticated_with_load<ViewChangeMsg>(data, size);
+        r = channels->template recv_authenticated_with_load<ViewChangeMsg>(
+          data, size);
       }
       catch (const std::logic_error& err)
       {
         LOG_FAIL_FMT("Error in recv_view_change message");
-        LOG_DEBUG_FMT(
-          "Error in recv_view_change message: {}", err.what());
+        LOG_DEBUG_FMT("Error in recv_view_change message: {}", err.what());
         return;
       }
 
@@ -1290,8 +1290,7 @@ namespace aft
       catch (const std::logic_error& err)
       {
         LOG_FAIL_FMT("Error in recv_nonce_reveal message");
-        LOG_DEBUG_FMT(
-          "Error in recv_nonce_reveal message: {}", err.what());
+        LOG_DEBUG_FMT("Error in recv_nonce_reveal message: {}", err.what());
         return;
       }
 

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -566,7 +566,7 @@ namespace aft
           vc->serialize(data, size);
           CCF_ASSERT_FMT(size == 0, "Did not write to everything");
 
-          LOG_INFO_FMT("AAAAAA sending view change msg view:{}", vc->view);
+          LOG_INFO_FMT("Sending view change msg view:{}", vc->view);
           for (auto it = nodes.begin(); it != nodes.end(); ++it)
           {
             auto send_to = it->first;
@@ -630,24 +630,12 @@ namespace aft
         return;
       }
 
-      LOG_INFO_FMT("AAAAAAAAAAA got view change from:{}", r.from_node);
       ccf::ViewChange v = ccf::ViewChange::deserialize(data, size);
       LOG_INFO_FMT(
-        "AAAAAAAAAAA got view change from:{}, view:{}", r.from_node, v.view);
+        "Received view change from:{}, view:{}", r.from_node, v.view);
 
       auto progress_tracker = store->get_progress_tracker();
       progress_tracker->apply_view_change_message(v, r.from_node);
-
-      /*
-            auto progress_tracker = store->get_progress_tracker();
-            CCF_ASSERT(progress_tracker != nullptr, "progress_tracker is not
-         set"); LOG_TRACE_FMT( "processing nonce_reveal, from:{} view:{},
-         seqno:{}", r.from_node, r.term, r.idx);
-            progress_tracker->add_nonce_reveal(
-              {r.term, r.idx}, r.nonce, r.from_node, node_count(), is_leader());
-
-            update_commit();
-      */
     }
 
     bool is_first_request = true;

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -198,7 +198,7 @@ namespace aft
     Nonce nonce;
   };
 
-  struct ViewChangeMsg : RaftHeader
+  struct RequestViewChangeMsg : RaftHeader
   {
     kv::Consensus::View view = 0;
     kv::Consensus::SeqNo seqno = 0;

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -200,7 +200,9 @@ namespace aft
 
   struct ViewChangeMsg : RaftHeader
   {
-    // size_t size;
+    kv::Consensus::View view = 0;
+    kv::Consensus::SeqNo seqno = 0;
+    crypto::Sha256Hash root;
   };
 
   struct RequestVote : RaftHeader

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -149,7 +149,8 @@ namespace aft
 
     bft_request,
     bft_signature_received_ack,
-    bft_nonce_reveal
+    bft_nonce_reveal,
+    bft_view_change
   };
 
 #pragma pack(push, 1)
@@ -195,6 +196,11 @@ namespace aft
     Term term;
     Index idx;
     Nonce nonce;
+  };
+
+  struct ViewChangeMsg : RaftHeader
+  {
+    size_t size;
   };
 
   struct RequestVote : RaftHeader

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -200,7 +200,7 @@ namespace aft
 
   struct ViewChangeMsg : RaftHeader
   {
-    size_t size;
+    // size_t size;
   };
 
   struct RequestVote : RaftHeader

--- a/src/consensus/aft/test/logging_stub.h
+++ b/src/consensus/aft/test/logging_stub.h
@@ -155,7 +155,8 @@ namespace aft
       return {};
     }
 
-    bool recv_authenticated_with_load(NodeId from_node, const uint8_t*& data, size_t& size) override
+    bool recv_authenticated_with_load(
+      NodeId from_node, const uint8_t*& data, size_t& size) override
     {
       return true;
     }

--- a/src/consensus/aft/test/logging_stub.h
+++ b/src/consensus/aft/test/logging_stub.h
@@ -154,6 +154,11 @@ namespace aft
     {
       return {};
     }
+
+    bool recv_authenticated_with_load(NodeId from_node, const uint8_t*& data, size_t& size) override
+    {
+      return true;
+    }
   };
 
   class LoggingStubStore

--- a/src/crypto/hash.cpp
+++ b/src/crypto/hash.cpp
@@ -16,7 +16,6 @@ namespace crypto
 {
   constexpr auto block_size = 64u; // No way to ask evercrypt for this
 
-
   void Sha256Hash::mbedtls_sha256(const CBuffer& data, uint8_t* h)
   {
     mbedtls_sha256_context ctx;
@@ -28,7 +27,8 @@ namespace crypto
     mbedtls_sha256_free(&ctx);
   }
 
-  void update_evercrypt_sha256(const CBuffer& data, EverCrypt_Hash_state_s* state)
+  void update_evercrypt_sha256(
+    const CBuffer& data, EverCrypt_Hash_state_s* state)
   {
     const auto data_begin = const_cast<uint8_t*>(data.p);
     const auto size = data.rawSize();
@@ -69,8 +69,7 @@ namespace crypto
   public:
     CSha256HashImpl()
     {
-      state =
-        EverCrypt_Hash_create(Spec_Hash_Definitions_SHA2_256);
+      state = EverCrypt_Hash_create(Spec_Hash_Definitions_SHA2_256);
       EverCrypt_Hash_init(state);
     }
 

--- a/src/crypto/hash.h
+++ b/src/crypto/hash.h
@@ -56,6 +56,34 @@ namespace crypto
   {
     return !(lhs == rhs);
   }
+
+  class CSha256HashImpl;
+  class CSha256Hash
+  {
+  public:
+    CSha256Hash();
+    ~CSha256Hash();
+
+    void update_hash(CBuffer data);
+
+    template<typename T>
+    void update(const T& t)
+    {
+      update_hash({reinterpret_cast<const uint8_t*>(&t), sizeof(T)});
+    }
+
+    template<>
+    void update<std::vector<uint8_t>>(const std::vector<uint8_t>& d)
+    {
+      update_hash({d.data(), d.size()});
+    }
+
+
+    Sha256Hash finalize();
+
+  private:
+    std::unique_ptr<CSha256HashImpl> p;
+  };
 }
 
 namespace fmt

--- a/src/crypto/hash.h
+++ b/src/crypto/hash.h
@@ -66,18 +66,17 @@ namespace crypto
 
     void update_hash(CBuffer data);
 
-    template<typename T>
+    template <typename T>
     void update(const T& t)
     {
       update_hash({reinterpret_cast<const uint8_t*>(&t), sizeof(T)});
     }
 
-    template<>
+    template <>
     void update<std::vector<uint8_t>>(const std::vector<uint8_t>& d)
     {
       update_hash({d.data(), d.size()});
     }
-
 
     Sha256Hash finalize();
 

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -52,6 +52,11 @@ TEST_CASE("SHA256 %32 consistency test")
   crypto::Sha256Hash::evercrypt_sha256(data, h1.h.data());
   crypto::Sha256Hash::mbedtls_sha256(data, h2.h.data());
   REQUIRE(h1 == h2);
+
+  CSha256Hash ch;
+  ch.update_hash(data);
+  crypto::Sha256Hash h3 = ch.finalize();
+  REQUIRE(h1 == h3);
 }
 
 TEST_CASE("SHA256 long consistency test")

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -815,8 +815,8 @@ namespace ccf
             auto progress_tracker = store.get_progress_tracker();
             CCF_ASSERT(
               progress_tracker != nullptr, "progress_tracker is not set");
-            auto r =
-              progress_tracker->record_primary(txid, id, root, primary_sig, hashed_nonce);
+            auto r = progress_tracker->record_primary(
+              txid, id, root, primary_sig, hashed_nonce);
             if (r != kv::TxHistory::Result::OK)
             {
               throw ccf::ccf_logic_error(fmt::format(
@@ -853,7 +853,7 @@ namespace ccf
             auto progress_tracker = store.get_progress_tracker();
             CCF_ASSERT(
               progress_tracker != nullptr, "progress_tracker is not set");
-              progress_tracker->record_primary_signature(txid, primary_sig);
+            progress_tracker->record_primary_signature(txid, primary_sig);
           }
 
           sig_view->put(0, sig_value);

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -674,6 +674,7 @@ namespace ccf
         {sig.view, sig.seqno},
         sig.node,
         sig.root,
+        sig.sig,
         sig.hashed_nonce,
         store.get_consensus()->node_count());
 
@@ -807,6 +808,7 @@ namespace ccf
           crypto::Sha256Hash root = replicated_state_tree.get_root();
 
           Nonce hashed_nonce;
+          std::vector<uint8_t> primary_sig;
           auto consensus = store.get_consensus();
           if (consensus != nullptr && consensus->type() == ConsensusType::BFT)
           {
@@ -814,7 +816,7 @@ namespace ccf
             CCF_ASSERT(
               progress_tracker != nullptr, "progress_tracker is not set");
             auto r =
-              progress_tracker->record_primary(txid, id, root, hashed_nonce);
+              progress_tracker->record_primary(txid, id, root, primary_sig, hashed_nonce);
             if (r != kv::TxHistory::Result::OK)
             {
               throw ccf::ccf_logic_error(fmt::format(
@@ -833,6 +835,8 @@ namespace ccf
             hashed_nonce.h.fill(0);
           }
 
+          primary_sig = kp.sign_hash(root.h.data(), root.h.size());
+
           PrimarySignature sig_value(
             id,
             txid.version,
@@ -841,8 +845,16 @@ namespace ccf
             commit_txid.first,
             root,
             hashed_nonce,
-            kp.sign_hash(root.h.data(), root.h.size()),
+            primary_sig,
             replicated_state_tree.serialise());
+
+          if (consensus != nullptr && consensus->type() == ConsensusType::BFT)
+          {
+            auto progress_tracker = store.get_progress_tracker();
+            CCF_ASSERT(
+              progress_tracker != nullptr, "progress_tracker is not set");
+              progress_tracker->record_primary_signature(txid, primary_sig);
+          }
 
           sig_view->put(0, sig_value);
           return sig.commit_reserved();

--- a/src/node/node_signature.h
+++ b/src/node/node_signature.h
@@ -19,13 +19,10 @@ namespace ccf
 
     NodeSignature(
       const std::vector<uint8_t>& sig_, NodeId node_, Nonce hashed_nonce_) :
-      sig(sig_),
-      node(node_),
-      hashed_nonce(hashed_nonce_)
+      sig(sig_), node(node_), hashed_nonce(hashed_nonce_)
     {}
     NodeSignature(ccf::NodeId node_, Nonce hashed_nonce_) :
-      node(node_),
-      hashed_nonce(hashed_nonce_)
+      node(node_), hashed_nonce(hashed_nonce_)
     {}
     NodeSignature(ccf::NodeId node_) : node(node_) {}
     NodeSignature() = default;
@@ -33,6 +30,39 @@ namespace ccf
     bool operator==(const NodeSignature& o) const
     {
       return sig == o.sig && hashed_nonce == o.hashed_nonce;
+    }
+
+    size_t get_serialized_size() const
+    {
+      return sizeof(node) + sizeof(hashed_nonce) + sizeof(size_t) + sig.size();
+    }
+
+    void serialize(uint8_t*& data, size_t& size) const
+    {
+      size_t sig_size = sig.size();
+      serialized::write(
+        data, size, reinterpret_cast<uint8_t*>(&sig_size), sizeof(sig_size));
+      serialized::write(data, size, sig.data(), sig_size);
+
+      serialized::write(
+        data, size, reinterpret_cast<const uint8_t*>(&node), sizeof(node));
+      serialized::write(
+        data,
+        size,
+        reinterpret_cast<const uint8_t*>(&hashed_nonce),
+        sizeof(hashed_nonce));
+    }
+
+    static NodeSignature deserialize(const uint8_t*& data, size_t& size)
+    {
+      NodeSignature n;
+
+      size_t sig_size = serialized::read<size_t>(data, size);
+      n.sig = serialized::read(data, size, sig_size);
+      n.node = serialized::read<ccf::NodeId>(data, size);
+      n.hashed_nonce = serialized::read<Nonce>(data, size);
+
+      return n;
     }
 
     MSGPACK_DEFINE(sig, node, hashed_nonce);

--- a/src/node/node_signature.h
+++ b/src/node/node_signature.h
@@ -17,16 +17,20 @@ namespace ccf
     ccf::NodeId node;
     Nonce hashed_nonce;
 
-    NodeSignature(
-      const NodeSignature& ns) :
-      sig(ns.sig), node(ns.node), hashed_nonce(ns.hashed_nonce)
+    NodeSignature(const NodeSignature& ns) :
+      sig(ns.sig),
+      node(ns.node),
+      hashed_nonce(ns.hashed_nonce)
     {}
     NodeSignature(
       const std::vector<uint8_t>& sig_, NodeId node_, Nonce hashed_nonce_) :
-      sig(sig_), node(node_), hashed_nonce(hashed_nonce_)
+      sig(sig_),
+      node(node_),
+      hashed_nonce(hashed_nonce_)
     {}
     NodeSignature(ccf::NodeId node_, Nonce hashed_nonce_) :
-      node(node_), hashed_nonce(hashed_nonce_)
+      node(node_),
+      hashed_nonce(hashed_nonce_)
     {}
     NodeSignature(ccf::NodeId node_) : node(node_) {}
     NodeSignature() = default;

--- a/src/node/node_signature.h
+++ b/src/node/node_signature.h
@@ -18,6 +18,10 @@ namespace ccf
     Nonce hashed_nonce;
 
     NodeSignature(
+      const NodeSignature& ns) :
+      sig(ns.sig), node(ns.node), hashed_nonce(ns.hashed_nonce)
+    {}
+    NodeSignature(
       const std::vector<uint8_t>& sig_, NodeId node_, Nonce hashed_nonce_) :
       sig(sig_), node(node_), hashed_nonce(hashed_nonce_)
     {}

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1765,6 +1765,7 @@ namespace ccf
       {
         auto store = std::make_unique<ccf::ProgressTrackerStoreAdapter>(
           *network.tables.get(),
+          *node_sign_kp,
           network.nodes,
           network.backup_signatures_map,
           network.revealed_nonces_map);

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1652,7 +1652,6 @@ namespace ccf
         std::chrono::milliseconds(consensus_config.raft_election_timeout),
         std::chrono::milliseconds(consensus_config.pbft_view_change_timeout),
         sig_tx_interval,
-        sig_ms_interval,
         public_only);
 
       consensus = std::make_shared<RaftConsensusType>(

--- a/src/node/node_to_node.h
+++ b/src/node/node_to_node.h
@@ -37,7 +37,6 @@ namespace ccf
         msg_type, to, reinterpret_cast<const uint8_t*>(&data), sizeof(T));
     }
 
-    // TODO: use this
     template <>
     bool send_authenticated(
       const NodeMsgType& msg_type, NodeId to, const std::vector<uint8_t>& data)

--- a/src/node/node_to_node.h
+++ b/src/node/node_to_node.h
@@ -83,7 +83,8 @@ namespace ccf
       return t;
     }
 
-    virtual bool recv_authenticated_with_load(NodeId from_node, const uint8_t*& data, size_t& size) = 0;
+    virtual bool recv_authenticated_with_load(
+      NodeId from_node, const uint8_t*& data, size_t& size) = 0;
 
     virtual bool recv_authenticated(
       NodeId from_node, CBuffer cb, const uint8_t*& data, size_t& size) = 0;
@@ -202,12 +203,12 @@ namespace ccf
       return n2n_channel.send(msg_type, cb, data);
     }
 
-    bool recv_authenticated_with_load(NodeId from_node, const uint8_t*& data, size_t& size) override
+    bool recv_authenticated_with_load(
+      NodeId from_node, const uint8_t*& data, size_t& size) override
     {
       auto& n2n_channel = channels->get(from_node);
       return n2n_channel.recv_authenticated_with_load(data, size);
     }
-
 
     std::vector<uint8_t> recv_encrypted(
       NodeId from_node, CBuffer cb, const uint8_t* data, size_t size) override

--- a/src/node/node_to_node.h
+++ b/src/node/node_to_node.h
@@ -202,29 +202,6 @@ namespace ccf
       return n2n_channel.send(msg_type, cb, data);
     }
 
-/*
-    template <class T>
-    const T& recv_authenticated_with_load(const uint8_t*& data, size_t& size)
-    {
-      // PBFT only
-      const auto* data_ = data;
-      auto size_ = size;
-
-      const auto& t = serialized::overlay<T>(data_, size_);
-      auto& n2n_channel = channels->get(t.from_node);
-
-      if (!n2n_channel.recv_authenticated_with_load(data, size))
-      {
-        throw std::logic_error(fmt::format(
-          "Invalid authenticated node2node message with load from node {}",
-          t.from_node));
-      }
-      serialized::skip(data, size, sizeof(T));
-
-      return t;
-    }
-    */
-
     bool recv_authenticated_with_load(NodeId from_node, const uint8_t*& data, size_t& size) override
     {
       auto& n2n_channel = channels->get(from_node);

--- a/src/node/node_to_node.h
+++ b/src/node/node_to_node.h
@@ -37,6 +37,7 @@ namespace ccf
         msg_type, to, reinterpret_cast<const uint8_t*>(&data), sizeof(T));
     }
 
+    // TODO: use this
     template <>
     bool send_authenticated(
       const NodeMsgType& msg_type, NodeId to, const std::vector<uint8_t>& data)

--- a/src/node/progress_tracker.h
+++ b/src/node/progress_tracker.h
@@ -528,7 +528,7 @@ namespace ccf
       return highest_commit_level;
     }
 
-    std::unique_ptr<ViewChange> get_view_change_message()
+    std::unique_ptr<ViewChange> get_view_change_message(kv::Consensus::View view)
     {
       auto it = certificates.find(CertKey(highest_prepared_level));
       if (it == certificates.end())
@@ -541,7 +541,7 @@ namespace ccf
 
       auto& cert = it->second;
       auto m = std::make_unique<ViewChange>(
-        highest_prepared_level.term, highest_prepared_level.version, cert.root);
+        view, highest_prepared_level.version, cert.root);
       
       for (const auto& sig : cert.sigs)
       {

--- a/src/node/progress_tracker.h
+++ b/src/node/progress_tracker.h
@@ -47,8 +47,9 @@ namespace ccf
         // We currently do not know what the root is, so lets save this
         // signature and and we will verify the root when we get it from the
         // primary
-        auto r = certificates.insert(
-          std::pair<kv::Consensus::SeqNo, CommitCert>(tx_id.version, CommitCert()));
+        auto r =
+          certificates.insert(std::pair<kv::Consensus::SeqNo, CommitCert>(
+            tx_id.version, CommitCert()));
         it = r.first;
       }
       else
@@ -102,8 +103,7 @@ namespace ccf
       {
         if (is_primary)
         {
-          ccf::BackupSignatures sig_value(
-            tx_id.term, tx_id.version, cert.root);
+          ccf::BackupSignatures sig_value(tx_id.term, tx_id.version, cert.root);
 
           for (const auto& sig : cert.sigs)
           {
@@ -236,13 +236,13 @@ namespace ccf
         return kv::TxHistory::Result::FAIL;
       }
 
-      for(auto& cert : it->second.sigs)
+      for (auto& cert : it->second.sigs)
       {
         if (!cert.second.is_primary)
         {
           continue;
         }
-        
+
         if (!cert.second.sig.empty())
         {
           LOG_FAIL_FMT(
@@ -403,8 +403,9 @@ namespace ccf
         // We currently do not know what the root is, so lets save this
         // signature and and we will verify the root when we get it from the
         // primary
-        auto r = certificates.insert(
-          std::pair<kv::Consensus::SeqNo, CommitCert>(tx_id.version, CommitCert()));
+        auto r =
+          certificates.insert(std::pair<kv::Consensus::SeqNo, CommitCert>(
+            tx_id.version, CommitCert()));
         it = r.first;
       }
 
@@ -438,8 +439,9 @@ namespace ccf
         // We currently do not know what the root is, so lets save this
         // signature and and we will verify the root when we get it from the
         // primary
-        auto r = certificates.insert(
-          std::pair<kv::Consensus::SeqNo, CommitCert>(tx_id.version, CommitCert()));
+        auto r =
+          certificates.insert(std::pair<kv::Consensus::SeqNo, CommitCert>(
+            tx_id.version, CommitCert()));
         it = r.first;
         did_add = true;
       }
@@ -561,7 +563,8 @@ namespace ccf
       return highest_commit_level;
     }
 
-    std::unique_ptr<ViewChange> get_view_change_message(kv::Consensus::View view)
+    std::unique_ptr<ViewChange> get_view_change_message(
+      kv::Consensus::View view)
     {
       auto it = certificates.find(highest_prepared_level.version);
       if (it == certificates.end())
@@ -575,7 +578,7 @@ namespace ccf
       auto& cert = it->second;
       auto m = std::make_unique<ViewChange>(
         view, highest_prepared_level.version, cert.root);
-      
+
       for (const auto& sig : cert.sigs)
       {
         m->signatures.push_back(sig.second);
@@ -598,8 +601,7 @@ namespace ccf
         view_change.view,
         view_change.seqno);
 
-      auto it =
-        certificates.find(view_change.seqno);
+      auto it = certificates.find(view_change.seqno);
 
       if (it == certificates.end())
       {
@@ -623,13 +625,14 @@ namespace ccf
 
       bool verified_signatures = true;
 
-      for(auto& sig : view_change.signatures)
+      for (auto& sig : view_change.signatures)
       {
         if (!store->verify_signature(
               sig.node, it->second.root, sig.sig.size(), sig.sig.data()))
         {
           LOG_FAIL_FMT(
-            "signatures do not match, view-change from:{}, view:{}, seqno:{}, node_id:{}",
+            "signatures do not match, view-change from:{}, view:{}, seqno:{}, "
+            "node_id:{}",
             from,
             view_change.view,
             view_change.seqno,
@@ -638,13 +641,14 @@ namespace ccf
           continue;
         }
 
-        if(it->second.sigs.find(sig.node) == it->second.sigs.end())
+        if (it->second.sigs.find(sig.node) == it->second.sigs.end())
         {
           continue;
         }
-        it->second.sigs.insert(std::pair<kv::NodeId, BftNodeSignature>(sig.node, sig));
+        it->second.sigs.insert(
+          std::pair<kv::NodeId, BftNodeSignature>(sig.node, sig));
       }
-      
+
       return verified_signatures;
     }
 
@@ -715,7 +719,8 @@ namespace ccf
       return 2 * f + 1;
     }
 
-    bool can_send_sig_ack(CommitCert& cert, const kv::TxID& tx_id, uint32_t node_count)
+    bool can_send_sig_ack(
+      CommitCert& cert, const kv::TxID& tx_id, uint32_t node_count)
     {
       if (
         cert.sigs.size() >= get_message_threshold(node_count) &&
@@ -730,7 +735,7 @@ namespace ccf
             highest_prepared_level.term);
           highest_prepared_level = tx_id;
         }
-        
+
         cert.ack_sent = true;
         return true;
       }

--- a/src/node/progress_tracker.h
+++ b/src/node/progress_tracker.h
@@ -243,14 +243,6 @@ namespace ccf
           continue;
         }
 
-        if (!cert.second.sig.empty())
-        {
-          LOG_FAIL_FMT(
-            "primary is not empty view:{}, seqno:{}",
-            tx_id.term,
-            tx_id.version);
-          return kv::TxHistory::Result::FAIL;
-        }
         cert.second.sig = sig;
         break;
       }

--- a/src/node/progress_tracker.h
+++ b/src/node/progress_tracker.h
@@ -587,7 +587,7 @@ namespace ccf
 
     bool apply_view_change_message(ViewChange& view_change, kv::NodeId from)
     {
-      if (!store->verify_view_change(view_change))
+      if (!store->verify_view_change(view_change, from))
       {
         LOG_FAIL_FMT("Failed to verify view-change from:{}", from);
         return false;

--- a/src/node/progress_tracker_types.h
+++ b/src/node/progress_tracker_types.h
@@ -33,6 +33,12 @@ namespace ccf
     Nonce nonce;
 
     BftNodeSignature(
+      const NodeSignature& ns) :
+      NodeSignature(ns),
+      is_primary(false)
+    {}
+
+    BftNodeSignature(
       const std::vector<uint8_t>& sig_, NodeId node_, Nonce hashed_nonce_) :
       NodeSignature(sig_, node_, hashed_nonce_),
       is_primary(false)
@@ -74,8 +80,8 @@ namespace ccf
       crypto::Sha256Hash& root,
       uint32_t sig_size,
       uint8_t* sig) = 0;
-
     virtual void sign_view_change(ViewChange& view_change) = 0;
+    virtual bool verify_view_change(ViewChange& view_change) = 0;
   };
 
   class ProgressTrackerStoreAdapter : public ProgressTrackerStore
@@ -175,7 +181,14 @@ namespace ccf
 
     void sign_view_change(ViewChange& view_change) override
     {
+      // TODO: fill this in
       view_change.signature = {1};
+    }
+
+    bool verify_view_change(ViewChange& /*view_change*/) override
+    {
+      // TODO: fill this in
+      return true;
     }
 
   private:

--- a/src/node/progress_tracker_types.h
+++ b/src/node/progress_tracker_types.h
@@ -11,22 +11,6 @@
 
 namespace ccf
 {
-  struct CertKey
-  {
-    CertKey(kv::TxID tx_id_) : tx_id(tx_id_) {}
-
-    kv::TxID tx_id;
-
-    bool operator<(const CertKey& rhs) const
-    {
-      if (tx_id.version == rhs.tx_id.version)
-      {
-        return tx_id.term < rhs.tx_id.term;
-      }
-      return tx_id.version < rhs.tx_id.version;
-    }
-  };
-
   struct BftNodeSignature : public ccf::NodeSignature
   {
     bool is_primary;

--- a/src/node/progress_tracker_types.h
+++ b/src/node/progress_tracker_types.h
@@ -16,8 +16,7 @@ namespace ccf
     bool is_primary;
     Nonce nonce;
 
-    BftNodeSignature(
-      const NodeSignature& ns) :
+    BftNodeSignature(const NodeSignature& ns) :
       NodeSignature(ns),
       is_primary(false)
     {}
@@ -65,7 +64,8 @@ namespace ccf
       uint32_t sig_size,
       uint8_t* sig) = 0;
     virtual void sign_view_change(ViewChange& view_change) = 0;
-    virtual bool verify_view_change(ViewChange& view_change, kv::NodeId from) = 0;
+    virtual bool verify_view_change(
+      ViewChange& view_change, kv::NodeId from) = 0;
   };
 
   class ProgressTrackerStoreAdapter : public ProgressTrackerStore
@@ -181,13 +181,15 @@ namespace ccf
       auto ni = ni_tv->get(from);
       if (!ni.has_value())
       {
-        LOG_FAIL_FMT(
-          "No node info, and therefore no cert for node {}", from);
+        LOG_FAIL_FMT("No node info, and therefore no cert for node {}", from);
         return false;
       }
       tls::VerifierPtr from_cert = tls::make_verifier(ni.value().cert);
       return from_cert->verify_hash(
-        h.h.data(), h.h.size(), view_change.signature.data(), view_change.signature.size());
+        h.h.data(),
+        h.h.size(),
+        view_change.signature.data(),
+        view_change.signature.size());
     }
 
   private:

--- a/src/node/progress_tracker_types.h
+++ b/src/node/progress_tracker_types.h
@@ -7,6 +7,7 @@
 #include "tls/hash.h"
 #include "tls/tls.h"
 #include "tls/verifier.h"
+#include "view_change.h"
 
 namespace ccf
 {
@@ -73,6 +74,8 @@ namespace ccf
       crypto::Sha256Hash& root,
       uint32_t sig_size,
       uint8_t* sig) = 0;
+
+    virtual void sign_view_change(ViewChange& view_change) = 0;
   };
 
   class ProgressTrackerStoreAdapter : public ProgressTrackerStore
@@ -168,6 +171,11 @@ namespace ccf
       tls::VerifierPtr from_cert = tls::make_verifier(ni.value().cert);
       return from_cert->verify_hash(
         root.h.data(), root.h.size(), sig, sig_size);
+    }
+
+    void sign_view_change(ViewChange& view_change) override
+    {
+      view_change.signature = {1};
     }
 
   private:

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -25,8 +25,8 @@ public:
     verify_signature,
     bool(kv::NodeId, crypto::Sha256Hash&, uint32_t, uint8_t*),
     override);
-
   MAKE_MOCK1(sign_view_change, void(ccf::ViewChange& view_change), override);
+  MAKE_MOCK1(verify_view_change, bool(ccf::ViewChange& view_change), override);
 };
 
 void ordered_execution(

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -45,11 +45,12 @@ void ordered_execution(
   auto h = pt->hash_data(nonce);
   ccf::Nonce hashed_nonce;
   std::copy(h.h.begin(), h.h.end(), hashed_nonce.h.begin());
+  std::vector<uint8_t> primary_sig;
 
   INFO("Adding signatures");
   {
     auto result =
-      pt->record_primary({view, seqno}, 0, root, hashed_nonce, node_count);
+      pt->record_primary({view, seqno}, 0, root, primary_sig, hashed_nonce, node_count);
     REQUIRE(result == kv::TxHistory::Result::OK);
 
     for (uint32_t i = 1; i < node_count; ++i)
@@ -301,6 +302,7 @@ TEST_CASE("View Changes")
   ccf::Nonce hashed_nonce;
   std::copy(h.h.begin(), h.h.end(), hashed_nonce.h.begin());
   std::array<uint8_t, MBEDTLS_ECDSA_MAX_LEN> sig;
+  std::vector<uint8_t> primary_sig;
 
   INFO("find first view-change message");
   {
@@ -309,7 +311,7 @@ TEST_CASE("View Changes")
       .TIMES(AT_LEAST(2));
     REQUIRE_CALL(store_mock, sign_view_change(_)).TIMES(AT_LEAST(2));
     auto result =
-      pt.record_primary({view, seqno}, 0, root, hashed_nonce, node_count);
+      pt.record_primary({view, seqno}, 0, root, primary_sig, hashed_nonce, node_count);
     REQUIRE(result == kv::TxHistory::Result::OK);
 
     for (uint32_t i = 1; i < node_count; ++i)
@@ -351,7 +353,7 @@ TEST_CASE("View Changes")
       .TIMES(AT_LEAST(2));
     REQUIRE_CALL(store_mock, sign_view_change(_)).TIMES(AT_LEAST(2));
     auto result =
-      pt.record_primary({view, new_seqno}, 0, root, hashed_nonce, node_count);
+      pt.record_primary({view, new_seqno}, 0, root, primary_sig, hashed_nonce, node_count);
     REQUIRE(result == kv::TxHistory::Result::OK);
 
     for (uint32_t i = 1; i < node_count; ++i)
@@ -394,7 +396,7 @@ TEST_CASE("View Changes")
       .TIMES(AT_LEAST(2));
     REQUIRE_CALL(store_mock, sign_view_change(_)).TIMES(AT_LEAST(2));
     auto result =
-      pt.record_primary({view, new_seqno}, 0, root, hashed_nonce, node_count);
+      pt.record_primary({view, new_seqno}, 0, root, primary_sig, hashed_nonce, node_count);
     REQUIRE(result == kv::TxHistory::Result::OK);
 
     for (uint32_t i = 1; i < node_count; ++i)

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -26,7 +26,7 @@ public:
     bool(kv::NodeId, crypto::Sha256Hash&, uint32_t, uint8_t*),
     override);
   MAKE_MOCK1(sign_view_change, void(ccf::ViewChange& view_change), override);
-  MAKE_MOCK1(verify_view_change, bool(ccf::ViewChange& view_change), override);
+  MAKE_MOCK2(verify_view_change, bool(ccf::ViewChange& view_change, kv::NodeId from), override);
 };
 
 void ordered_execution(
@@ -536,7 +536,7 @@ TEST_CASE("test progress_tracker apply_view_change")
 
   INFO("View-change signature does not verify");
   {
-    REQUIRE_CALL(store_mock, verify_view_change(_)).RETURN(false);
+    REQUIRE_CALL(store_mock, verify_view_change(_, _)).RETURN(false);
     ccf::ViewChange v;
     bool result = pt->apply_view_change_message(v, 1);
     REQUIRE(result == false);
@@ -544,7 +544,7 @@ TEST_CASE("test progress_tracker apply_view_change")
 
   INFO("Unknown seqno");
   {
-    REQUIRE_CALL(store_mock, verify_view_change(_)).RETURN(true);
+    REQUIRE_CALL(store_mock, verify_view_change(_, _)).RETURN(true);
     ccf::ViewChange v;
     v.seqno = 999;
     bool result = pt->apply_view_change_message(v, 1);
@@ -553,7 +553,7 @@ TEST_CASE("test progress_tracker apply_view_change")
 
   INFO("Incorrect root");
   {
-    REQUIRE_CALL(store_mock, verify_view_change(_)).RETURN(true);
+    REQUIRE_CALL(store_mock, verify_view_change(_, _)).RETURN(true);
     ccf::ViewChange v;
     v.seqno = 42;
     v.root.h.fill(1);
@@ -563,7 +563,7 @@ TEST_CASE("test progress_tracker apply_view_change")
 
   INFO("View-change matches - known node");
   {
-    REQUIRE_CALL(store_mock, verify_view_change(_)).RETURN(true);
+    REQUIRE_CALL(store_mock, verify_view_change(_, _)).RETURN(true);
     REQUIRE_CALL(store_mock, verify_signature(_, _, _, _)).RETURN(true);
     ccf::ViewChange v;
     v.seqno = 42;
@@ -575,7 +575,7 @@ TEST_CASE("test progress_tracker apply_view_change")
 
   INFO("View-change matches - unknown node");
   {
-    REQUIRE_CALL(store_mock, verify_view_change(_)).RETURN(true);
+    REQUIRE_CALL(store_mock, verify_view_change(_, _)).RETURN(true);
     REQUIRE_CALL(store_mock, verify_signature(_, _, _, _)).RETURN(false);
 
     ccf::ViewChange v;

--- a/src/node/view_change.h
+++ b/src/node/view_change.h
@@ -13,28 +13,14 @@ namespace ccf
 {
   struct ViewChange
   {
-    kv::Consensus::View view = 0;
-    kv::Consensus::SeqNo seqno = 0;
-    crypto::Sha256Hash root;
-
     std::vector<NodeSignature> signatures;
-
     std::vector<uint8_t> signature;
 
     ViewChange() = default;
-    ViewChange(
-      kv::Consensus::View view_,
-      kv::Consensus::SeqNo seqno_,
-      crypto::Sha256Hash root_) :
-      view(view_),
-      seqno(seqno_),
-      root(root_)
-    {}
 
     size_t get_serialized_size() const
     {
-      size_t size = sizeof(view) + sizeof(seqno) + sizeof(root) +
-        sizeof(size_t) + sizeof(size_t) + signature.size();
+      size_t size = sizeof(size_t) + sizeof(size_t) + signature.size();
 
       for (const auto& s : signatures)
       {
@@ -45,13 +31,6 @@ namespace ccf
 
     void serialize(uint8_t*& data, size_t& size)
     {
-      serialized::write(
-        data, size, reinterpret_cast<uint8_t*>(&view), sizeof(view));
-      serialized::write(
-        data, size, reinterpret_cast<uint8_t*>(&seqno), sizeof(seqno));
-      serialized::write(
-        data, size, reinterpret_cast<uint8_t*>(&root), sizeof(root));
-
       size_t num_sigs = signatures.size();
       serialized::write(
         data, size, reinterpret_cast<uint8_t*>(&num_sigs), sizeof(num_sigs));
@@ -70,11 +49,6 @@ namespace ccf
     static ViewChange deserialize(const uint8_t*& data, size_t& size)
     {
       ViewChange v;
-
-      v.view = serialized::read<kv::Consensus::View>(data, size);
-      v.seqno = serialized::read<kv::Consensus::SeqNo>(data, size);
-      v.root = serialized::read<crypto::Sha256Hash>(data, size);
-
       size_t num_sigs = serialized::read<size_t>(data, size);
       for (size_t i = 0; i < num_sigs; ++i)
       {

--- a/src/node/view_change.h
+++ b/src/node/view_change.h
@@ -26,7 +26,9 @@ namespace ccf
       kv::Consensus::View view_,
       kv::Consensus::SeqNo seqno_,
       crypto::Sha256Hash root_) :
-      view(view_), seqno(seqno_), root(root_)
+      view(view_),
+      seqno(seqno_),
+      root(root_)
     {}
 
     size_t get_serialized_size() const

--- a/src/node/view_change.h
+++ b/src/node/view_change.h
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+#include "crypto/hash.h"
+#include "kv/map.h"
+#include "node_signature.h"
+
+#include <msgpack/msgpack.hpp>
+#include <string>
+#include <vector>
+
+namespace ccf
+{
+  struct ViewChange
+  {
+    kv::Consensus::View view = 0;
+    kv::Consensus::SeqNo seqno = 0;
+    crypto::Sha256Hash root;
+
+    std::vector<NodeSignature> signatures;
+
+    std::vector<uint8_t> signature;
+
+    ViewChange() = default;
+    ViewChange(
+      kv::Consensus::View view_,
+      kv::Consensus::SeqNo seqno_,
+      crypto::Sha256Hash root_) :
+      view(view_), seqno(seqno_), root(root_)
+    {}
+
+    size_t get_serialized_size() const
+    {
+      size_t size = sizeof(view) + sizeof(seqno) + sizeof(root) +
+        sizeof(size_t) + sizeof(size_t) + signature.size();
+
+      for (const auto& s : signatures)
+      {
+        size += s.get_serialized_size();
+      }
+      return size;
+    }
+
+    void serialize(uint8_t*& data, size_t& size)
+    {
+      serialized::write(
+        data, size, reinterpret_cast<uint8_t*>(&view), sizeof(view));
+      serialized::write(
+        data, size, reinterpret_cast<uint8_t*>(&seqno), sizeof(seqno));
+      serialized::write(
+        data, size, reinterpret_cast<uint8_t*>(&root), sizeof(root));
+
+      size_t num_sigs = signatures.size();
+      serialized::write(
+        data, size, reinterpret_cast<uint8_t*>(&num_sigs), sizeof(num_sigs));
+
+      for (const auto& s : signatures)
+      {
+        s.serialize(data, size);
+      }
+
+      size_t sig_size = signature.size();
+      serialized::write(
+        data, size, reinterpret_cast<uint8_t*>(&sig_size), sizeof(sig_size));
+      serialized::write(data, size, signature.data(), sig_size);
+    }
+
+    static ViewChange deserialize(const uint8_t*& data, size_t& size)
+    {
+      ViewChange v;
+
+      v.view = serialized::read<kv::Consensus::View>(data, size);
+      v.seqno = serialized::read<kv::Consensus::SeqNo>(data, size);
+      v.root = serialized::read<crypto::Sha256Hash>(data, size);
+
+      size_t num_sigs = serialized::read<size_t>(data, size);
+      for (size_t i = 0; i < num_sigs; ++i)
+      {
+        v.signatures.push_back(ccf::NodeSignature::deserialize(data, size));
+      }
+
+      size_t sig_size = serialized::read<size_t>(data, size);
+      v.signature = serialized::read(data, size, sig_size);
+
+      return v;
+    }
+  };
+}

--- a/tests/election.py
+++ b/tests/election.py
@@ -79,14 +79,11 @@ def run(args):
         # Number of nodes F to stop until network cannot make progress
         nodes_to_stop = math.ceil(len(args.nodes) / 2)
         if args.consensus == "bft":
-            nodes_to_stop = math.ceil(len(args.nodes) / 3)
-            nodes_to_stop = 1
+            # nodes_to_stop = math.ceil(len(args.nodes) / 3)
 
-        LOG.error(
-            "AAAAAA nodes_to_stop:{}".format(
-                nodes_to_stop
-            )
-        )
+            # View Change implementation is in progress.
+            # https://github.com/microsoft/CCF/issues/1709
+            nodes_to_stop = 1
 
         primary_is_known = True
         for node_to_stop in range(nodes_to_stop):

--- a/tests/election.py
+++ b/tests/election.py
@@ -80,6 +80,13 @@ def run(args):
         nodes_to_stop = math.ceil(len(args.nodes) / 2)
         if args.consensus == "bft":
             nodes_to_stop = math.ceil(len(args.nodes) / 3)
+            nodes_to_stop = 1
+
+        LOG.error(
+            "AAAAAA nodes_to_stop:{}".format(
+                nodes_to_stop
+            )
+        )
 
         primary_is_known = True
         for node_to_stop in range(nodes_to_stop):

--- a/tests/election.py
+++ b/tests/election.py
@@ -81,6 +81,8 @@ def run(args):
         if args.consensus == "bft":
             # nodes_to_stop = math.ceil(len(args.nodes) / 3)
 
+            LOG.error("aaaaaaa {}", math.ceil(len(args.nodes) / 3))
+
             # View Change implementation is in progress.
             # https://github.com/microsoft/CCF/issues/1709
             nodes_to_stop = 1


### PR DESCRIPTION
Part of #1709 

When running in BFT mode we sometimes decide to send view change messages (#1770, #1813). This PR picks up at the point when we are ready to send a view change message. It includes:
- Create a view-change message will all the relevant evidence and send it to all the other replicas
- Receiving replicas validates the incoming message
- Receiving replicas update their progress tracker with the new evidence
- Rate limit how often a replica will send a view-change message