### PR TITLE
Fix Mermaid diagram whitespace by rewriting height attribute

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -238,6 +238,27 @@ js_language = "typescript"
 js_source_path = "../src/js"
 jsdoc_config_path = "../src/js/tsconfig.json"
 
+# sphinxcontrib-mermaid options
+# NB: The docs say the <script> tag will no longer be needed
+# from 0.7, but this is not yet released
+mermaid_init_js = """<script>
+mermaid.initialize({startOnLoad:true});
+
+// Remove height from all mermaid diagrams
+window.addEventListener(
+  'load',
+  function() {
+    let nodes = document.querySelectorAll('.mermaid');
+    for (let i = 0; i < nodes.length; i++) {
+      const element = nodes[i];
+      const svg = element.firstChild;
+      svg.removeAttribute('height');
+    }
+  },
+  false
+);
+</script>"""
+
 def typedoc_role(name: str, rawtext: str, text: str, lineno, inliner, options={}, content=[]):
     """
     Supported syntaxes:


### PR DESCRIPTION
An ugly fix, causes a second page reordering, but seems to work. Hopefully temporary - there are several issues around this, so maybe they'll add a better configuration option?

The other proposed fix was using `mermaid-cli`, but I think installing this (in our images) and testing it (at arms length through `sphinxcontrib-mermaid`) seems more difficult?