### PR TITLE
Disable BFT in CCF releases

### DIFF
--- a/.azure-pipelines-templates/install.yml
+++ b/.azure-pipelines-templates/install.yml
@@ -23,7 +23,7 @@ steps:
 
   - script: |
       sudo apt -y install ./$(pkgname)
-      cat /tmp/install_prefix | xargs -i bash -c "PYTHON_PACKAGE_PATH=../python ./test_install.sh {}"
+      cat /tmp/install_prefix | xargs -i bash -c "PYTHON_PACKAGE_PATH=../python ./test_install.sh {} release"
     workingDirectory: build
     displayName: Test installed CCF
 

--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -26,6 +26,8 @@ parameters:
       cmake_args: "-DCMAKE_BUILD_TYPE=Debug -DBUILD_SMALLBANK=OFF -DBUILD_TPCC=OFF"
     perf:
       cmake_args: '-DBUILD_UNIT_TESTS=OFF -DDISTRIBUTE_PERF_TESTS="`../.nodes.sh`"'
+    release:
+      cmake_args: '-DTLS_TEST=ON -DENABLE_BFT=OFF'
 
   test:
     NoSGX:
@@ -67,7 +69,7 @@ jobs:
         parameters:
           target: SGX
           env: ${{ parameters.env.SGX }}
-          cmake_args: "${{ parameters.build.common.cmake_args }} -DTLS_TEST=ON"
+          cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.release.cmake_args }}"
           suffix: "Release"
           artifact_name: "SGX_Release"
 

--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -27,7 +27,7 @@ parameters:
     perf:
       cmake_args: '-DBUILD_UNIT_TESTS=OFF -DDISTRIBUTE_PERF_TESTS="`../.nodes.sh`"'
     release:
-      cmake_args: '-DTLS_TEST=ON -DENABLE_BFT=OFF'
+      cmake_args: "-DTLS_TEST=ON -DENABLE_BFT=OFF"
 
   test:
     NoSGX:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,11 @@ configure_file(
 )
 configure_file(${CCF_DIR}/python/setup.py.in ${CCF_DIR}/python/setup.py @ONLY)
 
-set(CONSENSUSES cft bft)
+if(${ENABLE_BFT})
+  set(CONSENSUSES cft bft)
+else()
+  set(CONSENSUSES cft)
+endif()
 
 option(BUILD_TESTS "Build tests" ON)
 option(BUILD_UNIT_TESTS "Build unit tests" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ configure_file(
 )
 configure_file(${CCF_DIR}/python/setup.py.in ${CCF_DIR}/python/setup.py @ONLY)
 
-if(${ENABLE_BFT})
+if(ENABLE_BFT)
   set(CONSENSUSES cft bft)
 else()
   set(CONSENSUSES cft)

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -50,7 +50,7 @@ option(COVERAGE "Enable coverage mapping" OFF)
 option(SHUFFLE_SUITE "Shuffle end to end test suite" OFF)
 option(LONG_TESTS "Enable long end-to-end tests" OFF)
 
-option(ENABLE_BFT "Disable experimental BFT consensus at compile time" ON)
+option(ENABLE_BFT "Enable experimental BFT consensus at compile time" ON)
 if(ENABLE_BFT)
   add_compile_definitions(ENABLE_BFT)
 endif()

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -50,6 +50,11 @@ option(COVERAGE "Enable coverage mapping" OFF)
 option(SHUFFLE_SUITE "Shuffle end to end test suite" OFF)
 option(LONG_TESTS "Enable long end-to-end tests" OFF)
 
+option(ENABLE_BFT "Disable experimental BFT consensus at compile time" ON)
+if(ENABLE_BFT)
+  add_compile_definitions(ENABLE_BFT)
+endif()
+
 option(DEBUG_CONFIG "Enable non-production options options to aid debugging"
        OFF
 )

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -56,6 +56,15 @@ extern "C"
       return false;
     }
 
+#ifndef ENABLE_BFT
+    // As BFT consensus is currently experimental, disable it in release
+    // enclaves
+    if (consensus_type != ConsensusType::CFT)
+    {
+      return false;
+    }
+#endif
+
     num_pending_threads = (uint16_t)num_worker_threads + 1;
 
     if (

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -784,6 +784,17 @@ int main(int argc, char** argv)
       LOG_FATAL_FMT("Start command should be start|join|recover. Exiting.");
     }
 
+    if (consensus == ConsensusType::BFT)
+    {
+#ifdef ENABLE_BFT
+      LOG_INFO_FMT(
+        "Selected consensus BFT is experimental in {}", ccf::ccf_version);
+#else
+      LOG_FAIL_FMT(
+        "Selected consensus BFT is not supported in {}", ccf::ccf_version);
+#endif
+    }
+
     enclave.create_node(
       enclave_config,
       ccf_config,


### PR DESCRIPTION
As BFT support is still experimental, this PR disables it for CCF releases via a new CMake `ENABLE_BFT` flag (defaults to `ON`), which is set to `OFF` in our release CI job (tested in `test_install.sh`). 

The fact that BFT is enabled or not is captured at compile time so that it is part of the enclave measurement, so that operators cannot enable BFT for an already-trusted measurement. 