### PR TITLE
Disable rotation test for BFT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -811,6 +811,18 @@ if(BUILD_TESTS)
     ADDITIONAL_ARGS ${LTS_TEST_ARGS}
   )
 
+  if(LONG_TESTS)
+    set(ROTATION_TEST_ARGS --rotation-retirements 10 --rotation-suspensions 10)
+  endif()
+
+  add_e2e_test(
+    NAME rotation_test_cft
+    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/rotation.py
+    CONSENSUS cft
+    LABEL rotation
+    ADDITIONAL_ARGS ${ROTATION_TEST_ARGS}
+  )
+
   foreach(CONSENSUS ${CONSENSUSES})
     add_e2e_test(
       NAME cpp_e2e_logging_${CONSENSUS}
@@ -845,20 +857,6 @@ if(BUILD_TESTS)
       LABEL vegeta
       CONFIGURATIONS long_stress
       ADDITIONAL_ARGS -p liblogging --duration 45m
-    )
-
-    if(LONG_TESTS)
-      set(ROTATION_TEST_ARGS --rotation-retirements 10 --rotation-suspensions
-                             10
-      )
-    endif()
-
-    add_e2e_test(
-      NAME rotation_test_${CONSENSUS}
-      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/rotation.py
-      CONSENSUS ${CONSENSUS}
-      LABEL rotation
-      ADDITIONAL_ARGS ${ROTATION_TEST_ARGS}
     )
 
   endforeach()

--- a/tests/rotation.py
+++ b/tests/rotation.py
@@ -3,40 +3,9 @@
 import infra.e2e_args
 import infra.network
 import infra.proc
-import suite.test_requirements as reqs
 import reconfiguration
-import time
-from infra.checker import check_can_progress
-from ccf.clients import CCFConnectionException
 
 from loguru import logger as LOG
-
-
-@reqs.description("Suspend and resume primary")
-@reqs.can_kill_n_nodes(1)
-def test_suspend_primary(network, args):
-    primary, backup = network.find_primary_and_any_backup()
-    primary.suspend()
-    if args.consensus == "bft":
-        try:
-            for _ in range(3):
-                with backup.client("user0") as c:
-                    _ = c.post(
-                        "/app/log/private",
-                        {
-                            "id": -1,
-                            "msg": "This is submitted to force a view change",
-                        },
-                    )
-                time.sleep(5)
-                backup = network.find_any_backup()
-        except CCFConnectionException:
-            LOG.warning(f"Could not successfully connect to node {backup.node_id}.")
-    new_primary, _ = network.wait_for_new_primary(primary)
-    check_can_progress(new_primary)
-    primary.resume()
-    check_can_progress(new_primary)
-    return network
 
 
 def run(args):
@@ -46,20 +15,11 @@ def run(args):
         network.start_and_join(args)
 
         # Replace primary repeatedly and check the network still operates
-        if args.consensus != "bft":
-            LOG.info(f"Retiring primary {args.rotation_retirements} times")
-            for i in range(args.rotation_retirements):
-                LOG.warning(f"Retirement {i}")
-                reconfiguration.test_add_node(network, args)
-                reconfiguration.test_retire_primary(network, args)
-
-        if args.consensus == "bft":
+        LOG.info(f"Retiring primary {args.rotation_retirements} times")
+        for i in range(args.rotation_retirements):
+            LOG.warning(f"Retirement {i}")
             reconfiguration.test_add_node(network, args)
-            # Suspend primary repeatedly and check the network still operates
-            LOG.info(f"Suspending primary {args.rotation_suspensions} times")
-            for i in range(args.rotation_suspensions):
-                LOG.warning(f"Suspension {i}")
-                test_suspend_primary(network, args)
+            reconfiguration.test_retire_primary(network, args)
 
 
 if __name__ == "__main__":
@@ -67,13 +27,7 @@ if __name__ == "__main__":
     def add(parser):
         parser.add_argument(
             "--rotation-retirements",
-            help="Number of times to retired the primary",
-            type=int,
-            default=3,
-        )
-        parser.add_argument(
-            "--rotation-suspensions",
-            help="Number of times to suspend the primary",
+            help="Number of times to retire the primary",
             type=int,
             default=3,
         )


### PR DESCRIPTION
This test is unstable at the moment, turning it off until it can be made more stable, hopefully using the partition tooling instead.

Sample failure: https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=27624&view=results

```
80: 10:59:44.290 | INFO     | infra.network:stop_all_nodes:536 - All nodes stopped
80: Traceback (most recent call last):
80:   File "/mnt/build/1/s/tests/rotation.py", line 85, in <module>
80:     run(args)
80:   File "/mnt/build/1/s/tests/rotation.py", line 62, in run
80:     test_suspend_primary(network, args)
80:   File "/mnt/build/1/s/tests/suite/test_requirements.py", line 20, in wrapper
80:     return func(*args, **kwargs)
80:   File "/mnt/build/1/s/tests/suite/test_requirements.py", line 43, in wrapper
80:     return func(network, args, *nargs, **kwargs)
80:   File "/mnt/build/1/s/tests/rotation.py", line 38, in test_suspend_primary
80:     check_can_progress(new_primary)
80:   File "/mnt/build/1/s/tests/infra/checker.py", line 57, in check_can_progress
80:     assert False, f"Stuck at {r}: {pprint.pformat(details)}"
80: AssertionError: Stuck at <green>200</> <yellow>{"transaction_id":"12.493"}</>: {'details': {'acks': {'0000000000000000000000000000000000000000000000000000000000000000': 498,
80:                       '0000000000000000000000000000000000000000000000000000000000000001': 498,
80:                       '0000000000000000000000000000000000000000000000000000000000000003': 498},
80:              'configs': [{'idx': 38,
80:                           'nodes': {'0000000000000000000000000000000000000000000000000000000000000000': {'address': '127.127.225.32:46287'},
80:                                     '0000000000000000000000000000000000000000000000000000000000000001': {'address': '127.78.196.63:35973'},
80:                                     '0000000000000000000000000000000000000000000000000000000000000002': {'address': '127.196.133.80:38835'},
80:                                     '0000000000000000000000000000000000000000000000000000000000000003': {'address': '127.235.127.91:40473'}}}],
80:              'state': 'Leader'}}
```