### PR TITLE
Fix Signatures Table Name in Python Ledger module

### DIFF
--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -75,7 +75,7 @@ class PublicDomain:
         self._msgpacked_tables = {
             "public:ccf.gov.member_cert_ders",
             "public:ccf.gov.governance.history",
-            "public:ccf.gov.signatures",
+            "public:ccf.internal.signatures",
             "public:ccf.gov.nodes",
         }
         self._read()


### PR DESCRIPTION
Fixing Signatures table name as defined in CCF here: https://github.com/microsoft/CCF/blob/master/src/node/entities.h#L96