### PR TITLE
Bump nodejs to 14 LTS to fix ts-node issues

### DIFF
--- a/getting_started/setup_vm/roles/nodejs/vars/common.yml
+++ b/getting_started/setup_vm/roles/nodejs/vars/common.yml
@@ -1,1 +1,1 @@
-nodejs_version: 12
+nodejs_version: 14

--- a/samples/apps/forum/package.json
+++ b/samples/apps/forum/package.json
@@ -46,7 +46,7 @@
     "rollup": "^2.23.0",
     "selfsigned": "^1.10.8",
     "tmp": "^0.2.1",
-    "ts-node": "^9.0.0",
+    "ts-node": "^9.1.0",
     "tslib": "^2.0.1",
     "typescript": "^4.0.2"
   }


### PR DESCRIPTION
Recently nodejs 12.20 was released which broke `ts-node` (used by the forum app). The new version of `ts-node` contains fixes that only work on nodejs >= 14, and since this is an LTS as well, the easiest path forward is to bump to that version.