### PR TITLE
Use standard ringbuffer type safety + macros when writing `node_outbound`

### DIFF
--- a/src/ds/logger.h
+++ b/src/ds/logger.h
@@ -359,7 +359,7 @@ namespace logger
       line.finalize();
       config::writer()->write(
         config::msg(),
-        config::elapsed_us(),
+        config::elapsed_us().count(),
         line.file_name,
         line.line_number,
         line.log_level,

--- a/src/ds/serializer.h
+++ b/src/ds/serializer.h
@@ -251,8 +251,12 @@ namespace serializer
       return std::tuple_cat(std::make_tuple(cs), std::make_tuple(bfs));
     }
 
-    /// Generic case - use raw byte representation
-    template <typename T>
+    /// Generic case, for integral types - use raw byte representation
+    template <
+      typename T,
+      std::enable_if_t<
+        std::is_integral<T>::value || std::is_enum<T>::value,
+        bool> = true>
     static auto serialize_value(const T& t)
     {
       auto rs = std::make_shared<RawSection<T>>(t);
@@ -294,7 +298,9 @@ namespace serializer
     }
 
     /// Generic case
-    template <typename T>
+    template <
+      typename T,
+      std::enable_if_t<std::is_integral<T>::value, bool> = true>
     static T deserialize_value(
       const uint8_t*& data, size_t& size, const Tag<T>&)
     {

--- a/src/ds/serializer.h
+++ b/src/ds/serializer.h
@@ -87,17 +87,19 @@ namespace serializer
         // from the type so that a Serializer<int> will accept an argument of
         // type const int&.
         // Additionally, this will accept ByteRange arguments for parameters
-        // declared as std::vector<uint8_t> - when serializing we can copy bytes
-        // from either in the same way, but there is a distinction in the
-        // deserialized type of whether we are copying (to a byte vector) or
-        // referring to an existing byte range.
-        // It may be possible to generalise this further and replace with
+        // declared as std::vector<uint8_t> and vice versa - when serializing we
+        // can copy bytes from either in the same way, but there is a
+        // distinction in the deserialized type of whether we are copying (to a
+        // byte vector) or referring to an existing byte range. It may be
+        // possible to generalise this further and replace with
         // std::is_constructible, but these restrictions are sufficient for the
         // current uses.
         static constexpr bool value =
           std::is_same_v<CanonTarget, CanonArgument> ||
           (std::is_same_v<CanonTarget, std::vector<uint8_t>> &&
-           std::is_same_v<CanonArgument, ByteRange>);
+           std::is_same_v<CanonArgument, ByteRange>) ||
+          (std::is_same_v<CanonTarget, ByteRange> &&
+           std::is_same_v<CanonArgument, std::vector<uint8_t>>);
       };
 
       // Only reached when Ts is empty

--- a/src/ds/serializer.h
+++ b/src/ds/serializer.h
@@ -300,7 +300,9 @@ namespace serializer
     /// Generic case
     template <
       typename T,
-      std::enable_if_t<std::is_integral<T>::value, bool> = true>
+      std::enable_if_t<
+        std::is_integral<T>::value || std::is_enum<T>::value,
+        bool> = true>
     static T deserialize_value(
       const uint8_t*& data, size_t& size, const Tag<T>&)
     {

--- a/src/ds/serializer.h
+++ b/src/ds/serializer.h
@@ -94,7 +94,9 @@ namespace serializer
         // possible to generalise this further and replace with
         // std::is_constructible, but these restrictions are sufficient for the
         // current uses.
-        // TODO: Document non-contiguous addition
+        // Additionally again, this will accept an array-like of ByteRanges for
+        // a single ByteRange parameter. These will be serialised in-order, and
+        // produce a single ByteRange in deserialisation.
         static constexpr bool value =
           std::is_same_v<CanonTarget, CanonArgument> ||
           (std::is_same_v<CanonTarget, std::vector<uint8_t>> &&

--- a/src/ds/test/ring_buffer.cpp
+++ b/src/ds/test/ring_buffer.cpp
@@ -131,10 +131,17 @@ TEST_CASE("Variadic write" * doctest::test_suite("ringbuffer"))
   Reader r(buffer->bd);
   Writer w(r);
 
+  enum TEnum
+  {
+    Foo,
+    Bar = 42,
+    Baz
+  };
+
   const char v0 = 'h';
   const size_t v1 = 0xdeadbeef;
   const bool v2 = false;
-  const float v3 = 3.14f;
+  const TEnum v3 = Baz;
   const std::vector<uint8_t> v4 = {0xab, 0xac, 0xad, 0xae, 0xaf};
 
   const size_t v5_limit = 3;

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -275,21 +275,21 @@ namespace enclave
 
         DISPATCHER_SET_MESSAGE_HANDLER(
           bp, ccf::node_inbound, [this](const uint8_t* data, size_t size) {
-            const auto [body] =
+            auto data_ = data;
+            auto size_ = size;
+
+            auto [msg_type, from_id, payload] =
               ringbuffer::read_message<ccf::node_inbound>(data, size);
 
-            auto p = body.data();
-            auto psize = body.size();
-
             if (
-              serialized::peek<ccf::NodeMsgType>(p, psize) ==
+              msg_type ==
               ccf::NodeMsgType::forwarded_msg)
             {
-              cmd_forwarder->recv_message(p, psize);
+              cmd_forwarder->recv_message(data_, size_);
             }
             else
             {
-              node->node_msg(std::move(body));
+              node->node_msg({data_, data_ + size_});
             }
           });
 

--- a/src/enclave/interface.h
+++ b/src/enclave/interface.h
@@ -141,7 +141,7 @@ enum AdminMessage : ringbuffer::Message
 
 DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(
   AdminMessage::log_msg,
-  std::chrono::microseconds,
+  std::chrono::microseconds::rep,
   std::string,
   size_t,
   logger::Level,

--- a/src/host/handle_ring_buffer.h
+++ b/src/host/handle_ring_buffer.h
@@ -41,7 +41,7 @@ namespace asynchost
       DISPATCHER_SET_MESSAGE_HANDLER(
         bp, AdminMessage::log_msg, [](const uint8_t* data, size_t size) {
           auto
-            [log_time_us, file_name, line_number, log_level, thread_id, msg] =
+            [log_time_us_count, file_name, line_number, log_level, thread_id, msg] =
               ringbuffer::read_message<AdminMessage::log_msg>(data, size);
 
           logger::Out::write(
@@ -50,7 +50,7 @@ namespace asynchost
             log_level,
             thread_id,
             msg,
-            log_time_us.count());
+            log_time_us_count);
         });
 
       DISPATCHER_SET_MESSAGE_HANDLER(

--- a/src/host/handle_ring_buffer.h
+++ b/src/host/handle_ring_buffer.h
@@ -41,8 +41,12 @@ namespace asynchost
       DISPATCHER_SET_MESSAGE_HANDLER(
         bp, AdminMessage::log_msg, [](const uint8_t* data, size_t size) {
           auto
-            [log_time_us_count, file_name, line_number, log_level, thread_id, msg] =
-              ringbuffer::read_message<AdminMessage::log_msg>(data, size);
+            [log_time_us_count,
+             file_name,
+             line_number,
+             log_level,
+             thread_id,
+             msg] = ringbuffer::read_message<AdminMessage::log_msg>(data, size);
 
           logger::Out::write(
             file_name,

--- a/src/host/node_connections.h
+++ b/src/host/node_connections.h
@@ -80,7 +80,7 @@ namespace asynchost
           LOG_DEBUG_FMT(
             "node in: from node {}, size {}, type {}",
             node->trim(),
-            msg_size,
+            msg_size.value(),
             msg_type);
 
           RINGBUFFER_WRITE_MESSAGE(

--- a/src/host/node_connections.h
+++ b/src/host/node_connections.h
@@ -260,6 +260,7 @@ namespace asynchost
 
       DISPATCHER_SET_MESSAGE_HANDLER(
         disp, ccf::node_outbound, [this](const uint8_t* data, size_t size) {
+          // Read piece-by-piece rather than all at once
           ccf::NodeId to = serialized::read<ccf::NodeId::Value>(data, size);
           auto node = find(to, true);
 
@@ -268,13 +269,15 @@ namespace asynchost
             return;
           }
 
+          // Rather than reading and reserialising, use the msg_type and from_id
+          // that are already serialised on the ringbuffer
           auto data_to_send = data;
           auto size_to_send = size;
 
           // If the message is a consensus append entries message, affix the
           // corresponding ledger entries
           auto msg_type = serialized::read<ccf::NodeMsgType>(data, size);
-          ccf::NodeId from = serialized::read<ccf::NodeId::Value>(data, size);
+          serialized::read<ccf::NodeId::Value>(data, size); // Ignore from_id
           if (
             msg_type == ccf::NodeMsgType::consensus_msg &&
             (serialized::read<aft::RaftMsgType>(data, size) ==

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1424,9 +1424,12 @@ namespace ccf
       auto [msg_type, from, payload] =
         ringbuffer::read_message<ccf::node_inbound>(data, size);
 
+      auto payload_data = payload.data;
+      auto payload_size = payload.size;
+
       if (msg_type == ccf::NodeMsgType::forwarded_msg)
       {
-        cmd_forwarder->recv_message(from, data, size);
+        cmd_forwarder->recv_message(from, payload_data, payload_size);
       }
       else
       {
@@ -1443,12 +1446,12 @@ namespace ccf
         {
           case channel_msg:
           {
-            n2n_channels->recv_message(from, data, size);
+            n2n_channels->recv_message(from, payload_data, payload_size);
             break;
           }
           case consensus_msg:
           {
-            consensus->recv_message(from, data, size);
+            consensus->recv_message(from, payload_data, payload_size);
             break;
           }
 

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1419,15 +1419,14 @@ namespace ccf
       consensus->periodic_end();
     }
 
-    void recv_node_inbound(const uint8_t* payload_data, size_t payload_size)
+    void recv_node_inbound(const uint8_t* data, size_t size)
     {
-      NodeMsgType msg_type =
-        serialized::overlay<NodeMsgType>(payload_data, payload_size);
-      NodeId from = serialized::read<NodeId::Value>(payload_data, payload_size);
+      auto [msg_type, from, payload] =
+        ringbuffer::read_message<ccf::node_inbound>(data, size);
 
       if (msg_type == ccf::NodeMsgType::forwarded_msg)
       {
-        cmd_forwarder->recv_message(from, payload_data, payload_size);
+        cmd_forwarder->recv_message(from, data, size);
       }
       else
       {
@@ -1444,12 +1443,12 @@ namespace ccf
         {
           case channel_msg:
           {
-            n2n_channels->recv_message(from, payload_data, payload_size);
+            n2n_channels->recv_message(from, data, size);
             break;
           }
           case consensus_msg:
           {
-            consensus->recv_message(from, payload_data, payload_size);
+            consensus->recv_message(from, data, size);
             break;
           }
 

--- a/src/node/node_types.h
+++ b/src/node/node_types.h
@@ -78,6 +78,9 @@ namespace ccf
     DEFINE_RINGBUFFER_MSG_TYPE(node_inbound),
 
     /// Send data to another node. Enclave -> Host
+    /// Args are (to_id, msg_type, from_id, payload)
+    /// The host may inspect the first 3, and should write the last 3 (to
+    /// produce an equivalent node_inbound on the receiving node)
     DEFINE_RINGBUFFER_MSG_TYPE(node_outbound),
   };
 }
@@ -85,4 +88,14 @@ namespace ccf
 DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(
   ccf::add_node, ccf::NodeId::Value, std::string, std::string);
 DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(ccf::remove_node, ccf::NodeId::Value);
-DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(ccf::node_inbound, std::vector<uint8_t>);
+DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(
+  ccf::node_inbound,
+  ccf::NodeMsgType,
+  ccf::NodeId::Value,
+  serializer::ByteRange);
+DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(
+  ccf::node_outbound,
+  ccf::NodeId::Value,
+  ccf::NodeMsgType,
+  ccf::NodeId::Value,
+  serializer::ByteRange);

--- a/src/tls/key_exchange.h
+++ b/src/tls/key_exchange.h
@@ -109,7 +109,7 @@ namespace tls
       free_ctx();
     }
 
-    std::vector<uint8_t> get_own_key_share()
+    const std::vector<uint8_t>& get_own_key_share() const
     {
       if (!ctx)
       {
@@ -127,7 +127,7 @@ namespace tls
       return key_share;
     }
 
-    std::vector<uint8_t> get_peer_key_share()
+    const std::vector<uint8_t>& get_peer_key_share() const
     {
       return peer_key_share;
     }


### PR DESCRIPTION
Another cleanup carved off #2775.

`node_outbound` was written to ringbuffers directly, with `to_host->write`, rather than with the `RINGBUFFER_WRITE_MESSAGE` macro that every other instance used. This meant it didn't have the same error message handling and type-checking logic as every other ringbuffer write. This was done deliberately, since the types written were previously more distinct, and to allow appending multiple fields onto the ringbuffer without copying them into a single intermediate buffer. This removes those restrictions, getting the type safety without an additional copy, clarifying the exact types of the fields in this message and what they should be used for.

In particular, this lets us remove the generic 'blit anything' serialisation which occasionally failed when we accidentally passed new types - it is now _only_ used for integral and enum types.