### PR TITLE
Only retire backup when test suite can progress

### DIFF
--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -43,14 +43,24 @@ def check_can_progress(node, timeout=3):
         assert False, f"Stuck at {r}"
 
 
-@reqs.description("Adding a valid node from primary")
-def test_add_node(network, args):
+def add_node(network, args):
     new_node = network.create_and_trust_node(args.package, "local://localhost", args)
+    assert new_node
     with new_node.client() as c:
         s = c.get("/node/state")
         assert s.body.json()["id"] == new_node.node_id
-    assert new_node
     return network
+
+
+def retire_node(network, primary, backup_to_retire):
+    network.consortium.retire_node(primary, backup_to_retire)
+    backup_to_retire.stop()
+    return network
+
+
+@reqs.description("Adding a valid node from primary")
+def test_add_node(network, args):
+    return add_node(network, args)
 
 
 @reqs.description("Adding a valid node from a backup")
@@ -120,11 +130,42 @@ def test_add_node_untrusted_code(network, args):
 
 @reqs.description("Retiring a backup")
 @reqs.at_least_n_nodes(2)
+@reqs.can_kill_n_nodes(1)
 def test_retire_backup(network, args):
     primary, _ = network.find_primary()
     backup_to_retire = network.find_any_backup()
-    network.consortium.retire_node(primary, backup_to_retire)
-    backup_to_retire.stop()
+    return retire_node(network, primary, backup_to_retire)
+
+
+@reqs.description("Retiring all backups (then recreating the same number of nodes)")
+def test_retire_all_backups(network, args):
+    primary, backups = network.find_nodes()
+    original_backups = len(backups)
+    for backup in backups:
+        network = retire_node(network, primary, backup)
+    check_can_progress(primary)
+    LOG.info(
+        f"Retired {original_backups} original backups, replacing them with same number of new backups"
+    )
+    for _ in range(original_backups):
+        network = add_node(network, args)
+    return network
+
+
+@reqs.description("Retiring the primary")
+@reqs.can_kill_n_nodes(1)
+def test_retire_primary(network, args):
+    pre_count = count_nodes(node_configs(network), network)
+
+    primary, backup = network.find_primary_and_any_backup()
+    network.consortium.retire_node(primary, primary)
+    new_primary, new_term = network.wait_for_new_primary(primary.node_id)
+    LOG.debug(f"New primary is {new_primary.node_id} in term {new_term}")
+    check_can_progress(backup)
+    network.nodes.remove(primary)
+    post_count = count_nodes(node_configs(network), network)
+    assert pre_count == post_count + 1
+    primary.stop()
     return network
 
 
@@ -161,6 +202,7 @@ def run(args):
         test_add_node(network, args)
         test_add_node_untrusted_code(network, args)
         test_retire_backup(network, args)
+        test_retire_all_backups(network, args)
         test_add_as_many_pending_nodes(network, args)
         test_add_node(network, args)
         test_retire_primary(network, args)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -120,11 +120,13 @@ def test_add_node_untrusted_code(network, args):
 
 @reqs.description("Retiring a backup")
 @reqs.at_least_n_nodes(2)
+@reqs.can_kill_n_nodes(1)
 def test_retire_backup(network, args):
     primary, _ = network.find_primary()
     backup_to_retire = network.find_any_backup()
     network.consortium.retire_node(primary, backup_to_retire)
     backup_to_retire.stop()
+    check_can_progress(primary)
     return network
 
 

--- a/tests/suite/test_suite.py
+++ b/tests/suite/test_suite.py
@@ -51,7 +51,6 @@ suite_reconfiguration = [
     reconfiguration.test_add_node,
     reconfiguration.test_add_node,
     reconfiguration.test_retire_backup,
-    reconfiguration.test_retire_all_backups,
     reconfiguration.test_add_node,
     election.test_kill_primary,
 ]
@@ -96,7 +95,6 @@ all_tests_suite = [
     reconfiguration.test_add_as_many_pending_nodes,
     reconfiguration.test_add_node_untrusted_code,
     reconfiguration.test_retire_backup,
-    reconfiguration.test_retire_all_backups,
     # recovery:
     recovery.test,
     # rekey:

--- a/tests/suite/test_suite.py
+++ b/tests/suite/test_suite.py
@@ -51,6 +51,7 @@ suite_reconfiguration = [
     reconfiguration.test_add_node,
     reconfiguration.test_add_node,
     reconfiguration.test_retire_backup,
+    reconfiguration.test_retire_all_backups,
     reconfiguration.test_add_node,
     election.test_kill_primary,
 ]
@@ -95,6 +96,7 @@ all_tests_suite = [
     reconfiguration.test_add_as_many_pending_nodes,
     reconfiguration.test_add_node_untrusted_code,
     reconfiguration.test_retire_backup,
+    reconfiguration.test_retire_all_backups,
     # recovery:
     recovery.test,
     # rekey:


### PR DESCRIPTION
I was trying to work out what failed in this test (a specific seed for `full_test_suite`):
https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=16059&view=logs&j=5435e0ac-25e5-5426-50be-61b0d0ea8d34&t=63d660c3-6f76-573a-0154-fd0bcb096ded&l=11078

I thought maybe we had a bug where we're not able to retire the final backup, as the special case progress for a single-node network wasn't triggered? But that's not the case - I tried retiring all backups and the final lone primary is happy to proceed.

The actual fix is much simpler. This seed had previously run the test which _kills_ the primary, without retiring it. So the configuration currently contains 3 nodes, 1 of whom is not participating, and sure enough the primary can't reach consensus if the sole live backup is retired. So we should only retire this backup if `can_kill_n_nodes` (which counts the service's `TRUSTED` nodes directly, not just the Python clients running nodes) says we can.