### PR TITLE
Document auth policies in OpenAPI

### DIFF
--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -361,6 +361,23 @@
         },
         "type": "array"
       }
+    },
+    "securitySchemes": {
+      "bearer_jwt": {
+        "bearerFormat": "JWT",
+        "scheme": "bearer",
+        "type": "http"
+      },
+      "member_signature": {
+        "description": "Request must be signed according to the HTTP Signature scheme. The signer must be a member identity registered with this service.",
+        "scheme": "signature",
+        "type": "http"
+      },
+      "user_signature": {
+        "description": "Request must be signed according to the HTTP Signature scheme. The signer must be a user identity registered with this service.",
+        "scheme": "signature",
+        "type": "http"
+      }
     }
   },
   "info": {
@@ -782,7 +799,19 @@
             },
             "description": "Default response description"
           }
-        }
+        },
+        "security": [
+          {
+            "user_signature": []
+          },
+          {
+            "member_signature": []
+          },
+          {
+            "bearer_jwt": []
+          },
+          {}
+        ]
       }
     },
     "/network_info": {
@@ -966,7 +995,15 @@
             },
             "description": "Default response description"
           }
-        }
+        },
+        "security": [
+          {
+            "user_signature": []
+          },
+          {
+            "member_signature": []
+          }
+        ]
       }
     }
   },

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -470,6 +470,18 @@
         },
         "type": "array"
       }
+    },
+    "securitySchemes": {
+      "member_signature": {
+        "description": "Request must be signed according to the HTTP Signature scheme. The signer must be a member identity registered with this service.",
+        "scheme": "signature",
+        "type": "http"
+      },
+      "user_signature": {
+        "description": "Request must be signed according to the HTTP Signature scheme. The signer must be a user identity registered with this service.",
+        "scheme": "signature",
+        "type": "http"
+      }
     }
   },
   "info": {
@@ -502,7 +514,12 @@
             },
             "description": "Default response description"
           }
-        }
+        },
+        "security": [
+          {
+            "member_signature": []
+          }
+        ]
       }
     },
     "/ack/update_state_digest": {
@@ -518,7 +535,12 @@
             },
             "description": "Default response description"
           }
-        }
+        },
+        "security": [
+          {
+            "member_signature": []
+          }
+        ]
       }
     },
     "/api": {
@@ -728,7 +750,12 @@
             },
             "description": "Default response description"
           }
-        }
+        },
+        "security": [
+          {
+            "member_signature": []
+          }
+        ]
       }
     },
     "/proposals/{proposal_id}": {
@@ -744,7 +771,12 @@
             },
             "description": "Default response description"
           }
-        }
+        },
+        "security": [
+          {
+            "member_signature": []
+          }
+        ]
       },
       "parameters": [
         {
@@ -790,7 +822,12 @@
             },
             "description": "Default response description"
           }
-        }
+        },
+        "security": [
+          {
+            "member_signature": []
+          }
+        ]
       }
     },
     "/proposals/{proposal_id}/votes/{member_id}": {
@@ -806,7 +843,12 @@
             },
             "description": "Default response description"
           }
-        }
+        },
+        "security": [
+          {
+            "member_signature": []
+          }
+        ]
       },
       "parameters": [
         {
@@ -850,7 +892,12 @@
             },
             "description": "Default response description"
           }
-        }
+        },
+        "security": [
+          {
+            "member_signature": []
+          }
+        ]
       }
     },
     "/query": {
@@ -876,7 +923,12 @@
             },
             "description": "Default response description"
           }
-        }
+        },
+        "security": [
+          {
+            "member_signature": []
+          }
+        ]
       }
     },
     "/read": {
@@ -902,7 +954,12 @@
             },
             "description": "Default response description"
           }
-        }
+        },
+        "security": [
+          {
+            "member_signature": []
+          }
+        ]
       }
     },
     "/receipt": {
@@ -972,7 +1029,12 @@
             },
             "description": "Default response description"
           }
-        }
+        },
+        "security": [
+          {
+            "member_signature": []
+          }
+        ]
       },
       "post": {
         "requestBody": {
@@ -996,7 +1058,12 @@
             },
             "description": "Default response description"
           }
-        }
+        },
+        "security": [
+          {
+            "member_signature": []
+          }
+        ]
       }
     },
     "/tx": {
@@ -1060,7 +1127,15 @@
             },
             "description": "Default response description"
           }
-        }
+        },
+        "security": [
+          {
+            "user_signature": []
+          },
+          {
+            "member_signature": []
+          }
+        ]
       }
     }
   },

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -429,6 +429,18 @@
         },
         "type": "array"
       }
+    },
+    "securitySchemes": {
+      "member_signature": {
+        "description": "Request must be signed according to the HTTP Signature scheme. The signer must be a member identity registered with this service.",
+        "scheme": "signature",
+        "type": "http"
+      },
+      "user_signature": {
+        "description": "Request must be signed according to the HTTP Signature scheme. The signer must be a user identity registered with this service.",
+        "scheme": "signature",
+        "type": "http"
+      }
     }
   },
   "info": {
@@ -828,7 +840,15 @@
             },
             "description": "Default response description"
           }
-        }
+        },
+        "security": [
+          {
+            "user_signature": []
+          },
+          {
+            "member_signature": []
+          }
+        ]
       }
     }
   },

--- a/src/ds/openapi.h
+++ b/src/ds/openapi.h
@@ -9,6 +9,7 @@
 #include <llhttp/llhttp.h>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <regex>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
@@ -50,26 +51,16 @@ namespace ds
     }
 
     static inline std::string sanitise_components_key(
-      const std::string_view& s_)
+      const std::string_view& s)
     {
       // From the OpenAPI spec:
       // All the fixed fields declared above are objects that MUST use keys that
-      // match the regular expression: ^[a-zA-Z0-9\.\-_]+$."
-      std::string s(s_);
-
-      for (auto& c : s)
-      {
-        if (
-          (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-          (c >= '0' && c <= '9') || (c == '.') || (c == '-') || (c == '_'))
-        {
-          continue;
-        }
-
-        c = '_';
-      }
-
-      return s;
+      // match the regular expression: ^[a-zA-Z0-9\.\-_]+$
+      // So here we replace any non-matching characters with _
+      std::string result;
+      std::regex re("[^a-zA-Z0-9\\.\\-_]");
+      std::regex_replace (std::back_inserter(result), s.begin(), s.end(), re, "_");
+      return result;
     }
 
     static inline nlohmann::json create_document(

--- a/src/ds/openapi.h
+++ b/src/ds/openapi.h
@@ -8,8 +8,8 @@
 
 #include <llhttp/llhttp.h>
 #include <nlohmann/json.hpp>
-#include <string>
 #include <regex>
+#include <string>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
@@ -50,8 +50,7 @@ namespace ds
       }
     }
 
-    static inline std::string sanitise_components_key(
-      const std::string_view& s)
+    static inline std::string sanitise_components_key(const std::string_view& s)
     {
       // From the OpenAPI spec:
       // All the fixed fields declared above are objects that MUST use keys that
@@ -59,7 +58,8 @@ namespace ds
       // So here we replace any non-matching characters with _
       std::string result;
       std::regex re("[^a-zA-Z0-9\\.\\-_]");
-      std::regex_replace (std::back_inserter(result), s.begin(), s.end(), re, "_");
+      std::regex_replace(
+        std::back_inserter(result), s.begin(), s.end(), re, "_");
       return result;
     }
 

--- a/src/ds/openapi.h
+++ b/src/ds/openapi.h
@@ -49,15 +49,19 @@ namespace ds
       }
     }
 
-    static inline std::string sanitise_components_key(const std::string_view& s_)
+    static inline std::string sanitise_components_key(
+      const std::string_view& s_)
     {
       // From the OpenAPI spec:
-      // All the fixed fields declared above are objects that MUST use keys that match the regular expression: ^[a-zA-Z0-9\.\-_]+$."
+      // All the fixed fields declared above are objects that MUST use keys that
+      // match the regular expression: ^[a-zA-Z0-9\.\-_]+$."
       std::string s(s_);
 
       for (auto& c : s)
       {
-        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || (c == '.') || (c == '-') || (c == '_'))
+        if (
+          (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+          (c >= '0' && c <= '9') || (c == '.') || (c == '-') || (c == '_'))
         {
           continue;
         }
@@ -206,7 +210,7 @@ namespace ds
 
       return components_ref_object(name);
     }
-    
+
     static inline void add_security_scheme_to_components(
       nlohmann::json& document,
       const std::string& scheme_name,
@@ -226,7 +230,8 @@ namespace ds
         if (security_scheme != existing_scheme)
         {
           throw std::logic_error(fmt::format(
-            "Adding security scheme with name '{}'. Does not match previous scheme "
+            "Adding security scheme with name '{}'. Does not match previous "
+            "scheme "
             "registered with this name: {} vs {}",
             name,
             security_scheme.dump(),

--- a/src/ds/openapi.h
+++ b/src/ds/openapi.h
@@ -49,16 +49,20 @@ namespace ds
       }
     }
 
-    static inline std::string remove_invalid_chars(const std::string_view& s_)
+    static inline std::string sanitise_components_key(const std::string_view& s_)
     {
+      // From the OpenAPI spec:
+      // All the fixed fields declared above are objects that MUST use keys that match the regular expression: ^[a-zA-Z0-9\.\-_]+$."
       std::string s(s_);
 
       for (auto& c : s)
       {
-        if (c == ':')
+        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || (c == '.') || (c == '-') || (c == '_'))
         {
-          c = '_';
+          continue;
         }
+
+        c = '_';
       }
 
       return s;
@@ -89,7 +93,7 @@ namespace ds
     static inline nlohmann::json& path(
       nlohmann::json& document, const std::string& path)
     {
-      auto p = remove_invalid_chars(path);
+      auto p = path;
       if (p.find("/") != 0)
       {
         p = fmt::format("/{}", p);
@@ -116,16 +120,22 @@ namespace ds
       return access::get_array(path_operation, "parameters");
     }
 
+    static inline nlohmann::json& responses(nlohmann::json& path_operation)
+    {
+      return access::get_object(path_operation, "responses");
+    }
+
     static inline nlohmann::json& response(
       nlohmann::json& path_operation,
       http_status status,
       const std::string& description = "Default response description")
     {
-      auto& responses = access::get_object(path_operation, "responses");
+      auto& all_responses = responses(path_operation);
+
       // HTTP_STATUS_OK (aka an int-enum with value 200) becomes the string
       // "200"
       const auto s = std::to_string(status);
-      auto& response = access::get_object(responses, s);
+      auto& response = access::get_object(all_responses, s);
       response["description"] = description;
       return response;
     }
@@ -168,7 +178,7 @@ namespace ds
       const std::string& element_name,
       const nlohmann::json& schema_)
     {
-      const auto name = remove_invalid_chars(element_name);
+      const auto name = sanitise_components_key(element_name);
 
       auto& components = access::get_object(document, "components");
       auto& schemas = access::get_object(components, "schemas");
@@ -195,6 +205,38 @@ namespace ds
       }
 
       return components_ref_object(name);
+    }
+    
+    static inline void add_security_scheme_to_components(
+      nlohmann::json& document,
+      const std::string& scheme_name,
+      const nlohmann::json& security_scheme)
+    {
+      const auto name = sanitise_components_key(scheme_name);
+
+      auto& components = access::get_object(document, "components");
+      auto& schemes = access::get_object(components, "securitySchemes");
+
+      const auto schema_it = schemes.find(name);
+      if (schema_it != schemes.end())
+      {
+        // Check that the existing schema matches the new one being added with
+        // the same name
+        const auto& existing_scheme = schema_it.value();
+        if (security_scheme != existing_scheme)
+        {
+          throw std::logic_error(fmt::format(
+            "Adding security scheme with name '{}'. Does not match previous scheme "
+            "registered with this name: {} vs {}",
+            name,
+            security_scheme.dump(),
+            existing_scheme.dump()));
+        }
+      }
+      else
+      {
+        schemes.emplace(name, security_scheme);
+      }
     }
 
     struct SchemaHelper
@@ -271,7 +313,7 @@ namespace ds
         }
         else
         {
-          const auto name = remove_invalid_chars(ds::json::schema_name<T>());
+          const auto name = sanitise_components_key(ds::json::schema_name<T>());
 
           auto& components = access::get_object(document, "components");
           auto& schemas = access::get_object(components, "schemas");

--- a/src/ds/test/openapi.cpp
+++ b/src/ds/test/openapi.cpp
@@ -292,3 +292,18 @@ TEST_CASE("Manual function definitions")
       components_schemas.end());
   }
 }
+
+TEST_CASE("sanitise_components_key")
+{
+  using namespace ds::openapi;
+
+  CHECK(sanitise_components_key("User") == "User");
+  CHECK(sanitise_components_key("User_1") == "User_1");
+  CHECK(sanitise_components_key("User_Name") == "User_Name");
+  CHECK(sanitise_components_key("user-name") == "user-name");
+  CHECK(sanitise_components_key("my.org.User") == "my.org.User");
+  
+  CHECK(sanitise_components_key("abdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789") == "abdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789");
+  CHECK(sanitise_components_key("!\"$%^&*()") == "_________");
+  CHECK(sanitise_components_key(";:'@#~[{]}-_=+/?.>,<\\|") == "__________-_____._____");
+}

--- a/src/ds/test/openapi.cpp
+++ b/src/ds/test/openapi.cpp
@@ -302,8 +302,13 @@ TEST_CASE("sanitise_components_key")
   CHECK(sanitise_components_key("User_Name") == "User_Name");
   CHECK(sanitise_components_key("user-name") == "user-name");
   CHECK(sanitise_components_key("my.org.User") == "my.org.User");
-  
-  CHECK(sanitise_components_key("abdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789") == "abdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789");
+
+  CHECK(
+    sanitise_components_key(
+      "abdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789") ==
+    "abdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789");
   CHECK(sanitise_components_key("!\"$%^&*()") == "_________");
-  CHECK(sanitise_components_key(";:'@#~[{]}-_=+/?.>,<\\|") == "__________-_____._____");
+  CHECK(
+    sanitise_components_key(";:'@#~[{]}-_=+/?.>,<\\|") ==
+    "__________-_____._____");
 }

--- a/src/http/authentication/authentication_types.h
+++ b/src/http/authentication/authentication_types.h
@@ -15,7 +15,8 @@ namespace ccf
   };
 
   using OpenAPISecuritySchema = std::pair<std::string, nlohmann::json>;
-  static const OpenAPISecuritySchema unauthenticated_schema = std::make_pair("", nlohmann::json());
+  static const OpenAPISecuritySchema unauthenticated_schema =
+    std::make_pair("", nlohmann::json());
 
   class AuthnPolicy
   {

--- a/src/http/authentication/authentication_types.h
+++ b/src/http/authentication/authentication_types.h
@@ -14,12 +14,12 @@ namespace ccf
     virtual ~AuthnIdentity() = default;
   };
 
+  using OpenAPISecuritySchema = std::pair<std::string, nlohmann::json>;
+  static const OpenAPISecuritySchema unauthenticated_schema = std::make_pair("", nlohmann::json());
+
   class AuthnPolicy
   {
   public:
-    using OpenAPISecuritySchema = std::pair<std::string, nlohmann::json>;
-    static const OpenAPISecuritySchema unauthenticated_schema;
-
     virtual ~AuthnPolicy() = default;
 
     virtual std::unique_ptr<AuthnIdentity> authenticate(
@@ -39,9 +39,6 @@ namespace ccf
     virtual std::optional<OpenAPISecuritySchema> get_openapi_security_schema()
       const = 0;
   };
-
-  inline const AuthnPolicy::OpenAPISecuritySchema
-    AuthnPolicy::unauthenticated_schema = std::make_pair("", nlohmann::json());
 
   // To make authentication _optional_, we list no-auth as one of several
   // specified policies

--- a/src/http/authentication/cert_auth.h
+++ b/src/http/authentication/cert_auth.h
@@ -62,6 +62,9 @@ namespace ccf
     std::optional<OpenAPISecuritySchema> get_openapi_security_schema()
       const override
     {
+      // There is currently no OpenAPI-compliant way to describe cert-based TLS
+      // auth, so this policy is not documented. This should change in
+      // OpenAPI3.1: https://github.com/OAI/OpenAPI-Specification/pull/1764
       return std::nullopt;
     }
   };
@@ -115,6 +118,9 @@ namespace ccf
     std::optional<OpenAPISecuritySchema> get_openapi_security_schema()
       const override
     {
+      // There is currently no OpenAPI-compliant way to describe cert-based TLS
+      // auth, so this policy is not documented. This should change in
+      // OpenAPI3.1: https://github.com/OAI/OpenAPI-Specification/pull/1764
       return std::nullopt;
     }
   };
@@ -163,6 +169,9 @@ namespace ccf
     std::optional<OpenAPISecuritySchema> get_openapi_security_schema()
       const override
     {
+      // There is currently no OpenAPI-compliant way to describe cert-based TLS
+      // auth, so this policy is not documented. This should change in
+      // OpenAPI3.1: https://github.com/OAI/OpenAPI-Specification/pull/1764
       return std::nullopt;
     }
   };

--- a/src/http/authentication/jwt_auth.h
+++ b/src/http/authentication/jwt_auth.h
@@ -85,7 +85,7 @@ namespace ccf
     }
   };
 
-  inline const AuthnPolicy::OpenAPISecuritySchema
+  inline const OpenAPISecuritySchema
     JwtAuthnPolicy::security_schema = std::make_pair(
       "bearer_jwt",
       nlohmann::json{

--- a/src/http/authentication/jwt_auth.h
+++ b/src/http/authentication/jwt_auth.h
@@ -85,8 +85,8 @@ namespace ccf
     }
   };
 
-  inline const OpenAPISecuritySchema
-    JwtAuthnPolicy::security_schema = std::make_pair(
+  inline const OpenAPISecuritySchema JwtAuthnPolicy::security_schema =
+    std::make_pair(
       "bearer_jwt",
       nlohmann::json{
         {"type", "http"}, {"scheme", "bearer"}, {"bearerFormat", "JWT"}});

--- a/src/http/authentication/sig_auth.h
+++ b/src/http/authentication/sig_auth.h
@@ -116,7 +116,9 @@ namespace ccf
   inline const OpenAPISecuritySchema UserSignatureAuthnPolicy::security_schema =
     std::make_pair(
       "user_signature",
-      nlohmann::json{{"type", "http"}, {"scheme", "signature"},
+      nlohmann::json{
+        {"type", "http"},
+        {"scheme", "signature"},
         {"description",
          "Request must be signed according to the HTTP Signature scheme. The "
          "signer must be a user identity registered with this service."}});

--- a/src/http/authentication/sig_auth.h
+++ b/src/http/authentication/sig_auth.h
@@ -116,7 +116,10 @@ namespace ccf
   inline const OpenAPISecuritySchema UserSignatureAuthnPolicy::security_schema =
     std::make_pair(
       "user_signature",
-      nlohmann::json{{"type", "http"}, {"scheme", "signature"}});
+      nlohmann::json{{"type", "http"}, {"scheme", "signature"},
+        {"description",
+         "Request must be signed according to the HTTP Signature scheme. The "
+         "signer must be a user identity registered with this service."}});
 
   struct MemberSignatureAuthnIdentity : public AuthnIdentity
   {
@@ -210,5 +213,10 @@ namespace ccf
   inline const OpenAPISecuritySchema
     MemberSignatureAuthnPolicy::security_schema = std::make_pair(
       "member_signature",
-      nlohmann::json{{"type", "http"}, {"scheme", "signature"}});
+      nlohmann::json{
+        {"type", "http"},
+        {"scheme", "signature"},
+        {"description",
+         "Request must be signed according to the HTTP Signature scheme. The "
+         "signer must be a member identity registered with this service."}});
 }

--- a/src/http/authentication/sig_auth.h
+++ b/src/http/authentication/sig_auth.h
@@ -113,8 +113,8 @@ namespace ccf
     }
   };
 
-  inline const AuthnPolicy::OpenAPISecuritySchema
-    UserSignatureAuthnPolicy::security_schema = std::make_pair(
+  inline const OpenAPISecuritySchema UserSignatureAuthnPolicy::security_schema =
+    std::make_pair(
       "user_signature",
       nlohmann::json{{"type", "http"}, {"scheme", "signature"}});
 
@@ -207,7 +207,7 @@ namespace ccf
     }
   };
 
-  inline const AuthnPolicy::OpenAPISecuritySchema
+  inline const OpenAPISecuritySchema
     MemberSignatureAuthnPolicy::security_schema = std::make_pair(
       "member_signature",
       nlohmann::json{{"type", "http"}, {"scheme", "signature"}});

--- a/src/node/rpc/endpoint_registry.h
+++ b/src/node/rpc/endpoint_registry.h
@@ -692,7 +692,8 @@ namespace ccf
           const auto opt_scheme = auth_policy->get_openapi_security_schema();
           if (opt_scheme.has_value())
           {
-            auto& op_security = ds::openapi::access::get_array(path_op, "security");
+            auto& op_security =
+              ds::openapi::access::get_array(path_op, "security");
             if (opt_scheme.value() == ccf::unauthenticated_schema)
             {
               // This auth policy is empty, allowing (optionally)


### PR DESCRIPTION
Part of #2032.

Adds `components/securitySchemes` and per-path-operation `security` fields to generated OpenAPI documents.