### PR TITLE
Address warning flagged by CodeQL

### DIFF
--- a/src/http/http_jwt.h
+++ b/src/http/http_jwt.h
@@ -72,7 +72,7 @@ namespace http
       {
         second_dot = token.find(separator, first_dot + 1);
       }
-      size_t extra_dot;
+      size_t extra_dot = std::string::npos;
       if (second_dot != std::string::npos)
       {
         extra_dot = token.find(separator, second_dot + 1);


### PR DESCRIPTION
This is essentially a false positive, but it's inexpensive to silence in a way that makes the code slightly more robust to further changes.