### PR TITLE
Fix cpack dependency for OE 0.17.0 final

### DIFF
--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -20,7 +20,7 @@ endif()
 
 # CPack variables for Debian packages
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-    "open-enclave (>=0.16.9), libuv1 (>= 1.18.0), libc++1-8, libc++abi1-8"
+    "open-enclave (>=0.17.0), libuv1 (>= 1.18.0), libc++1-8, libc++abi1-8"
 )
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 


### PR DESCRIPTION
Forgotten during #2758, already fixed in the release branch.