### PR TITLE
[Don't Merge] Emulate bad network in CI

### DIFF
--- a/.azure-pipelines-templates/test.yml
+++ b/.azure-pipelines-templates/test.yml
@@ -5,6 +5,10 @@ parameters:
 
 steps:
   - script: |
+      sudo tc qdisc del dev lo root netem loss 10% 25% duplicate 2% corrupt 2% delay 1ms reorder 1% 10%
+    displayName: Emulate bad network
+
+  - script: |
       set -ex
       ./tests.sh -VV --timeout ${{ parameters.ctest_timeout }} --no-compress-output -T Test ${{ parameters.ctest_filter }}
     env:


### PR DESCRIPTION
Something we don't currently have great tests for is how CCF performs in adverse network conditions. This is a brute force attempt at a smoke test - use `tc` to emulate a poor connection for everything on localhost (within this Docker image), and then run all of our tests.

This will not be merged, and is simply to see what our CI picks up.