### PR TITLE
Silence uninitialized local variable warning

### DIFF
--- a/src/apps/js_generic/js_generic.cpp
+++ b/src/apps/js_generic/js_generic.cpp
@@ -832,7 +832,7 @@ namespace ccfapp
       }
 
       char const* policy_name = nullptr;
-      size_t id;
+      size_t id = ccf::INVALID_ID;
       nlohmann::json data;
       std::string cert_s;
 


### PR DESCRIPTION
CodeQL scanning warning raised [potential use of this uninitialized variable](https://github.com/microsoft/CCF/security/code-scanning/707). That's a false positive - we actually set all of these or none, and throw in the latter case. But its simple to silence the error, so we do that.