### PR TITLE
Use raw serialiser instead of msgpack when accessing tables from js

### DIFF
--- a/src/apps/js_generic/js_generic.cpp
+++ b/src/apps/js_generic/js_generic.cpp
@@ -17,7 +17,7 @@ namespace ccfapp
   using namespace kv;
   using namespace ccf;
 
-  using KVMap = kv::Map<std::vector<uint8_t>, std::vector<uint8_t>>;
+  using KVMap = kv::untyped::Map;
 
   JSClassID kv_class_id;
   JSClassID kv_map_view_class_id;


### PR DESCRIPTION
Currently, in JS, all data is queried/stored as msgpack-encoded `std::vector<uint8_t>`. This is clearly a mistake and should query/store data as-is.