### PR TITLE
Don't log every request in test_view_history

### DIFF
--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -500,7 +500,7 @@ def test_view_history(network, args):
             for seqno in range(1, commit_seqno + 1):
                 views = []
                 for view in range(1, commit_view + 1):
-                    r = c.get(f"/node/tx?view={view}&seqno={seqno}")
+                    r = c.get(f"/node/tx?view={view}&seqno={seqno}", log_capture=[])
                     check(r)
                     status = TxStatus(r.body.json()["status"])
                     if status == TxStatus.Committed:


### PR DESCRIPTION
`test_view_history` makes loads of requests, which quickly fill up the logs but don't show useful progress:

```
60: 10:19:31.794 | INFO     | __main__:test_view_history:503 - [0|user0|] GET /node/tx?view=1&seqno=15
60: 10:19:31.794 | INFO     | __main__:test_view_history:503 - 200 {"status":"INVALID"}
60: 10:19:31.798 | INFO     | __main__:test_view_history:503 - [0|user0|] GET /node/tx?view=2&seqno=15
60: 10:19:31.798 | INFO     | __main__:test_view_history:503 - 200 {"status":"COMMITTED"}
60: 10:19:31.800 | INFO     | __main__:test_view_history:503 - [0|user0|] GET /node/tx?view=1&seqno=16
60: 10:19:31.800 | INFO     | __main__:test_view_history:503 - 200 {"status":"INVALID"}
```

This is unnecessary since we already print a summary of the results, on success _or_ failure:

```
60: 10:19:32.099 | SUCCESS  | __main__:test_view_history:525 - Node 0: Found a valid sequence of Tx IDs:
60: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 2.10, 2.11, 2.12, 2.13, 2.14, 2.15, 2.16, 2.17, 2.18, 2.19, 2.20, 2.21, 2.22, 2.23, 2.24, 2.25, 2.26, 2.27, 2.28, 2.29, 2.30, 2.31, 2.32, 2.33, 2.34, 2.35, 2.36, 2.37, 2.38, 2.39, 2.40, 2.41, 2.42, 2.43, 2.44, 2.45, 2.46, 2.47, 2.48, 2.49, 2.50, 2.51, 2.52, 2.53, 2.54, 2.55, 2.56, 2.57, 2.58, 2.59, 2.60, 2.61, 2.62, 2.63, 2.64, 2.65, 2.66, 2.67, 2.68, 2.69, 2.70, 2.71, 2.72
```

This change swallows those log lines so the test output doesn't kill my scroll wheel so fast. Comparing just a `test + test_view_history` run:

```
# Before
$ ctest -VV -R cpp_e2e_logging_cft | wc -l
530

# After
$ ctest -VV -R cpp_e2e_logging_cft | wc -l
235
```
