### PR TITLE
Fix BFT threshold calculation

### DIFF
--- a/src/node/progress_tracker_types.h
+++ b/src/node/progress_tracker_types.h
@@ -301,11 +301,7 @@ namespace ccf
 
   static constexpr uint32_t get_endorsement_threshold(uint32_t count)
   {
-    uint32_t f = 0;
-    for (; 3 * f + 1 < count; ++f)
-      ;
-
-    return 2 * f + 1;
+    return count * 2 / 3 + 1;
   }
 
   // Counts the number of endorsements (backup signatures, nonces,

--- a/src/node/test/progress_tracker.cpp
+++ b/src/node/test/progress_tracker.cpp
@@ -866,3 +866,17 @@ TEST_CASE("Sending evidence out of band")
     }
   }
 }
+
+TEST_CASE("Endorsement threshold")
+{
+  REQUIRE(ccf::get_endorsement_threshold(1) == 1);
+  REQUIRE(ccf::get_endorsement_threshold(2) == 2);
+  REQUIRE(ccf::get_endorsement_threshold(3) == 3);
+  REQUIRE(ccf::get_endorsement_threshold(4) == 3);
+  REQUIRE(ccf::get_endorsement_threshold(5) == 4);
+  REQUIRE(ccf::get_endorsement_threshold(6) == 5);
+  REQUIRE(ccf::get_endorsement_threshold(7) == 5);
+  REQUIRE(ccf::get_endorsement_threshold(8) == 6);
+  REQUIRE(ccf::get_endorsement_threshold(9) == 7);
+  REQUIRE(ccf::get_endorsement_threshold(10) == 7);
+}


### PR DESCRIPTION
Previous code incorrectly computed threshold=3 when count=2, was unnecessarily complex.