### PR TITLE
Only build recent versions of docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -194,7 +194,7 @@ breathe_default_project = "CCF"
 # Set up multiversion extension
 
 # Build tags from ccf-0.16.3 onwards
-smv_tag_whitelist = r"^ccf-(0\.(1([6-9].[3-9]|[7-9].*)|[2-9].*)|[1-9].*)$"
+smv_tag_whitelist = r"^ccf-(0\.(1([6-9]\.[3-9]|[7-9].*)|[2-9].*)|[1-9].*)$"
 smv_branch_whitelist = r"^main$"
 smv_remote_whitelist = None
 smv_outputdir_format = "{ref.name}"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -193,7 +193,8 @@ breathe_default_project = "CCF"
 
 # Set up multiversion extension
 
-smv_tag_whitelist = r"^ccf-.*$"
+# Build tags from ccf-0.16.3 onwards
+smv_tag_whitelist = r"^ccf-(0\.(1([6-9].[3-9]|[7-9].*)|[2-9].*)|[1-9].*)$"
 smv_branch_whitelist = r"^main$"
 smv_remote_whitelist = None
 smv_outputdir_format = "{ref.name}"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 breathe
-sphinx
+sphinx==3.5.1 # Temporary workaround for duplicate definition error
 sphinx_rtd_theme
 pygments-style-solarized
 bottle

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,12 +1,12 @@
 breathe
-sphinx==3.5.1 # Temporary workaround for duplicate definition error
+sphinx
 sphinx_rtd_theme
 pygments-style-solarized
 bottle
 sphinx-autobuild
 sphinxcontrib-mermaid
 sphinx-multiversion
-pydata-sphinx-theme
+pydata-sphinx-theme==0.4.3
 sphinx-copybutton
 sphinxcontrib.openapi
 sphinx-panels

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,7 +6,7 @@ bottle
 sphinx-autobuild
 sphinxcontrib-mermaid
 sphinx-multiversion
-pydata-sphinx-theme==0.4.3
+pydata-sphinx-theme
 sphinx-copybutton
 sphinxcontrib.openapi
 sphinx-panels


### PR DESCRIPTION
~~The doc-building CI pipeline is broken this morning. I haven't found an immediate fix - in fact trying to repro locally I got a completely different error than the one seen on the CI. As an optimistic temporary fix, try pinning to an older version of Sphinx while I investigate further, maybe this unblocks other PRs.~~

We tracked the failure down to [this new release](https://github.com/pydata/pydata-sphinx-theme/releases/tag/v0.5.0), which isn't happy building our docs between versions `ccf-0.14.1` and `ccf-0.16.2`. We have a lot of very old versions that we don't want to support for ever, so taking this opportunity to cull some of the oldest and only build the docs since `ccf-0.16.3`. Its unfortunate that this needs to be expressed as a regex, but that's what we have. Please have a look and see if I've missed any tags (including expected/possible future tags!) that we want to be documented: regexr.com/5oe2d