### PR TITLE
Resharing hooks and RPC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,9 +432,7 @@ if(BUILD_TESTS)
     add_executable(
       raft_driver ${CMAKE_CURRENT_SOURCE_DIR}/src/consensus/aft/test/driver.cpp
     )
-    target_link_libraries(
-      raft_driver PRIVATE ccfcrypto.host openenclave::oehost
-    )
+    target_link_libraries(raft_driver PRIVATE ccfcrypto.host)
     target_include_directories(raft_driver PRIVATE src/aft)
 
     add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,7 @@ if(BUILD_TESTS)
       ${CMAKE_CURRENT_SOURCE_DIR}/src/consensus/aft/test/view_history.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/src/consensus/aft/test/committable_suffix.cpp
     )
-    target_link_libraries(raft_test PRIVATE ccfcrypto.host http_parser.host)
+    target_link_libraries(raft_test PRIVATE ccfcrypto.host)
 
     add_unit_test(
       raft_enclave_test
@@ -433,7 +433,7 @@ if(BUILD_TESTS)
       raft_driver ${CMAKE_CURRENT_SOURCE_DIR}/src/consensus/aft/test/driver.cpp
     )
     target_link_libraries(
-      raft_driver PRIVATE ccfcrypto.host openenclave::oehost http_parser.host
+      raft_driver PRIVATE ccfcrypto.host openenclave::oehost
     )
     target_include_directories(raft_driver PRIVATE src/aft)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,7 @@ if(BUILD_TESTS)
       ${CMAKE_CURRENT_SOURCE_DIR}/src/consensus/aft/test/view_history.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/src/consensus/aft/test/committable_suffix.cpp
     )
-    target_link_libraries(raft_test PRIVATE ccfcrypto.host)
+    target_link_libraries(raft_test PRIVATE ccfcrypto.host http_parser.host)
 
     add_unit_test(
       raft_enclave_test
@@ -432,7 +432,9 @@ if(BUILD_TESTS)
     add_executable(
       raft_driver ${CMAKE_CURRENT_SOURCE_DIR}/src/consensus/aft/test/driver.cpp
     )
-    target_link_libraries(raft_driver PRIVATE ccfcrypto.host)
+    target_link_libraries(
+      raft_driver PRIVATE ccfcrypto.host openenclave::oehost http_parser.host
+    )
     target_include_directories(raft_driver PRIVATE src/aft)
 
     add_test(

--- a/doc/audit/builtin_maps.rst
+++ b/doc/audit/builtin_maps.rst
@@ -108,7 +108,7 @@ Identity, status and attestations (endorsed quotes) of the nodes hosting the net
 .. doxygenenum:: ccf::QuoteFormat
    :project: CCF
 
-``nodes.configurations``
+``nodes.network.configurations``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The currently valid and in-flight network configurations of the network. The entry at 0 contains a dummy configuration that holds the largest ID used so far.

--- a/doc/audit/builtin_maps.rst
+++ b/doc/audit/builtin_maps.rst
@@ -108,7 +108,7 @@ Identity, status and attestations (endorsed quotes) of the nodes hosting the net
 .. doxygenenum:: ccf::QuoteFormat
    :project: CCF
 
-``network.configurations``
+``nodes.configurations``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The currently valid and in-flight network configurations of the network. The entry at 0 contains a dummy configuration that holds the largest ID used so far.

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -3081,18 +3081,11 @@ namespace aft
       for (const auto& [id, _] : c.nodes)
       {
         if (
-          nodes.find(id) != nodes.end() && learners.find(id) == learners.end())
-        {
-          LOG_TRACE_FMT("trusted: {}", id);
-          r++;
-        }
-        else if (id == state->my_node_id && !is_learner())
+          (nodes.find(id) != nodes.end() &&
+           learners.find(id) == learners.end()) ||
+          (id == state->my_node_id && !is_learner()))
         {
           r++;
-        }
-        else
-        {
-          LOG_TRACE_FMT("untrusted: {}", id);
         }
       }
       return r;

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -614,9 +614,6 @@ namespace aft
         guard.lock();
       }
 
-      // Hooks may be reordered, so the node info in `configurations` and
-      // `nodes` may not be available yet.
-
       if (
         use_two_tx_reconfig && !is_learner() && !is_retired() &&
         config.nodes.find(state->my_node_id) != config.nodes.end())

--- a/src/consensus/aft/raft_consensus.h
+++ b/src/consensus/aft/raft_consensus.h
@@ -156,6 +156,14 @@ namespace aft
       return aft->get_details();
     }
 
+    void add_identity(
+      ccf::SeqNo seqno,
+      kv::ReconfigurationId rid,
+      const ccf::Identity& identity) override
+    {
+      return aft->add_identity(seqno, rid, identity);
+    }
+
     void periodic(std::chrono::milliseconds elapsed) override
     {
       aft->periodic(elapsed);

--- a/src/consensus/aft/raft_consensus.h
+++ b/src/consensus/aft/raft_consensus.h
@@ -156,12 +156,12 @@ namespace aft
       return aft->get_details();
     }
 
-    void add_identity(
+    void add_resharing_result(
       ccf::SeqNo seqno,
       kv::ReconfigurationId rid,
-      const ccf::Identity& identity) override
+      const ccf::ResharingResult& result) override
     {
-      return aft->add_identity(seqno, rid, identity);
+      return aft->add_resharing_result(seqno, rid, result);
     }
 
     void periodic(std::chrono::milliseconds elapsed) override

--- a/src/consensus/aft/test/committable_suffix.cpp
+++ b/src/consensus/aft/test/committable_suffix.cpp
@@ -115,6 +115,7 @@ void keep_earliest_append_entries_for_each_target(
     nullptr, \
     nullptr, \
     nullptr, \
+    nullptr, \
     request_timeout, \
     election_timeout, \
     election_timeout); \

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -142,6 +142,7 @@ public:
         nullptr,
         std::make_shared<aft::RequestTracker>(),
         nullptr,
+        nullptr,
         ms(10),
         ms(100),
         ms(100));

--- a/src/consensus/aft/test/main.cpp
+++ b/src/consensus/aft/test/main.cpp
@@ -31,6 +31,7 @@ DOCTEST_TEST_CASE("Single node startup" * doctest::test_suite("single"))
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
     request_timeout,
     election_timeout,
     ms(1000));
@@ -77,6 +78,7 @@ DOCTEST_TEST_CASE("Single node commit" * doctest::test_suite("single"))
     nullptr,
     nullptr,
     request_timeout,
+    nullptr,
     election_timeout,
     ms(1000));
 
@@ -132,6 +134,7 @@ DOCTEST_TEST_CASE(
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
     request_timeout,
     ms(20),
     ms(1000));
@@ -148,6 +151,7 @@ DOCTEST_TEST_CASE(
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
     request_timeout,
     ms(100),
     ms(1000));
@@ -161,6 +165,7 @@ DOCTEST_TEST_CASE(
     nullptr,
     cert,
     std::make_shared<aft::State>(node_id2),
+    nullptr,
     nullptr,
     nullptr,
     nullptr,
@@ -304,6 +309,7 @@ DOCTEST_TEST_CASE(
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
     request_timeout,
     ms(20),
     ms(1000));
@@ -320,6 +326,7 @@ DOCTEST_TEST_CASE(
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
     request_timeout,
     ms(100),
     ms(1000));
@@ -333,6 +340,7 @@ DOCTEST_TEST_CASE(
     nullptr,
     cert,
     std::make_shared<aft::State>(node_id2),
+    nullptr,
     nullptr,
     nullptr,
     nullptr,
@@ -460,6 +468,7 @@ DOCTEST_TEST_CASE("Multiple nodes late join" * doctest::test_suite("multiple"))
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
     request_timeout,
     ms(20),
     ms(1000));
@@ -476,6 +485,7 @@ DOCTEST_TEST_CASE("Multiple nodes late join" * doctest::test_suite("multiple"))
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
     request_timeout,
     ms(100),
     ms(1000));
@@ -489,6 +499,7 @@ DOCTEST_TEST_CASE("Multiple nodes late join" * doctest::test_suite("multiple"))
     nullptr,
     cert,
     std::make_shared<aft::State>(node_id2),
+    nullptr,
     nullptr,
     nullptr,
     nullptr,
@@ -603,6 +614,7 @@ DOCTEST_TEST_CASE("Recv append entries logic" * doctest::test_suite("multiple"))
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
     request_timeout,
     ms(20),
     ms(1000));
@@ -616,6 +628,7 @@ DOCTEST_TEST_CASE("Recv append entries logic" * doctest::test_suite("multiple"))
     nullptr,
     cert,
     std::make_shared<aft::State>(node_id1),
+    nullptr,
     nullptr,
     nullptr,
     nullptr,
@@ -779,6 +792,7 @@ DOCTEST_TEST_CASE("Exceed append entries limit")
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
     request_timeout,
     ms(20),
     ms(1000));
@@ -795,6 +809,7 @@ DOCTEST_TEST_CASE("Exceed append entries limit")
     nullptr,
     nullptr,
     nullptr,
+    nullptr,
     request_timeout,
     ms(100),
     ms(1000));
@@ -808,6 +823,7 @@ DOCTEST_TEST_CASE("Exceed append entries limit")
     nullptr,
     cert,
     std::make_shared<aft::State>(node_id2),
+    nullptr,
     nullptr,
     nullptr,
     nullptr,

--- a/src/consensus/aft/test/main.cpp
+++ b/src/consensus/aft/test/main.cpp
@@ -77,8 +77,8 @@ DOCTEST_TEST_CASE("Single node commit" * doctest::test_suite("single"))
     nullptr,
     nullptr,
     nullptr,
-    request_timeout,
     nullptr,
+    request_timeout,
     election_timeout,
     ms(1000));
 

--- a/src/http/authentication/cert_auth.h
+++ b/src/http/authentication/cert_auth.h
@@ -122,6 +122,17 @@ namespace ccf
         return identity;
       }
 
+      std::vector<ccf::NodeId> known_nids;
+      nodes->foreach([&known_nids](const NodeId& nid, const NodeInfo& ni) {
+        known_nids.push_back(nid);
+        return true;
+      });
+      LOG_DEBUG_FMT(
+        "Could not find matching node certificate for node {}; we have "
+        "certificates for the following node ids: {}",
+        node_caller_id,
+        fmt::join(known_nids, ", "));
+
       error_reason = "Could not find matching node certificate";
       return nullptr;
     }

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -8,6 +8,7 @@
 #include "crypto/pem.h"
 #include "ds/nonstd.h"
 #include "enclave/consensus_type.h"
+#include "node/identity.h"
 #include "serialiser_declare.h"
 
 #include <array>
@@ -174,6 +175,10 @@ namespace kv
     virtual ConsensusDetails get_details() = 0;
     virtual void add_network_configuration(
       ccf::SeqNo seqno, const NetworkConfiguration& config) = 0;
+    virtual void add_identity(
+      ccf::SeqNo seqno,
+      ReconfigurationId rid,
+      const ccf::Identity& identity) = 0;
   };
 
   class ConsensusHook

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -9,6 +9,7 @@
 #include "ds/nonstd.h"
 #include "enclave/consensus_type.h"
 #include "node/identity.h"
+#include "node/resharing_types.h"
 #include "serialiser_declare.h"
 
 #include <array>
@@ -175,10 +176,10 @@ namespace kv
     virtual ConsensusDetails get_details() = 0;
     virtual void add_network_configuration(
       ccf::SeqNo seqno, const NetworkConfiguration& config) = 0;
-    virtual void add_identity(
+    virtual void add_resharing_result(
       ccf::SeqNo seqno,
       ReconfigurationId rid,
-      const ccf::Identity& identity) = 0;
+      const ccf::ResharingResult& result) = 0;
   };
 
   class ConsensusHook

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -170,6 +170,12 @@ namespace kv::test
       return ConsensusDetails{{}, {}, ReplicaState::Candidate};
     }
 
+    void add_identity(
+      ccf::SeqNo seqno,
+      kv::ReconfigurationId rid,
+      const ccf::Identity& identity) override
+    {}
+
     void emit_signature() override
     {
       return;

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -5,6 +5,7 @@
 #include "consensus/aft/impl/state.h"
 #include "crypto/symmetric_key.h"
 #include "kv/kv_types.h"
+#include "node/resharing_types.h"
 
 #include <algorithm>
 #include <iostream>
@@ -170,10 +171,10 @@ namespace kv::test
       return ConsensusDetails{{}, {}, ReplicaState::Candidate};
     }
 
-    void add_identity(
+    void add_resharing_result(
       ccf::SeqNo seqno,
-      kv::ReconfigurationId rid,
-      const ccf::Identity& identity) override
+      ReconfigurationId rid,
+      const ccf::ResharingResult& result) override
     {}
 
     void emit_signature() override

--- a/src/node/byzantine_identity.h
+++ b/src/node/byzantine_identity.h
@@ -142,11 +142,6 @@ namespace ccf
     bool have_identity_for(
       kv::ReconfigurationId rid, ccf::SeqNo commit_idx) const
     {
-      if (rid == (kv::ReconfigurationId)-1)
-      {
-        return false;
-      }
-
       auto idt = identities.find(rid);
       return idt != identities.end() && idt->second.seqno <= commit_idx;
     }

--- a/src/node/byzantine_identity.h
+++ b/src/node/byzantine_identity.h
@@ -1,0 +1,331 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ccf/tx_id.h"
+#include "consensus/aft/impl/state.h"
+#include "crypto/pem.h"
+#include "crypto/verifier.h"
+#include "enclave/rpc_sessions.h"
+#include "kv/kv_types.h"
+#include "node/identity.h"
+#include "node/rpc/call_types.h"
+#include "node/rpc/serdes.h"
+#include "node/rpc/serialization.h"
+#include "service_map.h"
+
+#include <vector>
+
+namespace ccf
+{
+  struct ByzantineIdentity : public Identity
+  {
+    ByzantineIdentity() : Identity()
+    {
+      type = IdentityType::BYZANTINE;
+    }
+  };
+
+  DECLARE_JSON_TYPE(ByzantineIdentity);
+  DECLARE_JSON_REQUIRED_FIELDS(ByzantineIdentity, cert);
+
+  using ByzantineIdentities =
+    ServiceMap<kv::ReconfigurationId, ByzantineIdentity>;
+
+  class ByzantineIdentitiesHook : public kv::ConsensusHook
+  {
+    kv::Version version;
+    std::unordered_map<kv::ReconfigurationId, ByzantineIdentity> byids;
+
+  public:
+    ByzantineIdentitiesHook(
+      kv::Version version_, const ByzantineIdentities::Write& w) :
+      version(version_)
+    {
+      for (const auto& [rid, opt_bid] : w)
+      {
+        if (opt_bid.has_value())
+        {
+          LOG_DEBUG_FMT(
+            "New Byzantine network identity, valid for configuration #{}.",
+            rid);
+          byids.try_emplace(rid, opt_bid.value());
+        }
+      }
+    }
+
+    void call(kv::ConfigurableConsensus* consensus) override
+    {
+      for (auto& [rid, id] : byids)
+      {
+        consensus->add_identity(version, rid, id);
+      }
+    }
+  };
+
+  class ByzantineIdentityTracker
+  {
+  public:
+    enum class SessionState
+    {
+      STARTED,
+      FINISHED
+    };
+
+    class Session
+    {
+    public:
+      SessionState state = SessionState::STARTED;
+      kv::NetworkConfiguration config;
+
+      Session(const kv::NetworkConfiguration& config_) : config(config_) {}
+    };
+
+    ByzantineIdentityTracker(
+      std::shared_ptr<aft::State> shared_state_,
+      std::shared_ptr<enclave::RPCMap> rpc_map_,
+      crypto::KeyPairPtr node_sign_kp_,
+      const crypto::Pem& node_cert_) :
+      shared_state(shared_state_),
+      rpc_map(rpc_map_),
+      node_sign_kp(node_sign_kp_),
+      node_cert(node_cert_)
+    {}
+
+    virtual ~ByzantineIdentityTracker() {}
+
+    void add_network_configuration(const kv::NetworkConfiguration& config)
+    {
+      network_configs[config.rid] = config;
+    }
+
+    void reshare(const kv::NetworkConfiguration& config)
+    {
+      auto rid = config.rid;
+      LOG_DEBUG_FMT("Identities: start resharing for configuration #{}", rid);
+      sessions.emplace(rid, Session(config));
+
+      auto msg = std::make_unique<threading::Tmsg<UpdateIdentityTaskMsg>>(
+        update_identity_cb, rid, rpc_map, node_sign_kp, node_cert);
+
+      threading::ThreadMessaging::thread_messaging.add_task(
+        threading::ThreadMessaging::get_execution_thread(
+          threading::MAIN_THREAD_ID),
+        std::move(msg));
+    }
+
+    kv::ReconfigurationId find_reconfiguration(
+      const kv::Configuration::Nodes& nodes) const
+    {
+      // We're searching for a configuration with the same set of nodes as
+      // `nodes`. We currently don't have an easy way to look up the
+      // reconfiguration ID, which would make this unnecessary.
+      for (auto& [rid, nc] : network_configs)
+      {
+        bool have_all = true;
+        for (auto& [nid, byid] : nodes)
+        {
+          if (nc.nodes.find(nid) == nc.nodes.end())
+          {
+            have_all = false;
+            break;
+          }
+        }
+        if (have_all)
+        {
+          return rid;
+        }
+      }
+      return -1;
+    }
+
+    bool have_identity_for(
+      kv::ReconfigurationId rid, ccf::SeqNo commit_idx) const
+    {
+      if (rid == (kv::ReconfigurationId)-1)
+      {
+        return false;
+      }
+
+      auto idt = identities.find(rid);
+      return idt != identities.end() && idt->second.seqno <= commit_idx;
+    }
+
+    void add_identity(
+      ccf::SeqNo seqno, kv::ReconfigurationId rid, ccf::Identity id)
+    {
+      LOG_DEBUG_FMT("Identities: adding identity for configuration #{}", rid);
+
+      assert(id.type == Identity::IdentityType::BYZANTINE);
+      SeqNoById entry = {seqno, *reinterpret_cast<ByzantineIdentity*>(&id)};
+      identities.emplace(rid, entry);
+
+      sessions.erase(rid);
+
+      // Delete old identities?
+      for (auto it = sessions.begin(); it != sessions.end();)
+      {
+        if (it->first <= rid)
+        {
+          it = sessions.erase(it);
+        }
+        else
+        {
+          it++;
+        }
+      }
+    }
+
+    ByzantineIdentity get_identity(kv::ReconfigurationId rid) const
+    {
+      auto iit = identities.find(rid);
+      if (iit == identities.end())
+      {
+        throw std::runtime_error("missing identity");
+      }
+      return iit->second.byid;
+    }
+
+    void rollback(SeqNo idx)
+    {
+      for (auto it = identities.begin(); it != identities.end();)
+      {
+        if (it->second.seqno > idx)
+        {
+          assert(sessions.find(it->first) == sessions.end());
+          it = identities.erase(it);
+        }
+        else
+        {
+          it++;
+        }
+      }
+    }
+
+    struct UpdateIdentityTaskMsg
+    {
+      UpdateIdentityTaskMsg(
+        kv::ReconfigurationId rid_,
+        std::shared_ptr<enclave::RPCMap> rpc_map_,
+        crypto::KeyPairPtr node_sign_kp_,
+        const crypto::Pem& node_cert_,
+        size_t retries_ = 10) :
+        rid(rid_),
+        rpc_map(rpc_map_),
+        node_sign_kp(node_sign_kp_),
+        node_cert(node_cert_),
+        retries(retries_)
+      {}
+
+      kv::ReconfigurationId rid;
+      std::shared_ptr<enclave::RPCMap> rpc_map;
+      crypto::KeyPairPtr node_sign_kp;
+      const crypto::Pem& node_cert;
+      size_t retries;
+    };
+
+  protected:
+    std::shared_ptr<aft::State> shared_state;
+    std::shared_ptr<enclave::RPCMap> rpc_map;
+    crypto::KeyPairPtr node_sign_kp;
+    const crypto::Pem& node_cert;
+    std::unordered_map<kv::ReconfigurationId, Session> sessions;
+    typedef struct
+    {
+      SeqNo seqno;
+      ByzantineIdentity byid;
+    } SeqNoById;
+    std::unordered_map<kv::ReconfigurationId, SeqNoById> identities;
+    std::unordered_map<kv::ReconfigurationId, kv::NetworkConfiguration>
+      network_configs;
+
+    static inline bool make_request(
+      http::Request& request,
+      std::shared_ptr<enclave::RPCMap> rpc_map,
+      crypto::KeyPairPtr node_sign_kp,
+      const crypto::Pem& node_cert)
+    {
+      auto node_cert_der = crypto::cert_pem_to_der(node_cert);
+      const auto key_id = crypto::Sha256Hash(node_cert_der).hex_str();
+
+      http::sign_request(request, node_sign_kp, key_id);
+      std::vector<uint8_t> packed = request.build_request();
+      auto node_session = std::make_shared<enclave::SessionContext>(
+        enclave::InvalidSessionId, node_cert.raw());
+      auto ctx = enclave::make_rpc_context(node_session, packed);
+
+      const auto actor_opt = http::extract_actor(*ctx);
+      if (!actor_opt.has_value())
+      {
+        throw std::logic_error("Unable to get actor");
+      }
+
+      const auto actor = rpc_map->resolve(actor_opt.value());
+      auto frontend_opt = rpc_map->find(actor);
+      if (!frontend_opt.has_value())
+      {
+        throw std::logic_error(
+          "RpcMap::find returned invalid (empty) frontend");
+      }
+
+      auto frontend = frontend_opt.value();
+      frontend->process(ctx);
+
+      auto rs = ctx->get_response_status();
+
+      if (rs != HTTP_STATUS_OK)
+      {
+        auto ser_res = ctx->serialise_response();
+        std::string str((char*)ser_res.data(), ser_res.size());
+        LOG_FAIL_FMT("request failed: {}", str);
+      }
+
+      return rs == HTTP_STATUS_OK;
+    }
+
+    static inline bool request_update_identity(
+      kv::ReconfigurationId rid,
+      std::shared_ptr<enclave::RPCMap> rpc_map,
+      crypto::KeyPairPtr node_sign_kp,
+      const crypto::Pem& node_cert)
+    {
+      LOG_DEBUG_FMT("Submitting RPC call to update identity");
+      ccf::UpdateIdentity::In ps = {rid};
+
+      http::Request request(fmt::format(
+        "/{}/{}",
+        ccf::get_actor_prefix(ccf::ActorsType::nodes),
+        "update-identity"));
+      request.set_header(
+        http::headers::CONTENT_TYPE, http::headervalues::contenttype::JSON);
+
+      auto body = serdes::pack(ps, serdes::Pack::Text);
+      request.set_body(&body);
+      return make_request(request, rpc_map, node_sign_kp, node_cert);
+    }
+
+    static void update_identity_cb(
+      std::unique_ptr<threading::Tmsg<UpdateIdentityTaskMsg>> msg)
+    {
+      if (!request_update_identity(
+            msg->data.rid,
+            msg->data.rpc_map,
+            msg->data.node_sign_kp,
+            msg->data.node_cert))
+      {
+        if (--msg->data.retries > 0)
+        {
+          threading::ThreadMessaging::thread_messaging.add_task(
+            threading::ThreadMessaging::get_execution_thread(
+              threading::MAIN_THREAD_ID),
+            std::move(msg));
+        }
+        else
+        {
+          LOG_DEBUG_FMT(
+            "Failed request, giving up as there are no more retries left");
+        }
+      }
+    }
+  };
+}

--- a/src/node/byzantine_identity.h
+++ b/src/node/byzantine_identity.h
@@ -290,7 +290,7 @@ namespace ccf
       http::Request request(fmt::format(
         "/{}/{}",
         ccf::get_actor_prefix(ccf::ActorsType::nodes),
-        "update-identity"));
+        "update_identity"));
       request.set_header(
         http::headers::CONTENT_TYPE, http::headervalues::contenttype::JSON);
 

--- a/src/node/entities.h
+++ b/src/node/entities.h
@@ -67,7 +67,7 @@ namespace ccf
     static constexpr auto NODES = "public:ccf.gov.nodes.info";
     static constexpr auto NODE_CODE_IDS = "public:ccf.gov.nodes.code_ids";
     static constexpr auto NODES_CONFIGURATIONS =
-      "public:ccf.gov.nodes.configurations";
+      "public:ccf.gov.nodes.network.configurations";
 
     // Service information
     static constexpr auto SERVICE = "public:ccf.gov.service.info";

--- a/src/node/entities.h
+++ b/src/node/entities.h
@@ -66,8 +66,8 @@ namespace ccf
     // Nodes identities and allowed code ids
     static constexpr auto NODES = "public:ccf.gov.nodes.info";
     static constexpr auto NODE_CODE_IDS = "public:ccf.gov.nodes.code_ids";
-    static constexpr auto NETWORK_CONFIGURATIONS =
-      "public:ccf.gov.network.configurations";
+    static constexpr auto NODES_CONFIGURATIONS =
+      "public:ccf.gov.nodes.configurations";
 
     // Service information
     static constexpr auto SERVICE = "public:ccf.gov.service.info";

--- a/src/node/entities.h
+++ b/src/node/entities.h
@@ -118,6 +118,10 @@ namespace ccf
     static constexpr auto CONSTITUTION = "public:ccf.gov.constitution";
     static constexpr auto PROPOSALS = "public:ccf.gov.proposals";
     static constexpr auto PROPOSALS_INFO = "public:ccf.gov.proposals_info";
+
+    // Byzantine network identities
+    static constexpr auto BYZANTINE_NETWORK_IDENTITIES =
+      "public:ccf.internal.byzantine_network_identities";
   };
 
 }

--- a/src/node/entities.h
+++ b/src/node/entities.h
@@ -119,9 +119,8 @@ namespace ccf
     static constexpr auto PROPOSALS = "public:ccf.gov.proposals";
     static constexpr auto PROPOSALS_INFO = "public:ccf.gov.proposals_info";
 
-    // Byzantine network identities
-    static constexpr auto BYZANTINE_NETWORK_IDENTITIES =
-      "public:ccf.internal.byzantine_network_identities";
+    // Identity resharings
+    static constexpr auto RESHARINGS = "public:ccf.internal.resharings";
   };
 
 }

--- a/src/node/hooks.h
+++ b/src/node/hooks.h
@@ -109,6 +109,9 @@ namespace ccf
     {
       // This hook is always executed after the hook for the nodes table above,
       // because the hooks are sorted by table name.
+      assert(
+        std::string(Tables::NODES) < std::string(Tables::NODES_CONFIGURATIONS));
+
       for (const auto& nc : configs)
       {
         consensus->add_network_configuration(version, nc);

--- a/src/node/hooks.h
+++ b/src/node/hooks.h
@@ -98,7 +98,7 @@ namespace ccf
     {
       for (const auto& [rid, opt_nc] : w)
       {
-        if (opt_nc.has_value())
+        if (rid != CONFIG_COUNT_KEY && opt_nc.has_value())
         {
           configs.insert(opt_nc.value());
         }
@@ -107,7 +107,9 @@ namespace ccf
 
     void call(kv::ConfigurableConsensus* consensus) override
     {
-      for (auto nc : configs)
+      // This hook is always executed after the hook for the nodes table above,
+      // because the hooks are sorted by table name.
+      for (const auto& nc : configs)
       {
         consensus->add_network_configuration(version, nc);
       }

--- a/src/node/identity.h
+++ b/src/node/identity.h
@@ -10,9 +10,20 @@
 
 namespace ccf
 {
-  struct NetworkIdentity
+  struct Identity
   {
+    enum class IdentityType
+    {
+      NORMAL,
+      BYZANTINE
+    };
+
+    IdentityType type = IdentityType::NORMAL;
     crypto::Pem cert;
+  };
+
+  struct NetworkIdentity : public Identity
+  {
     crypto::Pem priv_key;
 
     bool operator==(const NetworkIdentity& other) const

--- a/src/node/identity.h
+++ b/src/node/identity.h
@@ -28,14 +28,14 @@ namespace ccf
         type == other.type;
     }
 
-    NetworkIdentity() = default;
+    NetworkIdentity() : type(IdentityType::REPLICATED) {}
     NetworkIdentity(IdentityType type) : type(type) {}
   };
 
   class ReplicatedNetworkIdentity : public NetworkIdentity
   {
   public:
-    ReplicatedNetworkIdentity() = default;
+    ReplicatedNetworkIdentity() : NetworkIdentity(IdentityType::REPLICATED) {}
 
     ReplicatedNetworkIdentity(
       const std::string& name, crypto::CurveID curve_id) :
@@ -47,7 +47,8 @@ namespace ccf
       priv_key = identity_key_pair->private_key_pem();
     }
 
-    ReplicatedNetworkIdentity(const NetworkIdentity& other)
+    ReplicatedNetworkIdentity(const NetworkIdentity& other) :
+      NetworkIdentity(IdentityType::REPLICATED)
     {
       if (type != other.type)
       {
@@ -55,7 +56,6 @@ namespace ccf
       }
       priv_key = other.priv_key;
       cert = other.cert;
-      type = IdentityType::REPLICATED;
     }
   };
 
@@ -64,7 +64,8 @@ namespace ccf
   public:
     SplitNetworkIdentity() : NetworkIdentity(IdentityType::SPLIT) {}
 
-    SplitNetworkIdentity(const NetworkIdentity& other)
+    SplitNetworkIdentity(const NetworkIdentity& other) :
+      NetworkIdentity(IdentityType::SPLIT)
     {
       if (type != other.type)
       {
@@ -72,7 +73,6 @@ namespace ccf
       }
       priv_key = {};
       cert = other.cert;
-      type = IdentityType::SPLIT;
     }
   };
 }

--- a/src/node/identity.h
+++ b/src/node/identity.h
@@ -20,7 +20,7 @@ namespace ccf
   {
     crypto::Pem priv_key;
     crypto::Pem cert;
-    IdentityType type;
+    std::optional<IdentityType> type;
 
     bool operator==(const NetworkIdentity& other) const
     {

--- a/src/node/identity.h
+++ b/src/node/identity.h
@@ -10,35 +10,69 @@
 
 namespace ccf
 {
-  struct Identity
+  enum class IdentityType
   {
-    enum class IdentityType
-    {
-      NORMAL,
-      BYZANTINE
-    };
-
-    IdentityType type = IdentityType::NORMAL;
-    crypto::Pem cert;
+    REPLICATED,
+    SPLIT
   };
 
-  struct NetworkIdentity : public Identity
+  struct NetworkIdentity
   {
     crypto::Pem priv_key;
+    crypto::Pem cert;
+    IdentityType type;
 
     bool operator==(const NetworkIdentity& other) const
     {
-      return cert == other.cert && priv_key == other.priv_key;
+      return cert == other.cert && priv_key == other.priv_key &&
+        type == other.type;
     }
 
     NetworkIdentity() = default;
+    NetworkIdentity(IdentityType type) : type(type) {}
+  };
 
-    NetworkIdentity(const std::string& name, crypto::CurveID curve_id)
+  class ReplicatedNetworkIdentity : public NetworkIdentity
+  {
+  public:
+    ReplicatedNetworkIdentity() = default;
+
+    ReplicatedNetworkIdentity(
+      const std::string& name, crypto::CurveID curve_id) :
+      NetworkIdentity(IdentityType::REPLICATED)
     {
       auto identity_key_pair =
         std::make_shared<crypto::KeyPair_OpenSSL>(curve_id);
       cert = identity_key_pair->self_sign(name);
       priv_key = identity_key_pair->private_key_pem();
+    }
+
+    ReplicatedNetworkIdentity(const NetworkIdentity& other)
+    {
+      if (type != other.type)
+      {
+        throw std::runtime_error("invalid identity type conversion");
+      }
+      priv_key = other.priv_key;
+      cert = other.cert;
+      type = IdentityType::REPLICATED;
+    }
+  };
+
+  class SplitNetworkIdentity : public NetworkIdentity
+  {
+  public:
+    SplitNetworkIdentity() : NetworkIdentity(IdentityType::SPLIT) {}
+
+    SplitNetworkIdentity(const NetworkIdentity& other)
+    {
+      if (type != other.type)
+      {
+        throw std::runtime_error("invalid identity type conversion");
+      }
+      priv_key = {};
+      cert = other.cert;
+      type = IdentityType::SPLIT;
     }
   };
 }

--- a/src/node/network_tables.h
+++ b/src/node/network_tables.h
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 #include "backup_signatures.h"
+#include "byzantine_identity.h"
 #include "certs.h"
 #include "client_signatures.h"
 #include "code_id.h"
@@ -103,6 +104,7 @@ namespace ccf
     BackupSignaturesMap backup_signatures_map;
     aft::RevealedNoncesMap revealed_nonces_map;
     NewViewsMap new_views_map;
+    ByzantineIdentities byzantine_network_identities;
 
     // JS Constitution
     Constitution constitution;
@@ -140,6 +142,7 @@ namespace ccf
       backup_signatures_map(Tables::BACKUP_SIGNATURES),
       revealed_nonces_map(Tables::NONCES),
       new_views_map(Tables::NEW_VIEWS),
+      byzantine_network_identities(Tables::BYZANTINE_NETWORK_IDENTITIES),
       constitution(Tables::CONSTITUTION)
     {}
   };

--- a/src/node/network_tables.h
+++ b/src/node/network_tables.h
@@ -131,7 +131,7 @@ namespace ccf
       user_certs(Tables::USER_CERTS),
       user_info(Tables::USER_INFO),
       nodes(Tables::NODES),
-      network_configurations(Tables::NETWORK_CONFIGURATIONS),
+      network_configurations(Tables::NODES_CONFIGURATIONS),
       service(Tables::SERVICE),
       values(Tables::VALUES),
       secrets(Tables::ENCRYPTED_LEDGER_SECRETS),

--- a/src/node/network_tables.h
+++ b/src/node/network_tables.h
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 #include "backup_signatures.h"
-#include "byzantine_identity.h"
 #include "certs.h"
 #include "client_signatures.h"
 #include "code_id.h"
@@ -20,6 +19,7 @@
 #include "network_configurations.h"
 #include "nodes.h"
 #include "proposals.h"
+#include "resharing.h"
 #include "scripts.h"
 #include "secrets.h"
 #include "service.h"
@@ -104,7 +104,7 @@ namespace ccf
     BackupSignaturesMap backup_signatures_map;
     aft::RevealedNoncesMap revealed_nonces_map;
     NewViewsMap new_views_map;
-    ByzantineIdentities byzantine_network_identities;
+    Resharings resharings;
 
     // JS Constitution
     Constitution constitution;
@@ -142,7 +142,7 @@ namespace ccf
       backup_signatures_map(Tables::BACKUP_SIGNATURES),
       revealed_nonces_map(Tables::NONCES),
       new_views_map(Tables::NEW_VIEWS),
-      byzantine_network_identities(Tables::BYZANTINE_NETWORK_IDENTITIES),
+      resharings(Tables::RESHARINGS),
       constitution(Tables::CONSTITUTION)
     {}
   };

--- a/src/node/reconfig_id.h
+++ b/src/node/reconfig_id.h
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
-#include "network_state.h"
+#include "network_tables.h"
 
 #include <algorithm>
 

--- a/src/node/resharing.h
+++ b/src/node/resharing.h
@@ -32,12 +32,12 @@ namespace ccf
     ResharingsHook(kv::Version version_, const Resharings::Write& w) :
       version(version_)
     {
-      for (const auto& [rid, opt_bid] : w)
+      for (const auto& [rid, opt_rr] : w)
       {
-        if (opt_bid.has_value())
+        if (opt_rr.has_value())
         {
-          LOG_DEBUG_FMT("New resharing for configuration #{}.", rid);
-          results.try_emplace(rid, opt_bid.value());
+          LOG_DEBUG_FMT("New resharing result for configuration #{}.", rid);
+          results.try_emplace(rid, opt_rr.value());
         }
       }
     }
@@ -271,13 +271,12 @@ namespace ccf
       crypto::KeyPairPtr node_sign_kp,
       const crypto::Pem& node_cert)
     {
-      LOG_DEBUG_FMT("Submitting RPC call to update resharing");
       ccf::UpdateResharing::In ps = {rid};
 
       http::Request request(fmt::format(
         "/{}/{}",
         ccf::get_actor_prefix(ccf::ActorsType::nodes),
-        "update_resharing"));
+        "update-resharing"));
       request.set_header(
         http::headers::CONTENT_TYPE, http::headervalues::contenttype::JSON);
 

--- a/src/node/resharing_tracker.h
+++ b/src/node/resharing_tracker.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "consensus/aft/raft_types.h"
+#include "kv/kv_types.h"
+
+#include <optional>
+
+namespace ccf
+{
+  class ResharingTracker
+  {
+  public:
+    virtual void add_network_configuration(
+      const kv::NetworkConfiguration& config) = 0;
+    virtual void add_resharing_result(
+      ccf::SeqNo seqno,
+      kv::ReconfigurationId rid,
+      const ResharingResult& result) = 0;
+    virtual bool have_resharing_result_for(
+      kv::ReconfigurationId rid, ccf::SeqNo idx) const = 0;
+    virtual ResharingResult get_resharing_result(
+      kv::ReconfigurationId rid) const = 0;
+    virtual void reshare(const kv::NetworkConfiguration& config) = 0;
+    virtual std::optional<kv::ReconfigurationId> find_reconfiguration(
+      const kv::Configuration::Nodes& nodes) const = 0;
+
+    virtual void rollback(aft::Index idx) = 0;
+    virtual void compact(aft::Index idx) = 0;
+  };
+}

--- a/src/node/resharing_types.h
+++ b/src/node/resharing_types.h
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ds/json.h"
+
+#include <ccf/tx_id.h>
+
+namespace ccf
+{
+  using ReconfigurationId = uint64_t;
+
+  typedef struct
+  {
+    // SeqNo at which a resharing for a reconfiguration was completed
+    SeqNo seqno;
+    ReconfigurationId reconfiguration_id;
+  } ResharingResult;
+
+  DECLARE_JSON_TYPE(ResharingResult)
+  DECLARE_JSON_REQUIRED_FIELDS(ResharingResult, seqno, reconfiguration_id)
+}

--- a/src/node/rpc/call_types.h
+++ b/src/node/rpc/call_types.h
@@ -144,4 +144,12 @@ namespace ccf
       std::string message;
     };
   };
+
+  struct UpdateIdentity
+  {
+    struct In
+    {
+      kv::ReconfigurationId rid;
+    };
+  };
 }

--- a/src/node/rpc/call_types.h
+++ b/src/node/rpc/call_types.h
@@ -145,7 +145,7 @@ namespace ccf
     };
   };
 
-  struct UpdateIdentity
+  struct UpdateResharing
   {
     struct In
     {

--- a/src/node/rpc/error.h
+++ b/src/node/rpc/error.h
@@ -69,6 +69,7 @@ namespace ccf
     ERROR(VoteNotFound)
     ERROR(VoteAlreadyExists)
     ERROR(NodeCannotHandleRequest)
+    ERROR(IdentityAlreadyExists)
 
     // node-to-node (/join and /create):
     ERROR(ConsensusTypeMismatch)

--- a/src/node/rpc/error.h
+++ b/src/node/rpc/error.h
@@ -69,7 +69,6 @@ namespace ccf
     ERROR(VoteNotFound)
     ERROR(VoteAlreadyExists)
     ERROR(NodeCannotHandleRequest)
-    ERROR(IdentityAlreadyExists)
 
     // node-to-node (/join and /create):
     ERROR(ConsensusTypeMismatch)
@@ -77,6 +76,8 @@ namespace ccf
     ERROR(InvalidNodeState)
     ERROR(NodeAlreadyExists)
     ERROR(StartupSnapshotIsOld)
+
+    ERROR(ResharingAlreadyCompleted)
 
 #undef ERROR
   }

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -1230,7 +1230,7 @@ namespace ccf
       };
 
       make_endpoint(
-        "update-identity",
+        "update_identity",
         HTTP_POST,
         json_adapter(update_identity),
         // What type of auth do we require for nodes that aren't in the active

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -37,8 +37,16 @@ namespace ccf
     consensus_type,
     startup_seqno)
 
+  DECLARE_JSON_ENUM(
+    ccf::IdentityType,
+    {{ccf::IdentityType::REPLICATED, "Replicated"},
+     {ccf::IdentityType::SPLIT, "Split"}})
   DECLARE_JSON_TYPE(NetworkIdentity)
-  DECLARE_JSON_REQUIRED_FIELDS(NetworkIdentity, cert, priv_key)
+  DECLARE_JSON_REQUIRED_FIELDS(NetworkIdentity, cert, priv_key, type)
+  DECLARE_JSON_TYPE_WITH_BASE(ReplicatedNetworkIdentity, NetworkIdentity)
+  DECLARE_JSON_REQUIRED_FIELDS(ReplicatedNetworkIdentity, cert, priv_key, type)
+  DECLARE_JSON_TYPE_WITH_BASE(SplitNetworkIdentity, NetworkIdentity)
+  DECLARE_JSON_REQUIRED_FIELDS(SplitNetworkIdentity, cert, type)
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(
     JoinNetworkNodeToNode::Out::NetworkInfo)
@@ -134,6 +142,6 @@ namespace ccf
     current_allocated_heap_size,
     peak_allocated_heap_size)
 
-  DECLARE_JSON_TYPE(UpdateIdentity::In)
-  DECLARE_JSON_REQUIRED_FIELDS(UpdateIdentity::In, rid)
+  DECLARE_JSON_TYPE(UpdateResharing::In)
+  DECLARE_JSON_REQUIRED_FIELDS(UpdateResharing::In, rid)
 }

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -133,4 +133,7 @@ namespace ccf
     max_total_heap_size,
     current_allocated_heap_size,
     peak_allocated_heap_size)
+
+  DECLARE_JSON_TYPE(UpdateIdentity::In)
+  DECLARE_JSON_REQUIRED_FIELDS(UpdateIdentity::In, rid)
 }

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -41,10 +41,10 @@ namespace ccf
     ccf::IdentityType,
     {{ccf::IdentityType::REPLICATED, "Replicated"},
      {ccf::IdentityType::SPLIT, "Split"}})
-  DECLARE_JSON_TYPE(NetworkIdentity)
-  DECLARE_JSON_REQUIRED_FIELDS(NetworkIdentity, cert, priv_key, type)
+  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(NetworkIdentity)
+  DECLARE_JSON_REQUIRED_FIELDS(NetworkIdentity, cert, priv_key)
+  DECLARE_JSON_OPTIONAL_FIELDS(NetworkIdentity, type)
   DECLARE_JSON_TYPE_WITH_BASE(ReplicatedNetworkIdentity, NetworkIdentity)
-  DECLARE_JSON_REQUIRED_FIELDS(ReplicatedNetworkIdentity, cert, priv_key, type)
   DECLARE_JSON_TYPE_WITH_BASE(SplitNetworkIdentity, NetworkIdentity)
   DECLARE_JSON_REQUIRED_FIELDS(SplitNetworkIdentity, cert, type)
 

--- a/src/node/rpc/test/node_frontend_test.cpp
+++ b/src/node/rpc/test/node_frontend_test.cpp
@@ -93,7 +93,7 @@ TEST_CASE("Add a node to an opening service")
   NodeRpcFrontend frontend(network, context);
   frontend.open();
 
-  network.identity = std::make_unique<NetworkIdentity>();
+  network.identity = std::make_unique<ReplicatedNetworkIdentity>();
   network.ledger_secrets = std::make_shared<ccf::LedgerSecrets>();
   network.ledger_secrets->init();
 
@@ -224,7 +224,7 @@ TEST_CASE("Add a node to an open service")
   NodeRpcFrontend frontend(network, context);
   frontend.open();
 
-  network.identity = std::make_unique<NetworkIdentity>();
+  network.identity = std::make_unique<ReplicatedNetworkIdentity>();
 
   network.ledger_secrets = std::make_shared<ccf::LedgerSecrets>();
   network.ledger_secrets->init();

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -355,6 +355,7 @@ def test_retiring_nodes_emit_at_most_one_signature(network, args):
 
 @reqs.description("Adding a learner without snapshot")
 def test_learner_catches_up(network, args):
+    num_nodes_before = len(network.nodes)
     new_node = network.create_node("local://localhost")
     network.join_node(new_node, args.package, args, from_snapshot=False)
     network.trust_node(new_node, args, ccf.ledger.NodeStatus.LEARNER)
@@ -376,8 +377,17 @@ def test_learner_catches_up(network, args):
     primary, _ = network.find_primary()
     with primary.client() as c:
         s = c.get("/node/consensus")
-        print(s.body.json())
-        assert new_node.node_id in s.body.json()["details"]["learners"]
+        rj = s.body.json()
+        assert new_node.node_id in rj["details"]["learners"]
+
+        # At this point, there should be two configurations. The active one
+        # without the learner and the following one, which cannot be
+        # activated without promoting the node.
+        assert len(rj["details"]["configs"]) == 2
+        c0 = rj["details"]["configs"][0]["nodes"]
+        c1 = rj["details"]["configs"][1]["nodes"]
+        assert len(c0) == num_nodes_before and new_node.node_id not in c0
+        assert len(c1) == num_nodes_before + 1 and new_node.node_id in c1
     return network
 
 


### PR DESCRIPTION
Adds identity hooks and makes reconfiguration dependent on having an identity (if enabled). Addresses  #2724.