### PR TITLE
Add memory stats in suite

### DIFF
--- a/tests/e2e_suite.py
+++ b/tests/e2e_suite.py
@@ -26,8 +26,7 @@ def mem_stats(network):
     mem = {}
     for node in network.get_joined_nodes():
         try:
-            primary, _ = network.find_primary()
-            with primary.client() as c:
+            with node.client() as c:
                 r = c.get("/node/memory", 0.1)
                 mem[node.node_id] = r.body.json()
         except Exception:

--- a/tests/e2e_suite.py
+++ b/tests/e2e_suite.py
@@ -22,6 +22,19 @@ class TestStatus(Enum):
     skipped = 3
 
 
+def mem_stats(network):
+    mem = {}
+    for node in network.get_joined_nodes():
+        try:
+            primary, _ = network.find_primary()
+            with primary.client() as c:
+                r = c.get("/node/memory", 0.1)
+                mem[node.node_id] = r.body.json()
+        except Exception:
+            pass
+    return mem
+
+
 def run(args):
 
     chosen_suite = []
@@ -95,6 +108,7 @@ def run(args):
             "name": s.test_name(test),
             "status": status.name,
             "elapsed (s)": round(test_elapsed, 2),
+            "memory": mem_stats(network),
         }
 
         if reason is not None:


### PR DESCRIPTION
Print memory usage on each live node at the end of each test in the suite.

![image](https://user-images.githubusercontent.com/4016369/101191813-1ad02980-3652-11eb-8252-feda0a36d4bf.png)

Not useful to debug a bad_alloc this time, but could be in the future.