### PR TITLE
Document forwarding_required & mode in app.json

### DIFF
--- a/doc/build_apps/js_app_bundle.rst
+++ b/doc/build_apps/js_app_bundle.rst
@@ -55,7 +55,6 @@ The ``app.json`` file of an app bundle has the following structure:
             "js_module": "app.js",
             "js_function": "foo_post",
             "forwarding_required": "never",
-            "execute_outside_consensus": "never",
             "authn_policies": ["user_cert"],
             "mode": "readonly",
             "openapi": {

--- a/doc/build_apps/js_app_bundle.rst
+++ b/doc/build_apps/js_app_bundle.rst
@@ -57,7 +57,7 @@ The ``app.json`` file of an app bundle has the following structure:
             "forwarding_required": "never",
             "execute_outside_consensus": "never",
             "authn_policies": ["user_cert"],
-            "readonly": true,
+            "mode": "readonly",
             "openapi": {
               ...
             }
@@ -84,8 +84,18 @@ Each endpoint object contains the following information:
   - ``"jwt"``
   - ``"no_auth"``
   
-- ``"forwarding_required"``, ``"execute_outside_consensus"``,
-  ``"readonly"``: Request execution policies, see **TODO**.
+- ``"forwarding_required"``: A string indicating whether the endpoint is always forwarded, or whether it is safe to sometimes execute on followers. Possible values are:
+
+  - ``"always"``
+  - ``"sometimes"``
+  - ``"never"``
+
+- ``"mode"``: A string indicating whether the endpoint requires read/write or read-only access to the Key-Value Store, or whether it is a historical endpoint that sees the state written in a specific transaction. Possible values are:
+
+  - ``"readwrite"``
+  - ``"readonly"``
+  - ``"historical"``
+
 - ``"openapi"``:  An `OpenAPI Operation Object <https://swagger.io/specification/#operation-object>`_ 
   without `references <https://swagger.io/specification/#reference-object>`_. This is descriptive but not
   enforced - it will be inserted into the generated OpenAPI document for this service, but will not restrict the

--- a/samples/apps/forum/app.tmpl.json
+++ b/samples/apps/forum/app.tmpl.json
@@ -5,7 +5,6 @@
         "js_module": "PollControllerProxy.js",
         "js_function": "createPoll",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt"],
         "mode": "readwrite"
       },
@@ -13,7 +12,6 @@
         "js_module": "PollControllerProxy.js",
         "js_function": "submitOpinion",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt"],
         "mode": "readwrite"
       },
@@ -21,7 +19,6 @@
         "js_module": "PollControllerProxy.js",
         "js_function": "getPoll",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt"],
         "mode": "readonly"
       }
@@ -31,7 +28,6 @@
         "js_module": "PollControllerProxy.js",
         "js_function": "createPolls",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt"],
         "mode": "readwrite"
       },
@@ -39,7 +35,6 @@
         "js_module": "PollControllerProxy.js",
         "js_function": "submitOpinions",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt"],
         "mode": "readwrite"
       },
@@ -47,7 +42,6 @@
         "js_module": "PollControllerProxy.js",
         "js_function": "getPolls",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt"],
         "mode": "readonly"
       }
@@ -57,7 +51,6 @@
         "js_module": "SiteControllerProxy.js",
         "js_function": "getStartPage",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": [],
         "mode": "readonly"
       }
@@ -67,7 +60,6 @@
         "js_module": "SiteControllerProxy.js",
         "js_function": "getPollsCreatePage",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": [],
         "mode": "readonly"
       }
@@ -77,7 +69,6 @@
         "js_module": "SiteControllerProxy.js",
         "js_function": "getOpinionsSubmitPage",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": [],
         "mode": "readonly"
       }
@@ -87,7 +78,6 @@
         "js_module": "SiteControllerProxy.js",
         "js_function": "getViewPage",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": [],
         "mode": "readonly"
       }
@@ -97,7 +87,6 @@
         "js_module": "CsvControllerProxy.js",
         "js_function": "getOpinionsAsCsv",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt"],
         "mode": "readonly",
         "openapi_merge_patch": {
@@ -115,7 +104,6 @@
         "js_module": "CsvControllerProxy.js",
         "js_function": "submitOpinionsFromCSV",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt"],
         "mode": "readwrite",
         "openapi_merge_patch": {

--- a/samples/apps/forum/tsoa-support/postprocess.js
+++ b/samples/apps/forum/tsoa-support/postprocess.js
@@ -6,7 +6,6 @@ import jsonmergepatch from "json-merge-patch";
 // endpoint metadata defaults when first added to endpoints.json
 const metadataDefaults = (mode) => ({
   forwarding_required: "always",
-  execute_outside_consensus: "never",
   authn_policies: ["user_cert"],
   mode: mode,
 });

--- a/samples/apps/logging/js/app.json
+++ b/samples/apps/logging/js/app.json
@@ -5,7 +5,6 @@
         "js_module": "logging.js",
         "js_function": "get_private",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt", "user_cert"],
         "mode": "readonly",
         "openapi": {}
@@ -14,7 +13,6 @@
         "js_module": "logging.js",
         "js_function": "post_private",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt", "user_cert"],
         "mode": "readwrite",
         "openapi": {}
@@ -23,7 +21,6 @@
         "js_module": "logging.js",
         "js_function": "delete_private",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt", "user_cert"],
         "mode": "readwrite",
         "openapi": {}
@@ -34,7 +31,6 @@
         "js_module": "logging.js",
         "js_function": "get_historical",
         "forwarding_required": "never",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt", "user_cert"],
         "mode": "historical",
         "openapi": {}
@@ -45,7 +41,6 @@
         "js_module": "logging.js",
         "js_function": "get_historical_with_receipt",
         "forwarding_required": "never",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt", "user_cert"],
         "mode": "historical",
         "openapi": {}
@@ -56,7 +51,6 @@
         "js_module": "logging.js",
         "js_function": "get_public",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt", "user_cert"],
         "mode": "readonly",
         "openapi": {}
@@ -65,7 +59,6 @@
         "js_module": "logging.js",
         "js_function": "post_public",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt", "user_cert"],
         "mode": "readwrite",
         "openapi": {}
@@ -74,7 +67,6 @@
         "js_module": "logging.js",
         "js_function": "delete_public",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt", "user_cert"],
         "mode": "readwrite",
         "openapi": {}

--- a/src/apps/batched/app.json
+++ b/src/apps/batched/app.json
@@ -5,7 +5,6 @@
         "js_module": "batched.js",
         "js_function": "submit_batch",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {}
@@ -16,7 +15,6 @@
         "js_module": "batched.js",
         "js_function": "fetch_batch",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {}

--- a/tests/js-app-bundle/app.json
+++ b/tests/js-app-bundle/app.json
@@ -5,7 +5,6 @@
         "js_module": "math.js",
         "js_function": "compute",
         "forwarding_required": "never",
-        "execute_outside_consensus": "locally",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {
@@ -78,7 +77,6 @@
         "js_module": "math.js",
         "js_function": "compute2",
         "forwarding_required": "never",
-        "execute_outside_consensus": "locally",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {

--- a/tests/js-authentication/app.json
+++ b/tests/js-authentication/app.json
@@ -5,7 +5,6 @@
         "js_module": "endpoints.js",
         "js_function": "jwt",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["jwt"],
         "mode": "readonly",
         "openapi": {}
@@ -16,7 +15,6 @@
         "js_module": "endpoints.js",
         "js_function": "multi_auth",
         "forwarding_required": "sometimes",
-        "execute_outside_consensus": "never",
         "authn_policies": [
           "user_cert",
           "user_signature",

--- a/tests/js-content-types/app.json
+++ b/tests/js-content-types/app.json
@@ -5,7 +5,6 @@
         "js_module": "content_types.js",
         "js_function": "text",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {}
@@ -16,7 +15,6 @@
         "js_module": "content_types.js",
         "js_function": "json",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {}
@@ -27,7 +25,6 @@
         "js_module": "content_types.js",
         "js_function": "binary",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {}
@@ -38,7 +35,6 @@
         "js_module": "content_types.js",
         "js_function": "custom",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {}

--- a/tests/js-custom-authorization/app.json
+++ b/tests/js-custom-authorization/app.json
@@ -5,7 +5,6 @@
         "js_module": "custom_authorization.js",
         "js_function": "compare_bearer",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {}

--- a/tests/js-limits/app.json
+++ b/tests/js-limits/app.json
@@ -5,7 +5,6 @@
         "js_module": "limits.js",
         "js_function": "recursive",
         "forwarding_required": "never",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {}
@@ -16,7 +15,6 @@
         "js_module": "limits.js",
         "js_function": "alloc",
         "forwarding_required": "never",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {}

--- a/tests/js-modules/basic-module-import/app.json
+++ b/tests/js-modules/basic-module-import/app.json
@@ -5,7 +5,6 @@
         "js_module": "test_module.js",
         "js_function": "test_module",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {}

--- a/tests/npm-app/app.json
+++ b/tests/npm-app/app.json
@@ -5,7 +5,6 @@
         "js_module": "endpoints/jwt.js",
         "js_function": "jwt",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": [],
         "mode": "readonly",
         "openapi": {
@@ -55,7 +54,6 @@
         "js_module": "endpoints/crypto.js",
         "js_function": "crypto",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {
@@ -88,7 +86,6 @@
         "js_module": "endpoints/crypto.js",
         "js_function": "generateAesKey",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {
@@ -123,7 +120,6 @@
         "js_module": "endpoints/crypto.js",
         "js_function": "generateRsaKeyPair",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {
@@ -175,7 +171,6 @@
         "js_module": "endpoints/crypto.js",
         "js_function": "wrapKey",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {
@@ -216,7 +211,6 @@
         "js_module": "endpoints/crypto.js",
         "js_function": "digest",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {
@@ -254,7 +248,6 @@
         "js_module": "endpoints/partition.js",
         "js_function": "partition",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {
@@ -293,7 +286,6 @@
         "js_module": "endpoints/proto.js",
         "js_function": "proto",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {
@@ -319,7 +311,6 @@
         "js_module": "endpoints/log.js",
         "js_function": "getLogItem",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {
@@ -349,7 +340,6 @@
         "js_module": "endpoints/log.js",
         "js_function": "setLogItem",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readwrite",
         "openapi": {
@@ -386,7 +376,6 @@
         "js_module": "endpoints/log.js",
         "js_function": "getAllLogItems",
         "forwarding_required": "always",
-        "execute_outside_consensus": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {


### PR DESCRIPTION
Also, remove the non-functional `"execute_outside_consensus"` field from all the `app.json` files and the docs.