### PR TITLE
BFT: filter consensus messages on view and configuration

### DIFF
--- a/include/ccf/tx_id.h
+++ b/include/ccf/tx_id.h
@@ -92,11 +92,8 @@ namespace ccf
     {
       std::size_t operator()(const ccf::TxID& t) const
       {
-        size_t n = 0x444e414c544f4353;
-        std::hash<uint64_t> h{};
-        ds::hashutils::hash_combine(n, t.view, h);
-        ds::hashutils::hash_combine(n, t.seqno, h);
-        return n;
+        return ds::hashutils::hash_container<std::vector<uint64_t>>(
+          {t.view, t.seqno});
       }
     };
   };

--- a/include/ccf/tx_id.h
+++ b/include/ccf/tx_id.h
@@ -82,6 +82,23 @@ namespace ccf
 
       return tx_id;
     }
+
+    bool operator==(const TxID& other) const
+    {
+      return view == other.view && seqno == other.seqno;
+    }
+
+    struct TxIDHasher
+    {
+      std::size_t operator()(const ccf::TxID& t) const
+      {
+        size_t n = 0x444e414c544f4353;
+        std::hash<uint64_t> h{};
+        ds::hashutils::hash_combine(n, t.view, h);
+        ds::hashutils::hash_combine(n, t.seqno, h);
+        return n;
+      }
+    };
   };
 
   // ADL-found functions used during JSON conversion and OpenAPI/JSON schema

--- a/src/consensus/aft/impl/view_change_tracker.h
+++ b/src/consensus/aft/impl/view_change_tracker.h
@@ -97,8 +97,8 @@ namespace aft
       }
       it->second.received_view_changes.emplace(from, v);
 
-      uint32_t node_count =
-        get_message_intersection_count(it->second.received_view_changes, config);
+      uint32_t node_count = get_message_intersection_count(
+        it->second.received_view_changes, config);
 
       if (
         node_count == ccf::get_message_threshold(config.size()) &&

--- a/src/consensus/aft/impl/view_change_tracker.h
+++ b/src/consensus/aft/impl/view_change_tracker.h
@@ -86,7 +86,7 @@ namespace aft
       ccf::ViewChangeRequest& v,
       const ccf::NodeId& from,
       ccf::View view,
-      kv::Configuration::Nodes& config)
+      const kv::Configuration::Nodes& config)
     {
       auto it = view_changes.find(view);
       if (it == view_changes.end())
@@ -97,11 +97,11 @@ namespace aft
       }
       it->second.received_view_changes.emplace(from, v);
 
-      uint32_t node_count = get_message_intersection_count(
-        it->second.received_view_changes, config);
+      uint32_t endorsements =
+        count_endorsements_in_config(it->second.received_view_changes, config);
 
       if (
-        node_count == ccf::get_message_threshold(config.size()) &&
+        endorsements == ccf::get_endorsement_threshold(config.size()) &&
         it->second.new_view_sent == false)
       {
         it->second.new_view_sent = true;
@@ -135,7 +135,7 @@ namespace aft
       CBuffer data,
       ccf::View view,
       const ccf::NodeId& from,
-      kv::Configuration::Nodes& config)
+      const kv::Configuration::Nodes& config)
     {
       nlohmann::json j = nlohmann::json::parse(data.p);
       auto vc = j.get<ccf::ViewChangeConfirmation>();
@@ -163,18 +163,18 @@ namespace aft
         return false;
       }
 
-      uint32_t node_count =
-        get_message_intersection_count(vc.view_change_messages, config);
+      uint32_t endorsements =
+        count_endorsements_in_config(vc.view_change_messages, config);
 
       if (
         vc.view_change_messages.size() <
-        ccf::get_message_threshold(config.size()))
+        ccf::get_endorsement_threshold(config.size()))
       {
         LOG_INFO_FMT(
           "Add unknown evidence - not enough evidence, need:{}, have:{}, "
           "from:{}",
-          node_count,
-          ccf::get_message_threshold(config.size()),
+          endorsements,
+          ccf::get_endorsement_threshold(config.size()),
           from);
         return false;
       }

--- a/src/consensus/aft/impl/view_change_tracker.h
+++ b/src/consensus/aft/impl/view_change_tracker.h
@@ -97,16 +97,8 @@ namespace aft
       }
       it->second.received_view_changes.emplace(from, v);
 
-      uint32_t node_count = 0;
-      for (const auto node : config)
-      {
-        if (
-          it->second.received_view_changes.find(node.first) !=
-          it->second.received_view_changes.end())
-        {
-          ++node_count;
-        }
-      }
+      uint32_t node_count =
+        get_message_intersection_count(it->second.received_view_changes, config);
 
       if (
         node_count == ccf::get_message_threshold(config.size()) &&
@@ -171,19 +163,12 @@ namespace aft
         return false;
       }
 
-      uint32_t node_count = 0;
-      for (const auto node : config)
-      {
-        if (
-          vc.view_change_messages.find(node.first) !=
-          vc.view_change_messages.end())
-        {
-          ++node_count;
-        }
-      }
+      uint32_t node_count =
+        get_message_intersection_count(vc.view_change_messages, config);
 
       if (
-        vc.view_change_messages.size() < ccf::get_message_threshold(config.size()))
+        vc.view_change_messages.size() <
+        ccf::get_message_threshold(config.size()))
       {
         LOG_INFO_FMT(
           "Add unknown evidence - not enough evidence, need:{}, have:{}, "

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -2197,8 +2197,11 @@ namespace aft
             }
           }
           progress_tracker->add_nonce_reveal(
-            tx_id, nonce.value(), state->my_node_id, 
-            configurations.back().nodes, is_primary());
+            tx_id,
+            nonce.value(),
+            state->my_node_id,
+            configurations.back().nodes,
+            is_primary());
           break;
         }
         default:
@@ -2229,7 +2232,11 @@ namespace aft
         r.term,
         r.idx);
       progress_tracker->add_nonce_reveal(
-        {r.term, r.idx}, r.nonce, from, configurations.back().nodes, is_primary());
+        {r.term, r.idx},
+        r.nonce,
+        from,
+        configurations.back().nodes,
+        is_primary());
 
       update_commit();
     }

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -2045,8 +2045,16 @@ namespace aft
                                        static_cast<uint32_t>(sig.sig.size()),
                                        {}};
 
-      progress_tracker->get_node_hashed_nonce(
-        {state->current_view, state->last_idx}, r.hashed_nonce);
+      try
+      {
+        progress_tracker->get_node_hashed_nonce(
+          {state->current_view, state->last_idx}, r.hashed_nonce);
+      }
+      catch(const std::exception& e)
+      {
+        LOG_INFO_FMT("TTTTTT error:{}", e.what());
+        return;
+      }
 
       std::copy(sig.sig.begin(), sig.sig.end(), r.sig.data());
 

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -2062,7 +2062,7 @@ namespace aft
         r.signature_size,
         r.sig,
         r.hashed_nonce,
-        node_count(),
+        configurations.back().nodes,
         is_primary());
 
       for (auto it = nodes.begin(); it != nodes.end(); ++it)
@@ -2099,7 +2099,7 @@ namespace aft
         r.signature_size,
         r.sig,
         r.hashed_nonce,
-        node_count(),
+        configurations.back().nodes,
         is_primary());
       try_send_sig_ack({r.term, r.last_log_idx}, result);
     }
@@ -2131,7 +2131,7 @@ namespace aft
           CCF_ASSERT(
             progress_tracker != nullptr, "progress_tracker is not set");
           auto result = progress_tracker->add_signature_ack(
-            tx_id, state->my_node_id, node_count());
+            tx_id, state->my_node_id, &configurations.back().nodes);
           try_send_reply_and_nonce(tx_id, result);
           break;
         }
@@ -2165,7 +2165,7 @@ namespace aft
         r.idx);
 
       auto result = progress_tracker->add_signature_ack(
-        {r.term, r.idx}, from, node_count());
+        {r.term, r.idx}, from, &configurations.back().nodes);
       try_send_reply_and_nonce({r.term, r.idx}, result);
     }
 
@@ -2202,7 +2202,8 @@ namespace aft
             }
           }
           progress_tracker->add_nonce_reveal(
-            tx_id, nonce.value(), state->my_node_id, node_count(), is_primary());
+            tx_id, nonce.value(), state->my_node_id, 
+            configurations.back().nodes, is_primary());
           break;
         }
         default:
@@ -2233,7 +2234,7 @@ namespace aft
         r.term,
         r.idx);
       progress_tracker->add_nonce_reveal(
-        {r.term, r.idx}, r.nonce, from, node_count(), is_primary());
+        {r.term, r.idx}, r.nonce, from, configurations.back().nodes, is_primary());
 
       update_commit();
     }

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -543,11 +543,6 @@ namespace aft
       return details;
     }
 
-    uint32_t node_count() const
-    {
-      return get_latest_configuration_unsafe().size();
-    }
-
     template <typename T>
     bool replicate(
       const std::vector<
@@ -897,7 +892,7 @@ namespace aft
           if (
             aft::ViewChangeTracker::ResultAddView::APPEND_NEW_VIEW_MESSAGE ==
               view_change_tracker->add_request_view_change(
-                *vc, id(), new_view, node_count()) &&
+                *vc, id(), new_view, configurations.back().nodes) &&
             get_primary(new_view) == id())
           {
             // We need to reobtain the lock when writing to the ledger so we
@@ -985,7 +980,7 @@ namespace aft
       if (
         aft::ViewChangeTracker::ResultAddView::APPEND_NEW_VIEW_MESSAGE ==
           view_change_tracker->add_request_view_change(
-            v, from, r.view, node_count()) &&
+            v, from, r.view, configurations.back().nodes) &&
         get_primary(r.view) == id())
       {
         append_new_view(r.view);
@@ -1022,7 +1017,7 @@ namespace aft
         return;
       }
       if (!view_change_tracker->add_unknown_primary_evidence(
-            {data, size}, r.view, from, node_count()))
+            {data, size}, r.view, from, configurations.back().nodes))
       {
         LOG_FAIL_FMT("Failed to verify view_change_evidence from {}", from);
         return;

--- a/src/consensus/aft/raft_consensus.h
+++ b/src/consensus/aft/raft_consensus.h
@@ -157,11 +157,6 @@ namespace aft
       aft->enable_all_domains();
     }
 
-    uint32_t node_count() override
-    {
-      return aft->node_count();
-    }
-
     void emit_signature() override {}
 
     bool on_request(const kv::TxHistory::RequestCallbackArgs& args) override

--- a/src/ds/messaging.h
+++ b/src/ds/messaging.h
@@ -161,10 +161,11 @@ namespace messaging
       }
 
       // Handlers may register or remove handlers, so iterator is invalidated
-      try
+      //try
       {
         it->second(data, size);
       }
+      /*
       catch (const std::exception& e)
       {
         LOG_FAIL_FMT(
@@ -174,6 +175,7 @@ namespace messaging
         LOG_TRACE_FMT("{}", e.what());
         throw e;
       }
+      */
 
       auto& counts = message_counts[m];
       counts.messages++;

--- a/src/ds/messaging.h
+++ b/src/ds/messaging.h
@@ -161,11 +161,10 @@ namespace messaging
       }
 
       // Handlers may register or remove handlers, so iterator is invalidated
-      //try
+      try
       {
         it->second(data, size);
       }
-      /*
       catch (const std::exception& e)
       {
         LOG_FAIL_FMT(
@@ -175,7 +174,6 @@ namespace messaging
         LOG_TRACE_FMT("{}", e.what());
         throw e;
       }
-      */
 
       auto& counts = message_counts[m];
       counts.messages++;

--- a/src/kv/deserialise.h
+++ b/src/kv/deserialise.h
@@ -263,6 +263,7 @@ namespace kv
     SignatureBFTExec(
       ExecutionWrapperStore* store_,
       std::shared_ptr<TxHistory> history_,
+      std::shared_ptr<Consensus> consensus_,
       const std::vector<uint8_t>& data_,
       bool public_only_,
       kv::Version v_,
@@ -272,7 +273,7 @@ namespace kv
         store_,
         history_,
         nullptr,
-        nullptr,
+        consensus_,
         data_,
         public_only_,
         v_,
@@ -287,8 +288,9 @@ namespace kv
         return ApplyResult::FAIL;
       }
 
+      auto config = consensus->get_latest_configuration_unsafe();
       bool result = true;
-      auto r = history->verify_and_sign(sig, &term);
+      auto r = history->verify_and_sign(sig, &term, config);
       if (
         r != kv::TxHistory::Result::OK &&
         r != kv::TxHistory::Result::SEND_SIG_RECEIPT_ACK)
@@ -343,9 +345,9 @@ namespace kv
 
       ccf::TxID tx_id;
       auto success = ApplyResult::PASS;
-
+      auto config = consensus->get_latest_configuration_unsafe();
       auto r = progress_tracker->receive_backup_signatures(
-        tx_id, consensus->node_count(), consensus->is_primary());
+        tx_id, config, consensus->is_primary());
       if (r == kv::TxHistory::Result::SEND_SIG_RECEIPT_ACK)
       {
         success = ApplyResult::PASS_BACKUP_SIGNATURE_SEND_ACK;
@@ -450,7 +452,8 @@ namespace kv
         return ApplyResult::FAIL;
       }
 
-      if (!progress_tracker->apply_new_view(consensus->node_count(), term))
+      auto config = consensus->get_latest_configuration_unsafe();
+      if (!progress_tracker->apply_new_view(config, term))
       {
         LOG_FAIL_FMT("apply_new_view Failed");
         LOG_DEBUG_FMT("NewView in transaction {} failed to verify", v);

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -413,7 +413,6 @@ namespace kv
 
     virtual void enable_all_domains() {}
 
-    virtual uint32_t node_count() = 0;
     virtual void emit_signature() = 0;
     virtual ConsensusType type() = 0;
   };

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -301,7 +301,7 @@ namespace kv
 
     virtual ~TxHistory() {}
     virtual Result verify_and_sign(
-      ccf::PrimarySignature& signature, Term* term = nullptr) = 0;
+      ccf::PrimarySignature& signature, Term* term, kv::Configuration::Nodes& nodes) = 0;
     virtual bool verify(
       Term* term = nullptr, ccf::PrimarySignature* sig = nullptr) = 0;
     virtual void try_emit_signature() = 0;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -301,7 +301,9 @@ namespace kv
 
     virtual ~TxHistory() {}
     virtual Result verify_and_sign(
-      ccf::PrimarySignature& signature, Term* term, kv::Configuration::Nodes& nodes) = 0;
+      ccf::PrimarySignature& signature,
+      Term* term,
+      kv::Configuration::Nodes& nodes) = 0;
     virtual bool verify(
       Term* term = nullptr, ccf::PrimarySignature* sig = nullptr) = 0;
     virtual void try_emit_signature() = 0;

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -787,6 +787,7 @@ namespace kv
           exec = std::make_unique<SignatureBFTExec>(
             this,
             get_history(),
+            get_consensus(),
             std::move(data),
             public_only,
             v,

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -162,11 +162,6 @@ namespace kv::test
       return ConsensusDetails{{}, {}, ReplicaState::Candidate};
     }
 
-    uint32_t node_count() override
-    {
-      return 0;
-    }
-
     void emit_signature() override
     {
       return;

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -331,6 +331,8 @@ namespace ccf
             txid.version));
         }
 
+        // The nonce is generated in progress_racker->record_primary so it must
+        // exist.
         hashed_nonce = progress_tracker->get_node_hashed_nonce(txid).value();
       }
       else

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -134,7 +134,7 @@ namespace ccf
       version++;
     }
 
-    kv::TxHistory::Result verify_and_sign(PrimarySignature&, kv::Term*) override
+    kv::TxHistory::Result verify_and_sign(PrimarySignature&, kv::Term*, kv::Configuration::Nodes&) override
     {
       return kv::TxHistory::Result::OK;
     }
@@ -649,7 +649,7 @@ namespace ccf
     }
 
     kv::TxHistory::Result verify_and_sign(
-      PrimarySignature& sig, kv::Term* term = nullptr) override
+      PrimarySignature& sig, kv::Term* term, kv::Configuration::Nodes& config) override
     {
       if (!verify(term, &sig))
       {
@@ -667,7 +667,7 @@ namespace ccf
         sig.root,
         sig.sig,
         sig.hashed_nonce,
-        store.get_consensus()->node_count());
+        &config);
 
       sig.node = id;
       sig.sig = kp.sign_hash(sig.root.h.data(), sig.root.h.size());

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -330,7 +330,7 @@ namespace ccf
             txid.version));
         }
 
-        progress_tracker->get_node_hashed_nonce(txid, hashed_nonce);
+        hashed_nonce = progress_tracker->get_node_hashed_nonce(txid).value();
       }
       else
       {

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -134,7 +134,8 @@ namespace ccf
       version++;
     }
 
-    kv::TxHistory::Result verify_and_sign(PrimarySignature&, kv::Term*, kv::Configuration::Nodes&) override
+    kv::TxHistory::Result verify_and_sign(
+      PrimarySignature&, kv::Term*, kv::Configuration::Nodes&) override
     {
       return kv::TxHistory::Result::OK;
     }
@@ -649,7 +650,9 @@ namespace ccf
     }
 
     kv::TxHistory::Result verify_and_sign(
-      PrimarySignature& sig, kv::Term* term, kv::Configuration::Nodes& config) override
+      PrimarySignature& sig,
+      kv::Term* term,
+      kv::Configuration::Nodes& config) override
     {
       if (!verify(term, &sig))
       {

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -672,7 +672,7 @@ namespace ccf
         sig.root,
         sig.sig,
         sig.hashed_nonce,
-        &config);
+        config);
 
       sig.node = id;
       sig.sig = kp.sign_hash(sig.root.h.data(), sig.root.h.size());

--- a/src/node/progress_tracker.h
+++ b/src/node/progress_tracker.h
@@ -933,7 +933,8 @@ namespace ccf
     bool can_send_reply_and_nonce(
       CommitCert& cert, kv::Configuration::Nodes& config)
     {
-      uint32_t node_count = get_message_intersection_count(cert.sig_acks, config);
+      uint32_t node_count =
+        get_message_intersection_count(cert.sig_acks, config);
 
       if (
         node_count >= get_message_threshold(config.size()) &&
@@ -974,7 +975,8 @@ namespace ccf
     bool should_append_nonces_to_ledger(
       CommitCert& cert, kv::Configuration::Nodes& config, bool is_primary)
     {
-      uint32_t node_count = get_message_intersection_count(cert.nonce_set, config);
+      uint32_t node_count =
+        get_message_intersection_count(cert.nonce_set, config);
 
       if (
         node_count >= get_message_threshold(config.size()) &&

--- a/src/node/progress_tracker.h
+++ b/src/node/progress_tracker.h
@@ -953,7 +953,7 @@ namespace ccf
             }
           }
           CCF_ASSERT(
-            !certificates.empty(), "Should never deleted all certificates");
+            !certificates.empty(), "Should never delete all certificates");
         }
       }
     }

--- a/src/node/progress_tracker_types.h
+++ b/src/node/progress_tracker_types.h
@@ -301,4 +301,20 @@ namespace ccf
 
     return 2 * f + 1;
   }
+
+  template <typename T>
+  static uint32_t get_message_intersection_count(
+    T& messages, kv::Configuration::Nodes& config)
+  {
+    uint32_t node_count = 0;
+    for (const auto node : config)
+    {
+      if (messages.find(node.first) != messages.end())
+      {
+        ++node_count;
+      }
+    }
+
+    return node_count;
+  }
 }

--- a/src/node/progress_tracker_types.h
+++ b/src/node/progress_tracker_types.h
@@ -293,28 +293,30 @@ namespace ccf
     }
   };
 
-  static constexpr uint32_t get_message_threshold(uint32_t node_count)
+  static constexpr uint32_t get_endorsement_threshold(uint32_t count)
   {
     uint32_t f = 0;
-    for (; 3 * f + 1 < node_count; ++f)
+    for (; 3 * f + 1 < count; ++f)
       ;
 
     return 2 * f + 1;
   }
 
+  // Counts the number of endorsements (backup signatures, nonces,
+  // view-changes) that come from a specific configuration.
   template <typename T>
-  static uint32_t get_message_intersection_count(
-    T& messages, kv::Configuration::Nodes& config)
+  static uint32_t count_endorsements_in_config(
+    T& messages, const kv::Configuration::Nodes& config)
   {
-    uint32_t node_count = 0;
+    uint32_t endorsements = 0;
     for (const auto node : config)
     {
       if (messages.find(node.first) != messages.end())
       {
-        ++node_count;
+        ++endorsements;
       }
     }
 
-    return node_count;
+    return endorsements;
   }
 }

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -61,7 +61,6 @@ void ordered_execution(
 {
   ccf::View view = 0;
   ccf::SeqNo seqno = 42;
-  uint32_t node_count = 4;
   uint32_t node_count_quorum =
     2; // Takes into account that counting starts at 0
   bool am_i_primary = (my_node_id == kv::test::PrimaryNodeId);

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -384,7 +384,7 @@ TEST_CASE("Record primary signature")
         false);
       REQUIRE(result == kv::TxHistory::Result::OK);
       result = pt.record_primary(
-        {view + 1, seqno},
+        {view, seqno},
         kv::test::PrimaryNodeId,
         false,
         root,

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -95,7 +95,7 @@ void ordered_execution(
       if (node_id == my_node_id)
       {
         auto h = pt->get_node_hashed_nonce({view, seqno});
-        std::copy(h.h.begin(), h.h.end(), hashed_nonce.h.begin());
+        std::copy(h->h.begin(), h->h.end(), hashed_nonce.h.begin());
       }
       else
       {
@@ -141,7 +141,7 @@ void ordered_execution(
       {
         pt->add_nonce_reveal(
           {view, seqno},
-          pt->get_node_nonce({view, seqno}),
+          pt->get_node_nonce({view, seqno}).value(),
           node_id,
           node_count,
           am_i_primary);

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -679,7 +679,11 @@ TEST_CASE("view-change-tracker statemachine tests")
   ccf::ViewChangeRequest v;
   ccf::View view = 3;
   ccf::SeqNo seqno = 1;
-  uint32_t node_count = 4;
+  kv::Configuration::Nodes nodes;
+  for (auto const& node_id : node_ids)
+  {
+    nodes.insert({node_id, kv::Configuration::NodeInfo()});
+  }
 
   INFO("Can trigger view change");
   {
@@ -687,7 +691,7 @@ TEST_CASE("view-change-tracker statemachine tests")
     size_t i = 0;
     for (auto const& node_id : node_ids)
     {
-      auto r = vct.add_request_view_change(v, node_id, view, node_count);
+      auto r = vct.add_request_view_change(v, node_id, view, nodes);
       if (i == 2)
       {
         REQUIRE(
@@ -712,7 +716,7 @@ TEST_CASE("view-change-tracker statemachine tests")
     size_t i = 0;
     for (auto const& node_id : node_ids)
     {
-      auto r = vct.add_request_view_change(v, node_id, i, node_count);
+      auto r = vct.add_request_view_change(v, node_id, i, nodes);
       REQUIRE(r == aft::ViewChangeTracker::ResultAddView::OK);
       i++;
     }
@@ -813,7 +817,11 @@ TEST_CASE("Sending evidence out of band")
   ccf::ViewChangeRequest v;
   ccf::View view = 3;
   ccf::SeqNo seqno = 1;
-  constexpr uint32_t node_count = 4;
+  kv::Configuration::Nodes nodes;
+  for (auto const& node_id : node_ids)
+  {
+    nodes.insert({node_id, kv::Configuration::NodeInfo()});
+  }
 
   INFO("Can trigger view change");
   {
@@ -821,7 +829,7 @@ TEST_CASE("Sending evidence out of band")
     size_t i = 0;
     for (auto const& node_id : node_ids)
     {
-      auto r = vct.add_request_view_change(v, node_id, view, node_count);
+      auto r = vct.add_request_view_change(v, node_id, view, nodes);
       if (i == 2)
       {
         REQUIRE(
@@ -851,7 +859,7 @@ TEST_CASE("Sending evidence out of band")
           .RETURN(true);
         ccf::NodeId from;
         REQUIRE(vct_2.add_unknown_primary_evidence(
-          {data.data(), data.size()}, view, from, node_count));
+          {data.data(), data.size()}, view, from, nodes));
         REQUIRE(vct_2.check_evidence(view));
       }
       else
@@ -862,7 +870,7 @@ TEST_CASE("Sending evidence out of band")
           .RETURN(true);
         ccf::NodeId from;
         REQUIRE(!vct_2.add_unknown_primary_evidence(
-          {data.data(), data.size()}, view, from, node_count));
+          {data.data(), data.size()}, view, from, nodes));
         REQUIRE(!vct_2.check_evidence(view));
       }
       REQUIRE(!vct_2.check_evidence(view + 1));

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -87,7 +87,7 @@ void ordered_execution(
       root,
       primary_sig,
       hashed_nonce,
-      &nodes);
+      nodes);
     REQUIRE(result == kv::TxHistory::Result::OK);
     primary_sig = {1};
     result = pt->record_primary_signature({view, seqno}, primary_sig);
@@ -127,7 +127,7 @@ void ordered_execution(
     size_t i = 0;
     for (auto const& node_id : node_ids)
     {
-      auto result = pt->add_signature_ack({view, seqno}, node_id, &nodes);
+      auto result = pt->add_signature_ack({view, seqno}, node_id, nodes);
       REQUIRE(
         ((result == kv::TxHistory::Result::OK && i != node_count_quorum) ||
          (result == kv::TxHistory::Result::SEND_REPLY_AND_NONCE &&
@@ -454,7 +454,7 @@ TEST_CASE("View Changes")
       root,
       primary_sig,
       hashed_nonce,
-      &nodes);
+      nodes);
     REQUIRE(result == kv::TxHistory::Result::OK);
 
     size_t i = 1;
@@ -506,7 +506,7 @@ TEST_CASE("View Changes")
       root,
       primary_sig,
       hashed_nonce,
-      &nodes);
+      nodes);
     REQUIRE(result == kv::TxHistory::Result::OK);
 
     size_t i = 1;
@@ -559,7 +559,7 @@ TEST_CASE("View Changes")
       root,
       primary_sig,
       hashed_nonce,
-      &nodes);
+      nodes);
     REQUIRE(result == kv::TxHistory::Result::OK);
 
     size_t i = 1;


### PR DESCRIPTION
Currently, the ProgressTracker will combine message for the same seqno regardless of view or configuration and depends on rollback on view-changes. This will not work in the reconfiguration scenario so in this PR it will not combine messages from different views and also take a configuration (if deciding thresholds have been reached) to ensure messages are filtered correctly by configuration.