### PR TITLE
Update doc versions of `/gov` and `/node` OpenAPI

### DIFF
--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -336,7 +336,7 @@
   "info": {
     "description": "This CCF sample app implements a simple logging application, securely recording messages at client-specified IDs. It demonstrates most of the features available to CCF apps.",
     "title": "CCF Sample Logging App",
-    "version": "0.0.1"
+    "version": "0.1.0"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -552,7 +552,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/boolean"
+                  "$ref": "#/components/schemas/uint64"
                 }
               }
             },

--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -552,7 +552,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/uint64"
+                  "$ref": "#/components/schemas/boolean"
                 }
               }
             },

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -389,7 +389,7 @@
   "info": {
     "description": "This API is used to submit and query proposals which affect CCF's public governance tables.",
     "title": "CCF Governance API",
-    "version": "0.0.1"
+    "version": "1.0.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -389,7 +389,7 @@
   "info": {
     "description": "This API is used to submit and query proposals which affect CCF's public governance tables.",
     "title": "CCF Governance API",
-    "version": "1.0.0"
+    "version": "1.2.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -389,7 +389,7 @@
   "info": {
     "description": "This API is used to submit and query proposals which affect CCF's public governance tables.",
     "title": "CCF Governance API",
-    "version": "1.2.0"
+    "version": "1.0.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -412,7 +412,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "0.0.1"
+    "version": "1.0.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -1157,6 +1157,7 @@ namespace loggingapp
         "This CCF sample app implements a simple logging application, securely "
         "recording messages at client-specified IDs. It demonstrates most of "
         "the features available to CCF apps.";
+      logger_handlers.openapi_info.document_version = "0.1.0";
     }
   };
 }

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -473,6 +473,7 @@ namespace ccf
       openapi_info.description =
         "This API is used to submit and query proposals which affect CCF's "
         "public governance tables.";
+      openapi_info.document_version = "1.0.0";
     }
 
     static std::optional<MemberId> get_caller_member_id(

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -191,6 +191,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
+      openapi_info.document_version = "1.0.0";
     }
 
     void init_handlers() override

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -63,7 +63,9 @@ def run(args):
                     LOG.error(
                         f"Found differences in {openapi_target_file}, but not overwriting as retrieved version is not newer ({fetched_version} <= {file_version})"
                     )
-                    alt_file = os.path.join(args.schema_dir, f"{prefix}_{fetched_version}_openapi.json")
+                    alt_file = os.path.join(
+                        args.schema_dir, f"{prefix}_{fetched_version}_openapi.json"
+                    )
                     LOG.error(f"Writing to {alt_file} for comparison")
                     with open(alt_file, "w") as f2:
                         f2.write(formatted_schema)

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -63,6 +63,10 @@ def run(args):
                     LOG.error(
                         f"Found differences in {openapi_target_file}, but not overwriting as retrieved version is not newer ({fetched_version} <= {file_version})"
                     )
+                    alt_file = os.path.join(args.schema_dir, f"{prefix}_{fetched_version}_openapi.json")
+                    LOG.error(f"Writing to {alt_file} for comparison")
+                    with open(alt_file, "w") as f2:
+                        f2.write(formatted_schema)
                 changed_files.append(openapi_target_file)
             else:
                 LOG.debug("Schema matches in {}".format(openapi_target_file))


### PR DESCRIPTION
Resolves #2559.

These APIs are now stable enough that we should give them real versions, so they're now 1.0.0. To try and ensure that we change the version when we change the API, `schema_test` is now stricter - it will only overwrite the existing OpenAPI document if the fetched version is newer. This may turn out to be very annoying, as it will flag some minor things (adding docs) that don't need a version bump, and breaks an existing helpful flow ("Schema changed? Oh I'll just run that test and check in the file").