### PR TITLE
Fix find primary timeout

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Just want to be making daily records
+Just want to be making daily records.

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -695,14 +695,17 @@ class Network:
                     try:
                         logs = []
                         res = c.get("/node/network", log_capture=logs)
-                        if res.status_code != 200:
-                            continue
+                        assert res.status_code == http.HTTPStatus.OK.value, res
+
                         body = res.body.json()
                         view = body["current_view"]
                         if "primary_id" not in body:
                             continue
+
                         view_change_in_progress = body["view_change_in_progress"]
                         primary_id = body["primary_id"]
+                        if primary_id is not None:
+                            break
 
                     except CCFConnectionException:
                         LOG.warning(


### PR DESCRIPTION
In #2241, I incorrectly changed the logic of `network.find_primary()` so that we don't exit early if the primary is found. This meant that some end-to-end tests that rely heavily on this function took longer, and started to fail in the Daily pipeline. This PR should fix this.