### PR TITLE
Update codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,10 +29,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      # If this run was triggered by a pull request event, then checkout
-      # the head of the pull request instead of the merge commit.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
+      # 20210407: 1 issue was detected with this workflow: git checkout HEAD^2 is no longer necessary. 
+      # Please remove this step as Code Scanning recommends analyzing the merge commit for best results.
+
+      # # If this run was triggered by a pull request event, then checkout
+      # # the head of the pull request instead of the merge commit.
+      # - run: git checkout HEAD^2
+      #   if: ${{ github.event_name == 'pull_request' }}
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,14 +29,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      # 20210407: 1 issue was detected with this workflow: git checkout HEAD^2 is no longer necessary.
-      # Please remove this step as Code Scanning recommends analyzing the merge commit for best results.
-
-      # # If this run was triggered by a pull request event, then checkout
-      # # the head of the pull request instead of the merge commit.
-      # - run: git checkout HEAD^2
-      #   if: ${{ github.event_name == 'pull_request' }}
-
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      # 20210407: 1 issue was detected with this workflow: git checkout HEAD^2 is no longer necessary. 
+      # 20210407: 1 issue was detected with this workflow: git checkout HEAD^2 is no longer necessary.
       # Please remove this step as Code Scanning recommends analyzing the merge commit for best results.
 
       # # If this run was triggered by a pull request event, then checkout


### PR DESCRIPTION
CodeQL now prefers to analyze merge commits and wants us to remove `git checkout HEAD^2` from the yml.