### PR TITLE
Add clear method to KV store

### DIFF
--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -1417,7 +1417,7 @@ TEST_CASE("Store clear")
 
   INFO("Apply transactions and compact store");
   {
-    size_t tx_count = 100;
+    size_t tx_count = 10;
     for (int i = 0; i < tx_count; i++)
     {
       auto tx = kv_store.create_tx();
@@ -1441,7 +1441,7 @@ TEST_CASE("Store clear")
     REQUIRE(tx_id.version != 0);
   }
 
-  INFO("Verify that store state is clearer");
+  INFO("Verify that store state is cleared");
   {
     kv_store.clear();
     auto current_version = kv_store.current_version();


### PR DESCRIPTION
Related to #1539 

On join, when a node has verified the authenticity of a snapshot (i.e. proof in the ledger that evidence is globally committed), it can safely clear its state so far and join from there. 

Clearing the store at this point is safer than re-creating a store object that may have already been passed to other objects (i.e. frontends) when the node was created.