### PR TITLE
Fix TPCC BFT timeout issue

### DIFF
--- a/src/apps/tpcc/tpcc.cmake
+++ b/src/apps/tpcc/tpcc.cmake
@@ -25,10 +25,13 @@ sign_app_library(
 )
 
 if(BUILD_TESTS)
-
-  set(TPCC_ITERATIONS 200000)
-
   foreach(CONSENSUS ${CONSENSUSES})
+    if("bft" STREQUAL CONSENSUS)
+      set(TPCC_ITERATIONS 100000)
+    else()
+      set(TPCC_ITERATIONS 200000)
+    endif()
+
     add_perf_test(
       NAME tpcc
       PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/tpcc.py


### PR DESCRIPTION
resolves #2786

The tpcc_bft used to take close to 90s (timeout limit) to run. However, with #2682 there was a slight performance degradation and we are now seeing the test occasionally not completing on time.