### PR TITLE
Ignore stderr noise produced by 1.11 Intel DCAP

### DIFF
--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -81,7 +81,11 @@ def log_errors(out_path, err_path):
     fatal_error_lines = []
     try:
         with open(err_path, "r", errors="replace") as lines:
-            fatal_error_lines = lines.readlines()
+            fatal_error_lines = [
+                line
+                for line in lines.readlines()
+                if not line.startswith("[get_qpl_handle ")
+            ]
             if fatal_error_lines:
                 LOG.error(f"Contents of {err_path}:\n{''.join(fatal_error_lines)}")
     except IOError:


### PR DESCRIPTION
The latest Intel DCAP produces the following line on stderr, which causes our clean shutdown check to fail:

```
[get_qpl_handle ../qe_logic.cpp:295] Failed to set logging callback for the quote provider library
```