### PR TITLE
Release/1.0.0 fix1

### DIFF
--- a/.azure-pipelines-templates/install.yml
+++ b/.azure-pipelines-templates/install.yml
@@ -5,7 +5,9 @@ steps:
       cpack -V -G DEB
       INITIAL_PKG=`ls *.deb`
       GITHUB_PKG=${INITIAL_PKG//\~/_}
-      mv $INITIAL_PKG $GITHUB_PKG
+      if [[ "$INITIAL_PKG" != "$GITHUB_PKG" ]]; then
+        mv $INITIAL_PKG $GITHUB_PKG
+      fi
       cp $GITHUB_PKG $(Build.ArtifactStagingDirectory)
       echo "##vso[task.setvariable variable=pkgname]$GITHUB_PKG"
     workingDirectory: build


### PR DESCRIPTION
The 1.0.0 failed on the rename step we've added to deal with the fact that debian package names aren't compatible with GitHub artefact conventions. Because that step is a no-op on non-suffixed releases such as 1.0.0 (as opposed to 1.0.0-rc1), `mv` produces an error complaining the source and target are the same.