### PR TITLE
Remove failure log message when starting a node without a snapshot

### DIFF
--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -774,8 +774,8 @@ int main(int argc, char** argv)
       }
       else
       {
-        LOG_FAIL_FMT(
-          "No snapshot found: Node will request all historical transactions");
+        LOG_INFO_FMT(
+          "No snapshot found: Node will replay all historical transactions");
       }
     }
 

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -353,6 +353,7 @@ class Node:
     def get_committed_snapshots(self, pre_condition_func=lambda src_dir, _: True):
         return self.remote.get_committed_snapshots(pre_condition_func)
 
+
     def identity(self, name=None):
         if name is not None:
             return ccf.clients.Identity(

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -353,7 +353,6 @@ class Node:
     def get_committed_snapshots(self, pre_condition_func=lambda src_dir, _: True):
         return self.remote.get_committed_snapshots(pre_condition_func)
 
-
     def identity(self, name=None):
         if name is not None:
             return ccf.clients.Identity(

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -832,6 +832,9 @@ class CCFRemote(object):
         )
         return os.path.join(self.common_dir, self.snapshot_dir_name)
 
+    def log_path(self):
+        return self.remote.out
+
     def ledger_path(self):
         return os.path.join(self.remote.root, self.ledger_dir_name)
 

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -205,15 +205,14 @@ def run(args):
         test_add_node_from_snapshot(network, args)
         test_add_node_from_snapshot(network, args, from_backup=True)
         test_add_node_from_snapshot(network, args, copy_ledger_read_only=False)
+        latest_node_log = network.get_joined_nodes()[-1].remote.log_path()
+        with open(latest_node_log, "r+") as log:
+            assert any(
+                "No snapshot found: Node will replay all historical transactions" in l
+                for l in log.readlines()
+            ), "New nodes shouldn't join from snapshot if snapshot evidence cannot be verified"
+
         test_node_filter(network, args)
-        errors, _ = network.get_joined_nodes()[-1].stop()
-        if not any(
-            "No snapshot found: Node will request all historical transactions" in s
-            for s in errors
-        ):
-            raise ValueError(
-                "New node shouldn't join from snapshot if snapshot cannot be verified"
-            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Removing the annoying failure log when starting a join/recovery node without a snapshot. 