### PR TITLE
Reorder and cull perf metrics

### DIFF
--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -199,9 +199,10 @@ def run(get_command, args):
                         tx_rates.insert_metrics(**results)
 
                         # Construct name for heap metric, removing ^ suffix if present
-                        heap_peak_metric = f"Mem_{args.label}"
+                        heap_peak_metric = args.label
                         if heap_peak_metric.endswith("^"):
                             heap_peak_metric = heap_peak_metric[:-1]
+                        heap_peak_metric += "_mem"
 
                         peak_value = results["peak_allocated_heap_size"]
                         metrics.put(heap_peak_metric, peak_value)

--- a/tests/upload_pico_metrics.py
+++ b/tests/upload_pico_metrics.py
@@ -47,20 +47,6 @@ benchmark_specs = {
             "D": "2048",
         },
     ],
-    "tls_bench.csv": [
-        {
-            "_name": "secp256k1 verify (/s)^",
-            "Suite": "verify",
-            "Benchmark": "verify_256k1_bitc_1k",
-            "D": "1",
-        },
-        {
-            "_name": "secp256k1 sign (/s)^",
-            "Suite": "sign",
-            "Benchmark": "sign_256k1_bitc_1k",
-            "D": "1",
-        },
-    ],
     "digest_bench.csv": [
         {
             "_name": "mbedtls sha256 (/s)^",


### PR DESCRIPTION
Since we're renaming our CIMetrics labels and losing all history, take this opportunity to also:

- Remove `secp256k1`, since we don't care about its signing rate enough any more (and have the full picobench when we do)
- Move the `mem` decorator to suffix rather than prefix, so we get the memory use of each test adjacent to the throughput, rather than all mem followed by all throughput

I'm also wondering if `ls` is too brief and opaque a name for what was `logging_scenario`, is `log` better? Scream if you want to go longer.