### PR TITLE
Add indentation to make read_ledger.py collapsible

### DIFF
--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -450,6 +450,12 @@ class LedgerChunk:
     def __iter__(self):
         return self
 
+    def filename(self):
+        return self._filename
+
+    def is_committed(self):
+        return is_ledger_chunk_committed(self._filename)
+
 
 class Ledger:
     """

--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -508,7 +508,10 @@ class Ledger:
         return self._ledger_validator.signature_count
 
     def last_verified_txid(self):
-        return TxID(self._ledger_validator.last_verified_view, self._ledger_validator.last_verified_seqno)
+        return TxID(
+            self._ledger_validator.last_verified_view,
+            self._ledger_validator.last_verified_seqno,
+        )
 
 
 class InvalidRootException(Exception):

--- a/python/ccf/read_ledger.py
+++ b/python/ccf/read_ledger.py
@@ -8,16 +8,27 @@ import json
 from loguru import logger as LOG
 
 
-def print_key(k, is_removed=False):
-    if k == bytearray(8):
-        k = "0"
-    else:
-        k = f"{k.decode()}"
+def indent(n):
+    return " " * n
+
+
+def stringify_bytes(bs):
+    s = bs.decode()
+    if s.isprintable():
+        return s
+    if len(bs) > 0 and len(bs) <= 8:
+        n = int.from_bytes(bs, "big")
+        return f"<u{8 * len(bs)}: {n}>"
+    return bs
+
+
+def print_key(indent_s, k, is_removed=False):
+    k = stringify_bytes(k)
 
     if is_removed:
-        LOG.error(f"Removed {k}")
+        LOG.error(f"{indent_s}Removed {k}")
     else:
-        LOG.info(f"{k}:")
+        LOG.info(f"{indent_s}{k}:")
 
 
 if __name__ == "__main__":
@@ -40,19 +51,25 @@ if __name__ == "__main__":
             public_tables = public_transaction.get_tables()
 
             LOG.success(
-                f"seqno {public_transaction.get_seqno()} ({len(public_tables)} table{'s' if len(public_tables) > 1 else ''})"
+                f"seqno {public_transaction.get_seqno()} ({len(public_tables)} table{'s' * bool(len(public_tables))})"
             )
 
             for table_name, records in public_tables.items():
-                LOG.warning(f'table "{table_name}":')
+                LOG.warning(
+                    f'{indent(2)}table "{table_name}" ({len(records)} write{"s" * bool(len(records))}):'
+                )
+                key_indent = indent(4)
                 for key, value in records.items():
                     if value is not None:
                         try:
                             value = json.dumps(json.loads(value), indent=2)
+                            value = value.replace(
+                                "\n", f"\n{indent(6)}"
+                            )  # Indent every line within stringified JSON
                         except (json.decoder.JSONDecodeError, UnicodeDecodeError):
                             pass
                         finally:
-                            print_key(key)
-                            LOG.info(value)
+                            print_key(key_indent, key)
+                            LOG.info(f"{indent(6)}{value}")
                     else:
-                        print_key(key, is_removed=True)
+                        print_key(key_indent, key, is_removed=True)

--- a/python/ccf/read_ledger.py
+++ b/python/ccf/read_ledger.py
@@ -30,8 +30,10 @@ def print_key(indent_s, k, is_removed=False):
     else:
         LOG.info(f"{indent_s}{k}:")
 
+
 def counted_string(l, name):
     return f"{len(l)} {name}{'s' * bool(len(l) != 1)}"
+
 
 if __name__ == "__main__":
 
@@ -52,7 +54,9 @@ if __name__ == "__main__":
     LOG.info(f"Contains {counted_string(ledger, 'chunk')}")
 
     for chunk in ledger:
-        LOG.info(f"chunk {chunk.filename()} ({'' if chunk.is_committed() else 'un'}committed)")
+        LOG.info(
+            f"chunk {chunk.filename()} ({'' if chunk.is_committed() else 'un'}committed)"
+        )
         for transaction in chunk:
             public_transaction = transaction.get_public_domain()
             public_tables = public_transaction.get_tables()
@@ -63,7 +67,7 @@ if __name__ == "__main__":
 
             private_table_size = transaction.get_private_domain_size()
             if private_table_size:
-                LOG.error(f"-- private: {private_table_size} bytes")
+                LOG.error(f"{indent(2)}-- private: {private_table_size} bytes")
 
             for table_name, records in public_tables.items():
                 LOG.warning(
@@ -86,4 +90,6 @@ if __name__ == "__main__":
                     else:
                         print_key(key_indent, key, is_removed=True)
 
-    LOG.success(f"Ledger verification complete. Found {ledger.signature_count()} signatures, and verified till {ledger.last_verified_txid()}")
+    LOG.success(
+        f"Ledger verification complete. Found {ledger.signature_count()} signatures, and verified till {ledger.last_verified_txid()}"
+    )


### PR DESCRIPTION
As suggested in a comment on original PR, I think this aids navigation of large ledgers. I've also changed the formatting of bytes (to avoid using non-printable characters, make enum values more readable) and removed all the info logging from `ledger.py`. Current output looks like this:

![image](https://user-images.githubusercontent.com/6000239/114034452-18871180-9876-11eb-9f3e-294cbd3d2ae1.png)
