### PR TITLE
BFT rotation tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -849,7 +849,9 @@ if(BUILD_TESTS)
     )
 
     if(LONG_TESTS)
-      set(ROTATION_TEST_ARGS --rotation-retirements 10)
+      set(ROTATION_TEST_ARGS --rotation-retirements 10 --rotation-suspensions
+                             10
+      )
     endif()
 
     add_e2e_test(

--- a/tests/rotation.py
+++ b/tests/rotation.py
@@ -57,8 +57,7 @@ def run(args):
             reconfiguration.test_add_node(network, args)
             # Suspend primary repeatedly and check the network still operates
             LOG.info(f"Suspending primary {args.rotation_suspensions} times")
-            # for i in range(args.rotation_suspensions):
-            for i in range(10):
+            for i in range(args.rotation_suspensions):
                 LOG.warning(f"Suspension {i}")
                 test_suspend_primary(network, args)
 

--- a/tests/rotation.py
+++ b/tests/rotation.py
@@ -3,9 +3,40 @@
 import infra.e2e_args
 import infra.network
 import infra.proc
+import suite.test_requirements as reqs
 import reconfiguration
+import time
+from infra.checker import check_can_progress
+from ccf.clients import CCFConnectionException
 
 from loguru import logger as LOG
+
+
+@reqs.description("Suspend and resume primary")
+@reqs.can_kill_n_nodes(1)
+def test_suspend_primary(network, args):
+    primary, backup = network.find_primary_and_any_backup()
+    primary.suspend()
+    if args.consensus == "bft":
+        try:
+            for _ in range(3):
+                with backup.client("user0") as c:
+                    _ = c.post(
+                        "/app/log/private",
+                        {
+                            "id": -1,
+                            "msg": "This is submitted to force a view change",
+                        },
+                    )
+                time.sleep(5)
+                backup = network.find_any_backup()
+        except CCFConnectionException:
+            LOG.warning(f"Could not successfully connect to node {backup.node_id}.")
+    new_primary, _ = network.wait_for_new_primary(primary)
+    check_can_progress(new_primary)
+    primary.resume()
+    check_can_progress(new_primary)
+    return network
 
 
 def run(args):
@@ -22,6 +53,15 @@ def run(args):
                 reconfiguration.test_add_node(network, args)
                 reconfiguration.test_retire_primary(network, args)
 
+        if args.consensus == "bft":
+            reconfiguration.test_add_node(network, args)
+            # Suspend primary repeatedly and check the network still operates
+            LOG.info(f"Suspending primary {args.rotation_suspensions} times")
+            # for i in range(args.rotation_suspensions):
+            for i in range(10):
+                LOG.warning(f"Suspension {i}")
+                test_suspend_primary(network, args)
+
 
 if __name__ == "__main__":
 
@@ -29,6 +69,12 @@ if __name__ == "__main__":
         parser.add_argument(
             "--rotation-retirements",
             help="Number of times to retired the primary",
+            type=int,
+            default=3,
+        )
+        parser.add_argument(
+            "--rotation-suspensions",
+            help="Number of times to suspend the primary",
             type=int,
             default=3,
         )


### PR DESCRIPTION
BFT still relies on the rotation tests and has not been ported to suspension-based rotation tests. So this change in-part undoes https://github.com/microsoft/CCF/pull/2650 