### PR TITLE
Use latest version of Doxygen

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -7,7 +7,7 @@ trigger:
 
 jobs:
   - job: build_and_publish_docs
-    container: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
+    container: ccfciteam/ccf-ci:oe0.17.0-doxygen-1.9.1
     pool:
       vmImage: ubuntu-18.04
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -27,11 +27,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
+      image: ccfciteam/ccf-ci:oe0.17.0-doxygen-1.9.1
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
+      image: ccfciteam/ccf-ci:oe0.17.0-doxygen-1.9.1
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
 variables:

--- a/.daily.yml
+++ b/.daily.yml
@@ -23,11 +23,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
+      image: ccfciteam/ccf-ci:oe0.17.0-doxygen-1.9.1
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache
 
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
+      image: ccfciteam/ccf-ci:oe0.17.0-doxygen-1.9.1
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-18.04
-    container: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
+    container: ccfciteam/ccf-ci:oe0.17.0-doxygen-1.9.1
 
     steps:
       - name: Checkout repository

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -16,7 +16,7 @@ pr:
 resources:
   containers:
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
+      image: ccfciteam/ccf-ci:oe0.17.0-doxygen-1.9.1
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.stress.yml
+++ b/.stress.yml
@@ -21,7 +21,7 @@ schedules:
 resources:
   containers:
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.0-mbedtls-2.16.10
+      image: ccfciteam/ccf-ci:oe0.17.0-doxygen-1.9.1
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/doc/audit/builtin_maps.rst
+++ b/doc/audit/builtin_maps.rst
@@ -117,7 +117,7 @@ The currently valid and in-flight network configurations of the network. The ent
 
 **Value** A set of node IDs of the nodes in the respective configuration, represented as a JSON array.
 
-.. doxygenstruct:: ccf::NetworkConfiguration
+.. doxygenstruct:: kv::NetworkConfiguration
    :project: CCF
    :members:
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 breathe
-sphinx
+sphinx<4.1.0 # https://github.com/sphinx-doc/sphinx/issues/9433
 bottle
 sphinx-autobuild
 sphinxcontrib-mermaid

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 breathe
-sphinx<4.1.0 # https://github.com/sphinx-doc/sphinx/issues/9433
+sphinx
 bottle
 sphinx-autobuild
 sphinxcontrib-mermaid

--- a/getting_started/setup_vm/roles/ccf_build/tasks/install.yml
+++ b/getting_started/setup_vm/roles/ccf_build/tasks/install.yml
@@ -51,7 +51,7 @@
 - name: Build mbedtls
   shell: |
     cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON ..
-    make -j4
+    make
   args:
     chdir: "{{ workspace }}/mbedtls-{{ mbedtls_dir }}/build"
 
@@ -60,3 +60,47 @@
   args:
     chdir: "{{ workspace }}/mbedtls-{{ mbedtls_dir }}/build"
   become: true
+
+- name: Remove doxygen debian package
+  apt:
+    name: doxygen
+    state: absent
+  become: yes
+
+- name: Download doxygen
+  get_url:
+    url: https://github.com/doxygen/doxygen/archive/Release_{{ doxygen_src }}
+    dest: "{{ workspace }}/{{ doxygen_src }}"
+  become: true
+
+- name: Remove existing doxygen checkout
+  file:
+    path: "{{ workspace }}/doxygen-{{ doxygen_dir }}"
+    state: absent
+
+- name: Expand doxygen
+  unarchive:
+    src: "{{ workspace }}/{{ doxygen_src }}"
+    dest: "{{ workspace }}"
+    copy: no
+    creates: "{{ workspace }}/doxygen-{{ doxygen_dir }}/CMakeLists.txt"
+
+- name: Make doxygen build dir
+  file:
+    path: "{{ workspace }}/doxygen-{{ doxygen_dir }}/build"
+    state: directory
+
+- name: Build doxygen
+  shell: |
+    CC=$(which clang-8) CXX=$(which clang++-8) cmake -DCMAKE_BUILD_TYPE=Release ..
+    make
+  args:
+    chdir: "{{ workspace }}/doxygen-{{ doxygen_dir }}/build"
+
+- name: Install doxygen
+  command: make install
+  args:
+    chdir: "{{ workspace }}/doxygen-{{ doxygen_dir }}/build"
+  become: true
+
+

--- a/getting_started/setup_vm/roles/ccf_build/tasks/install.yml
+++ b/getting_started/setup_vm/roles/ccf_build/tasks/install.yml
@@ -102,5 +102,3 @@
   args:
     chdir: "{{ workspace }}/doxygen-{{ doxygen_dir }}/build"
   become: true
-
-

--- a/getting_started/setup_vm/roles/ccf_build/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_build/vars/common.yml
@@ -14,7 +14,6 @@ debs:
   - expect
   - git
   - ccache
-  - doxygen
   - kmod
   - cmake
   - libssl-dev
@@ -23,7 +22,14 @@ debs:
   - curl
   - shellcheck
   - iptables
+  - flex  # required to build doxygen
+  - bison  # required to build doxygen
 
 mbedtls_ver: "2.16.8"
 mbedtls_dir: "mbedtls-{{ mbedtls_ver }}"
 mbedtls_src: "{{ mbedtls_dir }}.tar.gz"
+
+doxygen_ver: "1_9_1"
+doxygen_dir: "Release_{{ doxygen_ver }}"
+doxygen_src: "{{ doxygen_ver }}.tar.gz"
+

--- a/getting_started/setup_vm/roles/ccf_build/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_build/vars/common.yml
@@ -22,8 +22,8 @@ debs:
   - curl
   - shellcheck
   - iptables
-  - flex  # required to build doxygen
-  - bison  # required to build doxygen
+  - flex # required to build doxygen
+  - bison # required to build doxygen
 
 mbedtls_ver: "2.16.10"
 mbedtls_dir: "mbedtls-{{ mbedtls_ver }}"
@@ -32,4 +32,3 @@ mbedtls_src: "{{ mbedtls_dir }}.tar.gz"
 doxygen_ver: "1_9_1"
 doxygen_dir: "Release_{{ doxygen_ver }}"
 doxygen_src: "{{ doxygen_ver }}.tar.gz"
-


### PR DESCRIPTION
Follow-up from #2787 

We now use the latest version of Doxygen, which we have to build from source.