### PR TITLE
Make join robust to primary retirement

### DIFF
--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -500,7 +500,7 @@ namespace ccf
 
           if (status != HTTP_STATUS_OK)
           {
-            const auto& location = headers.find("location");
+            const auto& location = headers.find(http::headers::LOCATION);
             if (
               status == HTTP_STATUS_PERMANENT_REDIRECT &&
               location != headers.end())
@@ -508,7 +508,7 @@ namespace ccf
               const auto& url = http::parse_url_full(location->second);
               config.joining.target_host = url.host;
               config.joining.target_port = url.port;
-              LOG_FAIL_FMT("Target node redirected to {}", location->second);
+              LOG_INFO_FMT("Target node redirected to {}", location->second);
             }
             else
             {

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -489,7 +489,9 @@ namespace ccf
         config.joining.target_host,
         config.joining.target_port,
         [this](
-          http_status status, http::HeaderMap&&, std::vector<uint8_t>&& data) {
+          http_status status,
+          http::HeaderMap&& headers,
+          std::vector<uint8_t>&& data) {
           std::lock_guard<SpinLock> guard(lock);
           if (!sm.check(State::pending))
           {
@@ -498,13 +500,26 @@ namespace ccf
 
           if (status != HTTP_STATUS_OK)
           {
-            LOG_FAIL_FMT(
-              "An error occurred while joining the network: {} {}{}",
-              status,
-              http_status_str(status),
-              data.empty() ?
-                "" :
-                fmt::format("  '{}'", std::string(data.begin(), data.end())));
+            const auto& location = headers.find("location");
+            if (
+              status == HTTP_STATUS_PERMANENT_REDIRECT &&
+              location != headers.end())
+            {
+              const auto& url = http::parse_url_full(location->second);
+              config.joining.target_host = url.host;
+              config.joining.target_port = url.port;
+              LOG_FAIL_FMT("Target node redirected to {}", location->second);
+            }
+            else
+            {
+              LOG_FAIL_FMT(
+                "An error occurred while joining the network: {} {}{}",
+                status,
+                http_status_str(status),
+                data.empty() ?
+                  "" :
+                  fmt::format("  '{}'", std::string(data.begin(), data.end())));
+            }
             return false;
           }
 

--- a/src/node/rpc/error.h
+++ b/src/node/rpc/error.h
@@ -68,6 +68,7 @@ namespace ccf
     ERROR(UnknownCertificate)
     ERROR(VoteNotFound)
     ERROR(VoteAlreadyExists)
+    ERROR(NodeRetired)
 
     // node-to-node (/join and /create):
     ERROR(ConsensusTypeMismatch)

--- a/src/node/rpc/error.h
+++ b/src/node/rpc/error.h
@@ -68,7 +68,7 @@ namespace ccf
     ERROR(UnknownCertificate)
     ERROR(VoteNotFound)
     ERROR(VoteAlreadyExists)
-    ERROR(NodeRetired)
+    ERROR(NodeCannotHandleRequest)
 
     // node-to-node (/join and /create):
     ERROR(ConsensusTypeMismatch)

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -301,7 +301,7 @@ namespace ccf
               if (info)
               {
                 args.rpc_ctx->set_response_header(
-                  "Location",
+                  http::headers::LOCATION,
                   fmt::format(
                     "https://{}:{}/node/join", info->pubhost, info->pubport));
 
@@ -379,7 +379,7 @@ namespace ccf
               if (info)
               {
                 args.rpc_ctx->set_response_header(
-                  "Location",
+                  http::headers::LOCATION,
                   fmt::format(
                     "https://{}:{}/node/join", info->pubhost, info->pubport));
 
@@ -689,7 +689,7 @@ namespace ccf
         {
           args.rpc_ctx->set_response_status(HTTP_STATUS_PERMANENT_REDIRECT);
           args.rpc_ctx->set_response_header(
-            "Location",
+            http::headers::LOCATION,
             fmt::format(
               "https://{}:{}/node/network/nodes/{}",
               info->pubhost,
@@ -730,7 +730,7 @@ namespace ccf
           {
             args.rpc_ctx->set_response_status(HTTP_STATUS_PERMANENT_REDIRECT);
             args.rpc_ctx->set_response_header(
-              "Location",
+              http::headers::LOCATION,
               fmt::format(
                 "https://{}:{}/node/network/nodes/{}",
                 info->pubhost,
@@ -776,7 +776,7 @@ namespace ccf
             if (info)
             {
               args.rpc_ctx->set_response_header(
-                "Location",
+                http::headers::LOCATION,
                 fmt::format(
                   "https://{}:{}/node/primary", info->pubhost, info->pubport));
             }

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -307,8 +307,8 @@ namespace ccf
 
                 return make_error(
                   HTTP_STATUS_PERMANENT_REDIRECT,
-                  ccf::errors::NodeRetired,
-                  "Retired");
+                  ccf::errors::NodeCannotHandleRequest,
+                  "Node is not primary; cannot handle write");
               }
             }
 
@@ -385,8 +385,8 @@ namespace ccf
 
                 return make_error(
                   HTTP_STATUS_PERMANENT_REDIRECT,
-                  ccf::errors::NodeRetired,
-                  "Retired");
+                  ccf::errors::NodeCannotHandleRequest,
+                  "Node is not primary; cannot handle write");
               }
             }
 

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -289,29 +289,29 @@ namespace ccf
             return make_success(rep);
           }
 
-          if (!this->context.get_node_state().is_primary())
+          if (
+            consensus != nullptr && consensus->type() == ConsensusType::CFT &&
+            !this->context.get_node_state().is_primary())
           {
-            if (consensus != nullptr)
+            auto primary_id = consensus->primary();
+            if (primary_id.has_value())
             {
-              auto primary_id = consensus->primary();
-              if (primary_id.has_value())
+              auto nodes = args.tx.ro(this->network.nodes);
+              auto info = nodes->get(primary_id.value());
+              if (info)
               {
-                auto nodes = args.tx.ro(this->network.nodes);
-                auto info = nodes->get(primary_id.value());
-                if (info)
-                {
-                  args.rpc_ctx->set_response_header(
-                    "Location",
-                    fmt::format(
-                      "https://{}:{}/node/join", info->pubhost, info->pubport));
+                args.rpc_ctx->set_response_header(
+                  "Location",
+                  fmt::format(
+                    "https://{}:{}/node/join", info->pubhost, info->pubport));
 
-                  return make_error(
-                    HTTP_STATUS_PERMANENT_REDIRECT,
-                    ccf::errors::NodeRetired,
-                    "Retired");
-                }
+                return make_error(
+                  HTTP_STATUS_PERMANENT_REDIRECT,
+                  ccf::errors::NodeRetired,
+                  "Retired");
               }
             }
+
             return make_error(
               HTTP_STATUS_INTERNAL_SERVER_ERROR,
               ccf::errors::InternalError,
@@ -367,29 +367,29 @@ namespace ccf
         }
         else
         {
-          if (!this->context.get_node_state().is_primary())
+          if (
+            consensus != nullptr && consensus->type() == ConsensusType::CFT &&
+            !this->context.get_node_state().is_primary())
           {
-            if (consensus != nullptr)
+            auto primary_id = consensus->primary();
+            if (primary_id.has_value())
             {
-              auto primary_id = consensus->primary();
-              if (primary_id.has_value())
+              auto nodes = args.tx.ro(this->network.nodes);
+              auto info = nodes->get(primary_id.value());
+              if (info)
               {
-                auto nodes = args.tx.ro(this->network.nodes);
-                auto info = nodes->get(primary_id.value());
-                if (info)
-                {
-                  args.rpc_ctx->set_response_header(
-                    "Location",
-                    fmt::format(
-                      "https://{}:{}/node/join", info->pubhost, info->pubport));
+                args.rpc_ctx->set_response_header(
+                  "Location",
+                  fmt::format(
+                    "https://{}:{}/node/join", info->pubhost, info->pubport));
 
-                  return make_error(
-                    HTTP_STATUS_PERMANENT_REDIRECT,
-                    ccf::errors::NodeRetired,
-                    "Retired");
-                }
+                return make_error(
+                  HTTP_STATUS_PERMANENT_REDIRECT,
+                  ccf::errors::NodeRetired,
+                  "Retired");
               }
             }
+
             return make_error(
               HTTP_STATUS_INTERNAL_SERVER_ERROR,
               ccf::errors::InternalError,

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -275,6 +275,46 @@ def test_node_replacement(network, args):
     return network
 
 
+@reqs.description("Join straddling a primary retirement")
+@reqs.at_least_n_nodes(3)
+def test_join_straddling_primary_replacement(network, args):
+    # We need a fourth node before we attempt the replacement, otherwise
+    # we will reach a situation where two out four nodes in the voting quorum
+    # are unable to participate (one retired and one not yet joined).
+    test_add_node(network, args)
+    primary, _ = network.find_primary()
+    new_node = network.create_and_add_pending_node(
+        args.package, "local://localhost", args
+    )
+
+    proposal_body = {
+        "actions": [
+            {
+                "name": "transition_node_to_trusted",
+                "args": {"node_id": new_node.node_id},
+            },
+            {"name": "remove_node", "args": {"node_id": primary.node_id}},
+        ]
+    }
+
+    proposal = network.consortium.get_any_active_member().propose(
+        primary, proposal_body
+    )
+    network.consortium.vote_using_majority(
+        primary,
+        proposal,
+        {"ballot": "export function vote (proposal, proposer_id) { return true }"},
+        timeout=10,
+    )
+
+    network.wait_for_new_primary(primary)
+    new_node.wait_for_node_to_join(timeout=10)
+
+    primary.stop()
+    network.nodes.remove(primary)
+    return network
+
+
 def run(args):
     txs = app.LoggingTxs("user0")
     with infra.network.network(
@@ -287,6 +327,7 @@ def run(args):
     ) as network:
         network.start_and_join(args)
 
+        test_join_straddling_primary_replacement(network, args)
         test_version(network, args)
         test_node_replacement(network, args)
         test_add_node_from_backup(network, args)


### PR DESCRIPTION
Fix #2610 

This change modifies the join endpoint to:

1. Never forward, but...
2. Execute locally when possible (`add_node` when primary, return Trusted status and secrets when applicable regardless of consensus role)
3. Redirect to the new primary otherwise

This typically wouldn't have been a problem under the old governance, which did not allow multiple actions in the same proposal. It is one of (several) problems spotted by #2606.