### PR TITLE
2-tx reconfiguration protocol updates

### DIFF
--- a/doc/overview/consensus.rst
+++ b/doc/overview/consensus.rst
@@ -160,13 +160,15 @@ This sample illustrates the addition of a single node to a one-node network with
         Note right of Node 0: Active configs := [Cfg 0]
         Node 0-->>-Members: Success
 
+        Node 1->>+Node 0: Poll join
+        Node 0-->>-Node 1: Learner
 
         Node 0->>Node 1: Replicate Tx ID 3.42
         Note over Node 1: State in KV := LEARNER
         Node 1->>Node 0: Acknowledge Tx ID 3.42
 
         Node 0->>Node 1: Notify commit 3.42
-        
+
         Node 1->>+Node 0: Up-to-date RPC for Node 1
         Note over Node 0: Node 1 in KV := UP_TO_DATE_LEARNER
         Note over Node 0: All nodes in Cfg 1 in KV := TRUSTED
@@ -206,6 +208,12 @@ The following example illustrates one possible execution of an addition of two n
         Note right of Node 0: Active configs := [Cfg 0]
         Node 0-->>-Members: Success
 
+        Node 1->>+Node 0: Poll join
+        Node 0-->>-Node 1: Learner
+
+        Node 2->>+Node 0: Poll join
+        Node 0-->>-Node 2: Learner
+
         Node 0->>Node 1: Replicate Tx ID 3.42
         Note over Node 1: State in KV := LEARNER
         Node 1->>Node 0: Acknowledge Tx ID 3.42
@@ -243,6 +251,42 @@ The following example illustrates one possible execution of an addition of two n
         Note right of Node 0: Active configs := [Cfg 1]
 
 Joining a small number of nodes to a large network will lead to almost-instant promotion of the joining node if both the existing and the new configuration have a sufficient number of nodes for quorums. Learners also help to improve the liveness of the system, because they do not necessarily have to receive the entire ledger from the leader immediately. Further, the two transactions on the ledger make it clear that the configuration change was not instant and it allows for other mechanisms to gate the switch to a new configuration on the committment to a number of other transactions on the ledger, for instance those required for the successful establishment of a Byzantine network identity.
+
+
+The following diagram illustrates retirement of the leader:
+
+.. mermaid::
+
+  sequenceDiagram
+      participant Members
+      participant Node 0
+      participant Node 1
+
+      Note over Node 0: State in KV: TRUSTED
+      Note over Node 0: Leader
+      Note over Node 1: State in KV: TRUSTED
+
+      Note right of Node 0: Cfg 0: [Node 0, Node 1]
+      Note right of Node 0: Active configs: [Cfg 0]
+
+      Members->>+Node 0: Vote for Node 0 to become RETIRED
+
+      Note right of Node 0: Tx ID := 3.42
+      Note right of Node 0: Cfg 1 := [Node 1]
+      Note right of Node 0: Active configs := [Cfg 0]
+      Node 0-->>-Members: Success
+
+      Note over Node 0: State in KV := RETIRED
+
+      Node 0->>Node 1: Replicate Tx ID 3.42
+      Node 1->>Node 0: Acknowledge Tx ID 3.42
+      Note right of Node 0: Active configs := [Cfg 0, Cfg 1]
+      Note right of Node 0: Tx ID 3.42 commits (meets quorum in Cfg 0 and 1)
+      Note right of Node 0: Active configs := [Cfg 1]
+
+      Node 0->>Node 1: Notify commit 3.42
+      Note right of Node 1: Active configs := [Cfg 1]
+      Note over Node 1: Leader
 
 
 Replica State Machine

--- a/doc/overview/consensus.rst
+++ b/doc/overview/consensus.rst
@@ -134,9 +134,10 @@ In our example above, the election timeout on Node 1 simply expires and causes N
 Two-transaction Reconfiguration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A two-transaction reconfiguration is triggered by the same mechanism as in one-transaction reconfiguration, i.e. a change to ``public:ccf.gov.nodes.info``. It does however not become active immediately. Joining nodes are held in a ``LEARNER`` and then ``UP_TO_DATE_LEARNER`` state in which they receive copies of the ledger, but they are not taken into account in commit-level decisions or leader selection until a quorum of them has caught up. They recognize this fact by observing the commit of the reconfiguration transaction that includes their own addition to ``public:ccf.gov.nodes.info`` while replaying the reconfiguration transaction. This means that they have seen all preceding transactions up until their addition to the network.
+A two-transaction reconfiguration is triggered by the same mechanism as in one-transaction reconfiguration, i.e. a change to ``public:ccf.gov.nodes.info``. It does however not become active immediately. Joining nodes are held in a ``LEARNER`` state in which they receive copies of the ledger, but they are not taken into account in commit-level decisions or leader selection until a quorum of them has caught up. Nodes recognize that they are added to the network by observing the commit of the transaction that includes their own addition to ``public:ccf.gov.nodes.info``. This means that they have seen all preceding transactions up until their addition to the network. Similary, nodes that are to be retired recognize that their state is changed to ``RETIRING`` in ``public:ccf.gov.nodes.info``.
 
-Once a node reaches this point, they submit an RPC call to the current leader, to notify them. The leader then changes the ``up_to_date`` flag in the nodes entry in ``public:ccf.gov.nodes.info``. When the number of nodes in the next scheduled configuration reaches the required quorum of acknowledgements, the new configuration becomes fully active and the leader confirms this by promoting all of the new nodes of the configuration (some of which may still be catching up) to ``TRUSTED``. It is also at this point that nodes scheduled for retirement can safely begin to retire.
+All nodes in the new configuration (including learners) submit an Observed Reconfiguration Commit (ORC) RPC call to the current leader once they observe a reconfiguration that changes their state. This allows the leader to track how many of the nodes in the new configuration are aware of that configuration. Once the number of nodes in the next scheduled configuration reaches the required quorum of acknowledgements, the leader changes the state of all
+nodes of the new configuration that are in the ``LEARNER`` and ``RETIRING`` states to ``TRUSTED`` and ``RETIRED`` respectively, in ``public:ccf.gov.nodes.info``.
 
 This sample illustrates the addition of a single node to a one-node network with two-transaction reconfiguration:
 
@@ -169,16 +170,14 @@ This sample illustrates the addition of a single node to a one-node network with
 
         Node 0->>Node 1: Notify commit 3.42
 
-        Node 1->>+Node 0: Up-to-date RPC for Node 1
-        Note over Node 0: Node 1 in KV := UP_TO_DATE_LEARNER
-        Note over Node 0: All nodes in Cfg 1 in KV := TRUSTED
+        Node 1->>+Node 0: ORC for Node 1
+        Note over Node 0: Quorum reached. All nodes in Cfg 1: State in KV := TRUSTED
         Note right of Node 0: Active configs := [Cfg 0, Cfg 1]
         Node 0-->>-Node 1: Success @ Tx ID 3.43
 
         Node 0->>Node 1: Replicate Tx ID 3.43
         Note over Node 1: State in KV := TRUSTED
         Node 1->>Node 0: Acknowledge Tx ID 3.43
-
 
         Note right of Node 0: Tx ID 3.43 commits (meets quorum in Cfg 0 and 1)
         Note right of Node 0: Active configs := [Cfg 1]
@@ -224,30 +223,24 @@ The following example illustrates one possible execution of an addition of two n
 
         Node 0->>Node 1: Notify commit 3.42
 
-        Node 1->>+Node 0: Up-to-date RPC for Node 1
-        Note over Node 0: Node 1 in KV := UP_TO_DATE_LEARNER
+        Node 1->>+Node 0: ORC for Node 1
         Note right of Node 0: Active configs := [Cfg 0]
-        Node 0-->>-Node 1: Success @ Tx ID 3.43
 
         Node 0->>Node 2: Notify commit 3.42
 
-        Node 2->>+Node 0: Up-to-date RPC for Node 2
-        Note over Node 0: Node 2 in KV := UP_TO_DATE_LEARNER
-        Note over Node 0: All nodes in Cfg 1 in KV := TRUSTED
+        Node 2->>+Node 0: ORC for Node 2
+        Note over Node 0: Quorum reached. All nodes in Cfg 1: State in KV := TRUSTED
         Note right of Node 0: Active configs := [Cfg 0, Cfg 1]
-        Node 0-->>-Node 2: Success @ Tx ID 3.44
+        Node 0-->>-Node 2: Success @ Tx ID 3.43
 
         Node 0->>Node 1: Replicate Tx ID 3.43
-        Note over Node 1: State in KV := UP_TO_DATE_LEARNER
-        Node 1->>Node 0: Acknowledge Tx ID 3.43
-        Node 0->>Node 1: Replicate Tx ID 3.44
         Note over Node 1: State in KV := TRUSTED
-        Node 1->>Node 0: Acknowledge Tx ID 3.44
-        Node 0->>Node 2: Replicate Tx ID 3.44
+        Node 1->>Node 0: Acknowledge Tx ID 3.43
+        Node 0->>Node 2: Replicate Tx ID 3.43
         Note over Node 2: State in KV := TRUSTED
-        Node 2->>Node 0: Acknowledge Tx ID 3.44
+        Node 2->>Node 0: Acknowledge Tx ID 3.43
 
-        Note right of Node 0: Tx ID 3.44 commits (meets quorum in Cfg 0 and 1)
+        Note right of Node 0: Tx ID 3.43 commits (meets quorum in Cfg 0 and 1)
         Note right of Node 0: Active configs := [Cfg 1]
 
 Joining a small number of nodes to a large network will lead to almost-instant promotion of the joining node if both the existing and the new configuration have a sufficient number of nodes for quorums. Learners also help to improve the liveness of the system, because they do not necessarily have to receive the entire ledger from the leader immediately. Further, the two transactions on the ledger make it clear that the configuration change was not instant and it allows for other mechanisms to gate the switch to a new configuration on the committment to a number of other transactions on the ledger, for instance those required for the successful establishment of a Byzantine network identity.
@@ -274,17 +267,28 @@ The following diagram illustrates retirement of the leader:
       Note right of Node 0: Tx ID := 3.42
       Note right of Node 0: Cfg 1 := [Node 1]
       Note right of Node 0: Active configs := [Cfg 0]
-      Node 0-->>-Members: Success
+      Node 0-->>-Members: Success @ Tx ID 3.42
 
-      Note over Node 0: State in KV := RETIRED
+      Note over Node 0: State in KV := RETIRING
 
       Node 0->>Node 1: Replicate Tx ID 3.42
       Node 1->>Node 0: Acknowledge Tx ID 3.42
-      Note right of Node 0: Active configs := [Cfg 0, Cfg 1]
-      Note right of Node 0: Tx ID 3.42 commits (meets quorum in Cfg 0 and 1)
-      Note right of Node 0: Active configs := [Cfg 1]
 
-      Node 0->>Node 1: Notify commit 3.42
+      Node 1->>+Node 0: ORC for Node 1
+      Note left of Node 0: Tx ID := 3.43
+      Note left of Node 0: (Quorum reached, all nodes in Cfg 1 are already TRUSTED)
+      Note left of Node 0: All RETIRING nodes in Cfg 1: state in KV := RETIRED
+      Note left of Node 0: Active configs := [Cfg 0, Cfg 1]
+      Node 0-->>-Node 1: Success @ Tx ID 3.43
+
+      Note over Node 0: State in KV := RETIRED
+
+      Node 0->>Node 1: Replicate Tx ID 3.43
+      Node 1->>Node 0: Acknowledge Tx ID 3.43
+      Note right of Node 0: Active configs := [Cfg 0, Cfg 1]
+      Note right of Node 0: Tx ID 3.43 commits (meets quorum in Cfg 0 and 1)
+
+      Node 0->>Node 1: Notify commit 3.43
       Note right of Node 1: Active configs := [Cfg 1]
       Note over Node 1: Leader
 


### PR DESCRIPTION
This adds the latest changes to the 2-tx reconfiguration protocol to the documentation. Also includes a diagram for the 2-tx leader retirement. Addresses #2721. 

![image](https://user-images.githubusercontent.com/10155819/124503076-b24e5400-ddbc-11eb-91d7-666488f18c9a.png)
![image](https://user-images.githubusercontent.com/10155819/124503092-b9756200-ddbc-11eb-9ea4-6dbb08a40e45.png)
![image](https://user-images.githubusercontent.com/10155819/124503102-c09c7000-ddbc-11eb-9f96-ce0fc46b5714.png)
