### PR TITLE
Fix locking in store rollback

### DIFF
--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -540,14 +540,26 @@ namespace kv
           term = t.value();
         if (v >= version)
           return;
-      }
 
-      if (v < commit_version())
-      {
-        throw std::logic_error(fmt::format(
-          "Attempting rollback to {}, earlier than commit version {}",
-          v,
-          commit_version()));
+        if (v < compacted)
+        {
+          throw std::logic_error(fmt::format(
+            "Attempting rollback to {}, earlier than commit version {}",
+            v,
+            compacted));
+        }
+
+        version = v;
+        last_replicated = v;
+        last_committable = v;
+        rollback_count++;
+        pending_txs.clear();
+        auto h = get_history();
+        if (h)
+          h->rollback(v);
+        auto e = get_encryptor();
+        if (e)
+          e->rollback(v);
       }
 
       for (auto& it : maps)
@@ -581,19 +593,6 @@ namespace kv
         auto& [_, map] = it.second;
         map->unlock();
       }
-
-      std::lock_guard<SpinLock> vguard(version_lock);
-      version = v;
-      last_replicated = v;
-      last_committable = v;
-      rollback_count++;
-      pending_txs.clear();
-      auto h = get_history();
-      if (h)
-        h->rollback(v);
-      auto e = get_encryptor();
-      if (e)
-        e->rollback(v);
     }
 
     void set_term(Term t) override


### PR DESCRIPTION
Store::rollback() acquires and holds the maps lock for its entire execution, and the version lock several times (twice explicitly, one or two more times indirectly via current_version()). The term is updated under the first acquisition, but the version (and other elements of state) are only updated in the final acquisition.

As a result, a transaction starting in the middle of a rollback() could when it captures current_txid() grab an incorrect (term, version) pair. Making all store state changes atomically under a single acquisition of the version lock fixes that.