### PR TITLE
Remove .js file from glob pattern when uploading JS apps

### DIFF
--- a/python/ccf/proposal_generator.py
+++ b/python/ccf/proposal_generator.py
@@ -205,7 +205,7 @@ def remove_js_app(**kwargs):
 
 def read_modules(modules_path: str) -> List[dict]:
     modules = []
-    for path in glob.glob(f"{modules_path}/**/*.js", recursive=True):
+    for path in glob.glob(f"{modules_path}/**/*", recursive=True):
         if not os.path.isfile(path):
             continue
         rel_module_name = os.path.relpath(path, modules_path)


### PR DESCRIPTION
Fixes `forum_app`, which has broken because of some dependency upgrade now using a `.js_commonjs-proxy` file (previously built but not used, so safely never uploaded). There's a risk that this uploads junk in future, if apps include more non-source things under their build folder, but seems a necessary tradeoff.