### PR TITLE
Remove NodeId `trim()`

### DIFF
--- a/include/ccf/entity_id.h
+++ b/include/ccf/entity_id.h
@@ -57,20 +57,6 @@ namespace ccf
       return id < other.id;
     }
 
-    std::string trim() const
-    {
-      // Some entities (typically NodeIds) are printed in many places when
-      // VERBOSE_LOGGING is activated so trim them explicitly whenever possible
-      // in this case. Otherwise, return the entire value.
-#ifdef VERBOSE_LOGGING
-      static constexpr size_t entity_id_truncation_max_char_count = 10;
-      return id.substr(
-        0, std::min(size(), entity_id_truncation_max_char_count));
-#else
-      return id;
-#endif
-    }
-
     Value& value()
     {
       return id;

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -690,7 +690,7 @@ namespace aft
 
         LOG_DEBUG_FMT(
           "Replicated on leader {}: {}{} ({} hooks)",
-          state->my_node_id.trim(),
+          state->my_node_id,
           index,
           (globally_committable ? " committable" : ""),
           hooks->size());
@@ -733,7 +733,7 @@ namespace aft
           entry_size_not_limited = 0;
           for (const auto& it : nodes)
           {
-            LOG_DEBUG_FMT("Sending updates to follower {}", it.first.trim());
+            LOG_DEBUG_FMT("Sending updates to follower {}", it.first);
             send_append_entries(it.first, it.second.sent_idx + 1);
           }
         }
@@ -1035,8 +1035,7 @@ namespace aft
 
       ccf::ViewChangeRequest v =
         ccf::ViewChangeRequest::deserialize(data, size);
-      LOG_INFO_FMT(
-        "Received view change from:{}, view:{}", from.trim(), r.view);
+      LOG_INFO_FMT("Received view change from:{}, view:{}", from, r.view);
 
       auto progress_tracker = store->get_progress_tracker();
       auto result =
@@ -1296,8 +1295,8 @@ namespace aft
 
       LOG_DEBUG_FMT(
         "Send append entries from {} to {}: {} to {} ({})",
-        state->my_node_id.trim(),
-        to.trim(),
+        state->my_node_id,
+        to,
         start_idx,
         end_idx,
         state->commit_idx);
@@ -1534,8 +1533,8 @@ namespace aft
 
       LOG_DEBUG_FMT(
         "Recv append entries to {} from {} for index {} and previous index {}",
-        state->my_node_id.trim(),
-        from.trim(),
+        state->my_node_id,
+        from,
         r.idx,
         r.prev_idx);
 
@@ -1578,8 +1577,7 @@ namespace aft
           continue;
         }
 
-        LOG_DEBUG_FMT(
-          "Replicating on follower {}: {}", state->my_node_id.trim(), i);
+        LOG_DEBUG_FMT("Replicating on follower {}: {}", state->my_node_id, i);
 
         std::vector<uint8_t> entry;
         try
@@ -2148,8 +2146,8 @@ namespace aft
 
       LOG_DEBUG_FMT(
         "Send append entries response from {} to {} for index {}: {}",
-        state->my_node_id.trim(),
-        to.trim(),
+        state->my_node_id,
+        to,
         matching_idx,
         answer);
 
@@ -2167,8 +2165,8 @@ namespace aft
     {
       LOG_DEBUG_FMT(
         "Send append entries signed response from {} to {} for index {}",
-        state->my_node_id.trim(),
-        to.trim(),
+        state->my_node_id,
+        to,
         state->last_idx);
 
       auto progress_tracker = store->get_progress_tracker();
@@ -2300,7 +2298,7 @@ namespace aft
       CCF_ASSERT(progress_tracker != nullptr, "progress_tracker is not set");
       LOG_TRACE_FMT(
         "processing recv_signature_received_ack, from:{} view:{}, seqno:{}",
-        from.trim(),
+        from,
         r.term,
         r.idx);
 
@@ -2374,7 +2372,7 @@ namespace aft
       CCF_ASSERT(progress_tracker != nullptr, "progress_tracker is not set");
       LOG_TRACE_FMT(
         "processing nonce_reveal, from:{} view:{}, seqno:{}",
-        from.trim(),
+        from,
         r.term,
         r.idx);
       progress_tracker->add_nonce_reveal(
@@ -2489,8 +2487,8 @@ namespace aft
 
       LOG_DEBUG_FMT(
         "Recv append entries response to {} from {} for index {}: success",
-        state->my_node_id.trim(),
-        from.trim(),
+        state->my_node_id,
+        from,
         r.last_log_idx);
       update_commit();
     }
@@ -2500,8 +2498,8 @@ namespace aft
       auto last_committable_idx = last_committable_index();
       LOG_INFO_FMT(
         "Send request vote from {} to {} at {}",
-        state->my_node_id.trim(),
-        to.trim(),
+        state->my_node_id,
+        to,
         last_committable_idx);
       CCF_ASSERT(last_committable_idx >= state->commit_idx, "lci < ci");
 
@@ -2600,8 +2598,8 @@ namespace aft
     {
       LOG_INFO_FMT(
         "Send request vote response from {} to {}: {}",
-        state->my_node_id.trim(),
-        to.trim(),
+        state->my_node_id,
+        to,
         answer);
 
       RequestVoteResponse response = {
@@ -3054,7 +3052,7 @@ namespace aft
       store->compact(idx);
       ledger->commit(idx);
 
-      LOG_DEBUG_FMT("Commit on {}: {}", state->my_node_id.trim(), idx);
+      LOG_DEBUG_FMT("Commit on {}: {}", state->my_node_id, idx);
 
       // Examine all configurations that are followed by a globally committed
       // configuration.

--- a/src/host/node_connections.h
+++ b/src/host/node_connections.h
@@ -37,7 +37,7 @@ namespace asynchost
       {
         LOG_DEBUG_FMT(
           "from node {} received {} bytes",
-          node.value_or(UnassociatedNode).trim(),
+          node.value_or(UnassociatedNode),
           len);
 
         pending.insert(pending.end(), incoming, incoming + len);
@@ -62,7 +62,7 @@ namespace asynchost
           {
             LOG_DEBUG_FMT(
               "from node {} have {}/{} bytes",
-              node.value_or(UnassociatedNode).trim(),
+              node.value_or(UnassociatedNode),
               size,
               msg_size.value());
             break;
@@ -79,7 +79,7 @@ namespace asynchost
 
           LOG_DEBUG_FMT(
             "node in: from node {}, size {}, type {}",
-            node->trim(),
+            node.value(),
             msg_size.value(),
             msg_type);
 
@@ -315,7 +315,7 @@ namespace asynchost
 
             LOG_DEBUG_FMT(
               "send AE to node {} [{}]: {}, {}",
-              to.trim(),
+              to,
               frame,
               ae.idx,
               ae.prev_idx);
@@ -325,7 +325,7 @@ namespace asynchost
             // Write as framed data to the recipient.
             uint32_t frame = (uint32_t)size_to_send;
 
-            LOG_DEBUG_FMT("node send to {} [{}]", to.trim(), frame);
+            LOG_DEBUG_FMT("node send to {} [{}]", to, frame);
 
             node.value()->write(sizeof(uint32_t), (uint8_t*)&frame);
             node.value()->write(size_to_send, data_to_send);


### PR DESCRIPTION
Now that we have a custom formatter for `NodeId`s, we no longer need the custom shortener for it. 