### PR TITLE
Fix forum app test

### DIFF
--- a/samples/apps/forum/test/poll.test.ts
+++ b/samples/apps/forum/test/poll.test.ts
@@ -18,9 +18,10 @@ import {
   SubmitOpinionsRequest,
   NumericPollResponse,
   StringPollResponse,
-  MINIMUM_OPINION_THRESHOLD,
   GetPollResponse,
 } from "../src/controllers/poll";
+
+const MINIMUM_OPINION_THRESHOLD = 10;
 
 tmp.setGracefulCleanup();
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/CCF/issues/2042.

This works around an issue related to the experimental ESM support used with mocha. By not importing the (runtime) constant from the ccf app code it doesn't try to import the module and its dependencies which caused the issue (NOTE: the error message in the issue is not the real error because that's swallowed by mocha, see also mocha/lib/esm-utils.js::requireOrImport).