### PR TITLE
Use LTS version of JS constitution

### DIFF
--- a/tests/infra/github.py
+++ b/tests/infra/github.py
@@ -45,9 +45,14 @@ def is_main_branch(branch_name):
     return branch_name == MAIN_BRANCH_NAME
 
 
+def strip_branch_name_suffix(branch_name):
+    return branch_name.split("_")[0]
+
+
 def strip_release_branch_name(branch_name):
     assert is_release_branch(branch_name), branch_name
-    return branch_name[len(BRANCH_RELEASE_PREFIX) :]
+    # Also discard "_suffix" if there is one
+    return strip_branch_name_suffix(branch_name[len(BRANCH_RELEASE_PREFIX) :])
 
 
 def get_major_version_from_release_branch_name(full_branch_name):
@@ -96,7 +101,7 @@ class Repository:
     def get_next_release_branch(self, release_branch_name):
         release_branches = self.get_release_branches_names()
         assert (
-            release_branch_name in release_branches
+            strip_branch_name_suffix(release_branch_name) in release_branches
         ), f"{release_branch_name} branch is not a valid release branch"
         after_index = release_branches.index(release_branch_name) + 1
         if after_index >= len(release_branches):

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -710,7 +710,7 @@ class CCFRemote(object):
             for fragment in constitution:
                 cmd.append(f"--constitution={os.path.basename(fragment)}")
                 data_files += [
-                    os.path.join(os.path.basename(self.common_dir), fragment)
+                    os.path.join(self.common_dir, os.path.basename(fragment))
                 ]
             if members_info is None:
                 raise ValueError(

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -48,6 +48,38 @@ def get_bin_and_lib_dirs_for_install_path(install_path):
     )
 
 
+def set_js_args(args, from_install_path):
+    # Use from_version's app and constitution as new JS features may not be available
+    # on older versions
+    js_app_directory = (
+        "../samples/apps/logging/js"
+        if from_install_path == LOCAL_CHECKOUT_DIRECTORY
+        else "samples/logging/js"
+    )
+    args.js_app_bundle = os.path.join(from_install_path, js_app_directory)
+
+    constitution_directory = os.path.join(
+        from_install_path,
+        "../src/runtime_config/default"
+        if from_install_path == LOCAL_CHECKOUT_DIRECTORY
+        else "bin",
+    )
+
+    def replace_constitution_fragment(args, fragment_name):
+        args.constitution[:] = [
+            os.path.join(constitution_directory, fragment_name)
+            if fragment_name in f
+            else f
+            for f in args.constitution
+        ]
+
+    # Note: Use resolve.js script from local checkout as only the trivial sandbox
+    # version is included in installation
+    replace_constitution_fragment(args, "actions.js")
+    replace_constitution_fragment(args, "apply.js")
+    replace_constitution_fragment(args, "validate.js")
+
+
 def run_code_upgrade_from(
     args,
     from_install_path,
@@ -62,13 +94,7 @@ def run_code_upgrade_from(
         to_install_path
     )
 
-    js_app_directory = (
-        "../samples/apps/logging/js"
-        if from_install_path == LOCAL_CHECKOUT_DIRECTORY
-        else "samples/logging/js"
-    )
-
-    args.js_app_bundle = os.path.join(from_install_path, js_app_directory)
+    set_js_args(args, from_install_path)
 
     jwt_issuer = infra.jwt_issuer.JwtIssuer("https://localhost")
     with jwt_issuer.start_openid_server():
@@ -252,9 +278,7 @@ def run_ledger_compatibility_since_first(args, use_snapshot):
                     lts_install_path
                 )
                 major_version = Version(version).release[0]
-                args.js_app_bundle = os.path.join(
-                    lts_install_path, "samples/logging/js"
-                )
+                set_js_args(args, lts_install_path)
             else:
                 version = args.ccf_version
                 binary_dir = LOCAL_CHECKOUT_DIRECTORY


### PR DESCRIPTION
As pointed in https://github.com/microsoft/CCF/pull/2643#issuecomment-859715259, we now use the constitution JS scripts from the LTS rather than from our local checkout, so that we don't break the test by adding new features to the constitution (e.g. addition of JS KV map's `clear()` function). 