### PR TITLE
Fix for `recovery_test_bft`: Restore old AppendEntriesResponse value

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -2141,6 +2141,11 @@ namespace aft
         state->commit_idx :
         state->last_idx;
 
+      if (consensus_type == ConsensusType::BFT)
+      {
+        matching_idx = state->last_idx;
+      }
+
       LOG_DEBUG_FMT(
         "Send append entries response from {} to {} for index {}: {}",
         state->my_node_id.trim(),


### PR DESCRIPTION
See discussion in #2853. Don't understand why this doesn't work, much less why it doesn't work _in the way it does_, but this workaround seems to placate the tests so seems a sensible compromise for now.