### PR TITLE
js gov: ca cert and jwt proposals

### DIFF
--- a/src/js/wrap.cpp
+++ b/src/js/wrap.cpp
@@ -7,6 +7,7 @@
 #include "js/conv.cpp"
 #include "js/crypto.cpp"
 #include "kv/untyped_map.h"
+#include "node/jwt.h"
 #include "node/rpc/call_types.h"
 #include "node/rpc/node_interface.h"
 #include "tls/base64.h"
@@ -410,6 +411,131 @@ namespace js
     return JS_UNDEFINED;
   }
 
+  JSValue js_gov_set_jwt_public_signing_keys(
+    JSContext* ctx,
+    [[maybe_unused]] JSValueConst this_val,
+    int argc,
+    JSValueConst* argv)
+  {
+    if (argc != 3)
+    {
+      return JS_ThrowTypeError(ctx, "Passed %d arguments but expected 3", argc);
+    }
+
+    // yikes
+    auto global_obj = JS_GetGlobalObject(ctx);
+    auto ccf = JS_GetPropertyStr(ctx, global_obj, "ccf");
+    auto kv = JS_GetPropertyStr(ctx, ccf, "kv");
+
+    auto tx_ctx_ptr = static_cast<TxContext*>(JS_GetOpaque(kv, kv_class_id));
+
+    if (tx_ctx_ptr->tx == nullptr)
+    {
+      return JS_ThrowInternalError(ctx, "No transaction available");
+    }
+
+    JS_FreeValue(ctx, kv);
+    JS_FreeValue(ctx, ccf);
+    JS_FreeValue(ctx, global_obj);
+
+    auto& tx = *tx_ctx_ptr->tx;
+
+    auto issuer_cstr = JS_ToCString(ctx, argv[0]);
+    if (issuer_cstr == nullptr)
+    {
+      return JS_ThrowTypeError(ctx, "issuer argument is not a string");
+    }
+    std::string issuer(issuer_cstr);
+    JS_FreeCString(ctx, issuer_cstr);
+
+    JSValue metadata_val = JS_JSONStringify(ctx, argv[1], JS_NULL, JS_NULL);
+    if (JS_IsException(metadata_val))
+    {
+      return JS_ThrowTypeError(ctx, "metadata argument is not a JSON object");
+    }
+    auto metadata_cstr = JS_ToCString(ctx, metadata_val);
+    std::string metadata_json(metadata_cstr);
+    JS_FreeCString(ctx, metadata_cstr);
+    JS_FreeValue(ctx, metadata_val);
+
+    JSValue jwks_val = JS_JSONStringify(ctx, argv[2], JS_NULL, JS_NULL);
+    if (JS_IsException(jwks_val))
+    {
+      return JS_ThrowTypeError(ctx, "jwks argument is not a JSON object");
+    }
+    auto jwks_cstr = JS_ToCString(ctx, jwks_val);
+    std::string jwks_json(jwks_cstr);
+    JS_FreeCString(ctx, jwks_cstr);
+    JS_FreeValue(ctx, jwks_val);
+
+    try
+    {
+      auto metadata =
+        nlohmann::json::parse(metadata_json).get<ccf::JwtIssuerMetadata>();
+      auto jwks = nlohmann::json::parse(jwks_json).get<ccf::JsonWebKeySet>();
+      auto success =
+        ccf::set_jwt_public_signing_keys(tx, "<js>", issuer, metadata, jwks);
+      if (!success)
+      {
+        return JS_ThrowInternalError(
+          ctx, "set_jwt_public_signing_keys() failed");
+      }
+    }
+    catch (std::exception& exc)
+    {
+      return JS_ThrowInternalError(ctx, "Unexpected error: %s", exc.what());
+    }
+    return JS_UNDEFINED;
+  }
+
+  JSValue js_gov_remove_jwt_public_signing_keys(
+    JSContext* ctx,
+    [[maybe_unused]] JSValueConst this_val,
+    int argc,
+    JSValueConst* argv)
+  {
+    if (argc != 1)
+    {
+      return JS_ThrowTypeError(ctx, "Passed %d arguments but expected 1", argc);
+    }
+
+    // yikes
+    auto global_obj = JS_GetGlobalObject(ctx);
+    auto ccf = JS_GetPropertyStr(ctx, global_obj, "ccf");
+    auto kv = JS_GetPropertyStr(ctx, ccf, "kv");
+
+    auto tx_ctx_ptr = static_cast<TxContext*>(JS_GetOpaque(kv, kv_class_id));
+
+    if (tx_ctx_ptr->tx == nullptr)
+    {
+      return JS_ThrowInternalError(ctx, "No transaction available");
+    }
+
+    JS_FreeValue(ctx, kv);
+    JS_FreeValue(ctx, ccf);
+    JS_FreeValue(ctx, global_obj);
+
+    auto& tx = *tx_ctx_ptr->tx;
+
+    auto issuer_cstr = JS_ToCString(ctx, argv[0]);
+    if (issuer_cstr == nullptr)
+    {
+      return JS_ThrowTypeError(ctx, "issuer argument is not a string");
+    }
+    std::string issuer(issuer_cstr);
+    JS_FreeCString(ctx, issuer_cstr);
+
+    try
+    {
+      ccf::remove_jwt_public_signing_keys(tx, issuer);
+    }
+    catch (std::exception& exc)
+    {
+      return JS_ThrowInternalError(ctx, "Unexpected error: %s", exc.what());
+    }
+    return JS_UNDEFINED;
+  }
+
   // Partially replicates https://developer.mozilla.org/en-US/docs/Web/API/Body
   // with a synchronous interface.
   static const JSCFunctionListEntry js_body_proto_funcs[] = {
@@ -629,6 +755,25 @@ namespace js
       auto kv = JS_NewObjectClass(ctx, kv_class_id);
       JS_SetOpaque(kv, txctx);
       JS_SetPropertyStr(ctx, ccf, "kv", kv);
+
+      JS_SetPropertyStr(
+        ctx,
+        ccf,
+        "setJwtPublicSigningKeys",
+        JS_NewCFunction(
+          ctx,
+          js_gov_set_jwt_public_signing_keys,
+          "setJwtPublicSigningKeys",
+          3));
+      JS_SetPropertyStr(
+        ctx,
+        ccf,
+        "removeJwtPublicSigningKeys",
+        JS_NewCFunction(
+          ctx,
+          js_gov_remove_jwt_public_signing_keys,
+          "removeJwtPublicSigningKeys",
+          1));
     }
 
     // Historical queries

--- a/src/js/wrap.cpp
+++ b/src/js/wrap.cpp
@@ -483,7 +483,7 @@ namespace js
     }
     catch (std::exception& exc)
     {
-      return JS_ThrowInternalError(ctx, "Unexpected error: %s", exc.what());
+      return JS_ThrowInternalError(ctx, "Error: %s", exc.what());
     }
     return JS_UNDEFINED;
   }
@@ -531,7 +531,7 @@ namespace js
     }
     catch (std::exception& exc)
     {
-      return JS_ThrowInternalError(ctx, "Unexpected error: %s", exc.what());
+      return JS_ThrowInternalError(ctx, "Error: %s", exc.what());
     }
     return JS_UNDEFINED;
   }

--- a/src/node/jwt.h
+++ b/src/node/jwt.h
@@ -1,11 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 #pragma once
+#include "crypto/verifier.h"
 #include "ds/json.h"
 #include "entities.h"
+#include "proposals.h"
 #include "service_map.h"
 
+#include <openenclave/attestation/verifier.h>
 #include <optional>
+#include <set>
+#include <sstream>
+#if defined(INSIDE_ENCLAVE) && !defined(VIRTUAL_ENCLAVE)
+#  include <openenclave/enclave.h>
+#else
+#  include <openenclave/host_verify.h>
+#endif
 
 namespace ccf
 {
@@ -54,4 +64,209 @@ namespace ccf
   using JwtPublicSigningKeys = kv::RawCopySerialisedMap<JwtKeyId, Cert>;
   using JwtPublicSigningKeyIssuer =
     kv::RawCopySerialisedMap<JwtKeyId, JwtIssuer>;
+
+  struct JsonWebKey
+  {
+    std::vector<std::string> x5c;
+    std::string kid;
+    std::string kty;
+
+    bool operator==(const JsonWebKey& rhs) const
+    {
+      return x5c == rhs.x5c && kid == rhs.kid && kty == rhs.kty;
+    }
+  };
+  DECLARE_JSON_TYPE(JsonWebKey)
+  DECLARE_JSON_REQUIRED_FIELDS(JsonWebKey, x5c, kid, kty)
+
+  struct JsonWebKeySet
+  {
+    std::vector<JsonWebKey> keys;
+
+    bool operator!=(const JsonWebKeySet& rhs) const
+    {
+      return keys != rhs.keys;
+    }
+  };
+  DECLARE_JSON_TYPE(JsonWebKeySet)
+  DECLARE_JSON_REQUIRED_FIELDS(JsonWebKeySet, keys)
+
+// Unused in all sample apps, but used by node frontend
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+  static void remove_jwt_public_signing_keys(kv::Tx& tx, std::string issuer)
+  {
+    auto keys = tx.rw<JwtPublicSigningKeys>(Tables::JWT_PUBLIC_SIGNING_KEYS);
+    auto key_issuer =
+      tx.rw<JwtPublicSigningKeyIssuer>(Tables::JWT_PUBLIC_SIGNING_KEY_ISSUER);
+
+    key_issuer->foreach(
+      [&issuer, &keys, &key_issuer](const auto& k, const auto& v) {
+        if (v == issuer)
+        {
+          keys->remove(k);
+          key_issuer->remove(k);
+        }
+        return true;
+      });
+  }
+
+  static oe_result_t oe_verify_attestation_certificate_with_evidence_cb(
+    oe_claim_t* claims, size_t claims_length, void* arg)
+  {
+    auto claims_map = (std::map<std::string, std::vector<uint8_t>>*)arg;
+    for (size_t i = 0; i < claims_length; i++)
+    {
+      std::string claim_name(claims[i].name);
+      std::vector<uint8_t> claim_value(
+        claims[i].value, claims[i].value + claims[i].value_size);
+      claims_map->emplace(std::move(claim_name), std::move(claim_value));
+    }
+    return OE_OK;
+  }
+
+  static bool set_jwt_public_signing_keys(
+    kv::Tx& tx,
+    const ProposalId& proposal_id,
+    std::string issuer,
+    const JwtIssuerMetadata& issuer_metadata,
+    const JsonWebKeySet& jwks)
+  {
+    auto keys = tx.rw<JwtPublicSigningKeys>(Tables::JWT_PUBLIC_SIGNING_KEYS);
+    auto key_issuer =
+      tx.rw<JwtPublicSigningKeyIssuer>(Tables::JWT_PUBLIC_SIGNING_KEY_ISSUER);
+
+    auto log_prefix = proposal_id.empty() ?
+      "JWT key auto-refresh" :
+      fmt::format("Proposal {}", proposal_id);
+
+    // add keys
+    if (jwks.keys.empty())
+    {
+      LOG_FAIL_FMT("{}: JWKS has no keys", log_prefix, proposal_id);
+      return false;
+    }
+    std::map<std::string, std::vector<uint8_t>> new_keys;
+    for (auto& jwk : jwks.keys)
+    {
+      if (keys->has(jwk.kid) && key_issuer->get(jwk.kid).value() != issuer)
+      {
+        LOG_FAIL_FMT(
+          "{}: key id {} already added for different issuer",
+          log_prefix,
+          jwk.kid);
+        return false;
+      }
+      if (jwk.x5c.empty())
+      {
+        LOG_FAIL_FMT("{}: JWKS is invalid (empty x5c)", log_prefix);
+        return false;
+      }
+
+      auto& der_base64 = jwk.x5c[0];
+      ccf::Cert der;
+      try
+      {
+        der = tls::raw_from_b64(der_base64);
+      }
+      catch (const std::invalid_argument& e)
+      {
+        LOG_FAIL_FMT(
+          "{}: Could not parse x5c of key id {}: {}",
+          log_prefix,
+          jwk.kid,
+          e.what());
+        return false;
+      }
+
+      std::map<std::string, std::vector<uint8_t>> claims;
+      bool has_key_policy_sgx_claims = issuer_metadata.key_policy.has_value() &&
+        issuer_metadata.key_policy.value().sgx_claims.has_value() &&
+        !issuer_metadata.key_policy.value().sgx_claims.value().empty();
+      if (
+        issuer_metadata.key_filter == JwtIssuerKeyFilter::SGX ||
+        has_key_policy_sgx_claims)
+      {
+        oe_verifier_initialize();
+        oe_verify_attestation_certificate_with_evidence(
+          der.data(),
+          der.size(),
+          oe_verify_attestation_certificate_with_evidence_cb,
+          &claims);
+      }
+
+      if (
+        issuer_metadata.key_filter == JwtIssuerKeyFilter::SGX && claims.empty())
+      {
+        LOG_INFO_FMT(
+          "{}: Skipping JWT signing key with kid {} (not OE "
+          "attested)",
+          log_prefix,
+          jwk.kid);
+        continue;
+      }
+
+      if (has_key_policy_sgx_claims)
+      {
+        for (auto& [claim_name, expected_claim_val_hex] :
+             issuer_metadata.key_policy.value().sgx_claims.value())
+        {
+          if (claims.find(claim_name) == claims.end())
+          {
+            LOG_FAIL_FMT(
+              "{}: JWKS kid {} is missing the {} SGX claim",
+              log_prefix,
+              jwk.kid,
+              claim_name);
+            return false;
+          }
+          auto& actual_claim_val = claims[claim_name];
+          auto actual_claim_val_hex = ds::to_hex(actual_claim_val);
+          if (expected_claim_val_hex != actual_claim_val_hex)
+          {
+            LOG_FAIL_FMT(
+              "{}: JWKS kid {} has a mismatching {} SGX claim",
+              log_prefix,
+              jwk.kid,
+              claim_name);
+            return false;
+          }
+        }
+      }
+      else
+      {
+        try
+        {
+          crypto::check_is_cert(der);
+        }
+        catch (std::invalid_argument& exc)
+        {
+          LOG_FAIL_FMT(
+            "{}: JWKS kid {} has an invalid X.509 certificate: {}",
+            log_prefix,
+            jwk.kid,
+            exc.what());
+          return false;
+        }
+      }
+      LOG_INFO_FMT(
+        "{}: Storing JWT signing key with kid {}", log_prefix, jwk.kid);
+      new_keys.emplace(jwk.kid, der);
+    }
+    if (new_keys.empty())
+    {
+      LOG_FAIL_FMT("{}: no keys left after applying filter", log_prefix);
+      return false;
+    }
+
+    remove_jwt_public_signing_keys(tx, issuer);
+    for (auto& [kid, der] : new_keys)
+    {
+      keys->put(kid, der);
+      key_issuer->put(kid, issuer);
+    }
+
+    return true;
+  }
+#pragma clang diagnostic pop
 }

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -26,33 +26,11 @@
 #include <initializer_list>
 #include <map>
 #include <memory>
-#include <openenclave/attestation/verifier.h>
 #include <set>
 #include <sstream>
-#if defined(INSIDE_ENCLAVE) && !defined(VIRTUAL_ENCLAVE)
-#  include <openenclave/enclave.h>
-#else
-#  include <openenclave/host_verify.h>
-#endif
 
 namespace ccf
 {
-  constexpr auto INVALID_PROPOSAL_ID = "INVALID";
-
-  static oe_result_t oe_verify_attestation_certificate_with_evidence_cb(
-    oe_claim_t* claims, size_t claims_length, void* arg)
-  {
-    auto claims_map = (std::map<std::string, std::vector<uint8_t>>*)arg;
-    for (size_t i = 0; i < claims_length; i++)
-    {
-      std::string claim_name(claims[i].name);
-      std::vector<uint8_t> claim_value(
-        claims[i].value, claims[i].value + claims[i].value_size);
-      claims_map->emplace(std::move(claim_name), std::move(claim_value));
-    }
-    return OE_OK;
-  }
-
   class MemberTsr : public lua::TxScriptRunner
   {
     void setup_environment(
@@ -124,32 +102,6 @@ namespace ccf
   };
   DECLARE_JSON_TYPE(DeployJsApp)
   DECLARE_JSON_REQUIRED_FIELDS(DeployJsApp, bundle)
-
-  struct JsonWebKey
-  {
-    std::vector<std::string> x5c;
-    std::string kid;
-    std::string kty;
-
-    bool operator==(const JsonWebKey& rhs) const
-    {
-      return x5c == rhs.x5c && kid == rhs.kid && kty == rhs.kty;
-    }
-  };
-  DECLARE_JSON_TYPE(JsonWebKey)
-  DECLARE_JSON_REQUIRED_FIELDS(JsonWebKey, x5c, kid, kty)
-
-  struct JsonWebKeySet
-  {
-    std::vector<JsonWebKey> keys;
-
-    bool operator!=(const JsonWebKeySet& rhs) const
-    {
-      return keys != rhs.keys;
-    }
-  };
-  DECLARE_JSON_TYPE(JsonWebKeySet)
-  DECLARE_JSON_REQUIRED_FIELDS(JsonWebKeySet, keys)
 
   struct SetJwtIssuer : public ccf::JwtIssuerMetadata
   {
@@ -325,167 +277,6 @@ namespace ccf
     {
       auto tx_modules = tx.rw(network.modules);
       return tx_modules->remove(name);
-    }
-
-    void remove_jwt_keys(kv::Tx& tx, std::string issuer)
-    {
-      auto keys = tx.rw(this->network.jwt_public_signing_keys);
-      auto key_issuer = tx.rw(this->network.jwt_public_signing_key_issuer);
-
-      key_issuer->foreach(
-        [&issuer, &keys, &key_issuer](const auto& k, const auto& v) {
-          if (v == issuer)
-          {
-            keys->remove(k);
-            key_issuer->remove(k);
-          }
-          return true;
-        });
-    }
-
-    bool set_jwt_public_signing_keys(
-      kv::Tx& tx,
-      const ProposalId& proposal_id,
-      std::string issuer,
-      const JwtIssuerMetadata& issuer_metadata,
-      const JsonWebKeySet& jwks)
-    {
-      auto keys = tx.rw(this->network.jwt_public_signing_keys);
-      auto key_issuer = tx.rw(this->network.jwt_public_signing_key_issuer);
-
-      auto log_prefix = proposal_id == INVALID_PROPOSAL_ID ?
-        "JWT key auto-refresh" :
-        fmt::format("Proposal {}", proposal_id);
-
-      // add keys
-      if (jwks.keys.empty())
-      {
-        LOG_FAIL_FMT("{}: JWKS has no keys", log_prefix, proposal_id);
-        return false;
-      }
-      std::map<std::string, std::vector<uint8_t>> new_keys;
-      for (auto& jwk : jwks.keys)
-      {
-        if (keys->has(jwk.kid) && key_issuer->get(jwk.kid).value() != issuer)
-        {
-          LOG_FAIL_FMT(
-            "{}: key id {} already added for different issuer",
-            log_prefix,
-            jwk.kid);
-          return false;
-        }
-        if (jwk.x5c.empty())
-        {
-          LOG_FAIL_FMT("{}: JWKS is invalid (empty x5c)", log_prefix);
-          return false;
-        }
-
-        auto& der_base64 = jwk.x5c[0];
-        ccf::Cert der;
-        try
-        {
-          der = tls::raw_from_b64(der_base64);
-        }
-        catch (const std::invalid_argument& e)
-        {
-          LOG_FAIL_FMT(
-            "{}: Could not parse x5c of key id {}: {}",
-            log_prefix,
-            jwk.kid,
-            e.what());
-          return false;
-        }
-
-        std::map<std::string, std::vector<uint8_t>> claims;
-        bool has_key_policy_sgx_claims =
-          issuer_metadata.key_policy.has_value() &&
-          issuer_metadata.key_policy.value().sgx_claims.has_value() &&
-          !issuer_metadata.key_policy.value().sgx_claims.value().empty();
-        if (
-          issuer_metadata.key_filter == JwtIssuerKeyFilter::SGX ||
-          has_key_policy_sgx_claims)
-        {
-          oe_verifier_initialize();
-          oe_verify_attestation_certificate_with_evidence(
-            der.data(),
-            der.size(),
-            oe_verify_attestation_certificate_with_evidence_cb,
-            &claims);
-        }
-
-        if (
-          issuer_metadata.key_filter == JwtIssuerKeyFilter::SGX &&
-          claims.empty())
-        {
-          LOG_INFO_FMT(
-            "{}: Skipping JWT signing key with kid {} (not OE "
-            "attested)",
-            log_prefix,
-            jwk.kid);
-          continue;
-        }
-
-        if (has_key_policy_sgx_claims)
-        {
-          for (auto& [claim_name, expected_claim_val_hex] :
-               issuer_metadata.key_policy.value().sgx_claims.value())
-          {
-            if (claims.find(claim_name) == claims.end())
-            {
-              LOG_FAIL_FMT(
-                "{}: JWKS kid {} is missing the {} SGX claim",
-                log_prefix,
-                jwk.kid,
-                claim_name);
-              return false;
-            }
-            auto& actual_claim_val = claims[claim_name];
-            auto actual_claim_val_hex = ds::to_hex(actual_claim_val);
-            if (expected_claim_val_hex != actual_claim_val_hex)
-            {
-              LOG_FAIL_FMT(
-                "{}: JWKS kid {} has a mismatching {} SGX claim",
-                log_prefix,
-                jwk.kid,
-                claim_name);
-              return false;
-            }
-          }
-        }
-        else
-        {
-          try
-          {
-            crypto::check_is_cert(der);
-          }
-          catch (std::invalid_argument& exc)
-          {
-            LOG_FAIL_FMT(
-              "{}: JWKS kid {} has an invalid X.509 certificate: {}",
-              log_prefix,
-              jwk.kid,
-              exc.what());
-            return false;
-          }
-        }
-        LOG_INFO_FMT(
-          "{}: Storing JWT signing key with kid {}", log_prefix, jwk.kid);
-        new_keys.emplace(jwk.kid, der);
-      }
-      if (new_keys.empty())
-      {
-        LOG_FAIL_FMT("{}: no keys left after applying filter", log_prefix);
-        return false;
-      }
-
-      remove_jwt_keys(tx, issuer);
-      for (auto& [kid, der] : new_keys)
-      {
-        keys->put(kid, der);
-        key_issuer->put(kid, issuer);
-      }
-
-      return true;
     }
 
     void remove_endpoints(kv::Tx& tx)
@@ -770,22 +561,17 @@ namespace ccf
            return success;
          }},
         {"remove_jwt_issuer",
-         [this](
-           const ProposalId& proposal_id,
-           kv::Tx& tx,
-           const nlohmann::json& args) {
+         [this](const ProposalId&, kv::Tx& tx, const nlohmann::json& args) {
            const auto parsed = args.get<RemoveJwtIssuer>();
            const auto issuer = parsed.issuer;
            auto issuers = tx.rw(this->network.jwt_issuers);
 
            if (!issuers->remove(issuer))
            {
-             LOG_FAIL_FMT(
-               "Proposal {}: {} is not a valid issuer", proposal_id, issuer);
-             return false;
+             return true;
            }
 
-           remove_jwt_keys(tx, issuer);
+           remove_jwt_public_signing_keys(tx, issuer);
 
            return true;
          }},
@@ -2181,7 +1967,7 @@ namespace ccf
 
         if (!set_jwt_public_signing_keys(
               ctx.tx,
-              INVALID_PROPOSAL_ID,
+              "<auto-refresh>",
               parsed.issuer,
               issuer_metadata,
               parsed.jwks))

--- a/src/runtime_config/actions.js
+++ b/src/runtime_config/actions.js
@@ -5,6 +5,24 @@ class Action {
   }
 }
 
+function parseUrl(url) {
+  // From https://tools.ietf.org/html/rfc3986#appendix-B
+  const re = new RegExp(
+    "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
+  );
+  const groups = url.match(re);
+  if (!groups) {
+    throw new TypeError(`${url} is not a valid URL.`);
+  }
+  return {
+    scheme: groups[2],
+    authority: groups[4],
+    path: groups[5],
+    query: groups[7],
+    fragment: groups[9],
+  };
+}
+
 function checkType(value, type, field) {
   const optional = type.endsWith("?");
   if (optional) {
@@ -47,6 +65,25 @@ function checkLength(value, min, max, field) {
   }
   if (max !== null && value.length > max) {
     throw new Error(`${field} must be an array of maximum ${max} elements`);
+  }
+}
+
+function checkJwks(value, field) {
+  checkType(value, "object", field);
+  checkType(value.keys, "array", `${field}.keys`);
+  for (const [i, jwk] of value.keys.entries()) {
+    checkType(jwk.kid, "string", `${field}.keys[${i}].kid`);
+    checkType(jwk.kty, "string", `${field}.keys[${i}].kty`);
+    checkType(jwk.x5c, "array", `${field}.keys[${i}].x5c`);
+    checkLength(jwk.x5c, 1, null, `${field}.keys[${i}].x5c`);
+    for (const [j, b64der] of jwk.x5c.entries()) {
+      checkType(b64der, "string", `${field}.keys[${i}].x5c[${j}]`);
+      const pem =
+        "-----BEGIN CERTIFICATE-----\n" +
+        b64der +
+        "\n-----END CERTIFICATE-----";
+      checkX509CertChain(pem, `${field}.keys[${i}].x5c[${j}]`);
+    }
   }
 }
 
@@ -220,6 +257,149 @@ const actions = new Map([
         checkX509CertChain(args.pem, "pem");
       },
       function (args) {}
+    ),
+  ],
+  [
+    "set_ca_cert_bundle",
+    new Action(
+      function (args) {
+        checkType(args.name, "string", "name");
+        // rename function to ..CertBundle?
+        checkX509CertChain(args.cert_bundle, "cert_bundle");
+      },
+      function (args) {
+        const name = args.name;
+        const bundle = args.cert_bundle;
+        const nameBuf = ccf.strToBuf(name);
+        const bundleBuf = ccf.jsonCompatibleToBuf(bundle);
+        ccf.kv["public:ccf.gov.tls.ca_cert_bundles"].set(nameBuf, bundleBuf);
+      }
+    ),
+  ],
+  [
+    "remove_ca_cert_bundle",
+    new Action(
+      function (args) {
+        checkType(args, "string", "args");
+      },
+      function (args) {
+        const name = args;
+        const nameBuf = ccf.strToBuf(name);
+        ccf.kv["public:ccf.gov.tls.ca_cert_bundles"].delete(nameBuf);
+      }
+    ),
+  ],
+  [
+    "set_jwt_issuer",
+    new Action(
+      function (args) {
+        checkType(args.issuer, "string", "issuer");
+        checkType(args.auto_refresh, "boolean?", "auto_refresh");
+        checkType(args.ca_cert_bundle_name, "string?", "ca_cert_bundle_name");
+        checkEnum(args.key_filter, ["all", "sgx"], "key_filter");
+        checkType(args.key_policy, "object?", "key_policy");
+        if (args.key_policy) {
+          checkType(
+            args.key_policy.sgx_claims,
+            "object?",
+            "key_policy.sgx_claims"
+          );
+          if (args.key_policy.sgx_claims) {
+            for (const [name, value] of Object.entries(
+              args.key_policy.sgx_claims
+            )) {
+              checkType(value, "string", `key_policy.sgx_claims["${name}"]`);
+            }
+          }
+        }
+        checkType(args.jwks, "object?", "jwks");
+        if (args.jwks) {
+          checkJwks(args.jwks, "jwks");
+        }
+        if (args.auto_refresh) {
+          if (!args.ca_cert_bundle_name) {
+            throw new Error(
+              "ca_cert_bundle_name is missing but required if auto_refresh is true"
+            );
+          }
+          let url;
+          try {
+            url = parseUrl(args.issuer);
+          } catch (e) {
+            throw new Error("issuer must be a URL if auto_refresh is true");
+          }
+          if (url.scheme != "https") {
+            throw new Error(
+              "issuer must be a URL starting with https:// if auto_refresh is true"
+            );
+          }
+          if (url.query || url.fragment) {
+            throw new Error(
+              "issuer must be a URL without query/fragment if auto_refresh is true"
+            );
+          }
+        }
+      },
+      function (args) {
+        if (args.auto_refresh) {
+          const caCertBundleName = args.ca_cert_bundle_name;
+          const caCertBundleNameBuf = ccf.strToBuf(args.ca_cert_bundle_name);
+          if (
+            !ccf.kv["public:ccf.gov.tls.ca_cert_bundles"].has(
+              caCertBundleNameBuf
+            )
+          ) {
+            throw new Error(
+              `No CA cert bundle found with name '${caCertBundleName}'`
+            );
+          }
+        }
+        const issuer = args.issuer;
+        const jwks = args.jwks;
+        delete args.jwks;
+        const metadata = args;
+        if (jwks) {
+          ccf.setJwtPublicSigningKeys(issuer, metadata, jwks);
+        }
+        const issuerBuf = ccf.strToBuf(issuer);
+        const metadataBuf = ccf.jsonCompatibleToBuf(metadata);
+        ccf.kv["public:ccf.gov.jwt.issuers"].set(issuerBuf, metadataBuf);
+      }
+    ),
+  ],
+  [
+    "set_jwt_public_signing_keys",
+    new Action(
+      function (args) {
+        checkType(args.issuer, "string", "issuer");
+        checkJwks(args.jwks, "jwks");
+      },
+      function (args) {
+        const issuer = args.issuer;
+        const issuerBuf = ccf.strToBuf(issuer);
+        const metadataBuf = ccf.kv["public:ccf.gov.jwt.issuers"].get(issuerBuf);
+        if (metadataBuf === undefined) {
+          throw new Error(`issuer ${issuer} not found`);
+        }
+        const metadata = ccf.bufToJsonCompatible(metadataBuf);
+        const jwks = args.jwks;
+        ccf.setJwtPublicSigningKeys(issuer, metadata, jwks);
+      }
+    ),
+  ],
+  [
+    "remove_jwt_issuer",
+    new Action(
+      function (args) {
+        checkType(args.issuer, "string", "issuer");
+      },
+      function (args) {
+        const issuerBuf = ccf.strToBuf(args.issuer);
+        if (!ccf.kv["public:ccf.gov.jwt.issuers"].delete(issuerBuf)) {
+          return;
+        }
+        ccf.removeJwtPublicSigningKeys(args.issuer);
+      }
     ),
   ],
 ]);

--- a/tests/jwt_test.py
+++ b/tests/jwt_test.py
@@ -68,7 +68,7 @@ def test_jwt_without_key_policy(network, args):
             network.consortium.set_jwt_public_signing_keys(
                 primary, issuer, jwks_fp.name
             )
-        except infra.proposal.ProposalNotAccepted:
+        except (infra.proposal.ProposalNotAccepted, infra.proposal.ProposalNotCreated):
             pass
         else:
             assert False, "Proposal should not have been created"


### PR DESCRIPTION
Note that I didn't move over the code of `set_jwt_public_signing_keys` / `remove_jwt_public_signing_keys` since those are still used in C++ for JWT auto-refresh and I didn't want to duplicate the code. Apart from that, `set_jwt_public_signing_keys` is quite complex, involving OE and cert parsing etc.