### PR TITLE
Fix for Release pipeline

### DIFF
--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -27,7 +27,7 @@ parameters:
     perf:
       cmake_args: '-DBUILD_UNIT_TESTS=OFF -DDISTRIBUTE_PERF_TESTS="`../.nodes.sh`"'
     release:
-      cmake_args: "-DTLS_TEST=ON -DENABLE_BFT=OFF -DENABLE_JS_GOV=OFF"
+      cmake_args: "-DTLS_TEST=ON -DENABLE_BFT=OFF"
 
   test:
     NoSGX:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -787,7 +787,7 @@ Some discrepancies with the TR remain, and are being tracked under https://githu
 
 Initial pre-release
 
-[0.19.4]: https://github.com/microsoft/CCF/releases/tag/ccf-0.19.4
+[0.99.0]: https://github.com/microsoft/CCF/releases/tag/ccf-0.99.0
 [0.19.3]: https://github.com/microsoft/CCF/releases/tag/ccf-0.19.3
 [0.19.2]: https://github.com/microsoft/CCF/releases/tag/ccf-0.19.2
 [0.19.1]: https://github.com/microsoft/CCF/releases/tag/ccf-0.19.1


### PR DESCRIPTION
Now that JS governance is the default for the tests, it shouldn't be disabled at compile time in Release builds.