### PR TITLE
Use thread messaging round robin for snapshot generation

### DIFF
--- a/src/ds/thread_messaging.h
+++ b/src/ds/thread_messaging.h
@@ -250,7 +250,8 @@ namespace threading
     {
       CCF_ASSERT_FMT(
         tid < thread_count || tid == 0,
-        "Attempting to add task to tid > thread_count, tid:{}, thread_count:{}",
+        "Attempting to add task to tid >= thread_count, tid:{}, "
+        "thread_count:{}",
         tid,
         thread_count);
       return tasks[tid];


### PR DESCRIPTION
Fixes issues related to multithreading (see #2069)

Asynchronous snapshot generation used its own round robin function which wasn't correct in a multi-threading setting (it would dispatch snapshots to the last thread + 1). Instead, use the one from `thread_messaging.h` directly.