### PR TITLE
Do not start the signature timer on the recovery store

### DIFF
--- a/src/node/history.h
+++ b/src/node/history.h
@@ -513,14 +513,18 @@ namespace ccf
       NodeId id_,
       tls::KeyPair& kp_,
       size_t sig_tx_interval_ = 0,
-      size_t sig_ms_interval_ = 0) :
+      size_t sig_ms_interval_ = 0,
+      bool signature_timer = true) :
       store(store_),
       id(id_),
       kp(kp_),
       sig_tx_interval(sig_tx_interval_),
       sig_ms_interval(sig_ms_interval_)
     {
-      start_signature_emit_timer();
+      if (signature_timer)
+      {
+        start_signature_emit_timer();
+      }
     }
 
     void start_signature_emit_timer()

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1060,7 +1060,8 @@ namespace ccf
         self,
         *node_sign_kp,
         sig_tx_interval,
-        sig_ms_interval);
+        sig_ms_interval,
+        false /* No signature timer on recovery_history */);
 
 #ifdef USE_NULL_ENCRYPTOR
       recovery_encryptor = std::make_shared<kv::NullTxEncryptor>();


### PR DESCRIPTION
That store is a pure replay construct to recover private state, emitting signatures over it neither makes sense nor works.