### PR TITLE
Remove unsafe cast in `raft_test`

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-cough
+*cough*

--- a/src/consensus/aft/test/main.cpp
+++ b/src/consensus/aft/test/main.cpp
@@ -348,6 +348,7 @@ static size_t dispatch_all_and_DOCTEST_CHECK(
     auto [tgt_node_id, contents] = messages.front();
     messages.pop_front();
 
+    if constexpr (!std::is_same_v<AssertionArg, void>)
     {
       AssertionArg arg = *(AssertionArg*)contents.data();
       assertion(arg);
@@ -366,7 +367,7 @@ static size_t dispatch_all(
   const ccf::NodeId& from,
   aft::ChannelStubProxy::MessageList& messages)
 {
-  return dispatch_all_and_DOCTEST_CHECK<bool>(
+  return dispatch_all_and_DOCTEST_CHECK<void>(
     nodes, from, messages, [](const auto&) {
       // Pass
     });


### PR DESCRIPTION
I made a change in #2840 to implement `raft_test`'s `dispatch_all` in terms of `dispatch_all_and_DOCTEST_CHECK`, to reduce code duplication. This introduced an unsafe cast, spotted by the SAN in the instrumented daily build. This removes that cast - `constexpr` out the assertion block, rather than passing and casting-to an incorrect type.