### PR TITLE
AFT: Resolve recursive lock issues with BFT

### DIFF
--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -103,6 +103,9 @@
           "primary_id": {
             "$ref": "#/components/schemas/uint64"
           },
+          "view_change_in_progress": {
+            "$ref": "#/components/schemas/boolean"
+          },
           "service_status": {
             "$ref": "#/components/schemas/ServiceStatus"
           }
@@ -110,7 +113,8 @@
         "required": [
           "service_status",
           "current_view",
-          "primary_id"
+          "primary_id",
+          "view_change_in_progress"
         ],
         "type": "object"
       },

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -103,11 +103,11 @@
           "primary_id": {
             "$ref": "#/components/schemas/uint64"
           },
-          "view_change_in_progress": {
-            "$ref": "#/components/schemas/boolean"
-          },
           "service_status": {
             "$ref": "#/components/schemas/ServiceStatus"
+          },
+          "view_change_in_progress": {
+            "$ref": "#/components/schemas/boolean"
           }
         },
         "required": [

--- a/src/consensus/aft/impl/execution.cpp
+++ b/src/consensus/aft/impl/execution.cpp
@@ -122,7 +122,9 @@ namespace aft
   }
 
   kv::Version ExecutorImpl::commit_replayed_request(
-    kv::Tx& tx, std::shared_ptr<aft::RequestTracker> request_tracker, kv::Consensus::SeqNo committed_seqno)
+    kv::Tx& tx,
+    std::shared_ptr<aft::RequestTracker> request_tracker,
+    kv::Consensus::SeqNo committed_seqno)
   {
     auto tx_view = tx.get_view<aft::RequestsMap>(ccf::Tables::AFT_REQUESTS);
     auto req_v = tx_view->get(0);

--- a/src/consensus/aft/impl/execution.cpp
+++ b/src/consensus/aft/impl/execution.cpp
@@ -94,7 +94,8 @@ namespace aft
   }
 
   std::unique_ptr<aft::RequestMessage> ExecutorImpl::create_request_message(
-    const kv::TxHistory::RequestCallbackArgs& args)
+    const kv::TxHistory::RequestCallbackArgs& args,
+    kv::Consensus::SeqNo committed_seqno)
   {
     Request request = {
       args.rid, args.caller_cert, args.request, args.frame_format};
@@ -113,12 +114,15 @@ namespace aft
 
     auto ctx = create_request_ctx(serialized_req.data(), serialized_req.size());
 
+    // Deprecated, this will be removed in future releases
+    ctx->ctx->set_global_commit(committed_seqno);
+
     return std::make_unique<RequestMessage>(
       std::move(serialized_req), args.rid, std::move(ctx), rep_cb);
   }
 
   kv::Version ExecutorImpl::commit_replayed_request(
-    kv::Tx& tx, std::shared_ptr<aft::RequestTracker> request_tracker)
+    kv::Tx& tx, std::shared_ptr<aft::RequestTracker> request_tracker, kv::Consensus::SeqNo committed_seqno)
   {
     auto tx_view = tx.get_view<aft::RequestsMap>(ccf::Tables::AFT_REQUESTS);
     auto req_v = tx_view->get(0);
@@ -128,6 +132,9 @@ namespace aft
     Request request = req_v.value();
 
     auto ctx = create_request_ctx(request);
+
+    // Deprecated, this will be removed in future releases
+    ctx->ctx->set_global_commit(committed_seqno);
 
     auto request_message = RequestMessage::deserialize(
       std::move(request.raw), request.rid, std::move(ctx), nullptr);

--- a/src/consensus/aft/impl/execution.h
+++ b/src/consensus/aft/impl/execution.h
@@ -40,10 +40,13 @@ namespace aft
       std::shared_ptr<aft::RequestTracker> request_tracker = nullptr) = 0;
 
     virtual std::unique_ptr<aft::RequestMessage> create_request_message(
-      const kv::TxHistory::RequestCallbackArgs& args) = 0;
+      const kv::TxHistory::RequestCallbackArgs& args,
+      kv::Consensus::SeqNo committed_seqno) = 0;
 
     virtual kv::Version commit_replayed_request(
-      kv::Tx& tx, std::shared_ptr<aft::RequestTracker> request_tracker) = 0;
+      kv::Tx& tx,
+      std::shared_ptr<aft::RequestTracker> request_tracker,
+      kv::Consensus::SeqNo committed_seqno) = 0;
   };
 
   class ExecutorImpl : public Executor
@@ -53,9 +56,7 @@ namespace aft
       std::shared_ptr<State> state_,
       std::shared_ptr<enclave::RPCMap> rpc_map_,
       std::shared_ptr<enclave::RPCSessions> rpc_sessions_) :
-      state(state_),
-      rpc_map(rpc_map_),
-      rpc_sessions(rpc_sessions_)
+      state(state_), rpc_map(rpc_map_), rpc_sessions(rpc_sessions_)
     {}
 
     std::unique_ptr<RequestCtx> create_request_ctx(
@@ -69,11 +70,13 @@ namespace aft
       std::shared_ptr<aft::RequestTracker> request_tracker = nullptr) override;
 
     std::unique_ptr<aft::RequestMessage> create_request_message(
-      const kv::TxHistory::RequestCallbackArgs& args) override;
+      const kv::TxHistory::RequestCallbackArgs& args,
+      kv::Consensus::SeqNo committed_seqno) override;
 
     kv::Version commit_replayed_request(
       kv::Tx& tx,
-      std::shared_ptr<aft::RequestTracker> request_tracker) override;
+      std::shared_ptr<aft::RequestTracker> request_tracker,
+      kv::Consensus::SeqNo committed_seqno) override;
 
   private:
     std::shared_ptr<State> state;

--- a/src/consensus/aft/impl/execution.h
+++ b/src/consensus/aft/impl/execution.h
@@ -56,7 +56,9 @@ namespace aft
       std::shared_ptr<State> state_,
       std::shared_ptr<enclave::RPCMap> rpc_map_,
       std::shared_ptr<enclave::RPCSessions> rpc_sessions_) :
-      state(state_), rpc_map(rpc_map_), rpc_sessions(rpc_sessions_)
+      state(state_),
+      rpc_map(rpc_map_),
+      rpc_sessions(rpc_sessions_)
     {}
 
     std::unique_ptr<RequestCtx> create_request_ctx(

--- a/src/consensus/aft/impl/view_change_tracker.h
+++ b/src/consensus/aft/impl/view_change_tracker.h
@@ -50,8 +50,9 @@ namespace aft
 
     bool is_view_change_in_progress(std::chrono::milliseconds time)
     {
-      return time <=
-        (time_between_attempts + time_previous_view_change_increment);
+      return (time <=
+              (time_between_attempts + time_previous_view_change_increment)) &&
+        (time_previous_view_change_increment != std::chrono::milliseconds(0));
     }
 
     kv::Consensus::View get_target_view() const

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -320,10 +320,6 @@ namespace aft
 
     Term get_term()
     {
-      if (consensus_type == ConsensusType::BFT && is_follower())
-      {
-        return state->current_view;
-      }
       std::lock_guard<SpinLock> guard(state->lock);
       return state->current_view;
     }

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -194,6 +194,21 @@ namespace aft
       return leader_id;
     }
 
+    bool view_change_in_progress()
+    {
+      std::unique_lock<SpinLock> guard(state->lock);
+      if (consensus_type == ConsensusType::BFT)
+      {
+        auto time = threading::ThreadMessaging::thread_messaging
+                      .get_current_time_offset();
+        return view_change_tracker->is_view_change_in_progress(time);
+      }
+      else
+      {
+        return (replica_state == Candidate);
+      }
+    }
+
     std::set<NodeId> active_nodes()
     {
       // Find all nodes present in any active configuration.

--- a/src/consensus/aft/raft_consensus.h
+++ b/src/consensus/aft/raft_consensus.h
@@ -106,6 +106,11 @@ namespace aft
       return aft->leader();
     }
 
+    bool view_change_in_progress() override
+    {
+      return aft->view_change_in_progress();
+    }
+
     std::set<NodeId> active_nodes() override
     {
       return aft->active_nodes();

--- a/src/enclave/rpc_context.h
+++ b/src/enclave/rpc_context.h
@@ -193,6 +193,8 @@ namespace enclave
       set_response_header(name, fmt::format("{}", n));
     }
 
+    virtual bool has_global_commit() = 0;
+
     virtual void set_error(
       http_status status, const std::string& code, std::string&& msg)
     {

--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -839,7 +839,7 @@ namespace asynchost
       {
         f->complete();
         require_new_file = true;
-        LOG_INFO_FMT("Ledger chunk completed at {}", last_idx);
+        LOG_DEBUG_FMT("Ledger chunk completed at {}", last_idx);
       }
 
       return last_idx;

--- a/src/http/http_rpc_context.h
+++ b/src/http/http_rpc_context.h
@@ -300,6 +300,12 @@ namespace http
       response_headers[std::string(name)] = value;
     }
 
+    virtual bool has_global_commit() override
+    {
+      return response_headers.find(http::headers::CCF_GLOBAL_COMMIT) !=
+        response_headers.end();
+    }
+
     virtual void set_apply_writes(bool apply) override
     {
       explicit_apply_writes = apply;

--- a/src/http/ws_rpc_context.h
+++ b/src/http/ws_rpc_context.h
@@ -190,6 +190,11 @@ namespace ws
       global_commit = gc;
     }
 
+    virtual bool has_global_commit() override
+    {
+      return global_commit != 0;
+    }
+
     virtual void set_apply_writes(bool apply) override
     {
       explicit_apply_writes = apply;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -362,6 +362,7 @@ namespace kv
     virtual void initialise_view_history(const std::vector<SeqNo>&) = 0;
     virtual SeqNo get_committed_seqno() = 0;
     virtual NodeId primary() = 0;
+    virtual bool view_change_in_progress() = 0;
     virtual std::set<NodeId> active_nodes() = 0;
 
     virtual void recv_message(OArray&& oa) = 0;

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -113,6 +113,11 @@ namespace kv
       return 1;
     }
 
+    bool view_change_in_progress() override
+    {
+      return false;
+    }
+
     std::set<NodeId> active_nodes() override
     {
       return {};

--- a/src/node/rpc/call_types.h
+++ b/src/node/rpc/call_types.h
@@ -60,6 +60,7 @@ namespace ccf
       ServiceStatus service_status;
       std::optional<kv::Consensus::View> current_view;
       std::optional<NodeId> primary_id;
+      std::optional<bool> view_change_in_progress;
     };
   };
 

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -298,9 +298,6 @@ namespace ccf
                   ctx->set_seqno(cv);
                   ctx->set_view(tx.commit_term());
                 }
-                // Deprecated, this will be removed in future releases
-                ctx->set_global_commit(consensus->get_committed_seqno());
-
                 if (history != nullptr && consensus->is_primary())
                 {
                   history->try_emit_signature();
@@ -538,6 +535,8 @@ namespace ccf
         }
       }
 
+      // Deprecated, this will be removed in future releases
+      ctx->set_global_commit(consensus->get_committed_seqno());
       return process_command(ctx, tx);
     }
 
@@ -618,6 +617,8 @@ namespace ccf
            ExecuteOutsideConsensus::Primary &&
          (consensus != nullptr && consensus->is_primary())))
       {
+        // Deprecated, this will be removed in future releases
+        ctx->set_global_commit(consensus->get_committed_seqno());
         auto rep = process_command(ctx, tx);
         if (!rep.has_value())
         {

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -298,6 +298,13 @@ namespace ccf
                   ctx->set_seqno(cv);
                   ctx->set_view(tx.commit_term());
                 }
+
+                // Deprecated, this will be removed in future releases
+                if (!ctx->has_global_commit())
+                {
+                  ctx->set_global_commit(consensus->get_committed_seqno());
+                }
+
                 if (history != nullptr && consensus->is_primary())
                 {
                   history->try_emit_signature();
@@ -535,8 +542,6 @@ namespace ccf
         }
       }
 
-      // Deprecated, this will be removed in future releases
-      ctx->set_global_commit(consensus->get_committed_seqno());
       return process_command(ctx, tx);
     }
 
@@ -617,8 +622,6 @@ namespace ccf
            ExecuteOutsideConsensus::Primary &&
          (consensus != nullptr && consensus->is_primary())))
       {
-        // Deprecated, this will be removed in future releases
-        ctx->set_global_commit(consensus->get_committed_seqno());
         auto rep = process_command(ctx, tx);
         if (!rep.has_value())
         {

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -361,8 +361,9 @@ namespace ccf
         HTTP_GET,
         json_read_only_adapter(network_status),
         no_auth_required)
+        .set_execute_outside_consensus(
+          ccf::endpoints::ExecuteOutsideConsensus::Locally)
         .set_auto_schema<void, GetNetworkInfo::Out>()
-        //.set_forwarding_required(ForwardingRequired::Never)
         .install();
 
       auto get_nodes = [this](auto& args, nlohmann::json&& params) {

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -340,11 +340,13 @@ namespace ccf
             out.current_view = consensus->get_view();
 
             auto primary_id = consensus->primary();
+            auto view_change_in_progress = consensus->view_change_in_progress();
             auto nodes_view = args.tx.get_read_only_view(this->network.nodes);
             auto info = nodes_view->get(primary_id);
             if (info)
             {
               out.primary_id = primary_id;
+              out.view_change_in_progress = view_change_in_progress;
             }
           }
           return make_success(out);
@@ -360,6 +362,7 @@ namespace ccf
         json_read_only_adapter(network_status),
         no_auth_required)
         .set_auto_schema<void, GetNetworkInfo::Out>()
+        //.set_forwarding_required(ForwardingRequired::Never)
         .install();
 
       auto get_nodes = [this](auto& args, nlohmann::json&& params) {

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -84,7 +84,7 @@ namespace ccf
 
   DECLARE_JSON_TYPE(GetNetworkInfo::Out)
   DECLARE_JSON_REQUIRED_FIELDS(
-    GetNetworkInfo::Out, service_status, current_view, primary_id)
+    GetNetworkInfo::Out, service_status, current_view, primary_id, view_change_in_progress)
 
   DECLARE_JSON_TYPE(GetNode::NodeInfo)
   DECLARE_JSON_REQUIRED_FIELDS(

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -84,7 +84,11 @@ namespace ccf
 
   DECLARE_JSON_TYPE(GetNetworkInfo::Out)
   DECLARE_JSON_REQUIRED_FIELDS(
-    GetNetworkInfo::Out, service_status, current_view, primary_id, view_change_in_progress)
+    GetNetworkInfo::Out,
+    service_status,
+    current_view,
+    primary_id,
+    view_change_in_progress)
 
   DECLARE_JSON_TYPE(GetNode::NodeInfo)
   DECLARE_JSON_REQUIRED_FIELDS(

--- a/tests/election.py
+++ b/tests/election.py
@@ -42,7 +42,7 @@ def test_kill_primary(network, args):
                 )
         except CCFConnectionException:
             LOG.warning(
-                f"Could not successfully connect to node {backup.node_id}. Retrying..."
+                f"Could not successfully connect to node {backup.node_id}."
             )
 
     new_primary, new_term = network.wait_for_new_primary(primary.node_id)

--- a/tests/election.py
+++ b/tests/election.py
@@ -41,9 +41,7 @@ def test_kill_primary(network, args):
                     },
                 )
         except CCFConnectionException:
-            LOG.warning(
-                f"Could not successfully connect to node {backup.node_id}."
-            )
+            LOG.warning(f"Could not successfully connect to node {backup.node_id}.")
 
     new_primary, new_term = network.wait_for_new_primary(primary.node_id)
     LOG.debug(f"New primary is {new_primary.node_id} in term {new_term}")

--- a/tests/election.py
+++ b/tests/election.py
@@ -131,13 +131,8 @@ def run(args):
 
             try:
                 test_kill_primary(network, args)
-            except (PrimaryNotFound, TimeoutError) as e:
+            except PrimaryNotFound:
                 if node_to_stop < nodes_to_stop - 1:
-                    raise
-                elif not (
-                    (type(e) == PrimaryNotFound and args.consensus == "cft")
-                    or (type(e) == TimeoutError and args.consensus == "bft")
-                ):
                     raise
                 else:
                     primary_is_known = False

--- a/tests/election.py
+++ b/tests/election.py
@@ -23,7 +23,7 @@ from loguru import logger as LOG
 
 @reqs.description("Stopping current primary and waiting for a new one to be elected")
 @reqs.can_kill_n_nodes(1)
-def test_kill_primary(network, args, current_view):
+def test_kill_primary(network, args):
     primary, backup = network.find_primary_and_any_backup()
     primary.stop()
 
@@ -36,8 +36,8 @@ def test_kill_primary(network, args, current_view):
                 _ = c.post(
                     "/app/log/private",
                     {
-                        "id": current_view,
-                        "msg": "This log is committed in view {}".format(current_view),
+                        "id": -1,
+                        "msg": "This is submitted to force a view change",
                     },
                 )
         except CCFConnectionException:
@@ -130,7 +130,7 @@ def run(args):
             wait_for_seqno_to_commit(seqno, current_view, network.get_joined_nodes())
 
             try:
-                test_kill_primary(network, args, current_view)
+                test_kill_primary(network, args)
             except (PrimaryNotFound, TimeoutError) as e:
                 if node_to_stop < nodes_to_stop - 1:
                     raise

--- a/tests/election.py
+++ b/tests/election.py
@@ -9,6 +9,7 @@ import infra.e2e_args
 import infra.checker
 import http
 import suite.test_requirements as reqs
+from ccf.clients import CCFConnectionException
 
 from ccf.tx_status import TxStatus
 from ccf.log_capture import flush_info
@@ -22,9 +23,28 @@ from loguru import logger as LOG
 
 @reqs.description("Stopping current primary and waiting for a new one to be elected")
 @reqs.can_kill_n_nodes(1)
-def test_kill_primary(network, args):
-    primary, _ = network.find_primary()
+def test_kill_primary(network, args, current_view):
+    primary, backup = network.find_primary_and_any_backup()
     primary.stop()
+
+    # When the consensus is BFT there is no status message timer that triggers a new election.
+    # It is triggered with a timeout from a message not executing. We need to send the message that
+    # will not execute because of the stopped primary which will then trigger a view change
+    if args.consensus == "bft":
+        try:
+            with backup.client("user0") as c:
+                _ = c.post(
+                    "/app/log/private",
+                    {
+                        "id": current_view,
+                        "msg": "This log is committed in view {}".format(current_view),
+                    },
+                )
+        except CCFConnectionException:
+            LOG.warning(
+                f"Could not successfully connect to node {backup.node_id}. Retrying..."
+            )
+
     new_primary, new_term = network.wait_for_new_primary(primary.node_id)
     LOG.debug(f"New primary is {new_primary.node_id} in term {new_term}")
 
@@ -110,9 +130,14 @@ def run(args):
             wait_for_seqno_to_commit(seqno, current_view, network.get_joined_nodes())
 
             try:
-                test_kill_primary(network, args)
-            except PrimaryNotFound:
+                test_kill_primary(network, args, current_view)
+            except (PrimaryNotFound, TimeoutError) as e:
                 if node_to_stop < nodes_to_stop - 1:
+                    raise
+                elif not (
+                    (type(e) == PrimaryNotFound and args.consensus == "cft")
+                    or (type(e) == TimeoutError and args.consensus == "bft")
+                ):
                     raise
                 else:
                     primary_is_known = False

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -676,7 +676,7 @@ class Network:
                 break
             time.sleep(0.1)
 
-        if primary_id is None:
+        if primary_id is None or view_change_in_progress:
             flush_info(logs, log_capture, 0)
             raise PrimaryNotFound
 

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -665,6 +665,7 @@ class Network:
                         body = res.body.json()
                         primary_id = body["primary_id"]
                         view = body["current_view"]
+                        view_change_in_progress = body["view_change_in_progress"]
                         if primary_id is not None:
                             break
 


### PR DESCRIPTION
Resolves #1601
Part of #2055

This resolves 2 issues:
- The "primary_info" endpoint should run outside of BFT consensus on the node that receives the request
- After executing a transaction the frontend returns the last global commit. This change adds a check to see if this value has been set and only sets it in the frontend if it has not been set. This allows for BFT to set this value at an appropriate time.

Minor: Change log level for a info log in ledger.h