### PR TITLE
Add `kv::Value` and `kv::Set`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add `kv::Value` and `kv::Set`, as a more error-proof alternative to `kv::Map`s which had a single key or meaningless values (#2599).
+
 ## [2.0.0-dev0]
 
 ### Added

--- a/doc/build_apps/kv/api.rst
+++ b/doc/build_apps/kv/api.rst
@@ -27,6 +27,18 @@ Map
 .. doxygentypedef:: kv::Map
    :project: CCF
 
+.. doxygenclass:: kv::TypedValue
+   :project: CCF
+
+.. doxygentypedef:: kv::Value
+   :project: CCF
+
+.. doxygenclass:: kv::TypedSet
+   :project: CCF
+
+.. doxygentypedef:: kv::Set
+   :project: CCF
+
 Transaction
 -----------
 
@@ -38,16 +50,38 @@ Transaction
    :project: CCF
    :members: rw, ro, wo
 
-Handle
-------
+Handles
+-------
 
 .. doxygenclass:: kv::ReadableMapHandle
    :project: CCF
-   :members: get, has, size, foreach, get_version_of_previous_write
+   :members:
 
 .. doxygenclass:: kv::WriteableMapHandle
    :project: CCF
-   :members: put, remove, clear
+   :members:
 
 .. doxygenclass:: kv::MapHandle
+   :project: CCF
+
+.. doxygenclass:: kv::ReadableValueHandle
+   :project: CCF
+   :members:
+
+.. doxygenclass:: kv::WriteableValueHandle
+   :project: CCF
+   :members:
+
+.. doxygenclass:: kv::ValueHandle
+   :project: CCF
+
+.. doxygenclass:: kv::ReadableSetHandle
+   :project: CCF
+   :members:
+
+.. doxygenclass:: kv::WriteableSetHandle
+   :project: CCF
+   :members:
+
+.. doxygenclass:: kv::SetHandle
    :project: CCF

--- a/include/ccf/tx.h
+++ b/include/ccf/tx.h
@@ -57,7 +57,7 @@ namespace kv
     // with a near-identical API if we return `shared_ptr`s, and assuming that
     // we don't actually care about returning exactly the same Handle instance
     // if `rw` is called multiple times
-    using PossibleHandles = std::list<std::unique_ptr<AbstractMapHandle>>;
+    using PossibleHandles = std::list<std::unique_ptr<AbstractHandle>>;
     std::map<std::string, PossibleHandles> all_handles;
 
     // In most places we use NoVersion to indicate an invalid version. In this
@@ -83,7 +83,7 @@ namespace kv
       {
         PossibleHandles handles;
         auto typed_handle = new THandle(change_set, name);
-        handles.emplace_back(std::unique_ptr<AbstractMapHandle>(typed_handle));
+        handles.emplace_back(std::unique_ptr<AbstractHandle>(typed_handle));
         all_handles[name] = std::move(handles);
         return typed_handle;
       }
@@ -99,7 +99,7 @@ namespace kv
           }
         }
         auto typed_handle = new THandle(change_set, name);
-        handles.emplace_back(std::unique_ptr<AbstractMapHandle>(typed_handle));
+        handles.emplace_back(std::unique_ptr<AbstractHandle>(typed_handle));
         return typed_handle;
       }
     }

--- a/js/ccf-app/package.json
+++ b/js/ccf-app/package.json
@@ -30,6 +30,6 @@
     "serve": "^11.3.2",
     "ts-node": "^9.1.1",
     "typedoc": "^0.20.34",
-    "typescript": "^4.2.3"
+    "typescript": "4.2.4"
   }
 }

--- a/src/kv/committable_tx.h
+++ b/src/kv/committable_tx.h
@@ -6,7 +6,6 @@
 #include "ccf/tx.h"
 #include "kv_serialiser.h"
 #include "kv_types.h"
-#include "map.h"
 
 #include <list>
 

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -457,20 +457,20 @@ namespace kv
     virtual ConsensusHookPtr post_commit() = 0;
   };
 
-  class AbstractMapHandle
+  class AbstractHandle
   {
   public:
-    virtual ~AbstractMapHandle() = default;
+    virtual ~AbstractHandle() = default;
   };
 
-  struct NamedMap
+  struct NamedHandleMixin
   {
   protected:
     std::string name;
 
   public:
-    NamedMap(const std::string& s) : name(s) {}
-    virtual ~NamedMap() = default;
+    NamedHandleMixin(const std::string& s) : name(s) {}
+    virtual ~NamedHandleMixin() = default;
 
     const std::string& get_name() const
     {
@@ -480,7 +480,7 @@ namespace kv
 
   class AbstractStore;
   class AbstractMap : public std::enable_shared_from_this<AbstractMap>,
-                      public NamedMap
+                      public NamedHandleMixin
   {
   public:
     class Snapshot
@@ -491,7 +491,7 @@ namespace kv
       virtual SecurityDomain get_security_domain() = 0;
     };
 
-    using NamedMap::NamedMap;
+    using NamedHandleMixin::NamedHandleMixin;
     virtual ~AbstractMap() {}
     virtual bool operator==(const AbstractMap& that) const = 0;
     virtual bool operator!=(const AbstractMap& that) const = 0;

--- a/src/kv/map.h
+++ b/src/kv/map.h
@@ -21,7 +21,7 @@ namespace kv
    * which leverages existing JSON serialisation is provided by CCF.
    */
   template <typename K, typename V, typename KSerialiser, typename VSerialiser>
-  class TypedMap : public NamedMap
+  class TypedMap : public NamedHandleMixin
   {
   protected:
     using This = TypedMap<K, V, KSerialiser, VSerialiser>;
@@ -44,7 +44,7 @@ namespace kv
     using KeySerialiser = KSerialiser;
     using ValueSerialiser = VSerialiser;
 
-    using NamedMap::NamedMap;
+    using NamedHandleMixin::NamedHandleMixin;
 
     static kv::untyped::Map::CommitHook wrap_commit_hook(const CommitHook& hook)
     {

--- a/src/kv/map.h
+++ b/src/kv/map.h
@@ -9,15 +9,17 @@
 
 namespace kv
 {
-  /** Defines the schema of a table within the @c kv::Store, exposing associated
-   * types.
+  /** Defines the schema of a map within the @c kv::Store, exposing associated
+   * types. This map is an unordered associative container of key-value pairs.
+   * Each key, if defined, is associated with a value, and can be used to
+   * efficiently lookup that value.
    *
    * K defines the type of the Key which indexes each entry, while V is the type
    * of the Value associated with a given Key. KSerialiser and VSerialiser
    * determine how each K and V are serialised and deserialised, so they may be
    * written to the ledger and replicated by the consensus algorithm. Note that
    * equality is always evaluated on the serialised form; if unequal Ks produce
-   * the same serialisation, they will coincide within this table. Serialiser
+   * the same serialisation, they will coincide within this map. Serialiser
    * which leverages existing JSON serialisation is provided by CCF.
    */
   template <typename K, typename V, typename KSerialiser, typename VSerialiser>

--- a/src/kv/map_handle.h
+++ b/src/kv/map_handle.h
@@ -81,7 +81,7 @@ namespace kv
      *
      * @param key Key to read
      *
-     * @return bool true if key exists
+     * @return Boolean true iff key exists
      */
     bool has(const K& key)
     {
@@ -93,8 +93,8 @@ namespace kv
      *
      * Returns nullopt when there is no value, because the key has no value
      * (never existed or has been removed). Note that this is always talking
-     * about the version of previously committed state and not the same values
-     * as @c get or @c has - this transaction's pending writes have no version
+     * about the version of previously applied state and not the same values
+     * as @c get or @c has. This transaction's pending writes have no version
      * yet, and this method does not talk about them.
      *
      * @param key Key to read

--- a/src/kv/map_handle.h
+++ b/src/kv/map_handle.h
@@ -215,7 +215,7 @@ namespace kv
    * @see kv::WriteableMapHandle
    */
   template <typename K, typename V, typename KSerialiser, typename VSerialiser>
-  class MapHandle : public AbstractMapHandle,
+  class MapHandle : public AbstractHandle,
                     public ReadableMapHandle<K, V, KSerialiser, VSerialiser>,
                     public WriteableMapHandle<K, V, KSerialiser, VSerialiser>
   {

--- a/src/kv/map_handle.h
+++ b/src/kv/map_handle.h
@@ -94,13 +94,13 @@ namespace kv
      * Returns nullopt when there is no value, because the key has no value
      * (never existed or has been removed). Note that this is always talking
      * about the version of previously applied state and not the same values
-     * as @c get or @c has. This transaction's pending writes have no version
-     * yet, and this method does not talk about them.
+     * as @c get or @c has. This current transaction's pending writes have no
+     * version yet, and this method does not talk about them.
      *
      * @param key Key to read
      *
      * @return Optional containing version of applied transaction which last
-     * wrote at this key, or nullopt if this key has no associated value
+     * wrote at this key, or nullopt if such a version does not exist
      */
     std::optional<Version> get_version_of_previous_write(const K& key)
     {

--- a/src/kv/map_handle.h
+++ b/src/kv/map_handle.h
@@ -130,10 +130,10 @@ namespace kv
      * visibility described above only applies to the keys and values passed to
      * this functor.
      *
-     * @tparam F Functor class, taking (const K& k, const V& v) and returning a
-     * bool. Return value determines whether the iteration should continue
-     * (true) or stop (false).
-     * @param f Functor instance
+     * @tparam F Functor type. Should usually be derived implicitly from f
+     * @param f Functor instance, taking (const K& k, const V& v) and returning
+     * a bool. Return value determines whether the iteration should continue
+     * (true) or stop (false)
      */
     template <class F>
     void foreach(F&& f)
@@ -178,8 +178,8 @@ namespace kv
      * If the key already exists, the previous value will be replaced with the
      * new value.
      *
-     * @param key Key
-     * @param value Value
+     * @param key Key at which to insert
+     * @param value Associated value to be inserted
      */
     void put(const K& key, const V& value)
     {
@@ -192,7 +192,7 @@ namespace kv
      * It is safe to call this on non-existent keys - it will simply return
      * false.
      *
-     * @param key Key
+     * @param key Key to be removed
      *
      * @return true if the key had a value previously
      */

--- a/src/kv/set.h
+++ b/src/kv/set.h
@@ -7,9 +7,21 @@
 #include "serialise_entry_json.h"
 #include "set_handle.h"
 
-// TODO: Docs
 namespace kv
 {
+  /** Defines the schema of a set type within the @c kv::Store. This set is an
+   * unordered container of unique keys. Each key is either present or missing
+   * within the set, and key presence can be efficiently tested.
+   *
+   * K defines the type of each entry in this set. KSerialiser determines how
+   * each K is serialised and deserialised, so they may be written to the ledger
+   * and replicated by the consensus algorithm. Note that equality is always
+   * evaluated on the serialised form; if unequal Ks produce the same
+   * serialisation, they will coincide within this set.
+   *
+   * This is implemented as a @c kv::Map from K to Unit, and the serialisation
+   * of the unit values is overridable with the Unit template parameter.
+   */
   template <
     typename K,
     typename KSerialiser,

--- a/src/kv/set.h
+++ b/src/kv/set.h
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "kv_types.h"
+#include "serialise_entry_blit.h"
+#include "serialise_entry_json.h"
+#include "set_handle.h"
+
+// TODO: Docs
+namespace kv
+{
+  template <typename K, typename KSerialiser>
+  class TypedSet : public NamedHandleMixin
+  {
+  protected:
+    using This = TypedSet<K, KSerialiser>;
+
+  public:
+    using ReadOnlyHandle = kv::ReadableSetHandle<K, KSerialiser>;
+    using WriteOnlyHandle = kv::WriteableSetHandle<K, KSerialiser>;
+    using Handle = kv::SetHandle<K, KSerialiser>;
+
+    using KeySerialiser = KSerialiser;
+
+    using NamedHandleMixin::NamedHandleMixin;
+  };
+
+  template <typename K, template <typename> typename KSerialiser>
+  using SetSerialisedWith = TypedSet<K, KSerialiser<K>>;
+
+  template <typename K>
+  using JsonSerialisedSet =
+    SetSerialisedWith<K, kv::serialisers::JsonSerialiser>;
+
+  template <typename K>
+  using RawCopySerialisedSet = TypedSet<K, kv::serialisers::BlitSerialiser<K>>;
+
+  template <typename K>
+  using Set = JsonSerialisedSet<K>;
+}

--- a/src/kv/set.h
+++ b/src/kv/set.h
@@ -10,7 +10,10 @@
 // TODO: Docs
 namespace kv
 {
-  template <typename K, typename KSerialiser, typename Unit= kv::UnitCreator>
+  template <
+    typename K,
+    typename KSerialiser,
+    typename Unit = kv::serialisers::ZeroBlitUnitCreator>
   class TypedSet : public NamedHandleMixin
   {
   protected:
@@ -30,7 +33,7 @@ namespace kv
     typename K,
     template <typename>
     typename KSerialiser,
-    typename Unit = kv::UnitCreator>
+    typename Unit = kv::serialisers::ZeroBlitUnitCreator>
   using SetSerialisedWith = TypedSet<K, KSerialiser<K>, Unit>;
 
   template <typename K>

--- a/src/kv/set.h
+++ b/src/kv/set.h
@@ -10,7 +10,7 @@
 // TODO: Docs
 namespace kv
 {
-  template <typename K, typename KSerialiser>
+  template <typename K, typename KSerialiser, typename Unit= kv::UnitCreator>
   class TypedSet : public NamedHandleMixin
   {
   protected:
@@ -18,16 +18,20 @@ namespace kv
 
   public:
     using ReadOnlyHandle = kv::ReadableSetHandle<K, KSerialiser>;
-    using WriteOnlyHandle = kv::WriteableSetHandle<K, KSerialiser>;
-    using Handle = kv::SetHandle<K, KSerialiser>;
+    using WriteOnlyHandle = kv::WriteableSetHandle<K, KSerialiser, Unit>;
+    using Handle = kv::SetHandle<K, KSerialiser, Unit>;
 
     using KeySerialiser = KSerialiser;
 
     using NamedHandleMixin::NamedHandleMixin;
   };
 
-  template <typename K, template <typename> typename KSerialiser>
-  using SetSerialisedWith = TypedSet<K, KSerialiser<K>>;
+  template <
+    typename K,
+    template <typename>
+    typename KSerialiser,
+    typename Unit = kv::UnitCreator>
+  using SetSerialisedWith = TypedSet<K, KSerialiser<K>, Unit>;
 
   template <typename K>
   using JsonSerialisedSet =

--- a/src/kv/set.h
+++ b/src/kv/set.h
@@ -55,6 +55,9 @@ namespace kv
   template <typename K>
   using RawCopySerialisedSet = TypedSet<K, kv::serialisers::BlitSerialiser<K>>;
 
+  /** Short name for default-serialised sets, using JSON serialisers. Support
+   * for custom types can be added through the DECLARE_JSON... macros.
+   */
   template <typename K>
   using Set = JsonSerialisedSet<K>;
 }

--- a/src/kv/set_handle.h
+++ b/src/kv/set_handle.h
@@ -47,7 +47,7 @@ namespace kv
     }
   };
 
-  template <typename K, typename KSerialiser>
+  template <typename K, typename KSerialiser, typename Unit>
   class WriteableSetHandle
   {
   protected:
@@ -58,7 +58,7 @@ namespace kv
 
     void insert(const K& key)
     {
-      write_handle.put(KSerialiser::to_serialised(key), kv::Unit::get());
+      write_handle.put(KSerialiser::to_serialised(key), Unit::get());
     }
 
     bool remove(const K& key)
@@ -72,16 +72,16 @@ namespace kv
     }
   };
 
-  template <typename K, typename KSerialiser>
+  template <typename K, typename KSerialiser, typename Unit>
   class SetHandle : public kv::AbstractHandle,
                     public ReadableSetHandle<K, KSerialiser>,
-                    public WriteableSetHandle<K, KSerialiser>
+                    public WriteableSetHandle<K, KSerialiser, Unit>
   {
   protected:
     kv::untyped::MapHandle untyped_handle;
 
     using ReadableBase = ReadableSetHandle<K, KSerialiser>;
-    using WriteableBase = WriteableSetHandle<K, KSerialiser>;
+    using WriteableBase = WriteableSetHandle<K, KSerialiser, Unit>;
 
   public:
     SetHandle(kv::untyped::ChangeSet& changes, const std::string& map_name) :

--- a/src/kv/set_handle.h
+++ b/src/kv/set_handle.h
@@ -56,7 +56,7 @@ namespace kv
   public:
     WriteableSetHandle(kv::untyped::MapHandle& uh) : write_handle(uh) {}
 
-    void put(const K& key)
+    void insert(const K& key)
     {
       write_handle.put(KSerialiser::to_serialised(key), kv::Unit::get());
     }

--- a/src/kv/set_handle.h
+++ b/src/kv/set_handle.h
@@ -19,7 +19,7 @@ namespace kv
 
     ReadableSetHandle(kv::untyped::MapHandle& uh) : read_handle(uh) {}
 
-    bool has(const K& key)
+    bool contains(const K& key)
     {
       return read_handle.has(KSerialiser::to_serialised(key));
     }

--- a/src/kv/set_handle.h
+++ b/src/kv/set_handle.h
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "kv/unit.h"
+#include "kv/untyped_map_handle.h"
+
+// TODO: Docs
+namespace kv
+{
+  template <typename K, typename KSerialiser>
+  class ReadableSetHandle
+  {
+  protected:
+    kv::untyped::MapHandle& read_handle;
+
+  public:
+    using KeyType = K;
+
+    ReadableSetHandle(kv::untyped::MapHandle& uh) : read_handle(uh) {}
+
+    bool has(const K& key)
+    {
+      return read_handle.has(KSerialiser::to_serialised(key));
+    }
+
+    std::optional<Version> get_version_of_previous_write(const K& key)
+    {
+      return read_handle.get_version_of_previous_write(
+        KSerialiser::to_serialised(key));
+    }
+
+    template <class F>
+    void foreach(F&& f)
+    {
+      auto g = [&](
+                 const kv::serialisers::SerialisedEntry& k_rep,
+                 const kv::serialisers::SerialisedEntry&) {
+        return f(KSerialiser::from_serialised(k_rep));
+      };
+      read_handle.foreach(g);
+    }
+
+    size_t size()
+    {
+      return read_handle.size();
+    }
+  };
+
+  template <typename K, typename KSerialiser>
+  class WriteableSetHandle
+  {
+  protected:
+    kv::untyped::MapHandle& write_handle;
+
+  public:
+    WriteableSetHandle(kv::untyped::MapHandle& uh) : write_handle(uh) {}
+
+    void put(const K& key)
+    {
+      write_handle.put(KSerialiser::to_serialised(key), kv::Unit::get());
+    }
+
+    bool remove(const K& key)
+    {
+      return write_handle.remove(KSerialiser::to_serialised(key));
+    }
+
+    void clear()
+    {
+      write_handle.clear();
+    }
+  };
+
+  template <typename K, typename KSerialiser>
+  class SetHandle : public kv::AbstractHandle,
+                    public ReadableSetHandle<K, KSerialiser>,
+                    public WriteableSetHandle<K, KSerialiser>
+  {
+  protected:
+    kv::untyped::MapHandle untyped_handle;
+
+    using ReadableBase = ReadableSetHandle<K, KSerialiser>;
+    using WriteableBase = WriteableSetHandle<K, KSerialiser>;
+
+  public:
+    SetHandle(kv::untyped::ChangeSet& changes, const std::string& map_name) :
+      ReadableBase(untyped_handle),
+      WriteableBase(untyped_handle),
+      untyped_handle(changes, map_name)
+    {}
+  };
+}

--- a/src/kv/set_handle.h
+++ b/src/kv/set_handle.h
@@ -43,7 +43,7 @@ namespace kv
      * @param key Key to read
      *
      * @return Optional containing version of applied transaction which last
-     * wrote at this key, or nullopt if this key is not present
+     * wrote at this key, or nullopt if such a version does not exist
      */
     std::optional<Version> get_version_of_previous_write(const K& key)
     {
@@ -101,7 +101,7 @@ namespace kv
      * This will always insert a value, producing a new write and updating
      * future calls to @c ReadableSetHandle::get_version_of_previous_write, even
      * if this key was already present.
-     * 
+     *
      * @param key Key to insert
      */
     void insert(const K& key)

--- a/src/kv/set_handle.h
+++ b/src/kv/set_handle.h
@@ -5,9 +5,10 @@
 #include "kv/unit.h"
 #include "kv/untyped_map_handle.h"
 
-// TODO: Docs
 namespace kv
 {
+  /** Grants read access to a @c kv::Set, as part of a @c kv::Tx.
+   */
   template <typename K, typename KSerialiser>
   class ReadableSetHandle
   {
@@ -19,17 +20,46 @@ namespace kv
 
     ReadableSetHandle(kv::untyped::MapHandle& uh) : read_handle(uh) {}
 
+    /** Test whether a key is present in the set.
+     *
+     * This returns true if the key is present, including if it was added to the
+     * set during this transaction.
+     *
+     * @param key Key to test
+     *
+     * @return Boolean true iff key exists
+     */
     bool contains(const K& key)
     {
       return read_handle.has(KSerialiser::to_serialised(key));
     }
 
+    /** Get version when this key was last added to the set.
+     *
+     * Returns nullopt if the key is not present.
+     *
+     * @see kv::ReadableMapHandle::get_version_of_previous_write
+     *
+     * @param key Key to read
+     *
+     * @return Optional containing version of applied transaction which last
+     * wrote at this key, or nullopt if this key is not present
+     */
     std::optional<Version> get_version_of_previous_write(const K& key)
     {
       return read_handle.get_version_of_previous_write(
         KSerialiser::to_serialised(key));
     }
 
+    /** Iterate over all entries in this set.
+     *
+     * @see kv::ReadableMapHandle::foreach
+     *
+     * @tparam F Functor class, taking (const K& k) and returning a
+     * bool. Return value determines whether the iteration should continue
+     * (true) or stop (false).
+     * @param f Functor instance
+     */
     template <class F>
     void foreach(F&& f)
     {
@@ -41,12 +71,22 @@ namespace kv
       read_handle.foreach(g);
     }
 
+    /** Returns number of entries in this set.
+     *
+     * This is the count of all currently present keys, including both those
+     * which were already committed and any modifications (taking into account
+     * new additions or removals) that have been made during this transaction.
+     *
+     * @return Count of entries
+     */
     size_t size()
     {
       return read_handle.size();
     }
   };
 
+  /** Grants write access to a @c kv::Set, as part of a @c kv::Tx.
+   */
   template <typename K, typename KSerialiser, typename Unit>
   class WriteableSetHandle
   {
@@ -56,22 +96,46 @@ namespace kv
   public:
     WriteableSetHandle(kv::untyped::MapHandle& uh) : write_handle(uh) {}
 
+    /** Insert an element into this set.
+     *
+     * This will always insert a value, producing a new write and updating
+     * future calls to @c ReadableSetHandle::get_version_of_previous_write, even
+     * if this key was already present.
+     * 
+     * @param key Key to insert
+     */
     void insert(const K& key)
     {
       write_handle.put(KSerialiser::to_serialised(key), Unit::get());
     }
 
+    /** Delete an element from this set.
+     *
+     * It is safe to call this on non-existent keys - it will simply return
+     * false.
+     *
+     * @param key Key to delete
+     *
+     * @return Boolean true iff the key was present in the set
+     */
     bool remove(const K& key)
     {
       return write_handle.remove(KSerialiser::to_serialised(key));
     }
 
+    /** Delete every element in this set.
+     */
     void clear()
     {
       write_handle.clear();
     }
   };
 
+  /** Grants read and write access to a @c kv::Set, as part of a @c kv::Tx.
+   *
+   * @see kv::ReadableSetHandle
+   * @see kv::WriteableSetHandle
+   */
   template <typename K, typename KSerialiser, typename Unit>
   class SetHandle : public kv::AbstractHandle,
                     public ReadableSetHandle<K, KSerialiser>,

--- a/src/kv/set_handle.h
+++ b/src/kv/set_handle.h
@@ -55,10 +55,10 @@ namespace kv
      *
      * @see kv::ReadableMapHandle::foreach
      *
-     * @tparam F Functor class, taking (const K& k) and returning a
+     * @tparam F Functor type. Should usually be derived implicitly from f
+     * @param f Functor instance, taking (const K& k) and returning a
      * bool. Return value determines whether the iteration should continue
-     * (true) or stop (false).
-     * @param f Functor instance
+     * (true) or stop (false)
      */
     template <class F>
     void foreach(F&& f)

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -8,7 +8,6 @@
 #include "kv/committable_tx.h"
 #include "kv_serialiser.h"
 #include "kv_types.h"
-#include "map.h"
 #include "node/entities.h"
 #include "node/progress_tracker.h"
 #include "node/signatures.h"

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -471,7 +471,7 @@ TEST_CASE("serialisation of Unit type")
     using ValueA = kv::TypedValue<
       std::string,
       kv::serialisers::BlitSerialiser<std::string>,
-      kv::UnitCreator>;
+      kv::serialisers::ZeroBlitUnitCreator>;
     std::vector<uint8_t> entry_a;
     {
       auto consensus = std::make_shared<kv::test::StubConsensus>();
@@ -488,7 +488,7 @@ TEST_CASE("serialisation of Unit type")
     using ValueB = kv::TypedValue<
       std::string,
       kv::serialisers::BlitSerialiser<std::string>,
-      kv::EmptyUnitCreator>;
+      kv::serialisers::EmptyUnitCreator>;
     std::vector<uint8_t> entry_b;
     {
       auto consensus = std::make_shared<kv::test::StubConsensus>();
@@ -1666,8 +1666,8 @@ TEST_CASE("Deserialise return status")
     auto sig_handle = tx.rw(signatures);
     auto tree_handle = tx.rw(serialised_tree);
     ccf::PrimarySignature sigv(kv::test::PrimaryNodeId, 2);
-    sig_handle->put(0, sigv);
-    tree_handle->put(0, {});
+    sig_handle->put(sigv);
+    tree_handle->put({});
     auto [success, data, hooks] = tx.commit_reserved();
     REQUIRE(success == kv::CommitResult::SUCCESS);
 
@@ -1682,7 +1682,7 @@ TEST_CASE("Deserialise return status")
     auto sig_handle = tx.rw(signatures);
     auto data_handle = tx.rw(data);
     ccf::PrimarySignature sigv(kv::test::PrimaryNodeId, 2);
-    sig_handle->put(0, sigv);
+    sig_handle->put(sigv);
     data_handle->put(43, 43);
     auto [success, data, hooks] = tx.commit_reserved();
     REQUIRE(success == kv::CommitResult::SUCCESS);

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -179,20 +179,20 @@ TEST_CASE("sets and values")
       auto tx = kv_store.create_tx();
       auto set_handle = tx.rw(set);
 
-      REQUIRE(!set_handle->has(k1));
+      REQUIRE(!set_handle->contains(k1));
       REQUIRE(set_handle->size() == 0);
 
       set_handle->insert(k1);
-      REQUIRE(set_handle->has(k1));
+      REQUIRE(set_handle->contains(k1));
       REQUIRE(set_handle->size() == 1);
 
-      REQUIRE(!set_handle->has(k2));
+      REQUIRE(!set_handle->contains(k2));
       set_handle->insert(k2);
-      REQUIRE(set_handle->has(k2));
+      REQUIRE(set_handle->contains(k2));
       REQUIRE(set_handle->size() == 2);
 
       REQUIRE(set_handle->remove(k2));
-      REQUIRE(!set_handle->has(k2));
+      REQUIRE(!set_handle->contains(k2));
       REQUIRE(set_handle->size() == 1);
 
       REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
@@ -202,8 +202,8 @@ TEST_CASE("sets and values")
       INFO("Read previous writes");
       auto tx = kv_store.create_tx();
       auto set_handle = tx.ro(set);
-      REQUIRE(set_handle->has(k1));
-      REQUIRE(!set_handle->has(k2));
+      REQUIRE(set_handle->contains(k1));
+      REQUIRE(!set_handle->contains(k2));
       REQUIRE(set_handle->size() == 1);
       std::set<std::string> std_set;
       set_handle->foreach([&std_set](const std::string& entry) {
@@ -221,15 +221,15 @@ TEST_CASE("sets and values")
       auto tx = kv_store.create_tx();
       auto set_handle = tx.rw(set);
 
-      REQUIRE(set_handle->has(k1));
+      REQUIRE(set_handle->contains(k1));
       REQUIRE(set_handle->size() == 1);
 
       REQUIRE(!set_handle->remove(k2));
-      REQUIRE(set_handle->has(k1));
+      REQUIRE(set_handle->contains(k1));
       REQUIRE(set_handle->size() == 1);
 
       REQUIRE(set_handle->remove(k1));
-      REQUIRE(!set_handle->has(k1));
+      REQUIRE(!set_handle->contains(k1));
       REQUIRE(set_handle->size() == 0);
 
       REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
@@ -353,7 +353,7 @@ TEST_CASE("sets and values")
 
       map_handle->foreach(
         [&map_handle, &set_handle](const std::string& k, const size_t& v) {
-          REQUIRE(set_handle->has(v));
+          REQUIRE(set_handle->contains(v));
 
           if (k[0] % 3 == 0)
           {

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -182,12 +182,12 @@ TEST_CASE("sets and values")
       REQUIRE(!set_handle->has(k1));
       REQUIRE(set_handle->size() == 0);
 
-      set_handle->put(k1);
+      set_handle->insert(k1);
       REQUIRE(set_handle->has(k1));
       REQUIRE(set_handle->size() == 1);
 
       REQUIRE(!set_handle->has(k2));
-      set_handle->put(k2);
+      set_handle->insert(k2);
       REQUIRE(set_handle->has(k2));
       REQUIRE(set_handle->size() == 2);
 
@@ -326,7 +326,7 @@ TEST_CASE("sets and values")
         const auto n = i * i;
         const char c[2] = {(char)('A' + i), 0};
         map_handle->put(std::string(c), n);
-        set_handle->put(n);
+        set_handle->insert(n);
       }
 
       REQUIRE(map_handle->size() == n_entries);
@@ -363,7 +363,7 @@ TEST_CASE("sets and values")
             const auto s = k + k;
             const auto n = ~v;
             map_handle->put(s, n);
-            set_handle->put(n);
+            set_handle->insert(n);
           }
 
           return true;

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -525,6 +525,40 @@ TEST_CASE("serialisation of Unit type")
   }
 }
 
+TEST_CASE("multiple handles")
+{
+  kv::Store kv_store;
+
+  MapTypes::NumString map("public:map");
+
+  constexpr auto k = 42;
+  constexpr auto v1 = "hello";
+  constexpr auto v2 = "saluton";
+
+  auto tx = kv_store.create_tx();
+
+  auto h1 = tx.ro(map);
+  auto h2 = tx.rw(map);
+  auto h3 = tx.wo(map);
+
+  REQUIRE(!h1->has(k));
+  REQUIRE(!h2->has(k));
+
+  h2->put(k, v1);
+
+  REQUIRE(h1->has(k));
+  REQUIRE(*h1->get(k) == v1);
+  REQUIRE(h2->has(k));
+  REQUIRE(*h2->get(k) == v1);
+
+  h3->put(k, v2);
+
+  REQUIRE(h1->has(k));
+  REQUIRE(*h1->get(k) == v2);
+  REQUIRE(h2->has(k));
+  REQUIRE(*h2->get(k) == v2);
+}
+
 TEST_CASE("clear")
 {
   kv::Store kv_store;

--- a/src/kv/unit.h
+++ b/src/kv/unit.h
@@ -8,7 +8,7 @@ namespace kv
 {
   // A single-valued type, used as a utility type to convert kv::Maps to
   // kv::Values and kv::Sets. Specifically, these are implemented as wrappers so
-  // that kv::Value<T> is implemented as kv::Map<Unit, T>, and kv::Set<T> is
+  // that kv::Value<T> is essentially kv::Map<Unit, T>, and kv::Set<T> is
   // kv::Map<T, Unit>.
   struct Unit
   {

--- a/src/kv/unit.h
+++ b/src/kv/unit.h
@@ -12,14 +12,15 @@ namespace kv
   // kv::Map<T, Unit>.
   struct Unit
   {
-    static kv::serialisers::SerialisedEntry get()
+    static const kv::serialisers::SerialisedEntry& get()
     {
       // TODO: Should this be a 0? Our existing mono-valued tables had a single
       // value at key 0, we could remain ledger-compatible if we produce the
       // same value here. But that only works where we can guess the
       // serialisation format of that 0, and we're stuck with that inefficiency
       // forever.
-      return {};
+      static kv::serialisers::SerialisedEntry the_value = {};
+      return the_value;
     }
   };
 }

--- a/src/kv/unit.h
+++ b/src/kv/unit.h
@@ -6,21 +6,23 @@
 
 namespace kv
 {
-  // A single-valued type, used as a utility type to convert kv::Maps to
-  // kv::Values and kv::Sets. Specifically, these are implemented as wrappers so
+  // Unit serialisations are used as a utility type to convert kv::Maps to
+  // kv::Maps and kv::Sets. Specifically, these are implemented as wrappers so
   // that kv::Value<T> is essentially kv::Map<Unit, T>, and kv::Set<T> is
   // kv::Map<T, Unit>.
-  struct Unit
+  // This type is used as a template parameter but could be replaced by any user
+  // type with the same signature get(), allowing the caller to specify what
+  // value is inserted into the ledger.
+  struct UnitCreator
   {
-    static const kv::serialisers::SerialisedEntry& get()
+    // This is the default UnitCreator, returning 8 null bytes for compatibility
+    // with old ledgers (where Values were previously Maps with a single entry
+    // at key 0, serialised as a uint64_t)
+    static kv::serialisers::SerialisedEntry get()
     {
-      // TODO: Should this be a 0? Our existing mono-valued tables had a single
-      // value at key 0, we could remain ledger-compatible if we produce the
-      // same value here. But that only works where we can guess the
-      // serialisation format of that 0, and we're stuck with that inefficiency
-      // forever.
-      static kv::serialisers::SerialisedEntry the_value = {};
-      return the_value;
-    }
+      kv::serialisers::SerialisedEntry e;
+      e.assign(8, 0u);
+      return e;
+    };
   };
 }

--- a/src/kv/unit.h
+++ b/src/kv/unit.h
@@ -10,19 +10,27 @@ namespace kv
   // kv::Maps and kv::Sets. Specifically, these are implemented as wrappers so
   // that kv::Value<T> is essentially kv::Map<Unit, T>, and kv::Set<T> is
   // kv::Map<T, Unit>.
-  // This type is used as a template parameter but could be replaced by any user
-  // type with the same signature get(), allowing the caller to specify what
+  // This is used as a template parameter allowing the caller to specify what
   // value is inserted into the ledger.
+
+  // This is the default UnitCreator, returning 8 null bytes for compatibility
+  // with old ledgers (where Values were previously Maps with a single entry
+  // at key 0, serialised as a uint64_t)
   struct UnitCreator
   {
-    // This is the default UnitCreator, returning 8 null bytes for compatibility
-    // with old ledgers (where Values were previously Maps with a single entry
-    // at key 0, serialised as a uint64_t)
     static kv::serialisers::SerialisedEntry get()
     {
       kv::serialisers::SerialisedEntry e;
       e.assign(8, 0u);
       return e;
-    };
+    }
+  };
+
+  struct EmptyUnitCreator
+  {
+    static kv::serialisers::SerialisedEntry get()
+    {
+      return {};
+    }
   };
 }

--- a/src/kv/unit.h
+++ b/src/kv/unit.h
@@ -4,7 +4,7 @@
 
 #include "kv/serialised_entry.h"
 
-namespace kv
+namespace kv::serialisers
 {
   // Unit serialisations are used as a utility type to convert kv::Maps to
   // kv::Maps and kv::Sets. Specifically, these are implemented as wrappers so
@@ -16,12 +16,12 @@ namespace kv
   // This is the default UnitCreator, returning 8 null bytes for compatibility
   // with old ledgers (where Values were previously Maps with a single entry
   // at key 0, serialised as a uint64_t)
-  struct UnitCreator
+  struct ZeroBlitUnitCreator
   {
     static kv::serialisers::SerialisedEntry get()
     {
       kv::serialisers::SerialisedEntry e;
-      e.assign(8, 0u);
+      e.assign(sizeof(uint64_t), 0u);
       return e;
     }
   };

--- a/src/kv/unit.h
+++ b/src/kv/unit.h
@@ -14,6 +14,11 @@ namespace kv
   {
     static kv::serialisers::SerialisedEntry get()
     {
+      // TODO: Should this be a 0? Our existing mono-valued tables had a single
+      // value at key 0, we could remain ledger-compatible if we produce the
+      // same value here. But that only works where we can guess the
+      // serialisation format of that 0, and we're stuck with that inefficiency
+      // forever.
       return {};
     }
   };

--- a/src/kv/unit.h
+++ b/src/kv/unit.h
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "kv/serialised_entry.h"
+
+namespace kv
+{
+  // A single-valued type, used as a utility type to convert kv::Maps to
+  // kv::Values and kv::Sets. Specifically, these are implemented as wrappers so
+  // that kv::Value<T> is implemented as kv::Map<Unit, T>, and kv::Set<T> is
+  // kv::Map<T, Unit>.
+  struct Unit
+  {
+    static kv::serialisers::SerialisedEntry get()
+    {
+      return {};
+    }
+  };
+}

--- a/src/kv/untyped_map_handle.h
+++ b/src/kv/untyped_map_handle.h
@@ -22,7 +22,7 @@ namespace kv::untyped
   using SnapshotChangeSet = kv::
     SnapshotChangeSet<SerialisedEntry, SerialisedEntry, SerialisedKeyHasher>;
 
-  class MapHandle : public kv::AbstractMapHandle
+  class MapHandle : public kv::AbstractHandle
   {
   public:
     // Expose these types so that other code can use them as MyTx::KeyType or

--- a/src/kv/value.h
+++ b/src/kv/value.h
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "kv_types.h"
+#include "serialise_entry_blit.h"
+#include "serialise_entry_json.h"
+#include "value_handle.h"
+
+// TODO: Docs
+namespace kv
+{
+  template <typename V, typename VSerialiser>
+  class TypedValue : public NamedHandleMixin
+  {
+  protected:
+    using This = TypedValue<V, VSerialiser>;
+
+  public:
+    using ReadOnlyHandle = kv::ReadableValueHandle<V, VSerialiser>;
+    using WriteOnlyHandle = kv::WriteableValueHandle<V, VSerialiser>;
+    using Handle = kv::ValueHandle<V, VSerialiser>;
+
+    using ValueSerialiser = VSerialiser;
+
+    using NamedHandleMixin::NamedHandleMixin;
+  };
+
+  template <typename V, template <typename> typename VSerialiser>
+  using ValueSerialisedWith = TypedValue<V, VSerialiser<V>>;
+
+  template <typename V>
+  using JsonSerialisedValue =
+    ValueSerialisedWith<V, kv::serialisers::JsonSerialiser>;
+
+  template <typename V>
+  using RawCopySerialisedValue =
+    TypedValue<V, kv::serialisers::BlitSerialiser<V>>;
+
+  template <typename V>
+  using Value = JsonSerialisedValue<V>;
+}

--- a/src/kv/value.h
+++ b/src/kv/value.h
@@ -55,6 +55,9 @@ namespace kv
   using RawCopySerialisedValue =
     TypedValue<V, kv::serialisers::BlitSerialiser<V>>;
 
+  /** Short name for default-serialised values, using JSON serialisers. Support
+   * for custom types can be added through the DECLARE_JSON... macros.
+   */
   template <typename V>
   using Value = JsonSerialisedValue<V>;
 }

--- a/src/kv/value.h
+++ b/src/kv/value.h
@@ -7,9 +7,20 @@
 #include "serialise_entry_json.h"
 #include "value_handle.h"
 
-// TODO: Docs
 namespace kv
 {
+  /** Defines the schema of a value type within the @c kv::Store. This value
+   * type is a container for an optional single element of type V. This may be
+   * undefined if the value has not been written to the KV, or else it has the
+   * value from the current or last-applied transaction.
+   *
+   * V defines the type of the contained Value. VSerialiser determines how
+   * this V is serialised and deserialised, so it may be written to the ledger
+   * and replicated by the consensus algorithm.
+   *
+   * This is implemented as a @c kv::Map from Unit to V, and the serialisation
+   * of the unit key is overridable with the Unit template parameter.
+   */
   template <
     typename V,
     typename VSerialiser,

--- a/src/kv/value.h
+++ b/src/kv/value.h
@@ -10,24 +10,28 @@
 // TODO: Docs
 namespace kv
 {
-  template <typename V, typename VSerialiser>
+  template <typename V, typename VSerialiser, typename Unit = kv::UnitCreator>
   class TypedValue : public NamedHandleMixin
   {
   protected:
     using This = TypedValue<V, VSerialiser>;
 
   public:
-    using ReadOnlyHandle = kv::ReadableValueHandle<V, VSerialiser>;
-    using WriteOnlyHandle = kv::WriteableValueHandle<V, VSerialiser>;
-    using Handle = kv::ValueHandle<V, VSerialiser>;
+    using ReadOnlyHandle = kv::ReadableValueHandle<V, VSerialiser, Unit>;
+    using WriteOnlyHandle = kv::WriteableValueHandle<V, VSerialiser, Unit>;
+    using Handle = kv::ValueHandle<V, VSerialiser, Unit>;
 
     using ValueSerialiser = VSerialiser;
 
     using NamedHandleMixin::NamedHandleMixin;
   };
 
-  template <typename V, template <typename> typename VSerialiser>
-  using ValueSerialisedWith = TypedValue<V, VSerialiser<V>>;
+  template <
+    typename V,
+    template <typename>
+    typename VSerialiser,
+    typename Unit = kv::UnitCreator>
+  using ValueSerialisedWith = TypedValue<V, VSerialiser<V>, Unit>;
 
   template <typename V>
   using JsonSerialisedValue =

--- a/src/kv/value.h
+++ b/src/kv/value.h
@@ -10,7 +10,10 @@
 // TODO: Docs
 namespace kv
 {
-  template <typename V, typename VSerialiser, typename Unit = kv::UnitCreator>
+  template <
+    typename V,
+    typename VSerialiser,
+    typename Unit = kv::serialisers::ZeroBlitUnitCreator>
   class TypedValue : public NamedHandleMixin
   {
   protected:
@@ -30,7 +33,7 @@ namespace kv
     typename V,
     template <typename>
     typename VSerialiser,
-    typename Unit = kv::UnitCreator>
+    typename Unit = kv::serialisers::ZeroBlitUnitCreator>
   using ValueSerialisedWith = TypedValue<V, VSerialiser<V>, Unit>;
 
   template <typename V>

--- a/src/kv/value_handle.h
+++ b/src/kv/value_handle.h
@@ -40,17 +40,6 @@ namespace kv
     {
       return read_handle.get_version_of_previous_write(kv::Unit::get());
     }
-
-    template <class F>
-    void foreach(F&& f)
-    {
-      auto g = [&](
-                 const kv::serialisers::SerialisedEntry&,
-                 const kv::serialisers::SerialisedEntry& v_rep) {
-        return f(VSerialiser::from_serialised(v_rep));
-      };
-      read_handle.foreach(g);
-    }
   };
 
   template <typename V, typename VSerialiser>

--- a/src/kv/value_handle.h
+++ b/src/kv/value_handle.h
@@ -5,9 +5,10 @@
 #include "kv/untyped_map_handle.h"
 #include "kv_types.h"
 
-// TODO: Docs
 namespace kv
 {
+  /** Grants read access to a @c kv::Value, as part of a @c kv::Tx.
+   */
   template <typename V, typename VSerialiser, typename Unit>
   class ReadableValueHandle
   {
@@ -19,6 +20,14 @@ namespace kv
 
     ReadableValueHandle(kv::untyped::MapHandle& uh) : read_handle(uh) {}
 
+    /** Get the stored value.
+     *
+     * This will return nullopt of the value has never been set, or has been
+     * removed.
+     *
+     * @return Optional containing associated value, or empty if the value
+     * doesn't exist
+     */
     std::optional<V> get()
     {
       const auto opt_v_rep = read_handle.get(Unit::get());
@@ -31,10 +40,15 @@ namespace kv
       return std::nullopt;
     }
 
+    /** Get globally committed value, which has been replicated and
+     * acknowledged by consensus protocol.
+     *
+     * @return Optional containing associated value, or empty if the value
+     * doesn't exist in globally committed state
+     */
     std::optional<V> get_globally_committed()
     {
-      const auto opt_v_rep =
-        read_handle.get_globally_committed(Unit::get());
+      const auto opt_v_rep = read_handle.get_globally_committed(Unit::get());
 
       if (opt_v_rep.has_value())
       {
@@ -44,17 +58,34 @@ namespace kv
       return std::nullopt;
     }
 
+    /** Test if value is defined.
+     *
+     * This is equivalent to `get().has_value()`, but is more efficient as it
+     * doesn't need to deserialise the value.
+     *
+     * @return Boolean true iff value is defined
+     */
     bool has()
     {
       return read_handle.has(Unit::get());
     }
 
+    /** Get version when this value was last written to, by a previous
+     * transaction.
+     *
+     * @see kv::ReadableMapHandle::get_version_of_previous_write
+     *
+     * @return Optional containing version of applied transaction which last
+     * wrote to this value, or nullopt if such a version does not exist
+     */
     std::optional<Version> get_version_of_previous_write()
     {
       return read_handle.get_version_of_previous_write(Unit::get());
     }
   };
 
+  /** Grants write access to a @c kv::Value, as part of a @c kv::Tx.
+   */
   template <typename V, typename VSerialiser, typename Unit>
   class WriteableValueHandle
   {
@@ -64,17 +95,32 @@ namespace kv
   public:
     WriteableValueHandle(kv::untyped::MapHandle& uh) : write_handle(uh) {}
 
+    /** Modify this value.
+     *
+     * If this value was previously defined, it will be overwritten. Even if the
+     * previous value was identical, this produces a serialised write in the
+     * ledger.
+     *
+     * @param value Value
+     */
     void put(const V& value)
     {
       write_handle.put(Unit::get(), VSerialiser::to_serialised(value));
     }
 
+    /** Delete this value, restoring its original undefined state.
+     */
     void clear()
     {
       write_handle.clear();
     }
   };
 
+  /** Grants read and write access to a @c kv::Value, as part of a @c kv::Tx.
+   *
+   * @see kv::ReadableValueHandle
+   * @see kv::WriteableValueHandle
+   */
   template <typename V, typename VSerialiser, typename Unit>
   class ValueHandle : public AbstractHandle,
                       public ReadableValueHandle<V, VSerialiser, Unit>,

--- a/src/kv/value_handle.h
+++ b/src/kv/value_handle.h
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "kv/untyped_map_handle.h"
+#include "kv_types.h"
+
+// TODO: Docs
+namespace kv
+{
+  template <typename V, typename VSerialiser>
+  class ReadableValueHandle
+  {
+  protected:
+    kv::untyped::MapHandle& read_handle;
+
+  public:
+    using ValueType = V;
+
+    ReadableValueHandle(kv::untyped::MapHandle& uh) : read_handle(uh) {}
+
+    std::optional<V> get()
+    {
+      const auto opt_v_rep = read_handle.get(kv::Unit::get());
+
+      if (opt_v_rep.has_value())
+      {
+        return VSerialiser::from_serialised(*opt_v_rep);
+      }
+
+      return std::nullopt;
+    }
+
+    bool has()
+    {
+      return read_handle.has(kv::Unit::get());
+    }
+
+    std::optional<Version> get_version_of_previous_write()
+    {
+      return read_handle.get_version_of_previous_write(kv::Unit::get());
+    }
+
+    template <class F>
+    void foreach(F&& f)
+    {
+      auto g = [&](
+                 const kv::serialisers::SerialisedEntry&,
+                 const kv::serialisers::SerialisedEntry& v_rep) {
+        return f(VSerialiser::from_serialised(v_rep));
+      };
+      read_handle.foreach(g);
+    }
+  };
+
+  template <typename V, typename VSerialiser>
+  class WriteableValueHandle
+  {
+  protected:
+    kv::untyped::MapHandle& write_handle;
+
+  public:
+    WriteableValueHandle(kv::untyped::MapHandle& uh) : write_handle(uh) {}
+
+    void put(const V& value)
+    {
+      write_handle.put(kv::Unit::get(), VSerialiser::to_serialised(value));
+    }
+
+    void clear()
+    {
+      write_handle.clear();
+    }
+  };
+
+  template <typename V, typename VSerialiser>
+  class ValueHandle : public AbstractHandle,
+                      public ReadableValueHandle<V, VSerialiser>,
+                      public WriteableValueHandle<V, VSerialiser>
+  {
+  protected:
+    kv::untyped::MapHandle untyped_handle;
+
+    using ReadableBase = ReadableValueHandle<V, VSerialiser>;
+    using WriteableBase = WriteableValueHandle<V, VSerialiser>;
+
+  public:
+    ValueHandle(kv::untyped::ChangeSet& changes, const std::string& map_name) :
+      ReadableBase(untyped_handle),
+      WriteableBase(untyped_handle),
+      untyped_handle(changes, map_name)
+    {}
+  };
+}

--- a/src/kv/value_handle.h
+++ b/src/kv/value_handle.h
@@ -31,6 +31,19 @@ namespace kv
       return std::nullopt;
     }
 
+    std::optional<V> get_globally_committed()
+    {
+      const auto opt_v_rep =
+        read_handle.get_globally_committed(Unit::get());
+
+      if (opt_v_rep.has_value())
+      {
+        return VSerialiser::from_serialised(*opt_v_rep);
+      }
+
+      return std::nullopt;
+    }
+
     bool has()
     {
       return read_handle.has(Unit::get());

--- a/src/kv/value_handle.h
+++ b/src/kv/value_handle.h
@@ -8,7 +8,7 @@
 // TODO: Docs
 namespace kv
 {
-  template <typename V, typename VSerialiser>
+  template <typename V, typename VSerialiser, typename Unit>
   class ReadableValueHandle
   {
   protected:
@@ -21,7 +21,7 @@ namespace kv
 
     std::optional<V> get()
     {
-      const auto opt_v_rep = read_handle.get(kv::Unit::get());
+      const auto opt_v_rep = read_handle.get(Unit::get());
 
       if (opt_v_rep.has_value())
       {
@@ -33,16 +33,16 @@ namespace kv
 
     bool has()
     {
-      return read_handle.has(kv::Unit::get());
+      return read_handle.has(Unit::get());
     }
 
     std::optional<Version> get_version_of_previous_write()
     {
-      return read_handle.get_version_of_previous_write(kv::Unit::get());
+      return read_handle.get_version_of_previous_write(Unit::get());
     }
   };
 
-  template <typename V, typename VSerialiser>
+  template <typename V, typename VSerialiser, typename Unit>
   class WriteableValueHandle
   {
   protected:
@@ -53,7 +53,7 @@ namespace kv
 
     void put(const V& value)
     {
-      write_handle.put(kv::Unit::get(), VSerialiser::to_serialised(value));
+      write_handle.put(Unit::get(), VSerialiser::to_serialised(value));
     }
 
     void clear()
@@ -62,16 +62,16 @@ namespace kv
     }
   };
 
-  template <typename V, typename VSerialiser>
+  template <typename V, typename VSerialiser, typename Unit>
   class ValueHandle : public AbstractHandle,
-                      public ReadableValueHandle<V, VSerialiser>,
-                      public WriteableValueHandle<V, VSerialiser>
+                      public ReadableValueHandle<V, VSerialiser, Unit>,
+                      public WriteableValueHandle<V, VSerialiser, Unit>
   {
   protected:
     kv::untyped::MapHandle untyped_handle;
 
-    using ReadableBase = ReadableValueHandle<V, VSerialiser>;
-    using WriteableBase = WriteableValueHandle<V, VSerialiser>;
+    using ReadableBase = ReadableValueHandle<V, VSerialiser, Unit>;
+    using WriteableBase = WriteableValueHandle<V, VSerialiser, Unit>;
 
   public:
     ValueHandle(kv::untyped::ChangeSet& changes, const std::string& map_name) :

--- a/src/kv/value_handle.h
+++ b/src/kv/value_handle.h
@@ -101,7 +101,7 @@ namespace kv
      * previous value was identical, this produces a serialised write in the
      * ledger.
      *
-     * @param value Value
+     * @param value New entry to assign to this Value
      */
     void put(const V& value)
     {

--- a/src/node/config.h
+++ b/src/node/config.h
@@ -19,6 +19,7 @@ namespace ccf
   DECLARE_JSON_REQUIRED_FIELDS(
     ServiceConfiguration, recovery_threshold, consensus)
 
-  // The there is always only one active configuration, so this is a single Value
+  // The there is always only one active configuration, so this is a single
+  // Value
   using Configuration = ServiceValue<ServiceConfiguration>;
 }

--- a/src/node/config.h
+++ b/src/node/config.h
@@ -19,7 +19,6 @@ namespace ccf
   DECLARE_JSON_REQUIRED_FIELDS(
     ServiceConfiguration, recovery_threshold, consensus)
 
-  // The key for this table is always 0 as there is always only one active
-  // configuration.
-  using Configuration = ServiceMap<size_t, ServiceConfiguration>;
+  // The there is always only one active configuration, so this is a single Value
+  using Configuration = ServiceValue<ServiceConfiguration>;
 }

--- a/src/node/genesis_gen.h
+++ b/src/node/genesis_gen.h
@@ -409,14 +409,14 @@ namespace ccf
     void init_configuration(const ServiceConfiguration& configuration)
     {
       auto config = tx.rw(tables.config);
-      if (config->get(0).has_value())
+      if (config->has())
       {
         throw std::logic_error(
           "Cannot initialise service configuration: configuration already "
           "exists");
       }
 
-      config->put(0, configuration);
+      config->put(configuration);
     }
 
     bool set_recovery_threshold(size_t threshold)
@@ -461,21 +461,21 @@ namespace ccf
         }
       }
 
-      auto current_config = config->get(0);
+      auto current_config = config->get();
       if (!current_config.has_value())
       {
         throw std::logic_error("Configuration should already be set");
       }
 
       current_config->recovery_threshold = threshold;
-      config->put(0, current_config.value());
+      config->put(current_config.value());
       return true;
     }
 
     size_t get_recovery_threshold()
     {
       auto config = tx.ro(tables.config);
-      auto current_config = config->get(0);
+      auto current_config = config->get();
       if (!current_config.has_value())
       {
         throw std::logic_error(

--- a/src/node/genesis_gen.h
+++ b/src/node/genesis_gen.h
@@ -136,7 +136,7 @@ namespace ccf
           id, member_pub_info.encryption_pub_key.value());
       }
 
-      auto s = signatures->get(0);
+      auto s = signatures->get();
       if (!s)
       {
         member_acks->put(id, MemberAck());
@@ -302,13 +302,13 @@ namespace ccf
     void create_service(const crypto::Pem& network_cert)
     {
       auto service = tx.rw(tables.service);
-      service->put(0, {network_cert, ServiceStatus::OPENING});
+      service->put({network_cert, ServiceStatus::OPENING});
     }
 
     bool is_service_created()
     {
       auto service = tx.ro(tables.service);
-      return service->get(0).has_value();
+      return service->get().has_value();
     }
 
     bool open_service()
@@ -326,7 +326,7 @@ namespace ccf
         return false;
       }
 
-      auto active_service = service->get(0);
+      auto active_service = service->get();
       if (!active_service.has_value())
       {
         LOG_FAIL_FMT("Failed to get active service");
@@ -348,7 +348,7 @@ namespace ccf
       }
 
       active_service->status = ServiceStatus::OPEN;
-      service->put(0, active_service.value());
+      service->put(active_service.value());
 
       return true;
     }
@@ -356,7 +356,7 @@ namespace ccf
     std::optional<ServiceStatus> get_service_status()
     {
       auto service = tx.ro(tables.service);
-      auto active_service = service->get(0);
+      auto active_service = service->get();
       if (!active_service.has_value())
       {
         LOG_FAIL_FMT("Failed to get active service");
@@ -392,7 +392,7 @@ namespace ccf
     auto get_last_signature()
     {
       auto signatures = tx.ro(tables.signatures);
-      return signatures->get(0);
+      return signatures->get();
     }
 
     void set_constitution(const std::string& constitution)

--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -24,7 +24,7 @@ namespace ccf::historical
   {
     auto tx = sig_store->create_read_only_tx();
     auto signatures = tx.ro<ccf::Signatures>(ccf::Tables::SIGNATURES);
-    return signatures->get(0);
+    return signatures->get();
   }
 
   static std::optional<std::vector<uint8_t>> get_tree(const StorePtr& sig_store)
@@ -32,7 +32,7 @@ namespace ccf::historical
     auto tx = sig_store->create_read_only_tx();
     auto tree =
       tx.ro<ccf::SerialisedMerkleTree>(ccf::Tables::SERIALISED_MERKLE_TREE);
-    return tree->get(0);
+    return tree->get();
   }
 
   class StateCache : public AbstractStateCache

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -108,8 +108,8 @@ namespace ccf
       auto serialised_tree = sig.template rw<ccf::SerialisedMerkleTree>(
         ccf::Tables::SERIALISED_MERKLE_TREE);
       PrimarySignature sig_value(id, txid.version);
-      signatures->put(0, sig_value);
-      serialised_tree->put(0, {});
+      signatures->put(sig_value);
+      serialised_tree->put({});
       return sig.commit_reserved();
     }
   };
@@ -356,9 +356,8 @@ namespace ccf
         progress_tracker->record_primary_signature(txid, primary_sig);
       }
 
-      signatures->put(0, sig_value);
+      signatures->put(sig_value);
       serialised_tree->put(
-        0,
         history.serialise_tree(commit_txid.previous_version, txid.version - 1));
       return sig.commit_reserved();
     }
@@ -614,7 +613,7 @@ namespace ccf
       auto tx = store.create_read_only_tx();
       auto tree_h = tx.template ro<ccf::SerialisedMerkleTree>(
         ccf::Tables::SERIALISED_MERKLE_TREE);
-      auto tree = tree_h->get(0);
+      auto tree = tree_h->get();
       if (!tree.has_value())
       {
         LOG_FAIL_FMT("No tree found in serialised tree map");
@@ -682,7 +681,7 @@ namespace ccf
       auto signatures =
         tx.template ro<ccf::Signatures>(ccf::Tables::SIGNATURES);
       auto nodes = tx.template ro<ccf::Nodes>(ccf::Tables::NODES);
-      auto sig = signatures->get(0);
+      auto sig = signatures->get();
       if (!sig.has_value())
       {
         LOG_FAIL_FMT("No signature found in signatures map");

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -609,7 +609,7 @@ namespace ccf
 
               auto tx = network.tables->create_read_only_tx();
               auto signatures = tx.ro(network.signatures);
-              auto sig = signatures->get(0);
+              auto sig = signatures->get();
               if (!sig.has_value())
               {
                 throw std::logic_error(
@@ -1277,7 +1277,7 @@ namespace ccf
       std::lock_guard<SpinLock> guard(lock);
 
       auto service = tx.rw<Service>(Tables::SERVICE);
-      auto service_info = service->get(0);
+      auto service_info = service->get();
       if (!service_info.has_value())
       {
         throw std::logic_error(
@@ -1301,7 +1301,7 @@ namespace ccf
         // shares
         share_manager.clear_submitted_recovery_shares(tx);
         service_info->status = ServiceStatus::WAITING_FOR_RECOVERY_SHARES;
-        service->put(0, service_info.value());
+        service->put(service_info.value());
         return;
       }
       else if (is_part_of_network())

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -470,7 +470,7 @@ namespace ccf
       if (!is_open_)
       {
         auto service = tx.ro<Service>(Tables::SERVICE);
-        auto s = service->get_globally_committed(0);
+        auto s = service->get_globally_committed();
         if (
           s.has_value() && s.value().status == ServiceStatus::OPEN &&
           service_identity != nullptr && s.value().cert == *service_identity)

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -548,7 +548,7 @@ namespace ccf
         }
 
         auto sig = ctx.tx.rw(this->network.signatures);
-        const auto s = sig->get(0);
+        const auto s = sig->get();
         if (!s)
         {
           mas->put(caller_identity.member_id, MemberAck({}, signed_request));
@@ -631,7 +631,7 @@ namespace ccf
               "No ACK record exists for caller {}.", member_id.value()));
         }
 
-        auto s = sig->get(0);
+        auto s = sig->get();
         if (s)
         {
           ma->state_digest = s->root.hex_str();

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -257,7 +257,7 @@ namespace ccf
         auto nodes = args.tx.rw(this->network.nodes);
         auto service = args.tx.rw(this->network.service);
 
-        auto active_service = service->get(0);
+        auto active_service = service->get();
         if (!active_service.has_value())
         {
           return make_error(
@@ -421,7 +421,7 @@ namespace ccf
             0);
 
         auto signatures = args.tx.template ro<Signatures>(Tables::SIGNATURES);
-        auto sig = signatures->get(0);
+        auto sig = signatures->get();
         if (!sig.has_value())
         {
           result.last_signed_seqno = 0;
@@ -520,7 +520,7 @@ namespace ccf
       auto network_status = [this](auto& args, nlohmann::json&&) {
         GetNetworkInfo::Out out;
         auto service = args.tx.ro(network.service);
-        auto service_state = service->get(0);
+        auto service_state = service->get();
         if (service_state.has_value())
         {
           const auto& service_value = service_state.value();

--- a/src/node/service.h
+++ b/src/node/service.h
@@ -31,7 +31,7 @@ namespace ccf
   DECLARE_JSON_TYPE(ServiceInfo);
   DECLARE_JSON_REQUIRED_FIELDS(ServiceInfo, cert, status);
 
-  // As there is only one service active at a given time, the key for the
-  // Service table is always 0.
-  using Service = ServiceMap<size_t, ServiceInfo>;
+  // As there is only one service active at a given time, it is stored in single
+  // Value in the KV
+  using Service = ServiceValue<ServiceInfo>;
 }

--- a/src/node/service_map.h
+++ b/src/node/service_map.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include "kv/map.h"
+#include "kv/set.h"
+#include "kv/value.h"
 
 namespace ccf
 {
@@ -18,4 +20,16 @@ namespace ccf
     V,
     kv::serialisers::BlitSerialiser,
     kv::serialisers::JsonSerialiser>;
+
+  template <typename V>
+  using ServiceValue = kv::ValueSerialisedWith<
+    V,
+    kv::serialisers::JsonSerialiser,
+    kv::serialisers::ZeroBlitUnitCreator>;
+
+  template <typename K>
+  using ServiceSet = kv::SetSerialisedWith<
+    K,
+    kv::serialisers::BlitSerialiser,
+    kv::serialisers::ZeroBlitUnitCreator>;
 }

--- a/src/node/share_manager.h
+++ b/src/node/share_manager.h
@@ -428,7 +428,7 @@ namespace ccf
     {
       auto service = tx.rw(network.service);
       auto submitted_shares = tx.rw(network.submitted_shares);
-      auto active_service = service->get(0);
+      auto active_service = service->get();
       if (!active_service.has_value())
       {
         throw std::logic_error("Failed to get active service");

--- a/src/node/share_manager.h
+++ b/src/node/share_manager.h
@@ -267,7 +267,7 @@ namespace ccf
         return true;
       });
 
-      auto recovery_threshold = config->get(0)->recovery_threshold;
+      auto recovery_threshold = config->get()->recovery_threshold;
       if (recovery_threshold > shares.size())
       {
         throw std::logic_error(fmt::format(

--- a/src/node/signatures.h
+++ b/src/node/signatures.h
@@ -54,10 +54,9 @@ namespace ccf
   DECLARE_JSON_REQUIRED_FIELDS(
     PrimarySignature, seqno, view, commit_seqno, commit_view, root)
 
-  // Signatures are always stored at key `0`
-  using Signatures = ServiceMap<size_t, PrimarySignature>;
+  // Most recent signature is a single Value in the KV
+  using Signatures = ServiceValue<PrimarySignature>;
 
-  // Serialised Merkle tree is always stored at key `0`
-  using SerialisedMerkleTree =
-    kv::RawCopySerialisedMap<size_t, std::vector<uint8_t>>;
+  // Serialised Merkle tree at most recent signature is a single Value in the KV
+  using SerialisedMerkleTree = kv::RawCopySerialisedValue<std::vector<uint8_t>>;
 }

--- a/src/node/test/historical_queries.cpp
+++ b/src/node/test/historical_queries.cpp
@@ -120,7 +120,7 @@ TestState create_and_init_state(bool initialise_ledger_rekey = true)
     auto tx = ts.kv_store->create_tx();
     auto config = tx.rw<ccf::Configuration>(ccf::Tables::CONFIGURATION);
     size_t recovery_threshold = 1;
-    config->put(0, {recovery_threshold});
+    config->put({recovery_threshold});
     auto member_info = tx.rw<ccf::MemberInfo>(ccf::Tables::MEMBER_INFO);
     auto member_public_encryption_keys = tx.rw<ccf::MmeberPublicEncryptionKeys>(
       ccf::Tables::MEMBER_ENCRYPTION_PUBLIC_KEYS);

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -109,10 +109,10 @@ TEST_CASE("Check signature verification")
   INFO("Issue a bogus signature, rejected by verification on the backup");
   {
     auto txs = primary_store.create_tx();
-    auto tx = txs.rw(signatures);
+    auto sigs = txs.rw(signatures);
     ccf::PrimarySignature bogus(kv::test::PrimaryNodeId, 0);
     bogus.sig = std::vector<uint8_t>(MBEDTLS_ECDSA_MAX_LEN, 1);
-    tx->put(0, bogus);
+    sigs->put(bogus);
     REQUIRE(txs.commit() == kv::CommitResult::FAIL_NO_REPLICATE);
   }
 }

--- a/src/node/test/snapshot.cpp
+++ b/src/node/test/snapshot.cpp
@@ -60,12 +60,12 @@ TEST_CASE("Snapshot with merkle tree" * doctest::test_suite("snapshot"))
     // mini-tree in a signature and the hash of the signature
     auto tx = source_store.create_read_only_tx();
     auto signatures = tx.ro<ccf::Signatures>(ccf::Tables::SIGNATURES);
-    REQUIRE(signatures->has(0));
-    auto sig = signatures->get(0).value();
+    REQUIRE(signatures->has());
+    auto sig = signatures->get().value();
     auto serialised_tree =
       tx.ro<ccf::SerialisedMerkleTree>(ccf::Tables::SERIALISED_MERKLE_TREE);
-    REQUIRE(serialised_tree->has(0));
-    auto tree = serialised_tree->get(0);
+    REQUIRE(serialised_tree->has());
+    auto tree = serialised_tree->get();
 
     auto serialised_signature = source_consensus->get_latest_data().value();
     auto serialised_signature_hash = crypto::Sha256Hash(serialised_signature);


### PR DESCRIPTION
Resolves #274.

Here's an implementation of a feature that's been on my mind for a while, adding `kv::Value` and `kv::Set` alongside `kv::Map`. 

There's a comment on #274 suggesting this could be done in user-space. This version doesn't actually need to be in `kv` - nothing in `kv` depends on them. But it does use internal `kv` details, and I think we should provide a standard implementation. This makes them look like first-class citizens at the app level (`tx.rw(my_set)` just like `tx.rw(my_map)`, whereas I believe anything that doesn't use internal `kv` details would need to look like `MySet(tx, "my_set_name")`). This doesn't actually require any changes to the existing `kv` code - the only changes in existing `kv` headers are renames, to make it clear they're actually abstract `Handle`s and don't need to represent `Map`s at all.

Opening as a draft for early input. There's still several things to do before this is ready for merging:
- [ ] Explore possible alternative APIs
- - [x] At the very least, find sensible names for the method calls that aren't just direct copies of the methods on `kv::Map`, and evaluate the names `Unit` and `Value`
- - [ ] At the extreme other end, see if we can make `kv::Value` act more like `std::optional` (in particular adding some assignment operators - almost certainly a dangerous idea)
- - [x] Also want to consider making the unit-type serialisation customisable, since all other serialisation choices are. This may make it easier to upgrade from a `Value` to a `Map` (if it was at 0 rather than null, its easier to decide you actually have entries at 1 and 2... but is that worthwhile, or are you just as likely to want an entry at "old" and "new"?)
- [x] Use these new types for our current value tables (`Signatures`, ...)
- [x] Add doxygen for the new types
- [ ] Describe new types in rst docs
- [x] CHANGELOG