### PR TITLE
Set joined status in the node

### DIFF
--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -262,7 +262,6 @@ class Network:
             except TimeoutError:
                 LOG.error(f"New node {node.node_id} failed to join the network")
                 raise
-            node.network_state = infra.node.NodeNetworkState.joined
 
     def _start_all_nodes(
         self,

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -316,6 +316,7 @@ class Node:
                 assert (
                     rep.status_code == 200
                 ), f"An error occured after node {self.local_node_id} joined the network: {rep.body}"
+                self.network_state = infra.node.NodeNetworkState.joined
         except ccf.clients.CCFConnectionException as e:
             raise TimeoutError(
                 f"Node {self.local_node_id} failed to join the network"


### PR DESCRIPTION
Small fix to the test infra, the status is set externally in network right now, which makes get_joined_nodes() somewhat unreliable.