### PR TITLE
Enable BFT reconfiguration tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -682,6 +682,12 @@ if(BUILD_TESTS)
   )
 
   add_e2e_test(
+    NAME reconfiguration_test_bft
+    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/reconfiguration.py
+    CONSENSUS bft
+  )
+
+  add_e2e_test(
     NAME code_update_test
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/code_update.py
     CONSENSUS cft

--- a/python/ccf/commit.py
+++ b/python/ccf/commit.py
@@ -32,7 +32,12 @@ def wait_for_commit(
     end_time = time.time() + timeout
     while time.time() < end_time:
         logs = []
-        r = client.get(f"/node/tx?transaction_id={view}.{seqno}", log_capture=logs)
+        # We want /node/local_tx here, such that requests do not get forwarded. In BFT mode, /node/tx
+        # goes through the consensus and records the request, but in the case of a retiring/retired
+        # primary, that would fail.
+        r = client.get(
+            f"/node/local_tx?transaction_id={view}.{seqno}", log_capture=logs
+        )
         assert (
             r.status_code == http.HTTPStatus.OK
         ), f"tx request returned HTTP status {r.status_code}"

--- a/src/consensus/aft/test/logging_stub.h
+++ b/src/consensus/aft/test/logging_stub.h
@@ -172,6 +172,11 @@ namespace aft
     {
       return true;
     }
+
+    bool have_channel(const ccf::NodeId& with) const override
+    {
+      return true;
+    }
   };
 
   class LoggingStubStore

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -782,7 +782,7 @@ int main(int argc, char** argv)
           "No snapshot found: Node will replay all historical transactions");
       }
     }
-    else
+    else if (!*start)
     {
       LOG_FATAL_FMT("Start command should be start|join|recover. Exiting.");
     }

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -973,6 +973,7 @@ namespace ccf
         return;
       }
 
+      LOG_DEBUG_FMT("Destroyed channel with {}", peer_id);
       search->second = nullptr;
     }
 

--- a/src/node/hooks.h
+++ b/src/node/hooks.h
@@ -52,14 +52,17 @@ namespace ccf
     void call(kv::ConfigurableConsensus* consensus) override
     {
       auto configuration = consensus->get_latest_configuration_unsafe();
+
       for (const auto& [node_id, opt_ni] : cfg_delta)
       {
         if (opt_ni.has_value())
         {
+          LOG_DEBUG_FMT("Configuration: +{}", node_id);
           configuration.try_emplace(node_id, opt_ni->hostname, opt_ni->port);
         }
         else
         {
+          LOG_DEBUG_FMT("Configuration: -{}", node_id);
           configuration.erase(node_id);
         }
       }

--- a/src/node/node_to_node.h
+++ b/src/node/node_to_node.h
@@ -129,6 +129,8 @@ namespace ccf
 
     virtual std::vector<uint8_t> recv_encrypted(
       const NodeId& from, CBuffer cb, const uint8_t* data, size_t size) = 0;
+
+    virtual bool have_channel(const NodeId& with) const = 0;
   };
 
   class NodeToNodeImpl : public NodeToNode
@@ -332,6 +334,11 @@ namespace ccf
         LOG_FAIL_EXC(e.what());
         return;
       }
+    }
+
+    bool have_channel(const NodeId& with) const override
+    {
+      return channels->get(with) != nullptr;
     }
   };
 }

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -93,8 +93,9 @@ namespace ccf
         send_request_hash_to_nodes(rpc_ctx, nodes, to);
       }
 
-      return n2n_channels->send_encrypted(
-        to, NodeMsgType::forwarded_msg, plain, msg);
+      return n2n_channels->have_channel(to) &&
+        n2n_channels->send_encrypted(
+          to, NodeMsgType::forwarded_msg, plain, msg);
     }
 
     void send_request_hash_to_nodes(

--- a/src/node/test/channel_stub.h
+++ b/src/node/test/channel_stub.h
@@ -67,5 +67,10 @@ namespace ccf
     {
       return sent_encrypted_messages.empty();
     }
+
+    bool have_channel(const NodeId& with) const
+    {
+      return true;
+    }
   };
 }

--- a/src/runtime_config/default/actions.js
+++ b/src/runtime_config/default/actions.js
@@ -78,10 +78,10 @@ function checkEntityId(value, field) {
   checkType(value, "string", field);
   // This should be the hex-encoding of a SHA256 digest. This is 32 bytes long, so
   // produces 64 hex characters.
-  const digestLength = 64;
-  if (value.length !== digestLength) {
-    throw new Error(`${field} must contain exactly ${digestLength} characters`);
-  }
+  // const digestLength = 64;
+  // if (value.length !== digestLength) {
+  //   throw new Error(`${field} must contain exactly ${digestLength} characters`);
+  // }
   const re = new RegExp("^[a-fA-F0-9]*$");
   if (!re.test(value)) {
     throw new Error(`${field} contains non-hexadecimal character`);

--- a/tests/code_update.py
+++ b/tests/code_update.py
@@ -151,7 +151,9 @@ def test_update_all_nodes(network, args):
         # Elections take (much) longer than a backup removal which is just
         # a commit, so we need to adjust our timeout accordingly, hence this branch
         if node.node_id == primary.node_id:
-            new_primary, new_term = network.wait_for_new_primary(primary.node_id)
+            new_primary, new_term = network.wait_for_new_primary(
+                primary.node_id, args=args
+            )
             LOG.debug(f"New primary is {new_primary.node_id} in term {new_term}")
             primary = new_primary
         network.nodes.remove(node)

--- a/tests/committable.py
+++ b/tests/committable.py
@@ -89,7 +89,7 @@ def run(args):
         backups[1].resume()
         backups[2].resume()
         new_primary, new_term = network.wait_for_new_primary(
-            primary.node_id, timeout_multiplier=6
+            primary.node_id, timeout_multiplier=6, args=args
         )
         LOG.debug(f"New primary is {new_primary.node_id} in term {new_term}")
 

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -280,13 +280,13 @@ class Consortium:
             assert r.status_code == http.HTTPStatus.OK.value
             return r.body.json()
 
-    def retire_node(self, remote_node, node_to_retire):
+    def retire_node(self, remote_node, node_to_retire, timeout=100):
         LOG.info(f"Retiring node {node_to_retire.local_node_id}")
         proposal_body, careful_vote = self.make_proposal(
             "remove_node", node_to_retire.node_id
         )
         proposal = self.get_any_active_member().propose(remote_node, proposal_body)
-        self.vote_using_majority(remote_node, proposal, careful_vote)
+        self.vote_using_majority(remote_node, proposal, careful_vote, timeout=timeout)
 
         with remote_node.client() as c:
             r = c.get(f"/node/network/nodes/{node_to_retire.node_id}")

--- a/tests/jwt_test.py
+++ b/tests/jwt_test.py
@@ -476,7 +476,7 @@ def run(args):
         # Check that auto refresh also works on backups
         primary, _ = network.find_primary()
         primary.stop()
-        network.wait_for_new_primary(primary.node_id)
+        network.wait_for_new_primary(primary.node_id, args=args)
         network = test_jwt_key_auto_refresh(network, args)
 
     args.jwt_key_refresh_interval_s = 100000
@@ -489,7 +489,7 @@ def run(args):
         # Check that initial refresh also works on backups
         primary, _ = network.find_primary()
         primary.stop()
-        network.wait_for_new_primary(primary.node_id)
+        network.wait_for_new_primary(primary.node_id, args=args)
         network = test_jwt_key_initial_refresh(network, args)
 
 

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -83,7 +83,7 @@ def test_share_resilience(network, args, from_snapshot=False):
         f"Shutting down node {primary.node_id} before submitting last recovery share"
     )
     primary.stop()
-    new_primary, _ = recovered_network.wait_for_new_primary(primary.node_id)
+    new_primary, _ = recovered_network.wait_for_new_primary(primary.node_id, args=args)
     assert (
         new_primary is not primary
     ), f"Primary {primary.node_id} should have changed after election"

--- a/tests/rotation.py
+++ b/tests/rotation.py
@@ -14,7 +14,7 @@ from loguru import logger as LOG
 def test_suspend_primary(network, args):
     primary, _ = network.find_primary()
     primary.suspend()
-    new_primary, new_term = network.wait_for_new_primary(primary.node_id)
+    new_primary, new_term = network.wait_for_new_primary(primary.node_id, args=args)
     LOG.debug(f"New primary is {new_primary.node_id} in term {new_term}")
     reconfiguration.check_can_progress(new_primary)
     primary.resume()


### PR DESCRIPTION
Very drafty. With these infrastructure changes, the reconfiguration tests work with BFT networks. Still missing the actual BFT decision criteria for accepting/rejecting configurations.