### PR TITLE
Move `StateMachine` to standalone ds header

### DIFF
--- a/src/ds/state_machine.h
+++ b/src/ds/state_machine.h
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ds/logger.h"
+
+#include <atomic>
+#include <string>
+
+namespace ds
+{
+  template <typename T>
+  class StateMachine
+  {
+    const std::string label;
+    std::atomic<T> s;
+
+  public:
+    StateMachine(std::string&& l, T s) : label(std::move(l)), s(s) {}
+
+    void expect(T s) const
+    {
+      auto state = this->s.load();
+      if (s != state)
+      {
+        throw std::logic_error(
+          fmt::format("[{}] State is {}, but expected {}", label, state, s));
+      }
+    }
+
+    bool check(T s) const
+    {
+      return s == this->s.load();
+    }
+
+    T value() const
+    {
+      return this->s.load();
+    }
+
+    void advance(T s)
+    {
+      LOG_DEBUG_FMT(
+        "[{}] Advancing to state {} (from {})", label, s, this->s.load());
+      this->s.store(s);
+    }
+  };
+}

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -10,6 +10,7 @@
 #include "crypto/symmetric_key.h"
 #include "crypto/verifier.h"
 #include "ds/logger.h"
+#include "ds/state_machine.h"
 #include "enclave/rpc_sessions.h"
 #include "encryptor.h"
 #include "entities.h"
@@ -71,40 +72,6 @@ namespace ccf
     crypto::Pem network_cert;
   };
 
-  template <typename T>
-  class StateMachine
-  {
-    std::atomic<T> s;
-
-  public:
-    StateMachine(T s) : s(s) {}
-    void expect(T s) const
-    {
-      auto state = this->s.load();
-      if (s != state)
-      {
-        throw std::logic_error(
-          fmt::format("State is {}, but expected {}", state, s));
-      }
-    }
-
-    bool check(T s) const
-    {
-      return s == this->s.load();
-    }
-
-    T value() const
-    {
-      return this->s.load();
-    }
-
-    void advance(T s)
-    {
-      LOG_DEBUG_FMT("Advancing to state {} (from {})", s, this->s.load());
-      this->s.store(s);
-    }
-  };
-
   void reset_data(std::vector<uint8_t>& data)
   {
     data.clear();
@@ -117,7 +84,7 @@ namespace ccf
     //
     // this node's core state
     //
-    StateMachine<State> sm;
+    ds::StateMachine<State> sm;
     std::mutex lock;
 
     CurveID curve_id;
@@ -287,7 +254,7 @@ namespace ccf
       std::shared_ptr<enclave::RPCSessions> rpcsessions,
       ShareManager& share_manager,
       CurveID curve_id_) :
-      sm(State::uninitialized),
+      sm("NodeState", State::uninitialized),
       curve_id(curve_id_),
       node_sign_kp(crypto::make_key_pair(curve_id_)),
       node_encrypt_kp(crypto::make_rsa_key_pair()),


### PR DESCRIPTION
We have a simple `StateMachine` class in `NodeState`. This moves it to `ds/` where it can be reused by other systems (eg - node-to-node channels). Eventually I'd like to add a restricted set of transitions to this implementation, so we can check that we're only transitioning through states in the expected order.