### PR TITLE
Avoid deadlocked channel state after interrupted key exchange

### DIFF
--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -542,10 +542,6 @@ namespace ccf
         if (!priority)
           return true;
       }
-      else if (status == WAITING_FOR_FINAL)
-      {
-        return false;
-      }
 
       key_exchange_in_progress = true;
 
@@ -706,9 +702,6 @@ namespace ccf
 
     void initiate()
     {
-      if (status == WAITING_FOR_FINAL)
-        return;
-
       LOG_INFO_FMT("Initiating node channel with {}.", peer_id);
 
       key_exchange_in_progress = true;


### PR DESCRIPTION
This resolves #2864.

The meaningful changes here are 2 removals in `channels.h`: handle channel initiation (on either side) as a restart when we were in state `WAITING_FOR_FINAL`.

I've added a unit test for this which tries dropping each of the key exchange messages, and tries to initiate a fresh key exchange and transmit messages after that. It fails without the `channels.h` changes, and passes with them.

I have an inkling that there's something else a little funky here. When we're re-establishing a new key exchange on a previously-successful channel, we remain in state `ESTABLISHED` and take some other early-out paths. I think this means we can get into a similar position if later messages are dropped (ie, if we `send` during a key re-establishment, what key is used on each end?). I'd like to add another unit test which exercises this, but don't think it needs to be bundled with this PR.