### PR TITLE
Keep accurate term in history on the primary

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1858,7 +1858,7 @@ namespace aft
     {
       election_index = last_committable_index();
       LOG_DEBUG_FMT(
-        "Election index is {} in term", election_index, state->current_view);
+        "Election index is {} in term {}", election_index, state->current_view);
       // Discard any un-committable updates we may hold,
       // since we have no signature for them. Except at startup,
       // where we do not want to roll back the genesis transaction.

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1857,7 +1857,8 @@ namespace aft
     void become_leader()
     {
       election_index = last_committable_index();
-      LOG_DEBUG_FMT("Election index is {}", election_index);
+      LOG_DEBUG_FMT(
+        "Election index is {} in term", election_index, state->current_view);
       // Discard any un-committable updates we may hold,
       // since we have no signature for them. Except at startup,
       // where we do not want to roll back the genesis transaction.

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -258,8 +258,9 @@ namespace kv
       const std::vector<uint8_t>& request,
       uint8_t frame_format) = 0;
     virtual void append(const std::vector<uint8_t>& replicated) = 0;
-    virtual void rollback(Version v) = 0;
+    virtual void rollback(Version v, kv::Term) = 0;
     virtual void compact(Version v) = 0;
+    virtual void set_term(kv::Term) = 0;
   };
 
   class Consensus : public ConfigurableConsensus

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -534,13 +534,6 @@ namespace kv
 
       {
         std::lock_guard<SpinLock> vguard(version_lock);
-        // The term should always be updated on rollback() when passed
-        // regardless of whether version needs to be updated or not
-        if (t.has_value())
-          term = t.value();
-        if (v >= version)
-          return;
-
         if (v < compacted)
         {
           throw std::logic_error(fmt::format(
@@ -549,14 +542,24 @@ namespace kv
             compacted));
         }
 
+        // The term should always be updated on rollback() when passed
+        // regardless of whether version needs to be updated or not
+        if (t.has_value())
+          term = t.value();
+        // History must be informed of the term change, even if no
+        // actual rollback is required
+        auto h = get_history();
+        if (h)
+          h->rollback(v, term);
+
+        if (v >= version)
+          return;
+
         version = v;
         last_replicated = v;
         last_committable = v;
         rollback_count++;
         pending_txs.clear();
-        auto h = get_history();
-        if (h)
-          h->rollback(v, term);
         auto e = get_encryptor();
         if (e)
           e->rollback(v);

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -556,7 +556,7 @@ namespace kv
         pending_txs.clear();
         auto h = get_history();
         if (h)
-          h->rollback(v);
+          h->rollback(v, term);
         auto e = get_encryptor();
         if (e)
           e->rollback(v);
@@ -599,6 +599,9 @@ namespace kv
     {
       std::lock_guard<SpinLock> vguard(version_lock);
       term = t;
+      auto h = get_history();
+      if (h)
+        h->set_term(term);
     }
 
     DeserialiseSuccess deserialise_views(

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -612,7 +612,9 @@ namespace kv
       term = t;
       auto h = get_history();
       if (h)
+      {
         h->set_term(term);
+      }
     }
 
     DeserialiseSuccess deserialise_views(

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -545,15 +545,21 @@ namespace kv
         // The term should always be updated on rollback() when passed
         // regardless of whether version needs to be updated or not
         if (t.has_value())
+        {
           term = t.value();
+        }
         // History must be informed of the term change, even if no
         // actual rollback is required
         auto h = get_history();
         if (h)
+        {
           h->rollback(v, term);
+        }
 
         if (v >= version)
+        {
           return;
+        }
 
         version = v;
         last_replicated = v;
@@ -562,7 +568,9 @@ namespace kv
         pending_txs.clear();
         auto e = get_encryptor();
         if (e)
+        {
           e->rollback(v);
+        }
       }
 
       for (auto& it : maps)

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -782,8 +782,6 @@ namespace ccf
 
     void append(const std::vector<uint8_t>& replicated) override
     {
-      std::lock_guard<SpinLock> tguard(term_lock);
-        LOG_INFO_FMT("Term is {}", term);
       crypto::Sha256Hash rh({replicated.data(), replicated.size()});
       log_hash(rh, APPEND);
       replicated_state_tree.append(rh);

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -132,7 +132,9 @@ namespace ccf
       return true;
     }
 
-    void rollback(kv::Version) override {}
+    void set_term(kv::Term) override {}
+
+    void rollback(kv::Version, kv::Term) override {}
 
     void compact(kv::Version) override {}
 
@@ -459,6 +461,9 @@ namespace ccf
     size_t sig_tx_interval;
     size_t sig_ms_interval;
 
+    SpinLock term_lock;
+    kv::Term term = 0;
+
   public:
     HashedTxHistory(
       kv::Store& store_,
@@ -657,8 +662,15 @@ namespace ccf
       return true;
     }
 
-    void rollback(kv::Version v) override
+    void set_term(kv::Term t) override
     {
+      std::lock_guard<SpinLock> tguard(term_lock);
+      term = t;
+    }
+
+    void rollback(kv::Version v, kv::Term t) override
+    {
+      set_term(t);
       replicated_state_tree.retract(v);
       log_hash(replicated_state_tree.get_root(), ROLLBACK);
     }
@@ -770,6 +782,8 @@ namespace ccf
 
     void append(const std::vector<uint8_t>& replicated) override
     {
+      std::lock_guard<SpinLock> tguard(term_lock);
+        LOG_INFO_FMT("Term is {}", term);
       crypto::Sha256Hash rh({replicated.data(), replicated.size()});
       log_hash(rh, APPEND);
       replicated_state_tree.append(rh);


### PR DESCRIPTION
Next part of #2087

This is necessary so the frontend can atomically capture a (term, version, root) and initialise the Tx with an up to date (term, read_version) and the corresponding merkle tree root.