### PR TITLE
AFT: locking issues

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -401,11 +401,6 @@ namespace aft
     {
       if (consensus_type == ConsensusType::BFT && is_follower())
       {
-        for (auto& [index, data, globally_committable] : entries)
-        {
-          state->last_idx = index;
-          ledger->put_entry(*data, globally_committable, false);
-        }
         return true;
       }
 
@@ -540,6 +535,7 @@ namespace aft
 
     void periodic(std::chrono::milliseconds elapsed)
     {
+      std::unique_lock<SpinLock> guard(state->lock);
       if (consensus_type == ConsensusType::BFT)
       {
         auto time = threading::ThreadMessaging::thread_messaging
@@ -595,12 +591,19 @@ namespace aft
                 *vc, id(), new_view, seqno, node_count()) &&
             get_primary(new_view) == id())
           {
+            // We need to reobtain the lock when writing to the ledger so we
+            // need to release it at this time.
+            //
+            // It is safe to release the lock here because there is no
+            // concurrency based dependency between appending to the ledger and
+            // replicating the ledger to other machines.
+            guard.unlock();
             append_new_view(new_view);
+            guard.lock();
           }
         }
       }
 
-      std::lock_guard<SpinLock> guard(state->lock);
       timeout_elapsed += elapsed;
 
       if (replica_state == Leader)
@@ -1176,8 +1179,16 @@ namespace aft
           {
             if (consensus_type == ConsensusType::BFT)
             {
+              LOG_INFO_FMT(
+                "AAAAAA - i:{} - recv_append_entries - before:{}",
+                i,
+                state->last_idx);
               state->last_idx =
                 executor->commit_replayed_request(tx, request_tracker);
+              LOG_INFO_FMT(
+                "AAAAAA - i:{} - recv_append_entries - after:{}",
+                i,
+                state->last_idx);
             }
             break;
           }

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1179,16 +1179,8 @@ namespace aft
           {
             if (consensus_type == ConsensusType::BFT)
             {
-              LOG_INFO_FMT(
-                "AAAAAA - i:{} - recv_append_entries - before:{}",
-                i,
-                state->last_idx);
               state->last_idx =
                 executor->commit_replayed_request(tx, request_tracker);
-              LOG_INFO_FMT(
-                "AAAAAA - i:{} - recv_append_entries - after:{}",
-                i,
-                state->last_idx);
             }
             break;
           }


### PR DESCRIPTION
part of #1601

I am fixing some of the locking issues, additional PRs will follow-up on this work

- In replicate raft.h:404, on the BFT backup we would go through the committed tx and put them on the ledger. This actually results in double adding ledger entries, raft.h:452, does this already
- There was a re-entrant lock issue if we ended up having to append the ViewChangeConfirmation message to the ledger, we solve this by release the lock for a short period of time. This is safe because there is no concurrency dependency by adding the view and propagating the ledger which would occur next.