### PR TITLE
Sample consistency pass

### DIFF
--- a/include/ccf/json_handler.h
+++ b/include/ccf/json_handler.h
@@ -19,12 +19,12 @@ namespace ccf
    * fields, to reduce handler complexity and repetition.
    *
    * Rather than:
-   * auto foo = [](auto& args) {
+   * auto foo = [](auto& ctx) {
    *   nlohmann::json params;
    *   serdes::Pack pack_type;
    *   if (<content-type is JSON>)
    *   {
-   *     params = unpack(args.rpc_ctx->get_request_body());
+   *     params = unpack(ctx.rpc_ctx->get_request_body());
    *     pack_type = Text;
    *   }
    *   else
@@ -34,14 +34,14 @@ namespace ccf
    *   auto result = fn(params);
    *   if (is_error(result))
    *   {
-   *     args.rpc_ctx->set_response_status(SOME_ERROR);
-   *     args.rpc_ctx->set_response_header(content_type, Text);
-   *     args.rpc_ctx->set_response_body(error_msg(result));
+   *     ctx.rpc_ctx->set_response_status(SOME_ERROR);
+   *     ctx.rpc_ctx->set_response_header(content_type, Text);
+   *     ctx.rpc_ctx->set_response_body(error_msg(result));
    *   }
    *   if (pack_type == Text)
    *   {
-   *     args.rpc_ctx->set_response_header(content_type, JSON);
-   *     args.rpc_ctx->set_response_body(pack(result, Text));
+   *     ctx.rpc_ctx->set_response_header(content_type, JSON);
+   *     ctx.rpc_ctx->set_response_body(pack(result, Text));
    *   }
    *   else
    *   {
@@ -266,43 +266,43 @@ namespace ccf
 
   using HandlerJsonParamsAndForward =
     std::function<jsonhandler::JsonAdapterResponse(
-      endpoints::EndpointContext& args, nlohmann::json&& params)>;
+      endpoints::EndpointContext& ctx, nlohmann::json&& params)>;
 
   inline endpoints::EndpointFunction json_adapter(
     const HandlerJsonParamsAndForward& f)
   {
-    return [f](endpoints::EndpointContext& args) {
-      auto [packing, params] = jsonhandler::get_json_params(args.rpc_ctx);
+    return [f](endpoints::EndpointContext& ctx) {
+      auto [packing, params] = jsonhandler::get_json_params(ctx.rpc_ctx);
       jsonhandler::set_response(
-        f(args, std::move(params)), args.rpc_ctx, packing);
+        f(ctx, std::move(params)), ctx.rpc_ctx, packing);
     };
   }
 
   using ReadOnlyHandlerWithJson =
     std::function<jsonhandler::JsonAdapterResponse(
-      endpoints::ReadOnlyEndpointContext& args, nlohmann::json&& params)>;
+      endpoints::ReadOnlyEndpointContext& ctx, nlohmann::json&& params)>;
 
   inline endpoints::ReadOnlyEndpointFunction json_read_only_adapter(
     const ReadOnlyHandlerWithJson& f)
   {
-    return [f](endpoints::ReadOnlyEndpointContext& args) {
-      auto [packing, params] = jsonhandler::get_json_params(args.rpc_ctx);
+    return [f](endpoints::ReadOnlyEndpointContext& ctx) {
+      auto [packing, params] = jsonhandler::get_json_params(ctx.rpc_ctx);
       jsonhandler::set_response(
-        f(args, std::move(params)), args.rpc_ctx, packing);
+        f(ctx, std::move(params)), ctx.rpc_ctx, packing);
     };
   }
 #pragma clang diagnostic pop
 
   using CommandHandlerWithJson = std::function<jsonhandler::JsonAdapterResponse(
-    endpoints::CommandEndpointContext& args, nlohmann::json&& params)>;
+    endpoints::CommandEndpointContext& ctx, nlohmann::json&& params)>;
 
   inline endpoints::CommandEndpointFunction json_command_adapter(
     const CommandHandlerWithJson& f)
   {
-    return [f](endpoints::CommandEndpointContext& args) {
-      auto [packing, params] = jsonhandler::get_json_params(args.rpc_ctx);
+    return [f](endpoints::CommandEndpointContext& ctx) {
+      auto [packing, params] = jsonhandler::get_json_params(ctx.rpc_ctx);
       jsonhandler::set_response(
-        f(args, std::move(params)), args.rpc_ctx, packing);
+        f(ctx, std::move(params)), ctx.rpc_ctx, packing);
     };
   }
 }

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -788,8 +788,7 @@ namespace loggingapp
         {
           // If no start point is specified, use the first time this ID was
           // written to
-          auto first_writes =
-            ctx.tx.ro<FirstWritesMap>("first_write_version");
+          auto first_writes = ctx.tx.ro<FirstWritesMap>("first_write_version");
           const auto first_write_version = first_writes->get(id);
           if (first_write_version.has_value())
           {

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -197,10 +197,10 @@ namespace loggingapp
         .install();
 
       // SNIPPET_START: get
-      auto get = [this](auto& args, nlohmann::json&&) {
+      auto get = [this](auto& ctx, nlohmann::json&&) {
         // Parse id from query
         const auto parsed_query =
-          http::parse_query(args.rpc_ctx->get_request_query());
+          http::parse_query(ctx.rpc_ctx->get_request_query());
 
         std::string error_reason;
         size_t id;
@@ -212,8 +212,7 @@ namespace loggingapp
             std::move(error_reason));
         }
 
-        auto records_handle =
-          args.tx.template ro<RecordsTable>(PRIVATE_RECORDS);
+        auto records_handle = ctx.tx.template ro<RecordsTable>(PRIVATE_RECORDS);
         auto record = records_handle->get(id);
 
         if (record.has_value())
@@ -293,10 +292,10 @@ namespace loggingapp
         .install();
 
       // SNIPPET_START: get_public
-      auto get_public = [this](auto& args, nlohmann::json&&) {
+      auto get_public = [this](auto& ctx, nlohmann::json&&) {
         // Parse id from query
         const auto parsed_query =
-          http::parse_query(args.rpc_ctx->get_request_query());
+          http::parse_query(ctx.rpc_ctx->get_request_query());
 
         std::string error_reason;
         size_t id;
@@ -309,7 +308,7 @@ namespace loggingapp
         }
 
         auto public_records_handle =
-          args.tx.template ro<RecordsTable>(PUBLIC_RECORDS);
+          ctx.tx.template ro<RecordsTable>(PUBLIC_RECORDS);
         auto record = public_records_handle->get(id);
 
         if (record.has_value())
@@ -360,14 +359,14 @@ namespace loggingapp
         .install();
 
       // SNIPPET_START: log_record_prefix_cert
-      auto log_record_prefix_cert = [this](auto& args) {
+      auto log_record_prefix_cert = [this](auto& ctx) {
         const nlohmann::json body_j =
-          nlohmann::json::parse(args.rpc_ctx->get_request_body());
+          nlohmann::json::parse(ctx.rpc_ctx->get_request_body());
 
         const auto in = body_j.get<LoggingRecord::In>();
         if (in.msg.empty())
         {
-          args.rpc_ctx->set_error(
+          ctx.rpc_ctx->set_error(
             HTTP_STATUS_BAD_REQUEST,
             ccf::errors::InvalidInput,
             "Cannot record an empty log message");
@@ -376,12 +375,12 @@ namespace loggingapp
 
         auto cert = mbedtls::make_unique<mbedtls::X509Crt>();
 
-        const auto& cert_data = args.rpc_ctx->session->caller_cert;
+        const auto& cert_data = ctx.rpc_ctx->session->caller_cert;
         const auto ret = mbedtls_x509_crt_parse(
           cert.get(), cert_data.data(), cert_data.size());
         if (ret != 0)
         {
-          args.rpc_ctx->set_error(
+          ctx.rpc_ctx->set_error(
             HTTP_STATUS_INTERNAL_SERVER_ERROR,
             ccf::errors::InternalError,
             "Cannot parse x509 caller certificate");
@@ -389,15 +388,14 @@ namespace loggingapp
         }
 
         const auto log_line = fmt::format("{}: {}", cert->subject, in.msg);
-        auto records_handle =
-          args.tx.template rw<RecordsTable>(PRIVATE_RECORDS);
+        auto records_handle = ctx.tx.template rw<RecordsTable>(PRIVATE_RECORDS);
         records_handle->put(in.id, log_line);
-        update_first_write(args.tx, in.id);
+        update_first_write(ctx.tx, in.id);
 
-        args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
-        args.rpc_ctx->set_response_header(
+        ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+        ctx.rpc_ctx->set_response_header(
           http::headers::CONTENT_TYPE, http::headervalues::contenttype::JSON);
-        args.rpc_ctx->set_response_body(nlohmann::json(true).dump());
+        ctx.rpc_ctx->set_response_body(nlohmann::json(true).dump());
       };
       make_endpoint(
         "log/private/prefix_cert",
@@ -408,7 +406,7 @@ namespace loggingapp
         .install();
       // SNIPPET_END: log_record_prefix_cert
 
-      auto log_record_anonymous = [this](auto& args, nlohmann::json&& params) {
+      auto log_record_anonymous = [this](auto& ctx, nlohmann::json&& params) {
         const auto in = params.get<LoggingRecord::In>();
         if (in.msg.empty())
         {
@@ -419,10 +417,9 @@ namespace loggingapp
         }
 
         const auto log_line = fmt::format("Anonymous: {}", in.msg);
-        auto records_handle =
-          args.tx.template rw<RecordsTable>(PRIVATE_RECORDS);
+        auto records_handle = ctx.tx.template rw<RecordsTable>(PRIVATE_RECORDS);
         records_handle->put(in.id, log_line);
-        update_first_write(args.tx, in.id);
+        update_first_write(ctx.tx, in.id);
         return ccf::make_success(true);
       };
       make_endpoint(
@@ -614,14 +611,14 @@ namespace loggingapp
       // SNIPPET_END: custom_auth_endpoint
 
       // SNIPPET_START: log_record_text
-      auto log_record_text = [this](auto& args) {
+      auto log_record_text = [this](auto& ctx) {
         const auto expected = http::headervalues::contenttype::TEXT;
         const auto actual =
-          args.rpc_ctx->get_request_header(http::headers::CONTENT_TYPE)
+          ctx.rpc_ctx->get_request_header(http::headers::CONTENT_TYPE)
             .value_or("");
         if (expected != actual)
         {
-          args.rpc_ctx->set_error(
+          ctx.rpc_ctx->set_error(
             HTTP_STATUS_UNSUPPORTED_MEDIA_TYPE,
             ccf::errors::InvalidHeaderValue,
             fmt::format(
@@ -629,11 +626,11 @@ namespace loggingapp
           return;
         }
 
-        const auto& path_params = args.rpc_ctx->get_request_path_params();
+        const auto& path_params = ctx.rpc_ctx->get_request_path_params();
         const auto id_it = path_params.find("id");
         if (id_it == path_params.end())
         {
-          args.rpc_ctx->set_error(
+          ctx.rpc_ctx->set_error(
             HTTP_STATUS_BAD_REQUEST,
             ccf::errors::InvalidInput,
             "Missing ID component in request path");
@@ -642,15 +639,14 @@ namespace loggingapp
 
         const auto id = strtoul(id_it->second.c_str(), nullptr, 10);
 
-        const std::vector<uint8_t>& content = args.rpc_ctx->get_request_body();
+        const std::vector<uint8_t>& content = ctx.rpc_ctx->get_request_body();
         const std::string log_line(content.begin(), content.end());
 
-        auto records_handle =
-          args.tx.template rw<RecordsTable>(PRIVATE_RECORDS);
+        auto records_handle = ctx.tx.template rw<RecordsTable>(PRIVATE_RECORDS);
         records_handle->put(id, log_line);
-        update_first_write(args.tx, id);
+        update_first_write(ctx.tx, id);
 
-        args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+        ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
       };
       make_endpoint(
         "log/private/raw_text/{id}", HTTP_POST, log_record_text, auth_policies)
@@ -659,19 +655,19 @@ namespace loggingapp
 
       // SNIPPET_START: get_historical
       auto get_historical = [this](
-                              ccf::endpoints::EndpointContext& args,
+                              ccf::endpoints::EndpointContext& ctx,
                               ccf::historical::StatePtr historical_state) {
-        const auto pack = ccf::jsonhandler::detect_json_pack(args.rpc_ctx);
+        const auto pack = ccf::jsonhandler::detect_json_pack(ctx.rpc_ctx);
 
         // Parse id from query
         const auto parsed_query =
-          http::parse_query(args.rpc_ctx->get_request_query());
+          http::parse_query(ctx.rpc_ctx->get_request_query());
 
         std::string error_reason;
         size_t id;
         if (!http::get_query_value(parsed_query, "id", id, error_reason))
         {
-          args.rpc_ctx->set_error(
+          ctx.rpc_ctx->set_error(
             HTTP_STATUS_BAD_REQUEST,
             ccf::errors::InvalidQueryParameterValue,
             std::move(error_reason));
@@ -688,11 +684,11 @@ namespace loggingapp
           LoggingGetHistorical::Out out;
           out.msg = v.value();
           nlohmann::json j = out;
-          ccf::jsonhandler::set_response(std::move(j), args.rpc_ctx, pack);
+          ccf::jsonhandler::set_response(std::move(j), ctx.rpc_ctx, pack);
         }
         else
         {
-          args.rpc_ctx->set_response_status(HTTP_STATUS_NO_CONTENT);
+          ctx.rpc_ctx->set_response_status(HTTP_STATUS_NO_CONTENT);
         }
       };
 
@@ -716,19 +712,19 @@ namespace loggingapp
       // SNIPPET_START: get_historical_with_receipt
       auto get_historical_with_receipt =
         [this](
-          ccf::endpoints::EndpointContext& args,
+          ccf::endpoints::EndpointContext& ctx,
           ccf::historical::StatePtr historical_state) {
-          const auto pack = ccf::jsonhandler::detect_json_pack(args.rpc_ctx);
+          const auto pack = ccf::jsonhandler::detect_json_pack(ctx.rpc_ctx);
 
           // Parse id from query
           const auto parsed_query =
-            http::parse_query(args.rpc_ctx->get_request_query());
+            http::parse_query(ctx.rpc_ctx->get_request_query());
 
           std::string error_reason;
           size_t id;
           if (!http::get_query_value(parsed_query, "id", id, error_reason))
           {
-            args.rpc_ctx->set_error(
+            ctx.rpc_ctx->set_error(
               HTTP_STATUS_BAD_REQUEST,
               ccf::errors::InvalidQueryParameterValue,
               std::move(error_reason));
@@ -745,11 +741,11 @@ namespace loggingapp
             LoggingGetReceipt::Out out;
             out.msg = v.value();
             historical_state->receipt->describe(out.receipt);
-            ccf::jsonhandler::set_response(std::move(out), args.rpc_ctx, pack);
+            ccf::jsonhandler::set_response(std::move(out), ctx.rpc_ctx, pack);
           }
           else
           {
-            args.rpc_ctx->set_response_status(HTTP_STATUS_NO_CONTENT);
+            ctx.rpc_ctx->set_response_status(HTTP_STATUS_NO_CONTENT);
           }
         };
       make_endpoint(
@@ -768,18 +764,18 @@ namespace loggingapp
 
       static constexpr auto get_historical_range_path =
         "log/private/historical/range";
-      auto get_historical_range = [&, this](
-                                    ccf::endpoints::EndpointContext& args) {
+      auto get_historical_range = [&,
+                                   this](ccf::endpoints::EndpointContext& ctx) {
         // Parse arguments from query
         const auto parsed_query =
-          http::parse_query(args.rpc_ctx->get_request_query());
+          http::parse_query(ctx.rpc_ctx->get_request_query());
 
         std::string error_reason;
 
         size_t id;
         if (!http::get_query_value(parsed_query, "id", id, error_reason))
         {
-          args.rpc_ctx->set_error(
+          ctx.rpc_ctx->set_error(
             HTTP_STATUS_BAD_REQUEST,
             ccf::errors::InvalidQueryParameterValue,
             std::move(error_reason));
@@ -793,7 +789,7 @@ namespace loggingapp
           // If no start point is specified, use the first time this ID was
           // written to
           auto first_writes =
-            args.tx.ro<FirstWritesTable>("first_write_version");
+            ctx.tx.ro<FirstWritesTable>("first_write_version");
           const auto first_write_version = first_writes->get(id);
           if (first_write_version.has_value())
           {
@@ -804,7 +800,7 @@ namespace loggingapp
             // It's possible there's been a single write but no subsequent
             // transaction to write this to the FirstWritesTable - check version
             // of previous write
-            auto records = args.tx.ro<RecordsTable>(PRIVATE_RECORDS);
+            auto records = ctx.tx.ro<RecordsTable>(PRIVATE_RECORDS);
             const auto last_written_version =
               records->get_version_of_previous_write(id);
             if (last_written_version.has_value())
@@ -817,11 +813,11 @@ namespace loggingapp
               // now
               LoggingGetHistoricalRange::Out response;
               nlohmann::json j_response = response;
-              args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
-              args.rpc_ctx->set_response_header(
+              ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+              ctx.rpc_ctx->set_response_header(
                 http::headers::CONTENT_TYPE,
                 http::headervalues::contenttype::JSON);
-              args.rpc_ctx->set_response_body(j_response.dump());
+              ctx.rpc_ctx->set_response_body(j_response.dump());
               return;
             }
           }
@@ -833,7 +829,7 @@ namespace loggingapp
         {
           // If no end point is specified, use the last time this ID was
           // written to
-          auto records = args.tx.ro<RecordsTable>(PRIVATE_RECORDS);
+          auto records = ctx.tx.ro<RecordsTable>(PRIVATE_RECORDS);
           const auto last_written_version =
             records->get_version_of_previous_write(id);
           if (last_written_version.has_value())
@@ -850,7 +846,7 @@ namespace loggingapp
             const auto result = get_last_committed_txid_v1(view, seqno);
             if (result != ccf::ApiResult::OK)
             {
-              args.rpc_ctx->set_error(
+              ctx.rpc_ctx->set_error(
                 HTTP_STATUS_INTERNAL_SERVER_ERROR,
                 ccf::errors::InternalError,
                 fmt::format(
@@ -864,7 +860,7 @@ namespace loggingapp
         // Range must be in order
         if (to_seqno < from_seqno)
         {
-          args.rpc_ctx->set_error(
+          ctx.rpc_ctx->set_error(
             HTTP_STATUS_BAD_REQUEST,
             ccf::errors::InvalidInput,
             fmt::format(
@@ -877,7 +873,7 @@ namespace loggingapp
         // End of range must be committed
         if (consensus == nullptr)
         {
-          args.rpc_ctx->set_error(
+          ctx.rpc_ctx->set_error(
             HTTP_STATUS_INTERNAL_SERVER_ERROR,
             ccf::errors::InternalError,
             "Node is not fully operational");
@@ -895,7 +891,7 @@ namespace loggingapp
           committed_seqno);
         if (tx_status != ccf::TxStatus::Committed)
         {
-          args.rpc_ctx->set_error(
+          ctx.rpc_ctx->set_error(
             HTTP_STATUS_BAD_REQUEST,
             ccf::errors::InvalidInput,
             fmt::format(
@@ -936,13 +932,13 @@ namespace loggingapp
           historical_cache.get_store_range(handle, range_begin, range_end);
         if (stores.empty())
         {
-          args.rpc_ctx->set_response_status(HTTP_STATUS_ACCEPTED);
+          ctx.rpc_ctx->set_response_status(HTTP_STATUS_ACCEPTED);
           static constexpr size_t retry_after_seconds = 3;
-          args.rpc_ctx->set_response_header(
+          ctx.rpc_ctx->set_response_header(
             http::headers::RETRY_AFTER, retry_after_seconds);
-          args.rpc_ctx->set_response_header(
+          ctx.rpc_ctx->set_response_header(
             http::headers::CONTENT_TYPE, http::headervalues::contenttype::TEXT);
-          args.rpc_ctx->set_response_body(fmt::format(
+          ctx.rpc_ctx->set_response_body(fmt::format(
             "Historical transactions from {} to {} are not yet "
             "available, fetching now",
             range_begin,
@@ -1001,10 +997,10 @@ namespace loggingapp
 
         // Construct the HTTP response
         nlohmann::json j_response = response;
-        args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
-        args.rpc_ctx->set_response_header(
+        ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+        ctx.rpc_ctx->set_response_header(
           http::headers::CONTENT_TYPE, http::headervalues::contenttype::JSON);
-        args.rpc_ctx->set_response_body(j_response.dump());
+        ctx.rpc_ctx->set_response_body(j_response.dump());
 
         // ALSO: Assume this response makes it all the way to the client, and
         // they're finished with it, so we can drop the retrieved state. In a

--- a/src/apps/js_generic/js_generic.cpp
+++ b/src/apps/js_generic/js_generic.cpp
@@ -93,16 +93,16 @@ namespace ccfapp
     }
 
     JSValue create_caller_obj(
-      ccf::endpoints::EndpointContext& args, JSContext* ctx)
+      ccf::endpoints::EndpointContext& endpoint_ctx, JSContext* ctx)
     {
-      if (args.caller == nullptr)
+      if (endpoint_ctx.caller == nullptr)
       {
         return JS_NULL;
       }
 
       auto caller = JS_NewObject(ctx);
 
-      if (auto jwt_ident = args.try_get_caller<ccf::JwtAuthnIdentity>())
+      if (auto jwt_ident = endpoint_ctx.try_get_caller<ccf::JwtAuthnIdentity>())
       {
         JS_SetPropertyStr(
           ctx,
@@ -126,7 +126,8 @@ namespace ccfapp
         return caller;
       }
       else if (
-        auto empty_ident = args.try_get_caller<ccf::EmptyAuthnIdentity>())
+        auto empty_ident =
+          endpoint_ctx.try_get_caller<ccf::EmptyAuthnIdentity>())
       {
         JS_SetPropertyStr(
           ctx,
@@ -142,7 +143,7 @@ namespace ccfapp
 
       if (
         auto user_cert_ident =
-          args.try_get_caller<ccf::UserCertAuthnIdentity>())
+          endpoint_ctx.try_get_caller<ccf::UserCertAuthnIdentity>())
       {
         policy_name = get_policy_name_from_ident(user_cert_ident);
         id = user_cert_ident->user_id;
@@ -150,7 +151,7 @@ namespace ccfapp
       }
       else if (
         auto member_cert_ident =
-          args.try_get_caller<ccf::MemberCertAuthnIdentity>())
+          endpoint_ctx.try_get_caller<ccf::MemberCertAuthnIdentity>())
       {
         policy_name = get_policy_name_from_ident(member_cert_ident);
         id = member_cert_ident->member_id;
@@ -158,7 +159,7 @@ namespace ccfapp
       }
       else if (
         auto user_sig_ident =
-          args.try_get_caller<ccf::UserSignatureAuthnIdentity>())
+          endpoint_ctx.try_get_caller<ccf::UserSignatureAuthnIdentity>())
       {
         policy_name = get_policy_name_from_ident(user_sig_ident);
         id = user_sig_ident->user_id;
@@ -166,7 +167,7 @@ namespace ccfapp
       }
       else if (
         auto member_sig_ident =
-          args.try_get_caller<ccf::MemberSignatureAuthnIdentity>())
+          endpoint_ctx.try_get_caller<ccf::MemberSignatureAuthnIdentity>())
       {
         policy_name = get_policy_name_from_ident(member_sig_ident);
         id = member_sig_ident->member_id;
@@ -184,11 +185,11 @@ namespace ccfapp
 
       if (is_member)
       {
-        result = get_member_data_v1(args.tx, id, data);
+        result = get_member_data_v1(endpoint_ctx.tx, id, data);
       }
       else
       {
-        result = get_user_data_v1(args.tx, id, data);
+        result = get_user_data_v1(endpoint_ctx.tx, id, data);
       }
 
       if (result == ccf::ApiResult::InternalError)
@@ -200,11 +201,11 @@ namespace ccfapp
       crypto::Pem cert;
       if (is_member)
       {
-        result = get_user_cert_v1(args.tx, id, cert);
+        result = get_user_cert_v1(endpoint_ctx.tx, id, cert);
       }
       else
       {
-        result = get_member_cert_v1(args.tx, id, cert);
+        result = get_member_cert_v1(endpoint_ctx.tx, id, cert);
       }
 
       if (result == ccf::ApiResult::InternalError)
@@ -227,13 +228,13 @@ namespace ccfapp
     }
 
     JSValue create_request_obj(
-      ccf::endpoints::EndpointContext& args, JSContext* ctx)
+      ccf::endpoints::EndpointContext& endpoint_ctx, JSContext* ctx)
     {
       auto request = JS_NewObject(ctx);
 
       auto headers = JS_NewObject(ctx);
       for (auto& [header_name, header_value] :
-           args.rpc_ctx->get_request_headers())
+           endpoint_ctx.rpc_ctx->get_request_headers())
       {
         JS_SetPropertyStr(
           ctx,
@@ -243,14 +244,14 @@ namespace ccfapp
       }
       JS_SetPropertyStr(ctx, request, "headers", headers);
 
-      const auto& request_query = args.rpc_ctx->get_request_query();
+      const auto& request_query = endpoint_ctx.rpc_ctx->get_request_query();
       auto query_str =
         JS_NewStringLen(ctx, request_query.c_str(), request_query.size());
       JS_SetPropertyStr(ctx, request, "query", query_str);
 
       auto params = JS_NewObject(ctx);
       for (auto& [param_name, param_value] :
-           args.rpc_ctx->get_request_path_params())
+           endpoint_ctx.rpc_ctx->get_request_path_params())
       {
         JS_SetPropertyStr(
           ctx,
@@ -260,19 +261,20 @@ namespace ccfapp
       }
       JS_SetPropertyStr(ctx, request, "params", params);
 
-      const auto& request_body = args.rpc_ctx->get_request_body();
+      const auto& request_body = endpoint_ctx.rpc_ctx->get_request_body();
       auto body_ = JS_NewObjectClass(ctx, js::body_class_id);
       JS_SetOpaque(body_, (void*)&request_body);
       JS_SetPropertyStr(ctx, request, "body", body_);
 
-      JS_SetPropertyStr(ctx, request, "caller", create_caller_obj(args, ctx));
+      JS_SetPropertyStr(
+        ctx, request, "caller", create_caller_obj(endpoint_ctx, ctx));
 
       return request;
     }
 
     void execute_request(
       const ccf::endpoints::EndpointProperties& props,
-      ccf::endpoints::EndpointContext& args)
+      ccf::endpoints::EndpointContext& endpoint_ctx)
     {
       if (props.mode == ccf::endpoints::Mode::Historical)
       {
@@ -284,35 +286,36 @@ namespace ccfapp
 
         ccf::historical::adapter(
           [this, &props](
-            ccf::endpoints::EndpointContext& args,
+            ccf::endpoints::EndpointContext& endpoint_ctx,
             ccf::historical::StatePtr state) {
             auto tx = state->store->create_tx();
             auto tx_id = state->transaction_id;
             auto receipt = state->receipt;
-            do_execute_request(props, args, tx, tx_id, receipt);
+            do_execute_request(props, endpoint_ctx, tx, tx_id, receipt);
           },
           context.get_historical_state(),
-          is_tx_committed)(args);
+          is_tx_committed)(endpoint_ctx);
       }
       else
       {
-        do_execute_request(props, args, args.tx, std::nullopt, nullptr);
+        do_execute_request(
+          props, endpoint_ctx, endpoint_ctx.tx, std::nullopt, nullptr);
       }
     }
 
     void do_execute_request(
       const ccf::endpoints::EndpointProperties& props,
-      ccf::endpoints::EndpointContext& args,
+      ccf::endpoints::EndpointContext& endpoint_ctx,
       kv::Tx& target_tx,
       const std::optional<ccf::TxID>& transaction_id,
       ccf::historical::TxReceiptPtr receipt)
     {
-      const auto modules = args.tx.ro(this->network.modules);
+      const auto modules = endpoint_ctx.tx.ro(this->network.modules);
 
       auto handler_script = modules->get(props.js_module);
       if (!handler_script.has_value())
       {
-        args.rpc_ctx->set_error(
+        endpoint_ctx.rpc_ctx->set_error(
           HTTP_STATUS_INTERNAL_SERVER_ERROR,
           ccf::errors::InternalError,
           fmt::format("Endpoint module not found: {}.", props.js_module));
@@ -322,7 +325,7 @@ namespace ccfapp
       js::Runtime rt;
       rt.add_ccf_classdefs();
 
-      JSModuleLoaderArg js_module_loader_arg{&this->network, &args.tx};
+      JSModuleLoaderArg js_module_loader_arg{&this->network, &endpoint_ctx.tx};
       JS_SetModuleLoaderFunc(
         rt, nullptr, js_module_loader, &js_module_loader_arg);
 
@@ -333,7 +336,7 @@ namespace ccfapp
       js::populate_global_console(ctx);
       js::populate_global_ccf(
         &txctx,
-        args.rpc_ctx.get(),
+        endpoint_ctx.rpc_ctx.get(),
         transaction_id,
         receipt,
         nullptr,
@@ -352,7 +355,7 @@ namespace ccfapp
       }
       catch (std::exception& exc)
       {
-        args.rpc_ctx->set_error(
+        endpoint_ctx.rpc_ctx->set_error(
           HTTP_STATUS_INTERNAL_SERVER_ERROR,
           ccf::errors::InternalError,
           exc.what());
@@ -360,7 +363,7 @@ namespace ccfapp
       }
 
       // Call exported function
-      auto request = create_request_obj(args, ctx);
+      auto request = create_request_obj(endpoint_ctx, ctx);
       int argc = 1;
       JSValueConst* argv = (JSValueConst*)&request;
       auto val = ctx(JS_Call(ctx, export_func, JS_UNDEFINED, argc, argv));
@@ -370,7 +373,7 @@ namespace ccfapp
       if (JS_IsException(val))
       {
         js::js_dump_error(ctx);
-        args.rpc_ctx->set_error(
+        endpoint_ctx.rpc_ctx->set_error(
           HTTP_STATUS_INTERNAL_SERVER_ERROR,
           ccf::errors::InternalError,
           "Exception thrown while executing.");
@@ -380,7 +383,7 @@ namespace ccfapp
       // Handle return value: {body, headers, statusCode}
       if (!JS_IsObject(val))
       {
-        args.rpc_ctx->set_error(
+        endpoint_ctx.rpc_ctx->set_error(
           HTTP_STATUS_INTERNAL_SERVER_ERROR,
           ccf::errors::InternalError,
           "Invalid endpoint function return value (not an object).");
@@ -410,7 +413,7 @@ namespace ccfapp
         }
         if (array_buffer)
         {
-          args.rpc_ctx->set_response_header(
+          endpoint_ctx.rpc_ctx->set_response_header(
             http::headers::CONTENT_TYPE,
             http::headervalues::contenttype::OCTET_STREAM);
           response_body =
@@ -421,14 +424,14 @@ namespace ccfapp
           const char* cstr = nullptr;
           if (JS_IsString(response_body_js))
           {
-            args.rpc_ctx->set_response_header(
+            endpoint_ctx.rpc_ctx->set_response_header(
               http::headers::CONTENT_TYPE,
               http::headervalues::contenttype::TEXT);
             cstr = JS_ToCString(ctx, response_body_js);
           }
           else
           {
-            args.rpc_ctx->set_response_header(
+            endpoint_ctx.rpc_ctx->set_response_header(
               http::headers::CONTENT_TYPE,
               http::headervalues::contenttype::JSON);
             JSValue rval =
@@ -436,7 +439,7 @@ namespace ccfapp
             if (JS_IsException(rval))
             {
               js::js_dump_error(ctx);
-              args.rpc_ctx->set_error(
+              endpoint_ctx.rpc_ctx->set_error(
                 HTTP_STATUS_INTERNAL_SERVER_ERROR,
                 ccf::errors::InternalError,
                 "Invalid endpoint function return value (error during JSON "
@@ -449,7 +452,7 @@ namespace ccfapp
           if (!cstr)
           {
             js::js_dump_error(ctx);
-            args.rpc_ctx->set_error(
+            endpoint_ctx.rpc_ctx->set_error(
               HTTP_STATUS_INTERNAL_SERVER_ERROR,
               ccf::errors::InternalError,
               "Invalid endpoint function return value (error during string "
@@ -461,7 +464,7 @@ namespace ccfapp
 
           response_body = std::vector<uint8_t>(str.begin(), str.end());
         }
-        args.rpc_ctx->set_response_body(std::move(response_body));
+        endpoint_ctx.rpc_ctx->set_response_body(std::move(response_body));
       }
 
       // Response headers
@@ -486,13 +489,14 @@ namespace ccfapp
             auto prop_val_cstr = JS_ToCString(ctx, prop_val);
             if (!prop_val_cstr)
             {
-              args.rpc_ctx->set_error(
+              endpoint_ctx.rpc_ctx->set_error(
                 HTTP_STATUS_INTERNAL_SERVER_ERROR,
                 ccf::errors::InternalError,
                 "Invalid endpoint function return value (header value type).");
               return;
             }
-            args.rpc_ctx->set_response_header(prop_name_cstr, prop_val_cstr);
+            endpoint_ctx.rpc_ctx->set_response_header(
+              prop_name_cstr, prop_val_cstr);
             JS_FreeCString(ctx, prop_val_cstr);
           }
           js_free(ctx, props);
@@ -507,7 +511,7 @@ namespace ccfapp
         {
           if (JS_VALUE_GET_TAG(status_code_js.val) != JS_TAG_INT)
           {
-            args.rpc_ctx->set_error(
+            endpoint_ctx.rpc_ctx->set_error(
               HTTP_STATUS_INTERNAL_SERVER_ERROR,
               ccf::errors::InternalError,
               "Invalid endpoint function return value (status code type).");
@@ -515,7 +519,7 @@ namespace ccfapp
           }
           response_status_code = JS_VALUE_GET_INT(status_code_js.val);
         }
-        args.rpc_ctx->set_response_status(response_status_code);
+        endpoint_ctx.rpc_ctx->set_response_status(response_status_code);
       }
 
       return;
@@ -633,16 +637,16 @@ namespace ccfapp
 
     void execute_endpoint(
       ccf::endpoints::EndpointDefinitionPtr e,
-      ccf::endpoints::EndpointContext& args) override
+      ccf::endpoints::EndpointContext& endpoint_ctx) override
     {
       auto endpoint = dynamic_cast<const JSDynamicEndpoint*>(e.get());
       if (endpoint != nullptr)
       {
-        execute_request(endpoint->properties, args);
+        execute_request(endpoint->properties, endpoint_ctx);
         return;
       }
 
-      ccf::endpoints::EndpointRegistry::execute_endpoint(e, args);
+      ccf::endpoints::EndpointRegistry::execute_endpoint(e, endpoint_ctx);
     }
 
     // Since we do our own dispatch within the default handler, report the

--- a/src/apps/smallbank/app/smallbank.cpp
+++ b/src/apps/smallbank/app/smallbank.cpp
@@ -29,25 +29,25 @@ namespace ccfapp
     metrics::Tracker metrics_tracker;
 
     void set_error_status(
-      ccf::endpoints::EndpointContext& args, int status, std::string&& message)
+      ccf::endpoints::EndpointContext& ctx, int status, std::string&& message)
     {
-      args.rpc_ctx->set_response_status(status);
-      args.rpc_ctx->set_response_header(
+      ctx.rpc_ctx->set_response_status(status);
+      ctx.rpc_ctx->set_response_header(
         http::headers::CONTENT_TYPE, http::headervalues::contenttype::TEXT);
-      args.rpc_ctx->set_response_body(std::move(message));
+      ctx.rpc_ctx->set_response_body(std::move(message));
     }
 
-    void set_ok_status(ccf::endpoints::EndpointContext& args)
+    void set_ok_status(ccf::endpoints::EndpointContext& ctx)
     {
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
-      args.rpc_ctx->set_response_header(
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+      ctx.rpc_ctx->set_response_header(
         http::headers::CONTENT_TYPE,
         http::headervalues::contenttype::OCTET_STREAM);
     }
 
-    void set_no_content_status(ccf::endpoints::EndpointContext& args)
+    void set_no_content_status(ccf::endpoints::EndpointContext& ctx)
     {
-      args.rpc_ctx->set_response_status(HTTP_STATUS_NO_CONTENT);
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_NO_CONTENT);
     }
 
   public:
@@ -60,63 +60,63 @@ namespace ccfapp
     {
       UserEndpointRegistry::init_handlers();
 
-      auto create = [this](auto& args) {
+      auto create = [this](auto& ctx) {
         // Create an account with a balance from thin air.
-        const auto& body = args.rpc_ctx->get_request_body();
+        const auto& body = ctx.rpc_ctx->get_request_body();
         auto ai = smallbank::AccountInfo::deserialize(body.data(), body.size());
         auto name = ai.name;
         uint64_t acc_id;
         std::from_chars(name.data(), name.data() + name.size(), acc_id);
         int64_t checking_amt = ai.checking_amt;
         int64_t savings_amt = ai.savings_amt;
-        auto accounts = args.tx.rw(tables.accounts);
+        auto accounts = ctx.tx.rw(tables.accounts);
         auto account_r = accounts->get(name);
 
         if (account_r.has_value())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "Account already exists");
+            ctx, HTTP_STATUS_BAD_REQUEST, "Account already exists");
           return;
         }
 
         accounts->put(name, acc_id);
 
-        auto savings = args.tx.rw(tables.savings);
+        auto savings = ctx.tx.rw(tables.savings);
         auto savings_r = savings->get(acc_id);
 
         if (savings_r.has_value())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "Account already exists");
+            ctx, HTTP_STATUS_BAD_REQUEST, "Account already exists");
           return;
         }
 
         savings->put(acc_id, savings_amt);
 
-        auto checkings = args.tx.rw(tables.checkings);
+        auto checkings = ctx.tx.rw(tables.checkings);
         auto checking_r = checkings->get(acc_id);
 
         if (checking_r.has_value())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "Account already exists");
+            ctx, HTTP_STATUS_BAD_REQUEST, "Account already exists");
           return;
         }
 
         checkings->put(acc_id, checking_amt);
 
-        set_no_content_status(args);
+        set_no_content_status(ctx);
       };
 
-      auto create_batch = [this](auto& args) {
+      auto create_batch = [this](auto& ctx) {
         // Create N accounts with identical balances from thin air.
-        const auto& body = args.rpc_ctx->get_request_body();
+        const auto& body = ctx.rpc_ctx->get_request_body();
         auto ac =
           smallbank::AccountCreation::deserialize(body.data(), body.size());
 
-        auto accounts = args.tx.rw(tables.accounts);
-        auto savings = args.tx.rw(tables.savings);
-        auto checkings = args.tx.rw(tables.checkings);
+        auto accounts = ctx.tx.rw(tables.accounts);
+        auto savings = ctx.tx.rw(tables.savings);
+        auto checkings = ctx.tx.rw(tables.checkings);
 
         for (auto acc_id = ac.new_id_from; acc_id < ac.new_id_to; ++acc_id)
         {
@@ -126,7 +126,7 @@ namespace ccfapp
           if (account_r.has_value())
           {
             set_error_status(
-              args,
+              ctx,
               HTTP_STATUS_BAD_REQUEST,
               fmt::format(
                 "Account already exists in accounts table: '{}'", name));
@@ -138,7 +138,7 @@ namespace ccfapp
           if (savings_r.has_value())
           {
             set_error_status(
-              args,
+              ctx,
               HTTP_STATUS_BAD_REQUEST,
               fmt::format(
                 "Account already exists in savings table: '{}'", name));
@@ -150,7 +150,7 @@ namespace ccfapp
           if (checking_r.has_value())
           {
             set_error_status(
-              args,
+              ctx,
               HTTP_STATUS_BAD_REQUEST,
               fmt::format(
                 "Account already exists in checkings table: '{}'", name));
@@ -159,56 +159,56 @@ namespace ccfapp
           checkings->put(acc_id, ac.initial_checking_amt);
         }
 
-        set_no_content_status(args);
+        set_no_content_status(ctx);
       };
 
-      auto balance = [this](auto& args) {
+      auto balance = [this](auto& ctx) {
         // Check the combined balance of an account
-        const auto& body = args.rpc_ctx->get_request_body();
+        const auto& body = ctx.rpc_ctx->get_request_body();
         auto account =
           smallbank::AccountName::deserialize(body.data(), body.size());
-        auto accounts = args.tx.rw(tables.accounts);
+        auto accounts = ctx.tx.rw(tables.accounts);
         auto account_r = accounts->get(account.name);
 
         if (!account_r.has_value())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "Account does not exist");
+            ctx, HTTP_STATUS_BAD_REQUEST, "Account does not exist");
           return;
         }
 
-        auto savings = args.tx.rw(tables.savings);
+        auto savings = ctx.tx.rw(tables.savings);
         auto savings_r = savings->get(account_r.value());
 
         if (!savings_r.has_value())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "Savings account does not exist");
+            ctx, HTTP_STATUS_BAD_REQUEST, "Savings account does not exist");
           return;
         }
 
-        auto checkings = args.tx.rw(tables.checkings);
+        auto checkings = ctx.tx.rw(tables.checkings);
         auto checking_r = checkings->get(account_r.value());
 
         if (!checking_r.has_value())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "Checking account does not exist");
+            ctx, HTTP_STATUS_BAD_REQUEST, "Checking account does not exist");
           return;
         }
 
         auto result = checking_r.value() + savings_r.value();
 
-        set_ok_status(args);
+        set_ok_status(ctx);
 
         smallbank::Balance b;
         b.value = result;
-        args.rpc_ctx->set_response_body(b.serialize());
+        ctx.rpc_ctx->set_response_body(b.serialize());
       };
 
-      auto transact_savings = [this](auto& args) {
+      auto transact_savings = [this](auto& ctx) {
         // Add or remove money to the savings account
-        const auto& body = args.rpc_ctx->get_request_body();
+        const auto& body = ctx.rpc_ctx->get_request_body();
         auto transaction =
           smallbank::Transaction::deserialize(body.data(), body.size());
         auto name = transaction.name;
@@ -217,45 +217,45 @@ namespace ccfapp
         if (name.empty())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "A name must be specified");
+            ctx, HTTP_STATUS_BAD_REQUEST, "A name must be specified");
           return;
         }
 
-        auto accounts = args.tx.rw(tables.accounts);
+        auto accounts = ctx.tx.rw(tables.accounts);
         auto account_r = accounts->get(name);
 
         if (!account_r.has_value())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "Account does not exist");
+            ctx, HTTP_STATUS_BAD_REQUEST, "Account does not exist");
         }
 
-        auto savings = args.tx.rw(tables.savings);
+        auto savings = ctx.tx.rw(tables.savings);
         auto savings_r = savings->get(account_r.value());
 
         if (!savings_r.has_value())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "Savings account does not exist");
+            ctx, HTTP_STATUS_BAD_REQUEST, "Savings account does not exist");
           return;
         }
 
         if (savings_r.value() + value < 0)
         {
           set_error_status(
-            args,
+            ctx,
             HTTP_STATUS_BAD_REQUEST,
             "Not enough money in savings account");
           return;
         }
 
         savings->put(account_r.value(), value + savings_r.value());
-        set_no_content_status(args);
+        set_no_content_status(ctx);
       };
 
-      auto deposit_checking = [this](auto& args) {
+      auto deposit_checking = [this](auto& ctx) {
         // Desposit money into the checking account out of thin air
-        const auto& body = args.rpc_ctx->get_request_body();
+        const auto& body = ctx.rpc_ctx->get_request_body();
         auto transaction =
           smallbank::Transaction::deserialize(body.data(), body.size());
         auto name = transaction.name;
@@ -264,52 +264,52 @@ namespace ccfapp
         if (name.empty())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "A name must be specified");
+            ctx, HTTP_STATUS_BAD_REQUEST, "A name must be specified");
           return;
         }
 
         if (value <= 0)
         {
-          set_error_status(args, HTTP_STATUS_BAD_REQUEST, "Value <= 0");
+          set_error_status(ctx, HTTP_STATUS_BAD_REQUEST, "Value <= 0");
           return;
         }
 
-        auto accounts = args.tx.rw(tables.accounts);
+        auto accounts = ctx.tx.rw(tables.accounts);
         auto account_r = accounts->get(name);
 
         if (!account_r.has_value())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "Account does not exist");
+            ctx, HTTP_STATUS_BAD_REQUEST, "Account does not exist");
           return;
         }
 
-        auto checkings = args.tx.rw(tables.checkings);
+        auto checkings = ctx.tx.rw(tables.checkings);
         auto checking_r = checkings->get(account_r.value());
 
         if (!checking_r.has_value())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "Checking account does not exist");
+            ctx, HTTP_STATUS_BAD_REQUEST, "Checking account does not exist");
           return;
         }
         checkings->put(account_r.value(), value + checking_r.value());
-        set_no_content_status(args);
+        set_no_content_status(ctx);
       };
 
-      auto amalgamate = [this](auto& args) {
+      auto amalgamate = [this](auto& ctx) {
         // Move the contents of one users account to another users account
-        const auto& body = args.rpc_ctx->get_request_body();
+        const auto& body = ctx.rpc_ctx->get_request_body();
         auto ad = smallbank::Amalgamate::deserialize(body.data(), body.size());
         auto name_1 = ad.src;
         auto name_2 = ad.dst;
-        auto accounts = args.tx.rw(tables.accounts);
+        auto accounts = ctx.tx.rw(tables.accounts);
         auto account_1_r = accounts->get(name_1);
 
         if (!account_1_r.has_value())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "Source account does not exist");
+            ctx, HTTP_STATUS_BAD_REQUEST, "Source account does not exist");
           return;
         }
 
@@ -318,31 +318,29 @@ namespace ccfapp
         if (!account_2_r.has_value())
         {
           set_error_status(
-            args,
-            HTTP_STATUS_BAD_REQUEST,
-            "Destination account does not exist");
+            ctx, HTTP_STATUS_BAD_REQUEST, "Destination account does not exist");
           return;
         }
 
-        auto savings = args.tx.rw(tables.savings);
+        auto savings = ctx.tx.rw(tables.savings);
         auto savings_r = savings->get(account_1_r.value());
 
         if (!savings_r.has_value())
         {
           set_error_status(
-            args,
+            ctx,
             HTTP_STATUS_BAD_REQUEST,
             "Source savings account does not exist");
           return;
         }
 
-        auto checkings = args.tx.rw(tables.checkings);
+        auto checkings = ctx.tx.rw(tables.checkings);
         auto checking_r = checkings->get(account_1_r.value());
 
         if (!checking_r.has_value())
         {
           set_error_status(
-            args,
+            ctx,
             HTTP_STATUS_BAD_REQUEST,
             "Source checking account does not exist");
           return;
@@ -357,7 +355,7 @@ namespace ccfapp
         if (!checking_2_r.has_value())
         {
           set_error_status(
-            args,
+            ctx,
             HTTP_STATUS_BAD_REQUEST,
             "Destination checking account does not exist");
           return;
@@ -366,44 +364,44 @@ namespace ccfapp
         checkings->put(
           account_2_r.value(), checking_2_r.value() + sum_account_1);
 
-        set_no_content_status(args);
+        set_no_content_status(ctx);
       };
 
-      auto writeCheck = [this](auto& args) {
+      auto writeCheck = [this](auto& ctx) {
         // Write a check, if not enough funds then also charge an extra 1 money
-        const auto& body = args.rpc_ctx->get_request_body();
+        const auto& body = ctx.rpc_ctx->get_request_body();
         auto transaction =
           smallbank::Transaction::deserialize(body.data(), body.size());
         auto name = transaction.name;
         auto amount = transaction.value;
 
-        auto accounts = args.tx.rw(tables.accounts);
+        auto accounts = ctx.tx.rw(tables.accounts);
         auto account_r = accounts->get(name);
 
         if (!account_r.has_value())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "Account does not exist");
+            ctx, HTTP_STATUS_BAD_REQUEST, "Account does not exist");
           return;
         }
 
-        auto savings = args.tx.rw(tables.savings);
+        auto savings = ctx.tx.rw(tables.savings);
         auto savings_r = savings->get(account_r.value());
 
         if (!savings_r.has_value())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "Savings account does not exist");
+            ctx, HTTP_STATUS_BAD_REQUEST, "Savings account does not exist");
           return;
         }
 
-        auto checkings = args.tx.rw(tables.checkings);
+        auto checkings = ctx.tx.rw(tables.checkings);
         auto checking_r = checkings->get(account_r.value());
 
         if (!checking_r.has_value())
         {
           set_error_status(
-            args, HTTP_STATUS_BAD_REQUEST, "Checking account does not exist");
+            ctx, HTTP_STATUS_BAD_REQUEST, "Checking account does not exist");
           return;
         }
 
@@ -413,7 +411,7 @@ namespace ccfapp
           ++amount;
         }
         checkings->put(account_r.value(), account_value - amount);
-        set_no_content_status(args);
+        set_no_content_status(ctx);
       };
 
       const ccf::AuthnPolicies user_sig_or_cert = {user_signature_auth_policy,

--- a/src/apps/tpcc/app/tpcc.cpp
+++ b/src/apps/tpcc/app/tpcc.cpp
@@ -22,25 +22,25 @@ namespace ccfapp
     metrics::Tracker metrics_tracker;
 
     void set_error_status(
-      ccf::endpoints::EndpointContext& args, int status, std::string&& message)
+      ccf::endpoints::EndpointContext& ctx, int status, std::string&& message)
     {
-      args.rpc_ctx->set_response_status(status);
-      args.rpc_ctx->set_response_header(
+      ctx.rpc_ctx->set_response_status(status);
+      ctx.rpc_ctx->set_response_header(
         http::headers::CONTENT_TYPE, http::headervalues::contenttype::TEXT);
-      args.rpc_ctx->set_response_body(std::move(message));
+      ctx.rpc_ctx->set_response_body(std::move(message));
     }
 
-    void set_ok_status(ccf::endpoints::EndpointContext& args)
+    void set_ok_status(ccf::endpoints::EndpointContext& ctx)
     {
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
-      args.rpc_ctx->set_response_header(
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+      ctx.rpc_ctx->set_response_header(
         http::headers::CONTENT_TYPE,
         http::headervalues::contenttype::OCTET_STREAM);
     }
 
-    void set_no_content_status(ccf::endpoints::EndpointContext& args)
+    void set_no_content_status(ccf::endpoints::EndpointContext& ctx)
     {
-      args.rpc_ctx->set_response_status(HTTP_STATUS_NO_CONTENT);
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_NO_CONTENT);
     }
 
   public:
@@ -51,70 +51,70 @@ namespace ccfapp
     {
       UserEndpointRegistry::init_handlers();
 
-      auto create = [this](auto& args) {
+      auto create = [this](auto& ctx) {
         LOG_DEBUG_FMT("Creating tpcc database");
-        const auto& body = args.rpc_ctx->get_request_body();
+        const auto& body = ctx.rpc_ctx->get_request_body();
         auto db = tpcc::DbCreation::deserialize(body.data(), body.size());
-        tpcc::SetupDb setup_db(args, db.new_orders_per_district, db.seed);
+        tpcc::SetupDb setup_db(ctx, db.new_orders_per_district, db.seed);
         setup_db.run();
         LOG_DEBUG_FMT("Creating tpcc database - end");
 
-        set_no_content_status(args);
+        set_no_content_status(ctx);
       };
 
-      auto do_stock_level = [this](auto& args) {
+      auto do_stock_level = [this](auto& ctx) {
         LOG_DEBUG_FMT("stock level");
-        const auto& body = args.rpc_ctx->get_request_body();
+        const auto& body = ctx.rpc_ctx->get_request_body();
         auto info = tpcc::StockLevel::deserialize(body.data(), body.size());
-        tpcc::TpccTransactions tx(args, info.seed);
+        tpcc::TpccTransactions tx(ctx, info.seed);
         tx.stock_level(info.warehouse_id, info.district_id, info.threshold);
         LOG_DEBUG_FMT("stock level - end");
 
-        set_no_content_status(args);
+        set_no_content_status(ctx);
       };
 
-      auto do_order_status = [this](auto& args) {
+      auto do_order_status = [this](auto& ctx) {
         LOG_DEBUG_FMT("order status");
-        const auto& body = args.rpc_ctx->get_request_body();
+        const auto& body = ctx.rpc_ctx->get_request_body();
         auto info = tpcc::TxInfo::deserialize(body.data(), body.size());
-        tpcc::TpccTransactions tx(args, info.seed);
+        tpcc::TpccTransactions tx(ctx, info.seed);
         tx.order_status();
         LOG_DEBUG_FMT("order status - end");
 
-        set_no_content_status(args);
+        set_no_content_status(ctx);
       };
 
-      auto do_delivery = [this](auto& args) {
+      auto do_delivery = [this](auto& ctx) {
         LOG_DEBUG_FMT("delivery");
-        const auto& body = args.rpc_ctx->get_request_body();
+        const auto& body = ctx.rpc_ctx->get_request_body();
         auto info = tpcc::TxInfo::deserialize(body.data(), body.size());
-        tpcc::TpccTransactions tx(args, info.seed);
+        tpcc::TpccTransactions tx(ctx, info.seed);
         tx.delivery();
         LOG_DEBUG_FMT("delivery - end");
 
-        set_no_content_status(args);
+        set_no_content_status(ctx);
       };
 
-      auto do_payment = [this](auto& args) {
+      auto do_payment = [this](auto& ctx) {
         LOG_DEBUG_FMT("payment");
-        const auto& body = args.rpc_ctx->get_request_body();
+        const auto& body = ctx.rpc_ctx->get_request_body();
         auto info = tpcc::TxInfo::deserialize(body.data(), body.size());
-        tpcc::TpccTransactions tx(args, info.seed);
+        tpcc::TpccTransactions tx(ctx, info.seed);
         tx.payment();
         LOG_DEBUG_FMT("payment - end");
 
-        set_no_content_status(args);
+        set_no_content_status(ctx);
       };
 
-      auto do_new_order = [this](auto& args) {
+      auto do_new_order = [this](auto& ctx) {
         LOG_DEBUG_FMT("new order");
-        const auto& body = args.rpc_ctx->get_request_body();
+        const auto& body = ctx.rpc_ctx->get_request_body();
         auto info = tpcc::TxInfo::deserialize(body.data(), body.size());
-        tpcc::TpccTransactions tx(args, info.seed);
+        tpcc::TpccTransactions tx(ctx, info.seed);
         tx.new_order();
         LOG_DEBUG_FMT("new order - end");
 
-        set_no_content_status(args);
+        set_no_content_status(ctx);
       };
 
       const ccf::AuthnPolicies user_sig_or_cert = {user_signature_auth_policy,

--- a/src/endpoints/common_endpoint_registry.cpp
+++ b/src/endpoints/common_endpoint_registry.cpp
@@ -19,15 +19,15 @@ namespace ccf
   namespace
   {
     std::optional<ccf::TxID> txid_from_query_string(
-      ccf::endpoints::EndpointContext& args)
+      ccf::endpoints::EndpointContext& ctx)
     {
       const auto parsed_query =
-        http::parse_query(args.rpc_ctx->get_request_query());
+        http::parse_query(ctx.rpc_ctx->get_request_query());
 
       const auto it = parsed_query.find(tx_id_param_key);
       if (it == parsed_query.end())
       {
-        args.rpc_ctx->set_error(
+        ctx.rpc_ctx->set_error(
           HTTP_STATUS_BAD_REQUEST,
           ccf::errors::InvalidQueryParameterValue,
           fmt::format(
@@ -40,7 +40,7 @@ namespace ccf
       const auto tx_id_opt = ccf::TxID::from_str(txid_str);
       if (!tx_id_opt.has_value())
       {
-        args.rpc_ctx->set_error(
+        ctx.rpc_ctx->set_error(
           HTTP_STATUS_BAD_REQUEST,
           ccf::errors::InvalidQueryParameterValue,
           fmt::format(
@@ -153,10 +153,10 @@ namespace ccf
         ccf::endpoints::ExecuteOutsideConsensus::Locally)
       .install();
 
-    auto get_code = [](auto& args, nlohmann::json&&) {
+    auto get_code = [](auto& ctx, nlohmann::json&&) {
       GetCode::Out out;
 
-      auto codes_ids = args.tx.template ro<CodeIDs>(Tables::NODE_CODE_IDS);
+      auto codes_ids = ctx.tx.template ro<CodeIDs>(Tables::NODE_CODE_IDS);
       codes_ids->foreach(
         [&out](const ccf::CodeDigest& cd, const ccf::CodeStatus& cs) {
           auto digest = ds::to_hex(cd.data);
@@ -252,14 +252,14 @@ namespace ccf
       };
 
     auto get_receipt =
-      [](auto& args, ccf::historical::StatePtr historical_state) {
+      [](auto& ctx, ccf::historical::StatePtr historical_state) {
         const auto [pack, params] =
-          ccf::jsonhandler::get_json_params(args.rpc_ctx);
+          ccf::jsonhandler::get_json_params(ctx.rpc_ctx);
 
         ccf::Receipt out;
         historical_state->receipt->describe(out);
-        args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
-        ccf::jsonhandler::set_response(out, args.rpc_ctx, pack);
+        ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+        ccf::jsonhandler::set_response(out, ctx.rpc_ctx, pack);
       };
 
     make_endpoint(

--- a/src/endpoints/endpoint_registry.cpp
+++ b/src/endpoints/endpoint_registry.cpp
@@ -101,10 +101,10 @@ namespace ccf::endpoints
     return make_endpoint(
              method,
              verb,
-             [f](EndpointContext& args) {
-               ReadOnlyEndpointContext ro_args(
-                 args.rpc_ctx, std::move(args.caller), args.tx);
-               f(ro_args);
+             [f](EndpointContext& ctx) {
+               ReadOnlyEndpointContext ro_ctx(
+                 ctx.rpc_ctx, std::move(ctx.caller), ctx.tx);
+               f(ro_ctx);
              },
              ap)
       .set_forwarding_required(ForwardingRequired::Sometimes);
@@ -117,7 +117,7 @@ namespace ccf::endpoints
     const AuthnPolicies& ap)
   {
     return make_endpoint(
-             method, verb, [f](EndpointContext& args) { f(args); }, ap)
+             method, verb, [f](EndpointContext& ctx) { f(ctx); }, ap)
       .set_forwarding_required(ForwardingRequired::Sometimes)
       .set_execute_outside_consensus(
         ccf::endpoints::ExecuteOutsideConsensus::Primary);
@@ -273,7 +273,7 @@ namespace ccf::endpoints
   }
 
   void EndpointRegistry::execute_endpoint(
-    EndpointDefinitionPtr e, EndpointContext& args)
+    EndpointDefinitionPtr e, EndpointContext& ctx)
   {
     auto endpoint = dynamic_cast<const Endpoint*>(e.get());
     if (endpoint == nullptr)
@@ -283,7 +283,7 @@ namespace ccf::endpoints
         "derived implementation to handle derived endpoint instances");
     }
 
-    endpoint->func(args);
+    endpoint->func(ctx);
   }
 
   std::set<RESTVerb> EndpointRegistry::get_allowed_verbs(

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -62,16 +62,16 @@ public:
   {
     open();
 
-    auto empty_function = [this](auto& args) {
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+    auto empty_function = [this](auto& ctx) {
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     make_endpoint(
       "empty_function", HTTP_POST, empty_function, {user_cert_auth_policy})
       .set_forwarding_required(ccf::endpoints::ForwardingRequired::Sometimes)
       .install();
 
-    auto empty_function_signed = [this](auto& args) {
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+    auto empty_function_signed = [this](auto& ctx) {
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     make_endpoint(
       "empty_function_signed",
@@ -81,8 +81,8 @@ public:
       .set_forwarding_required(ccf::endpoints::ForwardingRequired::Sometimes)
       .install();
 
-    auto empty_function_no_auth = [this](auto& args) {
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+    auto empty_function_no_auth = [this](auto& ctx) {
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     make_endpoint(
       "empty_function_no_auth",
@@ -150,18 +150,18 @@ public:
   {
     open();
 
-    auto get_only = [this](auto& args) {
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+    auto get_only = [this](auto& ctx) {
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     make_endpoint("get_only", HTTP_GET, get_only).install();
 
-    auto post_only = [this](auto& args) {
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+    auto post_only = [this](auto& ctx) {
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     make_endpoint("post_only", HTTP_POST, post_only).install();
 
-    auto put_or_delete = [this](auto& args) {
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+    auto put_or_delete = [this](auto& ctx) {
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     make_endpoint("put_or_delete", HTTP_PUT, put_or_delete).install();
     make_endpoint("put_or_delete", HTTP_DELETE, put_or_delete).install();
@@ -179,23 +179,23 @@ public:
   {
     open();
 
-    auto maybe_commit = [this](ccf::endpoints::EndpointContext& args) {
+    auto maybe_commit = [this](ccf::endpoints::EndpointContext& ctx) {
       const auto parsed =
-        serdes::unpack(args.rpc_ctx->get_request_body(), default_pack);
+        serdes::unpack(ctx.rpc_ctx->get_request_body(), default_pack);
 
       const auto new_value = parsed["value"].get<size_t>();
-      auto vs = args.tx.rw(values);
+      auto vs = ctx.tx.rw(values);
       vs->put(0, new_value);
 
       const auto apply_it = parsed.find("apply");
       if (apply_it != parsed.end())
       {
         const auto should_apply = apply_it->get<bool>();
-        args.rpc_ctx->set_apply_writes(should_apply);
+        ctx.rpc_ctx->set_apply_writes(should_apply);
       }
 
       const auto status = parsed["status"].get<http_status>();
-      args.rpc_ctx->set_response_status(status);
+      ctx.rpc_ctx->set_response_status(status);
     };
     make_endpoint("maybe_commit", HTTP_POST, maybe_commit).install();
   }
@@ -208,15 +208,15 @@ public:
   {
     open();
 
-    auto command = [this](auto& args) {
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+    auto command = [this](auto& ctx) {
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     endpoints
       .make_command_endpoint("command", HTTP_POST, command, no_auth_required)
       .install();
 
-    auto read_only = [this](auto& args) {
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+    auto read_only = [this](auto& ctx) {
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     endpoints
       .make_read_only_endpoint(
@@ -236,10 +236,10 @@ public:
   {
     open();
 
-    auto endpoint = [this](auto& args) {
-      nlohmann::json response_body = args.rpc_ctx->get_request_path_params();
-      args.rpc_ctx->set_response_body(response_body.dump(2));
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+    auto endpoint = [this](auto& ctx) {
+      nlohmann::json response_body = ctx.rpc_ctx->get_request_path_params();
+      ctx.rpc_ctx->set_response_body(response_body.dump(2));
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     make_endpoint("{foo}/{bar}/{baz}", HTTP_POST, endpoint).install();
   }
@@ -256,8 +256,8 @@ public:
   {
     open();
 
-    auto empty_function = [this](auto& args) {
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+    auto empty_function = [this](auto& ctx) {
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     member_endpoints
       .make_endpoint(
@@ -278,8 +278,8 @@ public:
   {
     open();
 
-    auto empty_function = [this](auto& args) {
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+    auto empty_function = [this](auto& ctx) {
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     endpoints
       .make_endpoint(
@@ -327,9 +327,9 @@ public:
   {
     open();
 
-    auto empty_function = [this](auto& args) {
-      record_ctx(args);
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+    auto empty_function = [this](auto& ctx) {
+      record_ctx(ctx);
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     // Note that this a Write function so that a backup executing this command
     // will forward it to the primary
@@ -337,9 +337,9 @@ public:
       "empty_function", HTTP_POST, empty_function, {user_cert_auth_policy})
       .install();
 
-    auto empty_function_no_auth = [this](auto& args) {
-      record_ctx(args);
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+    auto empty_function_no_auth = [this](auto& ctx) {
+      record_ctx(ctx);
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     make_endpoint("empty_function_no_auth", HTTP_POST, empty_function_no_auth)
       .install();
@@ -356,9 +356,9 @@ public:
   {
     open();
 
-    auto empty_function = [this](auto& args) {
-      record_ctx(args);
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+    auto empty_function = [this](auto& ctx) {
+      record_ctx(ctx);
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     // Note that this a Write function so that a backup executing this command
     // will forward it to the primary
@@ -382,9 +382,9 @@ public:
   {
     open();
 
-    auto empty_function = [this](auto& args) {
-      record_ctx(args);
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+    auto empty_function = [this](auto& ctx) {
+      record_ctx(ctx);
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     // Note that this a Write function so that a backup executing this command
     // will forward it to the primary
@@ -1458,15 +1458,15 @@ public:
   {
     open();
 
-    auto conflict = [this](auto& args) {
+    auto conflict = [this](auto& ctx) {
       size_t retry_count =
-        std::stoi(args.rpc_ctx->get_request_header("test-retry-count")
+        std::stoi(ctx.rpc_ctx->get_request_header("test-retry-count")
                     .value()); // This header only exists in the context of
                                // this test
 
       static size_t execution_count = 0;
 
-      auto conflict_map = args.tx.template rw<Values>("test_values_conflict");
+      auto conflict_map = ctx.tx.template rw<Values>("test_values_conflict");
       conflict_map->get(0); // Record a read dependency
 
       if (execution_count++ < retry_count)
@@ -1479,7 +1479,7 @@ public:
         REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
 
         // Indicate that the execution conflicted
-        args.rpc_ctx->set_response_header("test-has-conflicted", "true");
+        ctx.rpc_ctx->set_response_header("test-has-conflicted", "true");
       }
       else
       {
@@ -1487,12 +1487,11 @@ public:
         execution_count = 0;
       }
 
-      args.rpc_ctx->set_response_header(
-        "test-execution-count", execution_count);
+      ctx.rpc_ctx->set_response_header("test-execution-count", execution_count);
 
       conflict_map->put(0, 0);
 
-      args.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
     };
     make_endpoint("conflict", HTTP_POST, conflict).install();
   }


### PR DESCRIPTION
As outlined in #2345, our samples have got a mix of old and new styles in many places. In particular still using the old generic `args` variable name for the `EndpointContext` object. This replaces those with `ctx`, and removes some string duplication.

EDIT: Resolves #2345.