### PR TITLE
Highlight entity IDs in Python output

### DIFF
--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -67,7 +67,7 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         highlighted_message = (
             entity_id_highlight(record["message"]).replace("{", "{{").replace("}", "}}")
         )
-        return "<green>{time:HH:mm:ss.SSS}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{highlighted_message}</level>\n{exception}".format(
+        return "<green>{time:HH:mm:ss.SSS}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{highlighted_message}</level>\n".format(
             **record, highlighted_message=highlighted_message
         )
 


### PR DESCRIPTION
From an idea discussed briefly with @achamayou. This finds all entity IDs (or any long-enough hex-string) in the Python logging, and gives it a colour based on the string so it can be easily spotted/distinguished in the output:

![image](https://user-images.githubusercontent.com/6000239/120321904-bf6ab580-c2db-11eb-844b-16f07ac5257f.png)

This is a broad approach, giving consistency (every instance of a proposal ID is highlighted) at perhaps the cost of readability (its not so easy to identify a URL when part of it is coloured). 

This also produces some hard-to-read colours - I think we could mitigate this by scaling to avoid too-bright/too-dark colours, or just choosing from a dict.

I've also just noticed that it appears to have lost all _other_ colour coding in our messages, so I'll fix that.