### PR TITLE
Drop docs for pre-1.0.0 releases

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -197,8 +197,8 @@ breathe_default_project = "CCF"
 
 # Set up multiversion extension
 
-# Build tags from ccf-0.16.3 onwards
-smv_tag_whitelist = r"^ccf-(0\.(1([6-9]\.[3-9]|[7-9].*)|[2-9].*)|[1-9].*)$"
+# Build tags from ccf-1.0.0
+smv_tag_whitelist = r"^ccf-(1\.\d+\.\d+|2.*)$"
 smv_branch_whitelist = r"^main$"
 smv_remote_whitelist = None
 smv_outputdir_format = "{ref.name}"


### PR DESCRIPTION
Ordering `-rc`s and `-dev` releases with the _real_ release is hard. Instead we just drop docs for pre-1.0.0 releases, and we'll modify this regex to march boldly into the future as we get to future releases.