### PR TITLE
Pin TypeScript to a version TypeDoc supports

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -339,6 +339,7 @@ def config_inited(app, config):
         if app.config.smv_metadata_path:
             os.environ['SMV_METADATA_PATH'] = app.config.smv_metadata_path
             os.environ['SMV_CURRENT_VERSION'] = app.config.smv_current_version
+        subprocess.run(["sed", "s/\^4.2.3/4.2.4/g", "package.json"], cwd=js_pkg_dir, check=True)
         subprocess.run(["npm", "install", "--no-package-lock", "--no-audit", "--no-fund"],
                        cwd=js_pkg_dir, check=True)
         subprocess.run(["npm", "run", "docs", "--", "--out", str(js_docs_dir)],

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -339,7 +339,7 @@ def config_inited(app, config):
         if app.config.smv_metadata_path:
             os.environ['SMV_METADATA_PATH'] = app.config.smv_metadata_path
             os.environ['SMV_CURRENT_VERSION'] = app.config.smv_current_version
-        subprocess.run(["sed", "s/\^4.2.3/4.2.4/g", "package.json"], cwd=js_pkg_dir, check=True)
+        subprocess.run(["sed", "-i", "s/\^4.2.3/4.2.4/g", "package.json"], cwd=js_pkg_dir, check=True)
         subprocess.run(["npm", "install", "--no-package-lock", "--no-audit", "--no-fund"],
                        cwd=js_pkg_dir, check=True)
         subprocess.run(["npm", "run", "docs", "--", "--out", str(js_docs_dir)],

--- a/js/ccf-app/package.json
+++ b/js/ccf-app/package.json
@@ -30,6 +30,6 @@
     "serve": "^11.3.2",
     "ts-node": "^9.1.1",
     "typedoc": "^0.20.34",
-    "typescript": "^4.2.3"
+    "typescript": "4.2.4"
   }
 }

--- a/js/ccf-app/package.json
+++ b/js/ccf-app/package.json
@@ -30,6 +30,6 @@
     "serve": "^11.3.2",
     "ts-node": "^9.1.1",
     "typedoc": "^0.20.34",
-    "typescript": "4.2.4"
+    "typescript": "^4.2.3"
   }
 }


### PR DESCRIPTION
Doc build is hitting https://github.com/TypeStrong/typedoc/issues/1589: https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=26075&view=logs&j=f1fd332c-cd58-5ba4-fc7d-3c1d3a3f0cd3&t=31418c00-d4df-5619-e99a-3cbbc8fcc481

Pinning TypeScript until TypeDoc adds support for 4.3