### PR TITLE
Skip doxygen generation based on env var

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -229,4 +229,5 @@ def setup(self):
     srcdir = pathlib.Path(self.srcdir)
 
     breathe_projects["CCF"] = str(srcdir / breathe_projects["CCF"])
-    subprocess.run(["doxygen"], cwd=srcdir / "..", check=True)
+    if not os.environ.get("SKIP_DOXYGEN"):
+        subprocess.run(["doxygen"], cwd=srcdir / "..", check=True)


### PR DESCRIPTION
Running a Sphinx documentation server locally is super useful to check the formatting of local doc edits, etc.. However, running doxygen on every edit means that it takes a few seconds to render doc changes in the browser. The `SKIP_DOXYGEN` environment variable can now be set to skip this slow process, e.g. `$ SKIP_DOXYGEN=ON ./livehtml.sh`. 