### PR TITLE
Add C++ API to get untrusted host time

### DIFF
--- a/include/ccf/base_endpoint_registry.h
+++ b/include/ccf/base_endpoint_registry.h
@@ -146,5 +146,9 @@ namespace ccf
       kv::ReadOnlyTx& tx,
       const MemberId& member_id,
       crypto::Pem& member_cert_pem);
+
+    /** Get untrusted time from the host of the currently executing node.
+     */
+    ApiResult get_untrusted_time_v1(std::tm& time);
   };
 }

--- a/include/ccf/base_endpoint_registry.h
+++ b/include/ccf/base_endpoint_registry.h
@@ -149,6 +149,6 @@ namespace ccf
 
     /** Get untrusted time from the host of the currently executing node.
      */
-    ApiResult get_untrusted_time_v1(std::tm& time);
+    ApiResult get_untrusted_host_time_v1(::timespec& time);
   };
 }

--- a/src/endpoints/base_endpoint_registry.cpp
+++ b/src/endpoints/base_endpoint_registry.cpp
@@ -253,9 +253,6 @@ namespace ccf
     time.tv_sec = now_us.count() / us_per_s;
     time.tv_nsec = (now_us.count() % us_per_s) * 1'000;
 
-    LOG_INFO_FMT(
-      "{} -> {{ {}, {} }}", now_us.count(), time.tv_sec, time.tv_nsec);
-
     return ApiResult::OK;
   }
 }

--- a/src/endpoints/base_endpoint_registry.cpp
+++ b/src/endpoints/base_endpoint_registry.cpp
@@ -3,6 +3,7 @@
 
 #include "ccf/base_endpoint_registry.h"
 
+#include "enclave/enclave_time.h"
 #include "node/members.h"
 #include "node/users.h"
 
@@ -242,5 +243,16 @@ namespace ccf
       LOG_TRACE_FMT("{}", e.what());
       return ApiResult::InternalError;
     }
+  }
+  
+  ApiResult BaseEndpointRegistry::get_untrusted_time_v1(std::tm& time)
+  {
+    const auto now_us = enclave::get_enclave_time();
+    const auto now_s = std::chrono::duration_cast<std::chrono::seconds>(now_us);
+
+    const time_t now = (time_t)now_s.count();
+    ::gmtime_r(&now, &time);
+
+    return ApiResult::OK;
   }
 }

--- a/src/endpoints/base_endpoint_registry.cpp
+++ b/src/endpoints/base_endpoint_registry.cpp
@@ -244,14 +244,17 @@ namespace ccf
       return ApiResult::InternalError;
     }
   }
-  
-  ApiResult BaseEndpointRegistry::get_untrusted_time_v1(std::tm& time)
-  {
-    const auto now_us = enclave::get_enclave_time();
-    const auto now_s = std::chrono::duration_cast<std::chrono::seconds>(now_us);
 
-    const time_t now = (time_t)now_s.count();
-    ::gmtime_r(&now, &time);
+  ApiResult BaseEndpointRegistry::get_untrusted_host_time_v1(::timespec& time)
+  {
+    const std::chrono::microseconds now_us = enclave::get_enclave_time();
+
+    constexpr auto us_per_s = 1'000'000;
+    time.tv_sec = now_us.count() / us_per_s;
+    time.tv_nsec = (now_us.count() % us_per_s) * 1'000;
+
+    LOG_INFO_FMT(
+      "{} -> {{ {}, {} }}", now_us.count(), time.tv_sec, time.tv_nsec);
 
     return ApiResult::OK;
   }


### PR DESCRIPTION
Resolves #2523.

Adds the API `get_untrusted_host_time_v1`, which returns the host-written (UTC) time as a `timespec`.

Also adds an example endpoint using this in the `nobuiltins` app, and a few test calls to confirm the reported time is close enough to the true time.