### PR TITLE
Fix test install and full test suite in Daily

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Happy daily trigger.
+Happy daily trigger :)

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -58,8 +58,7 @@ class Consortium:
                 self.members.append(new_member)
         else:
             for f in os.listdir(self.common_dir):
-                result = re.search("member(.*)_cert.pem", f)
-                if result is not None:
+                if re.search("member(.*)_cert.pem", f) is not None:
                     local_id = f.split("_")[0]
                     new_member = infra.member.Member(
                         local_id,
@@ -71,7 +70,6 @@ class Consortium:
                         ),
                         authenticate_session=authenticate_session,
                     )
-
                     self.members.append(new_member)
                     LOG.info(
                         f"Successfully recovered member {local_id}: {new_member.service_id}"

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -105,25 +105,25 @@ class Network:
         txs=None,
         library_dir=".",
     ):
-        self.existing_network = existing_network
-        if self.existing_network is None:
+        if existing_network is None:
             self.consortium = None
+            self.users = []
             self.node_offset = 0
             self.txs = txs
         else:
-            self.consortium = self.existing_network.consortium
+            self.consortium = existing_network.consortium
+            self.users = existing_network.users
             # When creating a new network from an existing one (e.g. for recovery),
             # the node id of the nodes of the new network should start from the node
             # id of the existing network, so that new nodes id match the ones in the
             # nodes KV table
             self.node_offset = (
-                len(self.existing_network.nodes) + self.existing_network.node_offset
+                len(existing_network.nodes) + existing_network.node_offset
             )
-            self.txs = self.existing_network.txs
+            self.txs = existing_network.txs
 
         self.ignoring_shutdown_errors = False
         self.nodes = []
-        self.users = []
         self.hosts = hosts
         self.status = ServiceStatus.CLOSED
         self.binary_dir = binary_dir


### PR DESCRIPTION
Fixes two issues in the Daily following the member/user IDs changes in #2279:
- https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=20234&view=logs&j=5435e0ac-25e5-5426-50be-61b0d0ea8d34&t=63d660c3-6f76-573a-0154-fd0bcb096ded&l=10388: The users weren't recovered by the infra recovery network.
- https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=20231&view=logs&j=5435e0ac-25e5-5426-50be-61b0d0ea8d34&t=fe98d859-2537-5570-75af-de67d4290f3a&l=745: In a recovery sandbox, the member IDs were recovered only from the service. However, the service isn't aware of the members' local IDs, so the infra now recovers the members from the `common_dir` and only asks the service for their status. 