### PR TITLE
Add table of network configurations

### DIFF
--- a/doc/audit/builtin_maps.rst
+++ b/doc/audit/builtin_maps.rst
@@ -111,7 +111,7 @@ Identity, status and attestations (endorsed quotes) of the nodes hosting the net
 ``network_configurations``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The currently valid and in-flight network configurations of the network.
+The currently valid and in-flight network configurations of the network. The entry at -1 contains a dummy configuration that holds the largest ID used so far.
 
 **Key** Reconfiguration ID: a unique identifier of a configuration
 

--- a/doc/audit/builtin_maps.rst
+++ b/doc/audit/builtin_maps.rst
@@ -115,7 +115,7 @@ The currently valid and in-flight network configurations of the network.
 
 **Key** Reconfiguration ID: a unique identifier of a configuration
 
-**Value** A set of node IDs of the nodes in the respective configuration. Represented as JSON.
+**Value** A set of node IDs of the nodes in the respective configuration, represented as a JSON array.
 
 .. doxygenstruct:: ccf::NetworkConfiguration
    :project: CCF

--- a/doc/audit/builtin_maps.rst
+++ b/doc/audit/builtin_maps.rst
@@ -108,7 +108,7 @@ Identity, status and attestations (endorsed quotes) of the nodes hosting the net
 .. doxygenenum:: ccf::QuoteFormat
    :project: CCF
 
-``network_configurations``
+``network.configurations``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The currently valid and in-flight network configurations of the network. The entry at -1 contains a dummy configuration that holds the largest ID used so far.

--- a/doc/audit/builtin_maps.rst
+++ b/doc/audit/builtin_maps.rst
@@ -108,6 +108,19 @@ Identity, status and attestations (endorsed quotes) of the nodes hosting the net
 .. doxygenenum:: ccf::QuoteFormat
    :project: CCF
 
+``network_configurations``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The currently valid and in-flight network configurations of the network.
+
+**Key** Reconfiguration ID: a unique identifier of a configuration
+
+**Value** A set of node IDs of the nodes in the respective configuration. Represented as JSON.
+
+.. doxygenstruct:: ccf::NetworkConfiguration
+   :project: CCF
+   :members:
+
 ``nodes.code_ids``
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -326,6 +326,11 @@ namespace aft
       return replica_state == kv::ReplicaState::Learner;
     }
 
+    bool is_retired()
+    {
+      return replica_state == kv::ReplicaState::Retired;
+    }
+
     ccf::NodeId get_primary(ccf::View view)
     {
       CCF_ASSERT_FMT(
@@ -553,6 +558,28 @@ namespace aft
       }
       backup_nodes.clear();
       create_and_remove_node_state();
+    }
+
+    void add_network_configuration(
+      ccf::SeqNo seqno, const kv::NetworkConfiguration& config)
+    {
+      LOG_DEBUG_FMT("Configurations: new network config: {{{}}}", config);
+      std::unique_lock<std::mutex> guard(state->lock, std::defer_lock);
+
+      if (is_bft_reexecution() && threading::ThreadMessaging::thread_count > 1)
+      {
+        guard.lock();
+      }
+
+      // Hooks may be reordered, so the node info in `configurations` and
+      // `nodes` may not be available yet.
+
+      if (
+        use_two_tx_reconfig && !is_learner() && !is_retired() &&
+        config.nodes.find(state->my_node_id) != config.nodes.end())
+      {
+        // Send/schedule ORCs
+      }
     }
 
     Configuration::Nodes get_latest_configuration_unsafe() const
@@ -1226,7 +1253,7 @@ namespace aft
     {
       const auto prev_idx = start_idx - 1;
 
-      if (replica_state == kv::ReplicaState::Retired && start_idx >= end_idx)
+      if (is_retired() && start_idx >= end_idx)
       {
         // Continue to replicate, but do not send heartbeats if we are retired
         return;
@@ -2607,7 +2634,7 @@ namespace aft
 
     void become_leader()
     {
-      if (replica_state == kv::ReplicaState::Retired)
+      if (is_retired())
       {
         return;
       }

--- a/src/consensus/aft/raft_consensus.h
+++ b/src/consensus/aft/raft_consensus.h
@@ -135,6 +135,12 @@ namespace aft
       aft->add_configuration(seqno, conf, learners);
     }
 
+    void add_network_configuration(
+      ccf::SeqNo seqno, const kv::NetworkConfiguration& config) override
+    {
+      return aft->add_network_configuration(seqno, config);
+    }
+
     Configuration::Nodes get_latest_configuration() override
     {
       return aft->get_latest_configuration();

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -151,6 +151,10 @@ namespace kv::test
       const std::unordered_set<NodeId>& learners = {}) override
     {}
 
+    void add_network_configuration(
+      ccf::SeqNo seqno, const NetworkConfiguration& config) override
+    {}
+
     Configuration::Nodes get_latest_configuration_unsafe() const override
     {
       return {};

--- a/src/node/entities.h
+++ b/src/node/entities.h
@@ -67,7 +67,7 @@ namespace ccf
     static constexpr auto NODES = "public:ccf.gov.nodes.info";
     static constexpr auto NODE_CODE_IDS = "public:ccf.gov.nodes.code_ids";
     static constexpr auto NETWORK_CONFIGURATIONS =
-      "public:ccf.gov.network_configurations";
+      "public:ccf.gov.network.configurations";
 
     // Service information
     static constexpr auto SERVICE = "public:ccf.gov.service.info";

--- a/src/node/entities.h
+++ b/src/node/entities.h
@@ -66,6 +66,8 @@ namespace ccf
     // Nodes identities and allowed code ids
     static constexpr auto NODES = "public:ccf.gov.nodes.info";
     static constexpr auto NODE_CODE_IDS = "public:ccf.gov.nodes.code_ids";
+    static constexpr auto NETWORK_CONFIGURATIONS =
+      "public:ccf.gov.network_configurations";
 
     // Service information
     static constexpr auto SERVICE = "public:ccf.gov.service.info";

--- a/src/node/genesis_gen.h
+++ b/src/node/genesis_gen.h
@@ -281,6 +281,11 @@ namespace ccf
 
       auto node = tx.rw(tables.nodes);
       node->put(id, node_info);
+
+      kv::NetworkConfiguration nc =
+        get_latest_network_configuration(tables, tx);
+      nc.nodes.insert(id);
+      add_new_network_reconfiguration(tables, tx, nc);
     }
 
     auto get_trusted_and_learner_nodes(

--- a/src/node/genesis_gen.h
+++ b/src/node/genesis_gen.h
@@ -60,7 +60,7 @@ namespace ccf
       {
         ni.status = NodeStatus::RETIRED;
         nodes->put(nid, ni);
-        nc.nodes.insert(nid);
+        nc.nodes.erase(nid);
       }
 
       return nc;

--- a/src/node/hooks.h
+++ b/src/node/hooks.h
@@ -76,4 +76,33 @@ namespace ccf
       }
     }
   };
+
+  class NetworkConfigurationsHook : public kv::ConsensusHook
+  {
+    kv::Version version;
+    std::set<kv::NetworkConfiguration> configs;
+
+  public:
+    NetworkConfigurationsHook(
+      kv::Version version_, const NetworkConfigurations::Write& w) :
+      version(version_)
+    {
+      for (const auto& [rid, opt_nc] : w)
+      {
+        if (opt_nc.has_value())
+        {
+          configs.insert(opt_nc.value());
+        }
+      }
+    }
+
+    void call(kv::ConfigurableConsensus* consensus) override
+    {
+      for (auto nc : configs)
+      {
+        consensus->add_network_configuration(version, nc);
+      }
+    }
+  };
+
 }

--- a/src/node/network_configurations.h
+++ b/src/node/network_configurations.h
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ccf/entity_id.h"
+#include "entities.h"
+#include "kv/map.h"
+#include "network_tables.h"
+#include "node_info_network.h"
+#include "quote_info.h"
+#include "service_map.h"
+
+#include <string>
+#include <vector>
+
+namespace ccf
+{
+  using NetworkConfigurations =
+    ServiceMap<kv::ReconfigurationId, kv::NetworkConfiguration>;
+}

--- a/src/node/network_tables.h
+++ b/src/node/network_tables.h
@@ -16,6 +16,7 @@
 #include "kv/store.h"
 #include "members.h"
 #include "modules.h"
+#include "network_configurations.h"
 #include "nodes.h"
 #include "proposals.h"
 #include "scripts.h"
@@ -79,6 +80,7 @@ namespace ccf
     // Node table
     //
     Nodes nodes;
+    NetworkConfigurations network_configurations;
 
     //
     // Internal CCF tables
@@ -127,6 +129,7 @@ namespace ccf
       user_certs(Tables::USER_CERTS),
       user_info(Tables::USER_INFO),
       nodes(Tables::NODES),
+      network_configurations(Tables::NETWORK_CONFIGURATIONS),
       service(Tables::SERVICE),
       values(Tables::VALUES),
       secrets(Tables::ENCRYPTED_LEDGER_SECRETS),

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -952,7 +952,7 @@ namespace ccf
       auto tx = network.tables->create_tx();
       GenesisGenerator g(network, tx);
       g.create_service(network.identity->cert);
-      g.retire_active_nodes();
+      auto network_config = g.retire_active_nodes();
 
       if (network.consensus_type == ConsensusType::BFT)
       {
@@ -988,9 +988,11 @@ namespace ccf
          quote_info,
          node_encrypt_kp->public_key_pem().raw(),
          NodeStatus::PENDING,
-         get_next_reconfiguration_id(network, tx),
          std::nullopt,
          ds::to_hex(code_digest.data)});
+
+      network_config.nodes.insert(self);
+      add_new_network_reconfiguration(network, tx, network_config);
 
       LOG_INFO_FMT("Deleted previous nodes and added self as {}", self);
 
@@ -1972,6 +1974,14 @@ namespace ccf
           [](kv::Version version, const Nodes::Write& w)
             -> kv::ConsensusHookPtr {
             return std::make_unique<ConfigurationChangeHook>(version, w);
+          }));
+
+      network.tables->set_map_hook(
+        network.network_configurations.get_name(),
+        network.network_configurations.wrap_map_hook(
+          [](kv::Version version, const NetworkConfigurations::Write& w)
+            -> kv::ConsensusHookPtr {
+            return std::make_unique<NetworkConfigurationsHook>(version, w);
           }));
 
       setup_basic_hooks();

--- a/src/node/nodes.h
+++ b/src/node/nodes.h
@@ -41,8 +41,6 @@ namespace ccf
     crypto::Pem encryption_pub_key;
     /// Node status
     NodeStatus status = NodeStatus::PENDING;
-    /// The reconfiguration in which the node was added.
-    std::optional<uint64_t> reconfiguration_id;
 
     /** Set to the seqno of the latest ledger secret at the time the node is
         trusted */
@@ -54,8 +52,7 @@ namespace ccf
   DECLARE_JSON_TYPE_WITH_BASE_AND_OPTIONAL_FIELDS(NodeInfo, NodeInfoNetwork);
   DECLARE_JSON_REQUIRED_FIELDS(
     NodeInfo, cert, quote_info, encryption_pub_key, status);
-  DECLARE_JSON_OPTIONAL_FIELDS(
-    NodeInfo, ledger_secret_seqno, reconfiguration_id, code_digest);
+  DECLARE_JSON_OPTIONAL_FIELDS(NodeInfo, ledger_secret_seqno, code_digest);
 
   using Nodes = ServiceMap<NodeId, NodeInfo>;
 }

--- a/src/node/reconfig_id.h
+++ b/src/node/reconfig_id.h
@@ -8,14 +8,13 @@
 
 namespace ccf
 {
+  kv::ReconfigurationId CONFIG_COUNT_KEY = -1;
+
   inline kv::ReconfigurationId get_next_reconfiguration_id(
     ccf::NetworkTables& tables, kv::ReadOnlyTx& tx)
   {
-    // The entry at -1 contains a dummy configuration that holds the largest ID
-    // used so far.
-
     auto nconfigs = tx.ro(tables.network_configurations);
-    auto e = nconfigs->get((kv::ReconfigurationId)-1);
+    auto e = nconfigs->get(CONFIG_COUNT_KEY);
     if (!e.has_value())
     {
       return 0;
@@ -30,7 +29,7 @@ namespace ccf
     ccf::NetworkTables& tables, kv::Tx& tx)
   {
     auto nconfigs = tx.ro(tables.network_configurations);
-    auto e = nconfigs->get((kv::ReconfigurationId)-1);
+    auto e = nconfigs->get(CONFIG_COUNT_KEY);
     if (e.has_value())
     {
       return nconfigs->get(e.value().rid).value();
@@ -47,6 +46,6 @@ namespace ccf
       config);
     auto nconfigs = tx.rw(tables.network_configurations);
     nconfigs->put(config.rid, config);
-    nconfigs->put((kv::ReconfigurationId)-1, {config.rid, {}});
+    nconfigs->put(CONFIG_COUNT_KEY, {config.rid, {}});
   }
 }

--- a/src/node/reconfig_id.h
+++ b/src/node/reconfig_id.h
@@ -8,20 +8,41 @@
 
 namespace ccf
 {
-  inline size_t get_next_reconfiguration_id(
-    ccf::NetworkState& network, kv::ReadOnlyTx& tx)
+  inline kv::ReconfigurationId get_next_reconfiguration_id(
+    ccf::NetworkTables& tables, kv::ReadOnlyTx& tx)
   {
-    auto nodes = tx.ro(network.nodes);
+    auto nconfigs = tx.ro(tables.network_configurations);
+    auto e = nconfigs->get((kv::ReconfigurationId)-1);
+    if (!e.has_value())
+    {
+      return 0;
+    }
+    else
+    {
+      return e.value().rid + 1;
+    }
+  }
 
-    size_t max_id = 0;
-    nodes->foreach([&max_id](const auto& node_id, const auto& node_info) {
-      if (node_info.reconfiguration_id.has_value())
-      {
-        max_id = std::max(max_id, node_info.reconfiguration_id.value());
-      }
-      return true;
-    });
+  inline kv::NetworkConfiguration get_latest_network_configuration(
+    ccf::NetworkTables& tables, kv::Tx& tx)
+  {
+    auto nconfigs = tx.ro(tables.network_configurations);
+    auto e = nconfigs->get((kv::ReconfigurationId)-1);
+    if (e.has_value())
+    {
+      return nconfigs->get(e.value().rid).value();
+    }
+    return {};
+  }
 
-    return max_id + 1;
+  inline void add_new_network_reconfiguration(
+    ccf::NetworkTables& tables, kv::Tx& tx, kv::NetworkConfiguration& config)
+  {
+    config.rid = get_next_reconfiguration_id(tables, tx);
+    LOG_DEBUG_FMT(
+      "Configurations: adding new entry to network_configurations table: {}",
+      config);
+    auto nconfigs = tx.rw(tables.network_configurations);
+    nconfigs->put(config.rid, config);
   }
 }

--- a/src/node/reconfig_id.h
+++ b/src/node/reconfig_id.h
@@ -11,6 +11,9 @@ namespace ccf
   inline kv::ReconfigurationId get_next_reconfiguration_id(
     ccf::NetworkTables& tables, kv::ReadOnlyTx& tx)
   {
+    // The entry at -1 contains a dummy configuration that holds the largest ID
+    // used so far.
+
     auto nconfigs = tx.ro(tables.network_configurations);
     auto e = nconfigs->get((kv::ReconfigurationId)-1);
     if (!e.has_value())

--- a/src/node/reconfig_id.h
+++ b/src/node/reconfig_id.h
@@ -44,5 +44,6 @@ namespace ccf
       config);
     auto nconfigs = tx.rw(tables.network_configurations);
     nconfigs->put(config.rid, config);
+    nconfigs->put((kv::ReconfigurationId)-1, {config.rid, {}});
   }
 }

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -14,7 +14,6 @@
 #include "node/members.h"
 #include "node/nodes.h"
 #include "node/quote.h"
-#include "node/reconfig_id.h"
 #include "node/secret_share.h"
 #include "node/share_manager.h"
 #include "node_interface.h"
@@ -833,11 +832,6 @@ namespace ccf
            NodeStatus::TRUSTED,
            std::nullopt,
            ds::to_hex(in.code_digest.data)});
-
-        kv::NetworkConfiguration nc =
-          get_latest_network_configuration(network, ctx.tx);
-        nc.nodes.insert(in.node_id);
-        add_new_network_reconfiguration(network, ctx.tx, nc);
 
 #ifdef GET_QUOTE
         g.trust_node_code_id(in.code_digest);

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -831,9 +831,13 @@ namespace ccf
            {in.quote_info},
            in.public_encryption_key,
            NodeStatus::TRUSTED,
-           get_next_reconfiguration_id(network, ctx.tx),
            std::nullopt,
            ds::to_hex(in.code_digest.data)});
+
+        kv::NetworkConfiguration nc =
+          get_latest_network_configuration(network, ctx.tx);
+        nc.nodes.insert(in.node_id);
+        add_new_network_reconfiguration(network, ctx.tx, nc);
 
 #ifdef GET_QUOTE
         g.trust_node_code_id(in.code_digest);

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -189,9 +189,13 @@ namespace ccf
          in.quote_info,
          in.public_encryption_key,
          node_status,
-         get_next_reconfiguration_id(network, tx),
          ledger_secret_seqno,
          ds::to_hex(code_digest.data)});
+
+      kv::NetworkConfiguration nc =
+        get_latest_network_configuration(network, tx);
+      nc.nodes.insert(joining_node_id);
+      add_new_network_reconfiguration(network, tx, nc);
 
       LOG_INFO_FMT("Node {} added as {}", joining_node_id, node_status);
 


### PR DESCRIPTION
This adds a table of network configurations that assigns unique reconfiguration IDs and a hook on that table that will trigger ORC RPCs in the next reconfiguration PR. 