### PR TITLE
Fix signature verification

### DIFF
--- a/python/ccf/clients.py
+++ b/python/ccf/clients.py
@@ -376,6 +376,8 @@ class RequestClient:
     CCF default client and wrapper around Python Requests, handling HTTP signatures.
     """
 
+    _auth_provider = HTTPSignatureAuth_AlwaysDigest
+
     def __init__(
         self,
         host: str,
@@ -409,7 +411,7 @@ class RequestClient:
 
         auth_value = None
         if self.signing_auth is not None:
-            auth_value = HTTPSignatureAuth_AlwaysDigest(
+            auth_value = RequestClient._auth_provider(
                 algorithm="ecdsa-sha256",
                 key=open(self.signing_auth.key, "rb").read(),
                 key_id=self.key_id,

--- a/src/http/authentication/sig_auth.h
+++ b/src/http/authentication/sig_auth.h
@@ -35,7 +35,6 @@ namespace ccf
 
   struct VerifierCache
   {
-    // TODO: Make LRU
     SpinLock verifiers_lock;
     std::unordered_map<tls::Pem, tls::VerifierPtr> verifiers;
 

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -35,9 +35,6 @@ namespace ccf
     }
 
   private:
-    SpinLock verifiers_lock;
-    std::map<std::vector<uint8_t>, tls::VerifierPtr> verifiers;
-
     SpinLock open_lock;
     bool is_open_ = false;
 

--- a/src/tls/pem.h
+++ b/src/tls/pem.h
@@ -116,3 +116,15 @@ namespace tls
     }
   }
 }
+
+namespace std
+{
+  template <>
+  struct hash<tls::Pem>
+  {
+    size_t operator()(const tls::Pem& pem) const
+    {
+      return std::hash<std::string>()(pem.str());
+    }
+  };
+}

--- a/tests/memberclient.py
+++ b/tests/memberclient.py
@@ -8,7 +8,6 @@ import infra.network
 import infra.consortium
 import ccf.proposal_generator
 from infra.proposal import ProposalState
-from requests_http_signature import HTTPSignatureAuth  # type: ignore
 
 import suite.test_requirements as reqs
 
@@ -60,7 +59,9 @@ def missing_signature(request):
 
 def empty_signature(request):
     original = request.headers["Authorization"]
-    request.headers["Authorization"] = re.sub(signature_regex, 'signature="",', original)
+    request.headers["Authorization"] = re.sub(
+        signature_regex, 'signature="",', original
+    )
     return request
 
 
@@ -82,6 +83,8 @@ def test_corrupted_signature(network, args):
     primary, _ = network.find_primary()
     member = network.consortium.get_any_active_member()
     with primary.client(*member.auth(write=True)) as mc:
+        # pylint: disable=protected-access
+
         # Cache the original auth provider
         original_auth = ccf.clients.RequestClient._auth_provider
 
@@ -104,10 +107,8 @@ def run(args):
         network.start_and_join(args)
         primary, _ = network.find_primary()
 
-        # network = test_missing_signature_header(network, args)
+        network = test_missing_signature_header(network, args)
         network = test_corrupted_signature(network, args)
-
-        sys.exit(5)
 
         LOG.info("Original members can ACK")
         network.consortium.get_any_active_member().ack(primary)

--- a/tests/suite/test_suite.py
+++ b/tests/suite/test_suite.py
@@ -80,7 +80,8 @@ all_tests_suite = [
     membership.test_retire_member,
     membership.test_update_recovery_shares,
     # memberclient:
-    memberclient.test_missing_signature,
+    memberclient.test_missing_signature_header,
+    memberclient.test_corrupted_signature,
     # receipts:
     receipts.test,
     # reconfiguration:


### PR DESCRIPTION
In the auth refactor, we lost the step of actually verifying HTTP signatures. There is validation of the structure of the headers and the digest to construct a `SignedReq` object, but we weren't verifying that signed req against the expected caller cert.