### PR TITLE
Fix `check-format.sh` script: Pass -Werror

### DIFF
--- a/scripts/check-format.sh
+++ b/scripts/check-format.sh
@@ -32,7 +32,7 @@ file_name_regex="^[[:lower:]0-9_]+$"
 unformatted_files=""
 badly_named_files=""
 for file in $(git ls-files "$@" | grep -e '\.h$' -e '\.hpp$' -e '\.cpp$' -e '\.c$'); do
-  if ! clang-format-10 -n -style=file "$file"; then
+  if ! clang-format-10 -n -Werror -style=file "$file"; then
     if $fix ; then
       clang-format-10 -style=file -i "$file"
     fi


### PR DESCRIPTION
Without `-Werror`, this raises warnings but doesn't reformat. I think we want no warnings, to format all.