### PR TITLE
Fix network.wait_for_new_primary for BFT

### DIFF
--- a/tests/election.py
+++ b/tests/election.py
@@ -8,7 +8,6 @@ import infra.proc
 import infra.e2e_args
 import infra.checker
 import suite.test_requirements as reqs
-from ccf.clients import CCFConnectionException
 
 from loguru import logger as LOG
 
@@ -21,25 +20,8 @@ from loguru import logger as LOG
 @reqs.description("Stopping current primary and waiting for a new one to be elected")
 @reqs.can_kill_n_nodes(1)
 def test_kill_primary(network, args):
-    primary, backup = network.find_primary_and_any_backup()
+    primary, _ = network.find_primary_and_any_backup()
     primary.stop()
-
-    # When the consensus is BFT there is no status message timer that triggers a new election.
-    # It is triggered with a timeout from a message not executing. We need to send the message that
-    # will not execute because of the stopped primary which will then trigger a view change
-    if args.consensus == "bft":
-        try:
-            with backup.client("user0") as c:
-                _ = c.post(
-                    "/app/log/private",
-                    {
-                        "id": -1,
-                        "msg": "This is submitted to force a view change",
-                    },
-                )
-        except CCFConnectionException:
-            LOG.warning(f"Could not successfully connect to node {backup.node_id}.")
-
     network.wait_for_new_primary(primary)
 
     return network

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -908,7 +908,7 @@ class Network:
                                     "msg": "This is submitted to force a view change",
                                 },
                             )
-                        time.sleep(5)
+                        time.sleep(1)
                     except CCFConnectionException:
                         LOG.warning(
                             f"Could not successfully connect to node {backup.node_id}."

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -897,6 +897,22 @@ class Network:
         logs = []
         while time.time() < end_time:
             try:
+                backup = self.find_any_backup()
+                if backup.get_consensus() == "bft":
+                    try:
+                        with backup.client("user0") as c:
+                            _ = c.post(
+                                "/app/log/private",
+                                {
+                                    "id": -1,
+                                    "msg": "This is submitted to force a view change",
+                                },
+                            )
+                        time.sleep(5)
+                    except CCFConnectionException:
+                        LOG.warning(
+                            f"Could not successfully connect to node {backup.node_id}."
+                        )
                 logs = []
                 new_primary, new_term = self.find_primary(nodes=nodes, log_capture=logs)
                 if new_primary.node_id != old_primary.node_id:

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -89,6 +89,7 @@ class Node:
         self.node_id = None
         self.node_client_host = None
         self.version = version
+        self.consensus = None
 
         if host.startswith("local://"):
             self.remote_impl = infra.remote.LocalRemote
@@ -179,6 +180,9 @@ class Node:
         )
         self.network_state = NodeNetworkState.joined
 
+    def get_consensus(self):
+        return self.consensus
+
     def _start(
         self,
         start_type,
@@ -247,8 +251,9 @@ class Node:
                 self.remote.set_perf()
             self.remote.start()
         self.remote.get_startup_files(self.common_dir)
+        self.consensus = kwargs.get("consensus")
 
-        if kwargs.get("consensus") == "cft":
+        if self.consensus == "cft":
             with open(os.path.join(self.common_dir, f"{self.local_node_id}.pem")) as f:
                 self.node_id = infra.crypto.compute_public_key_der_hash_hex_from_pem(
                     f.read()


### PR DESCRIPTION
BFT view-changes are not timeout for a heartbeat based like CFT but require a timeout of a pending request. In this change the test will wait for a new primary to be elected (when appropriate) and if the consensus protocol is bft it will issue requests.