### PR TITLE
AFT: Async execution on backup

### DIFF
--- a/src/consensus/aft/impl/execution.cpp
+++ b/src/consensus/aft/impl/execution.cpp
@@ -16,7 +16,7 @@ namespace aft
     uint8_t* req_start, size_t req_size)
   {
     Request request;
-    request.deserialise(req_start, req_size);
+    request.apply(req_start, req_size);
     return create_request_ctx(request);
   }
 

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1114,8 +1114,19 @@ namespace aft
         kv::ConsensusHookPtrs hooks;
         if (consensus_type == ConsensusType::BFT)
         {
+            /*
           deserialise_success = store->deserialise_views(
             entry, hooks, public_only, &sig_term, &sig_index, &tx, &sig);
+          */
+          auto r = store->deserialise_views_async(
+            entry, hooks, public_only, &sig_term, &sig_index, &tx, &sig);
+
+          deserialise_success = kv::DeserialiseSuccess::FAILED;
+          if (r != nullptr)
+          {
+            deserialise_success = r->Execute();
+          }
+
         }
         else
         {

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1072,6 +1072,7 @@ namespace aft
         r.idx,
         r.prev_idx);
 
+      // TODO: we now know this is safe so start looking from here
       // Finally, deserialise each entry in the batch
       for (Index i = r.prev_idx + 1; i <= r.idx; i++)
       {

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1119,7 +1119,6 @@ namespace aft
       for (auto& d : foobar)
       {
         auto& [ds, i] = d;
-        LOG_INFO_FMT("current loop at i:{}", i);
         state->last_idx = i;
 
         kv::DeserialiseSuccess deserialise_success = kv::DeserialiseSuccess::FAILED;

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1073,7 +1073,7 @@ namespace aft
         r.prev_idx);
 
       std::vector<
-        std::tuple<std::unique_ptr<kv::IExecutionWrapper>, kv::Version>>
+        std::tuple<std::unique_ptr<kv::AbstractExecutionWrapper>, kv::Version>>
         append_entries;
       // Finally, deserialise each entry in the batch
       for (Index i = r.prev_idx + 1; i <= r.idx; i++)

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1128,7 +1128,7 @@ namespace aft
           apply_success = ds->execute();
           if (apply_success == kv::ApplySuccess::FAILED)
           {
-            rollback(last_committable_index());
+            state->last_idx = i - 1;
             ledger->truncate(state->last_idx);
             send_append_entries_response(
               r.from_node, AppendEntriesResponseType::FAIL);

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -41,7 +41,7 @@ namespace aft
     virtual void compact(Index v) = 0;
     virtual void rollback(Index v, std::optional<Term> t = std::nullopt) = 0;
     virtual void set_term(Term t) = 0;
-    virtual std::unique_ptr<kv::IExecutionWrapper> deserialise(
+    virtual std::unique_ptr<kv::AbstractExecutionWrapper> deserialise(
       const std::vector<uint8_t> data,
       ConsensusType consensus_type,
       bool public_only = false) = 0;
@@ -105,7 +105,7 @@ namespace aft
       throw std::logic_error("Can't create a tx without a store");
     }
 
-    std::unique_ptr<kv::IExecutionWrapper> deserialise(
+    std::unique_ptr<kv::AbstractExecutionWrapper> deserialise(
       const std::vector<uint8_t> data,
       ConsensusType consensus_type,
       bool public_only = false) override

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -55,6 +55,14 @@ namespace aft
       kv::Version* index_ = nullptr,
       kv::Tx* tx = nullptr,
       ccf::PrimarySignature* sig = nullptr) = 0;
+    virtual std::unique_ptr<kv::IExecutionWrapper> deserialise_views_async(
+      const std::vector<uint8_t>& data,
+      kv::ConsensusHookPtrs& hooks,
+      bool public_only = false,
+      kv::Term* term_ = nullptr,
+      kv::Version* index_ = nullptr,
+      kv::AbstractChangeContainer* tx = nullptr,
+      ccf::PrimarySignature* sig = nullptr) = 0;
     virtual std::shared_ptr<ccf::ProgressTracker> get_progress_tracker() = 0;
     virtual kv::Tx create_tx() = 0;
   };
@@ -144,6 +152,23 @@ namespace aft
           data, hooks, public_only, term, index, tx, sig);
       return S::FAILED;
     }
+
+    std::unique_ptr<kv::IExecutionWrapper> deserialise_views_async(
+      const std::vector<uint8_t>& data,
+      kv::ConsensusHookPtrs& hooks,
+      bool public_only = false,
+      kv::Term* term = nullptr,
+      kv::Version* index = nullptr,
+      kv::AbstractChangeContainer* tx = nullptr,
+      ccf::PrimarySignature* sig = nullptr) override
+      {
+        auto p = x.lock();
+        if (p)
+        {
+          return p->deserialise_views_async(data, hooks, public_only, term, index, tx, sig);
+        }
+      return nullptr;
+      }
   };
 
   enum RaftMsgType : Node2NodeMsg

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -39,30 +39,13 @@ namespace aft
   {
   public:
     virtual ~Store() {}
-    virtual S deserialise(
-      const std::vector<uint8_t>& data,
-      kv::ConsensusHookPtrs& hooks,
-      bool public_only = false,
-      Term* term = nullptr) = 0;
     virtual void compact(Index v) = 0;
     virtual void rollback(Index v, std::optional<Term> t = std::nullopt) = 0;
     virtual void set_term(Term t) = 0;
-    virtual S deserialise_views(
-      const std::vector<uint8_t>& data,
-      kv::ConsensusHookPtrs& hooks,
-      bool public_only = false,
-      kv::Term* term = nullptr,
-      kv::Version* index_ = nullptr,
-      kv::Tx* tx = nullptr,
-      ccf::PrimarySignature* sig = nullptr) = 0;
     virtual std::unique_ptr<kv::IExecutionWrapper> deserialise_views_async(
-      const std::vector<uint8_t>& data,
-      kv::ConsensusHookPtrs& hooks,
-      bool public_only = false,
-      kv::Term* term_ = nullptr,
-      kv::Version* index_ = nullptr,
-      kv::AbstractChangeContainer* tx = nullptr,
-      ccf::PrimarySignature* sig = nullptr) = 0;
+      const std::vector<uint8_t> data,
+      ConsensusType consensus_type,
+      bool public_only = false) = 0;
     virtual std::shared_ptr<ccf::ProgressTracker> get_progress_tracker() = 0;
     virtual kv::Tx create_tx() = 0;
   };
@@ -75,20 +58,6 @@ namespace aft
 
   public:
     Adaptor(std::shared_ptr<T> x) : x(x) {}
-
-    S deserialise(
-      const std::vector<uint8_t>& data,
-      kv::ConsensusHookPtrs& hooks,
-      bool public_only = false,
-      Term* term = nullptr) override
-    {
-      auto p = x.lock();
-      if (p)
-      {
-        return p->deserialise(data, hooks, public_only, term);
-      }
-      return S::FAILED;
-    }
 
     void compact(Index v) override
     {
@@ -137,35 +106,15 @@ namespace aft
       throw std::logic_error("Can't create a tx without a store");
     }
 
-    S deserialise_views(
-      const std::vector<uint8_t>& data,
-      kv::ConsensusHookPtrs& hooks,
-      bool public_only = false,
-      kv::Term* term = nullptr,
-      kv::Version* index = nullptr,
-      kv::Tx* tx = nullptr,
-      ccf::PrimarySignature* sig = nullptr) override
-    {
-      auto p = x.lock();
-      if (p)
-        return p->deserialise_views(
-          data, hooks, public_only, term, index, tx, sig);
-      return S::FAILED;
-    }
-
     std::unique_ptr<kv::IExecutionWrapper> deserialise_views_async(
-      const std::vector<uint8_t>& data,
-      kv::ConsensusHookPtrs& hooks,
-      bool public_only = false,
-      kv::Term* term = nullptr,
-      kv::Version* index = nullptr,
-      kv::AbstractChangeContainer* tx = nullptr,
-      ccf::PrimarySignature* sig = nullptr) override
+      const std::vector<uint8_t> data,
+      ConsensusType consensus_type,
+      bool public_only = false) override
       {
         auto p = x.lock();
         if (p)
         {
-          return p->deserialise_views_async(data, hooks, public_only, term, index, tx, sig);
+          return p->deserialise_views_async(data, consensus_type, public_only);
         }
       return nullptr;
       }

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -41,7 +41,7 @@ namespace aft
     virtual void compact(Index v) = 0;
     virtual void rollback(Index v, std::optional<Term> t = std::nullopt) = 0;
     virtual void set_term(Term t) = 0;
-    virtual std::unique_ptr<kv::AbstractExecutionWrapper> deserialise(
+    virtual std::unique_ptr<kv::AbstractExecutionWrapper> apply(
       const std::vector<uint8_t> data,
       ConsensusType consensus_type,
       bool public_only = false) = 0;
@@ -105,7 +105,7 @@ namespace aft
       throw std::logic_error("Can't create a tx without a store");
     }
 
-    std::unique_ptr<kv::AbstractExecutionWrapper> deserialise(
+    std::unique_ptr<kv::AbstractExecutionWrapper> apply(
       const std::vector<uint8_t> data,
       ConsensusType consensus_type,
       bool public_only = false) override
@@ -113,7 +113,7 @@ namespace aft
       auto p = x.lock();
       if (p)
       {
-        return p->deserialise(data, consensus_type, public_only);
+        return p->apply(data, consensus_type, public_only);
       }
       return nullptr;
     }

--- a/src/consensus/aft/request.h
+++ b/src/consensus/aft/request.h
@@ -48,7 +48,7 @@ namespace aft
       return serialized_req;
     }
 
-    void deserialise(const uint8_t* data_, size_t size_)
+    void apply(const uint8_t* data_, size_t size_)
     {
       rid = serialized::read<kv::TxHistory::RequestID>(data_, size_);
       auto includes_caller = serialized::read<bool>(data_, size_);

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -19,7 +19,7 @@ using ms = std::chrono::milliseconds;
 using TRaft =
   aft::Aft<aft::LedgerStubProxy, aft::ChannelStubProxy, aft::StubSnapshotter>;
 using Store = aft::LoggingStubStore;
-using Adaptor = aft::Adaptor<Store, kv::DeserialiseSuccess>;
+using Adaptor = aft::Adaptor<Store>;
 
 std::vector<uint8_t> cert;
 

--- a/src/consensus/aft/test/logging_stub.h
+++ b/src/consensus/aft/test/logging_stub.h
@@ -222,6 +222,27 @@ namespace aft
       return kv::DeserialiseSuccess::PASS;
     }
 
+    class ExecutionWrapper : public kv::IExecutionWrapper
+    {
+    public:
+      kv::DeserialiseSuccess Execute() override
+      {
+        return kv::DeserialiseSuccess::PASS;
+      }
+    };
+
+    virtual std::unique_ptr<kv::IExecutionWrapper> deserialise_views_async(
+      const std::vector<uint8_t>& data,
+      kv::ConsensusHookPtrs& hooks,
+      bool public_only = false,
+      kv::Term* term = nullptr,
+      kv::Version* index = nullptr,
+      kv::AbstractChangeContainer* tx = nullptr,
+      ccf::PrimarySignature* sig = nullptr)
+    {
+      return std::make_unique<ExecutionWrapper>();
+    }
+
     std::shared_ptr<ccf::ProgressTracker> get_progress_tracker()
     {
       return nullptr;

--- a/src/consensus/aft/test/logging_stub.h
+++ b/src/consensus/aft/test/logging_stub.h
@@ -225,22 +225,53 @@ namespace aft
     class ExecutionWrapper : public kv::IExecutionWrapper
     {
     public:
+      ExecutionWrapper(const std::vector<uint8_t>& data_) : data(data_) {}
+
       kv::DeserialiseSuccess Execute() override
       {
         return kv::DeserialiseSuccess::PASS;
       }
+
+      kv::ConsensusHookPtrs& get_hooks() override
+      {
+        return hooks;
+      }
+
+      const std::vector<uint8_t>& get_entry() override
+      {
+        return data;
+      }
+
+      Term get_term() override
+      {
+        return 0;
+      }
+
+      kv::Version get_index() override
+      {
+        return 0;
+      }
+      ccf::PrimarySignature& get_signature() override
+      {
+        throw std::logic_error("3. Not Implemented");
+      }
+
+      kv::Tx& get_tx() override
+      {
+        throw std::logic_error("4. Not Implemented");
+      }
+    private:
+      const std::vector<uint8_t>& data;
+      kv::ConsensusHookPtrs hooks;
+
     };
 
     virtual std::unique_ptr<kv::IExecutionWrapper> deserialise_views_async(
       const std::vector<uint8_t>& data,
-      kv::ConsensusHookPtrs& hooks,
-      bool public_only = false,
-      kv::Term* term = nullptr,
-      kv::Version* index = nullptr,
-      kv::AbstractChangeContainer* tx = nullptr,
-      ccf::PrimarySignature* sig = nullptr)
+      ConsensusType consensus_type,
+      bool public_only = false)
     {
-      return std::make_unique<ExecutionWrapper>();
+      return std::make_unique<ExecutionWrapper>(data);
     }
 
     std::shared_ptr<ccf::ProgressTracker> get_progress_tracker()

--- a/src/consensus/aft/test/logging_stub.h
+++ b/src/consensus/aft/test/logging_stub.h
@@ -253,12 +253,12 @@ namespace aft
       }
       ccf::PrimarySignature& get_signature() override
       {
-        throw std::logic_error("3. Not Implemented");
+        throw std::logic_error("Not Implemented");
       }
 
       kv::Tx& get_tx() override
       {
-        throw std::logic_error("4. Not Implemented");
+        throw std::logic_error("Not Implemented");
       }
 
     private:

--- a/src/consensus/aft/test/logging_stub.h
+++ b/src/consensus/aft/test/logging_stub.h
@@ -222,7 +222,7 @@ namespace aft
       return kv::DeserialiseSuccess::PASS;
     }
 
-    class ExecutionWrapper : public kv::IExecutionWrapper
+    class ExecutionWrapper : public kv::AbstractExecutionWrapper
     {
     public:
       ExecutionWrapper(const std::vector<uint8_t>& data_) : data(data_) {}
@@ -266,7 +266,7 @@ namespace aft
       kv::ConsensusHookPtrs hooks;
     };
 
-    virtual std::unique_ptr<kv::IExecutionWrapper> deserialise(
+    virtual std::unique_ptr<kv::AbstractExecutionWrapper> deserialise(
       const std::vector<uint8_t>& data,
       ConsensusType consensus_type,
       bool public_only = false)

--- a/src/consensus/aft/test/logging_stub.h
+++ b/src/consensus/aft/test/logging_stub.h
@@ -196,13 +196,13 @@ namespace aft
 #endif
     }
 
-    virtual kv::DeserialiseSuccess deserialise(
+    virtual kv::ApplySuccess apply(
       const std::vector<uint8_t>& data,
       kv::ConsensusHookPtrs& hooks,
       bool public_only = false,
       Term* term = nullptr)
     {
-      return kv::DeserialiseSuccess::PASS;
+      return kv::ApplySuccess::PASS;
     }
 
     kv::Version current_version()
@@ -210,7 +210,7 @@ namespace aft
       return kv::NoVersion;
     }
 
-    virtual kv::DeserialiseSuccess deserialise_views(
+    virtual kv::ApplySuccess deserialise_views(
       const std::vector<uint8_t>& data,
       kv::ConsensusHookPtrs& hooks,
       bool public_only = false,
@@ -219,7 +219,7 @@ namespace aft
       kv::Tx* tx = nullptr,
       ccf::PrimarySignature* sig = nullptr)
     {
-      return kv::DeserialiseSuccess::PASS;
+      return kv::ApplySuccess::PASS;
     }
 
     class ExecutionWrapper : public kv::AbstractExecutionWrapper
@@ -227,9 +227,9 @@ namespace aft
     public:
       ExecutionWrapper(const std::vector<uint8_t>& data_) : data(data_) {}
 
-      kv::DeserialiseSuccess Execute() override
+      kv::ApplySuccess execute() override
       {
-        return kv::DeserialiseSuccess::PASS;
+        return kv::ApplySuccess::PASS;
       }
 
       kv::ConsensusHookPtrs& get_hooks() override
@@ -266,7 +266,7 @@ namespace aft
       kv::ConsensusHookPtrs hooks;
     };
 
-    virtual std::unique_ptr<kv::AbstractExecutionWrapper> deserialise(
+    virtual std::unique_ptr<kv::AbstractExecutionWrapper> apply(
       const std::vector<uint8_t>& data,
       ConsensusType consensus_type,
       bool public_only = false)
@@ -290,13 +290,13 @@ namespace aft
   public:
     LoggingStubStoreSig(aft::NodeId id) : LoggingStubStore(id) {}
 
-    kv::DeserialiseSuccess deserialise(
+    kv::ApplySuccess apply(
       const std::vector<uint8_t>& data,
       kv::ConsensusHookPtrs& hooks,
       bool public_only = false,
       Term* term = nullptr) override
     {
-      return kv::DeserialiseSuccess::PASS_SIGNATURE;
+      return kv::ApplySuccess::PASS_SIGNATURE;
     }
   };
 

--- a/src/consensus/aft/test/logging_stub.h
+++ b/src/consensus/aft/test/logging_stub.h
@@ -260,13 +260,13 @@ namespace aft
       {
         throw std::logic_error("4. Not Implemented");
       }
+
     private:
       const std::vector<uint8_t>& data;
       kv::ConsensusHookPtrs hooks;
-
     };
 
-    virtual std::unique_ptr<kv::IExecutionWrapper> deserialise_views_async(
+    virtual std::unique_ptr<kv::IExecutionWrapper> deserialise(
       const std::vector<uint8_t>& data,
       ConsensusType consensus_type,
       bool public_only = false)

--- a/src/consensus/aft/test/main.cpp
+++ b/src/consensus/aft/test/main.cpp
@@ -18,7 +18,7 @@ using TRaft =
   aft::Aft<aft::LedgerStubProxy, aft::ChannelStubProxy, aft::StubSnapshotter>;
 using Store = aft::LoggingStubStore;
 using StoreSig = aft::LoggingStubStoreSig;
-using Adaptor = aft::Adaptor<Store, kv::DeserialiseSuccess>;
+using Adaptor = aft::Adaptor<Store>;
 
 threading::ThreadMessaging threading::ThreadMessaging::thread_messaging;
 std::atomic<uint16_t> threading::ThreadMessaging::thread_count = 0;

--- a/src/crypto/symmetric_key.h
+++ b/src/crypto/symmetric_key.h
@@ -91,7 +91,7 @@ namespace crypto
       return serial_hdr;
     }
 
-    void deserialise(const std::vector<uint8_t>& serial_hdr)
+    void apply(const std::vector<uint8_t>& serial_hdr)
     {
       auto data_ = serial_hdr.data();
       auto size = serial_hdr.size();
@@ -124,7 +124,7 @@ namespace crypto
       return serial;
     }
 
-    void deserialise(const std::vector<uint8_t>& serial)
+    void apply(const std::vector<uint8_t>& serial)
     {
       auto size = serial.size();
 

--- a/src/kv/deserialise.h
+++ b/src/kv/deserialise.h
@@ -30,7 +30,7 @@ namespace kv
       kv::ConsensusHookPtrs& hooks) = 0;
   };
 
-  class CFTExecutionWrapper : public IExecutionWrapper
+  class CFTExecutionWrapper : public AbstractExecutionWrapper
   {
   public:
     CFTExecutionWrapper(
@@ -38,12 +38,16 @@ namespace kv
       std::shared_ptr<TxHistory> history_,
       const std::vector<uint8_t>& data_,
       bool public_only_) :
-      self(self_), history(history_), data(data_), public_only(public_only_)
+      self(self_),
+      history(history_),
+      data(data_),
+      public_only(public_only_)
     {}
 
     DeserialiseSuccess Execute() override
     {
-      return fn(self, data, history, public_only, v, &term, changes, new_maps, hooks);
+      return fn(
+        self, data, history, public_only, v, &term, changes, new_maps, hooks);
     }
 
     kv::ConsensusHookPtrs& get_hooks() override
@@ -141,7 +145,7 @@ namespace kv
     kv::ConsensusHookPtrs hooks;
   };
 
-  class BFTExecutionWrapper : public IExecutionWrapper
+  class BFTExecutionWrapper : public AbstractExecutionWrapper
   {
   public:
     BFTExecutionWrapper(
@@ -194,19 +198,6 @@ namespace kv
     {
       return *tx;
     }
-
-    std::function<DeserialiseSuccess(
-      ExecutionWrapperStore* self,
-      const std::vector<uint8_t>& data,
-      bool public_only,
-      kv::Version& v,
-      Term* term,
-      Version* version,
-      ccf::PrimarySignature* sig,
-      OrderedChanges& changes,
-      MapCollection& new_maps,
-      kv::ConsensusHookPtrs& hooks)>
-      fn = nullptr;
 
     ExecutionWrapperStore* self;
     std::shared_ptr<TxHistory> history;
@@ -337,7 +328,18 @@ namespace kv
 
     DeserialiseSuccess Execute() override
     {
-      return fn(self, data, history, progress_tracker, consensus, v, &term, &version, changes, new_maps, hooks);
+      return fn(
+        self,
+        data,
+        history,
+        progress_tracker,
+        consensus,
+        v,
+        &term,
+        &version,
+        changes,
+        new_maps,
+        hooks);
     }
 
     std::function<DeserialiseSuccess(
@@ -356,8 +358,8 @@ namespace kv
              ExecutionWrapperStore* self,
              const std::vector<uint8_t>& data,
              std::shared_ptr<TxHistory> history,
-      std::shared_ptr<ccf::ProgressTracker> progress_tracker,
-      std::shared_ptr<Consensus> consensus,
+             std::shared_ptr<ccf::ProgressTracker> progress_tracker,
+             std::shared_ptr<Consensus> consensus,
              kv::Version& v,
              Term* term_,
              Version* index_,
@@ -426,7 +428,8 @@ namespace kv
 
     DeserialiseSuccess Execute() override
     {
-      return fn(self, data, history, progress_tracker, v, changes, new_maps, hooks);
+      return fn(
+        self, data, history, progress_tracker, v, changes, new_maps, hooks);
     }
 
     std::function<DeserialiseSuccess(
@@ -442,7 +445,7 @@ namespace kv
              ExecutionWrapperStore* self,
              const std::vector<uint8_t>& data,
              std::shared_ptr<TxHistory> history,
-      std::shared_ptr<ccf::ProgressTracker> progress_tracker,
+             std::shared_ptr<ccf::ProgressTracker> progress_tracker,
              kv::Version& v,
              OrderedChanges& changes,
              MapCollection& new_maps,
@@ -495,7 +498,18 @@ namespace kv
 
     DeserialiseSuccess Execute() override
     {
-      return fn(self, data, history, progress_tracker, consensus, v, &term, &version, changes, new_maps, hooks);
+      return fn(
+        self,
+        data,
+        history,
+        progress_tracker,
+        consensus,
+        v,
+        &term,
+        &version,
+        changes,
+        new_maps,
+        hooks);
     }
 
     std::function<DeserialiseSuccess(
@@ -514,8 +528,8 @@ namespace kv
              ExecutionWrapperStore* self,
              const std::vector<uint8_t>& data,
              std::shared_ptr<TxHistory> history,
-      std::shared_ptr<ccf::ProgressTracker> progress_tracker,
-      std::shared_ptr<Consensus> consensus,
+             std::shared_ptr<ccf::ProgressTracker> progress_tracker,
+             std::shared_ptr<Consensus> consensus,
              kv::Version& v,
              Term* term_,
              Version* index_,
@@ -531,10 +545,7 @@ namespace kv
       }
 
       if (!progress_tracker->apply_new_view(
-            consensus->primary(),
-            consensus->node_count(),
-            *term_,
-            *index_))
+            consensus->primary(), consensus->node_count(), *term_, *index_))
       {
         LOG_FAIL_FMT("apply_new_view Failed");
         LOG_DEBUG_FMT("NewView in transaction {} failed to verify", v);

--- a/src/kv/deserialise.h
+++ b/src/kv/deserialise.h
@@ -1,0 +1,588 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "kv_types.h"
+#include "node/progress_tracker.h"
+#include "node/signatures.h"
+#include "tx.h"
+#include "view_containers.h"
+
+#include <vector>
+
+namespace kv
+{
+  class ExecutionWrapperStore
+  {
+  public:
+    virtual bool fill_maps(
+      const std::vector<uint8_t>& data,
+      bool public_only,
+      kv::Version& v,
+      kv::OrderedChanges& changes,
+      kv::MapCollection& new_maps,
+      bool ignore_strict_versions = false) = 0;
+
+    virtual DeserialiseSuccess commit_deserialised(
+      kv::OrderedChanges& changes,
+      kv::Version& v,
+      const MapCollection& new_maps,
+      kv::ConsensusHookPtrs& hooks) = 0;
+  };
+
+  class CFTExecutionWrapper : public IExecutionWrapper
+  {
+  public:
+    CFTExecutionWrapper(
+      ExecutionWrapperStore* self_,
+      std::shared_ptr<TxHistory> history_,
+      const std::vector<uint8_t>& data_,
+      bool public_only_) :
+      self(self_), history(history_), data(data_), public_only(public_only_)
+    {}
+
+    DeserialiseSuccess Execute() override
+    {
+      return fn(self, data, history, public_only, v, &term, changes, new_maps, hooks);
+    }
+
+    kv::ConsensusHookPtrs& get_hooks() override
+    {
+      return hooks;
+    }
+
+    const std::vector<uint8_t>& get_entry() override
+    {
+      return data;
+    }
+
+    Term get_term() override
+    {
+      return term;
+    }
+
+    std::function<DeserialiseSuccess(
+      ExecutionWrapperStore* self,
+      const std::vector<uint8_t>& data,
+      std::shared_ptr<TxHistory> history,
+      bool public_only,
+      kv::Version& v,
+      Term* term,
+      OrderedChanges& changes,
+      MapCollection& new_maps,
+      kv::ConsensusHookPtrs& hooks)>
+      fn = [](
+             ExecutionWrapperStore* self,
+             const std::vector<uint8_t>& data,
+             std::shared_ptr<TxHistory> history,
+             bool public_only,
+             kv::Version& v,
+             Term* term_,
+             OrderedChanges& changes,
+             MapCollection& new_maps,
+             kv::ConsensusHookPtrs& hooks) -> DeserialiseSuccess {
+      if (!self->fill_maps(data, public_only, v, changes, new_maps, true))
+      {
+        return DeserialiseSuccess::FAILED;
+      }
+
+      DeserialiseSuccess success =
+        self->commit_deserialised(changes, v, new_maps, hooks);
+      if (success == DeserialiseSuccess::FAILED)
+      {
+        return success;
+      }
+
+      auto search = changes.find(ccf::Tables::SIGNATURES);
+      if (search != changes.end())
+      {
+        // Transactions containing a signature must only contain
+        // a signature and must be verified
+        if (changes.size() > 1)
+        {
+          LOG_FAIL_FMT("Failed to deserialise");
+          LOG_DEBUG_FMT("Unexpected contents in signature transaction {}", v);
+          return DeserialiseSuccess::FAILED;
+        }
+
+        if (history)
+        {
+          if (!history->verify(term_))
+          {
+            LOG_FAIL_FMT("Failed to deserialise");
+            LOG_DEBUG_FMT("Signature in transaction {} failed to verify", v);
+            return DeserialiseSuccess::FAILED;
+          }
+        }
+        success = DeserialiseSuccess::PASS_SIGNATURE;
+      }
+
+      search = changes.find(ccf::Tables::SNAPSHOT_EVIDENCE);
+      if (search != changes.end())
+      {
+        success = DeserialiseSuccess::PASS_SNAPSHOT_EVIDENCE;
+      }
+
+      if (history)
+      {
+        history->append(data);
+      }
+      return success;
+    };
+
+    ExecutionWrapperStore* self;
+    std::shared_ptr<TxHistory> history;
+    const std::vector<uint8_t> data;
+    bool public_only;
+    kv::Version v;
+    Term term;
+    OrderedChanges changes;
+    MapCollection new_maps;
+    kv::ConsensusHookPtrs hooks;
+  };
+
+  class BFTExecutionWrapper : public IExecutionWrapper
+  {
+  public:
+    BFTExecutionWrapper(
+      ExecutionWrapperStore* self_,
+      std::shared_ptr<TxHistory> history_,
+      std::shared_ptr<ccf::ProgressTracker> progress_tracker_,
+      std::shared_ptr<Consensus> consensus_,
+      const std::vector<uint8_t>& data_,
+      bool public_only_,
+      kv::Version v_,
+      OrderedChanges&& changes_,
+      MapCollection&& new_maps_) :
+      self(self_),
+      history(history_),
+      progress_tracker(progress_tracker_),
+      consensus(consensus_),
+      data(data_),
+      public_only(public_only_),
+      v(v_),
+      changes(std::move(changes_)),
+      new_maps(std::move(new_maps_))
+    {}
+
+    kv::ConsensusHookPtrs& get_hooks() override
+    {
+      return hooks;
+    }
+
+    const std::vector<uint8_t>& get_entry() override
+    {
+      return data;
+    }
+
+    Term get_term() override
+    {
+      return term;
+    }
+
+    kv::Version get_index() override
+    {
+      return version;
+    }
+
+    ccf::PrimarySignature& get_signature() override
+    {
+      return sig;
+    }
+
+    Tx& get_tx() override
+    {
+      return *tx;
+    }
+
+    std::function<DeserialiseSuccess(
+      ExecutionWrapperStore* self,
+      const std::vector<uint8_t>& data,
+      bool public_only,
+      kv::Version& v,
+      Term* term,
+      Version* version,
+      ccf::PrimarySignature* sig,
+      OrderedChanges& changes,
+      MapCollection& new_maps,
+      kv::ConsensusHookPtrs& hooks)>
+      fn = nullptr;
+
+    ExecutionWrapperStore* self;
+    std::shared_ptr<TxHistory> history;
+    std::shared_ptr<ccf::ProgressTracker> progress_tracker;
+    std::shared_ptr<Consensus> consensus;
+    const std::vector<uint8_t> data;
+    bool public_only;
+    kv::Version v;
+    Term term;
+    Version version;
+    ccf::PrimarySignature sig;
+    OrderedChanges changes;
+    MapCollection new_maps;
+    kv::ConsensusHookPtrs hooks;
+    std::unique_ptr<Tx> tx;
+  };
+
+  class SignatureBFTExec : public BFTExecutionWrapper
+  {
+  public:
+    SignatureBFTExec(
+      ExecutionWrapperStore* self_,
+      std::shared_ptr<TxHistory> history_,
+      const std::vector<uint8_t>& data_,
+      bool public_only_,
+      kv::Version v_,
+      OrderedChanges&& changes_,
+      MapCollection&& new_maps_) :
+      BFTExecutionWrapper(
+        self_,
+        history_,
+        nullptr,
+        nullptr,
+        data_,
+        public_only_,
+        v_,
+        std::move(changes_),
+        std::move(new_maps_))
+    {}
+
+    DeserialiseSuccess Execute() override
+    {
+      return fn(self, data, history, v, &term, &sig, changes, new_maps, hooks);
+    }
+
+    std::function<DeserialiseSuccess(
+      ExecutionWrapperStore* self,
+      const std::vector<uint8_t>& data,
+      std::shared_ptr<TxHistory> history,
+      kv::Version& v,
+      Term* term,
+      ccf::PrimarySignature* sig,
+      OrderedChanges& changes,
+      MapCollection& new_maps,
+      kv::ConsensusHookPtrs& hooks)>
+      fn = [](
+             ExecutionWrapperStore* self,
+             const std::vector<uint8_t>& data,
+             std::shared_ptr<TxHistory> history,
+             kv::Version& v,
+             Term* term_,
+             ccf::PrimarySignature* sig,
+             OrderedChanges& changes,
+             MapCollection& new_maps,
+             kv::ConsensusHookPtrs& hooks) -> DeserialiseSuccess
+
+    {
+      DeserialiseSuccess success =
+        self->commit_deserialised(changes, v, new_maps, hooks);
+      if (success == DeserialiseSuccess::FAILED)
+      {
+        return success;
+      }
+
+      bool result = true;
+      if (sig != nullptr)
+      {
+        auto r = history->verify_and_sign(*sig, term_);
+        if (
+          r != kv::TxHistory::Result::OK &&
+          r != kv::TxHistory::Result::SEND_SIG_RECEIPT_ACK)
+        {
+          result = false;
+        }
+      }
+      else
+      {
+        result = history->verify(term_);
+      }
+
+      if (!result)
+      {
+        LOG_FAIL_FMT("Failed to deserialise");
+        LOG_DEBUG_FMT("Signature in transaction {} failed to verify", v);
+        throw std::logic_error(
+          "Failed to verify signature, view-changes not implemented");
+        return DeserialiseSuccess::FAILED;
+      }
+      history->append(data);
+      return DeserialiseSuccess::PASS_SIGNATURE;
+    };
+  };
+
+  class BackupSignatureBFTExec : public BFTExecutionWrapper
+  {
+  public:
+    BackupSignatureBFTExec(
+      ExecutionWrapperStore* self_,
+      std::shared_ptr<TxHistory> history_,
+      std::shared_ptr<ccf::ProgressTracker> progress_tracker_,
+      std::shared_ptr<Consensus> consensus_,
+      const std::vector<uint8_t>& data_,
+      bool public_only_,
+      kv::Version v_,
+      OrderedChanges&& changes_,
+      MapCollection&& new_maps_) :
+      BFTExecutionWrapper(
+        self_,
+        history_,
+        progress_tracker_,
+        consensus_,
+        data_,
+        public_only_,
+        v_,
+        std::move(changes_),
+        std::move(new_maps_))
+    {}
+
+    DeserialiseSuccess Execute() override
+    {
+      return fn(self, data, history, progress_tracker, consensus, v, &term, &version, changes, new_maps, hooks);
+    }
+
+    std::function<DeserialiseSuccess(
+      ExecutionWrapperStore* self,
+      const std::vector<uint8_t>& data,
+      std::shared_ptr<TxHistory> history,
+      std::shared_ptr<ccf::ProgressTracker> progress_tracker,
+      std::shared_ptr<Consensus> consensus,
+      kv::Version& v,
+      Term* term,
+      Version* index,
+      OrderedChanges& changes,
+      MapCollection& new_maps,
+      kv::ConsensusHookPtrs& hooks)>
+      fn = [](
+             ExecutionWrapperStore* self,
+             const std::vector<uint8_t>& data,
+             std::shared_ptr<TxHistory> history,
+      std::shared_ptr<ccf::ProgressTracker> progress_tracker,
+      std::shared_ptr<Consensus> consensus,
+             kv::Version& v,
+             Term* term_,
+             Version* index_,
+             OrderedChanges& changes,
+             MapCollection& new_maps,
+             kv::ConsensusHookPtrs& hooks) -> DeserialiseSuccess {
+      DeserialiseSuccess success =
+        self->commit_deserialised(changes, v, new_maps, hooks);
+      if (success == DeserialiseSuccess::FAILED)
+      {
+        return success;
+      }
+
+      kv::TxID tx_id;
+
+      auto r = progress_tracker->receive_backup_signatures(
+        tx_id, consensus->node_count(), consensus->is_primary());
+      if (r == kv::TxHistory::Result::SEND_SIG_RECEIPT_ACK)
+      {
+        success = DeserialiseSuccess::PASS_BACKUP_SIGNATURE_SEND_ACK;
+      }
+      else if (r == kv::TxHistory::Result::OK)
+      {
+        success = DeserialiseSuccess::PASS_BACKUP_SIGNATURE;
+      }
+      else
+      {
+        LOG_FAIL_FMT("receive_backup_signatures Failed");
+        LOG_DEBUG_FMT("Signature in transaction {} failed to verify", v);
+        throw std::logic_error(
+          "Failed to verify signature, view-changes not implemented");
+        return DeserialiseSuccess::FAILED;
+      }
+
+      *term_ = tx_id.term;
+      *index_ = tx_id.version;
+
+      history->append(data);
+      return success;
+    };
+  };
+
+  class NoncesBFTExec : public BFTExecutionWrapper
+  {
+  public:
+    NoncesBFTExec(
+      ExecutionWrapperStore* self_,
+      std::shared_ptr<TxHistory> history_,
+      std::shared_ptr<ccf::ProgressTracker> progress_tracker_,
+      const std::vector<uint8_t>& data_,
+      bool public_only_,
+      kv::Version v_,
+      OrderedChanges&& changes_,
+      MapCollection&& new_maps_) :
+      BFTExecutionWrapper(
+        self_,
+        history_,
+        progress_tracker_,
+        nullptr,
+        data_,
+        public_only_,
+        v_,
+        std::move(changes_),
+        std::move(new_maps_))
+    {}
+
+    DeserialiseSuccess Execute() override
+    {
+      return fn(self, data, history, progress_tracker, v, changes, new_maps, hooks);
+    }
+
+    std::function<DeserialiseSuccess(
+      ExecutionWrapperStore* self,
+      const std::vector<uint8_t>& data,
+      std::shared_ptr<TxHistory> history,
+      std::shared_ptr<ccf::ProgressTracker> progress_tracker,
+      kv::Version& v,
+      OrderedChanges& changes,
+      MapCollection& new_maps,
+      kv::ConsensusHookPtrs& hooks)>
+      fn = [](
+             ExecutionWrapperStore* self,
+             const std::vector<uint8_t>& data,
+             std::shared_ptr<TxHistory> history,
+      std::shared_ptr<ccf::ProgressTracker> progress_tracker,
+             kv::Version& v,
+             OrderedChanges& changes,
+             MapCollection& new_maps,
+             kv::ConsensusHookPtrs& hooks) -> DeserialiseSuccess {
+      DeserialiseSuccess success =
+        self->commit_deserialised(changes, v, new_maps, hooks);
+      if (success == DeserialiseSuccess::FAILED)
+      {
+        return success;
+      }
+
+      auto r = progress_tracker->receive_nonces();
+      if (r != kv::TxHistory::Result::OK)
+      {
+        LOG_FAIL_FMT("receive_nonces Failed");
+        throw std::logic_error(
+          "Failed to verify nonces, view-changes not implemented");
+        return DeserialiseSuccess::FAILED;
+      }
+
+      history->append(data);
+      return DeserialiseSuccess::PASS_NONCES;
+    };
+  };
+
+  class NewViewBFTExec : public BFTExecutionWrapper
+  {
+  public:
+    NewViewBFTExec(
+      ExecutionWrapperStore* self_,
+      std::shared_ptr<TxHistory> history_,
+      std::shared_ptr<ccf::ProgressTracker> progress_tracker_,
+      std::shared_ptr<Consensus> consensus_,
+      const std::vector<uint8_t>& data_,
+      bool public_only_,
+      kv::Version v_,
+      OrderedChanges&& changes_,
+      MapCollection&& new_maps_) :
+      BFTExecutionWrapper(
+        self_,
+        history_,
+        progress_tracker_,
+        consensus_,
+        data_,
+        public_only_,
+        v_,
+        std::move(changes_),
+        std::move(new_maps_))
+    {}
+
+    DeserialiseSuccess Execute() override
+    {
+      return fn(self, data, history, progress_tracker, consensus, v, &term, &version, changes, new_maps, hooks);
+    }
+
+    std::function<DeserialiseSuccess(
+      ExecutionWrapperStore* self,
+      const std::vector<uint8_t>& data,
+      std::shared_ptr<TxHistory> history,
+      std::shared_ptr<ccf::ProgressTracker> progress_tracker,
+      std::shared_ptr<Consensus> consensus,
+      kv::Version& v,
+      Term* term,
+      Version* index,
+      OrderedChanges& changes,
+      MapCollection& new_maps,
+      kv::ConsensusHookPtrs& hooks)>
+      fn = [](
+             ExecutionWrapperStore* self,
+             const std::vector<uint8_t>& data,
+             std::shared_ptr<TxHistory> history,
+      std::shared_ptr<ccf::ProgressTracker> progress_tracker,
+      std::shared_ptr<Consensus> consensus,
+             kv::Version& v,
+             Term* term_,
+             Version* index_,
+             OrderedChanges& changes,
+             MapCollection& new_maps,
+             kv::ConsensusHookPtrs& hooks) -> DeserialiseSuccess {
+      LOG_INFO_FMT("Applying new view");
+      DeserialiseSuccess success =
+        self->commit_deserialised(changes, v, new_maps, hooks);
+      if (success == DeserialiseSuccess::FAILED)
+      {
+        return success;
+      }
+
+      if (!progress_tracker->apply_new_view(
+            consensus->primary(),
+            consensus->node_count(),
+            *term_,
+            *index_))
+      {
+        LOG_FAIL_FMT("apply_new_view Failed");
+        LOG_DEBUG_FMT("NewView in transaction {} failed to verify", v);
+        return DeserialiseSuccess::FAILED;
+      }
+
+      history->append(data);
+      return DeserialiseSuccess::PASS_NEW_VIEW;
+    };
+  };
+
+  class TxBFTExec : public BFTExecutionWrapper
+  {
+  public:
+    TxBFTExec(
+      ExecutionWrapperStore* self_,
+      std::shared_ptr<TxHistory> history_,
+      const std::vector<uint8_t>& data_,
+      bool public_only_,
+      std::unique_ptr<Tx> tx_,
+      kv::Version v_,
+      OrderedChanges&& changes_,
+      MapCollection&& new_maps_) :
+      BFTExecutionWrapper(
+        self_,
+        history_,
+        nullptr,
+        nullptr,
+        data_,
+        public_only_,
+        v_,
+        std::move(changes_),
+        std::move(new_maps_))
+    {
+      tx = std::move(tx_);
+    }
+
+    DeserialiseSuccess Execute() override
+    {
+      return fn(tx, term, changes);
+    }
+
+    std::function<DeserialiseSuccess(
+      std::unique_ptr<Tx>& tx, Term term, OrderedChanges& changes)>
+      fn = [](std::unique_ptr<Tx>& tx, Term term, OrderedChanges& changes)
+      -> DeserialiseSuccess {
+      tx->set_change_list(std::move(changes), term);
+      return DeserialiseSuccess::PASS;
+    };
+  };
+}

--- a/src/kv/deserialise.h
+++ b/src/kv/deserialise.h
@@ -65,6 +65,19 @@ namespace kv
       return term;
     }
 
+    kv::Version get_index() override
+    {
+      throw std::logic_error("get_index not implemented");
+    }
+    ccf::PrimarySignature& get_signature() override
+    {
+      throw std::logic_error("get_index not implemented");
+    }
+    kv::Tx& get_tx() override
+    {
+      throw std::logic_error("get_index not implemented");
+    }
+
     std::function<ApplySuccess(
       ExecutionWrapperStore* store,
       const std::vector<uint8_t>& data,

--- a/src/kv/encryptor.h
+++ b/src/kv/encryptor.h
@@ -97,7 +97,7 @@ namespace kv
       bool historical_hint = false) override
     {
       S hdr;
-      hdr.deserialise(serialised_header);
+      hdr.apply(serialised_header);
       plain.resize(cipher.size());
 
       auto ret =

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -533,18 +533,9 @@ namespace kv
     virtual kv::ConsensusHookPtrs& get_hooks() = 0;
     virtual const std::vector<uint8_t>& get_entry() = 0;
     virtual kv::Term get_term() = 0;
-    virtual kv::Version get_index()
-    {
-      throw std::logic_error("get_index not implemented");
-    }
-    virtual ccf::PrimarySignature& get_signature()
-    {
-      throw std::logic_error("get_index not implemented");
-    }
-    virtual kv::Tx& get_tx()
-    {
-      throw std::logic_error("get_index not implemented");
-    }
+    virtual kv::Version get_index() = 0;
+    virtual ccf::PrimarySignature& get_signature() = 0;
+    virtual kv::Tx& get_tx() = 0;
   };
 
   class AbstractStore

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -525,10 +525,10 @@ namespace kv
 
   class Tx;
 
-  class IExecutionWrapper
+  class AbstractExecutionWrapper
   {
   public:
-    virtual ~IExecutionWrapper() = default;
+    virtual ~AbstractExecutionWrapper() = default;
     virtual kv::DeserialiseSuccess Execute() = 0;
     virtual kv::ConsensusHookPtrs& get_hooks() = 0;
     virtual const std::vector<uint8_t>& get_entry() = 0;
@@ -581,7 +581,7 @@ namespace kv
     virtual std::shared_ptr<Consensus> get_consensus() = 0;
     virtual std::shared_ptr<TxHistory> get_history() = 0;
     virtual EncryptorPtr get_encryptor() = 0;
-    virtual std::unique_ptr<IExecutionWrapper> deserialise(
+    virtual std::unique_ptr<AbstractExecutionWrapper> deserialise(
       const std::vector<uint8_t> data,
       ConsensusType consensus_type,
       bool public_only = false) = 0;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -533,8 +533,14 @@ namespace kv
     virtual kv::ConsensusHookPtrs& get_hooks() = 0;
     virtual const std::vector<uint8_t>& get_entry() = 0;
     virtual kv::Term get_term() = 0;
-    virtual kv::Version get_index() = 0;
-    virtual ccf::PrimarySignature& get_signature() = 0;
+    virtual kv::Version get_index()
+    {
+      throw std::logic_error("get_index not implemented");
+    }
+    virtual ccf::PrimarySignature& get_signature()
+    {
+      throw std::logic_error("get_index not implemented");
+    }
     virtual kv::Tx& get_tx() = 0;
   };
 
@@ -572,7 +578,7 @@ namespace kv
     virtual std::shared_ptr<Consensus> get_consensus() = 0;
     virtual std::shared_ptr<TxHistory> get_history() = 0;
     virtual EncryptorPtr get_encryptor() = 0;
-    virtual std::unique_ptr<IExecutionWrapper> deserialise_views_async(
+    virtual std::unique_ptr<IExecutionWrapper> deserialise(
       const std::vector<uint8_t> data,
       ConsensusType consensus_type,
       bool public_only = false) = 0;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -523,6 +523,13 @@ namespace kv
     virtual void swap(AbstractMap* map) = 0;
   };
 
+  class IExecutionWrapper
+  {
+  public:
+    virtual ~IExecutionWrapper() = default;
+    virtual kv::DeserialiseSuccess Execute() = 0;
+  };
+
   class AbstractStore
   {
   public:
@@ -561,7 +568,13 @@ namespace kv
       const std::vector<uint8_t>& data,
       ConsensusHookPtrs& hooks,
       bool public_only = false,
-      Term* term = nullptr) = 0;
+      kv::Term* term = nullptr) = 0;
+    virtual std::unique_ptr<IExecutionWrapper> deserialise_async(
+      const std::vector<uint8_t>& data,
+      kv::ConsensusHookPtrs& hooks,
+      bool public_only = false,
+      kv::Term* term = nullptr) = 0;
+
     virtual void compact(Version v) = 0;
     virtual void rollback(Version v, std::optional<Term> t = std::nullopt) = 0;
     virtual void set_term(Term t) = 0;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -523,11 +523,19 @@ namespace kv
     virtual void swap(AbstractMap* map) = 0;
   };
 
+  class Tx;
+
   class IExecutionWrapper
   {
   public:
     virtual ~IExecutionWrapper() = default;
     virtual kv::DeserialiseSuccess Execute() = 0;
+    virtual kv::ConsensusHookPtrs& get_hooks() = 0;
+    virtual const std::vector<uint8_t>& get_entry() = 0;
+    virtual kv::Term get_term() = 0;
+    virtual kv::Version get_index() = 0;
+    virtual ccf::PrimarySignature& get_signature() = 0;
+    virtual kv::Tx& get_tx() = 0;
   };
 
   class AbstractStore
@@ -564,17 +572,10 @@ namespace kv
     virtual std::shared_ptr<Consensus> get_consensus() = 0;
     virtual std::shared_ptr<TxHistory> get_history() = 0;
     virtual EncryptorPtr get_encryptor() = 0;
-    virtual DeserialiseSuccess deserialise(
-      const std::vector<uint8_t>& data,
-      ConsensusHookPtrs& hooks,
-      bool public_only = false,
-      kv::Term* term = nullptr) = 0;
-    virtual std::unique_ptr<IExecutionWrapper> deserialise_async(
-      const std::vector<uint8_t>& data,
-      kv::ConsensusHookPtrs& hooks,
-      bool public_only = false,
-      kv::Term* term = nullptr) = 0;
-
+    virtual std::unique_ptr<IExecutionWrapper> deserialise_views_async(
+      const std::vector<uint8_t> data,
+      ConsensusType consensus_type,
+      bool public_only = false) = 0;
     virtual void compact(Version v) = 0;
     virtual void rollback(Version v, std::optional<Term> t = std::nullopt) = 0;
     virtual void set_term(Term t) = 0;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -167,9 +167,9 @@ namespace kv
   }
 
   // Note that failed = 0, and all other values are variants of PASS, which
-  // allows DeserialiseSuccess to be used as a boolean in code that does not
+  // allows ApplySuccess to be used as a boolean in code that does not
   // need any detail about what happened on success
-  enum DeserialiseSuccess
+  enum ApplySuccess
   {
     FAILED = 0,
     PASS = 1,
@@ -529,7 +529,7 @@ namespace kv
   {
   public:
     virtual ~AbstractExecutionWrapper() = default;
-    virtual kv::DeserialiseSuccess Execute() = 0;
+    virtual kv::ApplySuccess execute() = 0;
     virtual kv::ConsensusHookPtrs& get_hooks() = 0;
     virtual const std::vector<uint8_t>& get_entry() = 0;
     virtual kv::Term get_term() = 0;
@@ -581,7 +581,7 @@ namespace kv
     virtual std::shared_ptr<Consensus> get_consensus() = 0;
     virtual std::shared_ptr<TxHistory> get_history() = 0;
     virtual EncryptorPtr get_encryptor() = 0;
-    virtual std::unique_ptr<AbstractExecutionWrapper> deserialise(
+    virtual std::unique_ptr<AbstractExecutionWrapper> apply(
       const std::vector<uint8_t> data,
       ConsensusType consensus_type,
       bool public_only = false) = 0;
@@ -596,7 +596,7 @@ namespace kv
     virtual std::unique_ptr<AbstractSnapshot> snapshot(Version v) = 0;
     virtual std::vector<uint8_t> serialise_snapshot(
       std::unique_ptr<AbstractSnapshot> snapshot) = 0;
-    virtual DeserialiseSuccess deserialise_snapshot(
+    virtual ApplySuccess deserialise_snapshot(
       const std::vector<uint8_t>& data,
       ConsensusHookPtrs& hooks,
       std::vector<Version>* view_history = nullptr,

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -541,7 +541,10 @@ namespace kv
     {
       throw std::logic_error("get_index not implemented");
     }
-    virtual kv::Tx& get_tx() = 0;
+    virtual kv::Tx& get_tx()
+    {
+      throw std::logic_error("get_index not implemented");
+    }
   };
 
   class AbstractStore

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -617,7 +617,7 @@ namespace kv
       }
     }
 
-    bool fill_maps(
+    bool fill_maps (
       const std::vector<uint8_t>& data,
       bool public_only,
       kv::Version& v,

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -202,14 +202,6 @@ namespace kv
         {
           return map_ptr;
         }
-        else
-        {
-          LOG_INFO_FMT("1. PPPPPPP - v:{}, map_creation_version:{}", v, map_creation_version);
-        }
-      }
-      else
-      {
-        LOG_INFO_FMT("2. PPPPPPP - unknown map {}", map_name);
       }
 
       return nullptr;
@@ -821,7 +813,6 @@ namespace kv
             self->commit_deserialised(changes, v, new_maps, hooks);
           if (success == DeserialiseSuccess::FAILED)
           {
-            LOG_FAIL_FMT("1. Failed to deserialise");
             return success;
           }
 
@@ -830,12 +821,11 @@ namespace kv
           auto search = changes.find(ccf::Tables::SIGNATURES);
           if (search != changes.end())
           {
-            LOG_INFO_FMT("TTTTTT signature");
             // Transactions containing a signature must only contain
             // a signature and must be verified
             if (changes.size() > 1)
             {
-              LOG_FAIL_FMT("2. Failed to deserialise");
+              LOG_FAIL_FMT("Failed to deserialise");
               LOG_DEBUG_FMT(
                 "Unexpected contents in signature transaction {}", v);
               return DeserialiseSuccess::FAILED;
@@ -845,20 +835,18 @@ namespace kv
             {
               if (!h->verify(term_))
               {
-                LOG_FAIL_FMT("3. TTTTTTT Failed to deserialise");
+                LOG_FAIL_FMT("Failed to deserialise");
                 LOG_DEBUG_FMT(
                   "Signature in transaction {} failed to verify", v);
                 return DeserialiseSuccess::FAILED;
               }
             }
-            LOG_INFO_FMT("TTTTTTT signature verified");
             success = DeserialiseSuccess::PASS_SIGNATURE;
           }
 
           search = changes.find(ccf::Tables::SNAPSHOT_EVIDENCE);
           if (search != changes.end())
           {
-            LOG_INFO_FMT("TTTTTT snapshot evidence");
             success = DeserialiseSuccess::PASS_SNAPSHOT_EVIDENCE;
           }
 

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -714,7 +714,7 @@ namespace kv
       return true;
     }
 
-    std::unique_ptr<kv::IExecutionWrapper> deserialise(
+    std::unique_ptr<kv::AbstractExecutionWrapper> deserialise(
       const std::vector<uint8_t> data,
       ConsensusType consensus_type,
       bool public_only = false) override

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -87,7 +87,7 @@ namespace kv
     // If true, use historical ledger secrets to deserialise entries
     const bool is_historical = false;
 
-    DeserialiseSuccess commit_deserialised(
+    ApplySuccess commit_deserialised(
       OrderedChanges& changes,
       Version& v,
       const MapCollection& new_maps,
@@ -98,14 +98,14 @@ namespace kv
       if (!c.has_value())
       {
         LOG_FAIL_FMT("Failed to commit deserialised Tx at version {}", v);
-        return DeserialiseSuccess::FAILED;
+        return ApplySuccess::FAILED;
       }
       {
         std::lock_guard<SpinLock> vguard(version_lock);
         version = v;
         last_replicated = version;
       }
-      return DeserialiseSuccess::PASS;
+      return ApplySuccess::PASS;
     }
 
     bool has_map_internal(const std::string& name)
@@ -349,7 +349,7 @@ namespace kv
       return snapshot->serialise(e);
     }
 
-    DeserialiseSuccess deserialise_snapshot(
+    ApplySuccess deserialise_snapshot(
       const std::vector<uint8_t>& data,
       kv::ConsensusHookPtrs& hooks,
       std::vector<Version>* view_history = nullptr,
@@ -365,7 +365,7 @@ namespace kv
       if (!v_.has_value())
       {
         LOG_FAIL_FMT("Initialisation of deserialise object failed");
-        return DeserialiseSuccess::FAILED;
+        return ApplySuccess::FAILED;
       }
       auto [v, _] = v_.value();
 
@@ -423,7 +423,7 @@ namespace kv
         {
           LOG_FAIL_FMT("Failed to deserialise snapshot at version {}", v);
           LOG_DEBUG_FMT("Multiple writes on map {}", map_name);
-          return DeserialiseSuccess::FAILED;
+          return ApplySuccess::FAILED;
         }
 
         auto deserialised_snapshot_changes =
@@ -443,7 +443,7 @@ namespace kv
       if (!d.end())
       {
         LOG_FAIL_FMT("Unexpected content in snapshot at version {}", v);
-        return DeserialiseSuccess::FAILED;
+        return ApplySuccess::FAILED;
       }
 
       // Each map is committed at a different version, independently of the
@@ -454,7 +454,7 @@ namespace kv
       if (!r.has_value())
       {
         LOG_FAIL_FMT("Failed to commit deserialised snapshot at version {}", v);
-        return DeserialiseSuccess::FAILED;
+        return ApplySuccess::FAILED;
       }
 
       {
@@ -468,7 +468,7 @@ namespace kv
       {
         if (!h->init_from_snapshot(hash_at_snapshot))
         {
-          return DeserialiseSuccess::FAILED;
+          return ApplySuccess::FAILED;
         }
       }
 
@@ -477,7 +477,7 @@ namespace kv
         *view_history = std::move(view_history_);
       }
 
-      return DeserialiseSuccess::PASS;
+      return ApplySuccess::PASS;
     }
 
     void compact(Version v) override
@@ -644,7 +644,7 @@ namespace kv
       if (!v_.has_value())
       {
         LOG_FAIL_FMT("Initialisation of deserialise object failed");
-        return DeserialiseSuccess::FAILED;
+        return ApplySuccess::FAILED;
       }
       std::tie(v, std::ignore) = v_.value();
 
@@ -660,7 +660,7 @@ namespace kv
         {
           LOG_FAIL_FMT(
             "Tried to deserialise {} but current_version is {}", v, cv);
-          return DeserialiseSuccess::FAILED;
+          return ApplySuccess::FAILED;
         }
       }
 
@@ -714,7 +714,7 @@ namespace kv
       return true;
     }
 
-    std::unique_ptr<kv::AbstractExecutionWrapper> deserialise(
+    std::unique_ptr<kv::AbstractExecutionWrapper> apply(
       const std::vector<uint8_t> data,
       ConsensusType consensus_type,
       bool public_only = false) override

--- a/src/kv/test/kv_bench.cpp
+++ b/src/kv/test/kv_bench.cpp
@@ -117,9 +117,8 @@ static void deserialise(picobench::state& s)
   }
   tx.commit();
 
-  kv::ConsensusHookPtrs hooks;
   s.start_timer();
-  auto rc = kv_store2.deserialise(consensus->get_latest_data().value(), hooks);
+  auto rc = kv_store2.deserialise_views_async(consensus->get_latest_data().value(), ConsensusType::CFT)->Execute();
   if (rc != kv::DeserialiseSuccess::PASS)
     throw std::logic_error(
       "Transaction deserialisation failed: " + std::to_string(rc));

--- a/src/kv/test/kv_bench.cpp
+++ b/src/kv/test/kv_bench.cpp
@@ -118,7 +118,10 @@ static void deserialise(picobench::state& s)
   tx.commit();
 
   s.start_timer();
-  auto rc = kv_store2.deserialise_views_async(consensus->get_latest_data().value(), ConsensusType::CFT)->Execute();
+  auto rc =
+    kv_store2
+      .deserialise(consensus->get_latest_data().value(), ConsensusType::CFT)
+      ->Execute();
   if (rc != kv::DeserialiseSuccess::PASS)
     throw std::logic_error(
       "Transaction deserialisation failed: " + std::to_string(rc));

--- a/src/kv/test/kv_bench.cpp
+++ b/src/kv/test/kv_bench.cpp
@@ -89,7 +89,7 @@ static void serialise(picobench::state& s)
 }
 
 template <kv::SecurityDomain SD>
-static void deserialise(picobench::state& s)
+static void apply(picobench::state& s)
 {
   logger::config::level() = logger::INFO;
 
@@ -119,10 +119,9 @@ static void deserialise(picobench::state& s)
 
   s.start_timer();
   auto rc =
-    kv_store2
-      .deserialise(consensus->get_latest_data().value(), ConsensusType::CFT)
-      ->Execute();
-  if (rc != kv::DeserialiseSuccess::PASS)
+    kv_store2.apply(consensus->get_latest_data().value(), ConsensusType::CFT)
+      ->execute();
+  if (rc != kv::ApplySuccess::PASS)
     throw std::logic_error(
       "Transaction deserialisation failed: " + std::to_string(rc));
   s.stop_timer();
@@ -252,12 +251,12 @@ PICOBENCH(serialise<SD::PUBLIC>)
   .baseline();
 PICOBENCH(serialise<SD::PRIVATE>).iterations(tx_count).samples(sample_size);
 
-PICOBENCH_SUITE("deserialise");
-PICOBENCH(deserialise<SD::PUBLIC>)
+PICOBENCH_SUITE("apply");
+PICOBENCH(apply<SD::PUBLIC>)
   .iterations(tx_count)
   .samples(sample_size)
   .baseline();
-PICOBENCH(deserialise<SD::PRIVATE>).iterations(tx_count).samples(sample_size);
+PICOBENCH(apply<SD::PRIVATE>).iterations(tx_count).samples(sample_size);
 
 const uint32_t snapshot_sample_size = 10;
 const std::vector<int> map_count = {20, 100};

--- a/src/kv/test/kv_dynamic_tables.cpp
+++ b/src/kv/test/kv_dynamic_tables.cpp
@@ -378,10 +378,10 @@ TEST_CASE("Dynamic map serialisation" * doctest::test_suite("dynamic"))
     INFO("Deserialise transaction in target store");
     const auto latest_data = consensus->get_latest_data();
     REQUIRE(latest_data.has_value());
-    kv::ConsensusHookPtrs hooks;
     REQUIRE(
-      kv_store_target.deserialise(latest_data.value(), hooks) ==
-      kv::DeserialiseSuccess::PASS);
+      kv_store_target
+        .deserialise_views_async(latest_data.value(), ConsensusType::CFT)
+        ->Execute() == kv::DeserialiseSuccess::PASS);
 
     auto tx_target = kv_store_target.create_tx();
     auto view_target = tx_target.get_view<MapTypes::StringString>(map_name);

--- a/src/kv/test/kv_dynamic_tables.cpp
+++ b/src/kv/test/kv_dynamic_tables.cpp
@@ -379,8 +379,7 @@ TEST_CASE("Dynamic map serialisation" * doctest::test_suite("dynamic"))
     const auto latest_data = consensus->get_latest_data();
     REQUIRE(latest_data.has_value());
     REQUIRE(
-      kv_store_target
-        .deserialise_views_async(latest_data.value(), ConsensusType::CFT)
+      kv_store_target.deserialise(latest_data.value(), ConsensusType::CFT)
         ->Execute() == kv::DeserialiseSuccess::PASS);
 
     auto tx_target = kv_store_target.create_tx();

--- a/src/kv/test/kv_dynamic_tables.cpp
+++ b/src/kv/test/kv_dynamic_tables.cpp
@@ -379,8 +379,8 @@ TEST_CASE("Dynamic map serialisation" * doctest::test_suite("dynamic"))
     const auto latest_data = consensus->get_latest_data();
     REQUIRE(latest_data.has_value());
     REQUIRE(
-      kv_store_target.deserialise(latest_data.value(), ConsensusType::CFT)
-        ->Execute() == kv::DeserialiseSuccess::PASS);
+      kv_store_target.apply(latest_data.value(), ConsensusType::CFT)
+        ->execute() == kv::ApplySuccess::PASS);
 
     auto tx_target = kv_store_target.create_tx();
     auto view_target = tx_target.get_view<MapTypes::StringString>(map_name);

--- a/src/kv/test/kv_serialisation.cpp
+++ b/src/kv/test/kv_serialisation.cpp
@@ -46,8 +46,8 @@ TEST_CASE(
     REQUIRE(latest_data.has_value());
     REQUIRE(!latest_data.value().empty());
     REQUIRE(
-      kv_store_target.deserialise(latest_data.value(), ConsensusType::CFT)
-        ->Execute() == kv::DeserialiseSuccess::PASS);
+      kv_store_target.apply(latest_data.value(), ConsensusType::CFT)
+        ->execute() == kv::ApplySuccess::PASS);
 
     auto tx_target = kv_store_target.create_tx();
     auto view_target =
@@ -93,8 +93,8 @@ TEST_CASE(
       const auto latest_data = consensus->get_latest_data();
       REQUIRE(latest_data.has_value());
       REQUIRE(
-        kv_store_target.deserialise(latest_data.value(), ConsensusType::CFT)
-          ->Execute() == kv::DeserialiseSuccess::PASS);
+        kv_store_target.apply(latest_data.value(), ConsensusType::CFT)
+          ->execute() == kv::ApplySuccess::PASS);
 
       auto tx_target = kv_store_target.create_tx();
       auto view_target = tx_target.get_view<MapTypes::StringString>("priv_map");
@@ -137,8 +137,8 @@ TEST_CASE(
     const auto latest_data = consensus->get_latest_data();
     REQUIRE(latest_data.has_value());
     REQUIRE(
-      kv_store_target.deserialise(latest_data.value(), ConsensusType::CFT)
-        ->Execute() != kv::DeserialiseSuccess::FAILED);
+      kv_store_target.apply(latest_data.value(), ConsensusType::CFT)
+        ->execute() != kv::ApplySuccess::FAILED);
 
     auto tx_target = kv_store_target.create_tx();
     auto [view_priv, view_pub] =
@@ -175,8 +175,8 @@ TEST_CASE(
     const auto latest_data = consensus->get_latest_data();
     REQUIRE(latest_data.has_value());
     REQUIRE(
-      kv_store_target.deserialise(latest_data.value(), ConsensusType::CFT)
-        ->Execute() != kv::DeserialiseSuccess::FAILED);
+      kv_store_target.apply(latest_data.value(), ConsensusType::CFT)
+        ->execute() != kv::ApplySuccess::FAILED);
 
     auto tx_target = kv_store_target.create_tx();
     auto view_target = tx_target.get_view<MapTypes::StringString>("map");
@@ -224,8 +224,8 @@ TEST_CASE(
     const auto latest_data = consensus->get_latest_data();
     REQUIRE(latest_data.has_value());
     REQUIRE(
-      kv_store_target.deserialise(latest_data.value(), ConsensusType::CFT)
-        ->Execute() != kv::DeserialiseSuccess::FAILED);
+      kv_store_target.apply(latest_data.value(), ConsensusType::CFT)
+        ->execute() != kv::ApplySuccess::FAILED);
 
     auto tx_target = kv_store_target.create_tx();
     auto view_target = tx_target.get_view<MapTypes::StringString>("map");
@@ -476,8 +476,8 @@ TEST_CASE_TEMPLATE(
     kv_store.compact(kv_store.current_version());
 
     REQUIRE(
-      kv_store2.deserialise(data, ConsensusType::CFT)->Execute() ==
-      kv::DeserialiseSuccess::PASS);
+      kv_store2.apply(data, ConsensusType::CFT)->execute() ==
+      kv::ApplySuccess::PASS);
     auto tx2 = kv_store2.create_tx();
     auto view2 = tx2.get_view(map2);
 
@@ -517,8 +517,8 @@ TEST_CASE("nlohmann (de)serialisation" * doctest::test_suite("serialisation"))
     const auto latest_data = consensus->get_latest_data();
     REQUIRE(latest_data.has_value());
     REQUIRE(
-      s1.deserialise(latest_data.value(), ConsensusType::CFT)->Execute() !=
-      kv::DeserialiseSuccess::FAILED);
+      s1.apply(latest_data.value(), ConsensusType::CFT)->execute() !=
+      kv::ApplySuccess::FAILED);
   }
 
   SUBCASE("nlohmann")
@@ -536,8 +536,8 @@ TEST_CASE("nlohmann (de)serialisation" * doctest::test_suite("serialisation"))
     const auto latest_data = consensus->get_latest_data();
     REQUIRE(latest_data.has_value());
     REQUIRE(
-      s1.deserialise(latest_data.value(), ConsensusType::CFT)->Execute() !=
-      kv::DeserialiseSuccess::FAILED);
+      s1.apply(latest_data.value(), ConsensusType::CFT)->execute() !=
+      kv::ApplySuccess::FAILED);
   }
 }
 
@@ -578,14 +578,14 @@ TEST_CASE(
     auto [success, reqid, data, hooks] = tx.commit_reserved();
     REQUIRE(success == kv::CommitSuccess::OK);
     REQUIRE(
-      store.deserialise(data, ConsensusType::CFT)->Execute() ==
-      kv::DeserialiseSuccess::PASS);
+      store.apply(data, ConsensusType::CFT)->execute() ==
+      kv::ApplySuccess::PASS);
 
     INFO("check that second store derived data is not populated");
     {
       REQUIRE(
-        kv_store_target.deserialise(data, ConsensusType::CFT)->Execute() ==
-        kv::DeserialiseSuccess::PASS);
+        kv_store_target.apply(data, ConsensusType::CFT)->execute() ==
+        kv::ApplySuccess::PASS);
       auto tx = kv_store_target.create_tx();
       auto [data_view_r, data_view_r_p, data_view_d, data_view_d_p] =
         tx.get_view<T, T, T, T>(

--- a/src/kv/test/kv_serialisation.cpp
+++ b/src/kv/test/kv_serialisation.cpp
@@ -46,8 +46,7 @@ TEST_CASE(
     REQUIRE(latest_data.has_value());
     REQUIRE(!latest_data.value().empty());
     REQUIRE(
-      kv_store_target
-        .deserialise_views_async(latest_data.value(), ConsensusType::CFT)
+      kv_store_target.deserialise(latest_data.value(), ConsensusType::CFT)
         ->Execute() == kv::DeserialiseSuccess::PASS);
 
     auto tx_target = kv_store_target.create_tx();
@@ -94,8 +93,8 @@ TEST_CASE(
       const auto latest_data = consensus->get_latest_data();
       REQUIRE(latest_data.has_value());
       REQUIRE(
-        kv_store_target.deserialise_views_async(latest_data.value(), ConsensusType::CFT)->Execute() ==
-        kv::DeserialiseSuccess::PASS);
+        kv_store_target.deserialise(latest_data.value(), ConsensusType::CFT)
+          ->Execute() == kv::DeserialiseSuccess::PASS);
 
       auto tx_target = kv_store_target.create_tx();
       auto view_target = tx_target.get_view<MapTypes::StringString>("priv_map");
@@ -138,8 +137,8 @@ TEST_CASE(
     const auto latest_data = consensus->get_latest_data();
     REQUIRE(latest_data.has_value());
     REQUIRE(
-      kv_store_target.deserialise_views_async(latest_data.value(), ConsensusType::CFT)->Execute() !=
-      kv::DeserialiseSuccess::FAILED);
+      kv_store_target.deserialise(latest_data.value(), ConsensusType::CFT)
+        ->Execute() != kv::DeserialiseSuccess::FAILED);
 
     auto tx_target = kv_store_target.create_tx();
     auto [view_priv, view_pub] =
@@ -176,8 +175,8 @@ TEST_CASE(
     const auto latest_data = consensus->get_latest_data();
     REQUIRE(latest_data.has_value());
     REQUIRE(
-      kv_store_target.deserialise_views_async(latest_data.value(), ConsensusType::CFT)->Execute() !=
-      kv::DeserialiseSuccess::FAILED);
+      kv_store_target.deserialise(latest_data.value(), ConsensusType::CFT)
+        ->Execute() != kv::DeserialiseSuccess::FAILED);
 
     auto tx_target = kv_store_target.create_tx();
     auto view_target = tx_target.get_view<MapTypes::StringString>("map");
@@ -225,8 +224,8 @@ TEST_CASE(
     const auto latest_data = consensus->get_latest_data();
     REQUIRE(latest_data.has_value());
     REQUIRE(
-      kv_store_target.deserialise_views_async(latest_data.value(), ConsensusType::CFT)->Execute() !=
-      kv::DeserialiseSuccess::FAILED);
+      kv_store_target.deserialise(latest_data.value(), ConsensusType::CFT)
+        ->Execute() != kv::DeserialiseSuccess::FAILED);
 
     auto tx_target = kv_store_target.create_tx();
     auto view_target = tx_target.get_view<MapTypes::StringString>("map");
@@ -477,7 +476,7 @@ TEST_CASE_TEMPLATE(
     kv_store.compact(kv_store.current_version());
 
     REQUIRE(
-      kv_store2.deserialise_views_async(data, ConsensusType::CFT)->Execute() ==
+      kv_store2.deserialise(data, ConsensusType::CFT)->Execute() ==
       kv::DeserialiseSuccess::PASS);
     auto tx2 = kv_store2.create_tx();
     auto view2 = tx2.get_view(map2);
@@ -518,8 +517,8 @@ TEST_CASE("nlohmann (de)serialisation" * doctest::test_suite("serialisation"))
     const auto latest_data = consensus->get_latest_data();
     REQUIRE(latest_data.has_value());
     REQUIRE(
-      s1.deserialise_views_async(latest_data.value(), ConsensusType::CFT)
-        ->Execute() != kv::DeserialiseSuccess::FAILED);
+      s1.deserialise(latest_data.value(), ConsensusType::CFT)->Execute() !=
+      kv::DeserialiseSuccess::FAILED);
   }
 
   SUBCASE("nlohmann")
@@ -537,7 +536,7 @@ TEST_CASE("nlohmann (de)serialisation" * doctest::test_suite("serialisation"))
     const auto latest_data = consensus->get_latest_data();
     REQUIRE(latest_data.has_value());
     REQUIRE(
-      s1.deserialise_views_async(latest_data.value(), ConsensusType::CFT)->Execute() !=
+      s1.deserialise(latest_data.value(), ConsensusType::CFT)->Execute() !=
       kv::DeserialiseSuccess::FAILED);
   }
 }
@@ -578,13 +577,15 @@ TEST_CASE(
 
     auto [success, reqid, data, hooks] = tx.commit_reserved();
     REQUIRE(success == kv::CommitSuccess::OK);
-    REQUIRE(store.deserialise_views_async(data, ConsensusType::CFT)->Execute() == kv::DeserialiseSuccess::PASS);
+    REQUIRE(
+      store.deserialise(data, ConsensusType::CFT)->Execute() ==
+      kv::DeserialiseSuccess::PASS);
 
     INFO("check that second store derived data is not populated");
     {
       REQUIRE(
-        kv_store_target.deserialise_views_async(data, ConsensusType::CFT)
-          ->Execute() == kv::DeserialiseSuccess::PASS);
+        kv_store_target.deserialise(data, ConsensusType::CFT)->Execute() ==
+        kv::DeserialiseSuccess::PASS);
       auto tx = kv_store_target.create_tx();
       auto [data_view_r, data_view_r_p, data_view_d, data_view_d_p] =
         tx.get_view<T, T, T, T>(

--- a/src/kv/test/kv_snapshot.cpp
+++ b/src/kv/test/kv_snapshot.cpp
@@ -54,7 +54,7 @@ TEST_CASE("Simple snapshot" * doctest::test_suite("snapshot"))
     kv::ConsensusHookPtrs hooks;
     REQUIRE_EQ(
       new_store.deserialise_snapshot(first_serialised_snapshot, hooks),
-      kv::DeserialiseSuccess::PASS);
+      kv::ApplySuccess::PASS);
     REQUIRE_EQ(new_store.current_version(), 1);
 
     auto tx1 = new_store.create_tx();

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -948,8 +948,7 @@ TEST_CASE("Deserialising from other Store")
   clone.set_encryptor(encryptor);
 
   REQUIRE(
-    clone.deserialise(data, ConsensusType::CFT)->Execute() ==
-    kv::DeserialiseSuccess::PASS);
+    clone.apply(data, ConsensusType::CFT)->execute() == kv::ApplySuccess::PASS);
 }
 
 TEST_CASE("Deserialise return status")
@@ -973,8 +972,8 @@ TEST_CASE("Deserialise return status")
     REQUIRE(success == kv::CommitSuccess::OK);
 
     REQUIRE(
-      store.deserialise(data, ConsensusType::CFT)->Execute() ==
-      kv::DeserialiseSuccess::PASS);
+      store.apply(data, ConsensusType::CFT)->execute() ==
+      kv::ApplySuccess::PASS);
   }
 
   {
@@ -986,8 +985,8 @@ TEST_CASE("Deserialise return status")
     REQUIRE(success == kv::CommitSuccess::OK);
 
     REQUIRE(
-      store.deserialise(data, ConsensusType::CFT)->Execute() ==
-      kv::DeserialiseSuccess::PASS_SIGNATURE);
+      store.apply(data, ConsensusType::CFT)->execute() ==
+      kv::ApplySuccess::PASS_SIGNATURE);
   }
 
   INFO("Signature transactions with additional contents should fail");
@@ -1001,8 +1000,8 @@ TEST_CASE("Deserialise return status")
     REQUIRE(success == kv::CommitSuccess::OK);
 
     REQUIRE(
-      store.deserialise(data, ConsensusType::CFT)->Execute() ==
-      kv::DeserialiseSuccess::FAILED);
+      store.apply(data, ConsensusType::CFT)->execute() ==
+      kv::ApplySuccess::FAILED);
   }
 }
 

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -947,8 +947,7 @@ TEST_CASE("Deserialising from other Store")
   kv::Store clone;
   clone.set_encryptor(encryptor);
 
-  kv::ConsensusHookPtrs hooks_;
-  REQUIRE(clone.deserialise(data, hooks_) == kv::DeserialiseSuccess::PASS);
+  REQUIRE(clone.deserialise_views_async(data, ConsensusType::CFT)->Execute() == kv::DeserialiseSuccess::PASS);
 }
 
 TEST_CASE("Deserialise return status")
@@ -971,8 +970,7 @@ TEST_CASE("Deserialise return status")
     auto [success, reqid, data, hooks] = tx.commit_reserved();
     REQUIRE(success == kv::CommitSuccess::OK);
 
-    kv::ConsensusHookPtrs hooks_;
-    REQUIRE(store.deserialise(data, hooks_) == kv::DeserialiseSuccess::PASS);
+    REQUIRE(store.deserialise_views_async(data, ConsensusType::CFT)->Execute() == kv::DeserialiseSuccess::PASS);
   }
 
   {
@@ -983,9 +981,8 @@ TEST_CASE("Deserialise return status")
     auto [success, reqid, data, hooks] = tx.commit_reserved();
     REQUIRE(success == kv::CommitSuccess::OK);
 
-    kv::ConsensusHookPtrs hooks_;
     REQUIRE(
-      store.deserialise(data, hooks_) ==
+      store.deserialise_views_async(data, ConsensusType::CFT)->Execute() ==
       kv::DeserialiseSuccess::PASS_SIGNATURE);
   }
 
@@ -999,8 +996,7 @@ TEST_CASE("Deserialise return status")
     auto [success, reqid, data, hooks] = tx.commit_reserved();
     REQUIRE(success == kv::CommitSuccess::OK);
 
-    kv::ConsensusHookPtrs hooks_;
-    REQUIRE(store.deserialise(data, hooks_) == kv::DeserialiseSuccess::FAILED);
+    REQUIRE(store.deserialise_views_async(data, ConsensusType::CFT)->Execute() == kv::DeserialiseSuccess::FAILED);
   }
 }
 

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -947,7 +947,9 @@ TEST_CASE("Deserialising from other Store")
   kv::Store clone;
   clone.set_encryptor(encryptor);
 
-  REQUIRE(clone.deserialise_views_async(data, ConsensusType::CFT)->Execute() == kv::DeserialiseSuccess::PASS);
+  REQUIRE(
+    clone.deserialise(data, ConsensusType::CFT)->Execute() ==
+    kv::DeserialiseSuccess::PASS);
 }
 
 TEST_CASE("Deserialise return status")
@@ -970,7 +972,9 @@ TEST_CASE("Deserialise return status")
     auto [success, reqid, data, hooks] = tx.commit_reserved();
     REQUIRE(success == kv::CommitSuccess::OK);
 
-    REQUIRE(store.deserialise_views_async(data, ConsensusType::CFT)->Execute() == kv::DeserialiseSuccess::PASS);
+    REQUIRE(
+      store.deserialise(data, ConsensusType::CFT)->Execute() ==
+      kv::DeserialiseSuccess::PASS);
   }
 
   {
@@ -982,7 +986,7 @@ TEST_CASE("Deserialise return status")
     REQUIRE(success == kv::CommitSuccess::OK);
 
     REQUIRE(
-      store.deserialise_views_async(data, ConsensusType::CFT)->Execute() ==
+      store.deserialise(data, ConsensusType::CFT)->Execute() ==
       kv::DeserialiseSuccess::PASS_SIGNATURE);
   }
 
@@ -996,7 +1000,9 @@ TEST_CASE("Deserialise return status")
     auto [success, reqid, data, hooks] = tx.commit_reserved();
     REQUIRE(success == kv::CommitSuccess::OK);
 
-    REQUIRE(store.deserialise_views_async(data, ConsensusType::CFT)->Execute() == kv::DeserialiseSuccess::FAILED);
+    REQUIRE(
+      store.deserialise(data, ConsensusType::CFT)->Execute() ==
+      kv::DeserialiseSuccess::FAILED);
   }
 }
 

--- a/src/kv/view_containers.h
+++ b/src/kv/view_containers.h
@@ -73,7 +73,6 @@ namespace kv
     {
       if (!it->second->prepare(max_conflict_version))
       {
-        LOG_INFO_FMT("1. NNNNNNNNNN");
         ok = false;
         break;
       }
@@ -103,7 +102,6 @@ namespace kv
 
       if (store->get_map(current_v, map_name) != nullptr)
       {
-        LOG_INFO_FMT("2. NNNNNNNNNN, current_v:{}", current_v);
         ok = false;
         break;
       }

--- a/src/kv/view_containers.h
+++ b/src/kv/view_containers.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "kv_types.h"
+#include "untyped_tx_view.h"
 
 #include <functional>
 #include <map>

--- a/src/kv/view_containers.h
+++ b/src/kv/view_containers.h
@@ -73,6 +73,7 @@ namespace kv
     {
       if (!it->second->prepare(max_conflict_version))
       {
+        LOG_INFO_FMT("1. NNNNNNNNNN");
         ok = false;
         break;
       }
@@ -102,6 +103,7 @@ namespace kv
 
       if (store->get_map(current_v, map_name) != nullptr)
       {
+        LOG_INFO_FMT("2. NNNNNNNNNN, current_v:{}", current_v);
         ok = false;
         break;
       }

--- a/src/libmerklecpp/merklecpp.h
+++ b/src/libmerklecpp/merklecpp.h
@@ -107,14 +107,14 @@ namespace merkle
     {
       if (bytes.size() < SIZE)
         throw std::runtime_error("not enough bytes");
-      deserialise(bytes);
+      apply(bytes);
     }
 
     HashT<SIZE>(const std::vector<uint8_t>& bytes, size_t& position)
     {
       if (bytes.size() - position < SIZE)
         throw std::runtime_error("not enough bytes");
-      deserialise(bytes, position);
+      apply(bytes, position);
     }
 
     HashT<SIZE>(const std::array<uint8_t, SIZE>& bytes)
@@ -164,7 +164,7 @@ namespace merkle
         buffer.push_back(b);
     }
 
-    void deserialise(const std::vector<uint8_t>& buffer, size_t& position)
+    void apply(const std::vector<uint8_t>& buffer, size_t& position)
     {
       MERKLECPP_TRACE(MERKLECPP_TOUT << "> HashT::deserialise " << std::endl);
       if (buffer.size() - position < SIZE)
@@ -173,10 +173,10 @@ namespace merkle
         bytes[i] = buffer[position++];
     }
 
-    void deserialise(const std::vector<uint8_t>& buffer)
+    void apply(const std::vector<uint8_t>& buffer)
     {
       size_t position = 0;
-      deserialise(buffer, position);
+      apply(buffer, position);
     }
 
     operator std::vector<uint8_t>() const
@@ -233,12 +233,12 @@ namespace merkle
 
     PathT(const std::vector<uint8_t>& bytes)
     {
-      deserialise(bytes);
+      apply(bytes);
     }
 
     PathT(const std::vector<uint8_t>& bytes, size_t& position)
     {
-      deserialise(bytes, position);
+      apply(bytes, position);
     }
 
     std::shared_ptr<HashT<HASH_SIZE>> root() const
@@ -292,11 +292,11 @@ namespace merkle
       }
     }
 
-    void deserialise(const std::vector<uint8_t>& bytes, size_t& position)
+    void apply(const std::vector<uint8_t>& bytes, size_t& position)
     {
       MERKLECPP_TRACE(MERKLECPP_TOUT << "> PathT::deserialise " << std::endl);
       elements.clear();
-      _leaf.deserialise(bytes, position);
+      _leaf.apply(bytes, position);
       _leaf_index = deserialise_size_t(bytes, position);
       _max_index = deserialise_size_t(bytes, position);
       size_t num_elements = deserialise_size_t(bytes, position);
@@ -312,10 +312,10 @@ namespace merkle
       }
     }
 
-    void deserialise(const std::vector<uint8_t>& bytes)
+    void apply(const std::vector<uint8_t>& bytes)
     {
       size_t position = 0;
-      deserialise(bytes, position);
+      apply(bytes, position);
     }
 
     operator std::vector<uint8_t>() const
@@ -543,11 +543,11 @@ namespace merkle
     {}
     TreeT(const std::vector<uint8_t>& bytes)
     {
-      deserialise(bytes);
+      apply(bytes);
     }
     TreeT(const std::vector<uint8_t>& bytes, size_t& position)
     {
-      deserialise(bytes, position);
+      apply(bytes, position);
     }
     TreeT(const Hash& root)
     {
@@ -1056,13 +1056,13 @@ namespace merkle
       }
     }
 
-    void deserialise(const std::vector<uint8_t>& bytes)
+    void apply(const std::vector<uint8_t>& bytes)
     {
       size_t position = 0;
-      deserialise(bytes, position);
+      apply(bytes, position);
     }
 
-    void deserialise(const std::vector<uint8_t>& bytes, size_t& position)
+    void apply(const std::vector<uint8_t>& bytes, size_t& position)
     {
       MERKLECPP_TRACE(MERKLECPP_TOUT << "> deserialise " << std::endl;);
 

--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -202,7 +202,7 @@ namespace ccf::historical
 
       store->set_encryptor(source_store.get_encryptor());
       const auto deserialise_result =
-        store->deserialise_views_async(entry, ConsensusType::CFT)->Execute();
+        store->deserialise(entry, ConsensusType::CFT)->Execute();
 
       switch (deserialise_result)
       {

--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -202,22 +202,22 @@ namespace ccf::historical
 
       store->set_encryptor(source_store.get_encryptor());
       const auto deserialise_result =
-        store->deserialise(entry, ConsensusType::CFT)->Execute();
+        store->apply(entry, ConsensusType::CFT)->execute();
 
       switch (deserialise_result)
       {
-        case kv::DeserialiseSuccess::FAILED:
+        case kv::ApplySuccess::FAILED:
         {
           throw std::logic_error("Deserialise failed!");
           break;
         }
-        case kv::DeserialiseSuccess::PASS:
-        case kv::DeserialiseSuccess::PASS_SIGNATURE:
-        case kv::DeserialiseSuccess::PASS_BACKUP_SIGNATURE:
-        case kv::DeserialiseSuccess::PASS_BACKUP_SIGNATURE_SEND_ACK:
-        case kv::DeserialiseSuccess::PASS_NONCES:
-        case kv::DeserialiseSuccess::PASS_NEW_VIEW:
-        case kv::DeserialiseSuccess::PASS_SNAPSHOT_EVIDENCE:
+        case kv::ApplySuccess::PASS:
+        case kv::ApplySuccess::PASS_SIGNATURE:
+        case kv::ApplySuccess::PASS_BACKUP_SIGNATURE:
+        case kv::ApplySuccess::PASS_BACKUP_SIGNATURE_SEND_ACK:
+        case kv::ApplySuccess::PASS_NONCES:
+        case kv::ApplySuccess::PASS_NEW_VIEW:
+        case kv::ApplySuccess::PASS_SNAPSHOT_EVIDENCE:
         {
           LOG_DEBUG_FMT("Processed transaction at {}", idx);
 
@@ -241,7 +241,7 @@ namespace ccf::historical
             }
           }
 
-          if (deserialise_result == kv::DeserialiseSuccess::PASS_SIGNATURE)
+          if (deserialise_result == kv::ApplySuccess::PASS_SIGNATURE)
           {
             // This looks like a valid signature - try to use this signature to
             // move some stores from untrusted to trusted

--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -201,8 +201,8 @@ namespace ccf::historical
         true /* Make use of historical secrets */);
 
       store->set_encryptor(source_store.get_encryptor());
-      kv::ConsensusHookPtrs hooks;
-      const auto deserialise_result = store->deserialise_views(entry, hooks);
+      const auto deserialise_result =
+        store->deserialise_views_async(entry, ConsensusType::CFT)->Execute();
 
       switch (deserialise_result)
       {

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -206,7 +206,7 @@ namespace ccf
     Receipt(const std::vector<uint8_t>& v)
     {
       size_t position = 0;
-      root.deserialise(v, position);
+      root.apply(v, position);
       path = std::make_shared<HistoryTree::Path>(v, position);
     }
 
@@ -342,7 +342,7 @@ namespace ccf
       tree = nullptr;
     }
 
-    void deserialise(const std::vector<uint8_t>& serialised)
+    void apply(const std::vector<uint8_t>& serialised)
     {
       delete (tree);
       tree = new HistoryTree(serialised);
@@ -575,7 +575,7 @@ namespace ccf
         !replicated_state_tree.in_range(1),
         "Tree is not empty before initialising from snapshot");
 
-      replicated_state_tree.deserialise(sig->tree);
+      replicated_state_tree.apply(sig->tree);
 
       crypto::Sha256Hash hash;
       std::copy_n(

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -700,9 +700,9 @@ namespace ccf
       LOG_INFO_FMT(
         "Deserialising public ledger entry ({})", ledger_entry.size());
 
-      kv::ConsensusHookPtrs hooks;
       // When reading the public ledger, deserialise in the real store
-      auto result = network.tables->deserialise(ledger_entry, hooks, true);
+      auto r = network.tables->deserialise_views_async(ledger_entry, ConsensusType::CFT, true);
+      auto result = r->Execute();
       if (result == kv::DeserialiseSuccess::FAILED)
       {
         LOG_FAIL_FMT("Failed to deserialise entry in public ledger");
@@ -717,7 +717,7 @@ namespace ccf
       }
 
       // Not synchronised because consensus isn't effectively running then
-      for (auto& hook : hooks)
+      for (auto& hook : r->get_hooks())
       {
         hook->call(consensus.get());
       }
@@ -942,9 +942,8 @@ namespace ccf
       LOG_INFO_FMT(
         "Deserialising private ledger entry ({})", ledger_entry.size());
 
-      kv::ConsensusHookPtrs hooks;
       // When reading the private ledger, deserialise in the recovery store
-      auto result = recovery_store->deserialise(ledger_entry, hooks);
+      auto result = recovery_store->deserialise_views_async(ledger_entry, ConsensusType::CFT)->Execute();
       if (result == kv::DeserialiseSuccess::FAILED)
       {
         LOG_FAIL_FMT("Failed to deserialise entry in private ledger");

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -204,7 +204,7 @@ namespace ccf
       kv::ConsensusHookPtrs hooks;
       auto rc = network.tables->deserialise_snapshot(
         config.startup_snapshot, hooks, &view_history, true);
-      if (rc != kv::DeserialiseSuccess::PASS)
+      if (rc != kv::ApplySuccess::PASS)
       {
         throw std::logic_error(
           fmt::format("Failed to apply public snapshot: {}", rc));
@@ -494,7 +494,7 @@ namespace ccf
                 hooks,
                 &view_history,
                 resp.network_info.public_only);
-              if (rc != kv::DeserialiseSuccess::PASS)
+              if (rc != kv::ApplySuccess::PASS)
               {
                 throw std::logic_error(
                   fmt::format("Failed to apply snapshot on join: {}", rc));
@@ -701,10 +701,9 @@ namespace ccf
         "Deserialising public ledger entry ({})", ledger_entry.size());
 
       // When reading the public ledger, deserialise in the real store
-      auto r =
-        network.tables->deserialise(ledger_entry, ConsensusType::CFT, true);
-      auto result = r->Execute();
-      if (result == kv::DeserialiseSuccess::FAILED)
+      auto r = network.tables->apply(ledger_entry, ConsensusType::CFT, true);
+      auto result = r->execute();
+      if (result == kv::ApplySuccess::FAILED)
       {
         LOG_FAIL_FMT("Failed to deserialise entry in public ledger");
         network.tables->rollback(ledger_idx - 1);
@@ -723,7 +722,8 @@ namespace ccf
         hook->call(consensus.get());
       }
 
-      if (result == kv::DeserialiseSuccess::PASS_SIGNATURE)
+      // If the ledger entry is a signature, it is safe to compact the store
+      if (result == kv::ApplySuccess::PASS_SIGNATURE)
       {
         // If the ledger entry is a signature, it is safe to compact the store
         network.tables->compact(ledger_idx);
@@ -771,7 +771,7 @@ namespace ccf
         snapshotter->commit(ledger_idx);
       }
       else if (
-        result == kv::DeserialiseSuccess::PASS_SNAPSHOT_EVIDENCE &&
+        result == kv::ApplySuccess::PASS_SNAPSHOT_EVIDENCE &&
         startup_snapshot_info)
       {
         auto tx = network.tables->create_read_only_tx();
@@ -945,9 +945,8 @@ namespace ccf
 
       // When reading the private ledger, deserialise in the recovery store
       auto result =
-        recovery_store->deserialise(ledger_entry, ConsensusType::CFT)
-          ->Execute();
-      if (result == kv::DeserialiseSuccess::FAILED)
+        recovery_store->apply(ledger_entry, ConsensusType::CFT)->execute();
+      if (result == kv::ApplySuccess::FAILED)
       {
         LOG_FAIL_FMT("Failed to deserialise entry in private ledger");
         recovery_store->rollback(ledger_idx - 1);
@@ -955,7 +954,7 @@ namespace ccf
         return;
       }
 
-      if (result == kv::DeserialiseSuccess::PASS_SIGNATURE)
+      if (result == kv::ApplySuccess::PASS_SIGNATURE)
       {
         recovery_store->compact(ledger_idx);
       }
@@ -1094,7 +1093,7 @@ namespace ccf
         kv::ConsensusHookPtrs hooks;
         auto rc = recovery_store->deserialise_snapshot(
           startup_snapshot_info->raw, hooks, &view_history);
-        if (rc != kv::DeserialiseSuccess::PASS)
+        if (rc != kv::ApplySuccess::PASS)
         {
           throw std::logic_error(fmt::format(
             "Could not deserialise snapshot in recovery store: {}", rc));

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -701,7 +701,8 @@ namespace ccf
         "Deserialising public ledger entry ({})", ledger_entry.size());
 
       // When reading the public ledger, deserialise in the real store
-      auto r = network.tables->deserialise_views_async(ledger_entry, ConsensusType::CFT, true);
+      auto r =
+        network.tables->deserialise(ledger_entry, ConsensusType::CFT, true);
       auto result = r->Execute();
       if (result == kv::DeserialiseSuccess::FAILED)
       {
@@ -943,7 +944,9 @@ namespace ccf
         "Deserialising private ledger entry ({})", ledger_entry.size());
 
       // When reading the private ledger, deserialise in the recovery store
-      auto result = recovery_store->deserialise_views_async(ledger_entry, ConsensusType::CFT)->Execute();
+      auto result =
+        recovery_store->deserialise(ledger_entry, ConsensusType::CFT)
+          ->Execute();
       if (result == kv::DeserialiseSuccess::FAILED)
       {
         LOG_FAIL_FMT("Failed to deserialise entry in private ledger");
@@ -1687,8 +1690,7 @@ namespace ccf
       auto shared_state = std::make_shared<aft::State>(self);
       auto raft = std::make_unique<RaftType>(
         network.consensus_type,
-        std::make_unique<aft::Adaptor<kv::Store, kv::DeserialiseSuccess>>(
-          network.tables),
+        std::make_unique<aft::Adaptor<kv::Store>>(network.tables),
         std::make_unique<consensus::LedgerEnclave>(writer_factory),
         n2n_channels,
         snapshotter,

--- a/src/node/secret_broadcast.h
+++ b/src/node/secret_broadcast.h
@@ -102,7 +102,7 @@ namespace ccf
       const std::vector<uint8_t>& cipher)
     {
       crypto::GcmCipher gcmcipher;
-      gcmcipher.deserialise(cipher);
+      gcmcipher.apply(cipher);
       std::vector<uint8_t> plain(gcmcipher.cipher.size());
 
       crypto::KeyAesGcm primary_shared_key(

--- a/src/node/share_manager.h
+++ b/src/node/share_manager.h
@@ -69,7 +69,7 @@ namespace ccf
       const std::vector<uint8_t>& wrapped_latest_ledger_secret)
     {
       crypto::GcmCipher encrypted_ls;
-      encrypted_ls.deserialise(wrapped_latest_ledger_secret);
+      encrypted_ls.apply(wrapped_latest_ledger_secret);
       std::vector<uint8_t> decrypted_ls(encrypted_ls.cipher.size());
 
       if (!crypto::KeyAesGcm(data).decrypt(
@@ -218,7 +218,7 @@ namespace ccf
       LedgerSecret&& current_ledger_secret)
     {
       crypto::GcmCipher encrypted_share;
-      encrypted_share.deserialise(encrypted_submitted_share);
+      encrypted_share.apply(encrypted_submitted_share);
       std::vector<uint8_t> decrypted_share(encrypted_share.cipher.size());
 
       current_ledger_secret.key->decrypt(
@@ -349,7 +349,7 @@ namespace ccf
         }
 
         crypto::GcmCipher encrypted_ls;
-        encrypted_ls.deserialise(i->encrypted_ledger_secret);
+        encrypted_ls.apply(i->encrypted_ledger_secret);
         std::vector<uint8_t> decrypted_ls(encrypted_ls.cipher.size());
 
         if (!crypto::KeyAesGcm(decryption_key)

--- a/src/node/test/encryptor.cpp
+++ b/src/node/test/encryptor.cpp
@@ -265,7 +265,7 @@ TEST_CASE("KV encryption/decryption")
   {
     commit_one(primary_store, map);
     REQUIRE(
-      backup_store.deserialise(*consensus->get_latest_data(), hooks) ==
+      backup_store.deserialise_views_async(*consensus->get_latest_data(), ConsensusType::CFT)->Execute() ==
       kv::DeserialiseSuccess::PASS);
   }
 
@@ -290,8 +290,10 @@ TEST_CASE("KV encryption/decryption")
         current_version + i, std::move(ledger_secret_for_backup));
 
       REQUIRE(
-        backup_store.deserialise(*consensus->get_latest_data(), hooks) ==
-        kv::DeserialiseSuccess::PASS);
+        backup_store
+          .deserialise_views_async(
+            *consensus->get_latest_data(), ConsensusType::CFT)
+          ->Execute() == kv::DeserialiseSuccess::PASS);
     }
   }
 }
@@ -350,8 +352,10 @@ TEST_CASE("Backup catchup from many ledger secrets")
     while (next_entry.has_value())
     {
       REQUIRE(
-        backup_store.deserialise(*std::get<1>(next_entry.value()), hooks) ==
-        kv::DeserialiseSuccess::PASS);
+        backup_store
+          .deserialise_views_async(
+            *std::get<1>(next_entry.value()), ConsensusType::CFT)
+          ->Execute() == kv::DeserialiseSuccess::PASS);
       next_entry = consensus->pop_oldest_entry();
     }
   }
@@ -390,8 +394,8 @@ TEST_CASE("KV integrity verification")
   REQUIRE(corrupt_serialised_tx(latest_data.value(), value_to_corrupt));
 
   REQUIRE(
-    backup_store.deserialise(latest_data.value(), hooks) ==
-    kv::DeserialiseSuccess::FAILED);
+    backup_store.deserialise_views_async(latest_data.value(), ConsensusType::CFT) ==
+    nullptr);
 }
 
 TEST_CASE("Encryptor rollback")

--- a/src/node/test/encryptor.cpp
+++ b/src/node/test/encryptor.cpp
@@ -265,9 +265,8 @@ TEST_CASE("KV encryption/decryption")
   {
     commit_one(primary_store, map);
     REQUIRE(
-      backup_store
-        .deserialise(*consensus->get_latest_data(), ConsensusType::CFT)
-        ->Execute() == kv::DeserialiseSuccess::PASS);
+      backup_store.apply(*consensus->get_latest_data(), ConsensusType::CFT)
+        ->execute() == kv::ApplySuccess::PASS);
   }
 
   INFO("Rekeys");
@@ -292,8 +291,8 @@ TEST_CASE("KV encryption/decryption")
 
       REQUIRE(
         backup_store
-          .deserialise(*consensus->get_latest_data(), ConsensusType::CFT)
-          ->Execute() == kv::DeserialiseSuccess::PASS);
+          .apply(*consensus->get_latest_data(), ConsensusType::CFT)
+          ->execute() == kv::ApplySuccess::PASS);
     }
   }
 }
@@ -353,9 +352,9 @@ TEST_CASE("Backup catchup from many ledger secrets")
     {
       REQUIRE(
         backup_store
-          .deserialise(
+          .apply(
             *std::get<1>(next_entry.value()), ConsensusType::CFT)
-          ->Execute() == kv::DeserialiseSuccess::PASS);
+          ->execute() == kv::ApplySuccess::PASS);
       next_entry = consensus->pop_oldest_entry();
     }
   }
@@ -394,8 +393,8 @@ TEST_CASE("KV integrity verification")
   REQUIRE(corrupt_serialised_tx(latest_data.value(), value_to_corrupt));
 
   REQUIRE(
-    backup_store.deserialise(latest_data.value(), ConsensusType::CFT)
-      ->Execute() == kv::DeserialiseSuccess::FAILED);
+    backup_store.apply(latest_data.value(), ConsensusType::CFT)->execute() ==
+    kv::ApplySuccess::FAILED);
 }
 
 TEST_CASE("Encryptor rollback")

--- a/src/node/test/encryptor.cpp
+++ b/src/node/test/encryptor.cpp
@@ -265,8 +265,9 @@ TEST_CASE("KV encryption/decryption")
   {
     commit_one(primary_store, map);
     REQUIRE(
-      backup_store.deserialise_views_async(*consensus->get_latest_data(), ConsensusType::CFT)->Execute() ==
-      kv::DeserialiseSuccess::PASS);
+      backup_store
+        .deserialise(*consensus->get_latest_data(), ConsensusType::CFT)
+        ->Execute() == kv::DeserialiseSuccess::PASS);
   }
 
   INFO("Rekeys");
@@ -291,8 +292,7 @@ TEST_CASE("KV encryption/decryption")
 
       REQUIRE(
         backup_store
-          .deserialise_views_async(
-            *consensus->get_latest_data(), ConsensusType::CFT)
+          .deserialise(*consensus->get_latest_data(), ConsensusType::CFT)
           ->Execute() == kv::DeserialiseSuccess::PASS);
     }
   }
@@ -353,7 +353,7 @@ TEST_CASE("Backup catchup from many ledger secrets")
     {
       REQUIRE(
         backup_store
-          .deserialise_views_async(
+          .deserialise(
             *std::get<1>(next_entry.value()), ConsensusType::CFT)
           ->Execute() == kv::DeserialiseSuccess::PASS);
       next_entry = consensus->pop_oldest_entry();
@@ -394,8 +394,8 @@ TEST_CASE("KV integrity verification")
   REQUIRE(corrupt_serialised_tx(latest_data.value(), value_to_corrupt));
 
   REQUIRE(
-    backup_store.deserialise_views_async(latest_data.value(), ConsensusType::CFT) ==
-    nullptr);
+    backup_store.deserialise(latest_data.value(), ConsensusType::CFT)
+      ->Execute() == kv::DeserialiseSuccess::FAILED);
 }
 
 TEST_CASE("Encryptor rollback")

--- a/src/node/test/encryptor.cpp
+++ b/src/node/test/encryptor.cpp
@@ -290,8 +290,7 @@ TEST_CASE("KV encryption/decryption")
         current_version + i, std::move(ledger_secret_for_backup));
 
       REQUIRE(
-        backup_store
-          .apply(*consensus->get_latest_data(), ConsensusType::CFT)
+        backup_store.apply(*consensus->get_latest_data(), ConsensusType::CFT)
           ->execute() == kv::ApplySuccess::PASS);
     }
   }
@@ -352,8 +351,7 @@ TEST_CASE("Backup catchup from many ledger secrets")
     {
       REQUIRE(
         backup_store
-          .apply(
-            *std::get<1>(next_entry.value()), ConsensusType::CFT)
+          .apply(*std::get<1>(next_entry.value()), ConsensusType::CFT)
           ->execute() == kv::ApplySuccess::PASS);
       next_entry = consensus->pop_oldest_entry();
     }

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -30,7 +30,8 @@ public:
     if (store)
     {
       REQUIRE(entries.size() == 1);
-      return store->deserialise_views_async(*std::get<1>(entries[0]), ConsensusType::CFT)->Execute();
+      return store->deserialise(*std::get<1>(entries[0]), ConsensusType::CFT)
+        ->Execute();
     }
     return true;
   }

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -30,8 +30,7 @@ public:
     if (store)
     {
       REQUIRE(entries.size() == 1);
-      kv::ConsensusHookPtrs hooks;
-      return store->deserialise(*std::get<1>(entries[0]), hooks);
+      return store->deserialise_views_async(*std::get<1>(entries[0]), ConsensusType::CFT)->Execute();
     }
     return true;
   }

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -30,8 +30,8 @@ public:
     if (store)
     {
       REQUIRE(entries.size() == 1);
-      return store->deserialise(*std::get<1>(entries[0]), ConsensusType::CFT)
-        ->Execute();
+      return store->apply(*std::get<1>(entries[0]), ConsensusType::CFT)
+        ->execute();
     }
     return true;
   }

--- a/src/node/test/snapshot.cpp
+++ b/src/node/test/snapshot.cpp
@@ -134,8 +134,7 @@ TEST_CASE("Snapshot with merkle tree" * doctest::test_suite("snapshot"))
 
       auto serialised_tx = source_consensus->get_latest_data().value();
 
-      kv::ConsensusHookPtrs hooks;
-      target_store.deserialise(serialised_tx, hooks);
+      target_store.deserialise_views_async(serialised_tx, ConsensusType::CFT)->Execute();
 
       REQUIRE(
         target_history->get_replicated_state_root() ==

--- a/src/node/test/snapshot.cpp
+++ b/src/node/test/snapshot.cpp
@@ -100,7 +100,7 @@ TEST_CASE("Snapshot with merkle tree" * doctest::test_suite("snapshot"))
       REQUIRE(
         target_store.deserialise_snapshot(
           serialised_snapshot, hooks, &view_history) ==
-        kv::DeserialiseSuccess::FAILED);
+        kv::ApplySuccess::FAILED);
     }
 
     INFO("Apply snapshot taken at signature");
@@ -113,8 +113,7 @@ TEST_CASE("Snapshot with merkle tree" * doctest::test_suite("snapshot"))
       kv::ConsensusHookPtrs hooks;
       REQUIRE(
         target_store.deserialise_snapshot(
-          serialised_snapshot, hooks, &view_history) ==
-        kv::DeserialiseSuccess::PASS);
+          serialised_snapshot, hooks, &view_history) == kv::ApplySuccess::PASS);
 
       // Merkle history and view history thus far are restored when applying
       // snapshot
@@ -134,7 +133,7 @@ TEST_CASE("Snapshot with merkle tree" * doctest::test_suite("snapshot"))
 
       auto serialised_tx = source_consensus->get_latest_data().value();
 
-      target_store.deserialise(serialised_tx, ConsensusType::CFT)->Execute();
+      target_store.apply(serialised_tx, ConsensusType::CFT)->execute();
 
       REQUIRE(
         target_history->get_replicated_state_root() ==

--- a/src/node/test/snapshot.cpp
+++ b/src/node/test/snapshot.cpp
@@ -134,7 +134,7 @@ TEST_CASE("Snapshot with merkle tree" * doctest::test_suite("snapshot"))
 
       auto serialised_tx = source_consensus->get_latest_data().value();
 
-      target_store.deserialise_views_async(serialised_tx, ConsensusType::CFT)->Execute();
+      target_store.deserialise(serialised_tx, ConsensusType::CFT)->Execute();
 
       REQUIRE(
         target_history->get_replicated_state_root() ==


### PR DESCRIPTION
Part of #2055

This is the first set step of parallel execution on the backup. This PR does a bit of ground work in separating append entry deserialization & execution. There are also moved the deserialization logic out of store.h in deserialise.h this makes things a bit cleaner :) 