### PR TITLE
Unit and end-to-end tests for moving committed ledger files out of main ledger dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -724,6 +724,12 @@ if(BUILD_TESTS)
     CONSENSUS cft
   )
 
+  add_e2e_test(
+    NAME ledger_operation
+    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/ledger_operation.py
+    CONSENSUS cft
+  )
+
   if(NOT SAN)
     # Writing new ledger files and generating new snapshots uses more file
     # descriptors so disable those for this test

--- a/doc/operations/ledger_snapshot.rst
+++ b/doc/operations/ledger_snapshot.rst
@@ -1,3 +1,4 @@
+
 Ledger and Snapshots
 ====================
 
@@ -25,7 +26,7 @@ Ledger files containing only committed entries are named ``ledger_<start_seqno>-
 
 Ledger files that still contain some uncommitted entries are named ``ledger_<start_seqno>-<end_seqno>`` or ``ledger_<start_seqno>`` for the most recent one. These files are typically held open by the ``cchost`` process, which may modify their content, or even erase them completely. Uncommitted ledger files may differ arbitrarily across nodes.
 
-.. warning:: Removing files from the ``--ledger-dir`` ledger directory may cause a node to crash.
+.. warning:: Removing `uncommitted` ledger files from the ``--ledger-dir`` ledger directory may cause a node to crash.
 
 It is important to note that while all entries stored in ledger files ending in ``.committed`` are committed, not all committed entries are stored in such a file at any given time. A number of them are typically in the in-progress files, waiting to be flushed to a ``.committed`` file once the size threshold (``--ledger-chunk-bytes``) is met.
 

--- a/doc/operations/ledger_snapshot.rst
+++ b/doc/operations/ledger_snapshot.rst
@@ -1,4 +1,3 @@
-
 Ledger and Snapshots
 ====================
 
@@ -26,7 +25,7 @@ Ledger files containing only committed entries are named ``ledger_<start_seqno>-
 
 Ledger files that still contain some uncommitted entries are named ``ledger_<start_seqno>-<end_seqno>`` or ``ledger_<start_seqno>`` for the most recent one. These files are typically held open by the ``cchost`` process, which may modify their content, or even erase them completely. Uncommitted ledger files may differ arbitrarily across nodes.
 
-.. warning:: Removing `uncommitted` ledger files from the ``--ledger-dir`` ledger directory may cause a node to crash.
+.. warning:: Removing `uncommitted` ledger files from the ``--ledger-dir`` ledger directory may cause a node to crash. It is however safe to move `committed` ledger files to another directory, accessible to a CCF node via the ``--read-only-ledger-dir`` command line argument.
 
 It is important to note that while all entries stored in ledger files ending in ``.committed`` are committed, not all committed entries are stored in such a file at any given time. A number of them are typically in the in-progress files, waiting to be flushed to a ``.committed`` file once the size threshold (``--ledger-chunk-bytes``) is met.
 

--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -583,11 +583,11 @@ namespace asynchost
       // the read cache is full
       auto match_file =
         std::make_shared<LedgerFile>(ledger_dir_, match.value());
-      if (files_read_cache.size() >= max_read_cache_files)
+      files_read_cache.emplace_back(match_file);
+      if (files_read_cache.size() > max_read_cache_files)
       {
         files_read_cache.erase(files_read_cache.begin());
       }
-      files_read_cache.emplace_back(match_file);
 
       return match_file;
     }
@@ -652,8 +652,8 @@ namespace asynchost
         LOG_DEBUG_FMT("Recovering read-only ledger directory \"{}\"", read_dir);
         if (!fs::is_directory(read_dir))
         {
-          throw std::logic_error(
-            fmt::format("\"{}\" is not a directory", read_dir));
+          throw std::logic_error(fmt::format(
+            "\"{}\" read-only ledger is not a directory", read_dir));
         }
 
         for (auto const& f : fs::directory_iterator(read_dir))

--- a/src/host/test/ledger.cpp
+++ b/src/host/test/ledger.cpp
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include "host/ledger.h"
-
 #include "ds/serialized.h"
+#include "host/ledger.h"
 #include "host/snapshot.h"
 
 #include <doctest/doctest.h>
@@ -15,6 +14,7 @@ using namespace asynchost;
 using frame_header_type = uint32_t;
 static constexpr size_t frame_header_size = sizeof(frame_header_type);
 static constexpr auto ledger_dir = "ledger_dir";
+static constexpr auto ledger_dir_read_only = "ledger_dir_ro";
 static constexpr auto snapshot_dir = "snapshot_dir";
 
 static const auto dummy_snapshot = std::vector<uint8_t>(128, 42);
@@ -25,6 +25,19 @@ auto out_buffer = std::make_unique<ringbuffer::TestBuffer>(buffer_size);
 ringbuffer::Circuit eio(in_buffer->bd, out_buffer->bd);
 
 auto wf = ringbuffer::WriterFactory(eio);
+
+void move_all_from_to(
+  const std::string& from, const std::string& to, const std::string& suffix)
+{
+  for (auto const& f : fs::directory_iterator(from))
+  {
+    if (nonstd::ends_with(f.path().filename(), suffix))
+    {
+      fs::copy_file(f.path(), fs::path(to) / f.path().filename());
+      fs::remove(f.path());
+    }
+  }
+}
 
 std::string get_snapshot_file_name(
   size_t idx, size_t evidence_idx, size_t evidence_commit_idx)
@@ -119,8 +132,13 @@ void read_entry_from_ledger(Ledger& ledger, size_t idx)
 
 void read_entries_range_from_ledger(Ledger& ledger, size_t from, size_t to)
 {
-  verify_framed_entries_range(
-    ledger.read_framed_entries(from, to).value(), from, to);
+  auto entries = ledger.read_framed_entries(from, to);
+  if (!entries.has_value())
+  {
+    throw std::logic_error(
+      fmt::format("Failed to read ledger entries from {} to {}", from, to));
+  }
+  verify_framed_entries_range(entries.value(), from, to);
 }
 
 // Keeps track of ledger entries written to the ledger.
@@ -931,6 +949,71 @@ TEST_CASE("Invalid ledger file resilience")
       ledger.commit(last_idx);
       read_entries_range_from_ledger(ledger, 1, last_idx);
     }
+  }
+}
+
+TEST_CASE("Delete committed file from main directory")
+{
+  // Used to temporarily copy committed ledger files
+  static constexpr auto ledger_dir_tmp = "ledger_dir_tmp";
+
+  fs::remove_all(ledger_dir);
+  fs::remove_all(ledger_dir_read_only);
+  fs::remove_all(ledger_dir_tmp);
+
+  size_t chunk_threshold = 30;
+  size_t chunk_count = 5;
+
+  // Worst-case scenario: do not keep any committed file in cache
+  size_t max_read_cache_size = 0;
+
+  size_t entries_per_chunk = 0;
+  size_t last_idx = 0;
+  size_t last_committed_idx = 0;
+
+  fs::create_directory(ledger_dir_read_only);
+  fs::create_directory(ledger_dir_tmp);
+
+  Ledger ledger(
+    ledger_dir,
+    wf,
+    chunk_threshold,
+    max_read_cache_size,
+    {ledger_dir_read_only});
+  TestEntrySubmitter entry_submitter(ledger);
+
+  INFO("Write many entries on ledger");
+  {
+    entries_per_chunk =
+      initialise_ledger(entry_submitter, chunk_threshold, chunk_count);
+    last_committed_idx = entry_submitter.get_last_idx();
+    ledger.commit(last_committed_idx);
+
+    entry_submitter.write(true);
+    entry_submitter.write(true);
+    last_idx = entry_submitter.get_last_idx();
+
+    // Read all entries from ledger, filling up read cache
+    read_entries_range_from_ledger(ledger, 1, last_idx);
+  }
+
+  // Move all committed files to temporary directory
+  move_all_from_to(ledger_dir, ledger_dir_tmp, ledger_committed_suffix);
+
+  INFO("Only non-committed entries can be read");
+  {
+    read_entries_range_from_ledger(ledger, last_idx - 1, last_idx);
+    REQUIRE_FALSE(
+      ledger.read_framed_entries(1, last_committed_idx).has_value());
+  }
+
+  INFO("Move committed files back to read-only ledger directory");
+  {
+    // Move all committed files back to read-only ledger directory
+    move_all_from_to(
+      ledger_dir_tmp, ledger_dir_read_only, ledger_committed_suffix);
+
+    read_entries_range_from_ledger(ledger, 1, last_idx);
   }
 }
 

--- a/src/host/test/ledger.cpp
+++ b/src/host/test/ledger.cpp
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include "ds/serialized.h"
 #include "host/ledger.h"
+
+#include "ds/serialized.h"
 #include "host/snapshot.h"
 
 #include <doctest/doctest.h>
@@ -1009,7 +1010,6 @@ TEST_CASE("Delete committed file from main directory")
 
   INFO("Move committed files back to read-only ledger directory");
   {
-    // Move all committed files back to read-only ledger directory
     move_all_from_to(
       ledger_dir_tmp, ledger_dir_read_only, ledger_committed_suffix);
 

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -262,6 +262,11 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         help="Disable session auth for members",
         action="store_true",
     )
+    parser.add_argument(
+        "--read-only-ledger-dir",
+        help="Location of read-only ledger directory",
+        type=str,
+    )
 
     add(parser)
 

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -263,9 +263,10 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         action="store_true",
     )
     parser.add_argument(
-        "--read-only-ledger-dir",
-        help="Location of read-only ledger directory",
+        "--common-read-only-ledger-dir",
+        help="Location of read-only ledger directory available to all nodes",
         type=str,
+        default=None,
     )
 
     add(parser)

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -79,6 +79,7 @@ class Network:
         "domain",
         "snapshot_tx_interval",
         "jwt_key_refresh_interval_s",
+        "common_read_only_ledger_dir",
     ]
 
     # Maximum delay (seconds) for updates to propagate from the primary to backups

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -383,20 +383,6 @@ class SSHRemote(CmdMixin):
             client.close()
 
 
-@contextmanager
-def ssh_remote(*args, **kwargs):
-    """
-    Context Manager wrapper for SSHRemote
-    """
-    remote = SSHRemote(*args, **kwargs)
-    try:
-        remote.setup()
-        remote.start()
-        yield remote
-    finally:
-        remote.stop()
-
-
 class LocalRemote(CmdMixin):
     def __init__(
         self,
@@ -831,6 +817,9 @@ class CCFRemote(object):
 
     def ledger_path(self):
         return os.path.join(self.remote.root, self.ledger_dir_name)
+
+    def ledger_read_only_path(self):
+        return os.path.join(self.remote.root, self.read_only_ledger_dir)
 
 
 class StartType(Enum):

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -578,7 +578,8 @@ class CCFRemote(object):
         memory_reserve_startup=0,
         gov_script=None,
         ledger_dir=None,
-        read_only_ledger_dir=None,
+        read_only_ledger_dir=None,  # Read-only ledger dir to copy to node director
+        common_read_only_ledger_dir=None,  # Read-only ledger dir for all nodes
         log_format_json=None,
         binary_dir=".",
         ledger_chunk_bytes=(5 * 1000 * 1000),
@@ -605,14 +606,9 @@ class CCFRemote(object):
             if self.ledger_dir
             else f"{local_node_id}.ledger"
         )
-        self.read_only_ledger_dir = (
-            os.path.normpath(read_only_ledger_dir) if ledger_dir else None
-        )
-        self.read_only_ledger_dir_name = (
-            os.path.basename(self.read_only_ledger_dir)
-            if self.read_only_ledger_dir
-            else f"{local_node_id}.ro.ledger"
-        )
+
+        self.read_only_ledger_dir = read_only_ledger_dir
+        self.common_read_only_ledger_dir = common_read_only_ledger_dir
 
         self.snapshot_dir = os.path.normpath(snapshot_dir) if snapshot_dir else None
         self.snapshot_dir_name = (
@@ -647,7 +643,6 @@ class CCFRemote(object):
             f"--rpc-address-file={self.rpc_address_path}",
             f"--public-rpc-address={make_address(pubhost, rpc_port)}",
             f"--ledger-dir={self.ledger_dir_name}",
-            f"--read-only-ledger-dir={self.read_only_ledger_dir_name}",
             f"--snapshot-dir={self.snapshot_dir_name}",
             f"--node-cert-file={self.pem}",
             f"--host-log-level={host_log_level}",
@@ -681,10 +676,13 @@ class CCFRemote(object):
             cmd += [f"--jwt-key-refresh-interval-s={jwt_key_refresh_interval_s}"]
 
         if self.read_only_ledger_dir is not None:
-            # cmd += [
-            #     f"--read-only-ledger-dir={os.path.basename(self.read_only_ledger_dir)}"
-            # ]
+            cmd += [
+                f"--read-only-ledger-dir={os.path.basename(self.read_only_ledger_dir)}"
+            ]
             data_files += [os.path.join(self.common_dir, self.read_only_ledger_dir)]
+
+        if self.common_read_only_ledger_dir is not None:
+            cmd += [f"--read-only-ledger-dir={self.common_read_only_ledger_dir}"]
 
         if start_type == StartType.new:
             cmd += [
@@ -825,9 +823,6 @@ class CCFRemote(object):
 
     def ledger_path(self):
         return os.path.join(self.remote.root, self.ledger_dir_name)
-
-    def ledger_read_only_path(self):
-        return os.path.join(self.remote.root, self.read_only_ledger_dir_name)
 
 
 class StartType(Enum):

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -605,7 +605,14 @@ class CCFRemote(object):
             if self.ledger_dir
             else f"{local_node_id}.ledger"
         )
-        self.read_only_ledger_dir = read_only_ledger_dir
+        self.read_only_ledger_dir = (
+            os.path.normpath(read_only_ledger_dir) if ledger_dir else None
+        )
+        self.read_only_ledger_dir_name = (
+            os.path.basename(self.read_only_ledger_dir)
+            if self.read_only_ledger_dir
+            else f"{local_node_id}.ro.ledger"
+        )
 
         self.snapshot_dir = os.path.normpath(snapshot_dir) if snapshot_dir else None
         self.snapshot_dir_name = (
@@ -640,6 +647,7 @@ class CCFRemote(object):
             f"--rpc-address-file={self.rpc_address_path}",
             f"--public-rpc-address={make_address(pubhost, rpc_port)}",
             f"--ledger-dir={self.ledger_dir_name}",
+            f"--read-only-ledger-dir={self.read_only_ledger_dir_name}",
             f"--snapshot-dir={self.snapshot_dir_name}",
             f"--node-cert-file={self.pem}",
             f"--host-log-level={host_log_level}",
@@ -673,9 +681,9 @@ class CCFRemote(object):
             cmd += [f"--jwt-key-refresh-interval-s={jwt_key_refresh_interval_s}"]
 
         if self.read_only_ledger_dir is not None:
-            cmd += [
-                f"--read-only-ledger-dir={os.path.basename(self.read_only_ledger_dir)}"
-            ]
+            # cmd += [
+            #     f"--read-only-ledger-dir={os.path.basename(self.read_only_ledger_dir)}"
+            # ]
             data_files += [os.path.join(self.common_dir, self.read_only_ledger_dir)]
 
         if start_type == StartType.new:
@@ -819,7 +827,7 @@ class CCFRemote(object):
         return os.path.join(self.remote.root, self.ledger_dir_name)
 
     def ledger_read_only_path(self):
-        return os.path.join(self.remote.root, self.read_only_ledger_dir)
+        return os.path.join(self.remote.root, self.read_only_ledger_dir_name)
 
 
 class StartType(Enum):

--- a/tests/ledger_operation.py
+++ b/tests/ledger_operation.py
@@ -28,7 +28,7 @@ def save_committed_ledger_files(network, args):
         if infra.node.is_file_committed(l):
             shutil.move(
                 os.path.join(primary.remote.ledger_path(), l),
-                os.path.join("/tmp/ledger", l),
+                os.path.join(args.common_read_only_ledger_dir, l),
             )
 
     txs.verify(network)

--- a/tests/ledger_operation.py
+++ b/tests/ledger_operation.py
@@ -29,6 +29,8 @@ def run(args):
         args.perf_nodes,
         pdb=args.pdb,
     ) as network:
+
+        args.read_only_ledger_dir = "/tmp/lalala"
         network.start_and_join(args)
 
         save_committed_ledger_files(network, args)

--- a/tests/ledger_operation.py
+++ b/tests/ledger_operation.py
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+import http
+
+import infra.logging_app as app
+import infra.e2e_args
+import infra.network
+
+
+from loguru import logger as LOG
+
+
+def save_committed_ledger_files(network, args):
+    txs = app.LoggingTxs()
+    # Issue txs in a loop to force a signature and a new ledger chunk each time
+    for _ in range(1, 10):
+        txs.issue(network, 1)
+
+    primary, _ = network.find_primary()
+    LOG.error(primary.remote.ledger_path())
+    LOG.warning(primary.remote.ledger_read_only_path())
+
+
+def run(args):
+    with infra.network.network(
+        args.nodes,
+        args.binary_dir,
+        args.debug_nodes,
+        args.perf_nodes,
+        pdb=args.pdb,
+    ) as network:
+        network.start_and_join(args)
+
+        save_committed_ledger_files(network, args)
+
+
+if __name__ == "__main__":
+    args = infra.e2e_args.cli_args()
+    args.package = "liblogging"
+
+    args.nodes = infra.e2e_args.min_nodes(args, f=0)
+    args.initial_user_count = 1
+    args.ledger_chunk_bytes = "1"  # Chunk ledger at every signature transaction
+    run(args)

--- a/tests/ledger_operation.py
+++ b/tests/ledger_operation.py
@@ -1,24 +1,38 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
-import http
+import tempfile
+import os
+import shutil
 
 import infra.logging_app as app
 import infra.e2e_args
 import infra.network
+import suite.test_requirements as reqs
 
 
 from loguru import logger as LOG
 
 
+@reqs.description("Move committed ledger files to read-only directory")
 def save_committed_ledger_files(network, args):
     txs = app.LoggingTxs()
-    # Issue txs in a loop to force a signature and a new ledger chunk each time
-    for _ in range(1, 10):
-        txs.issue(network, 1)
+    # Issue txs in a loop to force a signature and a new ledger chunk
+    # each time. Record log messages at the same key (repeat=True) so
+    # that CCF makes use of historical queries when verifying messages
+    for _ in range(1, 5):
+        txs.issue(network, 1, repeat=True)
 
+    LOG.info(f"Moving committed ledger files to {args.common_read_only_ledger_dir}")
     primary, _ = network.find_primary()
-    LOG.error(primary.remote.ledger_path())
-    LOG.warning(primary.remote.ledger_read_only_path())
+    for l in os.listdir(primary.remote.ledger_path()):
+        if infra.node.is_file_committed(l):
+            shutil.move(
+                os.path.join(primary.remote.ledger_path(), l),
+                os.path.join("/tmp/ledger", l),
+            )
+
+    txs.verify(network)
+    return network
 
 
 def run(args):
@@ -30,17 +44,18 @@ def run(args):
         pdb=args.pdb,
     ) as network:
 
-        args.read_only_ledger_dir = "/tmp/lalala"
-        network.start_and_join(args)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            args.common_read_only_ledger_dir = tmp_dir
+            network.start_and_join(args)
 
-        save_committed_ledger_files(network, args)
+            save_committed_ledger_files(network, args)
 
 
 if __name__ == "__main__":
     args = infra.e2e_args.cli_args()
     args.package = "liblogging"
 
-    args.nodes = infra.e2e_args.min_nodes(args, f=0)
+    args.nodes = infra.e2e_args.max_nodes(args, f=0)
     args.initial_user_count = 1
     args.ledger_chunk_bytes = "1"  # Chunk ledger at every signature transaction
     run(args)


### PR DESCRIPTION
We didn't use to test what happened when a _committed_ ledger file was moved out of the main ledger directory (`--ledger-dir`) to another location, hopefully accessible via `--read-only-ledger-dir`. 

This is now done in the ledger unit test as well as in a new `ledger_operation` end-to-end test.

This actually worked fine as it was but found out an interesting point: the ledger keeps track of a few committed ledger files in its read cache (specified via the `max_read_cache_files` constructor argument and hardcoded to 5 in CCF). Even if these files are deleted, the node process still holds a reference to the underlying inode and the ledger entries in those files can still be read. Once more recent committed ledger files are read by the node, the node will drop the reference to these files and have to read historical entries from the `--read-only-ledger-dir`. 