### PR TITLE
Add `MapHandle::clear()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.99.3]
+
+### Added
+
+- `kv::MapHandle::clear()` can be used to remove all entries from a map.
+
 ## [0.99.2]
 
 ### Changed

--- a/doc/build_apps/kv/api.rst
+++ b/doc/build_apps/kv/api.rst
@@ -47,7 +47,7 @@ Handle
 
 .. doxygenclass:: kv::WriteableMapHandle
    :project: CCF
-   :members: put, remove
+   :members: put, remove, clear
 
 .. doxygenclass:: kv::MapHandle
    :project: CCF

--- a/src/kv/map_handle.h
+++ b/src/kv/map_handle.h
@@ -187,6 +187,13 @@ namespace kv
     {
       return write_handle.remove(KSerialiser::to_serialised(key));
     }
+
+    /** Delete every key-value pair.
+     */
+    void clear()
+    {
+      write_handle.clear();
+    }
   };
 
   /** Grants read and write access to a @c kv::Map, as part of a @c kv::Tx.

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -180,30 +180,50 @@ TEST_CASE("clear")
     REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
   }
 
+  SUBCASE("Basic")
   {
-    INFO("Clear removes all entries");
-    auto tx = kv_store.create_tx();
-    auto handle = tx.rw(map);
-    handle->put(k2, v);
+    {
+      INFO("Clear removes all entries");
+      auto tx = kv_store.create_tx();
+      auto handle = tx.rw(map);
+      handle->put(k2, v);
 
-    REQUIRE(handle->has(k1));
-    REQUIRE(handle->has(k2));
+      REQUIRE(handle->has(k1));
+      REQUIRE(handle->has(k2));
 
-    handle->clear();
+      handle->clear();
 
-    REQUIRE(!handle->has(k1));
-    REQUIRE(!handle->has(k2));
+      REQUIRE(!handle->has(k1));
+      REQUIRE(!handle->has(k2));
 
-    REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+      REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+    }
+
+    {
+      INFO("Clear is committed");
+      auto tx = kv_store.create_tx();
+      auto handle = tx.rw(map);
+
+      REQUIRE(!handle->has(k1));
+      REQUIRE(!handle->has(k2));
+      REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+    }
   }
 
+  SUBCASE("Clear conflicts correctly")
   {
-    INFO("Clear is committed");
-    auto tx = kv_store.create_tx();
-    auto handle = tx.rw(map);
+    auto tx1 = kv_store.create_tx();
+    auto handle1 = tx1.rw(map);
+    handle1->clear();
 
-    REQUIRE(!handle->has(k1));
-    REQUIRE(!handle->has(k2));
+    INFO("Another transaction creates a key and commits");
+    auto tx2 = kv_store.create_tx();
+    auto handle2 = tx2.rw(map);
+    handle2->put(k2, v);
+    REQUIRE(tx2.commit() == kv::CommitResult::SUCCESS);
+
+    INFO("clear() conflicts and must be retried");
+    REQUIRE(tx1.commit() == kv::CommitResult::FAIL_CONFLICT);
   }
 }
 

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -161,6 +161,52 @@ TEST_CASE("Reads/writes and deletions")
   }
 }
 
+TEST_CASE("clear")
+{
+  kv::Store kv_store;
+  MapTypes::StringString map("public:map");
+
+  const auto k1 = "k1";
+  const auto k2 = "k2";
+
+  const auto v = "v";
+
+  {
+    INFO("Setting committed state");
+    auto tx = kv_store.create_tx();
+    auto handle = tx.rw(map);
+    handle->put(k1, v);
+
+    REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+  }
+
+  {
+    INFO("Clear removes all entries");
+    auto tx = kv_store.create_tx();
+    auto handle = tx.rw(map);
+    handle->put(k2, v);
+
+    REQUIRE(handle->has(k1));
+    REQUIRE(handle->has(k2));
+
+    handle->clear();
+
+    REQUIRE(!handle->has(k1));
+    REQUIRE(!handle->has(k2));
+
+    REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+  }
+
+  {
+    INFO("Clear is committed");
+    auto tx = kv_store.create_tx();
+    auto handle = tx.rw(map);
+
+    REQUIRE(!handle->has(k1));
+    REQUIRE(!handle->has(k2));
+  }
+}
+
 TEST_CASE("get_version_of_previous_write")
 {
   kv::Store kv_store;

--- a/src/kv/untyped_map_handle.h
+++ b/src/kv/untyped_map_handle.h
@@ -199,6 +199,14 @@ namespace kv::untyped
       return true;
     }
 
+    void clear()
+    {
+      foreach([this](const auto& k, const auto&) {
+        remove(k);
+        return true;
+      });
+    }
+
     template <class F>
     void foreach(F&& f)
     {

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -166,10 +166,7 @@ namespace ccf
     {
       auto endpoints =
         tx.rw<ccf::endpoints::EndpointsMap>(ccf::Tables::ENDPOINTS);
-      endpoints->foreach([&endpoints](const auto& k, const auto&) {
-        endpoints->remove(k);
-        return true;
-      });
+      endpoints->clear();
     }
 
 #pragma clang diagnostic push


### PR DESCRIPTION
Same motivation as #2493 - create this API so it can be used now, and maybe we'll improve the implementation in future.

Note the second test `SUBCASE` - `clear()` actually needs to introduce a read dependency in the current implementation, since if its ordered after another operation it may miss new keys. If we find a different way to express the clear in the underlying implementation then we may not need to introduce this read dependency (ie - an app endpoint that just says `clear()` and does no reads _can_ be ordered before or after any other), but we'd need to ensure that we remove all keys which are present at _commit_ time.