### PR TITLE
Fix unknown curve error

### DIFF
--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -58,7 +58,6 @@ def test_illegal(network, args, verify=True):
     # Send malformed HTTP traffic and check the connection is closed
     cafile = os.path.join(network.common_dir, "networkcert.pem")
     context = ssl.create_default_context(cafile=cafile)
-    context.set_ecdh_curve(ccf.clients.get_curve(cafile).name)
     context.load_cert_chain(
         certfile=os.path.join(network.common_dir, "user0_cert.pem"),
         keyfile=os.path.join(network.common_dir, "user0_privk.pem"),


### PR DESCRIPTION
https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=24676&view=logs&j=5435e0ac-25e5-5426-50be-61b0d0ea8d34&t=63d660c3-6f76-573a-0154-fd0bcb096ded

![image](https://user-images.githubusercontent.com/4016369/116977954-f8067780-acba-11eb-986c-000e47151f3a.png)

It doesn't look like setting the curve name is necessary or useful on client sockets though: https://docs.python.org/3/library/ssl.html

Re-run with the same seed (SHUFFLE_SUITE_SEED=1620028147) successfully.