### PR TITLE
Move channel manager into node state

### DIFF
--- a/edl/ccf.edl
+++ b/edl/ccf.edl
@@ -6,7 +6,6 @@ enclave {
     from "openenclave/edl/time.edl" import *;
 
     include "common/enclave_interface_types.h"
-    include "enclave/consensus_type.h"
 
     trusted {
 
@@ -24,7 +23,6 @@ enclave {
             size_t enclave_version_size,
             [out] size_t* enclave_version_len,
             StartType start_type,
-            ConsensusType consensus_type,
             size_t num_worker_thread,
             [user_check] void* time_location,
         );

--- a/src/consensus/consensus_types.h
+++ b/src/consensus/consensus_types.h
@@ -10,6 +10,7 @@ namespace consensus
 {
   struct Configuration
   {
+    ConsensusType consensus_type;
     size_t raft_request_timeout;
     size_t raft_election_timeout;
     size_t bft_view_change_timeout;
@@ -18,6 +19,7 @@ namespace consensus
   DECLARE_JSON_TYPE(Configuration);
   DECLARE_JSON_REQUIRED_FIELDS(
     Configuration,
+    consensus_type,
     raft_request_timeout,
     raft_election_timeout,
     bft_view_change_timeout,

--- a/src/enclave/ccf_v.h
+++ b/src/enclave/ccf_v.h
@@ -78,7 +78,6 @@ extern "C"
     size_t,
     size_t*,
     StartType,
-    ConsensusType,
     size_t,
     void*);
 
@@ -121,7 +120,6 @@ extern "C"
     size_t enclave_version_size,
     size_t* enclave_version_len,
     StartType start_type,
-    ConsensusType consensus_type,
     size_t num_worker_thread,
     void* time_location)
   {
@@ -142,7 +140,6 @@ extern "C"
       enclave_version_size,
       enclave_version_len,
       start_type,
-      consensus_type,
       num_worker_thread,
       time_location);
     return OE_OK;

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -67,7 +67,6 @@ namespace enclave
     Enclave(
       const EnclaveConfig& ec,
       const CCFConfig::SignatureIntervals& signature_intervals,
-      const ConsensusType& consensus_type_,
       const consensus::Configuration& consensus_config,
       const CurveID& curve_id) :
       circuit(
@@ -79,7 +78,7 @@ namespace enclave
                               ec.from_enclave_buffer_offsets}),
       basic_writer_factory(circuit),
       writer_factory(basic_writer_factory, ec.writer_config),
-      network(consensus_type_),
+      network(consensus_config.consensus_type),
       share_manager(network),
       n2n_channels(std::make_shared<ccf::NodeToNodeImpl>(writer_factory)),
       rpc_map(std::make_shared<RPCMap>()),

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -143,10 +143,7 @@ extern "C"
 #endif
 
     auto enclave = new enclave::Enclave(
-      ec,
-      cc.signature_intervals,
-      cc.consensus_config,
-      cc.curve_id);
+      ec, cc.signature_intervals, cc.consensus_config, cc.curve_id);
 
     if (!enclave->create_new_node(
           start_type,

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -43,7 +43,6 @@ extern "C"
     size_t enclave_version_size,
     size_t* enclave_version_len,
     StartType start_type,
-    ConsensusType consensus_type,
     size_t num_worker_threads,
     void* time_location)
   {
@@ -146,7 +145,6 @@ extern "C"
     auto enclave = new enclave::Enclave(
       ec,
       cc.signature_intervals,
-      consensus_type,
       cc.consensus_config,
       cc.curve_id);
 

--- a/src/host/enclave.h
+++ b/src/host/enclave.h
@@ -92,7 +92,6 @@ namespace host
       std::vector<uint8_t>& node_cert,
       std::vector<uint8_t>& network_cert,
       StartType start_type,
-      ConsensusType consensus_type,
       size_t num_worker_thread,
       void* time_location)
     {
@@ -122,7 +121,6 @@ namespace host
         enclave_version_buf.size(),
         &enclave_version_len,
         start_type,
-        consensus_type,
         num_worker_thread,
         time_location);
 

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -708,7 +708,8 @@ int main(int argc, char** argv)
 #endif
 
     CCFConfig ccf_config;
-    ccf_config.consensus_config = {raft_timeout,
+    ccf_config.consensus_config = {consensus,
+                                   raft_timeout,
                                    raft_election_timeout,
                                    bft_view_change_timeout,
                                    bft_status_interval};
@@ -846,7 +847,6 @@ int main(int argc, char** argv)
       node_cert,
       network_cert,
       start_type,
-      consensus,
       num_worker_threads,
       time_updater->behaviour.get_value());
 

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -315,9 +315,7 @@ namespace ccf
 
       for (auto& [actor, fe] : rpc_map->frontends())
       {
-        fe->set_sig_intervals(
-          sig_tx_interval,
-          sig_ms_interval);
+        fe->set_sig_intervals(sig_tx_interval, sig_ms_interval);
         fe->set_cmd_forwarder(cmd_forwarder);
       }
     }
@@ -1422,8 +1420,7 @@ namespace ccf
         serialized::overlay<NodeMsgType>(payload_data, payload_size);
       NodeId from = serialized::read<NodeId::Value>(payload_data, payload_size);
 
-      if (
-        msg_type == ccf::NodeMsgType::forwarded_msg)
+      if (msg_type == ccf::NodeMsgType::forwarded_msg)
       {
         cmd_forwarder->recv_message(from, payload_data, payload_size);
       }
@@ -1438,25 +1435,25 @@ namespace ccf
           return;
         }
 
-      switch (msg_type)
-      {
-        case channel_msg:
+        switch (msg_type)
         {
-          n2n_channels->recv_message(from, payload_data, payload_size);
-          break;
-        }
-        case consensus_msg:
-        {
-          consensus->recv_message(from, payload_data, payload_size);
-          break;
-        }
+          case channel_msg:
+          {
+            n2n_channels->recv_message(from, payload_data, payload_size);
+            break;
+          }
+          case consensus_msg:
+          {
+            consensus->recv_message(from, payload_data, payload_size);
+            break;
+          }
 
-        default:
-        {
-          LOG_FAIL_FMT("Unknown node message type: {}", msg_type);
-          return;
+          default:
+          {
+            LOG_FAIL_FMT("Unknown node message type: {}", msg_type);
+            return;
+          }
         }
-      }
       }
     }
 

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -233,13 +233,10 @@ namespace ccf
       return m;
     }
 
-    void recv_message(const uint8_t* data, size_t size)
+    void recv_message(const NodeId& from, const uint8_t* data, size_t size)
     {
       try
       {
-        serialized::skip(data, size, sizeof(NodeMsgType));
-
-        NodeId from = serialized::read<NodeId::Value>(data, size);
         auto forwarded_msg = serialized::peek<ForwardedMsg>(data, size);
 
         switch (forwarded_msg)


### PR DESCRIPTION
Another part of #2775. The forwarder and node-to-node channels were owned by the enclave and passed to node state, but the enclave doesn't do anything with them. It makes more sense for them to be owned and constructed within the node state. To make that construction path a little cleaner, the `ConsensusType` in the configuration moves from the top-level to the `consensus::Configuration` struct.