### PR TITLE
Fix '/node/network/nodes' endpoint to return all nodes when no filter is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.18.1]
 
 ### Changed
 
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nodes' quotes format updated to Open Enclave's `SGX_ECDSA`. Quote endorsements are also stored in CCF and can be retrieved via the `quotes/self` and `quotes` endpoints (#2161).
 - `get_quote_for_this_node_v1()` takes a `QuoteInfo` structure (containing the format, raw quote and corresponding endorsements) as out parameter instead of the distinct format and raw quote as two out paramters (#2161).
 - Several internal tables are renamed (#2166).
+- `/node/network/nodes` correctly returns all nodes if no filter is specified (#2188).
 
 ## [0.18.0]
 
@@ -675,6 +676,7 @@ Some discrepancies with the TR remain, and are being tracked under https://githu
 
 Initial pre-release
 
+[0.18.1]: https://github.com/microsoft/CCF/releases/tag/ccf-0.18.1
 [0.18.0]: https://github.com/microsoft/CCF/releases/tag/ccf-0.18.0
 [0.17.2]: https://github.com/microsoft/CCF/releases/tag/ccf-0.17.2
 [0.17.1]: https://github.com/microsoft/CCF/releases/tag/ccf-0.17.1

--- a/src/node/rpc/json_handler.h
+++ b/src/node/rpc/json_handler.h
@@ -237,6 +237,10 @@ namespace ccf
       {
         params = get_params_from_query(ctx);
       }
+      else
+      {
+        params = nlohmann::json::object();
+      }
 
       return std::make_pair(pack, params);
     }

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -17,7 +17,6 @@ import tempfile
 import base64
 import json
 import ccf.clients
-import pprint
 
 from loguru import logger as LOG
 

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -17,6 +17,7 @@ import tempfile
 import base64
 import json
 import ccf.clients
+import pprint
 
 from loguru import logger as LOG
 
@@ -686,6 +687,20 @@ def test_network_node_info(network, args):
     primary, backups = network.find_nodes()
 
     all_nodes = [primary, *backups]
+
+    with primary.client() as c:
+        r = c.get("/node/network/nodes", allow_redirects=False)
+        assert r.status_code == http.HTTPStatus.OK
+        nodes = r.body.json()["nodes"]
+        nodes_by_id = {node["node_id"]: node for node in nodes}
+        for n in all_nodes:
+            node = nodes_by_id[n.node_id]
+            assert node["host"] == n.pubhost
+            assert node["port"] == str(n.pubport)
+            assert node["primary"] == (n == primary)
+            del nodes_by_id[n.node_id]
+
+        assert nodes_by_id == {}
 
     # Populate node_infos by calling self
     node_infos = {}


### PR DESCRIPTION
fix #2185 

Longer term, we need to get to #2153