### PR TITLE
Log when a replica changes its view

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -2627,6 +2627,8 @@ namespace aft
       restart_election_timeout();
 
       state->current_view = term;
+      LOG_INFO_FMT(
+        "Became aware of new view. Setting view to {}", state->current_view);
       voted_for.reset();
       votes_for_me.clear();
 


### PR DESCRIPTION
This is the only code path in which we do not log when a replica's current_view changes. Add a log line to capture this.