### PR TITLE
Release fix: Move `consenus_type` check to where it is now defined

### DIFF
--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -53,15 +53,6 @@ extern "C"
       return CreateNodeStatus::NodeAlreadyCreated;
     }
 
-#ifndef ENABLE_BFT
-    // As BFT consensus is currently experimental, disable it in release
-    // enclaves
-    if (consensus_type != ConsensusType::CFT)
-    {
-      return CreateNodeStatus::ConsensusNotAllowed;
-    }
-#endif
-
     // Report enclave version to host
     auto ccf_version_string = std::string(ccf::ccf_version);
     if (ccf_version_string.size() > enclave_version_size)
@@ -137,6 +128,15 @@ extern "C"
 
     CCFConfig cc =
       nlohmann::json::parse(ccf_config, ccf_config + ccf_config_size);
+
+#ifndef ENABLE_BFT
+    // As BFT consensus is currently experimental, disable it in release
+    // enclaves
+    if (cc.consensus_config.consensus_type != ConsensusType::CFT)
+    {
+      return CreateNodeStatus::ConsensusNotAllowed;
+    }
+#endif
 
 #ifdef DEBUG_CONFIG
     reserved_memory = new uint8_t[ec->debug_config.memory_reserve_startup];


### PR DESCRIPTION
I moved `consensus_type` in #2780, from a top-level argument to nested within the passed config.

This broke compilation, which tries to access an undefined variable, but only when `ENABLE_BFT=OFF`, which only happens in the release job. We should think about adding a regular build configuration which tests this flag, since every other build currently uses `ENABLE_BFT=ON` (and then runs tests on that BFT build).