### PR TITLE
Install public headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,14 @@ install(
   PATTERN "*/test*" EXCLUDE
 )
 
+# Install all public CCF headers
+install(
+  DIRECTORY include/
+  DESTINATION include
+  FILES_MATCHING
+  PATTERN "*.h"
+)
+
 # Install CCF Python infrastructure
 install(
   DIRECTORY tests/infra/


### PR DESCRIPTION
Missing CMake install that broke the attempted 0.18.5 release.