### PR TITLE
Add component governance CI job

### DIFF
--- a/.cg.yml
+++ b/.cg.yml
@@ -4,7 +4,6 @@ trigger:
     include:
       - main
       - "refs/tags/ccf-*"
-      - cwinter_com_gov
 
 pr:
   autoCancel: true

--- a/.cg.yml
+++ b/.cg.yml
@@ -31,7 +31,7 @@ jobs:
 
       - task: ComponentGovernanceComponentDetection@0
         inputs:
-          ignoreDirectories: 'tests,samples'
-          scanType: 'Register'
-          verbosity: 'Verbose'
-          alertWarningLevel: 'High'
+          ignoreDirectories: "tests,samples"
+          scanType: "Register"
+          verbosity: "Verbose"
+          alertWarningLevel: "High"

--- a/.cg.yml
+++ b/.cg.yml
@@ -1,0 +1,37 @@
+trigger:
+  batch: true
+  branches:
+    include:
+      - main
+      - "refs/tags/ccf-*"
+      - cwinter_com_gov
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+      - main
+
+schedules:
+  - cron: "0 3 * * Mon-Fri"
+    displayName: Daily Component Governance Check
+    branches:
+      include:
+        - main
+    always: true
+
+jobs:
+  - job: ComponentGovernance
+    displayName: "Component Governance"
+
+    steps:
+      - checkout: self
+        clean: true
+        fetchDepth: 1
+
+      - task: ComponentGovernanceComponentDetection@0
+        inputs:
+          ignoreDirectories: 'tests,samples'
+          scanType: 'Register'
+          verbosity: 'Verbose'
+          alertWarningLevel: 'High'


### PR DESCRIPTION
This adds a separate pipeline for component governance checks, so that we're not dependant on auto-injection anymore. The way it is set up in this PR, it produces 5 correct alerts and I'm working with CELA to get those resolved (problems on their end).