### PR TITLE
Read multiple directories to construct Python ledger

### DIFF
--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -500,22 +500,21 @@ class Ledger:
 
         self._filenames = []
 
-        ledgers = []
+        ledger_files = []
         for directory in directories:
-            ledgers += os.listdir(directory)
+            for path in os.listdir(directory):
+                chunk = os.path.join(directory, path)
+                if os.path.isfile(chunk):
+                    ledger_files.append(chunk)
 
         # Sorts the list based off the first number after ledger_ so that
         # the ledger is verified in sequence
-        sorted_ledgers = sorted(
-            ledgers,
+        self._filenames = sorted(
+            ledger_files,
             key=lambda x: int(
-                x.replace(".committed", "").replace("ledger_", "").split("-")[0]
+                os.path.basename(x).replace(".committed", "").replace("ledger_", "").split("-")[0]
             ),
         )
-
-        for chunk in sorted_ledgers:
-            if os.path.isfile(os.path.join(directory, chunk)):
-                self._filenames.append(os.path.join(directory, chunk))
 
         self._reset_iterators()
 

--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -512,7 +512,10 @@ class Ledger:
         self._filenames = sorted(
             ledger_files,
             key=lambda x: int(
-                os.path.basename(x).replace(".committed", "").replace("ledger_", "").split("-")[0]
+                os.path.basename(x)
+                .replace(".committed", "")
+                .replace("ledger_", "")
+                .split("-")[0]
             ),
         )
 

--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -6,7 +6,7 @@ import struct
 import os
 from enum import Enum
 
-from typing import BinaryIO, NamedTuple, Optional, Tuple, Dict
+from typing import BinaryIO, NamedTuple, Optional, Tuple, Dict, List
 
 import json
 import base64
@@ -496,11 +496,14 @@ class Ledger:
         # Initialize LedgerValidator instance which will be passed to LedgerChunks.
         self._ledger_validator = LedgerValidator()
 
-    def __init__(self, directory: str):
+    def __init__(self, directories: List[str]):
 
         self._filenames = []
 
-        ledgers = os.listdir(directory)
+        ledgers = []
+        for directory in directories:
+            ledgers += os.listdir(directory)
+
         # Sorts the list based off the first number after ledger_ so that
         # the ledger is verified in sequence
         sorted_ledgers = sorted(

--- a/python/ccf/read_ledger.py
+++ b/python/ccf/read_ledger.py
@@ -44,13 +44,13 @@ if __name__ == "__main__":
     )
 
     if len(sys.argv) < 2:
-        LOG.error("First argument should be CCF ledger directory")
+        LOG.error("At least one CCF ledger directory must be passed as an argument")
         sys.exit(1)
 
-    ledger_dir = sys.argv[1]
-    ledger = ccf.ledger.Ledger(ledger_dir)
+    ledger_dirs = sys.argv[1:]
+    ledger = ccf.ledger.Ledger(ledger_dirs)
 
-    LOG.info(f"Reading ledger from {ledger_dir}")
+    LOG.info(f"Reading ledger from {ledger_dirs}")
     LOG.info(f"Contains {counted_string(ledger, 'chunk')}")
 
     for chunk in ledger:

--- a/python/ledger_tutorial.py
+++ b/python/ledger_tutorial.py
@@ -20,13 +20,13 @@ if len(sys.argv) < 2:
     print("Error: Ledger directory should be specified as first argument")
     sys.exit(1)
 
-ledger_dir = sys.argv[1]
+ledger_dirs = sys.argv[1:]
 
 # SNIPPET: import_ledger
 import ccf.ledger
 
 # SNIPPET: create_ledger
-ledger = ccf.ledger.Ledger(ledger_dir)
+ledger = ccf.ledger.Ledger(ledger_dirs)
 
 # SNIPPET: target_table
 target_table = "public:ccf.gov.nodes.info"

--- a/tests/governance_history.py
+++ b/tests/governance_history.py
@@ -94,7 +94,7 @@ def test_ledger_is_readable(network, args):
         LOG.info(f"Reading ledger from {ledger_dirs}")
         ledger = ccf.ledger.Ledger(ledger_dirs)
         for chunk in ledger:
-            for tr in chunk:
+            for _ in chunk:
                 pass
     return network
 
@@ -156,7 +156,7 @@ def run(args):
         test_tables_doc(network, args)
 
     # Refresh ledger to beginning
-    ledger = ccf.ledger.Ledger(ledger_directory)
+    ledger = ccf.ledger.Ledger(ledger_directories)
 
     (
         final_proposals,

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -316,27 +316,27 @@ class Node:
         end_time = time.time() + timeout
         while time.time() < end_time:
             try:
-                ledger = ccf.ledger.Ledger(self.remote.ledger_path())
+                ledger = ccf.ledger.Ledger(self.remote.ledger_paths())
                 tx = ledger.get_transaction(seqno)
                 return tx.get_public_domain().get_tables()
             except Exception:
                 time.sleep(0.1)
 
         raise TimeoutError(
-            f"Could not read transaction at seqno {seqno} from ledger {self.remote.ledger_path()}"
+            f"Could not read transaction at seqno {seqno} from ledger {self.remote.ledger_paths()}"
         )
 
     def get_latest_ledger_public_state(self, timeout=3):
         end_time = time.time() + timeout
         while time.time() < end_time:
             try:
-                ledger = ccf.ledger.Ledger(self.remote.ledger_path())
+                ledger = ccf.ledger.Ledger(self.remote.ledger_paths())
                 return ledger.get_latest_public_state()
             except Exception:
                 time.sleep(0.1)
 
         raise TimeoutError(
-            f"Could not read latest state from ledger {self.remote.ledger_path()}"
+            f"Could not read latest state from ledger {self.remote.ledger_paths()}"
         )
 
     def get_ledger(self, include_read_only_dirs=False):

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -837,8 +837,11 @@ class CCFRemote(object):
     def log_path(self):
         return self.remote.out
 
-    def ledger_path(self):
-        return os.path.join(self.remote.root, self.ledger_dir_name)
+    def ledger_paths(self):
+        paths = [os.path.join(self.remote.root, self.ledger_dir_name)]
+        if self.read_only_ledger_dir is not None:
+            paths += os.path.join(self.remote.root, self.read_only_ledger_dir)
+        return paths
 
 
 class StartType(Enum):

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -840,7 +840,7 @@ class CCFRemote(object):
     def ledger_paths(self):
         paths = [os.path.join(self.remote.root, self.ledger_dir_name)]
         if self.read_only_ledger_dir is not None:
-            paths += os.path.join(self.remote.root, self.read_only_ledger_dir)
+            paths += [os.path.join(self.remote.root, self.read_only_ledger_dir)]
         return paths
 
 

--- a/tests/ledger_operation.py
+++ b/tests/ledger_operation.py
@@ -24,12 +24,13 @@ def save_committed_ledger_files(network, args):
 
     LOG.info(f"Moving committed ledger files to {args.common_read_only_ledger_dir}")
     primary, _ = network.find_primary()
-    for l in os.listdir(primary.remote.ledger_path()):
-        if infra.node.is_file_committed(l):
-            shutil.move(
-                os.path.join(primary.remote.ledger_path(), l),
-                os.path.join(args.common_read_only_ledger_dir, l),
-            )
+    for ledger_dir in primary.remote.ledger_paths():
+        for l in os.listdir(ledger_dir):
+            if infra.node.is_file_committed(l):
+                shutil.move(
+                    os.path.join(ledger_dir, l),
+                    os.path.join(args.common_read_only_ledger_dir, l),
+                )
 
     txs.verify(network)
     return network

--- a/tests/suite/test_suite.py
+++ b/tests/suite/test_suite.py
@@ -96,6 +96,7 @@ all_tests_suite = [
     # code update:
     code_update.test_verify_quotes,
     code_update.test_add_node_with_bad_code,
+    governance_history.test_ledger_is_readable,
     governance_history.test_tables_doc,
 ]
 suites["all"] = all_tests_suite


### PR DESCRIPTION
Fix for Daily CI. When a node's ledger is split across multiple directories, we should read from all of them to reconstruct the full ledger.