### PR TITLE
Remove unnecessary stub

### DIFF
--- a/3rdparty/stub/mem.c
+++ b/3rdparty/stub/mem.c
@@ -1,9 +1,0 @@
-#include <stdlib.h>
-
-/* oe_memset_s is an internal OE function, so not in any of the installed header files. */
-int oe_memset_s(void* dst, size_t dst_size, int value, size_t num_bytes);
-
-void explicit_bzero(void *s, size_t n)
-{
-  oe_memset_s(s, n, 0, n);
-}


### PR DESCRIPTION
Once was a dependency for the evercrypt code, no longer necessary.