### PR TITLE
Upgrade to OpenEnclave 0.16.1 (1.0.3)

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -7,7 +7,7 @@ trigger:
 
 jobs:
   - job: build_and_publish_docs
-    container: ccfciteam/ccf-ci:oe0.15.0
+    container: ccfciteam/ccf-ci:oe0.16.1
     pool:
       vmImage: ubuntu-18.04
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -27,12 +27,12 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfciteam/ccf-ci:oe0.15.0
-      options: --publish-all --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
+      image: ccfciteam/ccf-ci:oe0.16.1
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.15.0
-      options: --publish-all --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
+      image: ccfciteam/ccf-ci:oe0.16.1
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
 variables:
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/ccf-') }}:

--- a/.daily.yml
+++ b/.daily.yml
@@ -23,12 +23,12 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfciteam/ccf-ci:oe0.15.0
-      options: --publish-all --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache
+      image: ccfciteam/ccf-ci:oe0.16.1
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache
 
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.15.0
-      options: --publish-all --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
+      image: ccfciteam/ccf-ci:oe0.16.1
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:
   - template: .azure-pipelines-templates/daily-matrix.yml

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-18.04
-    container: ccfciteam/ccf-ci:oe0.15.0
+    container: ccfciteam/ccf-ci:oe0.16.1
 
     steps:
       - name: Checkout repository

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -16,8 +16,8 @@ pr:
 resources:
   containers:
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.15.0
-      options: --publish-all --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
+      image: ccfciteam/ccf-ci:oe0.16.1
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:
   - template: .azure-pipelines-templates/common.yml

--- a/.stress.yml
+++ b/.stress.yml
@@ -21,8 +21,8 @@ schedules:
 resources:
   containers:
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.15.0
-      options: --publish-all --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
+      image: ccfciteam/ccf-ci:oe0.16.1
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:
   - template: .azure-pipelines-templates/stress-matrix.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.3]
+
+### Dependency
+
+- Upgrade OpenEnclave from 0.15.0 to 0.16.1 (#2609)
+
 ## [1.0.2]
 
 ### Bugfix
@@ -864,6 +870,7 @@ Some discrepancies with the TR remain, and are being tracked under https://githu
 
 Initial pre-release
 
+[1.0.3]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.3
 [1.0.2]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.2
 [1.0.1]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.1
 [1.0.0]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.0

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -30,7 +30,7 @@ if((NOT ${IS_VALID_TARGET}))
 endif()
 
 # Find OpenEnclave package
-find_package(OpenEnclave 0.15 CONFIG REQUIRED)
+find_package(OpenEnclave 0.16.1 CONFIG REQUIRED)
 # As well as pulling in openenclave:: targets, this sets variables which can be
 # used for our edge cases (eg - for virtual libraries). These do not follow the
 # standard naming patterns, for example use OE_INCLUDEDIR rather than

--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -20,7 +20,7 @@ endif()
 
 # CPack variables for Debian packages
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-    "open-enclave (>=0.15.0), libuv1 (>= 1.18.0), libc++1-8, libc++abi1-8"
+    "open-enclave (>=0.16.1), libuv1 (>= 1.18.0), libc++1-8, libc++abi1-8"
 )
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 

--- a/getting_started/setup_vm/roles/openenclave/vars/common.yml
+++ b/getting_started/setup_vm/roles/openenclave/vars/common.yml
@@ -1,6 +1,6 @@
-oe_ver: "0.15.0"
+oe_ver: "0.16.1"
 # Usually the same, except for rc, where ver is -rc and ver_ is _rc
-oe_ver_: "0.15.0"
+oe_ver_: "0.16.1"
 
 # Source install
 workspace: "/tmp/"


### PR DESCRIPTION
Apply #2622 (issue #2609) to 1.x LTS.

Picking up some minor CI changes along the way that have no impact but will make merging easier in the future.