### PR TITLE
Fix SAN error from recent node ID changes and BFT

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-A daily, just for good measure.
+Just want to be making daily records

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -364,7 +364,11 @@ namespace ccf
             // BFT consensus requires a stable order of node IDs so that the
             // primary node in a given view can be computed deterministically by
             // all nodes in the network
-            self = "0";
+            // See https://github.com/microsoft/CCF/issues/1852
+
+            // Pad node id string to avoid memory alignment issues on
+            // node-to-node messages
+            self = fmt::format("{:#08}", 0);
           }
 
           setup_snapshotter();

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -124,8 +124,10 @@ namespace ccf
       }
       else
       {
-        joining_node_id = std::to_string(
-          get_next_id(tx.rw(this->network.values), NEXT_NODE_ID));
+        // Pad node id string to avoid memory alignment issues on
+        // node-to-node messages
+        joining_node_id = fmt::format(
+          "{:#08}", get_next_id(tx.rw(this->network.values), NEXT_NODE_ID));
       }
 
 #ifdef GET_QUOTE

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -238,7 +238,7 @@ class Node:
         else:
             # BFT consensus should deterministically compute the primary id from the
             # consensus view, so node ids are monotonic in this case
-            self.node_id = str(self.local_node_id)
+            self.node_id = "{:0>8}".format(self.local_node_id)
 
         self._read_ports()
         LOG.info(f"Node {self.local_node_id} started: {self.node_id}")


### PR DESCRIPTION
The recent node ID changes (#2241) introduced a memory misalignment with BFT. This PR fixes the issue by padding the monotic node ID in this case. Note that this is a quick fix and that the BFT node ID scheme will eventually be unified with CFT (see #1852). 