### PR TITLE
Add decoration around EntityID in node output

### DIFF
--- a/include/ccf/entity_id.h
+++ b/include/ccf/entity_id.h
@@ -136,7 +136,7 @@ namespace ccf
   {
     static std::string format(const std::string& core)
     {
-      return fmt::format("=[{}]=", core);
+      return fmt::format("m[{}]", core);
     }
   };
   using MemberId = EntityId<MemberIdFormatter>;
@@ -145,7 +145,7 @@ namespace ccf
   {
     static std::string format(const std::string& core)
     {
-      return fmt::format("-[{}]-", core);
+      return fmt::format("u[{}]", core);
     }
   };
   using UserId = EntityId<UserIdFormatter>;
@@ -154,7 +154,7 @@ namespace ccf
   {
     static std::string format(const std::string& core)
     {
-      return fmt::format("<[{}]>", core);
+      return fmt::format("n[{}]", core);
     }
   };
   using NodeId = EntityId<NodeIdFormatter>;

--- a/include/ccf/entity_id.h
+++ b/include/ccf/entity_id.h
@@ -133,7 +133,7 @@ namespace ccf
   {
     static std::string format(const std::string& core)
     {
-      return fmt::format("-[member:{}]-", core);
+      return fmt::format("=[{}]=", core);
     }
   };
   using MemberId = EntityId<MemberIdFormatter>;
@@ -142,7 +142,7 @@ namespace ccf
   {
     static std::string format(const std::string& core)
     {
-      return fmt::format("=[user:{}]=", core);
+      return fmt::format("-[{}]-", core);
     }
   };
   using UserId = EntityId<UserIdFormatter>;
@@ -151,7 +151,7 @@ namespace ccf
   {
     static std::string format(const std::string& core)
     {
-      return fmt::format("<[node:{}]>", core);
+      return fmt::format("<[{}]>", core);
     }
   };
   using NodeId = EntityId<NodeIdFormatter>;

--- a/include/ccf/entity_id.h
+++ b/include/ccf/entity_id.h
@@ -98,7 +98,8 @@ namespace ccf
   }
 
   template <typename FmtExtender>
-  inline void from_json(const nlohmann::json& j, EntityId<FmtExtender>& entity_id)
+  inline void from_json(
+    const nlohmann::json& j, EntityId<FmtExtender>& entity_id)
   {
     if (j.is_string())
     {
@@ -118,7 +119,8 @@ namespace ccf
   }
 
   template <typename FmtExtender>
-  inline void fill_json_schema(nlohmann::json& schema, const EntityId<FmtExtender>&)
+  inline void fill_json_schema(
+    nlohmann::json& schema, const EntityId<FmtExtender>&)
   {
     schema["type"] = "string";
 
@@ -126,7 +128,8 @@ namespace ccf
     // formats, even not those defined by the OpenAPI Specification"
     // https://swagger.io/docs/specification/data-models/data-types/#format
     schema["format"] = "hex";
-    schema["pattern"] = fmt::format("^[a-f0-9]{{{}}}$", EntityId<FmtExtender>::LENGTH);
+    schema["pattern"] =
+      fmt::format("^[a-f0-9]{{{}}}$", EntityId<FmtExtender>::LENGTH);
   }
 
   struct MemberIdFormatter

--- a/include/ccf/entity_id.h
+++ b/include/ccf/entity_id.h
@@ -9,6 +9,7 @@
 
 namespace ccf
 {
+  template <typename FmtExtender = void>
   struct EntityId
   {
   public:
@@ -90,12 +91,14 @@ namespace ccf
     }
   };
 
-  inline void to_json(nlohmann::json& j, const EntityId& entity_id)
+  template <typename FmtExtender>
+  inline void to_json(nlohmann::json& j, const EntityId<FmtExtender>& entity_id)
   {
     j = entity_id.value();
   }
 
-  inline void from_json(const nlohmann::json& j, EntityId& entity_id)
+  template <typename FmtExtender>
+  inline void from_json(const nlohmann::json& j, EntityId<FmtExtender>& entity_id)
   {
     if (j.is_string())
     {
@@ -108,12 +111,14 @@ namespace ccf
     }
   }
 
-  inline std::string schema_name(const EntityId&)
+  template <typename FmtExtender>
+  inline std::string schema_name(const EntityId<FmtExtender>&)
   {
     return "EntityId";
   }
 
-  inline void fill_json_schema(nlohmann::json& schema, const EntityId&)
+  template <typename FmtExtender>
+  inline void fill_json_schema(nlohmann::json& schema, const EntityId<FmtExtender>&)
   {
     schema["type"] = "string";
 
@@ -121,27 +126,58 @@ namespace ccf
     // formats, even not those defined by the OpenAPI Specification"
     // https://swagger.io/docs/specification/data-models/data-types/#format
     schema["format"] = "hex";
-    schema["pattern"] = fmt::format("^[a-f0-9]{{{}}}$", EntityId::LENGTH);
+    schema["pattern"] = fmt::format("^[a-f0-9]{{{}}}$", EntityId<FmtExtender>::LENGTH);
   }
 
-  using MemberId = EntityId;
-  using UserId = EntityId;
-  using NodeId = EntityId;
+  struct MemberIdFormatter
+  {
+    static std::string format(const std::string& core)
+    {
+      return fmt::format("-[member:{}]-", core);
+    }
+  };
+  using MemberId = EntityId<MemberIdFormatter>;
+
+  struct UserIdFormatter
+  {
+    static std::string format(const std::string& core)
+    {
+      return fmt::format("=[user:{}]=", core);
+    }
+  };
+  using UserId = EntityId<UserIdFormatter>;
+
+  struct NodeIdFormatter
+  {
+    static std::string format(const std::string& core)
+    {
+      return fmt::format("<[node:{}]>", core);
+    }
+  };
+  using NodeId = EntityId<NodeIdFormatter>;
 }
 
 namespace std
 {
+  template <typename FmtExtender>
   static inline std::ostream& operator<<(
-    std::ostream& os, const ccf::EntityId& entity_id)
+    std::ostream& os, const ccf::EntityId<FmtExtender>& entity_id)
   {
-    os << entity_id.value();
+    if constexpr (std::is_same_v<FmtExtender, void>)
+    {
+      os << entity_id.value();
+    }
+    else
+    {
+      os << FmtExtender::format(entity_id.value());
+    }
     return os;
   }
 
-  template <>
-  struct hash<ccf::EntityId>
+  template <typename FmtExtender>
+  struct hash<ccf::EntityId<FmtExtender>>
   {
-    size_t operator()(const ccf::EntityId& entity_id) const
+    size_t operator()(const ccf::EntityId<FmtExtender>& entity_id) const
     {
       return std::hash<std::string>{}(entity_id.value());
     }

--- a/src/apps/js_generic/js_generic.cpp
+++ b/src/apps/js_generic/js_generic.cpp
@@ -138,7 +138,7 @@ namespace ccfapp
       }
 
       char const* policy_name = nullptr;
-      EntityId id;
+      std::string id;
       bool is_member = false;
 
       if (

--- a/src/endpoints/base_endpoint_registry.cpp
+++ b/src/endpoints/base_endpoint_registry.cpp
@@ -253,7 +253,7 @@ namespace ccf
   {
     try
     {
-      auto member_certs = tx.ro<ccf::UserCerts>(Tables::MEMBER_CERTS);
+      auto member_certs = tx.ro<ccf::MemberCerts>(Tables::MEMBER_CERTS);
       auto mc = member_certs->get(member_id);
       if (!mc.has_value())
       {

--- a/src/node/blit.h
+++ b/src/node/blit.h
@@ -12,13 +12,15 @@ namespace kv::serialisers
   template <typename FmtExtender>
   struct BlitSerialiser<ccf::EntityId<FmtExtender>>
   {
-    static SerialisedEntry to_serialised(const ccf::EntityId<FmtExtender>& entity_id)
+    static SerialisedEntry to_serialised(
+      const ccf::EntityId<FmtExtender>& entity_id)
     {
       const auto& data = entity_id.value();
       return SerialisedEntry(data.begin(), data.end());
     }
 
-    static ccf::EntityId<FmtExtender> from_serialised(const SerialisedEntry& data)
+    static ccf::EntityId<FmtExtender> from_serialised(
+      const SerialisedEntry& data)
     {
       return ccf::EntityId<FmtExtender>(std::string(data.begin(), data.end()));
     }

--- a/src/node/blit.h
+++ b/src/node/blit.h
@@ -9,18 +9,18 @@
 
 namespace kv::serialisers
 {
-  template <>
-  struct BlitSerialiser<ccf::EntityId>
+  template <typename FmtExtender>
+  struct BlitSerialiser<ccf::EntityId<FmtExtender>>
   {
-    static SerialisedEntry to_serialised(const ccf::EntityId& entity_id)
+    static SerialisedEntry to_serialised(const ccf::EntityId<FmtExtender>& entity_id)
     {
       const auto& data = entity_id.value();
       return SerialisedEntry(data.begin(), data.end());
     }
 
-    static ccf::EntityId from_serialised(const SerialisedEntry& data)
+    static ccf::EntityId<FmtExtender> from_serialised(const SerialisedEntry& data)
     {
-      return ccf::EntityId(std::string(data.begin(), data.end()));
+      return ccf::EntityId<FmtExtender>(std::string(data.begin(), data.end()));
     }
   };
 

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -298,7 +298,7 @@ class RpcContextRecorder
 public:
   // session->caller_cert may be DER or PEM, we always convert to PEM
   crypto::Pem last_caller_cert;
-  std::optional<EntityId> last_caller_id = std::nullopt;
+  std::optional<std::string> last_caller_id = std::nullopt;
 
   void record_ctx(ccf::endpoints::EndpointContext& ctx)
   {
@@ -1400,7 +1400,7 @@ TEST_CASE("Userfrontend forwarding" * doctest::test_suite("forwarding"))
   CHECK(response.status == HTTP_STATUS_OK);
 
   CHECK(user_frontend_primary.last_caller_cert == user_caller);
-  CHECK(user_frontend_primary.last_caller_id.value() == user_id);
+  CHECK(user_frontend_primary.last_caller_id.value() == user_id.value());
 }
 
 TEST_CASE("Memberfrontend forwarding" * doctest::test_suite("forwarding"))
@@ -1446,7 +1446,7 @@ TEST_CASE("Memberfrontend forwarding" * doctest::test_suite("forwarding"))
   CHECK(response.status == HTTP_STATUS_OK);
 
   CHECK(member_frontend_primary.last_caller_cert == member_caller);
-  CHECK(member_frontend_primary.last_caller_id.value() == member_id);
+  CHECK(member_frontend_primary.last_caller_id.value() == member_id.value());
 }
 
 class TestConflictFrontend : public BaseTestFrontend


### PR DESCRIPTION
`EntityID`s are currently printed as long hex strings, and it can be hard to identify them in the output and hard to distinguish what domain they're in. This adds decoration to make grepping and domain-distinction easier.

So rather than a line in the node output saying:

```
012345 has voted to add 123456 on 234567
```

we'd see

```
=[012345]= has voted to add -[123456]- on <[234567]>
```

and (hopefully) learn to quickly recognise `=[members]=`, `-[users]-` and (most commonly) `<[nodes]>`.

This distinction relies on the strong typing of (now-distinct) `EntityID`s, so it won't work in places that see these IDs as raw strings (ie - in JS, or for ProposalIDs, or in places where we deliberately support any kind of `EntityID`).