### PR TITLE
Fix test_install.sh when testing a new CCF release

### DIFF
--- a/.azure-pipelines-templates/install.yml
+++ b/.azure-pipelines-templates/install.yml
@@ -23,7 +23,7 @@ steps:
 
   - script: |
       sudo apt -y install ./$(pkgname)
-      cat /tmp/install_prefix | xargs ./test_install.sh
+      cat /tmp/install_prefix | xargs -i bash -c "PYTHON_PACKAGE_PATH=../python ./test_install.sh {}"
     workingDirectory: build
     displayName: Test installed CCF
 

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -743,7 +743,7 @@ int main(int argc, char** argv)
       else
       {
         LOG_FAIL_FMT(
-          "No snapshot found. Node will request all historical transactions.");
+          "No snapshot found: Node will request all historical transactions");
       }
     }
 

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -743,8 +743,7 @@ int main(int argc, char** argv)
       else
       {
         LOG_FAIL_FMT(
-          "No snapshot found. Node will request transactions all historical "
-          "transactions");
+          "No snapshot found. Node will request all historical transactions.");
       }
     }
 

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -172,8 +172,7 @@ def run(args):
             test_add_node_from_snapshot(network, args, copy_ledger_read_only=False)
             errors, _ = network.get_joined_nodes()[-1].stop()
             if not any(
-                "No snapshot found. Node will request transactions all historical transactions"
-                in s
+                "No snapshot found: Node will request all historical transactions" in s
                 for s in errors
             ):
                 raise ValueError(

--- a/tests/sandbox/sandbox.sh
+++ b/tests/sandbox/sandbox.sh
@@ -38,7 +38,14 @@ if [ -f "${VERSION_FILE}" ]; then
     BINARY_DIR=${PATH_HERE}
     START_NETWORK_SCRIPT="${PATH_HERE}"/start_network.py
     VERSION=$(<"${VERSION_FILE}")
-    pip install --disable-pip-version-check -q -U ccf=="$VERSION"
+    if [ ! -z "${PYTHON_PACKAGE_PATH}" ]; then
+        # With an install tree, the python package can be specified, e.g. when testing
+        # an install just before it is released
+        echo "Using python package: ${PYTHON_PACKAGE_PATH}"
+        pip install --disable-pip-version-check -q -U -e "${PYTHON_PACKAGE_PATH}"
+    else
+        pip install --disable-pip-version-check -q -U ccf=="$VERSION"
+    fi
     pip install --disable-pip-version-check -q -U -r "${PATH_HERE}"/requirements.txt
 else
     # source tree


### PR DESCRIPTION
When testing a new release on the CI, the CCF Python package won't be published until `test_install.sh` has passed. However, `test_install.sh`, which now uses `sandbox.sh`, assumed that `pip install ccf=<version>` works. To fix this, we can now pass a `PYTHON_PACKAGE_PATH` env var to both `test_install.sh` and `sandbox.sh` so that the Python package is installed from there instead.