### PR TITLE
Fix mermaid diagram whitespace (again)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -239,10 +239,7 @@ js_source_path = "../src/js"
 jsdoc_config_path = "../src/js/tsconfig.json"
 
 # sphinxcontrib-mermaid options
-# NB: The docs say the <script> tag will no longer be needed
-# from 0.7, but this is not yet released
-mermaid_init_js = """<script>
-mermaid.initialize({startOnLoad:true});
+mermaid_init_js = """mermaid.initialize({startOnLoad:true});
 
 // Remove height from all mermaid diagrams
 window.addEventListener(
@@ -256,8 +253,7 @@ window.addEventListener(
     }
   },
   false
-);
-</script>"""
+);"""
 
 def typedoc_role(name: str, rawtext: str, text: str, lineno, inliner, options={}, content=[]):
     """


### PR DESCRIPTION
As noticed by @jumaffre, my hack to strip the `height` attribute (removing excess whitespace from our mermaid diagrams) was no longer working. Turns out this doesn't work since `sphinxcontrib-mermaid 0.7` (released [15 days ago](https://github.com/mgaitan/sphinxcontrib-mermaid/releases/tag/0.7)), as suggested in the comment. Removing the `<script>` tags fixes this.