### PR TITLE
Remove OE logging

### DIFF
--- a/src/enclave/ccf_v.h
+++ b/src/enclave/ccf_v.h
@@ -160,6 +160,21 @@ extern "C"
     return OE_FAILURE;
   }
 
+  using oe_log_level_t = size_t;
+  typedef void (*oe_log_callback_t)(
+    void* context,
+    bool is_enclave,
+    const struct tm* t,
+    long int usecs,
+    oe_log_level_t level,
+    uint64_t host_thread_id,
+    const char* message);
+
+  oe_result_t oe_log_set_callback(void* context, oe_log_callback_t callback)
+  {
+    return OE_OK;
+  }
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/host/enclave.h
+++ b/src/host/enclave.h
@@ -14,7 +14,21 @@
 #  include <ccf_u.h>
 #  include <openenclave/bits/result.h>
 #  include <openenclave/host.h>
+#  include <openenclave/trace.h>
 #endif
+
+extern "C"
+{
+  void nop_oe_logger(
+    void* context,
+    bool is_enclave,
+    const struct tm* t,
+    long int usecs,
+    oe_log_level_t level,
+    uint64_t host_thread_id,
+    const char* message)
+  {}
+}
 
 // Marker to create virtual enclaves, should be distinct from any valid
 // OE_ENCLAVE_FLAG combinations
@@ -56,6 +70,8 @@ namespace host
       }
       else
       {
+        oe_log_set_callback(nullptr, nop_oe_logger);
+
         auto err = oe_create_ccf_enclave(
           path.c_str(), OE_ENCLAVE_TYPE_SGX, flags, nullptr, 0, &e);
 


### PR DESCRIPTION
Swallow the OE logging so it doesn't log "logging is not enabled" in the wrong format.

Goodbye forever to this message:

```
2021-04-16T16:39:20+0100.498499Z [(H)WARN] tid(0x7ff6502ee600) | In-enclave logging is not supported. To enable, please add 

from "openenclave/edl/logging.edl" import *;

in the edl file.
 [/source/openenclave/host/sgx/create.c:oe_create_enclave:1178]
```