### PR TITLE
Remove undefined behaviour from `raft_test` (again)

### DIFF
--- a/src/consensus/aft/test/test_common.h
+++ b/src/consensus/aft/test/test_common.h
@@ -73,6 +73,7 @@ static size_t dispatch_all_and_DOCTEST_CHECK(
     auto [tgt_node_id, contents] = messages.front();
     messages.pop_front();
 
+    if constexpr (!std::is_same_v<AssertionArg, void>)
     {
       AssertionArg arg = *(AssertionArg*)contents.data();
       assertion(arg);
@@ -100,7 +101,7 @@ static size_t dispatch_all(
   const ccf::NodeId& from,
   aft::ChannelStubProxy::MessageList& messages)
 {
-  return dispatch_all_and_DOCTEST_CHECK<bool>(
+  return dispatch_all_and_DOCTEST_CHECK<void>(
     nodes, from, messages, [](const auto&) {
       // Pass
     });


### PR DESCRIPTION
Restore the fix from #2846, accidentally lost in the refactoring of #2852.

Resolves #2864.