### PR TITLE
Tentative fix for reconfiguration test failure

### DIFF
--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -176,7 +176,10 @@ def test_retire_primary(network, args):
 
     primary, backup = network.find_primary_and_any_backup()
     network.retire_node(primary, primary)
-    network.wait_for_new_primary(primary)
+    # Query this backup to find the new primary. If we ask any other
+    # node, then this backup may not know the new primary by the
+    # time we call check_can_progress.
+    network.wait_for_new_primary(primary, nodes=[backup])
     check_can_progress(backup)
     post_count = count_nodes(node_configs(network), network)
     assert pre_count == post_count + 1


### PR DESCRIPTION
https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=29917&view=logs&j=5435e0ac-25e5-5426-50be-61b0d0ea8d34&t=cf4e34b3-24ee-5d97-0df9-ba9302d9fe90&l=31023

Although I've not been able to reproduce this locally, I believe what is happening here is that a new primary has been elected, but the backup we then `check_for_progress` on hasn't heard this yet. It has received a `RequestVote` but nothing more by the time we call `/log/private` on it, so it has attempts to forward but has no primary to forward to. Another case of expecting session consistency, despite talking to different nodes!