### PR TITLE
Do not try to use non-existent focal-8 llvm repo (#2836)

### DIFF
--- a/getting_started/setup_vm/app-dev.yml
+++ b/getting_started/setup_vm/app-dev.yml
@@ -12,9 +12,6 @@
         name: openenclave
         tasks_from: binary_install.yml
     - import_role:
-        name: llvm_repo
-        tasks_from: install.yml
-    - import_role:
         name: ccf_build
         tasks_from: install.yml
     - import_role:

--- a/getting_started/setup_vm/app-run.yml
+++ b/getting_started/setup_vm/app-run.yml
@@ -12,8 +12,5 @@
         name: openenclave
         tasks_from: binary_install.yml
     - import_role:
-        name: llvm_repo
-        tasks_from: install.yml
-    - import_role:
         name: ccf_install
         tasks_from: deb_install.yml


### PR DESCRIPTION
This change was applied to build release images for 1.0.8 and is necessary going forward until the switch to clang-10.