### PR TITLE
Don't run perf tests in release pipeline

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -35,11 +35,13 @@ resources:
 variables:
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/ccf-') }}:
     perf_or_release: release
+    perf_tests: no_run
   ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/tags/ccf-')) }}:
     perf_or_release: perf
+    perf_tests: run
 
 jobs:
   - template: .azure-pipelines-templates/matrix.yml
     parameters:
       perf_or_release: ${{ variables['perf_or_release'] }}
-      perf_tests: run
+      perf_tests: ${{ variables['perf_tests'] }}


### PR DESCRIPTION
Fixes the issue which blocked [this](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=24259&view=logs&j=e2a2669a-638d-5159-fc94-d9196412c4a4&s=d654deb9-056d-50a2-1717-90c08683d50a) release.

We didn't previously run the perf tests in the release pipeline (they were gated on `perf_or_release`). We don't wait for them to pass before doing the release:

```
      - template: release.yml
        parameters:
          env: ${{ parameters.env.Hosted }}
          depends_on:
            - Checks
            - SGX_Release
```

But now they run, and if they fail before the release happens they may upload artifacts (logs from the failing tests) that we try to upload in the release.

We should probably be more precise about what we want to upload in the release - we currently do everything in the `ArtifactStagingDirectory`, which may include logs/junk from other tests - but that's a separate issue.