### PR TITLE
Enable code update and reconfiguration test with virtual enclaves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,21 +672,19 @@ if(BUILD_TESTS)
                     ${CMAKE_BINARY_DIR}/samples/apps/nobuiltins/libnobuiltins
   )
 
-  if(QUOTES_ENABLED)
-    add_e2e_test(
-      NAME reconfiguration_test
-      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/reconfiguration.py
-      CONSENSUS cft
-    )
+  add_e2e_test(
+    NAME reconfiguration_test
+    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/reconfiguration.py
+    CONSENSUS cft
+  )
 
-    add_e2e_test(
-      NAME code_update_test
-      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/code_update.py
-      CONSENSUS cft
-      ADDITIONAL_ARGS --oe-binary ${OE_BINDIR} --js-app-bundle
-                      ${CMAKE_SOURCE_DIR}/samples/apps/logging/js
-    )
-  endif()
+  add_e2e_test(
+    NAME code_update_test
+    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/code_update.py
+    CONSENSUS cft
+    ADDITIONAL_ARGS --oe-binary ${OE_BINDIR} --js-app-bundle
+                    ${CMAKE_SOURCE_DIR}/samples/apps/logging/js
+  )
 
   if(BUILD_SMALLBANK)
     include(${CMAKE_CURRENT_SOURCE_DIR}/src/apps/smallbank/smallbank.cmake)

--- a/tests/code_update.py
+++ b/tests/code_update.py
@@ -90,37 +90,40 @@ def test_update_all_nodes(network, args):
 
     primary, _ = network.find_nodes()
 
-    first_code_id, new_code_id = [
-        get_code_id(args.oe_binary, infra.path.build_lib_path(pkg, args.enclave_type))
-        for pkg in [args.package, replacement_package]
-    ]
+    if args.enclave_type != "virtual":
+        first_code_id, new_code_id = [
+            get_code_id(
+                args.oe_binary, infra.path.build_lib_path(pkg, args.enclave_type)
+            )
+            for pkg in [args.package, replacement_package]
+        ]
 
-    LOG.info("Add new code id")
-    network.consortium.add_new_code(primary, new_code_id)
-    with primary.client() as uc:
-        r = uc.get("/node/code")
-        versions = sorted(r.body.json()["versions"], key=lambda x: x["digest"])
-        expected = sorted(
-            [
-                {"digest": first_code_id, "status": "AllowedToJoin"},
-                {"digest": new_code_id, "status": "AllowedToJoin"},
-            ],
-            key=lambda x: x["digest"],
-        )
-        assert versions == expected, versions
+        LOG.info("Add new code id")
+        network.consortium.add_new_code(primary, new_code_id)
+        with primary.client() as uc:
+            r = uc.get("/node/code")
+            versions = sorted(r.body.json()["versions"], key=lambda x: x["digest"])
+            expected = sorted(
+                [
+                    {"digest": first_code_id, "status": "AllowedToJoin"},
+                    {"digest": new_code_id, "status": "AllowedToJoin"},
+                ],
+                key=lambda x: x["digest"],
+            )
+            assert versions == expected, versions
 
-    LOG.info("Remove old code id")
-    network.consortium.retire_code(primary, first_code_id)
-    with primary.client() as uc:
-        r = uc.get("/node/code")
-        versions = sorted(r.body.json()["versions"], key=lambda x: x["digest"])
-        expected = sorted(
-            [
-                {"digest": new_code_id, "status": "AllowedToJoin"},
-            ],
-            key=lambda x: x["digest"],
-        )
-        assert versions == expected, versions
+        LOG.info("Remove old code id")
+        network.consortium.retire_code(primary, first_code_id)
+        with primary.client() as uc:
+            r = uc.get("/node/code")
+            versions = sorted(r.body.json()["versions"], key=lambda x: x["digest"])
+            expected = sorted(
+                [
+                    {"digest": new_code_id, "status": "AllowedToJoin"},
+                ],
+                key=lambda x: x["digest"],
+            )
+            assert versions == expected, versions
 
     old_nodes = network.nodes.copy()
 
@@ -163,9 +166,6 @@ def run(args):
 
 if __name__ == "__main__":
     args = infra.e2e_args.cli_args()
-    if args.enclave_type == "virtual":
-        LOG.warning("Skipping code update test with virtual enclave")
-        sys.exit()
 
     args.package = "liblogging"
     args.nodes = infra.e2e_args.min_nodes(args, f=1)


### PR DESCRIPTION
These two end-to-end tests were disabled for virtual enclaves. For the code update test specifically, we skip the addition/removal of the new code IDs but add the new nodes anyway, and expected the test to succeed. 