### PR TITLE
Remove oesign shenanigans from CMake

### DIFF
--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -93,8 +93,10 @@ function(sign_app_library name app_oe_conf_path enclave_sign_key_path)
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so.debuggable
       # Copy conf file locally
       COMMAND cp ${app_oe_conf_path} ${DEBUG_CONF_NAME}
-      # Replace any existing Debug= lines with Debug=1
-      COMMAND sed -i "s/^Debug=\.*/Debug=1/" ${DEBUG_CONF_NAME}
+      # Remove any existing Debug= lines
+      COMMAND sed -i "/^Debug=\.*/d" ${DEBUG_CONF_NAME}
+      # Add Debug=1 line
+      COMMAND echo "Debug=1" >> ${DEBUG_CONF_NAME}
       COMMAND
         openenclave::oesign sign -e ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so -c
         ${DEBUG_CONF_NAME} -k ${enclave_sign_key_path} -o
@@ -114,8 +116,10 @@ function(sign_app_library name app_oe_conf_path enclave_sign_key_path)
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so.signed
       # Copy conf file locally
       COMMAND cp ${app_oe_conf_path} ${SIGNED_CONF_NAME}
-      # Replace any existing Debug= lines with Debug=0
-      COMMAND sed -i "s/^Debug=\.*/Debug=0/" ${SIGNED_CONF_NAME}
+      # Remove any existing Debug= lines
+      COMMAND sed -i "/^Debug=\.*/d" ${SIGNED_CONF_NAME}
+      # Add Debug=0 line
+      COMMAND echo "Debug=0" >> ${SIGNED_CONF_NAME}
       COMMAND
         openenclave::oesign sign -e ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so -c
         ${SIGNED_CONF_NAME} -k ${enclave_sign_key_path}

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -89,10 +89,9 @@ function(sign_app_library name app_oe_conf_path enclave_sign_key_path)
     # also stamps the other config (heap size etc) which _are_ needed
     set(DEBUG_CONF_NAME ${CMAKE_CURRENT_BINARY_DIR}/${name}.debuggable.conf)
 
-    # Need to put in a temp folder, as oesign has a fixed output path, so
-    # multiple calls will force unnecessary rebuilds
     add_custom_command(
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so.debuggable
+      # Copy conf file locally, add single Debug=1 line
       COMMAND
         cp ${app_oe_conf_path} ${DEBUG_CONF_NAME} && (grep
                                                       -q
@@ -122,6 +121,7 @@ function(sign_app_library name app_oe_conf_path enclave_sign_key_path)
     set(SIGNED_CONF_NAME ${CMAKE_CURRENT_BINARY_DIR}/${name}.signed.conf)
     add_custom_command(
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so.signed
+      # Copy conf file locally, add single Debug=0 line
       COMMAND
         cp ${app_oe_conf_path} ${SIGNED_CONF_NAME} && (grep
                                                        -q

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -91,7 +91,6 @@ function(sign_app_library name app_oe_conf_path enclave_sign_key_path)
 
     # Need to put in a temp folder, as oesign has a fixed output path, so
     # multiple calls will force unnecessary rebuilds
-    set(TMP_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/${name}_tmp)
     add_custom_command(
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so.debuggable
       COMMAND
@@ -106,14 +105,10 @@ function(sign_app_library name app_oe_conf_path enclave_sign_key_path)
                                                       ||
                                                       (echo "Debug=1" >>
                                                        ${DEBUG_CONF_NAME}))
-      COMMAND mkdir -p ${TMP_FOLDER}
-      COMMAND ln -s ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so
-              ${TMP_FOLDER}/lib${name}.so
-      COMMAND openenclave::oesign sign -e ${TMP_FOLDER}/lib${name}.so -c
-              ${DEBUG_CONF_NAME} -k ${enclave_sign_key_path}
-      COMMAND mv ${TMP_FOLDER}/lib${name}.so.signed
-              ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so.debuggable
-      COMMAND rm -rf ${TMP_FOLDER}
+      COMMAND
+        openenclave::oesign sign -e ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so -c
+        ${DEBUG_CONF_NAME} -k ${enclave_sign_key_path} -o
+        ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so.debuggable
       DEPENDS ${name} ${app_oe_conf_path} ${enclave_sign_key_path}
     )
 

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -91,19 +91,12 @@ function(sign_app_library name app_oe_conf_path enclave_sign_key_path)
 
     add_custom_command(
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so.debuggable
-      # Copy conf file locally, add single Debug=1 line
-      COMMAND
-        cp ${app_oe_conf_path} ${DEBUG_CONF_NAME} && (grep
-                                                      -q
-                                                      "Debug\=.*"
-                                                      ${DEBUG_CONF_NAME}
-                                                      &&
-                                                      (sed -i
-                                                       "s/Debug=\.*/Debug=1/"
-                                                       ${DEBUG_CONF_NAME})
-                                                      ||
-                                                      (echo "Debug=1" >>
-                                                       ${DEBUG_CONF_NAME}))
+      # Copy conf file locally
+      COMMAND cp ${app_oe_conf_path} ${DEBUG_CONF_NAME}
+      # Remove any existing Debug= lines
+      COMMAND sed -i "/^Debug=\.*/d" ${DEBUG_CONF_NAME}
+      # Add Debug=1 line
+      COMMAND echo "Debug=1" >> ${DEBUG_CONF_NAME}
       COMMAND
         openenclave::oesign sign -e ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so -c
         ${DEBUG_CONF_NAME} -k ${enclave_sign_key_path} -o
@@ -121,19 +114,12 @@ function(sign_app_library name app_oe_conf_path enclave_sign_key_path)
     set(SIGNED_CONF_NAME ${CMAKE_CURRENT_BINARY_DIR}/${name}.signed.conf)
     add_custom_command(
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so.signed
-      # Copy conf file locally, add single Debug=0 line
-      COMMAND
-        cp ${app_oe_conf_path} ${SIGNED_CONF_NAME} && (grep
-                                                       -q
-                                                       "Debug\=.*"
-                                                       ${SIGNED_CONF_NAME}
-                                                       &&
-                                                       (sed -i
-                                                        "s/Debug=\.*/Debug=0/"
-                                                        ${SIGNED_CONF_NAME})
-                                                       ||
-                                                       (echo "Debug=0" >>
-                                                        ${SIGNED_CONF_NAME}))
+      # Copy conf file locally
+      COMMAND cp ${app_oe_conf_path} ${SIGNED_CONF_NAME}
+      # Remove any existing Debug= lines
+      COMMAND sed -i "/^Debug=\.*/d" ${SIGNED_CONF_NAME}
+      # Add Debug=0 line
+      COMMAND echo "Debug=0" >> ${SIGNED_CONF_NAME}
       COMMAND
         openenclave::oesign sign -e ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so -c
         ${SIGNED_CONF_NAME} -k ${enclave_sign_key_path}

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -93,10 +93,8 @@ function(sign_app_library name app_oe_conf_path enclave_sign_key_path)
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so.debuggable
       # Copy conf file locally
       COMMAND cp ${app_oe_conf_path} ${DEBUG_CONF_NAME}
-      # Remove any existing Debug= lines
-      COMMAND sed -i "/^Debug=\.*/d" ${DEBUG_CONF_NAME}
-      # Add Debug=1 line
-      COMMAND echo "Debug=1" >> ${DEBUG_CONF_NAME}
+      # Replace any existing Debug= lines with Debug=1
+      COMMAND sed -i "s/^Debug=\.*/Debug=1/" ${DEBUG_CONF_NAME}
       COMMAND
         openenclave::oesign sign -e ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so -c
         ${DEBUG_CONF_NAME} -k ${enclave_sign_key_path} -o
@@ -116,10 +114,8 @@ function(sign_app_library name app_oe_conf_path enclave_sign_key_path)
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so.signed
       # Copy conf file locally
       COMMAND cp ${app_oe_conf_path} ${SIGNED_CONF_NAME}
-      # Remove any existing Debug= lines
-      COMMAND sed -i "/^Debug=\.*/d" ${SIGNED_CONF_NAME}
-      # Add Debug=0 line
-      COMMAND echo "Debug=0" >> ${SIGNED_CONF_NAME}
+      # Replace any existing Debug= lines with Debug=0
+      COMMAND sed -i "s/^Debug=\.*/Debug=0/" ${SIGNED_CONF_NAME}
       COMMAND
         openenclave::oesign sign -e ${CMAKE_CURRENT_BINARY_DIR}/lib${name}.so -c
         ${SIGNED_CONF_NAME} -k ${enclave_sign_key_path}


### PR DESCRIPTION
I added these CMake bodges a while ago to work around `oesign`. `oesign` insisted on a fixed output path. We want debuggable and non-debuggable variants of our enclaves, so I needed to create a temp directory to sign both, otherwise every build would overwrite its own files and cause unnecessary rebuilds. Additionally, I added a `grep|sed|echo` pipe to add a `Debug=0` or `Debug=1` to the `.conf` files used to sign, regardless of what the original `.conf` said.

`oesign` now takes a custom output path as an argument, so we can create the `.debuggable` enclave without overwriting any other files. Additionally, I realised my pipe was unnecessarily complicated - rather than trying to overwrite an existing line, we can just delete any existing `Debug=` lines and add our own at the end. This has a rather hilarious improvement to `cmake-format` time, which really _hated_ this piped `COMMAND` (even when it was correctly formatted):

**Before**
```
$ time cmake-format -i ../cmake/ccf_app.cmake 

real    0m26.391s
user    0m26.362s
sys     0m0.028s
```

**After**
```
$ time cmake-format -i ../cmake/ccf_app.cmake 

real    0m0.380s
user    0m0.372s
sys     0m0.008s
```