### PR TITLE
BFT rollback correctly on signature mismatch

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1847,8 +1847,18 @@ namespace aft
         // primary resends the append entries we will succeed as the map is
         // already there. This will only occur on BFT startup so not a perf
         // problem but still need to be resolved.
-        state->last_idx = i - 1;
-        ledger->truncate(state->last_idx);
+        // https://github.com/microsoft/CCF/issues/2799
+        if (ds->should_rollback_to_last_committed())
+        {
+          auto progress_tracker = store->get_progress_tracker();
+          ccf::SeqNo rollback_level = progress_tracker->get_rollback_seqno();
+          rollback(rollback_level);
+        }
+        else
+        {
+          state->last_idx = i - 1;
+          ledger->truncate(state->last_idx);
+        }
         send_append_entries_response(from, AppendEntriesResponseType::FAIL);
         return false;
       }

--- a/src/consensus/aft/test/logging_stub.h
+++ b/src/consensus/aft/test/logging_stub.h
@@ -293,6 +293,11 @@ namespace aft
       {
         return false;
       }
+
+      bool should_rollback_to_last_committed() override
+      {
+        return false;
+      }
     };
 
     virtual std::unique_ptr<kv::AbstractExecutionWrapper> deserialize(

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -621,6 +621,21 @@ namespace kv
     virtual kv::Version get_max_conflict_version() = 0;
     virtual bool support_async_execution() = 0;
     virtual bool is_public_only() = 0;
+
+    // Setting a short rollback is a work around that should be fixed
+    // shortly. In BFT mode when we deserialize and realize we need to
+    // create a new map we remember this. If we need to create the same
+    // map multiple times (for tx in the same group of append entries) the
+    // first create successes but the second fails because the map is
+    // already there. This works around the problem by stopping just
+    // before the 2nd create (which failed at this point) and when the
+    // primary resends the append entries we will succeed as the map is
+    // already there. This will only occur on BFT startup so not a perf
+    // problem but still need to be resolved.
+    //
+    // Thus, a large rollback is one which did not result from the map creating
+    // issue. https://github.com/microsoft/CCF/issues/2799
+    virtual bool should_rollback_to_last_committed() = 0;
   };
 
   class AbstractStore

--- a/src/node/progress_tracker.h
+++ b/src/node/progress_tracker.h
@@ -406,8 +406,6 @@ namespace ccf
 
       if (!match_nonces(hash_data(nonce), sig.hashed_nonce))
       {
-        // NOTE: We need to handle this case but for now having this make a
-        // test fail will be very handy
         LOG_FAIL_FMT(
           "Nonces do not match add_nonce_reveal view:{}, seqno:{}, node_id:{}, "
           "sig.hashed_nonce:{}, "
@@ -419,11 +417,7 @@ namespace ccf
           nonce,
           hash_data(nonce),
           did_add);
-        throw ccf::ccf_logic_error(fmt::format(
-          "nonces do not match verification from {} FAILED, view:{}, seqno:{}",
-          node_id,
-          tx_id.view,
-          tx_id.seqno));
+        return;
       }
       sig.nonce = nonce;
       cert.nonce_set.insert(node_id);


### PR DESCRIPTION
If a backup observes a signature mismatch it should rollback to the last committed index.