### PR TITLE
Extend timeout in recovery.test

### DIFF
--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -487,7 +487,8 @@ class Network:
                 infra.node.State.PART_OF_PUBLIC_NETWORK.value,
                 timeout=args.ledger_recovery_timeout,
             )
-        self.wait_for_all_nodes_to_commit(primary=primary)
+        # Catch-up in recovery can take a long time, so extend this timeout
+        self.wait_for_all_nodes_to_commit(primary=primary, timeout=20)
         LOG.success("All nodes joined public network")
 
     def recover(self, args):


### PR DESCRIPTION
Catch up in multi-threaded mode is slower (no parallelisation, additional dispatch costs), so recovery at the end of a `full_test_suite` in the Threading CI takes longer than expected, occasionally longer than the 10s timeout. This doubles that timeout.