### PR TITLE
Change log message to TRACE for replayed node-to-node nonces

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-hey ho
+quack

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -2030,9 +2030,12 @@ namespace aft
       {
         // We are behind, convert to a follower.
         LOG_DEBUG_FMT(
-          "Recv append entries response to {} from {}: more recent term",
+          "Recv append entries response to {} from {}: more recent term ({} "
+          "> {})",
           state->my_node_id,
-          from);
+          from,
+          r.term,
+          state->current_view);
         become_follower(r.term);
         return;
       }
@@ -2041,9 +2044,11 @@ namespace aft
         // Stale response, discard if success.
         // Otherwise reset sent_idx and try again.
         LOG_DEBUG_FMT(
-          "Recv append entries response to {} from {}: stale term",
+          "Recv append entries response to {} from {}: stale term ({} != {})",
           state->my_node_id,
-          from);
+          from,
+          r.term,
+          state->current_view);
         if (r.success == AppendEntriesResponseType::OK)
         {
           return;

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -160,7 +160,7 @@ namespace ccf
       }
 
       LOG_TRACE_FMT(
-        "<- {}: encrypted msg with nonce={}",
+        "<- {}: node msg with nonce={}",
         peer_id,
         (const uint64_t)recv_nonce.nonce);
 
@@ -775,7 +775,7 @@ namespace ccf
         cipher);
 
       LOG_TRACE_FMT(
-        "-> {}: encrypted msg with nonce={}", peer_id, (uint64_t)nonce.nonce);
+        "-> {}: node msg with nonce={}", peer_id, (uint64_t)nonce.nonce);
 
       return true;
     }
@@ -935,8 +935,10 @@ namespace ccf
       {
         // Channel with peer already exists but is incoming. Create host
         // outgoing connection.
-        LOG_DEBUG_FMT("Setting existing channel to {} as outgoing", peer_id);
-        search->second->set_outgoing(hostname, service);
+        // LOG_DEBUG_FMT("Setting existing channel to {} as outgoing", peer_id);
+        // search->second->set_outgoing(hostname, service);
+        LOG_DEBUG_FMT(
+          "No need to create channel as incoming channel already exists!");
         return;
       }
       else if (!search->second)

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -177,8 +177,9 @@ namespace ccf
       else if (recv_nonce.nonce <= *local_nonce)
       {
         // If the nonce received has already been processed, return
-        LOG_FAIL_FMT(
-          "Invalid nonce, possible replay attack, from:{} received:{}, "
+        // See https://github.com/microsoft/CCF/issues/2492 for more details
+        LOG_TRACE_FMT(
+          "Received past nonce from:{} received:{}, "
           "last_seen:{}, recv_nonce.tid:{}",
           peer_id,
           reinterpret_cast<uint64_t>(recv_nonce.nonce),
@@ -935,10 +936,8 @@ namespace ccf
       {
         // Channel with peer already exists but is incoming. Create host
         // outgoing connection.
-        // LOG_DEBUG_FMT("Setting existing channel to {} as outgoing", peer_id);
-        // search->second->set_outgoing(hostname, service);
-        LOG_DEBUG_FMT(
-          "No need to create channel as incoming channel already exists!");
+        LOG_DEBUG_FMT("Setting existing channel to {} as outgoing", peer_id);
+        search->second->set_outgoing(hostname, service);
         return;
       }
       else if (!search->second)

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -179,7 +179,7 @@ namespace ccf
         // If the nonce received has already been processed, return
         // See https://github.com/microsoft/CCF/issues/2492 for more details
         LOG_TRACE_FMT(
-          "Received past nonce from:{} received:{}, "
+          "Received past nonce from:{}, received:{}, "
           "last_seen:{}, recv_nonce.tid:{}",
           peer_id,
           reinterpret_cast<uint64_t>(recv_nonce.nonce),

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -177,7 +177,8 @@ namespace ccf
       else if (recv_nonce.nonce <= *local_nonce)
       {
         // If the nonce received has already been processed, return
-        // See https://github.com/microsoft/CCF/issues/2492 for more details
+        // See https://github.com/microsoft/CCF/issues/2492 for more details on
+        // how this can happen around election time
         LOG_TRACE_FMT(
           "Received past nonce from:{}, received:{}, "
           "last_seen:{}, recv_nonce.tid:{}",

--- a/tests/rotation.py
+++ b/tests/rotation.py
@@ -50,13 +50,13 @@ if __name__ == "__main__":
             "--rotation-retirements",
             help="Number of times to retired the primary",
             type=int,
-            default=10,
+            default=3,
         )
         parser.add_argument(
             "--rotation-suspensions",
             help="Number of times to suspend the primary",
             type=int,
-            default=10,
+            default=3,
         )
 
     args = infra.e2e_args.cli_args(add=add)

--- a/tests/rotation.py
+++ b/tests/rotation.py
@@ -50,13 +50,13 @@ if __name__ == "__main__":
             "--rotation-retirements",
             help="Number of times to retired the primary",
             type=int,
-            default=3,
+            default=10,
         )
         parser.add_argument(
             "--rotation-suspensions",
             help="Number of times to suspend the primary",
             type=int,
-            default=3,
+            default=10,
         )
 
     args = infra.e2e_args.cli_args(add=add)


### PR DESCRIPTION
Resolves #2492 

The investigation of the rogue "_Invalid nonce, possible replay attack_" log message (see https://github.com/microsoft/CCF/issues/2492#issuecomment-826838601) has led to the conclusion that this is currently a legitimate scenario that may arise around election time, and that there's no immediate fix for this.

Changing the level of the log to `TRACE` so that the message doesn't appear in CCF releases.

 