### PR TITLE
Switch all containerised SGX builds to hosted 1ES pool

### DIFF
--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -5,7 +5,7 @@ parameters:
       pool: Ubuntu-1804-D8s_v3
     SGX:
       container: sgx
-      pool: Ubuntu-1804-DC8_v2
+      pool: 1es-dcv2-focal
     Perf:
       pool: CCF-Perf
 

--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -11,7 +11,7 @@ parameters:
       pool: Ubuntu-1804-D8s_v3
     SGX:
       container: sgx
-      pool: Ubuntu-1804-DC8_v2
+      pool: 1es-dcv2-focal
     Perf:
       pool: CCF-Perf
 

--- a/.azure-pipelines-templates/stress-matrix.yml
+++ b/.azure-pipelines-templates/stress-matrix.yml
@@ -4,7 +4,7 @@ jobs:
       target: SGX
       env:
         container: sgx
-        pool: Ubuntu-1804-DC8_v2
+        pool: 1es-dcv2-focal
         timeoutInMinutes: 120 # Trying to run 2 45-minute tests; these must complete in < 2 hours
       cmake_args: "-DCOMPILE_TARGETS=sgx"
       suffix: "StressTest"

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -25,7 +25,7 @@ jobs:
       target: SGX
       env:
         container: sgx
-        pool: Ubuntu-1804-DC8_v2
+        pool: 1es-dcv2-focal
       cmake_args: "-DCOMPILE_TARGETS=sgx -DWORKER_THREADS=2"
       suffix: "MultiThread"
       artifact_name: "MultiThread"


### PR DESCRIPTION
Note `1es-dcv2-focal` is capped to two executors at the moment, for quota reasons. I will bump it up once this is merged and the old pool is no longer used.