### PR TITLE
Sign new-view-confirmation message earlier

### DIFF
--- a/src/consensus/aft/impl/view_change_tracker.h
+++ b/src/consensus/aft/impl/view_change_tracker.h
@@ -258,6 +258,7 @@ namespace aft
         nv.view_change_messages.emplace(it.first, it.second);
       }
 
+      store->sign_view_change_confirmation(nv);
       last_nvc = nv;
 
       return nv;

--- a/src/node/progress_tracker_types.h
+++ b/src/node/progress_tracker_types.h
@@ -79,6 +79,8 @@ namespace ccf
       ccf::SeqNo seqno) = 0;
     virtual ccf::SeqNo write_view_change_confirmation(
       ViewChangeConfirmation& new_view) = 0;
+    virtual void sign_view_change_confirmation(
+      ViewChangeConfirmation& new_view) = 0;
     virtual bool verify_view_change_request_confirmation(
       ViewChangeConfirmation& new_view, const NodeId& from) = 0;
   };
@@ -229,6 +231,13 @@ namespace ccf
       auto h = hash_new_view(new_view);
       return from_cert->verify_hash(
         h.h, new_view.signature, crypto::MDType::SHA256);
+    }
+
+    void sign_view_change_confirmation(
+      ViewChangeConfirmation& new_view) override
+    {
+      crypto::Sha256Hash h = hash_new_view(new_view);
+      new_view.signature = kp.sign_hash(h.h.data(), h.h.size());
     }
 
     ccf::SeqNo write_view_change_confirmation(

--- a/src/node/progress_tracker_types.h
+++ b/src/node/progress_tracker_types.h
@@ -246,9 +246,6 @@ namespace ccf
       kv::CommittableTx tx(&store);
       auto new_views_tv = tx.rw(new_views);
 
-      crypto::Sha256Hash h = hash_new_view(new_view);
-      new_view.signature = kp.sign_hash(h.h.data(), h.h.size());
-
       new_views_tv->put(0, new_view);
       auto r = tx.commit();
       if (r != kv::CommitResult::SUCCESS)

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -54,6 +54,10 @@ public:
     write_view_change_confirmation,
     ccf::SeqNo(ccf::ViewChangeConfirmation& new_view),
     override);
+  MAKE_MOCK1(
+    sign_view_change_confirmation,
+    void(ccf::ViewChangeConfirmation& new_view),
+    override);
 };
 
 void ordered_execution(
@@ -825,7 +829,12 @@ TEST_CASE("Sending evidence out of band")
 
   INFO("Can trigger view change");
   {
-    aft::ViewChangeTracker vct(nullptr, std::chrono::seconds(10));
+    auto store = std::make_shared<StoreMock>();
+    StoreMock& store_mock = *store.get();
+    REQUIRE_CALL(store_mock, sign_view_change_confirmation(_))
+      .TIMES(AT_LEAST(2));
+
+    aft::ViewChangeTracker vct(store, std::chrono::seconds(10));
     size_t i = 0;
     for (auto const& node_id : node_ids)
     {


### PR DESCRIPTION
We used to only sign the new-view-confirmation message just before the new primary wrote it to the ledger. That if it was requested by a replica that has not seen the version on the ledger the message was not signed.