### PR TITLE
Add test for `secp256r1` as service and node identities curve

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,6 +504,13 @@ if(BUILD_TESTS)
   )
 
   add_e2e_test(
+    NAME recovery_test_curve_256
+    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/recovery.py
+    CONSENSUS cft
+    ADDITIONAL_ARGS --recovery 3 --curve-id secp256r1
+  )
+
+  add_e2e_test(
     NAME recovery_test_suite
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_suite.py
     CONSENSUS cft

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -347,6 +347,19 @@ int main(int argc, char** argv)
       )
     ->capture_default_str();
 
+  crypto::CurveID curve_id = crypto::CurveID::SECP384R1;
+  std::vector<std::pair<std::string, crypto::CurveID>> curve_id_map = {
+    {"secp384r1", crypto::CurveID::SECP384R1},
+    {"secp256r1", crypto::CurveID::SECP256R1}};
+  app
+    .add_option(
+      "--curve-id",
+      curve_id,
+      "Elliptic curve to use as for node and network identities (used for TLS "
+      "and ledger signatures)")
+    ->transform(CLI::CheckedTransformer(curve_id_map, CLI::ignore_case))
+    ->capture_default_str();
+
   // The network certificate file can either be an input or output parameter,
   // depending on the subcommand.
   std::string network_cert_file = "networkcert.pem";
@@ -429,19 +442,6 @@ int main(int argc, char** argv)
       "Destination path to freshly created network certificate")
     ->capture_default_str()
     ->check(CLI::NonexistentPath);
-
-  crypto::CurveID curve_id = crypto::CurveID::SECP384R1;
-  std::vector<std::pair<std::string, crypto::CurveID>> curve_id_map = {
-    {"secp384r1", crypto::CurveID::SECP384R1},
-    {"secp256r1", crypto::CurveID::SECP256R1}};
-  app
-    .add_option(
-      "--curve-id",
-      curve_id,
-      "Elliptic curve to use as for node and network identities (used for TLS "
-      "and ledger signatures)")
-    ->transform(CLI::CheckedTransformer(curve_id_map, CLI::ignore_case))
-    ->capture_default_str();
 
   CLI11_PARSE(app, argc, argv);
 

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -439,8 +439,7 @@ int main(int argc, char** argv)
       "--curve-id",
       curve_id,
       "Elliptic curve to use as for node and network identities (used for TLS "
-      "and ledger "
-      "signatures")
+      "and ledger signatures)")
     ->transform(CLI::CheckedTransformer(curve_id_map, CLI::ignore_case))
     ->capture_default_str();
 

--- a/src/node/identity.h
+++ b/src/node/identity.h
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "crypto/curve.h"
 #include "crypto/key_pair.h"
 
 #include <string>
@@ -21,9 +22,9 @@ namespace ccf
 
     NetworkIdentity() = default;
 
-    NetworkIdentity(const std::string& name)
+    NetworkIdentity(const std::string& name, crypto::CurveID curve_id)
     {
-      auto identity_key_pair = crypto::make_key_pair();
+      auto identity_key_pair = crypto::make_key_pair(curve_id);
       cert = identity_key_pair->self_sign(name);
       priv_key = identity_key_pair->private_key_pem();
     }

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -119,6 +119,7 @@ namespace ccf
     StateMachine<State> sm;
     SpinLock lock;
 
+    CurveID curve_id;
     crypto::KeyPairPtr node_sign_kp;
     NodeId self;
     std::shared_ptr<crypto::RSAKeyPair> node_encrypt_kp;
@@ -284,9 +285,10 @@ namespace ccf
       NetworkState& network,
       std::shared_ptr<enclave::RPCSessions> rpcsessions,
       ShareManager& share_manager,
-      const CurveID& curve_id) :
+      CurveID curve_id_) :
       sm(State::uninitialized),
-      node_sign_kp(crypto::make_key_pair(curve_id)),
+      curve_id(curve_id_),
+      node_sign_kp(crypto::make_key_pair(curve_id_)),
       node_encrypt_kp(crypto::make_rsa_key_pair()),
       writer_factory(writer_factory),
       to_host(writer_factory.create_writer_to_outside()),
@@ -363,7 +365,7 @@ namespace ccf
         case StartType::New:
         {
           network.identity =
-            std::make_unique<NetworkIdentity>("CN=CCF Network");
+            std::make_unique<NetworkIdentity>("CN=CCF Network", curve_id);
 
           node_cert = create_endorsed_node_cert();
 
@@ -433,7 +435,7 @@ namespace ccf
           node_info_network = config.node_info_network;
 
           network.identity =
-            std::make_unique<NetworkIdentity>("CN=CCF Network");
+            std::make_unique<NetworkIdentity>("CN=CCF Network", curve_id);
           node_cert = create_endorsed_node_cert();
 
           setup_history();

--- a/tests/governance_history.py
+++ b/tests/governance_history.py
@@ -126,7 +126,7 @@ def run(args):
             _,
             careful_vote,
         ) = network.consortium.generate_and_propose_new_member(
-            primary, curve=infra.network.ParticipantsCurve.secp256r1
+            primary, curve=infra.network.EllipticCurve.secp256r1
         )
         proposals_issued += 1
 
@@ -139,7 +139,7 @@ def run(args):
 
         LOG.info("Create new proposal but withdraw it before it is accepted")
         new_member_proposal, _, _ = network.consortium.generate_and_propose_new_member(
-            primary, curve=infra.network.ParticipantsCurve.secp256r1
+            primary, curve=infra.network.EllipticCurve.secp256r1
         )
         proposals_issued += 1
 

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -269,6 +269,13 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         type=str,
         default=None,
     )
+    parser.add_argument(
+        "--curve-id",
+        help="Elliptic curve to use as for node and network identities",
+        default=infra.network.ParticipantsCurve.secp384r1.name,
+        type=lambda curve: infra.network.ParticipantsCurve[curve],
+        choices=list(infra.network.ParticipantsCurve),
+    )
 
     add(parser)
 

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -272,7 +272,7 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
     parser.add_argument(
         "--curve-id",
         help="Elliptic curve to use as for node and network identities",
-        default=infra.network.ParticipantsCurve.secp384r1.name,
+        default=None,
         type=lambda curve: infra.network.ParticipantsCurve[curve],
         choices=list(infra.network.ParticipantsCurve),
     )

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -197,9 +197,9 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
     parser.add_argument(
         "--participants-curve",
         help="Curve to use for member and user identities",
-        default=infra.network.ParticipantsCurve.secp384r1.name,
-        type=lambda curve: infra.network.ParticipantsCurve[curve],
-        choices=list(infra.network.ParticipantsCurve),
+        default=infra.network.EllipticCurve.secp384r1.name,
+        type=lambda curve: infra.network.EllipticCurve[curve],
+        choices=list(infra.network.EllipticCurve),
     )
     parser.add_argument(
         "--join-timer",
@@ -273,8 +273,8 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         "--curve-id",
         help="Elliptic curve to use as for node and network identities",
         default=None,
-        type=lambda curve: infra.network.ParticipantsCurve[curve],
-        choices=list(infra.network.ParticipantsCurve),
+        type=lambda curve: infra.network.EllipticCurve[curve],
+        choices=list(infra.network.EllipticCurve),
     )
 
     add(parser)

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -40,12 +40,12 @@ class ServiceStatus(Enum):
     CLOSED = "Closed"
 
 
-class ParticipantsCurve(IntEnum):
+class EllipticCurve(IntEnum):
     secp384r1 = 0
     secp256r1 = 1
 
     def next(self):
-        return ParticipantsCurve((self.value + 1) % len(ParticipantsCurve))
+        return EllipticCurve((self.value + 1) % len(EllipticCurve))
 
 
 class PrimaryNotFound(Exception):

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -97,6 +97,7 @@ class Network:
         "max_open_sessions",
         "jwt_key_refresh_interval_s",
         "common_read_only_ledger_dir",
+        "curve_id",
     ]
 
     # Maximum delay (seconds) for updates to propagate from the primary to backups

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -579,6 +579,7 @@ class CCFRemote(object):
         snapshot_tx_interval=None,
         max_open_sessions=None,
         jwt_key_refresh_interval_s=None,
+        curve_id=None,
     ):
         """
         Run a ccf binary on a remote host.
@@ -682,6 +683,9 @@ class CCFRemote(object):
 
         if self.common_read_only_ledger_dir is not None:
             cmd += [f"--read-only-ledger-dir={self.common_read_only_ledger_dir}"]
+
+        if curve_id is not None:
+            cmd += [f"--curve-id={curve_id.name}"]
 
         if start_type == StartType.new:
             cmd += [

--- a/tests/memberclient.py
+++ b/tests/memberclient.py
@@ -83,7 +83,7 @@ def test_corrupted_signature(network, args):
     node = network.find_node_by_role()
 
     # Test each supported curve
-    for curve in infra.network.ParticipantsCurve:
+    for curve in infra.network.EllipticCurve:
         LOG.info(f"Testing curve: {curve.name}")
         # Add a member so we have at least one on this curve
         member = network.consortium.generate_and_add_new_member(
@@ -142,7 +142,7 @@ def test_governance(network, args):
         careful_vote,
     ) = network.consortium.generate_and_propose_new_member(
         remote_node=node,
-        curve=infra.network.ParticipantsCurve(args.participants_curve).next(),
+        curve=infra.network.EllipticCurve(args.participants_curve).next(),
     )
 
     LOG.info("Check proposal has been recorded in open state")

--- a/tests/membership.py
+++ b/tests/membership.py
@@ -23,7 +23,7 @@ def test_add_member(network, args, recovery_member=True):
 
     new_member = network.consortium.generate_and_add_new_member(
         primary,
-        curve=infra.network.ParticipantsCurve(args.participants_curve).next(),
+        curve=infra.network.EllipticCurve(args.participants_curve).next(),
         member_data=member_data,
         recovery_member=recovery_member,
     )


### PR DESCRIPTION
NB: This still doesn't support _mixed curves_ within a service. If a node tries to join with an identity generated on a different curve, it will currently be unable to form channels with other nodes.