### PR TITLE
AFT: Verify append entry validity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -634,6 +634,13 @@ if(BUILD_TESTS)
   )
 
   add_e2e_test(
+    NAME rotation_test
+    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/rotation.py
+    CONSENSUS cft
+    ADDITIONAL_ARGS --raft-election-timeout 4000
+  )
+
+  add_e2e_test(
     NAME committable_suffix_test
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/committable.py
     CONSENSUS cft
@@ -840,13 +847,6 @@ if(BUILD_TESTS)
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/election.py
       CONSENSUS ${CONSENSUS}
       ADDITIONAL_ARGS "--raft-election-timeout" "4000"
-    )
-
-    add_e2e_test(
-      NAME rotation_test_${CONSENSUS}
-      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/rotation.py
-      CONSENSUS ${CONSENSUS}
-      ADDITIONAL_ARGS --raft-election-timeout 4000
     )
 
   endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -634,13 +634,6 @@ if(BUILD_TESTS)
   )
 
   add_e2e_test(
-    NAME rotation_test
-    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/rotation.py
-    CONSENSUS cft
-    ADDITIONAL_ARGS --raft-election-timeout 4000
-  )
-
-  add_e2e_test(
     NAME committable_suffix_test
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/committable.py
     CONSENSUS cft
@@ -847,6 +840,13 @@ if(BUILD_TESTS)
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/election.py
       CONSENSUS ${CONSENSUS}
       ADDITIONAL_ARGS "--raft-election-timeout" "4000"
+    )
+
+    add_e2e_test(
+      NAME rotation_test_${CONSENSUS}
+      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/rotation.py
+      CONSENSUS ${CONSENSUS}
+      ADDITIONAL_ARGS --raft-election-timeout 4000
     )
 
   endforeach()

--- a/src/consensus/aft/impl/state.h
+++ b/src/consensus/aft/impl/state.h
@@ -98,7 +98,8 @@ namespace aft
       my_node_id(my_node_id_),
       current_view(0),
       last_idx(0),
-      commit_idx(0)
+      commit_idx(0),
+      new_view_idx(0)
     {}
 
     SpinLock lock;
@@ -113,5 +114,6 @@ namespace aft
     kv::Version bft_watermark_idx;
 
     ViewHistory view_history;
+    kv::Version new_view_idx;
   };
 }

--- a/src/consensus/aft/impl/view_change_tracker.h
+++ b/src/consensus/aft/impl/view_change_tracker.h
@@ -100,7 +100,7 @@ namespace aft
       return ResultAddView::OK;
     }
 
-    void write_view_change_confirmation_append_entry(kv::Consensus::View view)
+    kv::Consensus::SeqNo write_view_change_confirmation_append_entry(kv::Consensus::View view)
     {
       auto it = view_changes.find(view);
       if (it == view_changes.end())
@@ -117,7 +117,7 @@ namespace aft
         nv.view_change_messages.emplace(it.first, it.second);
       }
 
-      store->write_view_change_confirmation(nv);
+      return store->write_view_change_confirmation(nv);
     }
 
     bool check_evidence(kv::Consensus::View view) const
@@ -125,7 +125,6 @@ namespace aft
       return last_valid_view == view;
     }
 
-    // TODO: use seqno
     void clear(bool is_primary, kv::Consensus::View view)
     {
       for (auto it = view_changes.begin(); it != view_changes.end();)
@@ -140,6 +139,7 @@ namespace aft
         }
       }
       view_changes.clear();
+      last_valid_view = view;
     }
 
   private:
@@ -148,7 +148,7 @@ namespace aft
     std::chrono::milliseconds time_previous_view_change_increment =
       std::chrono::milliseconds(0);
     kv::Consensus::View last_view_change_sent = 0;
-    kv::Consensus::View last_valid_view = 2; // TODO: this should be a const
+    kv::Consensus::View last_valid_view = aft::starting_view_change;
     const std::chrono::milliseconds time_between_attempts;
 
     bool should_send_new_view(size_t received_requests, size_t node_count) const

--- a/src/consensus/aft/impl/view_change_tracker.h
+++ b/src/consensus/aft/impl/view_change_tracker.h
@@ -100,7 +100,8 @@ namespace aft
       return ResultAddView::OK;
     }
 
-    kv::Consensus::SeqNo write_view_change_confirmation_append_entry(kv::Consensus::View view)
+    kv::Consensus::SeqNo write_view_change_confirmation_append_entry(
+      kv::Consensus::View view)
     {
       auto it = view_changes.find(view);
       if (it == view_changes.end())

--- a/src/consensus/aft/impl/view_change_tracker.h
+++ b/src/consensus/aft/impl/view_change_tracker.h
@@ -93,6 +93,7 @@ namespace aft
         it->second.new_view_sent == false)
       {
         it->second.new_view_sent = true;
+        last_valid_view = view;
         return ResultAddView::APPEND_NEW_VIEW_MESSAGE;
       }
 
@@ -119,6 +120,11 @@ namespace aft
       store->write_view_change_confirmation(nv);
     }
 
+    bool check_evidence(kv::Consensus::View view) const
+    {
+      return last_valid_view == view;
+    }
+
     void clear()
     {
       view_changes.clear();
@@ -130,6 +136,7 @@ namespace aft
     std::chrono::milliseconds time_previous_view_change_increment =
       std::chrono::milliseconds(0);
     kv::Consensus::View last_view_change_sent = 0;
+    kv::Consensus::View last_valid_view = 2; // TODO: this should be a const
     const std::chrono::milliseconds time_between_attempts;
 
     bool should_send_new_view(size_t received_requests, size_t node_count) const

--- a/src/consensus/aft/impl/view_change_tracker.h
+++ b/src/consensus/aft/impl/view_change_tracker.h
@@ -125,8 +125,20 @@ namespace aft
       return last_valid_view == view;
     }
 
-    void clear()
+    // TODO: use seqno
+    void clear(bool is_primary, kv::Consensus::View view)
     {
+      for (auto it = view_changes.begin(); it != view_changes.end();)
+      {
+        if (is_primary && it->first != view)
+        {
+          it = view_changes.erase(it);
+        }
+        else
+        {
+          ++it;
+        }
+      }
       view_changes.clear();
     }
 

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -218,7 +218,7 @@ namespace aft
       return state->my_node_id;
     }
 
-    bool is_leader()
+    bool is_primary()
     {
       return replica_state == Leader;
     }
@@ -709,7 +709,7 @@ namespace aft
       become_leader();
       view_change_tracker->write_view_change_confirmation_append_entry(view);
 
-      view_change_tracker->clear();
+      view_change_tracker->clear(get_primary(view) == id(), view);
       request_tracker->clear();
     }
 
@@ -1088,7 +1088,7 @@ namespace aft
           }
           case kv::DeserialiseSuccess::NEW_VIEW:
           {
-            view_change_tracker->clear();
+            view_change_tracker->clear(get_primary(sig_term) == id(), sig_term);
             request_tracker->clear();
             break;
           }
@@ -1192,7 +1192,7 @@ namespace aft
         r.sig,
         r.hashed_nonce,
         node_count(),
-        is_leader());
+        is_primary());
       for (auto it = nodes.begin(); it != nodes.end(); ++it)
       {
         auto send_to = it->first;
@@ -1242,7 +1242,7 @@ namespace aft
         r.sig,
         r.hashed_nonce,
         node_count(),
-        is_leader());
+        is_primary());
       try_send_sig_ack({r.term, r.last_log_idx}, result);
     }
 
@@ -1357,7 +1357,7 @@ namespace aft
             }
           }
           progress_tracker->add_nonce_reveal(
-            tx_id, nonce, state->my_node_id, node_count(), is_leader());
+            tx_id, nonce, state->my_node_id, node_count(), is_primary());
           break;
         }
         default:
@@ -1401,7 +1401,7 @@ namespace aft
         r.term,
         r.idx);
       progress_tracker->add_nonce_reveal(
-        {r.term, r.idx}, r.nonce, r.from_node, node_count(), is_leader());
+        {r.term, r.idx}, r.nonce, r.from_node, node_count(), is_primary());
 
       update_commit();
     }
@@ -1478,12 +1478,10 @@ namespace aft
 
       if (r.success == AppendEntriesResponseType::REQUIRE_EVIDENCE)
       {
-        // TODO: We would like to send the evidence there
-
-
         // Using this evidence we can move view backwards or forwards
         // When we get valid evident at seqno > ours then we do a rollback
         // finally keep track of the evidence view so we can never move backwards
+        throw std::logic_error("Not implemented yet");
 
       }
 

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -874,12 +874,14 @@ namespace aft
         else if (get_primary(r.term) != r.from_node)
         {
           LOG_DEBUG_FMT(
-            "Recv append entries to {} from {} at view:{} but the primary at this view should be {}",
+            "Recv append entries to {} from {} at view:{} but the primary at "
+            "this view should be {}",
             state->my_node_id,
             r.from_node,
             r.term,
             get_primary(r.term));
-          send_append_entries_response(r.from_node, AppendEntriesResponseType::FAIL);
+          send_append_entries_response(
+            r.from_node, AppendEntriesResponseType::FAIL);
           return;
         }
         else if (!view_change_tracker->check_evidence(r.term))
@@ -924,7 +926,8 @@ namespace aft
           r.from_node,
           state->current_view,
           r.term);
-        send_append_entries_response(r.from_node, AppendEntriesResponseType::FAIL);
+        send_append_entries_response(
+          r.from_node, AppendEntriesResponseType::FAIL);
         return;
       }
 
@@ -957,7 +960,8 @@ namespace aft
             prev_term,
             r.prev_term);
         }
-        send_append_entries_response(r.from_node, AppendEntriesResponseType::FAIL);
+        send_append_entries_response(
+          r.from_node, AppendEntriesResponseType::FAIL);
         return;
       }
 
@@ -1028,7 +1032,8 @@ namespace aft
             state->my_node_id,
             r.from_node,
             e.what());
-          send_append_entries_response(r.from_node, AppendEntriesResponseType::FAIL);
+          send_append_entries_response(
+            r.from_node, AppendEntriesResponseType::FAIL);
           return;
         }
 
@@ -1066,7 +1071,8 @@ namespace aft
           {
             LOG_FAIL_FMT("Follower failed to apply log entry: {}", i);
             state->last_idx--;
-            send_append_entries_response(r.from_node, AppendEntriesResponseType::FAIL);
+            send_append_entries_response(
+              r.from_node, AppendEntriesResponseType::FAIL);
             break;
           }
 
@@ -1146,7 +1152,8 @@ namespace aft
         rollback(last_committable_index());
         LOG_DEBUG_FMT(
           "Recv append entries to {} from {} at view:{} but we do not have "
-          "the evidence to support this view, append message was marked as containing evidence",
+          "the evidence to support this view, append message was marked as "
+          "containing evidence",
           state->my_node_id,
           r.from_node,
           r.term);
@@ -1169,7 +1176,8 @@ namespace aft
       send_append_entries_response(r.from_node, AppendEntriesResponseType::OK);
     }
 
-    void send_append_entries_response(NodeId to, AppendEntriesResponseType answer)
+    void send_append_entries_response(
+      NodeId to, AppendEntriesResponseType answer)
     {
       LOG_DEBUG_FMT(
         "Send append entries response from {} to {} for index {}: {}",

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -860,7 +860,7 @@ namespace aft
 
       // When we are running with in a Byzantine model we cannot trust that the
       // replica is sending up this data is correct so we need to validate
-      // additional properties that go above an beyond the non-byzantine
+      // additional properties that go above and beyond the non-byzantine
       // scenario.
       bool confirm_evidence = false;
       if (consensus_type == ConsensusType::BFT)
@@ -868,7 +868,7 @@ namespace aft
         if (active_nodes().size() == 0)
         {
           // The replica is just starting up, we want to check that this replica
-          // is part of the network we joined but that is dependant on Byzantine
+          // is part of the network we joined but that is dependent on Byzantine
           // identity
         }
         else if (get_primary(r.term) != r.from_node)

--- a/src/consensus/aft/raft_consensus.h
+++ b/src/consensus/aft/raft_consensus.h
@@ -32,7 +32,7 @@ namespace aft
 
     bool is_primary() override
     {
-      return aft->is_leader();
+      return aft->is_primary();
     }
 
     bool is_backup() override

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -32,6 +32,8 @@ namespace aft
 
   static constexpr NodeId NoNode = std::numeric_limits<NodeId>::max();
 
+  static constexpr size_t starting_view_change = 2;
+
   template <typename S>
   class Store
   {
@@ -167,6 +169,7 @@ namespace aft
     Term prev_term;
     Index leader_commit_idx;
     Term term_of_idx;
+    bool contains_new_view;
   };
 
   enum class AppendEntriesResponseType : uint8_t

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -169,11 +169,18 @@ namespace aft
     Term term_of_idx;
   };
 
+  enum class AppendEntriesResponseType : uint8_t
+  {
+    OK = 0,
+    FAIL = 1,
+    REQUIRE_EVIDENCE = 2
+  };
+
   struct AppendEntriesResponse : RaftHeader
   {
     Term term;
     Index last_log_idx;
-    bool success;
+    AppendEntriesResponseType success;
   };
 
   struct SignedAppendEntriesResponse : RaftHeader

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -151,7 +151,7 @@ public:
     std::cout << "  Note right of Node" << node_id << ": ";
     auto raft = _nodes.at(node_id).raft;
 
-    if (raft->is_leader())
+    if (raft->is_primary())
       std::cout << "L ";
 
     std::cout << " t: " << raft->get_term() << ", li: " << raft->get_last_idx()

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -118,7 +118,8 @@ public:
   {
     std::ostringstream s;
     s << "append_entries_response t: " << aer.term
-      << ", lli: " << aer.last_log_idx << ", s: " << static_cast<uint8_t>(aer.success);
+      << ", lli: " << aer.last_log_idx
+      << ", s: " << static_cast<uint8_t>(aer.success);
     rlog(node_id, tgt_node_id, s.str());
   }
 

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -118,7 +118,7 @@ public:
   {
     std::ostringstream s;
     s << "append_entries_response t: " << aer.term
-      << ", lli: " << aer.last_log_idx << ", s: " << aer.success;
+      << ", lli: " << aer.last_log_idx << ", s: " << static_cast<uint8_t>(aer.success);
     rlog(node_id, tgt_node_id, s.str());
   }
 

--- a/src/consensus/aft/test/main.cpp
+++ b/src/consensus/aft/test/main.cpp
@@ -54,7 +54,7 @@ DOCTEST_TEST_CASE("Single node startup" * doctest::test_suite("single"))
 
   DOCTEST_INFO("DOCTEST_REQUIRE Initial State");
 
-  DOCTEST_REQUIRE(!r0.is_leader());
+  DOCTEST_REQUIRE(!r0.is_primary());
   DOCTEST_REQUIRE(r0.leader() == aft::NoNode);
   DOCTEST_REQUIRE(r0.get_term() == 0);
   DOCTEST_REQUIRE(r0.get_commit_idx() == 0);
@@ -63,10 +63,10 @@ DOCTEST_TEST_CASE("Single node startup" * doctest::test_suite("single"))
     "In the absence of other nodes, become leader after election timeout");
 
   r0.periodic(ms(0));
-  DOCTEST_REQUIRE(!r0.is_leader());
+  DOCTEST_REQUIRE(!r0.is_primary());
 
   r0.periodic(election_timeout * 2);
-  DOCTEST_REQUIRE(r0.is_leader());
+  DOCTEST_REQUIRE(r0.is_primary());
   DOCTEST_REQUIRE(r0.leader() == node_id);
 }
 
@@ -100,7 +100,7 @@ DOCTEST_TEST_CASE("Single node commit" * doctest::test_suite("single"))
   DOCTEST_INFO("Become leader after election timeout");
 
   r0.periodic(election_timeout * 2);
-  DOCTEST_REQUIRE(r0.is_leader());
+  DOCTEST_REQUIRE(r0.is_primary());
 
   DOCTEST_INFO("Observe that data is committed on replicate immediately");
 
@@ -262,7 +262,7 @@ DOCTEST_TEST_CASE(
   DOCTEST_INFO(
     "Node 0 is now leader, and sends empty append entries to other nodes");
 
-  DOCTEST_REQUIRE(r0.is_leader());
+  DOCTEST_REQUIRE(r0.is_primary());
   DOCTEST_REQUIRE(
     ((aft::ChannelStubProxy*)r0.channels.get())->sent_append_entries.size() ==
     2);
@@ -741,7 +741,7 @@ DOCTEST_TEST_CASE("Recv append entries logic" * doctest::test_suite("multiple"))
         ((aft::ChannelStubProxy*)r1.channels.get())
           ->sent_request_vote_response));
 
-    DOCTEST_REQUIRE(r0.is_leader());
+    DOCTEST_REQUIRE(r0.is_primary());
     DOCTEST_REQUIRE(
       ((aft::ChannelStubProxy*)r0.channels.get())->sent_append_entries.size() ==
       1);

--- a/src/consensus/aft/test/main.cpp
+++ b/src/consensus/aft/test/main.cpp
@@ -436,7 +436,7 @@ DOCTEST_TEST_CASE(
       ((aft::ChannelStubProxy*)r1.channels.get())->sent_append_entries_response,
       [](const auto& msg) {
         DOCTEST_REQUIRE(msg.last_log_idx == 0);
-        DOCTEST_REQUIRE(msg.success);
+        DOCTEST_REQUIRE(msg.success == aft::AppendEntriesResponseType::OK);
       }));
   DOCTEST_REQUIRE(
     1 ==
@@ -445,7 +445,7 @@ DOCTEST_TEST_CASE(
       ((aft::ChannelStubProxy*)r2.channels.get())->sent_append_entries_response,
       [](const auto& msg) {
         DOCTEST_REQUIRE(msg.last_log_idx == 0);
-        DOCTEST_REQUIRE(msg.success);
+        DOCTEST_REQUIRE(msg.success == aft::AppendEntriesResponseType::OK);
       }));
 
   DOCTEST_INFO("There ought to be no messages pending anywhere now");
@@ -493,7 +493,7 @@ DOCTEST_TEST_CASE(
       ((aft::ChannelStubProxy*)r1.channels.get())->sent_append_entries_response,
       [](const auto& msg) {
         DOCTEST_REQUIRE(msg.last_log_idx == 1);
-        DOCTEST_REQUIRE(msg.success);
+        DOCTEST_REQUIRE(msg.success == aft::AppendEntriesResponseType::OK);
       }));
   DOCTEST_REQUIRE(
     1 ==
@@ -502,7 +502,7 @@ DOCTEST_TEST_CASE(
       ((aft::ChannelStubProxy*)r2.channels.get())->sent_append_entries_response,
       [](const auto& msg) {
         DOCTEST_REQUIRE(msg.last_log_idx == 1);
-        DOCTEST_REQUIRE(msg.success);
+        DOCTEST_REQUIRE(msg.success == aft::AppendEntriesResponseType::OK);
       }));
 }
 
@@ -603,7 +603,7 @@ DOCTEST_TEST_CASE("Multiple nodes late join" * doctest::test_suite("multiple"))
       ((aft::ChannelStubProxy*)r1.channels.get())->sent_append_entries_response,
       [](const auto& msg) {
         DOCTEST_REQUIRE(msg.last_log_idx == 0);
-        DOCTEST_REQUIRE(msg.success);
+        DOCTEST_REQUIRE(msg.success == aft::AppendEntriesResponseType::OK);
       }));
 
   DOCTEST_REQUIRE(
@@ -636,7 +636,7 @@ DOCTEST_TEST_CASE("Multiple nodes late join" * doctest::test_suite("multiple"))
       ((aft::ChannelStubProxy*)r1.channels.get())->sent_append_entries_response,
       [](const auto& msg) {
         DOCTEST_REQUIRE(msg.last_log_idx == 1);
-        DOCTEST_REQUIRE(msg.success);
+        DOCTEST_REQUIRE(msg.success == aft::AppendEntriesResponseType::OK);
       }));
 
   DOCTEST_INFO("Node 2 joins the ensemble");
@@ -804,7 +804,7 @@ DOCTEST_TEST_CASE("Recv append entries logic" * doctest::test_suite("multiple"))
                  .second;
     ((aft::ChannelStubProxy*)r1.channels.get())
       ->sent_append_entries_response.pop_front();
-    aer.success = false;
+    aer.success = aft::AppendEntriesResponseType::FAIL;
     r0.recv_message(reinterpret_cast<uint8_t*>(&aer), sizeof(aer));
     DOCTEST_REQUIRE(
       ((aft::ChannelStubProxy*)r0.channels.get())->sent_append_entries.size() ==
@@ -867,7 +867,7 @@ DOCTEST_TEST_CASE("Recv append entries logic" * doctest::test_suite("multiple"))
                  .second;
     ((aft::ChannelStubProxy*)r1.channels.get())
       ->sent_append_entries_response.pop_front();
-    aer.success = false;
+    aer.success = aft::AppendEntriesResponseType::FAIL;
     r0.recv_message(reinterpret_cast<uint8_t*>(&aer), sizeof(aer));
     DOCTEST_REQUIRE(
       ((aft::ChannelStubProxy*)r0.channels.get())->sent_append_entries.size() ==
@@ -984,7 +984,7 @@ DOCTEST_TEST_CASE("Exceed append entries limit")
       ((aft::ChannelStubProxy*)r1.channels.get())->sent_append_entries_response,
       [](const auto& msg) {
         DOCTEST_REQUIRE(msg.last_log_idx == 0);
-        DOCTEST_REQUIRE(msg.success);
+        DOCTEST_REQUIRE(msg.success == aft::AppendEntriesResponseType::OK);
       }));
 
   DOCTEST_REQUIRE(

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -897,7 +897,8 @@ namespace kv
             return success;
           }
 
-          if (!progress_tracker->apply_new_view(consensus->primary(),consensus->node_count(), *term_, *index_))
+          if (!progress_tracker->apply_new_view(
+                consensus->primary(), consensus->node_count(), *term_, *index_))
           {
             LOG_FAIL_FMT("apply_new_view Failed");
             LOG_DEBUG_FMT("NewView in transaction {} failed to verify", v);

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -897,7 +897,7 @@ namespace kv
             return success;
           }
 
-          if (!progress_tracker->apply_new_view(consensus->primary()))
+          if (!progress_tracker->apply_new_view(consensus->primary(),consensus->node_count(), *term_, *index_))
           {
             LOG_FAIL_FMT("apply_new_view Failed");
             LOG_DEBUG_FMT("NewView in transaction {} failed to verify", v);

--- a/src/node/progress_tracker.h
+++ b/src/node/progress_tracker.h
@@ -634,9 +634,6 @@ namespace ccf
       return verified_signatures;
     }
 
-    // TODO: Check that the info here is correct!
-    // 
-    // Check: View, seqno
     bool apply_new_view(kv::NodeId from, uint32_t node_count, kv::Consensus::View& view_, kv::Consensus::SeqNo& seqno_) const
     {
       auto new_view = store->get_new_view();

--- a/src/node/progress_tracker.h
+++ b/src/node/progress_tracker.h
@@ -634,14 +634,20 @@ namespace ccf
       return verified_signatures;
     }
 
-    bool apply_new_view(kv::NodeId from, uint32_t node_count, kv::Consensus::View& view_, kv::Consensus::SeqNo& seqno_) const
+    bool apply_new_view(
+      kv::NodeId from,
+      uint32_t node_count,
+      kv::Consensus::View& view_,
+      kv::Consensus::SeqNo& seqno_) const
     {
       auto new_view = store->get_new_view();
       CCF_ASSERT(new_view.has_value(), "new view does not have a value");
       kv::Consensus::View view = new_view->view;
       kv::Consensus::SeqNo seqno = new_view->seqno;
 
-      if (seqno < highest_prepared_level.version || view < highest_prepared_level.term)
+      if (
+        seqno < highest_prepared_level.version ||
+        view < highest_prepared_level.term)
       {
         LOG_FAIL_FMT(
           "Invalid view and seqno in the new view highest prepared from:{}, "
@@ -654,16 +660,18 @@ namespace ccf
         return false;
       }
 
-      if (new_view->view_change_messages.size() < ccf::get_message_threshold(node_count))
+      if (
+        new_view->view_change_messages.size() <
+        ccf::get_message_threshold(node_count))
       {
         LOG_FAIL_FMT(
-          "Not enough ViewChangeRequests from:{}, new_view view:{}, seqno:{}, num_requests:{}",
+          "Not enough ViewChangeRequests from:{}, new_view view:{}, seqno:{}, "
+          "num_requests:{}",
           from,
           view,
           seqno,
           new_view->view_change_messages.size());
         return false;
-
       }
 
       for (auto& vcp : new_view->view_change_messages)

--- a/src/node/progress_tracker.h
+++ b/src/node/progress_tracker.h
@@ -634,12 +634,40 @@ namespace ccf
       return verified_signatures;
     }
 
-    bool apply_new_view(kv::NodeId from) const
+    // TODO: Check that the info here is correct!
+    // 
+    // Check: View, seqno
+    bool apply_new_view(kv::NodeId from, uint32_t node_count, kv::Consensus::View& view_, kv::Consensus::SeqNo& seqno_) const
     {
       auto new_view = store->get_new_view();
       CCF_ASSERT(new_view.has_value(), "new view does not have a value");
       kv::Consensus::View view = new_view->view;
       kv::Consensus::SeqNo seqno = new_view->seqno;
+
+      if (seqno < highest_prepared_level.version || view < highest_prepared_level.term)
+      {
+        LOG_FAIL_FMT(
+          "Invalid view and seqno in the new view highest prepared from:{}, "
+          "view:{},seqno:{}, new_view view:{}, seqno:{}",
+          from,
+          highest_prepared_level.term,
+          highest_prepared_level.version,
+          view,
+          seqno);
+        return false;
+      }
+
+      if (new_view->view_change_messages.size() < ccf::get_message_threshold(node_count))
+      {
+        LOG_FAIL_FMT(
+          "Not enough ViewChangeRequests from:{}, new_view view:{}, seqno:{}, num_requests:{}",
+          from,
+          view,
+          seqno,
+          new_view->view_change_messages.size());
+        return false;
+
+      }
 
       for (auto& vcp : new_view->view_change_messages)
       {
@@ -664,6 +692,8 @@ namespace ccf
         return false;
       }
 
+      view_ = view;
+      seqno_ = seqno;
       return true;
     }
 

--- a/src/node/progress_tracker_types.h
+++ b/src/node/progress_tracker_types.h
@@ -73,7 +73,7 @@ namespace ccf
       kv::NodeId from,
       kv::Consensus::View view,
       kv::Consensus::SeqNo seqno) = 0;
-    virtual void write_view_change_confirmation(
+    virtual kv::Consensus::SeqNo write_view_change_confirmation(
       ccf::ViewChangeConfirmation& new_view) = 0;
     virtual bool verify_view_change_request_confirmation(
       ccf::ViewChangeConfirmation& new_view, kv::NodeId from) = 0;
@@ -246,7 +246,7 @@ namespace ccf
         new_view.signature.size());
     }
 
-    void write_view_change_confirmation(
+    kv::Consensus::SeqNo write_view_change_confirmation(
       ccf::ViewChangeConfirmation& new_view) override
     {
       kv::Tx tx(&store);
@@ -268,6 +268,8 @@ namespace ccf
           new_view.view,
           new_view.seqno));
       }
+
+      return tx.commit_version();
     }
 
     crypto::Sha256Hash hash_new_view(ccf::ViewChangeConfirmation& new_view)

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -531,7 +531,7 @@ TEST_CASE("view-change-tracker timeout tests")
 TEST_CASE("view-change-tracker statemachine tests")
 {
   ccf::ViewChangeRequest v;
-  kv::Consensus::View view = 1;
+  kv::Consensus::View view = 3;
   kv::Consensus::SeqNo seqno = 1;
   uint32_t node_count = 4;
 
@@ -550,7 +550,12 @@ TEST_CASE("view-change-tracker statemachine tests")
       {
         REQUIRE(r == aft::ViewChangeTracker::ResultAddView::OK);
       }
+      REQUIRE((vct.check_evidence(view) == i >= 2));
+      REQUIRE(!vct.check_evidence(view + 1));
     }
+    vct.clear(true, view);
+    REQUIRE(vct.check_evidence(view));
+    REQUIRE(!vct.check_evidence(view + 1));
   }
 
   INFO("Can differentiate view change for different view");

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -48,7 +48,7 @@ public:
     override);
   MAKE_MOCK1(
     write_view_change_confirmation,
-    void(ccf::ViewChangeConfirmation& new_view),
+    kv::Consensus::SeqNo(ccf::ViewChangeConfirmation& new_view),
     override);
 };
 


### PR DESCRIPTION
Part of #1709

This is still a work in progress and there will be follow-up PRs. In this PR we do the following:
- A backup checks the validity of the NewViewConfirmation append entry before it applies it
- Every time an append entry arrives a backup will check that it comes from a "valid" primary
- If the validity of a primary cannot be established from the information that the backup already has it will look at the append entry to see if it is a NewViewConfirmation entry that contains said proof.
