### PR TITLE
Create threading canary

### DIFF
--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -11,6 +11,7 @@ pr:
   paths:
     include:
       - .multi-thread.yml
+      - .threading_canary
 
 resources:
   containers:


### PR DESCRIPTION
Similar to the daily canary, this is so we can (more) easily kick off threading build runs on PRs that make changes related to threading.