### PR TITLE
Disable recovery_test_bft

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,6 +509,12 @@ if(BUILD_TESTS)
   )
 
   add_e2e_test(
+    NAME recovery_test_cft
+    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/recovery.py
+    CONSENSUS cft
+  )
+
+  add_e2e_test(
     NAME recovery_test_curve_256
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/recovery.py
     CONSENSUS cft
@@ -819,12 +825,6 @@ if(BUILD_TESTS)
     add_e2e_test(
       NAME election_test_${CONSENSUS}
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/election.py
-      CONSENSUS ${CONSENSUS}
-    )
-
-    add_e2e_test(
-      NAME recovery_test_${CONSENSUS}
-      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/recovery.py
       CONSENSUS ${CONSENSUS}
     )
 


### PR DESCRIPTION
I was incorrect in my comment on #2865 - `recovery_test_bft` is still unstable on `main`, so disabling it while it is a low priority.

Presumably my BFT-specific path in #2854 is insufficient after #2852, which introduces some other changes in the NACK process that are not compatible with BFT.