### PR TITLE
Read SubjectAltName field from CSR

### DIFF
--- a/src/crypto/key_pair.h
+++ b/src/crypto/key_pair.h
@@ -45,12 +45,13 @@ namespace crypto
 
     virtual std::vector<uint8_t> sign(CBuffer d, MDType md_type = {}) const = 0;
 
-    virtual Pem create_csr(const std::string& name) const = 0;
+    virtual Pem create_csr(
+      const std::string& name,
+      const std::vector<SubjectAltName>& sans = {}) const = 0;
 
     virtual Pem sign_csr(
       const Pem& issuer_cert,
       const Pem& signing_request,
-      const std::vector<SubjectAltName> subject_alt_names,
       bool ca = false) const = 0;
 
     Pem self_sign(
@@ -61,8 +62,8 @@ namespace crypto
       std::vector<SubjectAltName> sans;
       if (subject_alt_name.has_value())
         sans.push_back(subject_alt_name.value());
-      auto csr = create_csr(name);
-      return sign_csr(Pem(0), csr, sans, ca);
+      auto csr = create_csr(name, sans);
+      return sign_csr(Pem(0), csr, ca);
     }
 
     Pem self_sign(
@@ -70,8 +71,8 @@ namespace crypto
       const std::vector<SubjectAltName> subject_alt_names,
       bool ca = true) const
     {
-      auto csr = create_csr(name);
-      return sign_csr(Pem(0), csr, subject_alt_names, ca);
+      auto csr = create_csr(name, subject_alt_names);
+      return sign_csr(Pem(0), csr, ca);
     }
   };
 

--- a/src/crypto/mbedtls/key_pair.cpp
+++ b/src/crypto/mbedtls/key_pair.cpp
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 
+#include "key_pair.h"
+
 #include "curve.h"
 #include "ds/net.h"
 #include "entropy.h"
 #include "hash.h"
-#include "key_pair.h"
 
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>

--- a/src/crypto/mbedtls/key_pair.cpp
+++ b/src/crypto/mbedtls/key_pair.cpp
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 
-#include "key_pair.h"
-
 #include "curve.h"
 #include "ds/net.h"
 #include "entropy.h"
 #include "hash.h"
+#include "key_pair.h"
 
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
@@ -230,8 +229,17 @@ namespace crypto
 #endif
   }
 
-  Pem KeyPair_mbedTLS::create_csr(const std::string& name) const
+  Pem KeyPair_mbedTLS::create_csr(
+    const std::string& name, const std::vector<SubjectAltName>& sans) const
   {
+    // mbedtls does not support parsing x509v3 extensions from a CSR
+    // (https://github.com/ARMmbed/mbedtls/issues/2912) so disallow CSR creation
+    // if any SAN is specified (use OpenSSL implementation instead)
+    if (!sans.empty())
+    {
+      throw std::logic_error("mbedtls cannot create CSR with SAN");
+    }
+
     auto csr = mbedtls::make_unique<mbedtls::X509WriteCsr>();
     mbedtls_x509write_csr_set_md_alg(csr.get(), MBEDTLS_MD_SHA512);
 
@@ -286,192 +294,8 @@ namespace crypto
     registeredID = 8
   };
 
-  static inline int x509write_crt_set_subject_alt_name(
-    mbedtls_x509write_cert* ctx, const char* name, san_type san)
-  {
-    uint8_t san_buf[max_san_length];
-    int ret = 0;
-    size_t len = 0;
-
-    // mbedtls asn1 write API writes backward in san_buf
-    uint8_t* pc = san_buf + max_san_length;
-
-    auto name_len = strlen(name);
-    if (name_len > max_san_length)
-    {
-      throw std::logic_error(fmt::format(
-        "Subject Alternative Name {} is too long ({}>{})",
-        name,
-        name_len,
-        max_san_length));
-    }
-
-    switch (san)
-    {
-      case san_type::dns_name:
-      {
-        MBEDTLS_ASN1_CHK_ADD(
-          len,
-          mbedtls_asn1_write_raw_buffer(
-            &pc, san_buf, (const unsigned char*)name, name_len));
-        MBEDTLS_ASN1_CHK_ADD(
-          len, mbedtls_asn1_write_len(&pc, san_buf, name_len));
-        break;
-      }
-
-      // mbedtls (2.16.2) only supports parsing of subject alternative name
-      // that is DNS= (so no IPAddress=). When connecting to a node that has
-      // IPAddress set, mbedtls_ssl_set_hostname() should not be called.
-      // However, it should work fine with a majority of other clients (e.g.
-      // curl).
-      case san_type::ip_address:
-      {
-        auto addr = ds::ip_to_binary(name);
-        if (!addr.has_value())
-        {
-          throw std ::logic_error(fmt::format(
-            "Subject Alternative Name {} is not a valid IPv4 or "
-            "IPv6 address",
-            name));
-        }
-
-        MBEDTLS_ASN1_CHK_ADD(
-          len,
-          mbedtls_asn1_write_raw_buffer(
-            &pc, san_buf, (const unsigned char*)&addr->buf, addr->size));
-        MBEDTLS_ASN1_CHK_ADD(
-          len, mbedtls_asn1_write_len(&pc, san_buf, addr->size));
-
-        break;
-      }
-
-      default:
-      {
-        throw std::logic_error(
-          fmt::format("Subject Alternative Name {} is not supported", san));
-      }
-    }
-
-    MBEDTLS_ASN1_CHK_ADD(
-      len,
-      mbedtls_asn1_write_tag(
-        &pc, san_buf, MBEDTLS_ASN1_CONTEXT_SPECIFIC | san));
-    MBEDTLS_ASN1_CHK_ADD(len, mbedtls_asn1_write_len(&pc, san_buf, len));
-    MBEDTLS_ASN1_CHK_ADD(
-      len,
-      mbedtls_asn1_write_tag(
-        &pc, san_buf, MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE));
-
-    return mbedtls_x509write_crt_set_extension(
-      ctx,
-      MBEDTLS_OID_SUBJECT_ALT_NAME,
-      MBEDTLS_OID_SIZE(MBEDTLS_OID_SUBJECT_ALT_NAME),
-      0, // Mark SAN as non-critical
-      san_buf + max_san_length - len,
-      len);
-  }
-
-  static inline int x509write_crt_set_subject_alt_names(
-    mbedtls_x509write_cert* ctx, const std::vector<SubjectAltName>& sans)
-  {
-    if (sans.size() == 0)
-      return 0;
-
-    if (sans.size() > max_san_entries)
-    {
-      throw std::logic_error(fmt::format(
-        "Cannot set more than {} subject alternative names", max_san_entries));
-    }
-    // The factor of two is an extremely conservative provision for ASN.1
-    // metadata
-    size_t buf_len = sans.size() * max_san_length * 2;
-
-    std::vector<uint8_t> buf(buf_len);
-    uint8_t* san_buf = buf.data();
-
-    int ret = 0;
-    size_t len = 0;
-
-    // mbedtls asn1 write API writes backward in san_buf
-    uint8_t* pc = san_buf + buf_len;
-
-    for (auto& san : sans)
-    {
-      if (san.san.size() > max_san_length)
-      {
-        throw std::logic_error(fmt::format(
-          "Subject Alternative Name {} is too long ({}>{})",
-          san.san,
-          san.san.size(),
-          max_san_length));
-      }
-
-      if (san.is_ip)
-      {
-        // mbedtls (2.16.2) only supports parsing of subject alternative name
-        // that is DNS= (so no IPAddress=). When connecting to a node that has
-        // IPAddress set, mbedtls_ssl_set_hostname() should not be called.
-        // However, it should work fine with a majority of other clients (e.g.
-        // curl).
-
-        auto addr = ds::ip_to_binary(san.san.c_str());
-        if (!addr.has_value())
-        {
-          throw std ::logic_error(fmt::format(
-            "Subject Alternative Name {} is not a valid IPv4 or "
-            "IPv6 address",
-            san.san));
-        }
-
-        MBEDTLS_ASN1_CHK_ADD(
-          len,
-          mbedtls_asn1_write_raw_buffer(
-            &pc, san_buf, (const unsigned char*)&addr->buf, addr->size));
-        MBEDTLS_ASN1_CHK_ADD(
-          len, mbedtls_asn1_write_len(&pc, san_buf, addr->size));
-      }
-      else
-      {
-        MBEDTLS_ASN1_CHK_ADD(
-          len,
-          mbedtls_asn1_write_raw_buffer(
-            &pc,
-            san_buf,
-            (const unsigned char*)san.san.data(),
-            san.san.size()));
-        MBEDTLS_ASN1_CHK_ADD(
-          len, mbedtls_asn1_write_len(&pc, san_buf, san.san.size()));
-      }
-
-      MBEDTLS_ASN1_CHK_ADD(
-        len,
-        mbedtls_asn1_write_tag(
-          &pc,
-          san_buf,
-          MBEDTLS_ASN1_CONTEXT_SPECIFIC |
-            (san.is_ip ? san_type::ip_address : san_type::dns_name)));
-    }
-
-    MBEDTLS_ASN1_CHK_ADD(len, mbedtls_asn1_write_len(&pc, san_buf, len));
-    MBEDTLS_ASN1_CHK_ADD(
-      len,
-      mbedtls_asn1_write_tag(
-        &pc, san_buf, MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE));
-
-    return mbedtls_x509write_crt_set_extension(
-      ctx,
-      MBEDTLS_OID_SUBJECT_ALT_NAME,
-      MBEDTLS_OID_SIZE(MBEDTLS_OID_SUBJECT_ALT_NAME),
-      0, // Mark SAN as non-critical
-      san_buf + buf_len - len,
-      len);
-  }
-
   Pem KeyPair_mbedTLS::sign_csr(
-    const Pem& issuer_cert,
-    const Pem& signing_request,
-    const std::vector<SubjectAltName> subject_alt_names,
-    bool ca) const
+    const Pem& issuer_cert, const Pem& signing_request, bool ca) const
   {
     auto entropy = create_entropy();
     auto csr = mbedtls::make_unique<mbedtls::X509Csr>();
@@ -518,18 +342,9 @@ namespace crypto
     MCHK(mbedtls_x509write_crt_set_subject_key_identifier(crt.get()));
     MCHK(mbedtls_x509write_crt_set_authority_key_identifier(crt.get()));
 
-    // Because mbedtls does not support parsing x509v3 extensions from a
-    // CSR (https://github.com/ARMmbed/mbedtls/issues/2912), the CA sets the
-    // SAN directly instead of reading it from the CSR
-    try
-    {
-      MCHK(x509write_crt_set_subject_alt_names(crt.get(), subject_alt_names));
-    }
-    catch (const std::logic_error& err)
-    {
-      LOG_FAIL_FMT("Error writing SAN: {}", err.what());
-      return {};
-    }
+    // Warn: Because mbedtls does not support parsing x509v3 extensions from a
+    // CSR (https://github.com/ARMmbed/mbedtls/issues/2912), so those are
+    // ignored and not set in the certificate
 
     uint8_t buf[4096];
     memset(buf, 0, sizeof(buf));

--- a/src/crypto/mbedtls/key_pair.h
+++ b/src/crypto/mbedtls/key_pair.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "../key_pair.h"
+
 #include "../san.h"
 #include "mbedtls_wrappers.h"
 #include "public_key.h"

--- a/src/crypto/mbedtls/key_pair.h
+++ b/src/crypto/mbedtls/key_pair.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "../key_pair.h"
-
 #include "../san.h"
 #include "mbedtls_wrappers.h"
 #include "public_key.h"
@@ -50,12 +49,13 @@ namespace crypto
       size_t* sig_size,
       uint8_t* sig) const override;
 
-    virtual Pem create_csr(const std::string& name) const override;
+    virtual Pem create_csr(
+      const std::string& name,
+      const std::vector<SubjectAltName>& sans = {}) const override;
 
     virtual Pem sign_csr(
       const Pem& issuer_cert,
       const Pem& signing_request,
-      const std::vector<SubjectAltName> subject_alt_names,
       bool ca = false) const override;
   };
 }

--- a/src/crypto/openssl/key_pair.cpp
+++ b/src/crypto/openssl/key_pair.cpp
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 
+#include "key_pair.h"
+
 #include "crypto/curve.h"
 #include "crypto/openssl/public_key.h"
 #include "hash.h"
-#include "key_pair.h"
 #include "openssl_wrappers.h"
 
 #define FMT_HEADER_ONLY

--- a/src/crypto/openssl/key_pair.cpp
+++ b/src/crypto/openssl/key_pair.cpp
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 
+#include "key_pair.h"
+
 #include "crypto/curve.h"
 #include "crypto/openssl/public_key.h"
 #include "hash.h"
-#include "key_pair.h"
 #include "openssl_wrappers.h"
 
 #include <openssl/asn1.h>

--- a/src/crypto/openssl/key_pair.cpp
+++ b/src/crypto/openssl/key_pair.cpp
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 
-#include "key_pair.h"
-
 #include "crypto/curve.h"
 #include "crypto/openssl/public_key.h"
 #include "hash.h"
+#include "key_pair.h"
 #include "openssl_wrappers.h"
 
+#define FMT_HEADER_ONLY
+#include <fmt/format.h>
 #include <openssl/asn1.h>
 #include <openssl/ec.h>
 #include <openssl/engine.h>
@@ -192,34 +193,13 @@ namespace crypto
     {
       Unique_STACK_OF_X509_EXTENSIONS exts;
 
-      std::string all_alt_names;
-      bool first = true;
-      for (const auto& san : sans)
-      {
-        if (first)
-        {
-          first = !first;
-        }
-        else
-        {
-          all_alt_names += ", ";
-        }
-
-        if (san.is_ip)
-        {
-          all_alt_names += "IP:";
-        }
-        else
-        {
-          all_alt_names += "DNS:";
-        }
-        all_alt_names += san.san;
-      }
-
       X509_EXTENSION* ext = NULL;
       OpenSSL::CHECKNULL(
         ext = X509V3_EXT_conf_nid(
-          NULL, NULL, NID_subject_alt_name, all_alt_names.c_str()));
+          NULL,
+          NULL,
+          NID_subject_alt_name,
+          fmt::format("{}", fmt::join(sans, ", ")).c_str()));
       sk_X509_EXTENSION_push(exts, ext);
       X509_REQ_add_extensions(req, exts);
     }

--- a/src/crypto/openssl/key_pair.cpp
+++ b/src/crypto/openssl/key_pair.cpp
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 
-#include "key_pair.h"
-
 #include "crypto/curve.h"
 #include "crypto/openssl/public_key.h"
 #include "hash.h"
+#include "key_pair.h"
 #include "openssl_wrappers.h"
 
 #include <openssl/asn1.h>
@@ -160,7 +159,8 @@ namespace crypto
     return 0;
   }
 
-  Pem KeyPair_OpenSSL::create_csr(const std::string& name) const
+  Pem KeyPair_OpenSSL::create_csr(
+    const std::string& name, const std::vector<SubjectAltName>& sans) const
   {
     Unique_X509_REQ req;
 
@@ -187,6 +187,42 @@ namespace crypto
     if (key)
       OpenSSL::CHECK1(X509_REQ_sign(req, key, EVP_sha512()));
 
+    if (!sans.empty())
+    {
+      Unique_STACK_OF_X509_EXTENSIONS exts;
+
+      std::string all_alt_names;
+      bool first = true;
+      for (const auto& san : sans)
+      {
+        if (first)
+        {
+          first = !first;
+        }
+        else
+        {
+          all_alt_names += ", ";
+        }
+
+        if (san.is_ip)
+        {
+          all_alt_names += "IP:";
+        }
+        else
+        {
+          all_alt_names += "DNS:";
+        }
+        all_alt_names += san.san;
+      }
+
+      X509_EXTENSION* ext = NULL;
+      OpenSSL::CHECKNULL(
+        ext = X509V3_EXT_conf_nid(
+          NULL, NULL, NID_subject_alt_name, all_alt_names.c_str()));
+      sk_X509_EXTENSION_push(exts, ext);
+      X509_REQ_add_extensions(req, exts);
+    }
+
     Unique_BIO mem;
     OpenSSL::CHECK1(PEM_write_bio_X509_REQ(mem, req));
 
@@ -198,10 +234,7 @@ namespace crypto
   }
 
   Pem KeyPair_OpenSSL::sign_csr(
-    const Pem& issuer_cert,
-    const Pem& signing_request,
-    const std::vector<SubjectAltName> subject_alt_names,
-    bool ca) const
+    const Pem& issuer_cert, const Pem& signing_request, bool ca) const
   {
     X509* icrt = NULL;
     Unique_BIO mem(signing_request);
@@ -281,35 +314,21 @@ namespace crypto
     OpenSSL::CHECK1(X509_add_ext(crt, ext, -1));
     X509_EXTENSION_free(ext);
 
-    // Subject alternative names (Necessary? Shouldn't they be in the CSR?)
-    if (!subject_alt_names.empty())
+    // Add subject alternative names (read from csr)
+    Unique_STACK_OF_X509_EXTENSIONS exts = X509_REQ_get_extensions(csr);
+    int extension_count = sk_X509_EXTENSION_num(exts);
+    if (extension_count > 0)
     {
-      std::string all_alt_names;
-      bool first = true;
-      for (auto san : subject_alt_names)
+      for (size_t i = 0; i < extension_count; i++)
       {
-        if (first)
+        X509_EXTENSION* ext = sk_X509_EXTENSION_value(exts, i);
+        ASN1_OBJECT* obj = X509_EXTENSION_get_object(ext);
+        auto nid = OBJ_obj2nid(obj);
+        if (nid == NID_subject_alt_name)
         {
-          first = !first;
+          OpenSSL::CHECK1(X509_add_ext(crt, ext, -1));
         }
-        else
-        {
-          all_alt_names += ", ";
-        }
-
-        if (san.is_ip)
-          all_alt_names += "IP:";
-        else
-          all_alt_names += "DNS:";
-
-        all_alt_names += san.san;
       }
-
-      OpenSSL::CHECKNULL(
-        ext = X509V3_EXT_conf_nid(
-          NULL, &v3ctx, NID_subject_alt_name, all_alt_names.c_str()));
-      OpenSSL::CHECK1(X509_add_ext(crt, ext, -1));
-      X509_EXTENSION_free(ext);
     }
 
     // Sign

--- a/src/crypto/openssl/key_pair.h
+++ b/src/crypto/openssl/key_pair.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "../key_pair.h"
+
 #include "openssl_wrappers.h"
 #include "public_key.h"
 

--- a/src/crypto/openssl/key_pair.h
+++ b/src/crypto/openssl/key_pair.h
@@ -7,7 +7,6 @@
 #include "openssl_wrappers.h"
 #include "public_key.h"
 
-#include <optional>
 #include <stdexcept>
 #include <string>
 

--- a/src/crypto/openssl/key_pair.h
+++ b/src/crypto/openssl/key_pair.h
@@ -3,10 +3,10 @@
 #pragma once
 
 #include "../key_pair.h"
-
 #include "openssl_wrappers.h"
 #include "public_key.h"
 
+#include <optional>
 #include <stdexcept>
 #include <string>
 
@@ -51,12 +51,13 @@ namespace crypto
       size_t* sig_size,
       uint8_t* sig) const override;
 
-    virtual Pem create_csr(const std::string& name) const override;
+    virtual Pem create_csr(
+      const std::string& name,
+      const std::vector<SubjectAltName>& sans = {}) const override;
 
     virtual Pem sign_csr(
       const Pem& issuer_cert,
       const Pem& signing_request,
-      const std::vector<SubjectAltName> subject_alt_names,
       bool ca = false) const override;
   };
 }

--- a/src/crypto/openssl/openssl_wrappers.h
+++ b/src/crypto/openssl/openssl_wrappers.h
@@ -200,6 +200,32 @@ namespace crypto
       }
     };
 
+    class Unique_STACK_OF_X509_EXTENSIONS
+    {
+      std::unique_ptr<
+        STACK_OF(X509_EXTENSION),
+        void (*)(STACK_OF(X509_EXTENSION)*)>
+        p;
+
+    public:
+      Unique_STACK_OF_X509_EXTENSIONS() :
+        p(sk_X509_EXTENSION_new_null(),
+          [](auto x) { sk_X509_EXTENSION_pop_free(x, X509_EXTENSION_free); })
+      {
+        OpenSSL::CHECKNULL(p.get());
+      }
+
+      Unique_STACK_OF_X509_EXTENSIONS(STACK_OF(X509_EXTENSION) * exts) :
+        p(exts,
+          [](auto x) { sk_X509_EXTENSION_pop_free(x, X509_EXTENSION_free); })
+      {}
+
+      operator STACK_OF(X509_EXTENSION) * ()
+      {
+        return p.get();
+      }
+    };
+
     class Unique_ECDSA_SIG
     {
       std::unique_ptr<ECDSA_SIG, void (*)(ECDSA_SIG*)> p;

--- a/src/crypto/san.h
+++ b/src/crypto/san.h
@@ -4,6 +4,8 @@
 
 #include "ds/json.h"
 
+#define FMT_HEADER_ONLY
+#include <fmt/format.h>
 #include <string>
 
 namespace crypto
@@ -16,3 +18,31 @@ namespace crypto
   DECLARE_JSON_TYPE(SubjectAltName);
   DECLARE_JSON_REQUIRED_FIELDS(SubjectAltName, san, is_ip);
 }
+
+FMT_BEGIN_NAMESPACE
+template <>
+struct formatter<crypto::SubjectAltName>
+{
+  template <typename ParseContext>
+  auto parse(ParseContext& ctx)
+  {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(const crypto::SubjectAltName& san, FormatContext& ctx)
+    -> decltype(ctx.out())
+  {
+    std::string prefix;
+    if (san.is_ip)
+    {
+      prefix = "IP";
+    }
+    else
+    {
+      prefix = "DNS";
+    }
+    return format_to(ctx.out(), "{}:{}", prefix, san.san);
+  }
+};
+FMT_END_NAMESPACE

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -391,15 +391,19 @@ void run_csr()
 
   const char* subject_name = "CN=myname";
 
-  auto csr = kpm.create_csr(subject_name);
-
   std::vector<SubjectAltName> subject_alternative_names;
-  subject_alternative_names.push_back({"email:my-other-name", false});
-  subject_alternative_names.push_back({"www.microsoft.com", false});
-  subject_alternative_names.push_back({"192.168.0.1", true});
+
+  if constexpr (std::is_same_v<T, KeyPair_OpenSSL>)
+  {
+    subject_alternative_names.push_back({"email:my-other-name", false});
+    subject_alternative_names.push_back({"www.microsoft.com", false});
+    subject_alternative_names.push_back({"192.168.0.1", true});
+  }
+
+  auto csr = kpm.create_csr(subject_name, subject_alternative_names);
 
   auto icrt = kpm.self_sign("CN=issuer");
-  auto crt = kpm.sign_csr(icrt, csr, subject_alternative_names);
+  auto crt = kpm.sign_csr(icrt, csr);
 
   std::vector<uint8_t> content = {0, 1, 2, 3, 4};
   auto signature = kpm.sign(content);

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -393,6 +393,7 @@ void run_csr()
 
   std::vector<SubjectAltName> subject_alternative_names;
 
+  // mbedtls doesn't support parsing SAN from CSR
   if constexpr (std::is_same_v<T, KeyPair_OpenSSL>)
   {
     subject_alternative_names.push_back({"email:my-other-name", false});

--- a/src/node/identity.h
+++ b/src/node/identity.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "crypto/curve.h"
-#include "crypto/key_pair.h"
+#include "crypto/openssl/key_pair.h"
 
 #include <string>
 #include <vector>
@@ -24,7 +24,8 @@ namespace ccf
 
     NetworkIdentity(const std::string& name, crypto::CurveID curve_id)
     {
-      auto identity_key_pair = crypto::make_key_pair(curve_id);
+      auto identity_key_pair =
+        std::make_shared<crypto::KeyPair_OpenSSL>(curve_id);
       cert = identity_key_pair->self_sign(name);
       priv_key = identity_key_pair->private_key_pem();
     }

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -89,7 +89,7 @@ namespace ccf
     std::mutex lock;
 
     CurveID curve_id;
-    crypto::KeyPairPtr node_sign_kp;
+    std::shared_ptr<crypto::KeyPair_OpenSSL> node_sign_kp;
     NodeId self;
     std::shared_ptr<crypto::RSAKeyPair> node_encrypt_kp;
     crypto::Pem node_cert;
@@ -257,7 +257,7 @@ namespace ccf
       CurveID curve_id_) :
       sm("NodeState", State::uninitialized),
       curve_id(curve_id_),
-      node_sign_kp(crypto::make_key_pair(curve_id_)),
+      node_sign_kp(std::make_shared<crypto::KeyPair_OpenSSL>(curve_id_)),
       node_encrypt_kp(crypto::make_rsa_key_pair()),
       writer_factory(writer_factory),
       to_host(writer_factory.create_writer_to_outside()),
@@ -1596,9 +1596,9 @@ namespace ccf
     Pem create_endorsed_node_cert()
     {
       auto nw = crypto::make_key_pair(network.identity->priv_key);
-      auto csr = node_sign_kp->create_csr(config.subject_name);
       auto sans = get_subject_alternative_names();
-      return nw->sign_csr(network.identity->cert, csr, sans);
+      auto csr = node_sign_kp->create_csr(config.subject_name, sans);
+      return nw->sign_csr(network.identity->cert, csr);
     }
 
     void accept_node_tls_connections()

--- a/src/tls/test/cert.cpp
+++ b/src/tls/test/cert.cpp
@@ -25,8 +25,8 @@ int main(int argc, char** argv)
 
   auto kp = crypto::make_key_pair();
   auto icrt = kp->self_sign("CN=issuer");
-  auto csr = kp->create_csr(subject_name);
-  auto cert = kp->sign_csr(icrt, csr, subject_alternative_names);
+  auto csr = kp->create_csr(subject_name, subject_alternative_names);
+  auto cert = kp->sign_csr(icrt, csr);
 
   std::cout << cert.str() << std::endl;
   return 0;


### PR DESCRIPTION
Part of #2554 

Historically, mbedtls was the only crypto backend we used for generating node/service certificates. However, mbedtls [doesn't support parsing x509 v3 extensions from a CSR](https://github.com/ARMmbed/mbedtls/issues/2912) and we circumvented that by specifying the SANs explicitly when the certificate was created from the CSR, rather than reading the SANs from the CSR directly. This was OK while the CSRs and certificates were created on the same nodes, but won't be the case after #2554 (joining node will pass its CSR to the primary which will sign it when the node becomes trusted). 

This PR adds the ability to read the extensions from the CSR and apply them to the certificate directly (**OpenSSL implementation only**). This avoids having to store the SANs for each node in the KV separately (i.e. CSR on its own is sufficient - changes to come in a separate PR). It also disables the creation of certificates with SANs for the mbedtls implementation. This means that the node and service certificates now always use OpenSSL. 