### PR TITLE
Minor: Point at recent version of ccf-app in docs

### DIFF
--- a/doc/build_apps/js_app_ts.rst
+++ b/doc/build_apps/js_app_ts.rst
@@ -58,11 +58,11 @@ Dependencies
 The sample uses several runtime and development packages (see ``package.json``).
 One of them is the :typedoc:package:`ccf-app` package.
 This package is referenced locally using ``file:``.
-You should replace this with a reference to a published version (adjust the version number accordingly):
+You should replace this with a reference to a recently published version (adjust the version number accordingly), to match the version of CCF you are running:
 
 .. code-block:: js
 
-    "@microsoft/ccf-app": "~0.19.4",
+    "@microsoft/ccf-app": "~1.0.0",
 
 Now you can continue with installing all dependencies:
 

--- a/doc/build_apps/js_app_tsoa.rst
+++ b/doc/build_apps/js_app_tsoa.rst
@@ -87,11 +87,11 @@ Dependencies
 The sample uses several runtime and development packages (see ``package.json``).
 One of them is the :typedoc:package:`ccf-app` package.
 This package is referenced locally using ``file:``.
-You should replace this with a reference to a published version (adjust the version number accordingly):
+You should replace this with a reference to a recently published version (adjust the version number accordingly), to match the version of CCF you are running:
 
 .. code-block:: js
 
-    "@microsoft/ccf-app": "~0.19.4",
+    "@microsoft/ccf-app": "~1.0.0",
 
 Now you can continue with installing all dependencies:
 


### PR DESCRIPTION
Although the text suggested using a different version, its a little confusing that these docs reference an unpublished version of the `ccf-app` NPM package. This updates those to a safe-enough version (`1.0.0`), while clarifying that the actual choice should be determined by the version of the other CCF code.