### PR TITLE
Python ledger tweaks

### DIFF
--- a/doc/audit/python_library.rst
+++ b/doc/audit/python_library.rst
@@ -88,7 +88,7 @@ Alternatively, ``read_ledger.py`` can parse the content of a snapshot file:
 
 .. note::
 
-    The output of the ``read_ledger.py`` utility can be filtered by key-value store :ref:`table <build_apps/kv/kv_how_to/Creating a Map>` using the ``--tables <regex>`` arguments, e.g.:
+    The output of the ``read_ledger.py`` utility can be filtered by :ref:`key-value store table <build_apps/kv/kv_how_to:Creating a Map>` using the ``--tables <regex>`` arguments, e.g.:
 
     .. code-block:: bash
 

--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -643,7 +643,6 @@ class Ledger:
         self._fileindex = -1
         # Initialize LedgerValidator instance which will be passed to LedgerChunks.
         self._ledger_validator = LedgerValidator()
-        self._is_parsed = False
 
     @classmethod
     def _range_from_filename(cls, filename: str) -> Tuple[int, Optional[int]]:

--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -766,7 +766,7 @@ class Ledger:
 
         return public_tables, latest_seqno
 
-    def signature_count(self):
+    def signature_count(self) -> int:
         """
         Return the number of verified signature transactions in the *parsed* ledger.
 

--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -776,7 +776,7 @@ class Ledger:
         """
         return self._ledger_validator.signature_count
 
-    def last_verified_txid(self):
+    def last_verified_txid(self) -> TxID:
         """
         Return the :py:class:`ccf.tx_id.TxID` of the last verified signature transaction in the *parsed* ledger.
 

--- a/python/ccf/read_ledger.py
+++ b/python/ccf/read_ledger.py
@@ -118,13 +118,18 @@ if __name__ == "__main__":
         LOG.info(f"Reading ledger from {ledger_dirs}")
         LOG.info(f"Contains {counted_string(ledger, 'chunk')}")
 
-        for chunk in ledger:
+        try:
+            for chunk in ledger:
+                LOG.info(
+                    f"chunk {chunk.filename()} ({'' if chunk.is_committed() else 'un'}committed)"
+                )
+                for transaction in chunk:
+                    dump_entry(transaction, table_filter)
+        except Exception as e:
+            LOG.error(f"Error parsing ledger: {e}")
+        else:
+            LOG.success("Ledger verification complete")
+        finally:
             LOG.info(
-                f"chunk {chunk.filename()} ({'' if chunk.is_committed() else 'un'}committed)"
+                f"Found {ledger.signature_count()} signatures, and verified until {ledger.last_verified_txid()}"
             )
-            for transaction in chunk:
-                dump_entry(transaction, table_filter)
-
-        LOG.success(
-            f"Ledger verification complete. Found {ledger.signature_count()} signatures, and verified until {ledger.last_verified_txid()}"
-        )

--- a/python/ccf/read_ledger.py
+++ b/python/ccf/read_ledger.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
                 for transaction in chunk:
                     dump_entry(transaction, table_filter)
         except Exception as e:
-            LOG.error(f"Error parsing ledger: {e}")
+            LOG.exception(f"Error parsing ledger: {e}")
         else:
             LOG.success("Ledger verification complete")
         finally:


### PR DESCRIPTION
As discussed with @msftsettiy:
- Added docstrings for the `signature_count` and `last_verified_txid` functions
- Make `read_ledger.py` resilient to corrupted ledger files (the latest verified signature will still be displayed if any ledger file is corrupted)