### PR TITLE
Add check for double uv_close

### DIFF
--- a/src/host/proxy.h
+++ b/src/host/proxy.h
@@ -79,7 +79,10 @@ namespace asynchost
 
     void close()
     {
-      uv_close((uv_handle_t*)&uv_handle, on_close);
+      if (!uv_is_closing((uv_handle_t*)&uv_handle))
+      {
+        uv_close((uv_handle_t*)&uv_handle, on_close);
+      }
     }
 
     static void on_close(uv_handle_t* handle)


### PR DESCRIPTION
This adds another (necessary) check on uv_handles to avoid double-`uv_close`s. Pertains to #2378.