### PR TITLE
Remove receipts from suite

### DIFF
--- a/tests/suite/test_suite.py
+++ b/tests/suite/test_suite.py
@@ -80,9 +80,6 @@ all_tests_suite = [
     # memberclient:
     memberclient.test_missing_signature_header,
     memberclient.test_corrupted_signature,
-    # receipts:
-    e2e_logging.test_receipts,
-    e2e_logging.test_historical_receipts,
     # reconfiguration:
     reconfiguration.test_add_node,
     reconfiguration.test_add_node_from_backup,


### PR DESCRIPTION
Issue: https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=20114&view=logs&j=5435e0ac-25e5-5426-50be-61b0d0ea8d34&t=63d660c3-6f76-573a-0154-fd0bcb096ded

The current tests are not robust to:

1. view changes
2. recovery

The first problem can be resolved by keeping track of the node_id -> local_id mapping for the lifetime of a network, which is only a minor change. The second problem needs a slightly larger change, where recovered networks need to endorse the previous identity, and receipt verification logic needs to find that (potential sequence) of endorsements and the node identities of previous nodes.

I am not planning to look at this until JS governance is complete.