### PR TITLE
Rename debian packages containing tildes to underscores to avoid GitHub's auto-replace

### DIFF
--- a/.azure-pipelines-templates/install.yml
+++ b/.azure-pipelines-templates/install.yml
@@ -3,9 +3,11 @@ steps:
       set -ex
       cmake -L .. 2>/dev/null | grep CMAKE_INSTALL_PREFIX: | cut -d = -f 2 > /tmp/install_prefix
       cpack -V -G DEB
-      PKG=`ls *.deb`
-      cp $PKG $(Build.ArtifactStagingDirectory)
-      echo "##vso[task.setvariable variable=pkgname]$PKG"
+      INITIAL_PKG=`ls *.deb`
+      GITHUB_PKG=${INITIAL_PKG//\~/_}
+      mv $INITIAL_PKG $GITHUB_PKG
+      cp $GITHUB_PKG $(Build.ArtifactStagingDirectory)
+      echo "##vso[task.setvariable variable=pkgname]$GITHUB_PKG"
     workingDirectory: build
     displayName: "Make .deb package"
 

--- a/doc/build_apps/install_bin.rst
+++ b/doc/build_apps/install_bin.rst
@@ -42,10 +42,10 @@ Assuming that CCF was installed under ``/opt``, the following commands can be ru
 
 .. code-block:: bash
 
-    $ /opt/ccf-${CCF_VERSION}/bin/cchost --version
+    $ /opt/ccf/bin/cchost --version
     CCF host: ccf-<version>
 
-    $ /opt/ccf-${CCF_VERSION}/bin/sandbox.sh
+    $ /opt/ccf/bin/sandbox.sh
     No package/app specified. Defaulting to installed JS logging app
     Setting up Python environment...
     Python environment successfully setup

--- a/getting_started/setup_vm/roles/ccf_install/tasks/deb_install.yml
+++ b/getting_started/setup_vm/roles/ccf_install/tasks/deb_install.yml
@@ -7,7 +7,7 @@
       if [ "{{ ccf_ver }}" = "latest" ]; then
         curl -s https://api.github.com/repos/microsoft/ccf/releases/latest | egrep 'https://.*\.deb' | cut -d\" -f4
       else
-        echo "https://github.com/microsoft/CCF/releases/{{ ccf_suffix }}/ccf_{{ ccf_ver }}_amd64.deb"
+        echo "https://github.com/microsoft/CCF/releases/{{ ccf_suffix }}/ccf_{{ ccf_ver | replace('-', '_') }}_amd64.deb"
       fi
   register: ccf_deb_url
 
@@ -18,7 +18,7 @@
 
 - name: Copy cchost
   copy:
-    src: "/opt/ccf-{{ ccf_ver }}/bin/cchost"
+    src: "/opt/ccf/bin/cchost"
     dest: "/usr/bin/cchost"
     remote_src: true
     mode: a=rx

--- a/getting_started/setup_vm/roles/ccf_install/tasks/install.yml
+++ b/getting_started/setup_vm/roles/ccf_install/tasks/install.yml
@@ -8,21 +8,21 @@
 
 - name: Create directory
   file:
-    path: "/opt/ccf-{{ ccf_ver }}"
+    path: "/opt/ccf"
     state: directory
   become: true
 
 - name: Expand CCF release
   unarchive:
     src: "/tmp/{{ ccf_tarball }}"
-    dest: "/opt/ccf-{{ ccf_ver }}"
+    dest: "/opt/ccf"
     extra_opts:
       - --strip-components=1
   become: true
 
 - name: Copy cchost
   copy:
-    src: "/opt/ccf-{{ ccf_ver }}/bin/cchost"
+    src: "/opt/ccf/bin/cchost"
     dest: "/usr/bin/cchost"
     remote_src: true
     mode: a=rx
@@ -31,7 +31,7 @@
 
 - name: Remove release
   file:
-    path: "/opt/ccf-{{ ccf_ver }}"
+    path: "/opt/ccf"
     state: absent
   become: true
   when: run_only|bool

--- a/samples/apps/forum/README.md
+++ b/samples/apps/forum/README.md
@@ -19,7 +19,7 @@ npm install
 To run the demo and end-to-end tests, define the following environment variable:
 
 ```sh
-export CCF_BINARY_DIR=/opt/ccf-x.y.z/bin
+export CCF_BINARY_DIR=/opt/ccf/bin
 ```
 
 If not defined, it assumes you built CCF from source and defaults to `CCF_BINARY_DIR=<repo_root>/build`.


### PR DESCRIPTION
This is expected to fix the issue that cropped up during the release of 1.0.0-rc1.