### PR TITLE
Python infra: fix MemberStatus enum parsing

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Happy daily trigger :)
+Happy daily trigger :))

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -99,7 +99,7 @@ class Consortium:
                     member = self.get_member_by_service_id(member_service_id)
                     if member:
                         if (
-                            infra.member.MemberStatus[status]
+                            infra.member.MemberStatus(status)
                             == infra.member.MemberStatus.ACTIVE
                         ):
                             member.set_active()


### PR DESCRIPTION
Fixes daily build which [is broken](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=20791&view=logs&j=5435e0ac-25e5-5426-50be-61b0d0ea8d34&t=fe98d859-2537-5570-75af-de67d4290f3a)