### PR TITLE
Join shouldn't be allowed from stale snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0]
+
+### Added
+
+- `/node/state` endpoint also returns the `seqno` at which a node was started (i.e. `seqno` of the snapshot a node started from or `0` otherwise) (#2422).
+
 ## [0.99.0]
 
 This is a bridging release to simplify the upgrade to 1.0. It includes the new JS constitution, but also supports the existing Lua governance so that users can upgrade in 2 steps - first implementing all of the changes below with their existing Lua governance, then upgrading to the JS governance. Lua governance will be removed in CCF 1.0. See [temporary docs](https://microsoft.github.io/CCF/ccf-0.99.0/governance/js_gov.html) for help with transitioning from Lua to JS.

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -199,6 +199,9 @@
           "recovery_target_seqno": {
             "$ref": "#/components/schemas/uint64"
           },
+          "startup_seqno": {
+            "$ref": "#/components/schemas/uint64"
+          },
           "state": {
             "$ref": "#/components/schemas/ccf__State"
           }
@@ -206,7 +209,8 @@
         "required": [
           "node_id",
           "state",
-          "last_signed_seqno"
+          "last_signed_seqno",
+          "startup_seqno"
         ],
         "type": "object"
       },

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -767,9 +767,10 @@ int main(int argc, char** argv)
             snapshot));
         }
 
-        ccf_config.startup_snapshot = files::slurp(snapshot);
+        ccf_config.startup_snapshot = snapshots.read_snapshot(snapshot);
         ccf_config.startup_snapshot_evidence_seqno =
           snapshot_evidence_idx->first;
+
         LOG_INFO_FMT(
           "Found latest snapshot file: {} (size: {}, evidence seqno: {})",
           snapshot,

--- a/src/host/snapshot.h
+++ b/src/host/snapshot.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "consensus/ledger_enclave_types.h"
+#include "ds/files.h"
 #include "host/ledger.h"
 
 #include <charconv>

--- a/src/host/snapshot.h
+++ b/src/host/snapshot.h
@@ -123,6 +123,11 @@ namespace asynchost
       }
     }
 
+    std::vector<uint8_t> read_snapshot(const std::string& file_name)
+    {
+      return files::slurp(fs::path(snapshot_dir) / fs::path(file_name));
+    }
+
     void write_snapshot(
       consensus::Index idx,
       consensus::Index evidence_idx,
@@ -235,7 +240,7 @@ namespace asynchost
         size_t snapshot_idx = std::stol(file_name.substr(pos + 1));
         if (snapshot_idx > latest_idx)
         {
-          snapshot_file = f.path().string();
+          snapshot_file = file_name;
           latest_idx = snapshot_idx;
         }
       }

--- a/src/host/test/ledger.cpp
+++ b/src/host/test/ledger.cpp
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include "ds/serialized.h"
 #include "host/ledger.h"
+
+#include "ds/serialized.h"
 #include "host/snapshot.h"
 
 #include <doctest/doctest.h>

--- a/src/host/test/ledger.cpp
+++ b/src/host/test/ledger.cpp
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include "host/ledger.h"
-
 #include "ds/serialized.h"
+#include "host/ledger.h"
 #include "host/snapshot.h"
 
 #include <doctest/doctest.h>
@@ -1061,7 +1060,11 @@ TEST_CASE("Find latest snapshot with corresponding ledger chunk")
       snapshot_idx, snapshot_evidence_idx, snapshot_evidence_commit_idx);
 
     REQUIRE(
-      snapshots.find_latest_committed_snapshot().value() == snapshot_file_name);
+      fmt::format(
+        "{}/{}",
+        snapshot_dir,
+        snapshots.find_latest_committed_snapshot().value()) ==
+      snapshot_file_name);
 
     fs::remove(snapshot_file_name);
   }
@@ -1091,7 +1094,10 @@ TEST_CASE("Find latest snapshot with corresponding ledger chunk")
 
     // Snapshot is now valid
     REQUIRE(
-      snapshots.find_latest_committed_snapshot().value() ==
+      fmt::format(
+        "{}/{}",
+        snapshot_dir,
+        snapshots.find_latest_committed_snapshot().value()) ==
       get_snapshot_file_name(
         snapshot_idx, snapshot_evidence_idx, snapshot_evidence_commit_idx));
   }

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -902,10 +902,12 @@ namespace ccf
       if (!startup_snapshot_info->is_snapshot_verified())
       {
         // Node should shutdown if the startup snapshot cannot be verified
-        throw std::logic_error(fmt::format(
-          "Snapshot evidence at {} was not committed in ledger ending at {}",
+        LOG_FAIL_FMT(
+          "Snapshot evidence at {} was not committed in ledger ending at {}. "
+          "Node should be shutdown by operator.",
           startup_snapshot_info->evidence_seqno,
-          ledger_idx));
+          ledger_idx);
+        return;
       }
 
       ledger_truncate(startup_snapshot_info->seqno);

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1488,7 +1488,7 @@ namespace ccf
       return self;
     }
 
-    std::optional<kv::Version> get_startup_seqno() override
+    std::optional<kv::Version> get_startup_snapshot_seqno() override
     {
       std::lock_guard<SpinLock> guard(lock);
       return startup_seqno;

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -751,12 +751,12 @@ namespace ccf
         !sm.check(State::verifyingSnapshot))
       {
         throw std::logic_error(fmt::format(
-          "Node should be in state {} or {} to recover public ledger entry",
+          "Node should be in state {} or {} to start reading ledger",
           State::readingPublicLedger,
           State::verifyingSnapshot));
       }
 
-      LOG_INFO_FMT("Starting public recovery");
+      LOG_INFO_FMT("Starting to read public ledger");
       read_ledger_idx(++ledger_idx);
     }
 
@@ -861,13 +861,25 @@ namespace ccf
         auto tx = store->create_read_only_tx();
         auto snapshot_evidence = tx.ro(network.snapshot_evidence);
 
+        LOG_FAIL_FMT("Read snapshot evidence");
+        LOG_FAIL_FMT("ledger idx: {}", ledger_idx);
+        LOG_FAIL_FMT(
+          "evidence seqno: {}", startup_snapshot_info->evidence_seqno);
+
         if (ledger_idx == startup_snapshot_info->evidence_seqno)
         {
+          LOG_FAIL_FMT("here");
           auto evidence = snapshot_evidence->get(0);
           if (!evidence.has_value())
           {
             throw std::logic_error("Invalid snapshot evidence");
           }
+
+          LOG_FAIL_FMT(
+            "there: {} vs {} [{}]",
+            evidence->hash,
+            crypto::Sha256Hash(startup_snapshot_info->raw),
+            startup_snapshot_info->raw.size());
 
           if (evidence->hash == crypto::Sha256Hash(startup_snapshot_info->raw))
           {

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -861,11 +861,6 @@ namespace ccf
         auto tx = store->create_read_only_tx();
         auto snapshot_evidence = tx.ro(network.snapshot_evidence);
 
-        LOG_FAIL_FMT("Read snapshot evidence");
-        LOG_FAIL_FMT("ledger idx: {}", ledger_idx);
-        LOG_FAIL_FMT(
-          "evidence seqno: {}", startup_snapshot_info->evidence_seqno);
-
         if (ledger_idx == startup_snapshot_info->evidence_seqno)
         {
           LOG_FAIL_FMT("here");
@@ -874,12 +869,6 @@ namespace ccf
           {
             throw std::logic_error("Invalid snapshot evidence");
           }
-
-          LOG_FAIL_FMT(
-            "there: {} vs {} [{}]",
-            evidence->hash,
-            crypto::Sha256Hash(startup_snapshot_info->raw),
-            startup_snapshot_info->raw.size());
 
           if (evidence->hash == crypto::Sha256Hash(startup_snapshot_info->raw))
           {

--- a/src/node/rpc/error.h
+++ b/src/node/rpc/error.h
@@ -74,6 +74,7 @@ namespace ccf
     ERROR(InvalidQuote)
     ERROR(InvalidNodeState)
     ERROR(NodeAlreadyExists)
+    ERROR(StartupSnapshotIsOld)
 
 #undef ERROR
   }

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -68,6 +68,7 @@ namespace ccf
       QuoteInfo quote_info;
       crypto::Pem public_encryption_key;
       ConsensusType consensus_type = ConsensusType::CFT;
+      std::optional<kv::Version> startup_seqno = std::nullopt;
     };
 
     struct Out

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -35,6 +35,7 @@ namespace ccf
       ccf::NodeId node_id;
       ccf::State state;
       kv::Version last_signed_seqno;
+      kv::Version startup_seqno;
 
       // Only on recovery
       std::optional<kv::Version> recovery_target_seqno;

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -222,6 +222,23 @@ namespace ccf
               this->network.consensus_type));
         }
 
+        auto this_startup_seqno =
+          this->context.get_node_state().get_startup_seqno();
+
+        if (
+          this_startup_seqno.has_value() && in.startup_seqno.has_value() &&
+          this_startup_seqno.value() > in.startup_seqno.value())
+        {
+          return make_error(
+            HTTP_STATUS_BAD_REQUEST,
+            ccf::errors::StartupSnapshotIsOld,
+            fmt::format(
+              "Node requested to join from snapshot at seqno {} which is older "
+              "than this node's startup seqno {}",
+              in.startup_seqno.value(),
+              this_startup_seqno.value()));
+        }
+
         auto nodes = args.tx.rw(this->network.nodes);
         auto service = args.tx.rw(this->network.service);
 

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -235,7 +235,7 @@ namespace ccf
             ccf::errors::StartupSnapshotIsOld,
             fmt::format(
               "Node requested to join from snapshot at seqno {} which is older "
-              "than this node's startup seqno {}",
+              "than this node startup seqno {}",
               in.startup_seqno.value(),
               this_startup_seqno.value()));
         }

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -222,9 +222,10 @@ namespace ccf
               this->network.consensus_type));
         }
 
+        // If the joiner and this node both started from a snapshot, make sure
+        // that the joiner's snapshot is more recent than this node's snapshot
         auto this_startup_seqno =
-          this->context.get_node_state().get_startup_seqno();
-
+          this->context.get_node_state().get_startup_snapshot_seqno();
         if (
           this_startup_seqno.has_value() && in.startup_seqno.has_value() &&
           this_startup_seqno.value() > in.startup_seqno.value())
@@ -342,6 +343,9 @@ namespace ccf
         result.state = s;
         result.recovery_target_seqno = rts;
         result.last_recovered_seqno = lrs;
+        result.startup_seqno =
+          this->context.get_node_state().get_startup_snapshot_seqno().value_or(
+            0);
 
         auto signatures = args.tx.template ro<Signatures>(Tables::SIGNATURES);
         auto sig = signatures->get(0);

--- a/src/node/rpc/node_interface.h
+++ b/src/node/rpc/node_interface.h
@@ -42,5 +42,6 @@ namespace ccf
       kv::ReadOnlyTx& tx,
       const QuoteInfo& quote_info,
       const std::vector<uint8_t>& expected_node_public_key_der) = 0;
+    virtual std::optional<kv::Version> get_startup_seqno() = 0;
   };
 }

--- a/src/node/rpc/node_interface.h
+++ b/src/node/rpc/node_interface.h
@@ -42,6 +42,6 @@ namespace ccf
       kv::ReadOnlyTx& tx,
       const QuoteInfo& quote_info,
       const std::vector<uint8_t>& expected_node_public_key_der) = 0;
-    virtual std::optional<kv::Version> get_startup_seqno() = 0;
+    virtual std::optional<kv::Version> get_startup_snapshot_seqno() = 0;
   };
 }

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -30,7 +30,8 @@ namespace ccf
     node_info_network,
     quote_info,
     public_encryption_key,
-    consensus_type)
+    consensus_type,
+    startup_seqno)
 
   DECLARE_JSON_TYPE(NetworkIdentity)
   DECLARE_JSON_REQUIRED_FIELDS(NetworkIdentity, cert, priv_key)

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -20,7 +20,8 @@ namespace ccf
      {ccf::State::readingPrivateLedger, "ReadingPrivateLedger"},
      {ccf::State::verifyingSnapshot, "VerifyingSnapshot"}})
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(GetState::Out)
-  DECLARE_JSON_REQUIRED_FIELDS(GetState::Out, node_id, state, last_signed_seqno)
+  DECLARE_JSON_REQUIRED_FIELDS(
+    GetState::Out, node_id, state, last_signed_seqno, startup_seqno)
   DECLARE_JSON_OPTIONAL_FIELDS(
     GetState::Out, recovery_target_seqno, last_recovered_seqno)
 

--- a/src/node/rpc/test/node_stub.h
+++ b/src/node/rpc/test/node_stub.h
@@ -94,6 +94,11 @@ namespace ccf
     {
       return QuoteVerificationResult::Verified;
     }
+
+    std::optional<kv::Version> get_startup_snapshot_seqno() override
+    {
+      return std::nullopt;
+    }
   };
 
   class StubNodeStateCache : public historical::AbstractStateCache

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -55,6 +55,10 @@ class CodeIdNotFound(Exception):
     pass
 
 
+class StartupSnapshotIsOld(Exception):
+    pass
+
+
 class NodeShutdownError(Exception):
     pass
 
@@ -176,7 +180,7 @@ class Network:
         target_node=None,
         recovery=False,
         ledger_dir=None,
-        copy_ledger_read_only=False,
+        copy_ledger_read_only=True,
         read_only_ledger_dir=None,
         from_snapshot=True,
         snapshot_dir=None,
@@ -597,8 +601,10 @@ class Network:
             if errors:
                 # Throw accurate exceptions if known errors found in
                 for error in errors:
-                    if "Quote does not contain known enclave measurement" in error:
+                    if "FailedCodeIdNotFound" in error:
                         raise CodeIdNotFound from e
+                    if "StartupSnapshotIsOld" in error:
+                        raise StartupSnapshotIsOld from e
             raise
 
         return new_node

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -601,7 +601,7 @@ class Network:
             if errors:
                 # Throw accurate exceptions if known errors found in
                 for error in errors:
-                    if "FailedCodeIdNotFound" in error:
+                    if "Quote does not contain known enclave measurement" in error:
                         raise CodeIdNotFound from e
                     if "StartupSnapshotIsOld" in error:
                         raise StartupSnapshotIsOld from e

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -591,8 +591,6 @@ class Network:
                 ),
             )
         except TimeoutError as e:
-            # The node can be safely discarded since it has not been
-            # attributed a unique node_id by CCF
             LOG.error(f"New pending node {new_node.node_id} failed to join the network")
             errors, _ = new_node.stop()
             self.nodes.remove(new_node)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -306,5 +306,5 @@ if __name__ == "__main__":
     args.nodes = infra.e2e_args.max_nodes(args, f=0)
     args.initial_user_count = 1
 
-    # run(args)
+    run(args)
     run_join_old_snapshot(args)

--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -86,7 +86,7 @@ def run(args):
             f"Keys and certificates have been copied to the common folder: {network.common_dir}"
         )
         LOG.info(
-            "See https://microsoft.github.io/CCF/main/users/issue_commands.html for more information"
+            "See https://microsoft.github.io/CCF/main/use_apps/issue_commands.html for more information"
         )
         LOG.warning("Press Ctrl+C to shutdown the network")
 

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -163,6 +163,7 @@ def recover(number_txs=5):
     return decorator
 
 
+# TODO: Move to reconfiguration.py instead of decorator!
 def add_from_snapshot():
     # Before adding the node from a snapshot, override at least one app entry
     # and wait for a snapshot covering that entry. After the test, verify

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -5,6 +5,7 @@ import functools
 
 from loguru import logger as LOG
 from math import ceil
+import infra.network
 
 
 class TestRequirementsNotMet(Exception):

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -3,9 +3,9 @@
 
 import functools
 
+import infra.network
 from loguru import logger as LOG
 from math import ceil
-import infra.network
 
 
 class TestRequirementsNotMet(Exception):


### PR DESCRIPTION
Resolves item 2. in https://github.com/microsoft/CCF/issues/2020 

The snapshot used by new nodes to join the network shouldn't be older than the snapshot that was used by the current primary to join (either on recovery, or a previous join). Otherwise, if the snapshot used to join is older, the new joiner may not be given ledger secrets recent enough to decrypt ledger entries. 

Note that this may be too strict (ledger rekeys may not have happened between an old and a new snapshot), so this PR gives a clear and early error message for operators starting new nodes from snapshots. 