### PR TITLE
Disable SGX JWT tests

### DIFF
--- a/tests/jwt_test.py
+++ b/tests/jwt_test.py
@@ -408,8 +408,8 @@ def run(args):
     ) as network:
         network.start_and_join(args)
         network = test_jwt_without_key_policy(network, args)
-        network = test_jwt_with_sgx_key_policy(network, args)
-        network = test_jwt_with_sgx_key_filter(network, args)
+        # network = test_jwt_with_sgx_key_policy(network, args)
+        # network = test_jwt_with_sgx_key_filter(network, args)
         network = test_jwt_key_auto_refresh(network, args)
 
         # Check that auto refresh also works on backups


### PR DESCRIPTION
This is turning off two of the JWT tests that use attestation-based-validation, because they depend on an Open Enclave release-specific certificate, which needs a custom build to produce, and for which there isn't time.

It's worth noting that this issue is resolved on `main`, which is using 0.17-rc and calls the new `oeutil` CLI to avoid this issue. 