### PR TITLE
Serialise code ID as hex string

### DIFF
--- a/python/ccf/proposal_generator.py
+++ b/python/ccf/proposal_generator.py
@@ -383,14 +383,12 @@ def retire_node(node_id: str, **kwargs):
 
 @cli_proposal
 def new_node_code(code_digest: str, **kwargs):
-    code_digest_bytes = list(bytearray.fromhex(code_digest))
-    return build_proposal("new_node_code", code_digest_bytes, **kwargs)
+    return build_proposal("new_node_code", code_digest, **kwargs)
 
 
 @cli_proposal
 def retire_node_code(code_digest: str, **kwargs):
-    code_digest_bytes = list(bytearray.fromhex(code_digest))
-    return build_proposal("retire_node_code", code_digest_bytes, **kwargs)
+    return build_proposal("retire_node_code", code_digest, **kwargs)
 
 
 @cli_proposal

--- a/src/crypto/hash_provider.h
+++ b/src/crypto/hash_provider.h
@@ -94,7 +94,7 @@ namespace crypto
     auto value = j.get<std::string>();
     try
     {
-      ds::from_hex(value, hash.h.begin(), hash.h.end());
+      ds::from_hex(value, hash.h);
     }
     catch (const std::logic_error& e)
     {

--- a/src/ds/hex.h
+++ b/src/ds/hex.h
@@ -79,4 +79,10 @@ namespace ds
     from_hex(str, ret.begin(), ret.end());
     return ret;
   }
+
+  template <typename T>
+  inline static void from_hex(const std::string& str, T& out)
+  {
+    from_hex(str, out.begin(), out.end());
+  }
 }

--- a/src/endpoints/common_endpoint_registry.cpp
+++ b/src/endpoints/common_endpoint_registry.cpp
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 
-#include "ccf/common_endpoint_registry.h"
-
 #include "ccf/common_auth_policies.h"
+#include "ccf/common_endpoint_registry.h"
 #include "ccf/historical_queries_adapter.h"
 #include "ds/nonstd.h"
 #include "enclave/node_context.h"
@@ -159,7 +158,7 @@ namespace ccf
       auto codes_ids = args.tx.template ro<CodeIDs>(Tables::NODE_CODE_IDS);
       codes_ids->foreach(
         [&out](const ccf::CodeDigest& cd, const ccf::CodeStatus& cs) {
-          auto digest = ds::to_hex(cd);
+          auto digest = ds::to_hex(cd.data);
           out.versions.push_back({digest, cs});
           return true;
         });

--- a/src/endpoints/common_endpoint_registry.cpp
+++ b/src/endpoints/common_endpoint_registry.cpp
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 
-#include "ccf/common_auth_policies.h"
 #include "ccf/common_endpoint_registry.h"
+
+#include "ccf/common_auth_policies.h"
 #include "ccf/historical_queries_adapter.h"
 #include "ds/nonstd.h"
 #include "enclave/node_context.h"

--- a/src/kv/serialise_entry_blit.h
+++ b/src/kv/serialise_entry_blit.h
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ds/hex.h"
 #include "ds/nonstd.h"
 #include "serialised_entry.h"
 

--- a/src/kv/serialise_entry_blit.h
+++ b/src/kv/serialise_entry_blit.h
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
-#include "ds/hex.h"
 #include "ds/nonstd.h"
 #include "serialised_entry.h"
 

--- a/src/node/blit.h
+++ b/src/node/blit.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ccf/entity_id.h"
+#include "code_id.h"
 #include "crypto/pem.h"
 #include "kv/serialise_entry_blit.h"
 
@@ -35,6 +36,23 @@ namespace kv::serialisers
     static crypto::Pem from_serialised(const SerialisedEntry& data)
     {
       return crypto::Pem(data.data(), data.size());
+    }
+  };
+
+  template <>
+  struct BlitSerialiser<ccf::CodeDigest>
+  {
+    static SerialisedEntry to_serialised(const ccf::CodeDigest& code_digest)
+    {
+      auto hex_str = ds::to_hex(code_digest.data);
+      return SerialisedEntry(hex_str.begin(), hex_str.end());
+    }
+
+    static ccf::CodeDigest from_serialised(const SerialisedEntry& data)
+    {
+      ccf::CodeDigest ret;
+      ds::from_hex(std::string(data.data(), data.end()), ret.data);
+      return ret;
     }
   };
 }

--- a/src/node/code_id.h
+++ b/src/node/code_id.h
@@ -2,6 +2,8 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "crypto/hash_provider.h"
+#include "ds/hex.h"
 #include "ds/json.h"
 #include "entities.h"
 #include "service_map.h"
@@ -10,9 +12,32 @@
 
 namespace ccf
 {
-  // SGX MRENCLAVE is SHA256 digest
-  static constexpr size_t CODE_DIGEST_BYTES = 256 / 8;
-  using CodeDigest = std::array<uint8_t, CODE_DIGEST_BYTES>;
+  struct CodeDigest
+  {
+    std::array<uint8_t, crypto::Sha256Hash::SIZE> data;
+
+    CodeDigest() = default;
+    CodeDigest(const CodeDigest& other) : data(other.data) {}
+  };
+
+  inline void to_json(nlohmann::json& j, const CodeDigest& code_digest)
+  {
+    j = ds::to_hex(code_digest.data);
+  }
+
+  inline void from_json(const nlohmann::json& j, CodeDigest& code_digest)
+  {
+    if (j.is_string())
+    {
+      auto value = j.get<std::string>();
+      ds::from_hex(value, code_digest.data);
+    }
+    else
+    {
+      throw JsonParseError(
+        fmt::format("Code Digest should be hex-encoded string: {}", j.dump()));
+    }
+  }
 
   enum class CodeStatus
   {

--- a/src/node/genesis_gen.h
+++ b/src/node/genesis_gen.h
@@ -455,7 +455,7 @@ namespace ccf
       set_scripts(scripts, tables.gov_scripts, false);
     }
 
-    void trust_node_code_id(CodeDigest& node_code_id)
+    void trust_node_code_id(const CodeDigest& node_code_id)
     {
       auto codeid = tx.rw(tables.node_code_ids);
       codeid->put(node_code_id, CodeStatus::ALLOWED_TO_JOIN);

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1510,8 +1510,7 @@ namespace ccf
       create_params.network_cert = network.identity->cert;
       create_params.quote_info = quote_info;
       create_params.public_encryption_key = node_encrypt_kp->public_key_pem();
-      create_params.code_digest =
-        std::vector<uint8_t>(std::begin(node_code_id), std::end(node_code_id));
+      create_params.code_digest = node_code_id;
       create_params.node_info_network = config.node_info_network;
       create_params.configuration = {config.genesis.recovery_threshold,
                                      network.consensus_type};

--- a/src/node/quote.h
+++ b/src/node/quote.h
@@ -131,7 +131,9 @@ namespace ccf
         if (claim_name == OE_CLAIM_UNIQUE_ID)
         {
           std::copy(
-            claim.value, claim.value + claim.value_size, unique_id.begin());
+            claim.value,
+            claim.value + claim.value_size,
+            unique_id.data.begin());
           unique_id_found = true;
         }
         else if (claim_name == OE_CLAIM_CUSTOM_CLAIMS_BUFFER)

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -509,9 +509,9 @@ namespace ccf
       if (existing_code_id)
       {
         LOG_FAIL_FMT(
-          "Proposal {}: Code signature already exists with digest: {:02x}",
+          "Proposal {}: Code signature already exists with digest: {}",
           proposal_id,
-          fmt::join(new_code_id, ""));
+          ds::to_hex(new_code_id.data));
         return false;
       }
       code_ids->put(new_code_id, CodeStatus::ALLOWED_TO_JOIN);
@@ -529,9 +529,9 @@ namespace ccf
       if (!existing_code_id)
       {
         LOG_FAIL_FMT(
-          "Proposal {}: No such code id in table: {:02x}",
+          "Proposal {}: No such code id in table: {}",
           proposal_id,
-          fmt::join(code_id, ""));
+          ds::to_hex(code_id.data));
         return false;
       }
       code_ids->remove(code_id);
@@ -1989,12 +1989,7 @@ namespace ccf
            NodeStatus::TRUSTED});
 
 #ifdef GET_QUOTE
-        CodeDigest node_code_id;
-        std::copy_n(
-          std::begin(in.code_digest),
-          CODE_DIGEST_BYTES,
-          std::begin(node_code_id));
-        g.trust_node_code_id(node_code_id);
+        g.trust_node_code_id(in.code_digest);
 #endif
 
         for (const auto& wl : default_whitelists)

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -54,7 +54,7 @@ namespace ccf
       crypto::Pem network_cert;
       QuoteInfo quote_info;
       crypto::Pem public_encryption_key;
-      std::vector<uint8_t> code_digest;
+      CodeDigest code_digest;
       NodeInfoNetwork node_info_network;
       ServiceConfiguration configuration;
     };

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -360,7 +360,7 @@ namespace ccf
 #ifdef GET_QUOTE
           auto code_id =
             EnclaveAttestationProvider::get_code_id(node_quote_info);
-          q.mrenclave = ds::to_hex(code_id);
+          q.mrenclave = ds::to_hex(code_id.data);
 #endif
 
           return make_success(q);
@@ -406,7 +406,7 @@ namespace ccf
 #ifdef GET_QUOTE
             auto code_id =
               EnclaveAttestationProvider::get_code_id(node_info.quote_info);
-            q.mrenclave = ds::to_hex(code_id);
+            q.mrenclave = ds::to_hex(code_id.data);
 #endif
             quotes.emplace_back(q);
           }


### PR DESCRIPTION
The trusted node code ID were still serialised as raw bytes in the ledger and in the associated proposals.