### PR TITLE
ZAP test in 1es pool

### DIFF
--- a/.azure-pipelines-templates/common.yml
+++ b/.azure-pipelines-templates/common.yml
@@ -8,6 +8,7 @@ jobs:
     steps:
       - script: |
           sudo rm -rf build
+          env
         displayName: "Cleanup"
 
       - checkout: self

--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -7,6 +7,7 @@ parameters:
       container: sgx
       pool: 1es-dcv2-focal
     Perf:
+      container: nosgx-passthru
       pool: 1es-dv4-focal
 
   build:

--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -7,7 +7,7 @@ parameters:
       container: sgx
       pool: 1es-dcv2-focal
     Perf:
-      container: nosgx-passthru
+      container: nosgx-nested-docker
       pool: 1es-dv4-focal
 
   build:

--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -2,7 +2,7 @@ parameters:
   env:
     NoSGX:
       container: nosgx
-      pool: Ubuntu-1804-D8s_v3
+      pool: 1es-dv4-focal
     SGX:
       container: sgx
       pool: 1es-dcv2-focal

--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -7,7 +7,7 @@ parameters:
       container: sgx
       pool: 1es-dcv2-focal
     Perf:
-      pool: CCF-Perf
+      pool: 1es-dv4-focal
 
   build:
     common:

--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -8,7 +8,7 @@ parameters:
         vmImage: ubuntu-20.04
     NoSGX:
       container: nosgx
-      pool: Ubuntu-1804-D8s_v3
+      pool: 1es-dv4-focal
     SGX:
       container: sgx
       pool: 1es-dcv2-focal

--- a/.daily.yml
+++ b/.daily.yml
@@ -32,7 +32,7 @@ resources:
 
     - container: nosgx-nested-docker
       image: ccfciteam/ccf-ci:oe0.17.1-dockcker
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /var/run/docker.sock:/var/run/docker.sock
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache --privileged -d docker:dind
 
 jobs:
   - template: .azure-pipelines-templates/daily-matrix.yml

--- a/.daily.yml
+++ b/.daily.yml
@@ -32,7 +32,7 @@ resources:
 
     - container: nosgx-nested-docker
       image: ccfciteam/ccf-ci:oe0.17.1-dockcker
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /var/run/docker.sock:/var/run/docker.sock
+      options: -p 45000:45000 --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /var/run/docker.sock:/var/run/docker.sock
 
 jobs:
   - template: .azure-pipelines-templates/daily-matrix.yml

--- a/.daily.yml
+++ b/.daily.yml
@@ -30,8 +30,8 @@ resources:
       image: ccfciteam/ccf-ci:oe0.17.1-focal-clang10
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
-    - container: nosgx-passthru
-      image: ccfciteam/ccf-ci:oe0.17.1-focal-clang10
+    - container: nosgx-nested-docker
+      image: ccfciteam/ccf-ci:oe0.17.1-dockcker
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /var/run/docker.sock:/var/run/docker.sock
 
 jobs:

--- a/.daily.yml
+++ b/.daily.yml
@@ -30,5 +30,9 @@ resources:
       image: ccfciteam/ccf-ci:oe0.17.1-focal-clang10
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
+    - container: nosgx-passthru
+      image: ccfciteam/ccf-ci:oe0.17.1-focal-clang10
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /var/run/docker.sock:/var/run/docker.sock
+
 jobs:
   - template: .azure-pipelines-templates/daily-matrix.yml

--- a/.daily.yml
+++ b/.daily.yml
@@ -32,7 +32,7 @@ resources:
 
     - container: nosgx-nested-docker
       image: ccfciteam/ccf-ci:oe0.17.1-dockcker
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache --privileged -d docker:dind
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /var/run/docker.sock:/var/run/docker.sock
 
 jobs:
   - template: .azure-pipelines-templates/daily-matrix.yml

--- a/getting_started/setup_vm/roles/ccf_build/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_build/vars/common.yml
@@ -25,8 +25,7 @@ debs:
   - iptables # partition test infra
   - libclang1-9 # required by doxygen
   - libclang-cpp9 # required by doxygen
-  - flex # required to build doxygen
-  - bison # required to build doxygen
+  - docker.io # required to run ZAP fuzzer
 
 mbedtls_ver: "2.16.10"
 mbedtls_dir: "mbedtls-{{ mbedtls_ver }}"

--- a/tests/zap.py
+++ b/tests/zap.py
@@ -15,6 +15,7 @@ def test(network, args):
     openapi_endpoint = f"https://{node.pubhost}:{node.pubport}/node/api"
 
     args = [
+        "sudo",
         "docker",
         "run",
         "--rm",

--- a/tests/zap.py
+++ b/tests/zap.py
@@ -6,6 +6,7 @@ import infra.net
 import suite.test_requirements as reqs
 import infra.e2e_args
 import subprocess
+import os
 
 
 @reqs.description("HTTP fuzzing with ZAP")
@@ -13,6 +14,12 @@ import subprocess
 def test(network, args):
     node = network.nodes[0]
     openapi_endpoint = f"https://{node.pubhost}:{node.pubport}/node/api"
+
+    vm_binary_dir = args.binary_dir
+    local_path = os.getenv("BUILD_REPOSITORY_LOCALPATH")
+    if local_path:
+        vm_path = local_path.replace("__w", "mnt/vss/_work")
+        vm_binary_dir = args.binary_dir.replace(local_path, vm_path)
 
     args = [
         "sudo",
@@ -22,7 +29,7 @@ def test(network, args):
         "--network",
         "host",
         "-v",
-        f"{args.binary_dir}:/zap/wrk",
+        f"{vm_binary_dir}:/zap/wrk",
         "-t",
         "owasp/zap2docker-stable",
         "zap-api-scan.py",

--- a/tests/zap.py
+++ b/tests/zap.py
@@ -26,6 +26,8 @@ def test(network, args):
         "docker",
         "run",
         "--rm",
+        "--network",
+        "host",
         "-v",
         f"{vm_binary_dir}:/zap/wrk",
         "-t",
@@ -57,5 +59,5 @@ def run(args):
 if __name__ == "__main__":
     args = infra.e2e_args.cli_args()
     args.package = "liblogging"
-    args.nodes = ["local://127.0.0.1:45000"]
+    args.nodes = ["local://0.0.0.0:45000,127.0.0.1:45000"]
     run(args)

--- a/tests/zap.py
+++ b/tests/zap.py
@@ -26,8 +26,6 @@ def test(network, args):
         "docker",
         "run",
         "--rm",
-        "--network",
-        "host",
         "-v",
         f"{vm_binary_dir}:/zap/wrk",
         "-t",

--- a/tests/zap.py
+++ b/tests/zap.py
@@ -59,5 +59,5 @@ def run(args):
 if __name__ == "__main__":
     args = infra.e2e_args.cli_args()
     args.package = "liblogging"
-    args.nodes = ["local://localhost"]
+    args.nodes = ["local://localhost:45000"]
     run(args)

--- a/tests/zap.py
+++ b/tests/zap.py
@@ -13,7 +13,7 @@ import os
 @reqs.at_least_n_nodes(1)
 def test(network, args):
     node = network.nodes[0]
-    openapi_endpoint = f"https://{node.pubhost}:{node.pubport}/node/api"
+    openapi_endpoint = f"https://127.0.0.1:{node.pubport}/node/api"
 
     vm_binary_dir = args.binary_dir
     local_path = os.getenv("BUILD_REPOSITORY_LOCALPATH")
@@ -59,5 +59,5 @@ def run(args):
 if __name__ == "__main__":
     args = infra.e2e_args.cli_args()
     args.package = "liblogging"
-    args.nodes = ["local://localhost:45000"]
+    args.nodes = ["local://127.0.0.1:45000"]
     run(args)


### PR DESCRIPTION
We still have one test that uses the Perf pool, not for perf reasons, but because:

1. it wants to build CCF and requires the associated dependencies
2. it wants to start a docker container (the ZAP service) against a running copy of CCF

We've not historically managed to do 1 & 2 in regular container environments. We have three options:

1. Run ZAP outside docker. Looked at and considered with @letmaik, but ruled out because of the overwhelming dependency implications.
2. Run ZAP docker in docker. That's what I'm trying to do now.
  a. `-v /var/run/docker.sock:/var/run/docker.sock` does not work well, because then we need to mount the directory where the zap config lives in terms of the outer filesystem (VM, under build container). There is no easy way to calculate where that is every time, that's an ADO implementation detail.
 b. The other two methods listed under https://devopscube.com/run-docker-in-docker would require agent-side changes (change base container to the dind container, or install a plugin on the VM), which we do not want to do.
3. Give up and stop using ZAP. It would be sad, if of little practical impact, since it's not caught anything useful so far. Last resort if a reasonable crack at 2 fails.

Edit: after some fiddling with 2, I still can't get docker networking to behave in a way I understand. I will take ZAP out for now, we can't keep the perf kit around just for it.

For reference, the brittle FS hack is:

```
    vm_binary_dir = args.binary_dir
    local_path = os.getenv("BUILD_REPOSITORY_LOCALPATH")
    if local_path:
        vm_path = local_path.replace("__w", "mnt/vss/_work")
        vm_binary_dir = args.binary_dir.replace(local_path, vm_path)
```