### PR TITLE
Fix SAN error on rollback during recovery

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Time is a flat circle
+Time is a flat circle.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,6 +560,19 @@ if(BUILD_TESTS)
       --enforce-reqs
       --test-suite
       reconfiguration
+      --raft-election-timeout
+      4000
+  )
+
+  add_e2e_test(
+    NAME reconfiguration_rekey_test_suite
+    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_suite.py
+    CONSENSUS cft
+    LABEL suite
+    ADDITIONAL_ARGS
+      --test-duration
+      200
+      --enforce-reqs
       --test-suite
       rekey_reconfiguration
       --raft-election-timeout

--- a/src/node/ledger_secrets.h
+++ b/src/node/ledger_secrets.h
@@ -227,6 +227,11 @@ namespace ccf
     void rollback(kv::Version version)
     {
       std::lock_guard<SpinLock> guard(lock);
+      if (ledger_secrets.empty())
+      {
+        return;
+      }
+
       auto start = commit_key_it.value_or(ledger_secrets.begin());
       if (version < start->first)
       {


### PR DESCRIPTION
At the end of the public recovery, the store is rolled back to discard any unsigned entries. The rollback propagates to the ledger secrets which haven't yet been set, which caused a SAN error as we were accessing the first ledger secret.