### PR TITLE
Release/1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Bugfix
 
 - Requests with a url-encoded query string are now forwarded correctly from backups to the primary (#2587).
+- Signed requests with a url-encoded query string are now handled correctly rather than rejected (#2592).
 
 ## [1.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -858,6 +858,8 @@ Some discrepancies with the TR remain, and are being tracked under https://githu
 
 Initial pre-release
 
+[1.0.1]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.1
+[1.0.0]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.0
 [1.0.0-rc3]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.0-rc3
 [1.0.0-rc2]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.0-rc2
 [1.0.0-rc1]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.0-rc1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1]
+
+### Bugfix
+
+- Requests with a url-encoded query string are now forwarded correctly from backups to the primary (#2587).
+
 ## [1.0.0]
 
 The Confidential Consortium Framework CCF is an open-source framework for building a new category of secure, highly available, and performant applications that focus on multi-party compute and data.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 breathe
-sphinx
+sphinx<4,>=3
 sphinx_rtd_theme
 pygments-style-solarized
 bottle

--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -845,6 +845,43 @@
         ]
       }
     },
+    "/log/request_query": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/string"
+                }
+              }
+            },
+            "description": "Default response description"
+          }
+        }
+      }
+    },
+    "/log/signed_request_query": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/string"
+                }
+              }
+            },
+            "description": "Default response description"
+          }
+        },
+        "security": [
+          {
+            "user_signature": []
+          }
+        ]
+      }
+    },
     "/metrics": {
       "get": {
         "responses": {

--- a/samples/apps/forum/test/e2e/api.test.ts
+++ b/samples/apps/forum/test/e2e/api.test.ts
@@ -467,8 +467,10 @@ describe("REST API", function () {
           null,
           fakeAuth.user(userId)
         );
-        const kvRows = papa.parse(csvOut, { header: true, dynamicTyping: true })
-          .data;
+        const kvRows = papa.parse(csvOut, {
+          header: true,
+          dynamicTyping: true,
+        }).data;
         assert.deepEqual(kvRows, rows);
       });
     });

--- a/samples/apps/forum/test/unit/csvService.test.ts
+++ b/samples/apps/forum/test/unit/csvService.test.ts
@@ -46,8 +46,10 @@ describe("CsvService", function () {
       pollService.submitOpinion(user, topicB, opinionB);
 
       const csvOut = csvService.getOpinions(user);
-      const rowsOut = papa.parse(csvOut, { header: true, dynamicTyping: true })
-        .data;
+      const rowsOut = papa.parse(csvOut, {
+        header: true,
+        dynamicTyping: true,
+      }).data;
       assert.deepEqual(rowsOut, [
         { Topic: topicA, Opinion: opinionA },
         { Topic: topicB, Opinion: opinionB },

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -981,6 +981,35 @@ namespace loggingapp
         .set_auto_schema<LoggingRecord::In, bool>()
         .install();
 
+      auto get_request_query = [this](auto& ctx) {
+        ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+        std::vector<uint8_t> rq(
+          ctx.rpc_ctx->get_request_query().begin(),
+          ctx.rpc_ctx->get_request_query().end());
+        ctx.rpc_ctx->set_response_body(rq);
+      };
+
+      make_endpoint(
+        "log/request_query", HTTP_GET, get_request_query, ccf::no_auth_required)
+        .set_auto_schema<void, std::string>()
+        .install();
+
+      auto get_signed_request_query = [this](auto& ctx) {
+        ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+        std::vector<uint8_t> rq(
+          ctx.rpc_ctx->get_request_query().begin(),
+          ctx.rpc_ctx->get_request_query().end());
+        ctx.rpc_ctx->set_response_body(rq);
+      };
+
+      make_endpoint(
+        "log/signed_request_query",
+        HTTP_GET,
+        get_signed_request_query,
+        {ccf::user_signature_auth_policy})
+        .set_auto_schema<void, std::string>()
+        .install();
+
       metrics_tracker.install_endpoint(*this);
     }
 

--- a/src/enclave/rpc_context.h
+++ b/src/enclave/rpc_context.h
@@ -184,6 +184,7 @@ namespace enclave
       const std::string_view& name) = 0;
 
     virtual const std::vector<uint8_t>& get_serialised_request() = 0;
+    virtual const std::string& get_request_url() const = 0;
 
     /// Response details
     virtual void set_response_body(const std::vector<uint8_t>& body) = 0;

--- a/src/http/authentication/sig_auth.h
+++ b/src/http/authentication/sig_auth.h
@@ -15,8 +15,7 @@ namespace ccf
     {
       return http::HttpSignatureVerifier::parse(
         ctx->get_request_verb().c_str(),
-        ctx->get_request_path(),
-        ctx->get_request_query(),
+        ctx->get_request_url(),
         ctx->get_request_headers(),
         ctx->get_request_body());
     }

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -164,17 +164,14 @@ namespace http
 
     void handle_request(
       llhttp_method verb,
-      const std::string_view& path,
-      const std::string& query,
-      const std::string&,
+      const std::string_view& url,
       http::HeaderMap&& headers,
       std::vector<uint8_t>&& body) override
     {
       LOG_TRACE_FMT(
-        "Processing msg({}, {}, {}, [{} bytes])",
+        "Processing msg({}, {} [{} bytes])",
         llhttp_method_name(verb),
-        path,
-        query,
+        url,
         body.size());
 
       try
@@ -203,7 +200,7 @@ namespace http
           if (is_websocket)
           {
             rpc_ctx = std::make_shared<ws::WsRpcContext>(
-              request_index++, session_ctx, path, std::move(body));
+              request_index++, session_ctx, url, std::move(body));
           }
           else
           {
@@ -211,8 +208,7 @@ namespace http
               request_index++,
               session_ctx,
               verb,
-              path,
-              query,
+              url,
               std::move(headers),
               std::move(body));
           }

--- a/src/http/http_parser.h
+++ b/src/http/http_parser.h
@@ -18,6 +18,24 @@
 
 namespace http
 {
+  inline auto split_url_path(const std::string_view& url)
+  {
+    LOG_TRACE_FMT("Received url to parse: {}", std::string_view(url));
+
+    const auto path_end = url.find('?');
+    const auto query_start =
+      path_end == std::string::npos ? url.size() : path_end + 1;
+
+    const auto query_end = url.find('#', query_start);
+    const auto fragment_start =
+      query_end == std::string::npos ? url.size() : query_end + 1;
+
+    return std::make_tuple(
+      url.substr(0, path_end),
+      url.substr(query_start, query_end - query_start),
+      url.substr(fragment_start));
+  }
+
   static std::string url_decode(const std::string_view& s_)
   {
     std::string s(s_);
@@ -59,9 +77,7 @@ namespace http
     struct Request
     {
       llhttp_method method;
-      std::string path;
-      std::string query;
-      std::string fragment;
+      std::string url;
       http::HeaderMap headers;
       std::vector<uint8_t> body;
     };
@@ -70,18 +86,11 @@ namespace http
 
     virtual void handle_request(
       llhttp_method method,
-      const std::string_view& path,
-      const std::string& query,
-      const std::string& fragment,
+      const std::string_view& url,
       http::HeaderMap&& headers,
       std::vector<uint8_t>&& body) override
     {
-      received.emplace(Request{method,
-                               std::string(path),
-                               std::string(query),
-                               std::string(fragment),
-                               headers,
-                               body});
+      received.emplace(Request{method, std::string(url), headers, body});
     }
   };
 
@@ -119,24 +128,6 @@ namespace http
   static int on_headers_complete(llhttp_t* parser);
   static int on_body(llhttp_t* parser, const char* at, size_t length);
   static int on_msg_end(llhttp_t* parser);
-
-  inline auto split_url_path(const std::string_view& url)
-  {
-    LOG_TRACE_FMT("Received url to parse: {}", std::string_view(url));
-
-    const auto path_end = url.find('?');
-    const auto query_start =
-      path_end == std::string::npos ? url.size() : path_end + 1;
-
-    const auto query_end = url.find('#', query_start);
-    const auto fragment_start =
-      query_end == std::string::npos ? url.size() : query_end + 1;
-
-    return std::make_tuple(
-      url.substr(0, path_end),
-      url.substr(query_start, query_end - query_start),
-      url.substr(fragment_start));
-  }
 
   struct URL
   {
@@ -383,21 +374,14 @@ namespace http
         proc.handle_request(
           llhttp_method(parser.method),
           {},
-          {},
-          {},
           std::move(headers),
           std::move(body_buf));
       }
       else
       {
-        const auto [path, query, fragment] = split_url_path(url);
-        const std::string decoded_query = url_decode(query);
-        const std::string decoded_fragment = url_decode(fragment);
         proc.handle_request(
           llhttp_method(parser.method),
-          path,
-          decoded_query,
-          decoded_fragment,
+          url,
           std::move(headers),
           std::move(body_buf));
       }

--- a/src/http/http_proc.h
+++ b/src/http/http_proc.h
@@ -20,9 +20,7 @@ namespace http
   public:
     virtual void handle_request(
       llhttp_method method,
-      const std::string_view& path,
-      const std::string& query,
-      const std::string& fragment,
+      const std::string_view& url,
       HeaderMap&& headers,
       std::vector<uint8_t>&& body) = 0;
   };

--- a/src/http/http_rpc_context.h
+++ b/src/http/http_rpc_context.h
@@ -218,6 +218,11 @@ namespace http
       return std::nullopt;
     }
 
+    virtual const std::string& get_request_url() const override
+    {
+      return url;
+    }
+
     virtual void set_response_body(const std::vector<uint8_t>& body) override
     {
       response_body = body;

--- a/src/http/http_rpc_context.h
+++ b/src/http/http_rpc_context.h
@@ -64,9 +64,12 @@ namespace http
     size_t request_index;
 
     ccf::RESTVerb verb;
+    std::string url = {};
+
     std::string whole_path = {};
     std::string path = {};
     std::string query = {};
+    std::string fragment = {};
 
     http::HeaderMap request_headers = {};
 
@@ -79,80 +82,37 @@ namespace http
     std::vector<uint8_t> response_body = {};
     http_status response_status = HTTP_STATUS_OK;
 
-    bool canonicalised = false;
+    bool serialised = false;
 
     std::optional<bool> explicit_apply_writes = std::nullopt;
 
-    void canonicalise()
+    void serialise()
     {
-      if (!canonicalised)
+      if (!serialised)
       {
-        // Build a canonical serialization of this request. If the request is
-        // signed, then all unsigned headers must be removed
-        const auto auth_it = request_headers.find(http::headers::AUTHORIZATION);
-        if (auth_it != request_headers.end())
-        {
-          std::string_view authz_header = auth_it->second;
-
-          if (http::HttpSignatureVerifier::parse_auth_scheme(authz_header))
-          {
-            auto parsed_sign_params =
-              http::HttpSignatureVerifier::parse_signature_params(authz_header);
-
-            if (!parsed_sign_params.has_value())
-            {
-              throw std::logic_error(fmt::format(
-                "Unable to parse signature params from: {}", authz_header));
-            }
-
-            // Keep all signed headers, and the auth header containing the
-            // signature itself
-            auto& signed_headers = parsed_sign_params->signed_headers;
-            signed_headers.emplace_back(http::headers::AUTHORIZATION);
-
-            auto it = request_headers.begin();
-            while (it != request_headers.end())
-            {
-              if (
-                std::find(
-                  signed_headers.begin(), signed_headers.end(), it->first) ==
-                signed_headers.end())
-              {
-                it = request_headers.erase(it);
-              }
-              else
-              {
-                ++it;
-              }
-            }
-          }
-        }
-
-        const auto canonical_request_header = fmt::format(
-          "{} {}{} HTTP/1.1\r\n"
+        const auto request_prefix = fmt::format(
+          "{} {} HTTP/1.1\r\n"
           "{}"
           "\r\n",
           verb.c_str(),
-          whole_path,
-          query.empty() ? "" : fmt::format("?{}", query),
+          url,
           http::get_header_string(request_headers));
 
-        serialised_request.resize(
-          canonical_request_header.size() + request_body.size());
+        serialised_request.resize(request_prefix.size() + request_body.size());
         ::memcpy(
           serialised_request.data(),
-          canonical_request_header.data(),
-          canonical_request_header.size());
+          request_prefix.data(),
+          request_prefix.size());
         if (!request_body.empty())
         {
           ::memcpy(
-            serialised_request.data() + canonical_request_header.size(),
+            serialised_request.data() + request_prefix.size(),
             request_body.data(),
             request_body.size());
         }
       }
 
-      canonicalised = true;
+      serialised = true;
     }
 
   public:
@@ -160,8 +120,7 @@ namespace http
       size_t request_index_,
       std::shared_ptr<enclave::SessionContext> s,
       llhttp_method verb_,
-      const std::string_view& path_,
-      const std::string_view& query_,
+      const std::string_view& url_,
       const http::HeaderMap& headers_,
       const std::vector<uint8_t>& body_,
       const std::vector<uint8_t>& raw_request_ = {},
@@ -169,17 +128,20 @@ namespace http
       RpcContext(s, raw_bft_),
       request_index(request_index_),
       verb(verb_),
-      path(path_),
-      query(query_),
+      url(url_),
       request_headers(headers_),
       request_body(body_),
       serialised_request(raw_request_)
     {
-      whole_path = path;
+      const auto [path_, query_, fragment_] = split_url_path(url);
+      path = path_;
+      whole_path = path_;
+      query = url_decode(query_);
+      fragment = url_decode(fragment_);
 
       if (!serialised_request.empty())
       {
-        canonicalised = true;
+        serialised = true;
       }
     }
 
@@ -225,7 +187,7 @@ namespace http
 
     virtual const std::vector<uint8_t>& get_serialised_request() override
     {
-      canonicalise();
+      serialise();
       return serialised_request;
     }
 
@@ -350,15 +312,7 @@ namespace enclave
     const auto& msg = processor.received.front();
 
     return std::make_shared<http::HttpRpcContext>(
-      0,
-      s,
-      msg.method,
-      msg.path,
-      msg.query,
-      msg.headers,
-      msg.body,
-      packed,
-      raw_bft);
+      0, s, msg.method, msg.url, msg.headers, msg.body, packed, raw_bft);
   }
 
   inline std::shared_ptr<enclave::RpcContext> make_fwd_rpc_context(
@@ -399,7 +353,7 @@ namespace enclave
         const auto& msg = processor.received.front();
 
         return std::make_shared<ws::WsRpcContext>(
-          0, s, msg.path, msg.body, packed, raw_bft);
+          0, s, msg.url, msg.body, packed, raw_bft);
       }
       default:
         throw std::logic_error("Unknown Frame Format");

--- a/src/http/http_sig.h
+++ b/src/http/http_sig.h
@@ -18,8 +18,7 @@ namespace http
 {
   inline std::optional<std::vector<uint8_t>> construct_raw_signed_string(
     std::string verb,
-    const std::string_view& path,
-    const std::string_view& query,
+    const std::string_view& url,
     const http::HeaderMap& headers,
     const std::vector<std::string_view>& headers_to_sign)
   {
@@ -33,11 +32,7 @@ namespace http
       {
         // Store verb as lowercase
         nonstd::to_lower(verb);
-        value = fmt::format("{} {}", verb, path);
-        if (!query.empty())
-        {
-          value.append(fmt::format("?{}", query));
-        }
+        value = fmt::format("{} {}", verb, url);
       }
       else
       {
@@ -90,8 +85,7 @@ namespace http
 
     const auto to_sign = construct_raw_signed_string(
       llhttp_method_name(request.get_method()),
-      request.get_path(),
-      request.get_formatted_query(),
+      fmt::format("{}{}", request.get_path(), request.get_formatted_query()),
       request.get_headers(),
       headers_to_sign);
 
@@ -349,8 +343,7 @@ namespace http
 
     static std::optional<ccf::SignedReq> parse(
       const std::string& verb,
-      const std::string_view& path,
-      const std::string_view& query,
+      const std::string_view& url,
       const http::HeaderMap& headers,
       const std::vector<uint8_t>& body)
     {
@@ -405,8 +398,8 @@ namespace http
           return std::nullopt;
         }
 
-        auto signed_raw = construct_raw_signed_string(
-          verb, path, query, headers, signed_headers);
+        auto signed_raw =
+          construct_raw_signed_string(verb, url, headers, signed_headers);
         if (!signed_raw.has_value())
         {
           LOG_TRACE_FMT("Error constructing signed string");

--- a/src/http/test/http_test.cpp
+++ b/src/http/test/http_test.cpp
@@ -48,7 +48,7 @@ DOCTEST_TEST_CASE("Complete request")
     DOCTEST_CHECK(!sp.received.empty());
     const auto& m = sp.received.front();
     DOCTEST_CHECK(m.method == method);
-    DOCTEST_CHECK(m.path == url);
+    DOCTEST_CHECK(m.url == url);
     DOCTEST_CHECK(m.body == r);
   }
 }
@@ -237,10 +237,11 @@ DOCTEST_TEST_CASE("URL parsing")
   const auto& m = sp.received.front();
   DOCTEST_CHECK(m.method == HTTP_POST);
   DOCTEST_CHECK(m.body == body);
-  DOCTEST_CHECK(m.path == path);
-  DOCTEST_CHECK(m.query.find("balance=42") != std::string::npos);
-  DOCTEST_CHECK(m.query.find("id=100") != std::string::npos);
-  DOCTEST_CHECK(m.query.find("&") != std::string::npos);
+  const auto [path_, query_, fragment_] = http::split_url_path(m.url);
+  DOCTEST_CHECK(path_ == path);
+  DOCTEST_CHECK(query_.find("balance=42") != std::string::npos);
+  DOCTEST_CHECK(query_.find("id=100") != std::string::npos);
+  DOCTEST_CHECK(query_.find("&") != std::string::npos);
 }
 
 DOCTEST_TEST_CASE("Pessimal transport")
@@ -330,9 +331,12 @@ DOCTEST_TEST_CASE("Escaping")
     DOCTEST_CHECK(!sp.received.empty());
     const auto& m = sp.received.front();
     DOCTEST_CHECK(m.method == HTTP_GET);
-    DOCTEST_CHECK(m.path == "/foo/bar");
-    DOCTEST_CHECK(m.query == "this=that&awkward=escaped string :;-=?!\"%#");
-    DOCTEST_CHECK(m.fragment == "AndThisFragment :;-=?!\"%#");
+    const auto [path_, query_, fragment_] = http::split_url_path(m.url);
+    DOCTEST_CHECK(path_ == "/foo/bar");
+    DOCTEST_CHECK(
+      http::url_decode(query_) ==
+      "this=that&awkward=escaped string :;-=?!\"%#");
+    DOCTEST_CHECK(http::url_decode(fragment_) == "AndThisFragment :;-=?!\"%#");
   }
 
   {
@@ -350,9 +354,11 @@ DOCTEST_TEST_CASE("Escaping")
     DOCTEST_CHECK(!sp.received.empty());
     const auto& m = sp.received.front();
     DOCTEST_CHECK(m.method == HTTP_GET);
-    DOCTEST_CHECK(m.path == "/hello%20world");
+    const auto [path_, query_, fragment_] = http::split_url_path(m.url);
+    DOCTEST_CHECK(path_ == "/hello%20world");
     DOCTEST_CHECK(
-      m.query == "hello world=hello world&saluton mondo=saluton mondo");
+      http::url_decode(query_) ==
+      "hello world=hello world&saluton mondo=saluton mondo");
   }
 }
 
@@ -528,14 +534,13 @@ struct SignedRequestProcessor : public http::SimpleRequestProcessor
 
   virtual void handle_request(
     llhttp_method method,
-    const std::string_view& path,
-    const std::string& query,
-    const std::string& fragment,
+    const std::string_view& url,
     http::HeaderMap&& headers,
     std::vector<uint8_t>&& body) override
   {
+    const auto [path_, query_, fragment_] = http::split_url_path(url);
     const auto signed_req = http::HttpSignatureVerifier::parse(
-      llhttp_method_name(method), path, query, headers, body);
+      llhttp_method_name(method), path_, query_, headers, body);
 
     if (signed_req.has_value())
     {
@@ -543,7 +548,7 @@ struct SignedRequestProcessor : public http::SimpleRequestProcessor
     }
 
     http::SimpleRequestProcessor::handle_request(
-      method, path, query, fragment, std::move(headers), std::move(body));
+      method, url, std::move(headers), std::move(body));
   }
 };
 

--- a/src/http/test/http_test.cpp
+++ b/src/http/test/http_test.cpp
@@ -538,9 +538,8 @@ struct SignedRequestProcessor : public http::SimpleRequestProcessor
     http::HeaderMap&& headers,
     std::vector<uint8_t>&& body) override
   {
-    const auto [path_, query_, fragment_] = http::split_url_path(url);
     const auto signed_req = http::HttpSignatureVerifier::parse(
-      llhttp_method_name(method), path_, query_, headers, body);
+      llhttp_method_name(method), url, headers, body);
 
     if (signed_req.has_value())
     {

--- a/src/http/ws_parser.h
+++ b/src/http/ws_parser.h
@@ -224,8 +224,6 @@ namespace ws
           proc.handle_request(
             llhttp_method::HTTP_POST,
             path,
-            {},
-            {},
             {{"Content-type", "application/json"}},
             std::move(body));
           state = INIT;

--- a/src/http/ws_rpc_context.h
+++ b/src/http/ws_rpc_context.h
@@ -44,6 +44,7 @@ namespace ws
 
     ccf::RESTVerb verb = ws::Verb::WEBSOCKET;
 
+    std::string url = {};
     std::string path = {};
     std::string method = {};
 
@@ -143,6 +144,11 @@ namespace ws
       const std::string_view&) override
     {
       return std::nullopt;
+    }
+
+    virtual const std::string& get_request_url() const override
+    {
+      return url;
     }
 
     virtual void set_response_body(const std::vector<uint8_t>& body) override

--- a/src/runtime_config/default/actions.js
+++ b/src/runtime_config/default/actions.js
@@ -232,9 +232,8 @@ const actions = new Map([
       },
       function (args) {
         const rawMemberId = ccf.strToBuf(args.member_id);
-        const rawMemberInfo = ccf.kv["public:ccf.gov.members.info"].get(
-          rawMemberId
-        );
+        const rawMemberInfo =
+          ccf.kv["public:ccf.gov.members.info"].get(rawMemberId);
         if (rawMemberInfo === undefined) {
           return; // Idempotent
         }
@@ -741,7 +740,8 @@ const actions = new Map([
         const nodeInfo = ccf.bufToJsonCompatible(node);
         if (nodeInfo.status === "Pending") {
           nodeInfo.status = "Trusted";
-          nodeInfo.ledger_secret_seqno = ccf.network.getLatestLedgerSecretSeqno();
+          nodeInfo.ledger_secret_seqno =
+            ccf.network.getLatestLedgerSecretSeqno();
           ccf.kv["public:ccf.gov.nodes.info"].set(
             ccf.strToBuf(args.node_id),
             ccf.jsonCompatibleToBuf(nodeInfo)

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -24,6 +24,7 @@ from ccf.tx_id import TxID
 from cryptography.x509 import load_pem_x509_certificate
 from cryptography.hazmat.backends import default_backend
 from cryptography.exceptions import InvalidSignature
+import urllib.parse
 
 from loguru import logger as LOG
 
@@ -631,6 +632,39 @@ def test_forwarding_frontends(network, args):
             result=True,
         )
         check(c.get(f"/app/log/private?id={log_id}"), result={"msg": msg})
+
+        if args.package == "liblogging":
+
+            samples = [
+                {"this": "that"},
+                {"this": "that", "other": "with spaces"},
+                {"this with spaces": "with spaces"},
+                {
+                    "arg": 'This has many@many many \\% " AWKWARD :;-=?!& characters %20%20'
+                },
+            ]
+            for query in samples:
+                unescaped_query = "&".join([f"{k}={v}" for k, v in query.items()])
+                query_to_send = unescaped_query
+                if os.getenv("CURL_CLIENT"):
+                    query_to_send = urllib.parse.urlencode(query)
+                r = c.get(f"/app/log/request_query?{query_to_send}")
+                assert r.body.text() == unescaped_query, (
+                    r.body.text(),
+                    unescaped_query,
+                )
+
+            for i in range(0, 255):
+                ci = chr(i)
+                ch = urllib.parse.urlencode({"arg": ci})
+                r = c.get(f"/app/log/request_query?{ch}")
+                assert r.body.data() == f"arg={ci}".encode(), r.body.data()
+
+            for i in range(0, 255):
+                ci = chr(i)
+                ch = urllib.parse.urlencode({f"arg{ci}": "value"})
+                r = c.get(f"/app/log/request_query?{ch}")
+                assert r.body.data() == f"arg{ci}=value".encode(), r.body.data()
 
     return network
 


### PR DESCRIPTION
- Fix signed requests with escaped urls (#2594)
- Fix forwarding escaped urls (#2591)
- Formatting pass because `prettier` has been updated since `1.0.0`
- Pin Sphinx to 3.x to avoid doc build break