### PR TITLE
Update documentation to use x-ms-ccf-transaction-id everywhere

### DIFF
--- a/doc/governance/accept_recovery.rst
+++ b/doc/governance/accept_recovery.rst
@@ -65,16 +65,14 @@ The recovery share retrieval, decryption and submission steps are conveniently p
     --key member0_privk --cacert network_cert
     HTTP/1.1 200 OK
     content-type: text/plain
-    x-ccf-tx-seqno: 28
-    x-ccf-tx-view: 4
+    x-ms-ccf-transaction-id: 4.28
     1/2 recovery shares successfully submitted.
 
     $ submit_recovery_share.sh https://<ccf-node-address> --member-enc-privk member1_enc_privk.pem --cert member1_cert
     --key member1_privk --cacert network_cert
     HTTP/1.1 200 OK
     content-type: text/plain
-    x-ccf-tx-seqno: 30
-    x-ccf-tx-view: 4
+    x-ms-ccf-transaction-id: 4.30
     2/2 recovery shares successfully submitted. End of recovery procedure initiated.
 
 When the recovery threshold is reached, the ``POST /gov/recovery_share`` RPC returns that the end of the recovery procedure is initiated and the private ledger is now being recovered.

--- a/doc/use_apps/issue_commands.rst
+++ b/doc/use_apps/issue_commands.rst
@@ -17,15 +17,13 @@ For example, to record a message at a specific id with the :doc:`C++ sample logg
     HTTP/1.1 200 OK
     content-length: 5
     content-type: application/json
-    x-ccf-tx-seqno: 23
-    x-ccf-tx-view: 2
+    x-ms-ccf-transaction-id: 2.32
 
     true
 
 The HTTP response some CCF commit information in the headers:
 
-- ``"x-ccf-tx-seqno"`` is the unique version at which the request was executed
-- ``"x-ccf-tx-view"`` indicates the consensus view at which the request was executed
+- ``"x-ms-ccf-transaction-id"`` indicates the consensus view, and the unique version at which the request was executed, separated by a ``"."``.
 
 The response body (the JSON value ``true``) indicates that the request was executed successfully. For many RPCs this will be a JSON object with more details about the execution result.
 

--- a/doc/use_apps/issue_commands.rst
+++ b/doc/use_apps/issue_commands.rst
@@ -17,7 +17,7 @@ For example, to record a message at a specific id with the :doc:`C++ sample logg
     HTTP/1.1 200 OK
     content-length: 5
     content-type: application/json
-    x-ms-ccf-transaction-id: 2.32
+    x-ms-ccf-transaction-id: 2.23
 
     true
 

--- a/doc/use_apps/verify_tx.rst
+++ b/doc/use_apps/verify_tx.rst
@@ -16,12 +16,11 @@ To guarantee that their request is successfully committed to the ledger, a user 
     HTTP/1.1 200 OK
     content-length: 23
     content-type: application/json
-    x-ccf-tx-seqno: 42
-    x-ccf-tx-view: 5
+    x-ms-ccf-transaction-id: 5.42
 
     {"status":"COMMITTED"}
 
-This example queries the status of transaction ID ``2.18`` (constructed from view ``2`` and sequence number ``18``). The response indicates this was successfully committed. The headers also show that the service has since made progress with other requests (``x-ccf-tx-seqno: 42``) and changed view (``x-ccf-tx-view: 5``).
+This example queries the status of transaction ID ``2.18`` (constructed from view ``2`` and sequence number ``18``). The response indicates this was successfully committed. The headers also show that the service has since made progress with other requests and changed view (``x-ms-ccf-transaction-id: 5.42``).
 
 The possible statuses returned by ``GET /tx`` are:
 


### PR DESCRIPTION
Fix #2759 