### PR TITLE
Fix for ledger chunking and snapshot out-of-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The per-node session cap behaviour has changed. The `--max-open-sessions` is now a soft cap on the number of sessions. Beyond this, new sessions will receive a HTTP 503 error immediately after completing the TLS handshake. The existing hard cap (where sessions are closed immediately, before the TLS handshake) is still available, under the new argument `--max-open-sessions-hard` (#2583).
 - Requests with a url-encoded query string are now forwarded correctly from backups to the primary (#2587).
 - Signed requests with a url-encoded query string are now handled correctly rather than rejected (#2592).
+- Fixed consistency issue between ledger files on different nodes when snapshotting is active (#2607).
+
+## [1.0.2]
+
+### Bugfix
+
+- Fixed consistency issue between ledger files on different nodes when snapshotting is active (#2607).
 
 ## [1.0.1]
 
@@ -875,6 +882,9 @@ Some discrepancies with the TR remain, and are being tracked under https://githu
 
 Initial pre-release
 
+[1.0.2]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.2
+[1.0.1]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.1
+[1.0.0]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.0
 [1.0.0-rc3]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.0-rc3
 [1.0.0-rc2]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.0-rc2
 [1.0.0-rc1]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.0-rc1

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -2567,12 +2567,10 @@ namespace aft
       state->commit_idx = idx;
 
       LOG_DEBUG_FMT("Compacting...");
-      snapshotter->commit(idx);
-      if (consensus_type == ConsensusType::CFT)
-      {
-        // Snapshots are not yet supported with BFT
-        snapshotter->update(idx, replica_state == Leader);
-      }
+      // Snapshots are not yet supported with BFT
+      snapshotter->commit(
+        idx, replica_state == Leader && consensus_type == ConsensusType::CFT);
+
       store->compact(idx);
       ledger->commit(idx);
 

--- a/src/consensus/aft/test/logging_stub.h
+++ b/src/consensus/aft/test/logging_stub.h
@@ -333,7 +333,7 @@ namespace aft
       return false;
     }
 
-    void commit(Index)
+    void commit(Index, bool)
     {
       // For now, do not test snapshots in unit tests
       return;

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -853,7 +853,7 @@ namespace ccf
           // continue generating snapshots at the correct interval once the
           // recovery is complete
           snapshotter->record_committable(ledger_idx);
-          snapshotter->commit(ledger_idx);
+          snapshotter->commit(ledger_idx, false);
         }
       }
       else if (

--- a/src/node/snapshotter.h
+++ b/src/node/snapshotter.h
@@ -221,7 +221,7 @@ namespace ccf
     void commit(consensus::Index idx, bool generate_snapshot)
     {
       // If generate_snapshot is true, takes a snapshot of the key value store
-      // at the last committable index before idx, and schedule snapshot
+      // at the last snapshottable index before idx, and schedule snapshot
       // serialisation on another thread (round-robin). Otherwise, only record
       // that a snapshot was generated.
       std::lock_guard<SpinLock> guard(lock);

--- a/src/node/snapshotter.h
+++ b/src/node/snapshotter.h
@@ -126,6 +126,36 @@ namespace ccf
         snapshot_hash);
     }
 
+    void update_indices(consensus::Index idx)
+    {
+      while ((next_snapshot_indices.size() > 1) &&
+             (*std::next(next_snapshot_indices.begin()) <= idx))
+      {
+        next_snapshot_indices.pop_front();
+      }
+
+      for (auto it = snapshot_evidence_indices.begin();
+           it != snapshot_evidence_indices.end();)
+      {
+        if (it->evidence_commit_idx.has_value())
+        {
+          if (idx > it->evidence_commit_idx.value())
+          {
+            commit_snapshot(it->idx, idx);
+            auto it_ = it;
+            it++;
+            snapshot_evidence_indices.erase(it_);
+            continue;
+          }
+        }
+        else if (idx >= it->evidence_idx)
+        {
+          it->evidence_commit_idx = idx;
+        }
+        it++;
+      }
+    }
+
   public:
     Snapshotter(
       ringbuffer::AbstractWriterFactory& writer_factory,
@@ -172,13 +202,31 @@ namespace ccf
       next_snapshot_indices.push_back(last_snapshot_idx);
     }
 
-    void update(consensus::Index idx, bool generate_snapshot)
+    bool record_committable(consensus::Index idx)
+    {
+      // Returns true if the committable idx will require the generation of a
+      // snapshot, and thus a new ledger chunk
+      std::lock_guard<SpinLock> guard(lock);
+
+      if ((idx - next_snapshot_indices.back()) >= snapshot_tx_interval)
+      {
+        next_snapshot_indices.push_back(idx);
+        LOG_TRACE_FMT("Recorded {} as snapshot index", idx);
+        return true;
+      }
+
+      return false;
+    }
+
+    void commit(consensus::Index idx, bool generate_snapshot)
     {
       // If generate_snapshot is true, takes a snapshot of the key value store
-      // at idx, and schedule snapshot serialisation on another thread
-      // (round-robin). Otherwise, only record that a snapshot was
-      // generated at idx.
+      // at the last committable index before idx, and schedule snapshot
+      // serialisation on another thread (round-robin). Otherwise, only record
+      // that a snapshot was generated.
       std::lock_guard<SpinLock> guard(lock);
+
+      update_indices(idx);
 
       if (idx < last_snapshot_idx)
       {
@@ -189,69 +237,31 @@ namespace ccf
           last_snapshot_idx));
       }
 
-      if (idx - last_snapshot_idx >= snapshot_tx_interval)
-      {
-        last_snapshot_idx = idx;
+      CCF_ASSERT_FMT(
+        idx >= next_snapshot_indices.front(),
+        "Cannot commit snapshotter at {}, which is before last snapshottable "
+        "idx {}",
+        idx,
+        next_snapshot_indices.front());
 
-        if (generate_snapshot && snapshot_generation_enabled)
+      auto snapshot_idx = next_snapshot_indices.front();
+      if (snapshot_idx - last_snapshot_idx >= snapshot_tx_interval)
+      {
+        if (generate_snapshot && snapshot_generation_enabled && snapshot_idx)
         {
           auto msg =
             std::make_unique<threading::Tmsg<SnapshotMsg>>(&snapshot_cb);
           msg->data.self = shared_from_this();
-          msg->data.snapshot = store->snapshot(idx);
-
+          msg->data.snapshot = store->snapshot(snapshot_idx);
           static uint32_t generation_count = 0;
           threading::ThreadMessaging::thread_messaging.add_task(
             threading::ThreadMessaging::get_execution_thread(
               generation_count++),
             std::move(msg));
         }
-      }
-    }
 
-    bool record_committable(consensus::Index idx)
-    {
-      // Returns true if the committable idx will require the generation of a
-      // snapshot, and thus a new ledger chunk
-      std::lock_guard<SpinLock> guard(lock);
-
-      if ((idx - next_snapshot_indices.back()) >= snapshot_tx_interval)
-      {
-        next_snapshot_indices.push_back(idx);
-        return true;
-      }
-      return false;
-    }
-
-    void commit(consensus::Index idx)
-    {
-      std::lock_guard<SpinLock> guard(lock);
-
-      while ((next_snapshot_indices.size() > 1) &&
-             (next_snapshot_indices.front() < idx))
-      {
-        next_snapshot_indices.pop_front();
-      }
-
-      for (auto it = snapshot_evidence_indices.begin();
-           it != snapshot_evidence_indices.end();)
-      {
-        if (it->evidence_commit_idx.has_value())
-        {
-          if (idx > it->evidence_commit_idx.value())
-          {
-            commit_snapshot(it->idx, idx);
-            auto it_ = it;
-            it++;
-            snapshot_evidence_indices.erase(it_);
-            continue;
-          }
-        }
-        else if (idx >= it->evidence_idx)
-        {
-          it->evidence_commit_idx = idx;
-        }
-        it++;
+        last_snapshot_idx = snapshot_idx;
+        LOG_TRACE_FMT("Recorded {} as last snapshot index", last_snapshot_idx);
       }
     }
 
@@ -269,6 +279,10 @@ namespace ccf
       {
         next_snapshot_indices.push_back(last_snapshot_idx);
       }
+
+      LOG_TRACE_FMT(
+        "Rolled back snapshotter: last snapshottable idx is now {}",
+        next_snapshot_indices.front());
 
       while (!snapshot_evidence_indices.empty() &&
              (snapshot_evidence_indices.back().evidence_idx > idx))

--- a/src/node/test/snapshotter.cpp
+++ b/src/node/test/snapshotter.cpp
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 
+#include "node/snapshotter.h"
+
 #include "ds/logger.h"
 #include "kv/test/null_encryptor.h"
-#include "node/snapshotter.h"
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>

--- a/tests/infra/logging_app.py
+++ b/tests/infra/logging_app.py
@@ -203,11 +203,6 @@ class LoggingTxs:
                             raise ValueError(
                                 f"Response with status {rep.status_code} is missing 'retry-after' header"
                             )
-                        sleep_time = 0.5
-                        LOG.info(
-                            f"Sleeping for {sleep_time}s waiting for historical query processing..."
-                        )
-                        time.sleep(sleep_time)
                     elif rep.status_code == http.HTTPStatus.NO_CONTENT:
                         raise ValueError(
                             f"Historical query response claims there was no write to {idx} at {view}.{seqno}"

--- a/tests/infra/logging_app.py
+++ b/tests/infra/logging_app.py
@@ -244,11 +244,6 @@ class LoggingTxs:
                         raise ValueError(
                             f"Response with status {rep.status_code} is missing 'retry-after' header"
                         )
-                    sleep_time = 0.5
-                    LOG.info(
-                        f"Sleeping for {sleep_time}s waiting for historical query processing..."
-                    )
-                    time.sleep(sleep_time)
                 elif rep.status_code == http.HTTPStatus.NO_CONTENT:
                     raise ValueError(
                         f"Historical query response claims there was no write to {idx} at {view}.{seqno}"


### PR DESCRIPTION
Resolves #2491 

I'd been tracking down this bug for a while, [without success](https://github.com/microsoft/CCF/pull/2526), but activating JWT auto-refresh for the test suites (see https://github.com/microsoft/CCF/pull/2600) triggers the bug much more consistently.

This is the proposed fix for it. This issue was that, while we record "snapshottable" `seqno`s as we replicate entries (on both primary and backups) based on the value of `snapshot_tx_interval`, nodes would generate snapshots on (global) commit at the `seqno` of that commit. However, commits can happen at any signature `seqno`, and don't necessarily match the "snapshottable" `seqno` which was record on the replication code path. In other words, for a `snapshot_tx_interval` of `10`, we may have recorded `seqnos` 10, 20 and 30 as "snapshottable" `seqno`s (and thus forced new ledger chunks at those) but the global commit would come at 15 and we would create a snapshot at 15, instead of 10. Then, when a new node joins from the snapshot at 15, the ledger chunks it creates would be "chunked" at different intervals than those of the primary node. 

This is very obvious in hindsight, and the snapshotter unit test now covers my original misunderstanding. I'm also very surprised that this hasn't showed up in other tests, but I'm assuming our end-to-end tests are simple enough that a service commits all committable `seqno`s? 
