### PR TITLE
Fix pylint: Disable warning

### DIFF
--- a/tests/infra/crypto.py
+++ b/tests/infra/crypto.py
@@ -188,7 +188,7 @@ def sign(algorithm: dict, key_pem: str, data: bytes) -> bytes:
             raise ValueError("Unsupported signing algorithm")
     elif isinstance(key, ec.EllipticCurvePrivateKey):
         if algorithm["name"] == "ECDSA":
-            return key.sign(data, ec.ECDSA(hash_alg))
+            return key.sign(data, ec.ECDSA(hash_alg), hash_alg)
         else:
             raise ValueError("Unsupported signing algorithm")
     else:

--- a/tests/infra/crypto.py
+++ b/tests/infra/crypto.py
@@ -188,7 +188,8 @@ def sign(algorithm: dict, key_pem: str, data: bytes) -> bytes:
             raise ValueError("Unsupported signing algorithm")
     elif isinstance(key, ec.EllipticCurvePrivateKey):
         if algorithm["name"] == "ECDSA":
-            return key.sign(data, ec.ECDSA(hash_alg), hash_alg)
+            # pylint: disable=no-value-for-parameter
+            return key.sign(data, ec.ECDSA(hash_alg))
         else:
             raise ValueError("Unsupported signing algorithm")
     else:


### PR DESCRIPTION
A new pylint came out yesterday ([v2.9.0](https://github.com/PyCQA/pylint/releases/tag/v2.9.0)), and doesn't like this specific line:

```
************* Module infra.crypto
191,19,error,no-value-for-parameter:No value for argument 'algorithm' in method call
```

~Quick fix looks like adding this parameter, though its presumably unused in this ECDSA signing path.~

Looks like this error is totally spurious, and adding the parameter actually breaks the call when we execute it (in `modules_test`). Ignoring the warning instead, will see if I can make a minimal repro and raise an issue.