### PR TITLE
Track the max version a transaction would conflict with

### DIFF
--- a/doc/build_apps/kv/kv_serialisation.rst
+++ b/doc/build_apps/kv/kv_serialisation.rst
@@ -25,6 +25,9 @@ The following table describes the structure of a serialised KV Store transaction
 +          +------------------------------------------+-------------------------------------------------------------------------+
 |          | :cpp:type:`kv::Version`                  | Transaction version                                                     |
 +          +------------------------------------------+-------------------------------------------------------------------------+
+|          | :cpp:type:`kv::Version`                  | Indicates after which version can this ledger entry be executed while   |
+|          |                                          | maintaining linearizability                                             |
++          +------------------------------------------+-------------------------------------------------------------------------+
 |          | **Repeating [0..n]**                     | With ``n`` the number of maps in the transaction                        |
 +          +-----+------------------------------------+-------------------------------------------------------------------------+
 |          |     | | ``KOT_MAP_START_INDICATOR``      | | Indicates the start of a new serialised :cpp:type:`kv::Map`           |

--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -58,6 +58,7 @@ class PublicDomain:
     _unpacker: msgpack.Unpacker
     _is_snapshot: bool
     _version: int
+    _max_conflict_version: int
     _tables: dict
     _msgpacked_tables: Set[str]
 
@@ -67,6 +68,7 @@ class PublicDomain:
         self._unpacker = msgpack.Unpacker(self._buffer, **UNPACK_ARGS)
         self._is_snapshot = self._read_next()
         self._version = self._read_next()
+        self._max_conflict_version = self._read_next()
         self._tables = {}
         # Keys and Values may have custom serialisers.
         # Store most as raw bytes, only decode a few which we know are msgpack.

--- a/src/kv/generic_serialise_wrapper.h
+++ b/src/kv/generic_serialise_wrapper.h
@@ -312,7 +312,8 @@ namespace kv
       domain_restriction(domain_restriction)
     {}
 
-    std::optional<Version> init(const uint8_t* data, size_t size)
+    std::optional<std::tuple<Version, Version>> init(
+      const uint8_t* data, size_t size)
     {
       current_reader = &public_reader;
       auto data_ = data;
@@ -324,7 +325,7 @@ namespace kv
       {
         public_reader.init(data, size);
         read_public_header();
-        return version;
+        return std::make_tuple(version, max_conflict_version);
       }
 
       // Skip gcm hdr and read length of public domain
@@ -343,7 +344,7 @@ namespace kv
         domain_restriction.has_value() &&
         domain_restriction.value() == SecurityDomain::PUBLIC)
       {
-        return version;
+        return std::make_tuple(version, max_conflict_version);
       }
 
       // Go to start of private domain
@@ -362,7 +363,7 @@ namespace kv
 
       // Set private reader
       private_reader.init(decrypted_buffer.data(), decrypted_buffer.size());
-      return version;
+      return std::make_tuple(version, max_conflict_version);
     }
 
     std::optional<std::string> start_map()

--- a/src/kv/generic_serialise_wrapper.h
+++ b/src/kv/generic_serialise_wrapper.h
@@ -50,6 +50,7 @@ namespace kv
     W private_writer;
     W* current_writer;
     Version version;
+    Version max_conflict_version;
     bool is_snapshot;
 
     std::shared_ptr<AbstractTxEncryptor> crypto_util;
@@ -90,14 +91,17 @@ namespace kv
     GenericSerialiseWrapper(
       std::shared_ptr<AbstractTxEncryptor> e,
       const Version& version_,
+      const Version& max_conflict_version_,
       bool is_snapshot_ = false) :
       version(version_),
+      max_conflict_version(max_conflict_version_),
       is_snapshot(is_snapshot_),
       crypto_util(e)
     {
       set_current_domain(SecurityDomain::PUBLIC);
       serialise_internal(is_snapshot);
       serialise_internal(version);
+      serialise_internal(max_conflict_version);
     }
 
     void start_map(const std::string& name, SecurityDomain domain)
@@ -248,6 +252,7 @@ namespace kv
     KvOperationType unhandled_op;
     bool is_snapshot;
     Version version;
+    Version max_conflict_version;
     std::shared_ptr<AbstractTxEncryptor> crypto_util;
     std::optional<SecurityDomain> domain_restriction;
 
@@ -295,6 +300,7 @@ namespace kv
     {
       is_snapshot = public_reader.template read_next<bool>();
       version = public_reader.template read_next<Version>();
+      max_conflict_version = public_reader.template read_next<Version>();
     }
 
   public:

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -446,7 +446,7 @@ namespace kv
     virtual ~AbstractCommitter() = default;
 
     virtual bool has_writes() = 0;
-    virtual bool prepare(kv::Version& max_update_version) = 0;
+    virtual bool prepare(kv::Version& max_conflict_version) = 0;
     virtual void commit(Version v) = 0;
     virtual void post_commit() = 0;
   };

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -446,7 +446,7 @@ namespace kv
     virtual ~AbstractCommitter() = default;
 
     virtual bool has_writes() = 0;
-    virtual bool prepare() = 0;
+    virtual bool prepare(kv::Version& max_update_version) = 0;
     virtual void commit(Version v) = 0;
     virtual void post_commit() = 0;
   };

--- a/src/kv/snapshot.h
+++ b/src/kv/snapshot.h
@@ -41,7 +41,7 @@ namespace kv
     std::vector<uint8_t> serialise(
       std::shared_ptr<AbstractTxEncryptor> encryptor)
     {
-      KvStoreSerialiser serialiser(encryptor, version, true);
+      KvStoreSerialiser serialiser(encryptor, version, version - 1, true);
 
       if (hash_at_snapshot.has_value())
       {

--- a/src/kv/snapshot.h
+++ b/src/kv/snapshot.h
@@ -41,6 +41,9 @@ namespace kv
     std::vector<uint8_t> serialise(
       std::shared_ptr<AbstractTxEncryptor> encryptor)
     {
+      // Set the execution dependency for the snapshot to be the version
+      // previous to said snaphot to ensure that the correct snaphot is
+      // serialized.
       KvStoreSerialiser serialiser(encryptor, version, version - 1, true);
 
       if (hash_at_snapshot.has_value())

--- a/src/kv/snapshot.h
+++ b/src/kv/snapshot.h
@@ -42,7 +42,7 @@ namespace kv
       std::shared_ptr<AbstractTxEncryptor> encryptor)
     {
       // Set the execution dependency for the snapshot to be the version
-      // previous to said snaphot to ensure that the correct snaphot is
+      // previous to said snapshot to ensure that the correct snapshot is
       // serialized.
       KvStoreSerialiser serialiser(encryptor, version, version - 1, true);
 

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -352,7 +352,7 @@ namespace kv
         LOG_FAIL_FMT("Initialisation of deserialise object failed");
         return DeserialiseSuccess::FAILED;
       }
-      auto v = v_.value();
+      auto [v, _] = v_.value();
 
       std::lock_guard<SpinLock> mguard(maps_lock);
 
@@ -628,7 +628,7 @@ namespace kv
         LOG_FAIL_FMT("Initialisation of deserialise object failed");
         return DeserialiseSuccess::FAILED;
       }
-      auto v = v_.value();
+      auto [v, _] = v_.value();
 
       // Throw away any local commits that have not propagated via the
       // consensus.

--- a/src/kv/tx.h
+++ b/src/kv/tx.h
@@ -389,7 +389,13 @@ namespace kv
       auto map = all_changes.begin()->second.map;
       auto e = map->get_store()->get_encryptor();
 
-      KvStoreSerialiser replicated_serialiser(e, version, max_conflict_version);
+      kv::Version mcv = max_conflict_version;
+      if (mcv == NoVersion)
+      {
+        mcv = version - 1;
+      }
+
+      KvStoreSerialiser replicated_serialiser(e, version, mcv);
 
       // Process in security domain order
       for (auto domain : {SecurityDomain::PUBLIC, SecurityDomain::PRIVATE})

--- a/src/kv/tx.h
+++ b/src/kv/tx.h
@@ -47,6 +47,7 @@ namespace kv
     bool success = false;
     Version read_version = NoVersion;
     Version version = NoVersion;
+    Version max_conflict_version = NoVersion;
     Term term = 0;
 
     kv::TxHistory::RequestID req_id;
@@ -295,7 +296,7 @@ namespace kv
       else
       {
         committed = true;
-        version = c.value();
+        std::tie(version, max_conflict_version) = c.value();
 
         // From here, we have received a unique commit version and made
         // modifications to our local kv. If we fail in any way, we cannot
@@ -388,7 +389,7 @@ namespace kv
       auto map = all_changes.begin()->second.map;
       auto e = map->get_store()->get_encryptor();
 
-      KvStoreSerialiser replicated_serialiser(e, version);
+      KvStoreSerialiser replicated_serialiser(e, version, max_conflict_version);
 
       // Process in security domain order
       for (auto domain : {SecurityDomain::PUBLIC, SecurityDomain::PRIVATE})

--- a/src/kv/tx.h
+++ b/src/kv/tx.h
@@ -389,13 +389,12 @@ namespace kv
       auto map = all_changes.begin()->second.map;
       auto e = map->get_store()->get_encryptor();
 
-      kv::Version mcv = max_conflict_version;
-      if (mcv == NoVersion)
+      if (max_conflict_version == NoVersion)
       {
-        mcv = version - 1;
+        max_conflict_version = version - 1;
       }
 
-      KvStoreSerialiser replicated_serialiser(e, version, mcv);
+      KvStoreSerialiser replicated_serialiser(e, version, max_conflict_version);
 
       // Process in security domain order
       for (auto domain : {SecurityDomain::PUBLIC, SecurityDomain::PRIVATE})

--- a/src/kv/untyped_map.h
+++ b/src/kv/untyped_map.h
@@ -141,7 +141,7 @@ namespace kv::untyped
         return committed_writes || change_set.has_writes();
       }
 
-      bool prepare() override
+      bool prepare(kv::Version& max_update_version) override
       {
         if (change_set.writes.empty())
           return true;
@@ -170,6 +170,10 @@ namespace kv::untyped
         {
           // Get the value from the current state.
           auto search = current->state.get(it->first);
+          if (max_update_version < search.value().version)
+          {
+            max_update_version = search.value().version;
+          }
 
           if (it->second == NoVersion)
           {
@@ -409,7 +413,7 @@ namespace kv::untyped
         return true;
       }
 
-      bool prepare() override
+      bool prepare(kv::Version&) override
       {
         // Snapshots never conflict
         return true;

--- a/src/kv/untyped_map.h
+++ b/src/kv/untyped_map.h
@@ -190,9 +190,9 @@ namespace kv::untyped
               return false;
             }
 
-            if (max_conflict_version < search.value().version)
+            if (max_conflict_version < search->version)
             {
-              max_conflict_version = search.value().version;
+              max_conflict_version = search->version;
             }
           }
         }

--- a/src/kv/untyped_map.h
+++ b/src/kv/untyped_map.h
@@ -141,7 +141,7 @@ namespace kv::untyped
         return committed_writes || change_set.has_writes();
       }
 
-      bool prepare(kv::Version& max_update_version) override
+      bool prepare(kv::Version& max_conflict_version) override
       {
         if (change_set.writes.empty())
           return true;
@@ -190,9 +190,9 @@ namespace kv::untyped
               return false;
             }
 
-            if (max_update_version < search.value().version)
+            if (max_conflict_version < search.value().version)
             {
-              max_update_version = search.value().version;
+              max_conflict_version = search.value().version;
             }
           }
         }

--- a/src/kv/untyped_map.h
+++ b/src/kv/untyped_map.h
@@ -170,10 +170,6 @@ namespace kv::untyped
         {
           // Get the value from the current state.
           auto search = current->state.get(it->first);
-          if (max_update_version < search.value().version)
-          {
-            max_update_version = search.value().version;
-          }
 
           if (it->second == NoVersion)
           {
@@ -192,6 +188,11 @@ namespace kv::untyped
             {
               LOG_DEBUG_FMT("Read depends on invalid version of entry");
               return false;
+            }
+
+            if (max_update_version < search.value().version)
+            {
+              max_update_version = search.value().version;
             }
           }
         }

--- a/src/kv/view_containers.h
+++ b/src/kv/view_containers.h
@@ -34,8 +34,10 @@ namespace kv
 
   // Atomically checks for conflicts then applies the writes in the given change
   // sets to their underlying Maps. Calls f() at most once, iff the writes are
-  // applied, to retrieve a unique Version for the write set.
-  static inline std::optional<Version> apply_changes(
+  // applied, to retrieve a unique Version for the write set and return the max
+  // version which can have a conflict with the transaction.
+
+  static inline std::optional<std::tuple<Version, Version>> apply_changes(
     OrderedChanges& changes,
     std::function<Version()> f,
     const MapCollection& new_maps = {},
@@ -64,10 +66,11 @@ namespace kv
     }
 
     bool ok = true;
+    kv::Version max_conflict_version = kv::NoVersion;
 
     for (auto it = views.begin(); it != views.end(); ++it)
     {
-      if (!it->second->prepare())
+      if (!it->second->prepare(max_conflict_version))
       {
         ok = false;
         break;
@@ -143,6 +146,6 @@ namespace kv
       return std::nullopt;
     }
 
-    return version;
+    return std::make_tuple(version, max_conflict_version);
   }
 }


### PR DESCRIPTION
part of #2055

To allow parallelism on the backup we need to know where conflict could occur. Step 1 is tracking the max version that a transaction reads from.