### PR TITLE
Add 0.99.0 release notes and docs on upgrading from Lua to JS governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.19.4]
+## [0.99.0]
+
+This is a bridging release to simplify the upgrade to 1.0. It includes the new JS constitution, but also supports the existing Lua governance so that users can upgrade in 2 steps - first implementing all of the changes below with their existing Lua governance, then upgrading to the JS governance. Lua governance will be removed in CCF 1.0. See [temporary docs](https://microsoft.github.io/CCF/ccf-0.99.0/governance/js_gov.html) for help with transitioning from Lua to JS.
+
+The 1.0 release will require minimal changes from this release.
 
 ### Added
 

--- a/doc/governance/index.rst
+++ b/doc/governance/index.rst
@@ -1,6 +1,11 @@
 Governance
 ==========
 
+.. warning::
+    These pages describes the deprecated Lua constitution.
+    These docs will be replaced shortly to describe the new JS constitution.
+    See :doc:`/governance/js_gov` for pointers on converting from Lua to JS.
+
 This section describes how a consortium of trusted :term:`Members` governs an existing CCF network. It explains how members can submit proposals to CCF and how these proposals are accepted based on the rules defined in the :term:`Constitution`.
 
 Before creating a new CCF network, the identity of the initial member(s) of the consortium must be generated. See :ref:`governance/adding_member:Generating Member Keys and Certificates`.

--- a/doc/governance/js_gov.rst
+++ b/doc/governance/js_gov.rst
@@ -63,3 +63,5 @@ See `this Discussion <https://github.com/microsoft/CCF/discussions/2169#discussi
     }
 
 If you have custom tooling to generate proposals or votes, please use ``proposal_generator`` as a guide to the format these should now have. Note that if you have a custom constitution, then the format of the proposals themselves is also under your control.
+
+Finally, these proposals and votes should be submitted to URL paths under ``/gov/proposals.js`` rather than ``/gov/proposals``.

--- a/doc/governance/js_gov.rst
+++ b/doc/governance/js_gov.rst
@@ -1,0 +1,65 @@
+JavaScript Governance
+=====================
+
+Constitution
+------------
+
+The constitution for a CCF service is implemented as a set of JS scripts. These scripts can be submitted at network startup as ``--constitution`` args to ``cchost``, or updated by a governance proposal. They will be concatenated into a single entry in the ``public:ccf.gov.constitution`` table, and should export 3 named functions:
+
+    - ``validate``: This takes the raw body of a proposal, and should check that this proposal is correctly formed. For instance it may parse the body as JSON, extract the list of proposed actions, and confirm that each action is known and has parameters matching the expected schema. This should not interact with the KV, and should operate purely on the given proposal.
+    - ``resolve``: This takes a proposal and the votes (the results of ballot scripts) which have been submitted against it, and determines whether the proposal should be enacted. In the simple case this might simply look accept proposals after a majority of members have voted in favour, but it could also examine member data to give each member a different role or weight, or have different thresholds for each action. This has read-only access to the KV.
+    - ``apply``: This takes a proposal which has been accepted by ``resolve``, and should make the proposed changes to the service's state. For instance if the proposal added a new user, this should extract their cert and data from the proposal and write them to the appropriate KV tables. This has full read-write access to the KV.
+
+Sample constitutions are available in the `src/runtime_config directory <https://github.com/microsoft/CCF/tree/main/src/runtime_config>`_, for instance the default implementation of ``apply`` which parses a JSON object from the proposal body, and then delegates the application of each action within the proposal to a named entry from ``actions.js``:
+
+.. literalinclude:: ../../src/runtime_config/default/apply.js
+    :language: js
+
+There are also more involved examples such as ``veto/resolve.js``, which accepts proposals when a majority of members vote in favour but also allows any single member to veto the proposal, marking it ``Rejected`` with a single vote against:
+
+.. literalinclude:: ../../src/runtime_config/veto/resolve.js
+    :language: js
+
+Upgrading from Lua to JS
+------------------------
+
+The ``0.99.0`` release of CCF supports both Lua and JS governance so that you can upgrade to this release with your existing Lua governance tooling, and then separately migrate to the JS governance, in preparation for the ``1.0`` release where Lua governance will be removed. To migrate, you will need to replace your constitution, your proposals, and your votes.
+
+Upgrading constitution
+~~~~~~~~~~~~~~~~~~~~~~
+
+If you were using a Lua constitution provided by CCF, then you can replace this with an equivalent JS constitution which we have also provided. All of these use the same list of proposable actions from ``default/actions.js``, which is called from ``default/validate.js`` and ``default/apply.js``, but may have a custom ``resolve.js``. For instance if you were previously passing ``--gov-script <path/to/>gov_veto.lua``, you should now pass ``--constitution <path/to/>default/actions.js --constitution <path/to/>default/validate.js --constitution <path/to/>default/apply.js --constitution <path/to/>veto/resolve.js``. If you were using ``operator_gov.lua``, the resolve arg should instead be ``--constitution <path/to/>operator/resolve.js``. The sandbox also has a trivial ``resolve`` implementation which accepts all proposals in the same way as ``sanbox_gov.lua``, and this is the version which will be installed in the CCF ``bin`` directory and used by ``sandbox.sh``.
+
+If you have adapted these constitutions to write your own, you will need to port those adaptations to JS. The default constitutions should provide an example of how to do this. Please raise an issue on GitHub if you experience any problems.
+
+Upgrading proposals and votes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+While the functionality of the proposals remains similar, the name and body schema of many proposals has been modified. Additionally the semantics may be slightly different, as the new default proposal actions aim to be idempotent, so will be executed successfully in some situations where they would previously have thrown (eg - adding a user who already exists). Similarly the format of the vote body has changed, now expecting a JS script exporting a ``vote`` function.
+
+See `this Discussion <https://github.com/microsoft/CCF/discussions/2169#discussioncomment-373490>`_ for the mapping between proposal names in Lua and JS. The ``ccf.proposal_generator`` Python utility can be used to generate proposals by using the env var ``JS_GOVERNANCE``. For instance:
+
+.. code-block:: bash
+
+    $ JS_GOVERNANCE=1 python -m ccf.proposal_generator --pretty-print set_user bob_cert.pem 
+    [2021-04-06 11:10:00.194] SUCCESS | Writing proposal to ./set_user_proposal.json
+    [2021-04-06 11:10:00.194] SUCCESS | Wrote vote to ./set_user_vote_for.json
+
+    $ cat ./set_user_proposal.json 
+    {
+        "actions": [
+            {
+                "name": "set_user",
+                "args": {
+                    "cert": "-----BEGIN CERTIFICATE-----\nMIIBrjCCATSgAwIBAgIUGCKB69cgr9N+EEMFvrVu6cInLvgwCgYIKoZIzj0EAwMw\nDjEMMAoGA1UEAwwDYm9iMB4XDTIxMDQwNjEwMDc0OFoXDTIyMDQwNjEwMDc0OFow\nDjEMMAoGA1UEAwwDYm9iMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEAdgT5JJTVd0x\nyxphNeF8nccwu+Ro1lAEsKEdxzZhD461kv/ecOiqGtHnqlahiHxdQoiAhSfErjpx\n4bCQTCQeZkjZ/7FvOkS9St4uIwUf+/0CU0YxtVLGlSLRep0Sr5nZo1MwUTAdBgNV\nHQ4EFgQUOTRHQS8XOiS0Tf8yh6reB++Fzc8wHwYDVR0jBBgwFoAUOTRHQS8XOiS0\nTf8yh6reB++Fzc8wDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAwNoADBlAjBt\nkHZNFMtWT/79or93gasIuuKItFFjwyMYCMyDq2xUQyX2GtLhVfiVt0Te6hNeVE0C\nMQC7paiA2jrZjJ6qaFbDsJvrY7y9YioIrXA5txGgEEYhlPRDA2+5/5hG+bHLeQbi\noIU=\n-----END CERTIFICATE-----\n"
+                }
+            }
+        ]
+    }
+
+    $ cat ./set_user_vote_for.json 
+    {
+        "ballot": "export function vote (raw_proposal, proposer_id) {\n  let proposal = JSON.parse(raw_proposal);\n  if (!('actions' in proposal)) { return false; };\n  let actions = proposal['actions'];\n  if (actions.length !== 1) { return false; };\n  let action = actions[0];\n  if (!('name' in action)) { return false; };\n  if (action.name !== 'set_user') { return false; };\n  if (!('args' in action)) { return false; };\n  let args = action.args;\n  {\n    if (!('cert' in args)) { return false; };\n    let expected = \"-----BEGIN CERTIFICATE-----\\nMIIBrjCCATSgAwIBAgIUGCKB69cgr9N+EEMFvrVu6cInLvgwCgYIKoZIzj0EAwMw\\nDjEMMAoGA1UEAwwDYm9iMB4XDTIxMDQwNjEwMDc0OFoXDTIyMDQwNjEwMDc0OFow\\nDjEMMAoGA1UEAwwDYm9iMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEAdgT5JJTVd0x\\nyxphNeF8nccwu+Ro1lAEsKEdxzZhD461kv/ecOiqGtHnqlahiHxdQoiAhSfErjpx\\n4bCQTCQeZkjZ/7FvOkS9St4uIwUf+/0CU0YxtVLGlSLRep0Sr5nZo1MwUTAdBgNV\\nHQ4EFgQUOTRHQS8XOiS0Tf8yh6reB++Fzc8wHwYDVR0jBBgwFoAUOTRHQS8XOiS0\\nTf8yh6reB++Fzc8wDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAwNoADBlAjBt\\nkHZNFMtWT/79or93gasIuuKItFFjwyMYCMyDq2xUQyX2GtLhVfiVt0Te6hNeVE0C\\nMQC7paiA2jrZjJ6qaFbDsJvrY7y9YioIrXA5txGgEEYhlPRDA2+5/5hG+bHLeQbi\\noIU=\\n-----END CERTIFICATE-----\\n\";\n    if (JSON.stringify(args['cert']) !== JSON.stringify(expected)) { return false; };\n  }\n  return true;\n}"
+    }
+
+If you have custom tooling to generate proposals or votes, please use ``proposal_generator`` as a guide to the format these should now have. Note that if you have a custom constitution, then the format of the proposals themselves is also under your control.

--- a/doc/governance/js_gov.rst
+++ b/doc/governance/js_gov.rst
@@ -6,16 +6,16 @@ Constitution
 
 The constitution for a CCF service is implemented as a set of JS scripts. These scripts can be submitted at network startup as ``--constitution`` args to ``cchost``, or updated by a governance proposal. They will be concatenated into a single entry in the ``public:ccf.gov.constitution`` table, and should export 3 named functions:
 
-    - ``validate``: This takes the raw body of a proposal, and should check that this proposal is correctly formed. For instance it may parse the body as JSON, extract the list of proposed actions, and confirm that each action is known and has parameters matching the expected schema. This should not interact with the KV, and should operate purely on the given proposal.
-    - ``resolve``: This takes a proposal and the votes (the results of ballot scripts) which have been submitted against it, and determines whether the proposal should be enacted. In the simple case this might simply look accept proposals after a majority of members have voted in favour, but it could also examine member data to give each member a different role or weight, or have different thresholds for each action. This has read-only access to the KV.
-    - ``apply``: This takes a proposal which has been accepted by ``resolve``, and should make the proposed changes to the service's state. For instance if the proposal added a new user, this should extract their cert and data from the proposal and write them to the appropriate KV tables. This has full read-write access to the KV.
+    - ``validate``: This takes the raw body of a proposal and checks that this proposal is correctly formed. For instance it may parse the body as JSON, extract the list of proposed actions, and confirm that each action is known and has parameters matching the expected schema. This should not interact with the KV, and should operate purely on the given proposal.
+    - ``resolve``: This takes a proposal and the votes (the results of ballot scripts) which have been submitted against it, and determines whether the proposal should be accepted or rejected. In the simple case this might simply accept proposals after a majority of members have voted in favour. It could also examine member data to give each member a different role or weight, or have different thresholds for each action. This has read-only access to the KV.
+    - ``apply``: This takes a proposal which has been accepted by ``resolve``, and should make the proposed changes to the service's state. For instance if the proposal added a new user this should extract their cert and data from the proposal and write them to the appropriate KV tables. This has full read-write access to the KV.
 
 Sample constitutions are available in the `src/runtime_config directory <https://github.com/microsoft/CCF/tree/main/src/runtime_config>`_, for instance the default implementation of ``apply`` which parses a JSON object from the proposal body, and then delegates the application of each action within the proposal to a named entry from ``actions.js``:
 
 .. literalinclude:: ../../src/runtime_config/default/apply.js
     :language: js
 
-There are also more involved examples such as ``veto/resolve.js``, which accepts proposals when a majority of members vote in favour but also allows any single member to veto the proposal, marking it ``Rejected`` with a single vote against:
+There are also more involved examples such as ``veto/resolve.js``. This accepts proposals when a majority of members vote in favour, but also allows any single member to veto the proposal, marking it ``Rejected`` after a single vote against:
 
 .. literalinclude:: ../../src/runtime_config/veto/resolve.js
     :language: js
@@ -23,19 +23,19 @@ There are also more involved examples such as ``veto/resolve.js``, which accepts
 Upgrading from Lua to JS
 ------------------------
 
-The ``0.99.0`` release of CCF supports both Lua and JS governance so that you can upgrade to this release with your existing Lua governance tooling, and then separately migrate to the JS governance, in preparation for the ``1.0`` release where Lua governance will be removed. To migrate, you will need to replace your constitution, your proposals, and your votes.
+The ``0.99.0`` release of CCF supports both Lua and JS governance. You should be able to upgrade to this release with your existing Lua governance tooling, then separately migrate to the JS governance, in preparation for the ``1.0`` release where Lua governance will be removed. To migrate, you will need to upgrade your constitution, your proposals, and your votes.
 
 Upgrading constitution
 ~~~~~~~~~~~~~~~~~~~~~~
 
-If you were using a Lua constitution provided by CCF, then you can replace this with an equivalent JS constitution which we have also provided. All of these use the same list of proposable actions from ``default/actions.js``, which is called from ``default/validate.js`` and ``default/apply.js``, but may have a custom ``resolve.js``. For instance if you were previously passing ``--gov-script <path/to/>gov_veto.lua``, you should now pass ``--constitution <path/to/>default/actions.js --constitution <path/to/>default/validate.js --constitution <path/to/>default/apply.js --constitution <path/to/>veto/resolve.js``. If you were using ``operator_gov.lua``, the resolve arg should instead be ``--constitution <path/to/>operator/resolve.js``. The sandbox also has a trivial ``resolve`` implementation which accepts all proposals in the same way as ``sanbox_gov.lua``, and this is the version which will be installed in the CCF ``bin`` directory and used by ``sandbox.sh``.
+If you were using a Lua constitution provided by CCF then you can you can find an equivalent JS constitution in the CCF repo. All of these use the same list of proposable actions from ``default/actions.js``, and the same simple implementations of ``default/validate.js`` and ``default/apply.js``, but may have a custom ``resolve.js``. For instance if you were previously passing ``--gov-script <path/to/>gov_veto.lua`` you should now pass ``--constitution <path/to/>default/actions.js --constitution <path/to/>default/validate.js --constitution <path/to/>default/apply.js --constitution <path/to/>veto/resolve.js``. If you were using ``operator_gov.lua`` the resolve arg should instead be ``--constitution <path/to/>operator/resolve.js``. The sandbox also has a trivial ``resolve`` implementation which accepts all proposals in the same way as ``sanbox_gov.lua``. This is the version which will be installed in the CCF ``bin`` directory and used by ``sandbox.sh``.
 
 If you have adapted these constitutions to write your own, you will need to port those adaptations to JS. The default constitutions should provide an example of how to do this. Please raise an issue on GitHub if you experience any problems.
 
 Upgrading proposals and votes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-While the functionality of the proposals remains similar, the name and body schema of many proposals has been modified. Additionally the semantics may be slightly different, as the new default proposal actions aim to be idempotent, so will be executed successfully in some situations where they would previously have thrown (eg - adding a user who already exists). Similarly the format of the vote body has changed, now expecting a JS script exporting a ``vote`` function.
+While the functionality of the proposals remains similar, the name and body schema of many proposals has been modified. Additionally the semantics may be slightly different as the new default proposal actions aim to be idempotent, so will execute successfully in some situations where they would previously have thrown (eg - adding a user who already exists). Similarly the format of the vote body has changed as it now expects a JS script exporting a ``vote`` function.
 
 See `this Discussion <https://github.com/microsoft/CCF/discussions/2169#discussioncomment-373490>`_ for the mapping between proposal names in Lua and JS. The ``ccf.proposal_generator`` Python utility can be used to generate proposals by using the env var ``JS_GOVERNANCE``. For instance:
 

--- a/doc/governance/proposals.rst
+++ b/doc/governance/proposals.rst
@@ -1,6 +1,11 @@
 Proposing and Voting for a Proposal
 ===================================
 
+.. warning::
+    This page describes the deprecated Lua constitution.
+    These docs will be replaced shortly to describe the new JS constitution.
+    See :doc:`/governance/js_gov` for pointers on converting from Lua to JS.
+
 This page explains how members can submit and vote for proposals.
 
 Proposals and vote ballots are submitted as Lua scripts. These scripts are executed transactionally, able to read from the current KV state but not write directly to it. Proposals return a list of proposed actions which can make writes, but are only applied when the proposal is accepted. Each vote script is given this list of proposed actions, and also able to read from the KV, and returns a Boolean indicating whether it supports or rejects the proposed actions.

--- a/doc/overview/constitution.rst
+++ b/doc/overview/constitution.rst
@@ -1,6 +1,11 @@
 Constitution
 ============
 
+.. warning::
+    This page describes the deprecated Lua constitution.
+    These docs will be replaced shortly to describe the new JS constitution.
+    See :doc:`/governance/js_gov` for pointers on converting from Lua to JS.
+
 The :term:`Constitution` defines the set of rules and conditions (as a Lua script) that members must follow for their proposals to be accepted. For example, in a CCF network governed by `4` members, a strict majority constitution would only execute proposals once `3` members (`4/2 + 1`) have voted for that proposal.
 
 Votes for the proposal are evaluated by the constitution's ``pass`` function. If the `pass` function returns ``true``, the vote is passed, and its consequences are applied to the KV in a transaction.

--- a/tests/sandbox/sandbox.sh
+++ b/tests/sandbox/sandbox.sh
@@ -10,8 +10,6 @@ PATH_HERE=$(dirname "$(realpath -s "$0")")
 VERSION_FILE="${PATH_HERE}"/../share/VERSION
 GOV_SCRIPT="${PATH_HERE}"/sandbox_gov.lua
 
-export JS_GOVERNANCE=1
-
 is_package_specified=false
 is_js_bundle_specified=false
 


### PR DESCRIPTION
Not a complete docs rewrite. Instead a warning on the most deprecated pages, with a link to a transitionary doc describing the basics of the JS constitution and how to migrate from Lua to JS.