### PR TITLE
Reduce spam in Python infra

### DIFF
--- a/tests/infra/checker.py
+++ b/tests/infra/checker.py
@@ -58,6 +58,6 @@ def check_does_not_progress(node, timeout=3):
         try:
             c.wait_for_commit(r, timeout=timeout)
         except TimeoutError:
-            pass
+            return r
         else:
             assert False, f"Commit unexpectedly advanced past {r.view}.{r.seqno}"

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -894,24 +894,24 @@ class Network:
         end_time = time.time() + timeout
         error = TimeoutError
         logs = []
+
+        backup = self.find_any_backup()
+        if backup.get_consensus() == "bft":
+            try:
+                with backup.client("user0") as c:
+                    _ = c.post(
+                        "/app/log/private",
+                        {
+                            "id": -1,
+                            "msg": "This is submitted to force a view change",
+                        },
+                    )
+                time.sleep(1)
+            except CCFConnectionException:
+                LOG.warning(f"Could not successfully connect to node {backup.node_id}.")
+
         while time.time() < end_time:
             try:
-                backup = self.find_any_backup()
-                if backup.get_consensus() == "bft":
-                    try:
-                        with backup.client("user0") as c:
-                            _ = c.post(
-                                "/app/log/private",
-                                {
-                                    "id": -1,
-                                    "msg": "This is submitted to force a view change",
-                                },
-                            )
-                        time.sleep(1)
-                    except CCFConnectionException:
-                        LOG.warning(
-                            f"Could not successfully connect to node {backup.node_id}."
-                        )
                 logs = []
                 new_primary, new_term = self.find_primary(nodes=nodes, log_capture=logs)
                 if new_primary.node_id != old_primary.node_id:

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -895,7 +895,7 @@ class Network:
         error = TimeoutError
         logs = []
 
-        backup = self.find_any_backup()
+        backup = self.find_any_backup(old_primary)
         if backup.get_consensus() == "bft":
             try:
                 with backup.client("user0") as c:


### PR DESCRIPTION
I noticed the partitions test had gotten very verbose, printing repeated identical calls to `find_primary`:

![image](https://user-images.githubusercontent.com/6000239/126770737-2684bbed-0db5-4725-b727-b77969e58fdc.png)

We explicitly capture these repeated attempts to remove this spam. However, we recently added a call to `find_backup()` which doesn't have this protection, and transitively calls `find_primary()` if not given a node, resulting in this spam.

The fix is 2-fold: don't do this in the loop (to trigger a view change, we should be able to submit a single transaction?), and pass an existing node so that even this doesn't need to call `find_primary()`.

Halves the output length of `partitions_test`:

```
$ sudo ./tests.sh -VV -R partitions_cft | wc -l
720

$ sudo ./tests.sh -VV -R partitions_cft | wc -l
339
```