### PR TITLE
Fix N2N channel destruction/recreation and logging

### DIFF
--- a/src/host/node_connections.h
+++ b/src/host/node_connections.h
@@ -318,7 +318,7 @@ namespace asynchost
       decltype(reconnect_queue) local_queue;
       std::swap(reconnect_queue, local_queue);
 
-      for (const auto node : local_queue)
+      for (const auto& node : local_queue)
       {
         LOG_DEBUG_FMT("reconnecting node {}", node);
         auto s = outgoing.find(node);

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -787,7 +787,7 @@ namespace ccf
       if (status != ESTABLISHED)
       {
         LOG_INFO_FMT(
-          "Node channel with {} cannot receive authenticated message: not yet "
+          "Node channel with {} cannot receive authenticated message: not "
           "established, status={}",
           peer_id,
           status);
@@ -814,7 +814,7 @@ namespace ccf
       {
         LOG_INFO_FMT(
           "node channel with {} cannot receive authenticated with payload "
-          "message: not yet established, status={}",
+          "message: not established, status={}",
           peer_id,
           status);
         return false;
@@ -843,7 +843,7 @@ namespace ccf
       if (status != ESTABLISHED)
       {
         LOG_INFO_FMT(
-          "Node channel with {} cannot receive encrypted message: not yet "
+          "Node channel with {} cannot receive encrypted message: not "
           "established",
           peer_id);
         return std::nullopt;

--- a/src/node/node_to_node.h
+++ b/src/node/node_to_node.h
@@ -56,8 +56,7 @@ namespace ccf
 
       if (!recv_authenticated(from, asCb(t), data, size))
       {
-        throw std::logic_error(fmt::format(
-          "Invalid authenticated node2node message from node {}", from));
+        LOG_INFO_FMT("Dropping invalid authenticated message from {}", from);
       }
 
       return t;
@@ -74,9 +73,8 @@ namespace ccf
 
       if (!recv_authenticated_with_load(from, data, size))
       {
-        throw std::logic_error(fmt::format(
-          "Invalid authenticated node2node message with load from node {}",
-          from));
+        LOG_INFO_FMT(
+          "Dropping invalid authenticated message with load from {}", from);
       }
       serialized::skip(data, size, sizeof(T));
 
@@ -253,8 +251,7 @@ namespace ccf
       auto plain = n2n_channel->recv_encrypted(cb, data, size);
       if (!plain.has_value())
       {
-        throw std::logic_error(fmt::format(
-          "Invalid encrypted node2node message from node {}", from));
+        LOG_INFO_FMT("Dropping invalid encrypted message from {}", from);
       }
 
       return plain.value();

--- a/src/node/node_to_node.h
+++ b/src/node/node_to_node.h
@@ -229,6 +229,7 @@ namespace ccf
       const std::vector<uint8_t>& data) override
     {
       auto n2n_channel = channels->get(to);
+      assert(n2n_channel);
       return n2n_channel ? n2n_channel->send(type, cb, data) : true;
     }
 


### PR DESCRIPTION
Fixes at least one more part of #2378. Attempting to send on a channel that has previously been closed is now allowed and triggers a new key exchange.

Also, less `[fail]` logging.