### PR TITLE
Do not attempt to use invalid tags for releases

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -9,7 +9,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
   find_package(Git)
 
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --tags
+    COMMAND "bash" "-c" "${GIT_EXECUTABLE} describe --tags | grep ccf-"
     OUTPUT_VARIABLE "CCF_VERSION"
     OUTPUT_STRIP_TRAILING_WHITESPACE
     RESULT_VARIABLE RETURN_CODE
@@ -17,7 +17,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
   if(NOT RETURN_CODE STREQUAL "0")
     message(
       FATAL_ERROR
-        "Git repository does not appear to contain any tag (the repository should be cloned with sufficient depth to access the latest \"ccf-*\" tag)"
+        "Git repository does not appear to contain any tag starting with ccf- (the repository should be cloned with sufficient depth to access the latest \"ccf-*\" tag)"
     )
   endif()
   execute_process(


### PR DESCRIPTION
If the current tag is not a valid release tag (ie. doesn't start with "ccf-"), things will go wrong during release, and in particular the install prefix will be broken.

fix #2253 