### PR TITLE
Add quickjs/cutils.c to UBSAN blacklist

### DIFF
--- a/src/ubsan.blacklist
+++ b/src/ubsan.blacklist
@@ -8,5 +8,6 @@ src:*/3rdparty/test/msgpack/v2/create_object_visitor.hpp
 src:*/3rdparty/internal/sss/hazmat.c
 src:*/3rdparty/exported/quickjs/quickjs.c
 src:*/3rdparty/exported/quickjs/quickjs.h
+src:*/3rdparty/exported/quickjs/cutils.c
 
 #############################################################################

--- a/src/ubsan.blacklist
+++ b/src/ubsan.blacklist
@@ -9,5 +9,6 @@ src:*/3rdparty/internal/sss/hazmat.c
 src:*/3rdparty/exported/quickjs/quickjs.c
 src:*/3rdparty/exported/quickjs/quickjs.h
 src:*/3rdparty/exported/quickjs/cutils.c
+src:*/3rdparty/exported/quickjs/cutils.h
 
 #############################################################################


### PR DESCRIPTION
Resolves #2702.

The recently added JS module bytecode cache exposed another instance of undefined behaviour in QuickJS. Calling `JS_WriteObject` on a module with no debug information eventually calls `dbuf_put(&s->dbuf, b->debug.pc2line_buf, b->debug.pc2line_len)` with a null second argument, and _that_ calls `memcpy(P, null, 0)`, which is technically UB. We already blacklist `quickjs`'s other sources for similar reasons, so I think it sensible to blacklist `cutils` as well and ignore these SAN errors.