### PR TITLE
Add N2N channel key rotation

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-chirp
+beep beep beep

--- a/src/consensus/aft/test/logging_stub.h
+++ b/src/consensus/aft/test/logging_stub.h
@@ -84,7 +84,8 @@ namespace aft
     void create_channel(
       const ccf::NodeId& peer_id,
       const std::string& peer_hostname,
-      const std::string& peer_service) override
+      const std::string& peer_service,
+      size_t message_limit = ccf::Channel::default_message_limit) override
     {}
 
     void destroy_channel(const ccf::NodeId& peer_id) override {}

--- a/src/consensus/aft/test/logging_stub.h
+++ b/src/consensus/aft/test/logging_stub.h
@@ -87,8 +87,6 @@ namespace aft
       const std::string& peer_service) override
     {}
 
-    void restart() override {}
-
     void destroy_channel(const ccf::NodeId& peer_id) override {}
 
     void destroy_all_channels() override {}

--- a/src/crypto/symmetric_key.h
+++ b/src/crypto/symmetric_key.h
@@ -91,7 +91,7 @@ namespace crypto
       return serial_hdr;
     }
 
-    void apply(const std::vector<uint8_t>& serial_hdr)
+    void deserialise(const std::vector<uint8_t>& serial_hdr)
     {
       auto data_ = serial_hdr.data();
       auto size = serial_hdr.size();

--- a/src/kv/encryptor.h
+++ b/src/kv/encryptor.h
@@ -106,7 +106,7 @@ namespace kv
       bool historical_hint = false) override
     {
       S hdr;
-      hdr.apply(serialised_header);
+      hdr.deserialise(serialised_header);
       plain.resize(cipher.size());
 
       auto key =

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -23,6 +23,13 @@ namespace ccf
   using SeqNo = uint64_t;
   using GcmHdr = crypto::GcmHeader<sizeof(SeqNo)>;
 
+#ifndef NDEBUG
+  static constexpr size_t message_limit = 25;
+#else
+  // 2**24.5 as per RFC8446 Section 5.5
+  static constexpr size_t message_limit = 23726566;
+#endif
+
   struct RecvNonce
   {
     uint8_t tid;
@@ -92,9 +99,11 @@ namespace ccf
     static constexpr size_t salt_len = 32;
     static constexpr size_t shared_key_size = 32;
     std::vector<uint8_t> hkdf_salt;
+    bool key_exchange_in_progress = false;
 
     // Used for AES GCM authentication/encryption
     std::unique_ptr<crypto::KeyAesGcm> key;
+    std::unique_ptr<crypto::KeyAesGcm> next_key;
 
     // Incremented for each tagged/encrypted message
     std::atomic<SeqNo> send_nonce{1};
@@ -126,6 +135,7 @@ namespace ccf
 
       RecvNonce recv_nonce(header.get_iv_int());
       auto tid = recv_nonce.tid;
+      assert(tid < threading::ThreadMessaging::max_num_threads);
 
       uint16_t current_tid = threading::get_current_thread_id();
       assert(
@@ -142,7 +152,18 @@ namespace ccf
         local_nonce = &local_recv_nonce[tid].tid_seqno;
       }
 
-      if (recv_nonce.nonce <= *local_nonce)
+      LOG_TRACE_FMT(
+        "<- {}: encrypted msg with nonce={}",
+        peer_id,
+        (const uint64_t)recv_nonce.nonce);
+
+      if (recv_nonce.nonce == 1 && next_key)
+      {
+        LOG_TRACE_FMT("Changing to next channel key");
+        key.swap(next_key);
+        next_key.reset();
+      }
+      else if (recv_nonce.nonce <= *local_nonce)
       {
         // If the nonce received has already been processed, return
         LOG_FAIL_FMT(
@@ -162,6 +183,16 @@ namespace ccf
         // Set local recv nonce to received nonce only if verification is
         // successful
         *local_nonce = recv_nonce.nonce;
+      }
+
+      size_t num_messages = send_nonce + recv_nonce.nonce;
+      if (num_messages >= message_limit && !key_exchange_in_progress)
+      {
+        LOG_TRACE_FMT(
+          "Reached message limit ({}+{}), triggering new key exchange",
+          send_nonce,
+          (uint64_t)recv_nonce.nonce);
+        initiate();
       }
 
       return ret;
@@ -487,7 +518,9 @@ namespace ccf
     {
       LOG_TRACE_FMT("status == {}", status);
 
-      if (status == INITIATED)
+      key_exchange_in_progress = true;
+
+      if (status == INITIATED || status == ESTABLISHED)
       {
         // Both nodes tried to initiate the channel, the one with priority wins.
         if (!priority)
@@ -547,7 +580,9 @@ namespace ccf
       }
 
       kex_ctx.load_peer_key_share(ks);
-      status = WAITING_FOR_FINAL;
+
+      if (status != ESTABLISHED)
+        status = WAITING_FOR_FINAL;
 
       // We are the responder and we return a signature over both public key
       // shares back to the initiator
@@ -582,7 +617,7 @@ namespace ccf
     {
       LOG_TRACE_FMT("status == {}", status);
 
-      if (status != WAITING_FOR_FINAL)
+      if (status != WAITING_FOR_FINAL && status != ESTABLISHED)
       {
         return false;
       }
@@ -618,10 +653,25 @@ namespace ccf
         shared_secret,
         hkdf_salt,
         info);
-      key = crypto::make_key_aes_gcm(key_bytes);
-      kex_ctx.free_ctx();
 
+      next_key = crypto::make_key_aes_gcm(key_bytes);
+
+      kex_ctx.free_ctx();
+      send_nonce = 1;
+      for (size_t i = 0; i < local_recv_nonce.size(); i++)
+      {
+        local_recv_nonce[i].main_thread_seqno = 0;
+        local_recv_nonce[i].tid_seqno = 0;
+      }
       status = ESTABLISHED;
+      key_exchange_in_progress = false;
+      LOG_INFO_FMT("Node channel with {} is now established.", peer_id);
+
+      auto node_cv = make_verifier(node_cert);
+      LOG_TRACE_FMT(
+        "Node certificate serial numbers: node={} peer={}",
+        node_cv->serial_number(),
+        peer_cv->serial_number());
 
       if (outgoing_msg.has_value())
       {
@@ -631,24 +681,29 @@ namespace ccf
           outgoing_msg->raw_cipher);
         outgoing_msg.reset();
       }
-
-      auto node_cv = make_verifier(node_cert);
-      LOG_INFO_FMT("Node channel with {} is now established.", peer_id);
-
-      LOG_TRACE_FMT(
-        "Node certificate serial numbers: node={} peer={}",
-        node_cv->serial_number(),
-        peer_cv->serial_number());
     }
 
     void initiate()
     {
-      if (status == WAITING_FOR_FINAL || status == ESTABLISHED)
+      if (status == WAITING_FOR_FINAL)
         return;
 
       LOG_INFO_FMT("Initiating node channel with {}.", peer_id);
 
-      status = INITIATED;
+      key_exchange_in_progress = true;
+
+      if (status != ESTABLISHED)
+        status = INITIATED;
+      else
+      {
+        // Restart with new key exchange
+        kex_ctx.reset();
+        peer_cert = {};
+        peer_cv.reset();
+
+        auto e = crypto::create_entropy();
+        hkdf_salt = e->random(salt_len);
+      }
 
       to_host->write(
         node_outbound,
@@ -677,8 +732,11 @@ namespace ccf
       GcmHdr gcm_hdr;
       gcm_hdr.set_iv_seq(nonce.get_val());
 
+      assert(key || next_key);
+
       std::vector<uint8_t> cipher(plain.n);
-      key->encrypt(gcm_hdr.get_iv(), plain, aad, cipher.data(), gcm_hdr.tag);
+      (next_key ? next_key : key)
+        ->encrypt(gcm_hdr.get_iv(), plain, aad, cipher.data(), gcm_hdr.tag);
 
       to_host->write(
         node_outbound,
@@ -689,7 +747,8 @@ namespace ccf
         gcm_hdr,
         cipher);
 
-      LOG_TRACE_FMT("-> {}: encrypted msg", peer_id);
+      LOG_TRACE_FMT(
+        "-> {}: encrypted msg with nonce={}", peer_id, (uint64_t)nonce.nonce);
 
       return true;
     }
@@ -701,9 +760,10 @@ namespace ccf
       if (status != ESTABLISHED)
       {
         LOG_FAIL_FMT(
-          "Node channel with {} cannot receive authenticated message: not "
-          "yet established",
-          peer_id);
+          "Node channel with {} cannot receive authenticated message: not yet "
+          "established, status={}",
+          peer_id,
+          status);
         return false;
       }
 
@@ -727,8 +787,9 @@ namespace ccf
       {
         LOG_FAIL_FMT(
           "node channel with {} cannot receive authenticated with payload "
-          "message: not yet established",
-          peer_id);
+          "message: not yet established, status={}",
+          peer_id,
+          status);
         return false;
       }
 
@@ -774,31 +835,18 @@ namespace ccf
 
     void reset()
     {
-      LOG_INFO_FMT("Resetting channel with {}", peer_id);
+      LOG_TRACE_FMT("Resetting channel with {}", peer_id);
 
       status = INACTIVE;
-
       kex_ctx.reset();
-      key.reset();
       peer_cert = {};
       peer_cv.reset();
+      key.reset();
+      next_key.reset();
+      outgoing_msg.reset();
 
       auto e = crypto::create_entropy();
       hkdf_salt = e->random(salt_len);
-    }
-
-    void restart()
-    {
-      LOG_TRACE_FMT("Restarting node channel with {}", peer_id);
-
-      to_host->write(
-        node_outbound,
-        peer_id.value(),
-        NodeMsgType::channel_msg,
-        self.value(),
-        ChannelMsg::key_exchange_restart);
-
-      LOG_TRACE_FMT("key_exchange_restart -> {}", peer_id);
     }
   };
 
@@ -859,14 +907,6 @@ namespace ccf
         LOG_DEBUG_FMT("Setting existing channel to {} as outgoing", peer_id);
         search->second->set_outgoing(hostname, service);
         return;
-      }
-    }
-
-    void restart()
-    {
-      for (auto c : channels)
-      {
-        c.second->restart();
       }
     }
 

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -24,7 +24,7 @@ namespace ccf
   using GcmHdr = crypto::GcmHeader<sizeof(SeqNo)>;
 
 #ifndef NDEBUG
-  static constexpr size_t message_limit = 25;
+  static constexpr size_t message_limit = 2048;
 #else
   // 2**24.5 as per RFC8446 Section 5.5
   static constexpr size_t message_limit = 23726566;

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -693,7 +693,9 @@ namespace ccf
       key_exchange_in_progress = true;
 
       if (status != ESTABLISHED)
+      {
         status = INITIATED;
+      }
       else
       {
         // Restart with new key exchange

--- a/src/node/node_to_node.h
+++ b/src/node/node_to_node.h
@@ -22,7 +22,8 @@ namespace ccf
     virtual void create_channel(
       const NodeId& peer_id,
       const std::string& peer_hostname,
-      const std::string& peer_service) = 0;
+      const std::string& peer_service,
+      size_t message_limit = Channel::default_message_limit) = 0;
 
     virtual void destroy_channel(const NodeId& peer_id) = 0;
 
@@ -166,14 +167,15 @@ namespace ccf
     void create_channel(
       const NodeId& peer_id,
       const std::string& hostname,
-      const std::string& service) override
+      const std::string& service,
+      size_t message_limit = Channel::default_message_limit) override
     {
       if (peer_id == self.value())
       {
         return;
       }
 
-      channels->create_channel(peer_id, hostname, service);
+      channels->create_channel(peer_id, hostname, service, message_limit);
     }
 
     void destroy_channel(const NodeId& peer_id) override

--- a/src/node/node_to_node.h
+++ b/src/node/node_to_node.h
@@ -24,8 +24,6 @@ namespace ccf
       const std::string& peer_hostname,
       const std::string& peer_service) = 0;
 
-    virtual void restart() = 0;
-
     virtual void destroy_channel(const NodeId& peer_id) = 0;
 
     virtual void close_all_outgoing() = 0;
@@ -178,14 +176,6 @@ namespace ccf
       channels->create_channel(peer_id, hostname, service);
     }
 
-    virtual void restart() override
-    {
-      if (channels)
-      {
-        channels->restart();
-      }
-    }
-
     void destroy_channel(const NodeId& peer_id) override
     {
       if (peer_id == self.value())
@@ -267,10 +257,7 @@ namespace ccf
       // with the lower ID wins.
 
       auto n2n_channel = channels->get(from);
-      if (!n2n_channel->consume_initiator_key_share(data, size, self < from))
-      {
-        /* Unchecked ok? */
-      }
+      n2n_channel->consume_initiator_key_share(data, size, self < from);
     }
 
     void process_key_exchange_response(
@@ -278,10 +265,7 @@ namespace ccf
     {
       LOG_DEBUG_FMT("key_exchange_response from {}", from);
       auto n2n_channel = channels->get(from);
-      if (!n2n_channel->consume_responder_key_share(data, size))
-      {
-        /* Unchecked ok? */
-      }
+      n2n_channel->consume_responder_key_share(data, size);
     }
 
     void process_key_exchange_final(
@@ -293,15 +277,6 @@ namespace ccf
       {
         n2n_channel->reset();
       }
-    }
-
-    void process_key_exchange_restart(
-      const NodeId& from, const uint8_t*, size_t)
-    {
-      LOG_DEBUG_FMT("key_exchange_restart from {}", from);
-      auto n2n_channel = channels->get(from);
-      n2n_channel->reset();
-      n2n_channel->initiate();
     }
 
     void recv_message(const NodeId& from, OArray&& oa) override
@@ -328,12 +303,6 @@ namespace ccf
           case key_exchange_final:
           {
             process_key_exchange_final(from, data, size);
-            break;
-          }
-
-          case key_exchange_restart:
-          {
-            process_key_exchange_restart(from, data, size);
             break;
           }
 

--- a/src/node/node_types.h
+++ b/src/node/node_types.h
@@ -26,8 +26,7 @@ namespace ccf
   {
     key_exchange_init = 0,
     key_exchange_response,
-    key_exchange_final,
-    key_exchange_restart
+    key_exchange_final
   };
 
   // Types of frontend messages


### PR DESCRIPTION
This adds the facilities to trigger key exchanges for node-to-node channels when the message limits have been reached. This is item 3 of #2092.