### PR TITLE
Add new `/node/version` endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,6 +679,7 @@ if(BUILD_TESTS)
     NAME reconfiguration_test
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/reconfiguration.py
     CONSENSUS cft
+    ADDITIONAL_ARGS --ccf-version ${CCF_VERSION}
   )
 
   add_e2e_test(

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -233,6 +233,17 @@
         ],
         "type": "object"
       },
+      "GetVersion__Out": {
+        "properties": {
+          "version": {
+            "$ref": "#/components/schemas/string"
+          }
+        },
+        "required": [
+          "version"
+        ],
+        "type": "object"
+      },
       "MemoryUsage__Out": {
         "properties": {
           "current_allocated_heap_size": {
@@ -723,6 +734,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetTxStatus__Out"
+                }
+              }
+            },
+            "description": "Default response description"
+          }
+        }
+      }
+    },
+    "/version": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetVersion__Out"
                 }
               }
             },

--- a/src/endpoints/common_endpoint_registry.cpp
+++ b/src/endpoints/common_endpoint_registry.cpp
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 
-#include "ccf/common_endpoint_registry.h"
-
 #include "ccf/common_auth_policies.h"
+#include "ccf/common_endpoint_registry.h"
 #include "ccf/historical_queries_adapter.h"
 #include "ccf/http_query.h"
 #include "ccf/json_handler.h"
@@ -88,7 +87,7 @@ namespace ccf
       "commit", HTTP_GET, json_command_adapter(get_commit), no_auth_required)
       .set_execute_outside_consensus(
         ccf::endpoints::ExecuteOutsideConsensus::Locally)
-      .set_auto_schema<void, GetCommit::Out>()
+      .set_auto_schema<GetCommit>()
       .install();
 
     auto get_tx_status = [this](auto& ctx, nlohmann::json&&) {

--- a/src/endpoints/common_endpoint_registry.cpp
+++ b/src/endpoints/common_endpoint_registry.cpp
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 
-#include "ccf/common_auth_policies.h"
 #include "ccf/common_endpoint_registry.h"
+
+#include "ccf/common_auth_policies.h"
 #include "ccf/historical_queries_adapter.h"
 #include "ccf/http_query.h"
 #include "ccf/json_handler.h"

--- a/src/node/rpc/call_types.h
+++ b/src/node/rpc/call_types.h
@@ -20,6 +20,8 @@ namespace ccf
 {
   struct GetCommit
   {
+    using In = void;
+
     struct Out
     {
       ccf::TxID transaction_id;

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -43,6 +43,16 @@ namespace ccf
     };
   };
 
+  struct GetVersion
+  {
+    using In = void;
+
+    struct Out
+    {
+      std::string version;
+    };
+  };
+
   struct CreateNetworkNodeToNode
   {
     struct In

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -6,6 +6,7 @@
 #include "ccf/common_endpoint_registry.h"
 #include "ccf/http_query.h"
 #include "ccf/json_handler.h"
+#include "ccf/version.h"
 #include "crypto/hash.h"
 #include "frontend.h"
 #include "node/entities.h"
@@ -422,7 +423,7 @@ namespace ccf
             q.node_id = node_id;
             q.raw = node_info.quote_info.quote;
             q.endorsements = node_info.quote_info.endorsements;
-            q.format = QuoteFormat::oe_sgx_v1;
+            q.format = node_info.quote_info.format;
 
 #ifdef GET_QUOTE
             auto code_id =
@@ -772,6 +773,20 @@ namespace ccf
         .set_execute_outside_consensus(
           ccf::endpoints::ExecuteOutsideConsensus::Locally)
         .set_auto_schema<MemoryUsage>()
+        .install();
+
+      auto version = [this](auto&, nlohmann::json&&) {
+        GetVersion::Out result;
+        result.version = ccf::ccf_version;
+        return make_success(result);
+      };
+
+      make_command_endpoint(
+        "version", HTTP_GET, json_command_adapter(version), no_auth_required)
+        .set_forwarding_required(endpoints::ForwardingRequired::Never)
+        .set_auto_schema<GetVersion>()
+        .set_execute_outside_consensus(
+          ccf::endpoints::ExecuteOutsideConsensus::Locally)
         .install();
     }
   };

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -25,6 +25,9 @@ namespace ccf
   DECLARE_JSON_OPTIONAL_FIELDS(
     GetState::Out, recovery_target_seqno, last_recovered_seqno)
 
+  DECLARE_JSON_TYPE(GetVersion::Out)
+  DECLARE_JSON_REQUIRED_FIELDS(GetVersion::Out, version)
+
   DECLARE_JSON_TYPE(JoinNetworkNodeToNode::In)
   DECLARE_JSON_REQUIRED_FIELDS(
     JoinNetworkNodeToNode::In,

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -307,11 +307,6 @@ def run(args):
         network.start_and_join(args)
 
         test_version(network, args)
-
-        import sys
-
-        sys.exit(0)
-
         test_node_replacement(network, args)
         test_add_node_from_backup(network, args)
         test_add_node(network, args)


### PR DESCRIPTION
Follow-up from #2562 

This PR adds a new `/node/version` endpoint to return the CCF version a node was built from. This is useful for operators during a code update to check which nodes run the new version of CCF, without having to deal with the opaque `mrenclave`. 