### PR TITLE
Remove pbft notice

### DIFF
--- a/scripts/notice-check.py
+++ b/scripts/notice-check.py
@@ -10,24 +10,11 @@ NOTICE_LINES_CCF = [
     "Licensed under the Apache 2.0 License.",
 ]
 
-NOTICE_LINES_PBFT = [
-    "Copyright (c) Microsoft Corporation.",
-    "Copyright (c) 1999 Miguel Castro, Barbara Liskov.",
-    "Copyright (c) 2000, 2001 Miguel Castro, Rodrigo Rodrigues, Barbara Liskov.",
-    "Licensed under the MIT license.",
-]
-
 PREFIXES_CCF = [
     os.linesep.join([prefix + " " + line for line in NOTICE_LINES_CCF])
     for prefix in ["//", "--", "#"]
 ]
 PREFIXES_CCF.append("#!/bin/bash" + os.linesep + PREFIXES_CCF[-1])
-PREFIXES_CCF.append(os.linesep.join(["//" + " " + line for line in NOTICE_LINES_PBFT]))
-PREFIXES_CCF.append(
-    os.linesep.join(
-        ["//" + " " + line for line in [NOTICE_LINES_PBFT[0], NOTICE_LINES_PBFT[3]]]
-    )
-)
 
 
 def has_notice(path, prefixes):

--- a/src/ds/ccf_assert.h
+++ b/src/ds/ccf_assert.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
 #pragma once
 
 #include "ds/logger.h"

--- a/src/ds/stacktrace_utils.h
+++ b/src/ds/stacktrace_utils.h
@@ -1,7 +1,5 @@
-// Copyright (c) Microsoft Corporation.
-// Copyright (c) 1999 Miguel Castro, Barbara Liskov.
-// Copyright (c) 2000, 2001 Miguel Castro, Rodrigo Rodrigues, Barbara Liskov.
-// Licensed under the MIT license.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
 #pragma once
 
 #ifndef INSIDE_ENCLAVE


### PR DESCRIPTION
All the contents of this file except for a few squiggly brackets has been replaced (*), none of the code to which the original notice applied still exists.

(*) See file history in git, but mostly #1261, #1309 and #1633

This change simplifies the notice check, and removes the sole MIT-licensed file from the otherwise all-Apache 2.0 `src/`.