### PR TITLE
History lock

### DIFF
--- a/src/node/history.h
+++ b/src/node/history.h
@@ -470,7 +470,7 @@ namespace ccf
     size_t sig_tx_interval;
     size_t sig_ms_interval;
 
-    SpinLock term_lock;
+    SpinLock state_lock;
     kv::Term term = 0;
 
   public:
@@ -595,13 +595,14 @@ namespace ccf
 
     crypto::Sha256Hash get_replicated_state_root() override
     {
+      std::lock_guard<SpinLock> tguard(state_lock);
       return replicated_state_tree.get_root();
     }
 
     std::pair<kv::TxID, crypto::Sha256Hash> get_replicated_state_txid_and_root()
       override
     {
-      std::lock_guard<SpinLock> tguard(term_lock);
+      std::lock_guard<SpinLock> tguard(state_lock);
       return {
         {term, static_cast<kv::Version>(replicated_state_tree.end_index())},
         replicated_state_tree.get_root()};
@@ -684,19 +685,21 @@ namespace ccf
 
     void set_term(kv::Term t) override
     {
-      std::lock_guard<SpinLock> tguard(term_lock);
+      std::lock_guard<SpinLock> tguard(state_lock);
       term = t;
     }
 
     void rollback(kv::Version v, kv::Term t) override
     {
-      set_term(t);
+      std::lock_guard<SpinLock> tguard(state_lock);
+      term = t;
       replicated_state_tree.retract(v);
       log_hash(replicated_state_tree.get_root(), ROLLBACK);
     }
 
     void compact(kv::Version v) override
     {
+      std::lock_guard<SpinLock> tguard(state_lock);
       // Receipts can only be retrieved to the flushed index. Keep a range of
       // history so that a range of receipts are available.
       if (v > MAX_HISTORY_LEN)
@@ -767,17 +770,20 @@ namespace ccf
 
     std::vector<uint8_t> get_receipt(kv::Version index) override
     {
+      std::lock_guard<SpinLock> tguard(state_lock);
       return replicated_state_tree.get_receipt(index).to_v();
     }
 
     bool verify_receipt(const std::vector<uint8_t>& v) override
     {
+      std::lock_guard<SpinLock> tguard(state_lock);
       Receipt r(v);
       return replicated_state_tree.verify(r);
     }
 
     std::vector<uint8_t> get_raw_leaf(uint64_t index) override
     {
+      std::lock_guard<SpinLock> tguard(state_lock);
       auto leaf = replicated_state_tree.get_leaf(index);
       return {leaf.h.begin(), leaf.h.end()};
     }
@@ -802,6 +808,7 @@ namespace ccf
 
     void append(const std::vector<uint8_t>& replicated) override
     {
+      std::lock_guard<SpinLock> tguard(state_lock);
       crypto::Sha256Hash rh({replicated.data(), replicated.size()});
       log_hash(rh, APPEND);
       replicated_state_tree.append(rh);

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -567,6 +567,7 @@ namespace ccf
     bool init_from_snapshot(
       const std::vector<uint8_t>& hash_at_snapshot) override
     {
+      std::lock_guard<SpinLock> guard(state_lock);
       // The history can be initialised after a snapshot has been applied by
       // deserialising the tree in the signatures table and then applying the
       // hash of the transaction at which the snapshot was taken
@@ -595,14 +596,14 @@ namespace ccf
 
     crypto::Sha256Hash get_replicated_state_root() override
     {
-      std::lock_guard<SpinLock> tguard(state_lock);
+      std::lock_guard<SpinLock> guard(state_lock);
       return replicated_state_tree.get_root();
     }
 
     std::pair<kv::TxID, crypto::Sha256Hash> get_replicated_state_txid_and_root()
       override
     {
-      std::lock_guard<SpinLock> tguard(state_lock);
+      std::lock_guard<SpinLock> guard(state_lock);
       return {
         {term, static_cast<kv::Version>(replicated_state_tree.end_index())},
         replicated_state_tree.get_root()};
@@ -685,13 +686,13 @@ namespace ccf
 
     void set_term(kv::Term t) override
     {
-      std::lock_guard<SpinLock> tguard(state_lock);
+      std::lock_guard<SpinLock> guard(state_lock);
       term = t;
     }
 
     void rollback(kv::Version v, kv::Term t) override
     {
-      std::lock_guard<SpinLock> tguard(state_lock);
+      std::lock_guard<SpinLock> guard(state_lock);
       term = t;
       replicated_state_tree.retract(v);
       log_hash(replicated_state_tree.get_root(), ROLLBACK);
@@ -699,7 +700,7 @@ namespace ccf
 
     void compact(kv::Version v) override
     {
-      std::lock_guard<SpinLock> tguard(state_lock);
+      std::lock_guard<SpinLock> guard(state_lock);
       // Receipts can only be retrieved to the flushed index. Keep a range of
       // history so that a range of receipts are available.
       if (v > MAX_HISTORY_LEN)
@@ -770,20 +771,20 @@ namespace ccf
 
     std::vector<uint8_t> get_receipt(kv::Version index) override
     {
-      std::lock_guard<SpinLock> tguard(state_lock);
+      std::lock_guard<SpinLock> guard(state_lock);
       return replicated_state_tree.get_receipt(index).to_v();
     }
 
     bool verify_receipt(const std::vector<uint8_t>& v) override
     {
-      std::lock_guard<SpinLock> tguard(state_lock);
+      std::lock_guard<SpinLock> guard(state_lock);
       Receipt r(v);
       return replicated_state_tree.verify(r);
     }
 
     std::vector<uint8_t> get_raw_leaf(uint64_t index) override
     {
-      std::lock_guard<SpinLock> tguard(state_lock);
+      std::lock_guard<SpinLock> guard(state_lock);
       auto leaf = replicated_state_tree.get_leaf(index);
       return {leaf.h.begin(), leaf.h.end()};
     }
@@ -808,7 +809,7 @@ namespace ccf
 
     void append(const std::vector<uint8_t>& replicated) override
     {
-      std::lock_guard<SpinLock> tguard(state_lock);
+      std::lock_guard<SpinLock> guard(state_lock);
       crypto::Sha256Hash rh({replicated.data(), replicated.size()});
       log_hash(rh, APPEND);
       replicated_state_tree.append(rh);


### PR DESCRIPTION
We have had a couple of places in the code where we access the history without a lock, version or term lock. This causes issues when there is multi-threading. Discussed this with @achamayou  and we decided to convert the term_lock in history to protect more than just the term.