### PR TITLE
Clear member submitted shares on error

### DIFF
--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -1753,6 +1753,7 @@ namespace ccf
           LOG_FAIL_FMT(error_msg);
           LOG_DEBUG_FMT("Error: {}", e.what());
           share_manager.clear_submitted_recovery_shares(args.tx);
+          args.rpc_ctx->set_apply_writes(true);
           args.rpc_ctx->set_response_status(HTTP_STATUS_INTERNAL_SERVER_ERROR);
           args.rpc_ctx->set_response_body(std::move(error_msg));
           return;

--- a/src/node/rpc/test/member_voting_test.cpp
+++ b/src/node/rpc/test/member_voting_test.cpp
@@ -2100,7 +2100,7 @@ DOCTEST_TEST_CASE("Submit recovery shares")
       {
         check_error(rep, HTTP_STATUS_INTERNAL_SERVER_ERROR);
 
-        // On error, all submitted shares should have been clearer
+        // On error, all submitted shares should have been cleared
         size_t submitted_shares_count = 0;
         submitted_shares->foreach(
           [&submitted_shares_count](const auto& member_id, const auto& share) {


### PR DESCRIPTION
Spotted by @eddyashton 

On recovery, when a threshold of member shares have been submitted and one (or more) of the recovery shares was bogus, the share combination fails and the endpoint returns an error. In this scenario, we want to clear all the submitted recovery shares from the `ccf.gov.submitted_shares` table to let members try again (and because it is hard to find out which share was bogus). 

Because the endpoint returned an error, the write set wasn't actually applied, which meant the submitted recovery shares weren't cleared. This is now the case, via `ctx->set_apply_writes(true)`. 