### PR TITLE
AFT: New primary send evidence extremely delayed backup

### DIFF
--- a/src/consensus/aft/impl/state.h
+++ b/src/consensus/aft/impl/state.h
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "consensus/aft/raft_types.h"
 #include "ds/logger.h"
 #include "ds/spin_lock.h"
 #include "kv/kv_types.h"
@@ -99,7 +100,8 @@ namespace aft
       current_view(0),
       last_idx(0),
       commit_idx(0),
-      new_view_idx(0)
+      new_view_idx(0),
+      requested_evidence_from(NoNode)
     {}
 
     SpinLock lock;
@@ -115,5 +117,6 @@ namespace aft
 
     ViewHistory view_history;
     kv::Version new_view_idx;
+    kv::NodeId requested_evidence_from;
   };
 }

--- a/src/consensus/aft/impl/view_change_tracker.h
+++ b/src/consensus/aft/impl/view_change_tracker.h
@@ -116,12 +116,7 @@ namespace aft
       nlohmann::json j;
       to_json(j, nv);
       std::string s = j.dump();
-
-      std::vector<uint8_t> ret;
-      ret.resize(s.size() + 1);
-      std::copy(s.begin(), s.end(), ret.data());
-
-      return ret;
+      return {s.begin(), s.end() + 1};
     }
 
     bool add_unknown_primary_evidence(

--- a/src/consensus/aft/impl/view_change_tracker.h
+++ b/src/consensus/aft/impl/view_change_tracker.h
@@ -100,7 +100,6 @@ namespace aft
       return ResultAddView::OK;
     }
 
-    // TODO we generate the view here
     kv::Consensus::SeqNo write_view_change_confirmation_append_entry(
       kv::Consensus::View view)
     {
@@ -119,16 +118,16 @@ namespace aft
       std::string s = j.dump();
 
       std::vector<uint8_t> ret;
-      ret.resize(s.size()+1);
+      ret.resize(s.size() + 1);
       std::copy(s.begin(), s.end(), ret.data());
 
       return ret;
     }
 
     bool add_unknown_primary_evidence(
-      std::vector<uint8_t>& data, kv::Consensus::View view, uint32_t node_count)
+      CBuffer data, kv::Consensus::View view, uint32_t node_count)
     {
-      nlohmann::json j = nlohmann::json::parse(data.data());
+      nlohmann::json j = nlohmann::json::parse(data.p);
       auto vc = j.get<ccf::ViewChangeConfirmation>();
 
       if (view != vc.view)
@@ -186,7 +185,8 @@ namespace aft
     kv::Consensus::View last_valid_view = aft::starting_view_change;
     const std::chrono::milliseconds time_between_attempts;
 
-    ccf::ViewChangeConfirmation create_view_change_confirmation_msg(kv::Consensus::View view)
+    ccf::ViewChangeConfirmation create_view_change_confirmation_msg(
+      kv::Consensus::View view)
     {
       auto it = view_changes.find(view);
       if (it == view_changes.end())

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -708,9 +708,7 @@ namespace aft
       if (r.from_node != state->requested_evidence_from)
       {
         // Ignore if we didn't request this evidence.
-        LOG_FAIL_FMT(
-          "we received evidence which we did not request, ignoring it {}",
-          r.from_node);
+        LOG_FAIL_FMT("Received unrequested evidence from {}", r.from_node);
         return;
       }
       state->requested_evidence_from = NoNode;

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1517,7 +1517,12 @@ namespace aft
         // We need to provide evidence to the replica that we can send it append
         // entries. This should only happened if there is some kind of network
         // partition.
-        throw std::logic_error("Not implemented yet");
+        kv::Consensus::View view = 1;
+        kv::Consensus::SeqNo seqno = 1;
+        ViewChangeEvidenceMsg vw = {
+          {bft_view_change_evidence, state->my_node_id}, view, seqno};
+
+        channels->send_authenticated(ccf::NodeMsgType::consensus_msg, r.from_node, vw);
       }
 
       if (r.success != AppendEntriesResponseType::OK)

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -152,7 +152,8 @@ namespace aft
     bft_request,
     bft_signature_received_ack,
     bft_nonce_reveal,
-    bft_view_change
+    bft_view_change,
+    bft_view_change_evidence
   };
 
 #pragma pack(push, 1)
@@ -209,6 +210,12 @@ namespace aft
   };
 
   struct RequestViewChangeMsg : RaftHeader
+  {
+    kv::Consensus::View view = 0;
+    kv::Consensus::SeqNo seqno = 0;
+  };
+
+  struct ViewChangeEvidenceMsg : RaftHeader
   {
     kv::Consensus::View view = 0;
     kv::Consensus::SeqNo seqno = 0;

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -218,7 +218,6 @@ namespace aft
   struct ViewChangeEvidenceMsg : RaftHeader
   {
     kv::Consensus::View view = 0;
-    kv::Consensus::SeqNo seqno = 0;
   };
 
   struct RequestVote : RaftHeader

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -668,12 +668,14 @@ TEST_CASE("Sending evidence out of band")
           .RETURN(true)
           .TIMES(AT_LEAST(1));
 
-        REQUIRE(vct_2.add_unknown_primary_evidence(data, view, node_count));
+        REQUIRE(vct_2.add_unknown_primary_evidence(
+          {data.data(), data.size()}, view, node_count));
         REQUIRE(vct_2.check_evidence(view));
       }
       else
       {
-        REQUIRE(!vct_2.add_unknown_primary_evidence(data, view, node_count));
+        REQUIRE(!vct_2.add_unknown_primary_evidence(
+          {data.data(), data.size()}, view, node_count));
         REQUIRE(!vct_2.check_evidence(view));
       }
       REQUIRE(!vct_2.check_evidence(view + 1));

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -516,7 +516,7 @@ TEST_CASE("view-change-tracker timeout tests")
 {
   INFO("Check timeout works correctly");
   {
-    aft::ViewChangeTracker vct(0, std::chrono::seconds(10));
+    aft::ViewChangeTracker vct(nullptr, std::chrono::seconds(10));
     REQUIRE(vct.should_send_view_change(std::chrono::seconds(1)) == false);
     REQUIRE(vct.get_target_view() == 0);
     REQUIRE(vct.should_send_view_change(std::chrono::seconds(11)));
@@ -537,7 +537,7 @@ TEST_CASE("view-change-tracker statemachine tests")
 
   INFO("Can trigger view change");
   {
-    aft::ViewChangeTracker vct(0, std::chrono::seconds(10));
+    aft::ViewChangeTracker vct(nullptr, std::chrono::seconds(10));
     for (uint32_t i = 0; i < node_count; ++i)
     {
       auto r = vct.add_request_view_change(v, i, view, seqno, node_count);
@@ -560,7 +560,7 @@ TEST_CASE("view-change-tracker statemachine tests")
 
   INFO("Can differentiate view change for different view");
   {
-    aft::ViewChangeTracker vct(0, std::chrono::seconds(10));
+    aft::ViewChangeTracker vct(nullptr, std::chrono::seconds(10));
     for (uint32_t i = 0; i < node_count; ++i)
     {
       auto r = vct.add_request_view_change(v, i, i, seqno, node_count);
@@ -627,5 +627,56 @@ TEST_CASE("test progress_tracker apply_view_change")
 
     bool result = pt->apply_view_change_message(v, 1, 1, 42);
     REQUIRE(result == false);
+  }
+}
+
+TEST_CASE("Sending evidence out of band")
+{
+  using trompeloeil::_;
+
+  ccf::ViewChangeRequest v;
+  kv::Consensus::View view = 3;
+  kv::Consensus::SeqNo seqno = 1;
+  constexpr uint32_t node_count = 4;
+
+  INFO("Can trigger view change");
+  {
+    aft::ViewChangeTracker vct(nullptr, std::chrono::seconds(10));
+    for (uint32_t i = 0; i < node_count; ++i)
+    {
+      auto r = vct.add_request_view_change(v, i, view, seqno, node_count);
+      if (i == 2)
+      {
+        REQUIRE(
+          r == aft::ViewChangeTracker::ResultAddView::APPEND_NEW_VIEW_MESSAGE);
+      }
+      else
+      {
+        REQUIRE(r == aft::ViewChangeTracker::ResultAddView::OK);
+      }
+
+      auto data = vct.get_serialized_view_change_confirmation(view);
+      std::shared_ptr<ccf::ProgressTrackerStore> store =
+        std::make_unique<StoreMock>();
+
+      aft::ViewChangeTracker vct_2(store, std::chrono::seconds(10));
+      if (i >= 2)
+      {
+        REQUIRE_CALL(
+          *reinterpret_cast<StoreMock*>(store.get()),
+          verify_view_change_request(_, _, _, _))
+          .RETURN(true)
+          .TIMES(AT_LEAST(1));
+
+        REQUIRE(vct_2.add_unknown_primary_evidence(data, view, node_count));
+        REQUIRE(vct_2.check_evidence(view));
+      }
+      else
+      {
+        REQUIRE(!vct_2.add_unknown_primary_evidence(data, view, node_count));
+        REQUIRE(!vct_2.check_evidence(view));
+      }
+      REQUIRE(!vct_2.check_evidence(view + 1));
+    }
   }
 }


### PR DESCRIPTION
resolves #1709

This is closing a hole that exists in view-changes where: if there is a network partition a replica that is considerably behind the primary and did receive any of the view-change messages could receive append entries from the new primary and no evidence that supports this new primary is the actual primary.