### PR TITLE
Correct Tx status transitions

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,7 +4,7 @@ sphinx_rtd_theme
 pygments-style-solarized
 bottle
 sphinx-autobuild
-sphinxcontrib-mermaid==0.6.0
+sphinxcontrib-mermaid
 sphinx-multiversion
 pydata-sphinx-theme
 sphinx-copybutton

--- a/doc/use_apps/verify_tx.rst
+++ b/doc/use_apps/verify_tx.rst
@@ -36,10 +36,11 @@ On a given node, the possible transitions between states are described in the fo
 
     stateDiagram
         UNKNOWN --> PENDING
+        PENDING --> UNKNOWN
         PENDING --> COMMITTED
         PENDING --> INVALID
 
-It is possible that intermediate states are not visible (e.g. a transition from ``UNKNOWN`` to ``COMMITTED`` may never publically show a ``PENDING`` result). Nodes may disagree on the current state due to communication delays, but will never disagree on transitions (in other words, they may believe a ``COMMITTED`` transaction is still ``UNKNOWN`` or ``PENDING``, but will never report it as ``INVALID``).
+It is possible that intermediate states are not visible (e.g. a transition from ``UNKNOWN`` to ``COMMITTED`` may never publically show a ``PENDING`` result). Nodes may disagree on the current state due to communication delays, but will never disagree on transitions (in other words, they may believe a ``COMMITTED`` transaction is still ``UNKNOWN`` or ``PENDING``, but will never report it as ``INVALID``). A transition from ``PENDING`` to ``UNKNOWN`` can only occur immediately after an election, while the node is confirming where the new view starts, and will usually resolve to ``COMMITTED`` or ``PENDING`` quickly afterwards.
 
 Note that transaction IDs are uniquely assigned by the service - once a request has been assigned an ID, this ID will never be associated with a different write transaction. In normal operation, the next requests will be given versions 2.19, then 2.20, and so on, and after a short delay ``2.18`` will be committed. If requests are submitted in parallel, they will be applied in a consistent order indicated by their assigned versions.
 

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -632,7 +632,7 @@ def test_tx_statuses(network, args):
         target_seqno = r.seqno
         SentTxs.update_status(target_view, target_seqno)
         SentTxs.update_status(target_view, target_seqno + 1)
-        SentTxs.update_status(target_view - 1, target_seqno, TxStatus.Invalid)
+        SentTxs.update_status(target_view - 1, target_seqno)
 
         end_time = time.time() + 10
         while True:


### PR DESCRIPTION
Noticed while exploring #2224 with @jumaffre. We'd previously thought that a TxID could not transition from `PENDING` back to `UNKNOWN`, but this is not true - it can happen after an election. Updating the docs, and fixing a related occasional CI failure from this assumption.