### PR TITLE
Fix N2N channel exception behaviour

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -673,6 +673,11 @@ namespace aft
           }
         }
       }
+      catch (const ccf::NodeToNode::DroppedMessageException &e)
+      {
+        LOG_INFO_FMT("Dropped invalid message from {}", e.from);
+        return;
+      }
       catch (const std::exception& e)
       {
         LOG_FAIL_EXC(e.what());
@@ -969,7 +974,7 @@ namespace aft
         return true;
       }
 
-      // Check if there have been too many entried since the last signature
+      // Check if there have been too many entries since the last signature
       if (
         sig_tx_interval != 0 &&
         last_sig_seqno + sig_tx_interval * wait_factor <

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -673,7 +673,7 @@ namespace aft
           }
         }
       }
-      catch (const ccf::NodeToNode::DroppedMessageException &e)
+      catch (const ccf::NodeToNode::DroppedMessageException& e)
       {
         LOG_INFO_FMT("Dropped invalid message from {}", e.from);
         return;

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -971,16 +971,13 @@ namespace ccf
         return;
       }
 
-      search->second->reset();
+      search->second = nullptr;
     }
 
     void destroy_all_channels()
     {
       std::lock_guard<SpinLock> guard(lock);
-      for (auto& c : channels)
-      {
-        c.second->reset();
-      }
+      channels.clear();
     }
 
     void close_all_outgoing()

--- a/src/node/node_to_node.h
+++ b/src/node/node_to_node.h
@@ -56,7 +56,9 @@ namespace ccf
 
       if (!recv_authenticated(from, asCb(t), data, size))
       {
-        LOG_INFO_FMT("Dropping invalid authenticated message from {}", from);
+        throw std::logic_error(fmt::format(
+          "Invalid authenticated node2node message with load from node {}",
+          from));
       }
 
       return t;
@@ -73,8 +75,9 @@ namespace ccf
 
       if (!recv_authenticated_with_load(from, data, size))
       {
-        LOG_INFO_FMT(
-          "Dropping invalid authenticated message with load from {}", from);
+        throw std::logic_error(fmt::format(
+          "Invalid authenticated node2node message with load from node {}",
+          from));
       }
       serialized::skip(data, size, sizeof(T));
 
@@ -251,7 +254,9 @@ namespace ccf
       auto plain = n2n_channel->recv_encrypted(cb, data, size);
       if (!plain.has_value())
       {
-        LOG_INFO_FMT("Dropping invalid encrypted message from {}", from);
+        throw std::logic_error(fmt::format(
+          "Invalid authenticated node2node message with load from node {}",
+          from));
       }
 
       return plain.value();


### PR DESCRIPTION
This reverts part of a previous change to the N2N channel exception behaviour. There is a bug in `Node2Node::recv_authenticated`; it should not return `t` when a message is dropped. This caused outdated (and potentially unauthenticated) messages to be delivered, which is likely the only reason for #2456. 

The ugly part is that this brings back failure log messages that aren't really failures; for instance:

```
43: 17:39:49.084 | ERROR    | infra.remote:log_errors:70 - /data/cwinter/CCF/build/workspace/rotation_test_3/out: 2021-04-13T17:39:48.114058Z -0.005 0   [fail ] ../src/consensus/aft/raft.h:678      | Exception in void aft::Aft<consensus::LedgerEnclave, ccf::NodeToNode, ccf::Snapshotter>::recv_message(const ccf::NodeId &, OArray &&) [LedgerProxy = consensus::LedgerEnclave, ChannelProxy = ccf::NodeToNode, SnapshotterProxy = ccf::Snapshotter]
```

This is hard to interpret for users and I would much prefer these to be info log messages (about dropping the message) or to be completely silent. So, perhaps 

```
if (!recv_authenticated(from, asCb(t), data, size))
{
  LOG_INFO_FMT("Dropping invalid authenticated message from {}", from);
  t = T();
}
```

is preferable?