### PR TITLE
Fix modules_test in CI

### DIFF
--- a/src/apps/js_generic/js_generic.cpp
+++ b/src/apps/js_generic/js_generic.cpp
@@ -1404,9 +1404,20 @@ namespace ccfapp
         if (!properties.openapi_hidden)
         {
           auto& path_op = ds::openapi::path_operation(
-            ds::openapi::path(document, key.uri_path), http_verb.value());
+            ds::openapi::path(document, key.uri_path),
+            http_verb.value(),
+            false);
+          LOG_INFO_FMT(
+            "Building OpenAPI for {} {}", key.verb.c_str(), key.uri_path);
+          const auto dumped = document.dump(2);
+          LOG_INFO_FMT(
+            "Starting from: {}", std::string(dumped.begin(), dumped.end()));
           if (!properties.openapi.empty())
           {
+            for (const auto& [k, v] : properties.openapi.items())
+            {
+              LOG_INFO_FMT("Inserting field {}", k);
+            }
             path_op.insert(
               properties.openapi.cbegin(), properties.openapi.cend());
           }

--- a/src/ds/openapi.h
+++ b/src/ds/openapi.h
@@ -99,14 +99,20 @@ namespace ds
     }
 
     static inline nlohmann::json& path_operation(
-      nlohmann::json& path, llhttp_method verb)
+      nlohmann::json& path, llhttp_method verb, bool default_responses = true)
     {
       // HTTP_GET becomes the string "get"
       std::string s = llhttp_method_name(verb);
       nonstd::to_lower(s);
       auto& po = access::get_object(path, s);
-      // responses is required field in a path_operation
-      access::get_object(po, "responses");
+
+      if (default_responses)
+      {
+        // responses is required field in a path_operation, but caller may
+        // choose to add their own later
+        access::get_object(po, "responses");
+      }
+
       return po;
     }
 

--- a/tests/js-app-bundle/app.json
+++ b/tests/js-app-bundle/app.json
@@ -108,7 +108,8 @@
                 "type": "number"
               }
             }
-          ]
+          ],
+          "responses": { "default": { "description": "Default response" } }
         }
       }
     }

--- a/tests/npm-app/app.json
+++ b/tests/npm-app/app.json
@@ -109,6 +109,7 @@
           },
           "responses": {
             "200": {
+              "description": "Generated key",
               "content": {
                 "application/octet-stream": {}
               }
@@ -149,6 +150,7 @@
           },
           "responses": {
             "200": {
+              "description": "Wrapped key",
               "content": {
                 "application/octet-stream": {}
               }
@@ -213,6 +215,7 @@
           },
           "responses": {
             "200": {
+              "description": "Protobuf encoded data",
               "content": {
                 "application/x-protobuf": {}
               }


### PR DESCRIPTION
Latest update to the OpenAPI validator we use requires descriptions in responses. Fair enough - we can add default descriptions to the places where we didn't have them (OpenAPI snippets in JS app bundles).

This also exposed another issue, where those snippets weren't correctly inserted. Because we previously added at least an _empty_ `"responses"` object for every `path_operation`, we failed to insert any real response objects from the JSON endpoint definition (we just insert any new fields, but don't try and merge if the key is already present). Work around this by not inserting that empty `"responses"`.