### PR TITLE
Move format and license checks to GH actions

### DIFF
--- a/.azure-pipelines-templates/checks.yml
+++ b/.azure-pipelines-templates/checks.yml
@@ -1,6 +1,6 @@
 jobs:
   - job: Checks
-    displayName: "Formatting, License and Lint Checks"
+    displayName: "Release notes check"
 
     ${{ insert }}: ${{ parameters.env }}
 
@@ -9,10 +9,5 @@ jobs:
         clean: true
         fetchDepth: 1
 
-      - script: ./scripts/ci-checks.sh
-        displayName: "Checks"
-        condition: succeededOrFailed()
-
       - script: python3.8 scripts/extract-release-notes.py /dev/null
         displayName: "Check presence of release notes entry"
-        condition: eq('${{ parameters.perf_or_release }}', 'release')

--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -40,11 +40,6 @@ parameters:
       ctest_args: '-L "zaptest"'
 
 jobs:
-  - template: checks.yml
-    parameters:
-      env: ${{ parameters.env.Hosted }}
-      perf_or_release: ${{ parameters.perf_or_release }}
-
   # Debug
   - ${{ each target in parameters.target }}:
       - template: common.yml
@@ -79,6 +74,10 @@ jobs:
 
   # Release
   - ${{ if eq(parameters.perf_or_release, 'release') }}:
+      - template: checks.yml
+        parameters:
+          env: ${{ parameters.env.Hosted }}
+
       - template: common.yml
         parameters:
           target: SGX

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -13,6 +13,6 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
 
       - run: ./scripts/ci-checks.sh

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,0 +1,20 @@
+name: "Format and License Checks"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  checks:
+    runs-on: ubuntu-18.04
+    container: ccfciteam/ccf-ci:oe0.13.0
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - run: ./scripts/ci-checks.sh

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -14,7 +14,5 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
 
       - run: ./scripts/ci-checks.sh


### PR DESCRIPTION
I did this because I thought I could add a path exclude on the AZP CI, and save the CI runs on PRs that only touch documentation and .md files. Then I realised it wouldn't help, because deciding which checks are gating is very much a Settings checkbox and not something that's decided by the config. Bummer.

Still, I think it's marginally nicer that way, it's fewer clicks to get the error, to re-run etc.