### PR TITLE
Return compliant URL in `Location` header of `TEMPORARY_REDIRECT` responses

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-*cough*
+*cough!*

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -135,9 +135,13 @@ namespace ccf
 
           if (info)
           {
-            ctx->set_response_header(
-              http::headers::LOCATION,
-              fmt::format("{}:{}", info->pubhost, info->pubport));
+            const auto location = fmt::format(
+              "https://{}:{}{}",
+              info->pubhost,
+              info->pubport,
+              ctx->get_request_path());
+            ctx->set_response_header(http::headers::LOCATION, location);
+            LOG_DEBUG_FMT("Redirecting to {}", location);
           }
         }
 


### PR DESCRIPTION
Fix for #2847.

I misread the spec for the `Location` header when first implementing this `TEMPORARY_REDIRECT` response, and as a result it was junk. We returned `Location: 127.4.5.6:1234`, and the client treats this as an alternative relative path, so if it's a redirection for `/app/log/private` it produces `/app/log/127.4.5.6:1234`. We now correctly return a complete URL to the redirected resource, in the same way we do for `PERMANENT_REDIRECT`s in the `node_frontend`, including the same assumption that `pubhost:pubport` is useable by the client.

I'm surprised this wasn't seen before. I think we only hit this path when a forwarded request reaches a node who is no longer primary, and the recent `check_can_progress` changes made that more common. I can't think of a way to trigger that consistently - we'd need to partition a node from the new primary, but keep them in touch with the old primary, and send a request in the window _after_ the old primary knows it is not primary, but before this follower has timed out and triggered an election? Tricky.