### PR TITLE
Remove unnecessary `SpinLock` typedef

### DIFF
--- a/include/ccf/endpoint_registry.h
+++ b/include/ccf/endpoint_registry.h
@@ -161,7 +161,7 @@ namespace ccf::endpoints
       std::map<RESTVerb, std::shared_ptr<PathTemplatedEndpoint>>>
       templated_endpoints;
 
-    SpinLock metrics_lock;
+    std::mutex metrics_lock;
     std::map<std::string, std::map<std::string, Metrics>> metrics;
 
     EndpointRegistry::Metrics& get_metrics_for_endpoint(

--- a/src/consensus/aft/impl/state.h
+++ b/src/consensus/aft/impl/state.h
@@ -6,7 +6,6 @@
 #include "crypto/key_pair.h"
 #include "crypto/verifier.h"
 #include "ds/logger.h"
-#include "ds/spin_lock.h"
 #include "kv/kv_types.h"
 #include "node/rpc/tx_status.h"
 
@@ -103,7 +102,7 @@ namespace aft
       new_view_idx(0)
     {}
 
-    SpinLock lock;
+    std::mutex lock;
     std::map<ccf::NodeId, std::shared_ptr<Replica>> configuration;
 
     ccf::NodeId my_node_id;

--- a/src/ds/messaging.h
+++ b/src/ds/messaging.h
@@ -4,7 +4,6 @@
 
 #include "logger.h"
 #include "ring_buffer.h"
-#include "spin_lock.h"
 
 #include <atomic>
 #include <condition_variable>

--- a/src/ds/spin_lock.h
+++ b/src/ds/spin_lock.h
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the Apache 2.0 License.
-#pragma once
-
-#include <mutex>
-using SpinLock = std::mutex;

--- a/src/endpoints/common_endpoint_registry.cpp
+++ b/src/endpoints/common_endpoint_registry.cpp
@@ -197,7 +197,7 @@ namespace ccf
       .install();
 
     auto endpoint_metrics_fn = [this](auto&, nlohmann::json&&) {
-      std::lock_guard<SpinLock> guard(metrics_lock);
+      std::lock_guard<std::mutex> guard(metrics_lock);
       EndpointMetrics::Out out;
       for (const auto& [path, verb_metrics] : metrics)
       {

--- a/src/endpoints/endpoint_registry.cpp
+++ b/src/endpoints/endpoint_registry.cpp
@@ -353,28 +353,28 @@ namespace ccf::endpoints
 
   void EndpointRegistry::increment_metrics_calls(const EndpointDefinitionPtr& e)
   {
-    std::lock_guard<SpinLock> guard(metrics_lock);
+    std::lock_guard<std::mutex> guard(metrics_lock);
     get_metrics_for_endpoint(e).calls++;
   }
 
   void EndpointRegistry::increment_metrics_errors(
     const EndpointDefinitionPtr& e)
   {
-    std::lock_guard<SpinLock> guard(metrics_lock);
+    std::lock_guard<std::mutex> guard(metrics_lock);
     get_metrics_for_endpoint(e).errors++;
   }
 
   void EndpointRegistry::increment_metrics_failures(
     const EndpointDefinitionPtr& e)
   {
-    std::lock_guard<SpinLock> guard(metrics_lock);
+    std::lock_guard<std::mutex> guard(metrics_lock);
     get_metrics_for_endpoint(e).failures++;
   }
 
   void EndpointRegistry::increment_metrics_retries(
     const EndpointDefinitionPtr& e)
   {
-    std::lock_guard<SpinLock> guard(metrics_lock);
+    std::lock_guard<std::mutex> guard(metrics_lock);
     get_metrics_for_endpoint(e).retries++;
   }
 }

--- a/src/http/authentication/sig_auth.h
+++ b/src/http/authentication/sig_auth.h
@@ -35,7 +35,7 @@ namespace ccf
   {
     static constexpr size_t DEFAULT_MAX_VERIFIERS = 50;
 
-    SpinLock verifiers_lock;
+    std::mutex verifiers_lock;
     LRU<crypto::Pem, crypto::VerifierPtr> verifiers;
 
     VerifierCache(size_t max_verifiers = DEFAULT_MAX_VERIFIERS) :
@@ -44,7 +44,7 @@ namespace ccf
 
     crypto::VerifierPtr get_verifier(const crypto::Pem& pem)
     {
-      std::lock_guard<SpinLock> guard(verifiers_lock);
+      std::lock_guard<std::mutex> guard(verifiers_lock);
 
       crypto::VerifierPtr verifier = nullptr;
 

--- a/src/kv/untyped_map.h
+++ b/src/kv/untyped_map.h
@@ -4,7 +4,6 @@
 
 #include "ds/dl_list.h"
 #include "ds/logger.h"
-#include "ds/spin_lock.h"
 #include "kv/kv_serialiser.h"
 #include "kv/kv_types.h"
 #include "kv/untyped_map_handle.h"
@@ -81,7 +80,7 @@ namespace kv::untyped
     CommitHook global_hook = nullptr;
     MapHook hook = nullptr;
     std::list<std::pair<Version, Write>> commit_deltas;
-    SpinLock sl;
+    std::mutex sl;
     const SecurityDomain security_domain;
     const bool replicated;
     const bool include_conflict_read_version;

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -503,7 +503,7 @@ namespace ccf
     size_t sig_tx_interval;
     size_t sig_ms_interval;
 
-    SpinLock state_lock;
+    std::mutex state_lock;
     kv::Term term = 0;
 
   public:
@@ -538,7 +538,7 @@ namespace ccf
         [](std::unique_ptr<threading::Tmsg<EmitSigMsg>> msg) {
           auto self = msg->data.self;
 
-          std::unique_lock<SpinLock> mguard(
+          std::unique_lock<std::mutex> mguard(
             self->signature_lock, std::defer_lock);
 
           const int64_t sig_ms_interval = self->sig_ms_interval;
@@ -606,7 +606,7 @@ namespace ccf
     bool init_from_snapshot(
       const std::vector<uint8_t>& hash_at_snapshot) override
     {
-      std::lock_guard<SpinLock> guard(state_lock);
+      std::lock_guard<std::mutex> guard(state_lock);
       // The history can be initialised after a snapshot has been applied by
       // deserialising the tree in the signatures table and then applying the
       // hash of the transaction at which the snapshot was taken
@@ -635,14 +635,14 @@ namespace ccf
 
     crypto::Sha256Hash get_replicated_state_root() override
     {
-      std::lock_guard<SpinLock> guard(state_lock);
+      std::lock_guard<std::mutex> guard(state_lock);
       return replicated_state_tree.get_root();
     }
 
     std::pair<kv::TxID, crypto::Sha256Hash> get_replicated_state_txid_and_root()
       override
     {
-      std::lock_guard<SpinLock> guard(state_lock);
+      std::lock_guard<std::mutex> guard(state_lock);
       return {
         {term, static_cast<kv::Version>(replicated_state_tree.end_index())},
         replicated_state_tree.get_root()};
@@ -723,19 +723,19 @@ namespace ccf
 
     std::vector<uint8_t> serialise_tree(size_t from, size_t to) override
     {
-      std::lock_guard<SpinLock> guard(state_lock);
+      std::lock_guard<std::mutex> guard(state_lock);
       return replicated_state_tree.serialise(from, to);
     }
 
     void set_term(kv::Term t) override
     {
-      std::lock_guard<SpinLock> guard(state_lock);
+      std::lock_guard<std::mutex> guard(state_lock);
       term = t;
     }
 
     void rollback(kv::Version v, kv::Term t) override
     {
-      std::lock_guard<SpinLock> guard(state_lock);
+      std::lock_guard<std::mutex> guard(state_lock);
       term = t;
       replicated_state_tree.retract(v);
       log_hash(replicated_state_tree.get_root(), ROLLBACK);
@@ -743,7 +743,7 @@ namespace ccf
 
     void compact(kv::Version v) override
     {
-      std::lock_guard<SpinLock> guard(state_lock);
+      std::lock_guard<std::mutex> guard(state_lock);
       // Receipts can only be retrieved to the flushed index. Keep a range of
       // history so that a range of receipts are available.
       if (v > MAX_HISTORY_LEN)
@@ -757,11 +757,11 @@ namespace ccf
     std::chrono::milliseconds time_of_last_signature =
       std::chrono::milliseconds(0);
 
-    SpinLock signature_lock;
+    std::mutex signature_lock;
 
     void try_emit_signature() override
     {
-      std::unique_lock<SpinLock> mguard(signature_lock, std::defer_lock);
+      std::unique_lock<std::mutex> mguard(signature_lock, std::defer_lock);
       if (store.commit_gap() < sig_tx_interval || !mguard.try_lock())
       {
         return;
@@ -815,20 +815,20 @@ namespace ccf
 
     std::vector<uint8_t> get_proof(kv::Version index) override
     {
-      std::lock_guard<SpinLock> guard(state_lock);
+      std::lock_guard<std::mutex> guard(state_lock);
       return replicated_state_tree.get_proof(index).to_v();
     }
 
     bool verify_proof(const std::vector<uint8_t>& v) override
     {
-      std::lock_guard<SpinLock> guard(state_lock);
+      std::lock_guard<std::mutex> guard(state_lock);
       Proof proof(v);
       return replicated_state_tree.verify(proof);
     }
 
     std::vector<uint8_t> get_raw_leaf(uint64_t index) override
     {
-      std::lock_guard<SpinLock> guard(state_lock);
+      std::lock_guard<std::mutex> guard(state_lock);
       auto leaf = replicated_state_tree.get_leaf(index);
       return {leaf.h.begin(), leaf.h.end()};
     }
@@ -852,7 +852,7 @@ namespace ccf
 
     void append(const std::vector<uint8_t>& data) override
     {
-      std::lock_guard<SpinLock> guard(state_lock);
+      std::lock_guard<std::mutex> guard(state_lock);
       crypto::Sha256Hash rh({data.data(), data.size()});
       log_hash(rh, APPEND);
       replicated_state_tree.append(rh);

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -117,7 +117,7 @@ namespace ccf
     // this node's core state
     //
     StateMachine<State> sm;
-    SpinLock lock;
+    std::mutex lock;
 
     CurveID curve_id;
     crypto::KeyPairPtr node_sign_kp;
@@ -329,7 +329,7 @@ namespace ccf
       size_t sig_tx_interval_,
       size_t sig_ms_interval_)
     {
-      std::lock_guard<SpinLock> guard(lock);
+      std::lock_guard<std::mutex> guard(lock);
       sm.expect(State::uninitialized);
 
       consensus_config = consensus_config_;
@@ -346,7 +346,7 @@ namespace ccf
     //
     NodeCreateInfo create(StartType start_type, CCFConfig&& config_)
     {
-      std::lock_guard<SpinLock> guard(lock);
+      std::lock_guard<std::mutex> guard(lock);
       sm.expect(State::initialized);
 
       config = std::move(config_);
@@ -492,7 +492,7 @@ namespace ccf
           http_status status,
           http::HeaderMap&& headers,
           std::vector<uint8_t>&& data) {
-          std::lock_guard<SpinLock> guard(lock);
+          std::lock_guard<std::mutex> guard(lock);
           if (!sm.check(State::pending))
           {
             return false;
@@ -725,7 +725,7 @@ namespace ccf
 
     void join()
     {
-      std::lock_guard<SpinLock> guard(lock);
+      std::lock_guard<std::mutex> guard(lock);
       sm.expect(State::pending);
       start_join_timer();
     }
@@ -762,7 +762,7 @@ namespace ccf
     //
     void start_ledger_recovery()
     {
-      std::lock_guard<SpinLock> guard(lock);
+      std::lock_guard<std::mutex> guard(lock);
       if (
         !sm.check(State::readingPublicLedger) &&
         !sm.check(State::verifyingSnapshot))
@@ -779,7 +779,7 @@ namespace ccf
 
     void recover_public_ledger_entry(const std::vector<uint8_t>& ledger_entry)
     {
-      std::lock_guard<SpinLock> guard(lock);
+      std::lock_guard<std::mutex> guard(lock);
 
       std::shared_ptr<kv::Store> store;
       if (sm.check(State::readingPublicLedger))
@@ -901,7 +901,7 @@ namespace ccf
 
     void verify_snapshot_end()
     {
-      std::lock_guard<SpinLock> guard(lock);
+      std::lock_guard<std::mutex> guard(lock);
       if (!sm.check(State::verifyingSnapshot))
       {
         LOG_FAIL_FMT(
@@ -1048,7 +1048,7 @@ namespace ccf
     //
     void recover_private_ledger_entry(const std::vector<uint8_t>& ledger_entry)
     {
-      std::lock_guard<SpinLock> guard(lock);
+      std::lock_guard<std::mutex> guard(lock);
       if (!sm.check(State::readingPrivateLedger))
       {
         LOG_FAIL_FMT(
@@ -1189,7 +1189,7 @@ namespace ccf
     //
     void recover_ledger_end()
     {
-      std::lock_guard<SpinLock> guard(lock);
+      std::lock_guard<std::mutex> guard(lock);
 
       if (is_reading_public_ledger())
       {
@@ -1274,7 +1274,7 @@ namespace ccf
 
     void transition_service_to_open(kv::Tx& tx) override
     {
-      std::lock_guard<SpinLock> guard(lock);
+      std::lock_guard<std::mutex> guard(lock);
 
       auto service = tx.rw<Service>(Tables::SERVICE);
       auto service_info = service->get();
@@ -1334,7 +1334,7 @@ namespace ccf
 
     void initiate_private_recovery(kv::Tx& tx) override
     {
-      std::lock_guard<SpinLock> guard(lock);
+      std::lock_guard<std::mutex> guard(lock);
       sm.expect(State::partOfPublicNetwork);
 
       auto restored_ledger_secrets = share_manager.restore_recovery_shares_info(
@@ -1469,7 +1469,7 @@ namespace ccf
 
     ExtendedState state() override
     {
-      std::lock_guard<SpinLock> guard(lock);
+      std::lock_guard<std::mutex> guard(lock);
       State s = sm.value();
       if (s == State::readingPrivateLedger)
       {
@@ -1483,7 +1483,7 @@ namespace ccf
 
     bool rekey_ledger(kv::Tx& tx) override
     {
-      std::lock_guard<SpinLock> guard(lock);
+      std::lock_guard<std::mutex> guard(lock);
       sm.expect(State::partOfNetwork);
 
       // The ledger should not be re-keyed when the service is not open because:
@@ -1517,7 +1517,7 @@ namespace ccf
 
     std::optional<kv::Version> get_startup_snapshot_seqno() override
     {
-      std::lock_guard<SpinLock> guard(lock);
+      std::lock_guard<std::mutex> guard(lock);
       return startup_seqno;
     }
 
@@ -1827,7 +1827,7 @@ namespace ccf
       // from. If the primary changes while the network is public-only, the
       // new primary should also know at which version the new ledger secret
       // is applicable from.
-      std::lock_guard<SpinLock> guard(lock);
+      std::lock_guard<std::mutex> guard(lock);
       return last_recovered_signed_idx;
     }
 

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -6,7 +6,6 @@
 #include "consensus/aft/request.h"
 #include "crypto/verifier.h"
 #include "ds/buffer.h"
-#include "ds/spin_lock.h"
 #include "enclave/rpc_handler.h"
 #include "forwarder.h"
 #include "http/http_jwt.h"
@@ -32,7 +31,7 @@ namespace ccf
     endpoints::EndpointRegistry& endpoints;
 
   private:
-    SpinLock open_lock;
+    std::mutex open_lock;
     bool is_open_ = false;
 
     kv::Consensus* consensus;
@@ -447,7 +446,7 @@ namespace ccf
 
     void open(std::optional<crypto::Pem*> identity = std::nullopt) override
     {
-      std::lock_guard<SpinLock> mguard(open_lock);
+      std::lock_guard<std::mutex> mguard(open_lock);
       // open() without an identity unconditionally opens the frontend.
       // If an identity is passed, the frontend must instead wait for
       // the KV to read that this is identity is present and open,
@@ -468,7 +467,7 @@ namespace ccf
 
     bool is_open(kv::Tx& tx) override
     {
-      std::lock_guard<SpinLock> mguard(open_lock);
+      std::lock_guard<std::mutex> mguard(open_lock);
       if (!is_open_)
       {
         auto service = tx.ro<Service>(Tables::SERVICE);


### PR DESCRIPTION
We no longer have multiple implementations of `SpinLock`, its always a `std::mutex`, so remove the obfuscating typedef.