### PR TITLE
Extend certificate validity range

### DIFF
--- a/src/crypto/mbedtls/key_pair.cpp
+++ b/src/crypto/mbedtls/key_pair.cpp
@@ -460,7 +460,7 @@ namespace crypto
     // Note: 825-day validity range
     // https://support.apple.com/en-us/HT210176
     MCHK(mbedtls_x509write_crt_set_validity(
-      crt.get(), "20191101000000", "20211231235959"));
+      crt.get(), "20210311000000", "20230611235959"));
 
     MCHK(mbedtls_x509write_crt_set_basic_constraints(crt.get(), ca ? 1 : 0, 0));
     MCHK(mbedtls_x509write_crt_set_subject_key_identifier(crt.get()));

--- a/src/crypto/openssl/key_pair.cpp
+++ b/src/crypto/openssl/key_pair.cpp
@@ -234,8 +234,8 @@ namespace crypto
     ASN1_TIME *before = NULL, *after = NULL;
     OpenSSL::CHECKNULL(before = ASN1_TIME_new());
     OpenSSL::CHECKNULL(after = ASN1_TIME_new());
-    OpenSSL::CHECK1(ASN1_TIME_set_string(before, "20191101000000Z"));
-    OpenSSL::CHECK1(ASN1_TIME_set_string(after, "20211231235959Z"));
+    OpenSSL::CHECK1(ASN1_TIME_set_string(before, "20210311000000Z"));
+    OpenSSL::CHECK1(ASN1_TIME_set_string(after, "20230611235959Z"));
     OpenSSL::CHECK1(ASN1_TIME_normalize(before));
     OpenSSL::CHECK1(ASN1_TIME_normalize(after));
     OpenSSL::CHECK1(X509_set1_notBefore(crt, before));


### PR DESCRIPTION
Fix #2190 for now.

Longer term, we probably want to add the following features:

1. Make node and network cert validity ranges user-configurable
2. Add a mechanism allowing a periodic refresh of the self-signed network certificate without creating a new identity 