### PR TITLE
Fix detection of object vs list-of-pairs JSON serialisation

### DIFF
--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -93,58 +93,22 @@
         "type": "string"
       },
       "EntityId_to_Failure": {
-        "items": {
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/EntityId"
-              },
-              {
-                "$ref": "#/components/schemas/Failure"
-              }
-            ]
-          },
-          "maxItems": 2,
-          "minItems": 2,
-          "type": "array"
+        "additionalProperties": {
+          "$ref": "#/components/schemas/Failure"
         },
-        "type": "array"
+        "type": "object"
       },
       "EntityId_to_boolean": {
-        "items": {
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/EntityId"
-              },
-              {
-                "$ref": "#/components/schemas/boolean"
-              }
-            ]
-          },
-          "maxItems": 2,
-          "minItems": 2,
-          "type": "array"
+        "additionalProperties": {
+          "$ref": "#/components/schemas/boolean"
         },
-        "type": "array"
+        "type": "object"
       },
       "EntityId_to_string": {
-        "items": {
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/EntityId"
-              },
-              {
-                "$ref": "#/components/schemas/string"
-              }
-            ]
-          },
-          "maxItems": 2,
-          "minItems": 2,
-          "type": "array"
+        "additionalProperties": {
+          "$ref": "#/components/schemas/string"
         },
-        "type": "array"
+        "type": "object"
       },
       "Failure": {
         "properties": {

--- a/src/ds/json_schema.h
+++ b/src/ds/json_schema.h
@@ -212,8 +212,8 @@ namespace ds
         // Nlohmann JSON serialises some maps as objects, if the keys can be
         // converted to strings. This should detect those cases. The others are
         // serialised as list-of-pairs
-        if constexpr (nlohmann::detail::is_compatible_object_type<nlohmann::json, T>::
-              value)
+        if constexpr (nlohmann::detail::
+                        is_compatible_object_type<nlohmann::json, T>::value)
         {
           schema["type"] = "object";
           schema["additionalProperties"] =

--- a/src/ds/json_schema.h
+++ b/src/ds/json_schema.h
@@ -110,18 +110,10 @@ namespace ds
         nonstd::is_specialization<T, std::map>::value ||
         nonstd::is_specialization<T, std::unordered_map>::value)
       {
-        if (std::is_same<typename T::key_type, std::string>::value)
-        {
-          return fmt::format(
-            "named_{}", schema_name<typename T::mapped_type>());
-        }
-        else
-        {
-          return fmt::format(
-            "{}_to_{}",
-            schema_name<typename T::key_type>(),
-            schema_name<typename T::mapped_type>());
-        }
+        return fmt::format(
+          "{}_to_{}",
+          schema_name<typename T::key_type>(),
+          schema_name<typename T::mapped_type>());
       }
       else if constexpr (nonstd::is_specialization<T, std::pair>::value)
       {
@@ -204,7 +196,8 @@ namespace ds
         if constexpr (std::is_same<T, std::vector<uint8_t>>::value)
         {
           // Byte vectors are always base64 encoded
-          schema["type"] = "base64string";
+          schema["type"] = "string";
+          schema["format"] = "base64";
         }
         else
         {
@@ -216,10 +209,12 @@ namespace ds
         nonstd::is_specialization<T, std::map>::value ||
         nonstd::is_specialization<T, std::unordered_map>::value)
       {
-        // Nlohmann serialises maps to an array of (K, V) pairs...
-        if (std::is_same<typename T::key_type, std::string>::value)
+        // Nlohmann JSON serialises some maps as objects, if the keys can be
+        // converted to strings. This should detect those cases. The others are
+        // serialised as list-of-pairs
+        if constexpr (nlohmann::detail::is_compatible_object_type<nlohmann::json, T>::
+              value)
         {
-          // ...unless the keys are strings!
           schema["type"] = "object";
           schema["additionalProperties"] =
             schema_element<typename T::mapped_type>();

--- a/src/ds/nonstd.h
+++ b/src/ds/nonstd.h
@@ -53,12 +53,19 @@ namespace nonstd
    * static_assert which will fail only when invalid paths are called, but
    * allows compilation otherwise
    */
-  template <typename T, T = T{}>
+  template <typename T>
   struct dependent_false : public std::false_type
   {};
 
-  template <typename T, T t = T{}>
-  static constexpr bool dependent_false_v = dependent_false<T, t>::value;
+  template <typename T>
+  static constexpr bool dependent_false_v = dependent_false<T>::value;
+
+  template <typename T, T>
+  struct value_dependent_false : public std::false_type
+  {};
+
+  template <typename T, T t>
+  static constexpr bool value_dependent_false_v = dependent_false<T>::value;
 
   /** remove_cvref combines remove_cv and remove_reference - this is present in
    * C++20

--- a/src/ds/openapi.h
+++ b/src/ds/openapi.h
@@ -283,10 +283,9 @@ namespace ds
           nonstd::is_specialization<T, std::map>::value ||
           nonstd::is_specialization<T, std::unordered_map>::value)
         {
-          // Nlohmann serialises maps to an array of (K, V) pairs
-          if (std::is_same<typename T::key_type, std::string>::value)
+          if constexpr (nlohmann::detail::
+                          is_compatible_object_type<nlohmann::json, T>::value)
           {
-            // ...unless the keys are strings!
             schema["type"] = "object";
             schema["additionalProperties"] =
               add_schema_component<typename T::mapped_type>();

--- a/src/ds/ring_buffer_types.h
+++ b/src/ds/ring_buffer_types.h
@@ -144,7 +144,7 @@ namespace ringbuffer
   struct MessageSerializers
   {
     static_assert(
-      nonstd::dependent_false<ringbuffer::Message, m>::value,
+      nonstd::value_dependent_false<ringbuffer::Message, m>::value,
       "No payload specialization for this Message");
   };
 

--- a/src/kv/map.h
+++ b/src/kv/map.h
@@ -112,7 +112,7 @@ namespace kv
     kv::serialisers::BlitSerialiser<K>,
     kv::serialisers::BlitSerialiser<V>>;
 
-  /** Short name for default-serialised maps, using msgpack serialisers. Support
+  /** Short name for default-serialised maps, using JSON serialisers. Support
    * for custom types can be added through the DECLARE_JSON... macros.
    */
   template <typename K, typename V>

--- a/src/kv/serialise_entry_json.h
+++ b/src/kv/serialise_entry_json.h
@@ -13,6 +13,11 @@ namespace kv::serialisers
   {
     static SerialisedEntry to_serialised(const T& t)
     {
+      static_assert(
+        std::is_convertible_v<T, nlohmann::json>,
+        "Cannot convert this type to JSON - either define to_json or use "
+        "DECLARE_JSON... macros");
+
       const nlohmann::json j = t;
       const auto dumped = j.dump();
       return SerialisedEntry(dumped.begin(), dumped.end());


### PR DESCRIPTION
Our generated OpenAPI document should now match the actual serialisation for map types with stringifiable keys (ie - `EntityID`), describing these as objects.

Includes some vaguely related cleanup:
- Prefer to gives these objects names like `EntityId_to_Failure` rather than `named_Failure`. Even if the key _is_ just a string, we'd prefer `string_to_Foo`.
- Give an earlier, clearer error when creating `kv::Map`s with non-serialisable types.