### PR TITLE
Decorate vectors and arrays through libfmt

### DIFF
--- a/src/ds/logger_formatters.h
+++ b/src/ds/logger_formatters.h
@@ -21,7 +21,8 @@ namespace fmt
     template <typename FormatContext>
     auto format(const std::vector<uint8_t>& v, FormatContext& ctx)
     {
-      return format_to(ctx.out(), "<vec[{}]: {:02x}>", v.size(), fmt::join(v, " "));
+      return format_to(
+        ctx.out(), "<vec[{}]: {:02x}>", v.size(), fmt::join(v, " "));
     }
   };
 

--- a/src/ds/logger_formatters.h
+++ b/src/ds/logger_formatters.h
@@ -9,17 +9,6 @@
 
 namespace fmt
 {
-  inline std::string uint8_vector_to_hex_string(const std::vector<uint8_t>& v)
-  {
-    std::stringstream ss;
-    for (auto it = v.begin(); it != v.end(); it++)
-    {
-      ss << std::hex << static_cast<unsigned>(*it);
-    }
-
-    return ss.str();
-  }
-
   template <>
   struct formatter<std::vector<uint8_t>>
   {
@@ -32,12 +21,12 @@ namespace fmt
     template <typename FormatContext>
     auto format(const std::vector<uint8_t>& p, FormatContext& ctx)
     {
-      return format_to(ctx.out(), uint8_vector_to_hex_string(p));
+      return format_to(ctx.out(), "{:02x}", fmt::join(p, ""));
     }
   };
 
-  template <>
-  struct formatter<std::array<uint8_t, 32>>
+  template <size_t N>
+  struct formatter<std::array<uint8_t, N>>
   {
     template <typename ParseContext>
     constexpr auto parse(ParseContext& ctx)
@@ -46,10 +35,9 @@ namespace fmt
     }
 
     template <typename FormatContext>
-    auto format(const std::array<uint8_t, 32>& p, FormatContext& ctx)
+    auto format(const std::array<uint8_t, N>& p, FormatContext& ctx)
     {
-      return format_to(
-        ctx.out(), uint8_vector_to_hex_string({p.begin(), p.end()}));
+      return format_to(ctx.out(), "{:02x}", fmt::join(p, ""));
     }
   };
 }

--- a/src/ds/logger_formatters.h
+++ b/src/ds/logger_formatters.h
@@ -19,9 +19,9 @@ namespace fmt
     }
 
     template <typename FormatContext>
-    auto format(const std::vector<uint8_t>& p, FormatContext& ctx)
+    auto format(const std::vector<uint8_t>& v, FormatContext& ctx)
     {
-      return format_to(ctx.out(), "{:02x}", fmt::join(p, ""));
+      return format_to(ctx.out(), "<vec[{}]: {:02x}>", v.size(), fmt::join(v, " "));
     }
   };
 
@@ -35,9 +35,9 @@ namespace fmt
     }
 
     template <typename FormatContext>
-    auto format(const std::array<uint8_t, N>& p, FormatContext& ctx)
+    auto format(const std::array<uint8_t, N>& a, FormatContext& ctx)
     {
-      return format_to(ctx.out(), "{:02x}", fmt::join(p, ""));
+      return format_to(ctx.out(), "<arr[{}]: {:02x}>", N, fmt::join(a, " "));
     }
   };
 }


### PR DESCRIPTION
I noticed these custom formatters while investigating something else. This PR removes the unnecessary copy when formatting `std::array`s, generalises to any length of array, and decorates the types so its easier to grep where the hexification has come from.

```
  std::vector<uint8_t> v{0xde, 0xad, 0xbe, 0xef};
  LOG_INFO_FMT("{}", v);

  std::array<uint8_t, 7> a{1, 2, 3, 4, 5, 6, 7};
  LOG_INFO_FMT("What about my keys? {}!", a);
```
```
[info ] ... | <vec[4]: de ad be ef>
[info ] ... | What about my keys? <arr[7]: 01 02 03 04 05 06 07>!
```
