### PR TITLE
Cache clients

### DIFF
--- a/python/ccf/clients.py
+++ b/python/ccf/clients.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache 2.0 License.
 import abc
 import contextlib
+import functools
 import json
 import time
 import sys
@@ -76,7 +77,7 @@ class Request:
         return string
 
 
-@dataclass
+@dataclass(eq=True, frozen=True)
 class Identity:
     """
     Identity (as private key and corresponding certificate) for a :py:class:`ccf.clients.CCFClient` client.
@@ -674,6 +675,11 @@ class CCFClient:
         ccf.commit.wait_for_commit(self, response.seqno, response.view, timeout)
 
 
+@functools.lru_cache()
+def _client(*args, **kwargs):
+    return CCFClient(*args, **kwargs)
+
+
 @contextlib.contextmanager
 def client(*args, **kwargs):
-    yield CCFClient(*args, **kwargs)
+    yield _client(*args, **kwargs)


### PR DESCRIPTION
This seemed like a reasonable thing to try after https://github.com/microsoft/CCF/pull/2766, but it turns out it's slower than not caching.

My best guess is that it somehow interferes with something requests does internally, although I don't know what that might be.

Edit: it looks like it's about the same overall in fact. This change unsurprisingly breaks the connections test, but also more surprisingly the lts and committable suffix tests, probably because we effectively never reset the connection timeout.