### PR TITLE
Do not build docs with latest version of Sphinx

### DIFF
--- a/doc/audit/builtin_maps.rst
+++ b/doc/audit/builtin_maps.rst
@@ -117,7 +117,7 @@ The currently valid and in-flight network configurations of the network. The ent
 
 **Value** A set of node IDs of the nodes in the respective configuration, represented as a JSON array.
 
-.. doxygenstruct:: ccf::NetworkConfiguration
+.. doxygenstruct:: kv::NetworkConfiguration
    :project: CCF
    :members:
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 breathe
-sphinx
+sphinx<4.1.0 # https://github.com/sphinx-doc/sphinx/issues/9433
 bottle
 sphinx-autobuild
 sphinxcontrib-mermaid


### PR DESCRIPTION
Temporary fix for https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=28845&view=logs&j=f1fd332c-cd58-5ba4-fc7d-3c1d3a3f0cd3&t=31418c00-d4df-5619-e99a-3cbbc8fcc481&l=3437 

Issue tracked in https://github.com/sphinx-doc/sphinx/issues/9433