### PR TITLE
Renamed Store::commit_version() to the more accurate compacted_version()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-rc3]
+
+### Changed
+
+- Rename `Store::commit_version()` to the more accurate `Store::compacted_version()` (#1355).
+
 ## [1.0.0-rc2]
 
 ### Changed
@@ -835,6 +841,7 @@ Some discrepancies with the TR remain, and are being tracked under https://githu
 
 Initial pre-release
 
+[1.0.0-rc3]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.0-rc3
 [1.0.0-rc2]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.0-rc2
 [1.0.0-rc1]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.0-rc1
 [0.99.4]: https://github.com/microsoft/CCF/releases/tag/ccf-0.99.4

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -559,7 +559,7 @@ namespace kv
     virtual Version current_version() = 0;
     virtual TxID current_txid() = 0;
 
-    virtual Version commit_version() = 0;
+    virtual Version compacted_version() = 0;
 
     virtual std::shared_ptr<AbstractMap> get_map(
       Version v, const std::string& map_name) = 0;

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -312,13 +312,14 @@ namespace kv
 
     std::unique_ptr<AbstractSnapshot> snapshot(Version v) override
     {
-      if (v < commit_version())
+      auto cv = compacted_version();
+      if (v < cv)
       {
         throw std::logic_error(fmt::format(
-          "Cannot snapshot at version {} which is earlier than committed "
-          "version {} ",
+          "Cannot snapshot at version {} which is earlier than last "
+          "compacted version {} ",
           v,
-          commit_version()));
+          cv));
       }
 
       if (v > current_version())
@@ -913,7 +914,7 @@ namespace kv
       return {term, version};
     }
 
-    Version commit_version() override
+    Version compacted_version() override
     {
       // Must lock in case the store is being compacted.
       std::lock_guard<SpinLock> vguard(version_lock);

--- a/src/kv/test/kv_contention.cpp
+++ b/src/kv/test/kv_contention.cpp
@@ -160,7 +160,7 @@ DOCTEST_TEST_CASE("Concurrent kv access" * doctest::test_suite("concurrency"))
       &ca);
   }
 
-  const auto initial_version = kv_store.commit_version();
+  const auto initial_version = kv_store.compacted_version();
 
   // Start tx threads
   for (size_t i = 0u; i < thread_count; ++i)
@@ -192,7 +192,7 @@ DOCTEST_TEST_CASE("Concurrent kv access" * doctest::test_suite("concurrency"))
   DOCTEST_REQUIRE(compact_state.load() == Done);
 
   // Sanity check that all transactions were compacted
-  const auto now_compacted = kv_store.commit_version();
+  const auto now_compacted = kv_store.compacted_version();
   DOCTEST_REQUIRE(now_compacted > initial_version);
   const auto expected = initial_version + (tx_count * thread_count);
   DOCTEST_REQUIRE(now_compacted == expected);

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -1493,7 +1493,7 @@ TEST_CASE("Private recovery map swap")
       REQUIRE(val.has_value());
       REQUIRE(val.value() == "45");
 
-      REQUIRE(s1.commit_version() == 3);
+      REQUIRE(s1.compacted_version() == 3);
     }
     {
       for (size_t i : {12, 13, 14, 15})
@@ -1971,7 +1971,7 @@ TEST_CASE("Store clear")
     REQUIRE(kv_store.get_map(current_version, map_b_name) != nullptr);
 
     REQUIRE(kv_store.current_version() != 0);
-    REQUIRE(kv_store.commit_version() != 0);
+    REQUIRE(kv_store.compacted_version() != 0);
     auto tx_id = kv_store.current_txid();
     REQUIRE(tx_id.term != 0);
     REQUIRE(tx_id.version != 0);
@@ -1986,7 +1986,7 @@ TEST_CASE("Store clear")
     REQUIRE(kv_store.get_map(current_version, map_b_name) == nullptr);
 
     REQUIRE(kv_store.current_version() == 0);
-    REQUIRE(kv_store.commit_version() == 0);
+    REQUIRE(kv_store.compacted_version() == 0);
     auto tx_id = kv_store.current_txid();
     REQUIRE(tx_id.term == 0);
     REQUIRE(tx_id.version == 0);


### PR DESCRIPTION
fix #1355