### PR TITLE
Update mbedtls from 2.16.8 to 2.16.10 to track Open Enclave

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -7,7 +7,7 @@ trigger:
 
 jobs:
   - job: build_and_publish_docs
-    container: ccfciteam/ccf-ci:oe0.17.0
+    container: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
     pool:
       vmImage: ubuntu-18.04
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -27,11 +27,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfciteam/ccf-ci:oe0.17.0
+      image: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.0
+      image: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
 variables:

--- a/.daily.yml
+++ b/.daily.yml
@@ -23,11 +23,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfciteam/ccf-ci:oe0.17.0
+      image: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache
 
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.0
+      image: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-18.04
-    container: ccfciteam/ccf-ci:oe0.17.0
+    container: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
 
     steps:
       - name: Checkout repository

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -16,7 +16,7 @@ pr:
 resources:
   containers:
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.0
+      image: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.stress.yml
+++ b/.stress.yml
@@ -21,7 +21,7 @@ schedules:
 resources:
   containers:
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.0
+      image: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/getting_started/setup_vm/roles/ccf_build/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_build/vars/common.yml
@@ -24,6 +24,6 @@ debs:
   - shellcheck
   - iptables
 
-mbedtls_ver: "2.16.8"
+mbedtls_ver: "2.16.10"
 mbedtls_dir: "mbedtls-{{ mbedtls_ver }}"
 mbedtls_src: "{{ mbedtls_dir }}.tar.gz"


### PR DESCRIPTION
We only build mbedtls for the virtual build, and LTS changes there are very minor, but it's still good to stay in sync with the version we get from Open Enclave.