### PR TITLE
Test non-msgpack serialisers

### DIFF
--- a/src/kv/serialise_entry_json.h
+++ b/src/kv/serialise_entry_json.h
@@ -20,7 +20,7 @@ namespace kv::serialisers
 
     static T from_serialised(const SerialisedEntry& rep)
     {
-      const auto j = nlohmann::json::parse(rep);
+      const auto j = nlohmann::json::parse(rep.begin(), rep.end());
       return j.get<T>();
     }
   };

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -270,6 +270,7 @@ namespace kv
           "Can't add dynamic map - already have a map named {}", map_name));
       }
 
+      LOG_DEBUG_FMT("Adding newly created map '{}' at version {}", map_name, v);
       maps[map_name] = std::make_pair(v, map);
 
       {

--- a/src/kv/test/kv_serialisation.cpp
+++ b/src/kv/test/kv_serialisation.cpp
@@ -222,6 +222,49 @@ struct CustomClass
 DECLARE_JSON_TYPE(CustomClass);
 DECLARE_JSON_REQUIRED_FIELDS(CustomClass, s, n);
 
+// Not really intended to be extended, but lets us use the BlitSerialiser for
+// this specific type
+namespace kv::serialisers
+{
+  template <>
+  struct BlitSerialiser<CustomClass>
+  {
+    static SerialisedEntry to_serialised(const CustomClass& cc)
+    {
+      // Don't encode size, entire remainder of buffer is string
+      const auto s_size = cc.s.size();
+      const auto total_size = sizeof(cc.n) + s_size;
+      SerialisedEntry s(total_size);
+
+      uint8_t* data = s.data();
+      size_t remaining = s.size();
+
+      memcpy(data, (void*)&cc.n, sizeof(cc.n));
+      data += sizeof(cc.n);
+      remaining -= sizeof(cc.n);
+
+      memcpy(data, (void*)cc.s.c_str(), remaining);
+
+      return s;
+    }
+
+    static CustomClass from_serialised(const SerialisedEntry& s)
+    {
+      CustomClass cc;
+      const uint8_t* data = s.data();
+      size_t remaining = s.size();
+
+      cc.n = *(decltype(cc.n)*)data;
+      data += sizeof(cc.n);
+      remaining -= sizeof(cc.n);
+
+      cc.s.assign(data, data + remaining);
+
+      return cc;
+    }
+  };
+}
+
 // SNIPPET_START: CustomSerialiser definition
 struct CustomSerialiser
 {
@@ -332,22 +375,22 @@ struct CustomVerboseDumbSerialiser
 
 using DefaultSerialisedMap = kv::Map<CustomClass, CustomClass>;
 using JsonSerialisedMap = kv::JsonSerialisedMap<CustomClass, CustomClass>;
-// using RawCopySerialisedMap = kv::RawCopySerialisedMap<CustomClass, CustomClass>;
+using RawCopySerialisedMap = kv::RawCopySerialisedMap<CustomClass, CustomClass>;
 using MixSerialisedMapA = kv::TypedMap<
   CustomClass,
   CustomClass,
   kv::serialisers::MsgPackSerialiser<CustomClass>,
   kv::serialisers::JsonSerialiser<CustomClass>>;
-// using MixSerialisedMapB = kv::TypedMap<
-//   CustomClass,
-//   CustomClass,
-//   kv::serialisers::JsonSerialiser<CustomClass>,
-//   kv::serialisers::BlitSerialiser<CustomClass>>;
-// using MixSerialisedMapC = kv::TypedMap<
-//   CustomClass,
-//   CustomClass,
-//   kv::serialisers::BlitSerialiser<CustomClass>,
-//   kv::serialisers::MsgPackSerialiser<CustomClass>>;
+using MixSerialisedMapB = kv::TypedMap<
+  CustomClass,
+  CustomClass,
+  kv::serialisers::JsonSerialiser<CustomClass>,
+  kv::serialisers::BlitSerialiser<CustomClass>>;
+using MixSerialisedMapC = kv::TypedMap<
+  CustomClass,
+  CustomClass,
+  kv::serialisers::BlitSerialiser<CustomClass>,
+  kv::serialisers::MsgPackSerialiser<CustomClass>>;
 
 // SNIPPET_START: CustomSerialisedMap definition
 using CustomSerialisedMap =
@@ -370,10 +413,10 @@ TEST_CASE_TEMPLATE(
   MapType,
   DefaultSerialisedMap,
   JsonSerialisedMap,
-  // RawCopySerialisedMap,
+  RawCopySerialisedMap,
   MixSerialisedMapA,
-  // MixSerialisedMapB,
-  // MixSerialisedMapC,
+  MixSerialisedMapB,
+  MixSerialisedMapC,
   CustomSerialisedMap,
   CustomJsonMap,
   VerboseSerialisedMap)

--- a/src/kv/test/kv_serialisation.cpp
+++ b/src/kv/test/kv_serialisation.cpp
@@ -327,6 +327,23 @@ struct CustomVerboseDumbSerialiser
 };
 
 using DefaultSerialisedMap = kv::Map<CustomClass, CustomClass>;
+using JsonSerialisedMap = kv::JsonSerialisedMap<CustomClass, CustomClass>;
+using RawCopySerialisedMap = kv::RawCopySerialisedMap<CustomClass, CustomClass>;
+using MixSerialisedMapA = kv::TypedMap<
+  CustomClass,
+  CustomClass,
+  kv::serialisers::MsgPackSerialiser<CustomClass>,
+  kv::serialisers::JsonSerialiser<CustomClass>>;
+using MixSerialisedMapB = kv::TypedMap<
+  CustomClass,
+  CustomClass,
+  kv::serialisers::JsonSerialiser<CustomClass>,
+  kv::serialisers::BlitSerialiser<CustomClass>>;
+using MixSerialisedMapC = kv::TypedMap<
+  CustomClass,
+  CustomClass,
+  kv::serialisers::BlitSerialiser<CustomClass>,
+  kv::serialisers::MsgPackSerialiser<CustomClass>>;
 
 // SNIPPET_START: CustomSerialisedMap definition
 using CustomSerialisedMap =
@@ -348,6 +365,11 @@ TEST_CASE_TEMPLATE(
   "Custom type serialisation test" * doctest::test_suite("serialisation"),
   MapType,
   DefaultSerialisedMap,
+  JsonSerialisedMap,
+  RawCopySerialisedMap,
+  MixSerialisedMapA,
+  MixSerialisedMapB,
+  MixSerialisedMapC,
   CustomSerialisedMap,
   CustomJsonMap,
   VerboseSerialisedMap)

--- a/src/kv/test/kv_serialisation.cpp
+++ b/src/kv/test/kv_serialisation.cpp
@@ -218,6 +218,10 @@ struct CustomClass
 };
 // SNIPPET_END: CustomClass definition
 
+// These macros allow the default nlohmann JSON serialiser to be used
+DECLARE_JSON_TYPE(CustomClass);
+DECLARE_JSON_REQUIRED_FIELDS(CustomClass, s, n);
+
 // SNIPPET_START: CustomSerialiser definition
 struct CustomSerialiser
 {
@@ -328,22 +332,22 @@ struct CustomVerboseDumbSerialiser
 
 using DefaultSerialisedMap = kv::Map<CustomClass, CustomClass>;
 using JsonSerialisedMap = kv::JsonSerialisedMap<CustomClass, CustomClass>;
-using RawCopySerialisedMap = kv::RawCopySerialisedMap<CustomClass, CustomClass>;
+// using RawCopySerialisedMap = kv::RawCopySerialisedMap<CustomClass, CustomClass>;
 using MixSerialisedMapA = kv::TypedMap<
   CustomClass,
   CustomClass,
   kv::serialisers::MsgPackSerialiser<CustomClass>,
   kv::serialisers::JsonSerialiser<CustomClass>>;
-using MixSerialisedMapB = kv::TypedMap<
-  CustomClass,
-  CustomClass,
-  kv::serialisers::JsonSerialiser<CustomClass>,
-  kv::serialisers::BlitSerialiser<CustomClass>>;
-using MixSerialisedMapC = kv::TypedMap<
-  CustomClass,
-  CustomClass,
-  kv::serialisers::BlitSerialiser<CustomClass>,
-  kv::serialisers::MsgPackSerialiser<CustomClass>>;
+// using MixSerialisedMapB = kv::TypedMap<
+//   CustomClass,
+//   CustomClass,
+//   kv::serialisers::JsonSerialiser<CustomClass>,
+//   kv::serialisers::BlitSerialiser<CustomClass>>;
+// using MixSerialisedMapC = kv::TypedMap<
+//   CustomClass,
+//   CustomClass,
+//   kv::serialisers::BlitSerialiser<CustomClass>,
+//   kv::serialisers::MsgPackSerialiser<CustomClass>>;
 
 // SNIPPET_START: CustomSerialisedMap definition
 using CustomSerialisedMap =
@@ -366,10 +370,10 @@ TEST_CASE_TEMPLATE(
   MapType,
   DefaultSerialisedMap,
   JsonSerialisedMap,
-  RawCopySerialisedMap,
+  // RawCopySerialisedMap,
   MixSerialisedMapA,
-  MixSerialisedMapB,
-  MixSerialisedMapC,
+  // MixSerialisedMapB,
+  // MixSerialisedMapC,
   CustomSerialisedMap,
   CustomJsonMap,
   VerboseSerialisedMap)

--- a/src/kv/tx.h
+++ b/src/kv/tx.h
@@ -141,7 +141,6 @@ namespace kv
           kv::get_security_domain(map_name),
           store->is_map_replicated(map_name));
         created_maps[map_name] = new_map;
-        LOG_DEBUG_FMT("Creating new map '{}'", map_name);
 
         abstract_map = new_map;
       }


### PR DESCRIPTION
We say "you can bring your own serialiser", and have a test that defines a few custom nonsense serialisers to confirm that. We _also_ say "here's a few serialisers for you", via msgpack, JSON, and blitting-a-few-primitive-types, but we were only actually testing the msgpack serialiser (since its used everywhere).

At some point these have rotted, and dropping in `JsonSerialisedMap` for `Map` stopped working! This fixes that, and adds use of these serialisers to the `kv_serialisation` test.