### PR TITLE
Forum sample: fix demo script & other cleanup

### DIFF
--- a/samples/apps/forum/.gitignore
+++ b/samples/apps/forum/.gitignore
@@ -6,3 +6,4 @@ build/
 .workspace_ccf/
 *_opinions.csv
 *.jwt
+*.pem

--- a/samples/apps/forum/README.md
+++ b/samples/apps/forum/README.md
@@ -14,6 +14,8 @@ Start the sandbox:
 npm start
 ```
 
+(Use `VERBOSE=1 npm start` for verbose output)
+
 Open your browser at https://127.0.0.1:8000/app/site
 
 Generate opinions, user identities and submit:

--- a/samples/apps/forum/package.json
+++ b/samples/apps/forum/package.json
@@ -9,9 +9,9 @@
   "type": "module",
   "dependencies": {
     "@microsoft/ccf-app": "file:../../../js/ccf-app",
-    "@tsoa/runtime": "^3.3.0",
+    "@tsoa/runtime": "^3.6.1",
     "lodash-es": "^4.17.15",
-    "mathjs": "^7.5.1",
+    "mathjs": "^9.3.0",
     "papaparse": "^5.3.0"
   },
   "devDependencies": {
@@ -19,7 +19,7 @@
     "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@rollup/plugin-typescript": "^5.0.2",
-    "@tsoa/cli": "^3.3.0",
+    "@tsoa/cli": "^3.6.1",
     "@types/bent": "^7.3.1",
     "@types/chai": "^4.2.13",
     "@types/jsonwebtoken": "^8.5.0",
@@ -41,10 +41,9 @@
     "mocha": "^8.1.3",
     "node-forge": "^0.10.0",
     "rollup": "^2.23.0",
-    "selfsigned": "^1.10.8",
     "tmp": "^0.2.1",
     "ts-node": "^9.1.0",
-    "tslib": "^2.0.1",
-    "typescript": "^4.0.2"
+    "tslib": "^2.2.0",
+    "typescript": "^4.2.4"
   }
 }

--- a/samples/apps/forum/test/demo/submit-opinions.ts
+++ b/samples/apps/forum/test/demo/submit-opinions.ts
@@ -5,7 +5,7 @@ import * as fs from "fs";
 import * as path from "path";
 import glob from "glob";
 import bent from "bent";
-import { parse } from "papaparse";
+import papa from "papaparse";
 import { NODE_ADDR } from "../util";
 import { SubmitOpinionsRequest } from "../../src/controllers/poll";
 
@@ -14,7 +14,7 @@ const ENDPOINT_URL = `${NODE_ADDR}/app/polls`;
 function getAuth(jwt: string) {
   // See src/util.ts.
   return {
-    authorization: `Bearer ${jwt}'`,
+    authorization: `Bearer ${jwt}`,
   };
 }
 
@@ -36,7 +36,7 @@ async function main() {
     const jwtPath = path.join(folder, user + ".jwt");
     const jwt = fs.readFileSync(jwtPath, "utf8");
     const csv = fs.readFileSync(csvPath, "utf8");
-    const rows = parse(csv, { header: true }).data as CSVRow[];
+    const rows = papa.parse(csv, { header: true }).data as CSVRow[];
 
     const req: SubmitOpinionsRequest = { opinions: {} };
     for (const row of rows) {

--- a/samples/apps/forum/test/start.ts
+++ b/samples/apps/forum/test/start.ts
@@ -4,7 +4,6 @@
 import { spawnSync } from "child_process";
 import * as fs from "fs";
 import * as crypto from "crypto";
-import selfsigned from "selfsigned";
 import tmp from "tmp";
 import bent from "bent";
 import forge from "node-forge";
@@ -71,13 +70,20 @@ function generateKeyPair(keyPath: string, certPath: string) {
       format: "pem",
     },
   });
-  const certPem = selfsigned.generate(null, {
-    algorithm: "sha256",
-    keyPair: {
-      privateKey: keys.privateKey,
-      publicKey: keys.publicKey,
+  const cert = forge.pki.createCertificate();
+  const attrs = [
+    {
+      name: "commonName",
+      value: "Test",
     },
-  }).cert;
+  ];
+  cert.setIssuer(attrs);
+  cert.publicKey = forge.pki.publicKeyFromPem(keys.publicKey);
+  cert.sign(
+    forge.pki.privateKeyFromPem(keys.privateKey),
+    forge.md.sha256.create()
+  );
+  const certPem = forge.pki.certificateToPem(cert);
   fs.writeFileSync(keyPath, keys.privateKey);
   fs.writeFileSync(certPath, certPem);
 }

--- a/samples/apps/forum/tsoa-support/entry.ts
+++ b/samples/apps/forum/tsoa-support/entry.ts
@@ -1,1 +1,0 @@
-// tsoa's CLI requires an entry script but it is not actually used.

--- a/samples/apps/forum/tsoa.json
+++ b/samples/apps/forum/tsoa.json
@@ -1,5 +1,4 @@
 {
-  "entryFile": "tsoa-support/entry.ts",
   "noImplicitAdditionalProperties": "throw-on-extras",
   "controllerPathGlobs": ["src/controllers/*.ts"],
   "spec": {

--- a/src/js/crypto.cpp
+++ b/src/js/crypto.cpp
@@ -140,6 +140,7 @@ namespace js
     }
     catch (const std::logic_error& e)
     {
+      LOG_DEBUG_FMT("isValidX509Chain: {}", e.what());
       return JS_FALSE;
     }
 

--- a/src/tls/ca.h
+++ b/src/tls/ca.h
@@ -25,19 +25,21 @@ namespace tls
       if (ca_.n > 0)
       {
         crypto::Pem pem_ca(ca_);
-        if (
-          mbedtls_x509_crt_parse(tmp_ca.get(), pem_ca.data(), pem_ca.size()) !=
-          0)
-          throw std::logic_error("Could not parse CA");
+        auto ret =
+          mbedtls_x509_crt_parse(tmp_ca.get(), pem_ca.data(), pem_ca.size());
+        if (ret != 0)
+          throw std::logic_error(
+            "Could not parse CA: " + tls::error_string(ret));
       }
 
       if (crl_.n > 0)
       {
         crypto::Pem pem_crl(crl_);
-        if (
-          mbedtls_x509_crl_parse(
-            tmp_crl.get(), pem_crl.data(), pem_crl.size()) != 0)
-          throw std::logic_error("Could not parse CRL");
+        auto ret =
+          mbedtls_x509_crl_parse(tmp_crl.get(), pem_crl.data(), pem_crl.size());
+        if (ret != 0)
+          throw std::logic_error(
+            "Could not parse CRL: " + tls::error_string(ret));
       }
 
       ca = std::move(tmp_ca);


### PR DESCRIPTION
The `samples/apps/forum/test/demo/submit-opinions.ts` script isn't tested in CI and missed a fix that was already applied to the unit tests earlier.

Other changes:
- Removed `selfsigned` dependency in favour of using `node-forge` directly.
- Update to latest `tsoa` version and remove redundant (empty) entry script.
- Some better error logging during debugging.