### PR TITLE
Add `get_quotes_for_all_trusted_nodes_v1` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- Added `get_untrusted_host_time_v1` API. This can be used to retrieve a timestamp during endpoint execution, accurate to within a few milliseconds. Note that this timestamp comes directly from the host so is not trusted, and should not be used to make sensitive decisions within a transaction (#2550).
+- Added `get_quotes_for_all_trusted_nodes_v1` API. This returns the ID and quote for all nodes which are currently trusted and participating in the service, for live audit (#2511).
+
 ### Changed
 
 - The curve-id selected for the identity of joining nodes no longer needs to match that of the network (#2525).

--- a/include/ccf/base_endpoint_registry.h
+++ b/include/ccf/base_endpoint_registry.h
@@ -122,7 +122,7 @@ namespace ccf
     /** Get quotes attesting to the hardware that each node in the service is
      * running on.
      */
-    ApiResult get_quotes_for_all_nodes_v1(
+    ApiResult get_quotes_for_all_trusted_nodes_v1(
       kv::ReadOnlyTx& tx, std::map<NodeId, QuoteInfo>& quotes);
 
     /** Get the view associated with a given seqno, to construct a valid TxID.

--- a/include/ccf/base_endpoint_registry.h
+++ b/include/ccf/base_endpoint_registry.h
@@ -119,6 +119,12 @@ namespace ccf
      */
     ApiResult get_id_for_this_node_v1(NodeId& node_id);
 
+    /** Get quotes attesting to the hardware that each node in the service is
+     * running on.
+     */
+    ApiResult get_quotes_for_all_nodes_v1(
+      kv::ReadOnlyTx& tx, std::map<NodeId, QuoteInfo>& quotes);
+
     /** Get the view associated with a given seqno, to construct a valid TxID.
      */
     ApiResult get_view_for_seqno_v1(ccf::SeqNo seqno, ccf::View& view);

--- a/samples/apps/nobuiltins/nobuiltins.cpp
+++ b/samples/apps/nobuiltins/nobuiltins.cpp
@@ -123,7 +123,7 @@ namespace nobuiltins
         ccf::ApiResult result;
 
         std::map<ccf::NodeId, ccf::QuoteInfo> node_id_to_quote_info;
-        result = get_quotes_for_all_nodes_v1(ctx.tx, node_id_to_quote_info);
+        result = get_quotes_for_all_trusted_nodes_v1(ctx.tx, node_id_to_quote_info);
         if (result != ccf::ApiResult::OK)
         {
           ctx.rpc_ctx->set_error(

--- a/samples/apps/nobuiltins/nobuiltins.cpp
+++ b/samples/apps/nobuiltins/nobuiltins.cpp
@@ -131,7 +131,8 @@ namespace nobuiltins
         ccf::ApiResult result;
 
         std::map<ccf::NodeId, ccf::QuoteInfo> node_id_to_quote_info;
-        result = get_quotes_for_all_trusted_nodes_v1(ctx.tx, node_id_to_quote_info);
+        result =
+          get_quotes_for_all_trusted_nodes_v1(ctx.tx, node_id_to_quote_info);
         if (result != ccf::ApiResult::OK)
         {
           ctx.rpc_ctx->set_error(

--- a/src/endpoints/base_endpoint_registry.cpp
+++ b/src/endpoints/base_endpoint_registry.cpp
@@ -126,6 +126,28 @@ namespace ccf
     }
   }
 
+  ApiResult BaseEndpointRegistry::get_quotes_for_all_nodes_v1(
+    kv::ReadOnlyTx& tx, std::map<NodeId, QuoteInfo>& quotes)
+  {
+    try
+    {
+      std::map<NodeId, QuoteInfo> tmp;
+      auto nodes = tx.ro<ccf::Nodes>(Tables::NODES);
+      nodes->foreach([&tmp](const NodeId& node_id, const NodeInfo& ni) {
+        tmp[node_id] = ni.quote_info;
+        return true;
+      });
+
+      quotes = std::move(tmp);
+      return ApiResult::OK;
+    }
+    catch (const std::exception& e)
+    {
+      LOG_TRACE_FMT("{}", e.what());
+      return ApiResult::InternalError;
+    }
+  }
+
   ApiResult BaseEndpointRegistry::get_view_for_seqno_v1(
     ccf::SeqNo seqno, ccf::View& view)
   {

--- a/src/endpoints/base_endpoint_registry.cpp
+++ b/src/endpoints/base_endpoint_registry.cpp
@@ -126,7 +126,7 @@ namespace ccf
     }
   }
 
-  ApiResult BaseEndpointRegistry::get_quotes_for_all_nodes_v1(
+  ApiResult BaseEndpointRegistry::get_quotes_for_all_trusted_nodes_v1(
     kv::ReadOnlyTx& tx, std::map<NodeId, QuoteInfo>& quotes)
   {
     try
@@ -134,7 +134,10 @@ namespace ccf
       std::map<NodeId, QuoteInfo> tmp;
       auto nodes = tx.ro<ccf::Nodes>(Tables::NODES);
       nodes->foreach([&tmp](const NodeId& node_id, const NodeInfo& ni) {
-        tmp[node_id] = ni.quote_info;
+        if (ni.status == ccf::NodeStatus::TRUSTED)
+        {
+          tmp[node_id] = ni.quote_info;
+        }
         return true;
       });
 

--- a/tests/nobuiltins.py
+++ b/tests/nobuiltins.py
@@ -10,7 +10,7 @@ import time
 
 
 def test_nobuiltins_endpoints(network, args):
-    primary, _ = network.find_primary()
+    primary, backups = network.find_nodes()
     with primary.client() as c:
         r = c.get("/app/commit")
         assert r.status_code == HTTPStatus.OK
@@ -50,6 +50,16 @@ def test_nobuiltins_endpoints(network, args):
             # more lenient
             assert abs(diff) < 1, diff
 
+        r = c.get(f"/app/all_nodes")
+        assert r.status_code == HTTPStatus.OK
+        body_j = r.body.json()
+        known_node_ids = [node.node_id for node in (primary, *backups)]
+        for node_id, node_info in body_j["nodes"].items():
+            assert (
+                node_id in known_node_ids
+            ), f"Response contains '{node_id}', which is not in known IDs: {known_node_ids}"
+            assert node_info["quote_format"] == "OE_SGX_v1"
+
 
 def run(args):
     with infra.network.network(
@@ -63,5 +73,5 @@ def run(args):
 if __name__ == "__main__":
     args = infra.e2e_args.cli_args()
 
-    args.nodes = infra.e2e_args.min_nodes(args, f=0)
+    args.nodes = infra.e2e_args.min_nodes(args, f=1)
     run(args)

--- a/tests/nobuiltins.py
+++ b/tests/nobuiltins.py
@@ -50,7 +50,7 @@ def test_nobuiltins_endpoints(network, args):
             # more lenient
             assert abs(diff) < 1, diff
 
-        r = c.get(f"/app/all_nodes")
+        r = c.get("/app/all_nodes")
         assert r.status_code == HTTPStatus.OK
         body_j = r.body.json()
         known_node_ids = [node.node_id for node in (primary, *backups)]


### PR DESCRIPTION
Completes #2206.

Opening as a draft for now because I think this API needs a little more thought. This initial version includes _all known_ node quotes directly from the KV, with no indication as to the node's current status. If the aim is to allow apps to build their own status endpoints, they will need to see node status (and perhaps other node data, like public RPC address?). I'm tempted to just make a `get_status_for_node_v1`, to keep these queries cleanly separated, and perhaps even make this `get_quote_for_node_v1` with a separate `get_ids_for_all_nodes_v1`, but the core question remains - what do we mean by "all nodes"? The current behaviour, where all historic nodes happen to remain in the KV, is supposed to be temporary. So maybe this API should ignore `Retired` nodes already? Do we need to provide an API to retrieve the quote for `Retired` nodes, which will eventually/in general require a historic query?