### PR TITLE
Change schemas of /recovery_share GET/POST endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `/network`, `/network_info`, `/node/ids`, `/primary_info` have been restructured into `/network`, `/network/nodes`, `/network/nodes/{id}`, `/network/nodes/self`, `/network/nodes/primary` while also changing the response schemas (#1954).
 - `/ack` responds with HTTP status `204` now instead of `200` and `true` as body (#2088).
+- `/recovery_share` has new request and response schemas (#2089).
 
 ## [0.16.3]
 

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -106,14 +106,14 @@
         ],
         "type": "object"
       },
-      "GetRecoveryShare__RecoveryShare": {
+      "GetRecoveryShare__Out": {
         "properties": {
-          "share": {
+          "encrypted_share": {
             "$ref": "#/components/schemas/string"
           }
         },
         "required": [
-          "share"
+          "encrypted_share"
         ],
         "type": "object"
       },
@@ -232,6 +232,17 @@
         },
         "required": [
           "state_digest"
+        ],
+        "type": "object"
+      },
+      "SubmitRecoveryShare__In": {
+        "properties": {
+          "share": {
+            "$ref": "#/components/schemas/string"
+          }
+        },
+        "required": [
+          "share"
         ],
         "type": "object"
       },
@@ -817,7 +828,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetRecoveryShare__RecoveryShare"
+                  "$ref": "#/components/schemas/GetRecoveryShare__Out"
                 }
               }
             },
@@ -835,7 +846,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GetRecoveryShare__RecoveryShare"
+                "$ref": "#/components/schemas/SubmitRecoveryShare__In"
               }
             }
           },

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -106,6 +106,17 @@
         ],
         "type": "object"
       },
+      "GetRecoveryShare__RecoveryShare": {
+        "properties": {
+          "share": {
+            "$ref": "#/components/schemas/string"
+          }
+        },
+        "required": [
+          "share"
+        ],
+        "type": "object"
+      },
       "GetTxStatus__Out": {
         "properties": {
           "status": {
@@ -221,6 +232,17 @@
         },
         "required": [
           "state_digest"
+        ],
+        "type": "object"
+      },
+      "SubmitRecoveryShare__Out": {
+        "properties": {
+          "message": {
+            "$ref": "#/components/schemas/string"
+          }
+        },
+        "required": [
+          "message"
         ],
         "type": "object"
       },
@@ -795,7 +817,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/string"
+                  "$ref": "#/components/schemas/GetRecoveryShare__RecoveryShare"
                 }
               }
             },
@@ -813,7 +835,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/string"
+                "$ref": "#/components/schemas/GetRecoveryShare__RecoveryShare"
               }
             }
           },
@@ -824,7 +846,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/string"
+                  "$ref": "#/components/schemas/SubmitRecoveryShare__Out"
                 }
               }
             },

--- a/python/utils/submit_recovery_share.sh
+++ b/python/utils/submit_recovery_share.sh
@@ -51,4 +51,4 @@ encrypted_share=$(curl -sS --fail -X GET "${node_rpc_address}"/gov/recovery_shar
 
 # Then, decrypt encrypted share with member private key submit decrypted recovery share
 # Note: all in one line so that the decrypted recovery share is not exposed
-echo "${encrypted_share}" | openssl base64 -d | openssl pkeyutl -inkey "${member_enc_privk}" -decrypt -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256 | openssl base64 | jq -R '{share: (.)}' | curl -i -sS --fail -X POST "${node_rpc_address}"/gov/recovery_share "${@}" -d @-
+echo "${encrypted_share}" | openssl base64 -d | openssl pkeyutl -inkey "${member_enc_privk}" -decrypt -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256 | openssl base64 -A | jq -R '{share: (.)}' | curl -i -sS --fail -H "Content-Type: application/json" -X POST "${node_rpc_address}"/gov/recovery_share "${@}" -d @-

--- a/python/utils/submit_recovery_share.sh
+++ b/python/utils/submit_recovery_share.sh
@@ -47,8 +47,8 @@ if [ -z "${member_enc_privk}" ]; then
 fi
 
 # First, retrieve the encrypted recovery share
-encrypted_share=$(curl -sS --fail -X GET "${node_rpc_address}"/gov/recovery_share "${@}")
+encrypted_share=$(curl -sS --fail -X GET "${node_rpc_address}"/gov/recovery_share "${@}" | jq -r '.encrypted_share')
 
 # Then, decrypt encrypted share with member private key submit decrypted recovery share
 # Note: all in one line so that the decrypted recovery share is not exposed
-echo "${encrypted_share}" | tr -d '"' | openssl base64 -d | openssl pkeyutl -inkey "${member_enc_privk}" -decrypt -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256 | openssl base64 | curl -i -sS --fail -X POST "${node_rpc_address}"/gov/recovery_share "${@}" -d @-
+echo "${encrypted_share}" | openssl base64 -d | openssl pkeyutl -inkey "${member_enc_privk}" -decrypt -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256 | openssl base64 | jq -R '{share: (.)}' | curl -i -sS --fail -X POST "${node_rpc_address}"/gov/recovery_share "${@}" -d @-

--- a/src/node/rpc/call_types.h
+++ b/src/node/rpc/call_types.h
@@ -158,19 +158,20 @@ namespace ccf
 
   struct GetRecoveryShare
   {
-    struct RecoveryShare
-    {
-      std::string share = {};
-    };
-
     using In = void;
 
-    using Out = RecoveryShare;
+    struct Out
+    {
+      std::string encrypted_share;
+    };
   };
 
   struct SubmitRecoveryShare
   {
-    using In = GetRecoveryShare::RecoveryShare;
+    struct In
+    {
+      std::string share;
+    };
 
     struct Out
     {

--- a/src/node/rpc/call_types.h
+++ b/src/node/rpc/call_types.h
@@ -155,4 +155,26 @@ namespace ccf
       bool valid = false;
     };
   };
+
+  struct GetRecoveryShare
+  {
+    struct RecoveryShare
+    {
+      std::string share = {};
+    };
+
+    using In = void;
+
+    using Out = RecoveryShare;
+  };
+
+  struct SubmitRecoveryShare
+  {
+    using In = GetRecoveryShare::RecoveryShare;
+
+    struct Out
+    {
+      std::string message;
+    };
+  };
 }

--- a/src/node/rpc/error.h
+++ b/src/node/rpc/error.h
@@ -56,8 +56,10 @@ namespace ccf
     // client-facing:
     ERROR(FrontendNotOpen)
     ERROR(KeyNotFound)
+    ERROR(NodeAlreadyRecovering)
     ERROR(ProposalNotOpen)
     ERROR(ProposalNotFound)
+    ERROR(ServiceNotWaitingForRecoveryShares)
     ERROR(StateDigestMismatch)
     ERROR(TransactionNotFound)
     ERROR(TransactionCommitAttemptsExceedLimit)

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -135,9 +135,11 @@ namespace ccf
   DECLARE_JSON_TYPE(GetCode::Out)
   DECLARE_JSON_REQUIRED_FIELDS(GetCode::Out, versions)
 
-  DECLARE_JSON_TYPE(GetRecoveryShare::RecoveryShare)
-  DECLARE_JSON_REQUIRED_FIELDS(GetRecoveryShare::RecoveryShare, share)
+  DECLARE_JSON_TYPE(GetRecoveryShare::Out)
+  DECLARE_JSON_REQUIRED_FIELDS(GetRecoveryShare::Out, encrypted_share)
 
+  DECLARE_JSON_TYPE(SubmitRecoveryShare::In)
+  DECLARE_JSON_REQUIRED_FIELDS(SubmitRecoveryShare::In, share)
   DECLARE_JSON_TYPE(SubmitRecoveryShare::Out)
   DECLARE_JSON_REQUIRED_FIELDS(SubmitRecoveryShare::Out, message)
 

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -135,6 +135,12 @@ namespace ccf
   DECLARE_JSON_TYPE(GetCode::Out)
   DECLARE_JSON_REQUIRED_FIELDS(GetCode::Out, versions)
 
+  DECLARE_JSON_TYPE(GetRecoveryShare::RecoveryShare)
+  DECLARE_JSON_REQUIRED_FIELDS(GetRecoveryShare::RecoveryShare, share)
+
+  DECLARE_JSON_TYPE(SubmitRecoveryShare::Out)
+  DECLARE_JSON_REQUIRED_FIELDS(SubmitRecoveryShare::Out, message)
+
   DECLARE_JSON_TYPE(MemoryUsage::Out)
   DECLARE_JSON_REQUIRED_FIELDS(
     MemoryUsage::Out,

--- a/src/node/rpc/test/member_voting_test.cpp
+++ b/src/node/rpc/test/member_voting_test.cpp
@@ -1951,10 +1951,10 @@ DOCTEST_TEST_CASE("Submit recovery shares")
 
     for (auto const& m : members)
     {
-      auto resp = parse_response_body<std::string>(
+      auto resp = parse_response_body<GetRecoveryShare::Out>(
         frontend_process(frontend, get_recovery_shares, m.second.first));
 
-      auto encrypted_share = tls::raw_from_b64(resp);
+      auto encrypted_share = tls::raw_from_b64(resp.share);
       retrieved_shares[m.first] = m.second.second->unwrap(encrypted_share);
     }
   }
@@ -1962,8 +1962,9 @@ DOCTEST_TEST_CASE("Submit recovery shares")
   DOCTEST_INFO("Submit share before the service is in correct state");
   {
     MemberId member_id = 0;
-    const auto submit_recovery_share = create_text_request(
-      tls::b64_from_raw(retrieved_shares[member_id]), "recovery_share");
+    const auto submit_recovery_share = create_request(
+      SubmitRecoveryShare::In{tls::b64_from_raw(retrieved_shares[member_id])},
+      "recovery_share");
 
     check_error(
       frontend_process(
@@ -1994,8 +1995,9 @@ DOCTEST_TEST_CASE("Submit recovery shares")
     {
       auto bogus_recovery_share = retrieved_shares[m.first];
       bogus_recovery_share[0] = bogus_recovery_share[0] + 1;
-      const auto submit_recovery_share = create_text_request(
-        tls::b64_from_raw(bogus_recovery_share), "recovery_share");
+      const auto submit_recovery_share = create_request(
+        SubmitRecoveryShare::In{tls::b64_from_raw(bogus_recovery_share)},
+        "recovery_share");
 
       auto rep =
         frontend_process(frontend, submit_recovery_share, m.second.first);
@@ -2035,8 +2037,9 @@ DOCTEST_TEST_CASE("Submit recovery shares")
     size_t submitted_shares_count = 0;
     for (auto const& m : members)
     {
-      const auto submit_recovery_share = create_text_request(
-        tls::b64_from_raw(retrieved_shares[m.first]), "recovery_share");
+      const auto submit_recovery_share = create_request(
+        SubmitRecoveryShare::In{tls::b64_from_raw(retrieved_shares[m.first])},
+        "recovery_share");
 
       auto rep =
         frontend_process(frontend, submit_recovery_share, m.second.first);

--- a/src/node/rpc/test/member_voting_test.cpp
+++ b/src/node/rpc/test/member_voting_test.cpp
@@ -1954,7 +1954,7 @@ DOCTEST_TEST_CASE("Submit recovery shares")
       auto resp = parse_response_body<GetRecoveryShare::Out>(
         frontend_process(frontend, get_recovery_shares, m.second.first));
 
-      auto encrypted_share = tls::raw_from_b64(resp.share);
+      auto encrypted_share = tls::raw_from_b64(resp.encrypted_share);
       retrieved_shares[m.first] = m.second.second->unwrap(encrypted_share);
     }
   }

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -166,7 +166,7 @@ class Member:
                 "r",
             ) as priv_enc_key:
                 return infra.crypto.unwrap_key_rsa_oaep(
-                    base64.b64decode(r.body.json()["share"]),
+                    base64.b64decode(r.body.json()["encrypted_share"]),
                     priv_enc_key.read(),
                 )
 

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -166,7 +166,7 @@ class Member:
                 "r",
             ) as priv_enc_key:
                 return infra.crypto.unwrap_key_rsa_oaep(
-                    base64.b64decode(r.body.text()),
+                    base64.b64decode(r.body.json()["share"]),
                     priv_enc_key.read(),
                 )
 


### PR DESCRIPTION
Addresses the second point of https://github.com/microsoft/CCF/issues/1944.

GET /recovery_share now returns `{"encrypted_share": "..base64"}` while POST /recovery_share has as input `{"share": "..base64"}` and returns `{"message": "status message..."}`.