### PR TITLE
Add a minimal JS logging app for perf testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -909,7 +909,7 @@ if(BUILD_TESTS)
   )
 
   add_perf_test(
-    NAME ls_big_js
+    NAME ls_full_js
     PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/infra/perfclient.py
     CONSENSUS cft
     CLIENT_BIN ./scenario_perf_client
@@ -933,7 +933,7 @@ if(BUILD_TESTS)
     CLIENT_BIN ./scenario_perf_client
     ADDITIONAL_ARGS
       --js-app-bundle
-      ${CMAKE_SOURCE_DIR}/samples/apps/logging/js
+      ${CMAKE_SOURCE_DIR}/samples/apps/logging/js_perf
       --scenario-file
       ${CMAKE_CURRENT_LIST_DIR}/tests/perf_logging_scenario_100txs.json
       --max-writes-ahead

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -926,7 +926,6 @@ if(BUILD_TESTS)
       text
   )
 
-  
   add_perf_test(
     NAME ls_js_jwt
     PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/infra/perfclient.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -897,6 +897,24 @@ if(BUILD_TESTS)
     CLIENT_BIN ./scenario_perf_client
     ADDITIONAL_ARGS
       --js-app-bundle
+      ${CMAKE_SOURCE_DIR}/samples/apps/logging/js_perf
+      --scenario-file
+      ${CMAKE_CURRENT_LIST_DIR}/tests/perf_logging_scenario_100txs.json
+      --max-writes-ahead
+      1000
+      --repetitions
+      1000
+      --msg-ser-fmt
+      text
+  )
+
+  add_perf_test(
+    NAME ls_big_js
+    PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/infra/perfclient.py
+    CONSENSUS cft
+    CLIENT_BIN ./scenario_perf_client
+    ADDITIONAL_ARGS
+      --js-app-bundle
       ${CMAKE_SOURCE_DIR}/samples/apps/logging/js
       --scenario-file
       ${CMAKE_CURRENT_LIST_DIR}/tests/perf_logging_scenario_100txs.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -926,6 +926,7 @@ if(BUILD_TESTS)
       text
   )
 
+  
   add_perf_test(
     NAME ls_js_jwt
     PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/infra/perfclient.py

--- a/samples/apps/logging/js_perf/app.json
+++ b/samples/apps/logging/js_perf/app.json
@@ -1,0 +1,22 @@
+{
+  "endpoints": {
+    "/log/private": {
+      "get": {
+        "js_module": "logging.js",
+        "js_function": "get_private",
+        "forwarding_required": "always",
+        "authn_policies": ["jwt", "user_cert"],
+        "mode": "readonly",
+        "openapi": {}
+      },
+      "post": {
+        "js_module": "logging.js",
+        "js_function": "post_private",
+        "forwarding_required": "always",
+        "authn_policies": ["jwt", "user_cert"],
+        "mode": "readwrite",
+        "openapi": {}
+      }
+    }
+  }
+}

--- a/samples/apps/logging/js_perf/src/logging.js
+++ b/samples/apps/logging/js_perf/src/logging.js
@@ -1,0 +1,32 @@
+function get_id_from_request_query(request) {
+  const elements = request.query.split("&");
+  for (const kv of elements) {
+    const [k, v] = kv.split("=");
+    if (k == "id") {
+      return ccf.strToBuf(v);
+    }
+  }
+  throw new Error("Could not find 'id' in query");
+}
+
+function get_record(map, id) {
+  const msg = map.get(id);
+  if (msg === undefined) {
+    return { body: { error: "No such key" } };
+  }
+  return { body: { msg: ccf.bufToStr(msg) } };
+}
+
+export function get_private(request) {
+  const id = get_id_from_request_query(request);
+  return get_record(ccf.kv["records"], id);
+}
+
+export function post_private(request) {
+  let params = request.body.json();
+  ccf.kv["records"].set(
+    ccf.strToBuf(params.id.toString()),
+    ccf.strToBuf(params.msg)
+  );
+  return { body: true };
+}


### PR DESCRIPTION
The perf drop in #2569 has shown that our JS perf numbers are very sensitive to changes in the JS app size. This means they're unduly affected when we're just trying to add functional changes to the JS interpreter, that are unused by the perf test. This splits the JS app used for functional testing (`logging/js`) from the minimal app that only has the endpoints used by the perf test (`logging/js_perf`). We now run perf tests on both, but the number for `ls_js_sgx_cft` should only be affected by changes to the interpreter, not a (largely unrelated) app.