### PR TITLE
Non-deterministic/randomized ECDSA

### DIFF
--- a/src/node/test/channels.cpp
+++ b/src/node/test/channels.cpp
@@ -200,12 +200,9 @@ TEST_CASE("Client/Server key exchange")
     REQUIRE(msgs[1].type == channel_msg);
     REQUIRE(read_outbound_msgs<MsgType>(eio2).size() == 0);
 
-#ifndef CRYPTO_PROVIDER_IS_MBEDTLS
+#ifndef DETERMINISTIC_ECDSA
     // Signing twice should have produced different signatures
     REQUIRE(msgs[0].unauthenticated_data() != msgs[1].unauthenticated_data());
-
-    // Note: mbedTLS seems to produce identical signatures (sometimes if not
-    // always). This may require investigation.
 #endif
 
     channel1_signed_key_share = msgs[0].unauthenticated_data();


### PR DESCRIPTION
ECDSA signatures are non-deterministic/randomized, i.e. signing the same message twice produces different signatures (and both verify correctly). Our implementations of signing with mbedTLS and OpenSSL don't agree on that; mbedTLS is deterministic and OpenSSL is not. mbedTLS makes it hard to sign non-deterministically (see code changes here), while OpenSSL doesn't support deterministic signatures (work in progress: https://github.com/openssl/openssl/pull/9223). 

I believe we should be using non-deterministic signatures because we have a good enough source of randomness, at least in enclaves, via the Intel DRNG (see also https://tools.ietf.org/html/rfc6979), so that's what I opted to implement. Our tests tolerate either, so I can be convinced otherwise (and perhaps help out with the OpenSSL implementation at their end to speed up integration).