### PR TITLE
Serialise `service_status` field in Join response

### DIFF
--- a/src/node/config.h
+++ b/src/node/config.h
@@ -17,7 +17,12 @@ namespace ccf
     ConsensusType consensus = ConsensusType::CFT;
     std::optional<ReconfigurationType> reconfiguration_type = std::nullopt;
 
-    bool operator==(const ServiceConfiguration&) const = default;
+    bool operator==(const ServiceConfiguration& other) const
+    {
+      return recovery_threshold == other.recovery_threshold &&
+        consensus == other.consensus &&
+        reconfiguration_type == other.reconfiguration_type;
+    }
   };
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(ServiceConfiguration)
   DECLARE_JSON_REQUIRED_FIELDS(

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -534,20 +534,20 @@ namespace ccf
             resp.node_status == NodeStatus::LEARNER)
           {
             network.identity =
-              std::make_unique<NetworkIdentity>(resp.network_info.identity);
+              std::make_unique<NetworkIdentity>(resp.network_info->identity);
 
             node_cert = create_endorsed_node_cert();
 
             network.ledger_secrets->init_from_map(
-              std::move(resp.network_info.ledger_secrets));
+              std::move(resp.network_info->ledger_secrets));
 
-            if (resp.network_info.consensus_type != network.consensus_type)
+            if (resp.network_info->consensus_type != network.consensus_type)
             {
               throw std::logic_error(fmt::format(
                 "Enclave initiated with consensus type {} but target node "
                 "responded with consensus {}",
                 network.consensus_type,
-                resp.network_info.consensus_type));
+                resp.network_info->consensus_type));
             }
 
             if (network.consensus_type == ConsensusType::BFT)
@@ -560,15 +560,17 @@ namespace ccf
             setup_snapshotter();
             setup_encryptor();
             setup_consensus(
-              resp.network_info.service_status, resp.network_info.public_only);
+              resp.network_info->service_status.value_or(
+                ServiceStatus::OPENING),
+              resp.network_info->public_only);
             setup_progress_tracker();
             setup_history();
             auto_refresh_jwt_keys();
 
-            if (resp.network_info.public_only)
+            if (resp.network_info->public_only)
             {
               last_recovered_signed_idx =
-                resp.network_info.last_recovered_signed_idx;
+                resp.network_info->last_recovered_signed_idx;
               setup_recovery_hook();
               snapshotter->set_snapshot_generation(false);
             }
@@ -586,7 +588,7 @@ namespace ccf
                 startup_snapshot_info->raw,
                 hooks,
                 &view_history,
-                resp.network_info.public_only);
+                resp.network_info->public_only);
               if (rc != kv::ApplyResult::PASS)
               {
                 throw std::logic_error(
@@ -610,7 +612,7 @@ namespace ccf
               auto seqno = network.tables->current_version();
               consensus->init_as_backup(seqno, sig->view, view_history);
 
-              if (!resp.network_info.public_only)
+              if (!resp.network_info->public_only)
               {
                 // Only clear snapshot if not recovering. When joining the
                 // public network the snapshot is used later to initialise the
@@ -629,7 +631,7 @@ namespace ccf
 
             accept_network_tls_connections();
 
-            if (resp.network_info.public_only)
+            if (resp.network_info->public_only)
             {
               sm.advance(State::partOfPublicNetwork);
             }
@@ -643,7 +645,7 @@ namespace ccf
             LOG_INFO_FMT(
               "Node has now joined the network as node {}: {}",
               self,
-              (resp.network_info.public_only ? "public only" : "all domains"));
+              (resp.network_info->public_only ? "public only" : "all domains"));
 
             // The network identity is now known, the user frontend can be
             // opened once the KV state catches up

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -96,7 +96,6 @@ namespace ccf
       NodeStatus node_status;
       NodeId node_id; // Only used in BFT
 
-      // Only if the caller node is trusted
       struct NetworkInfo
       {
         bool public_only = false;
@@ -105,25 +104,31 @@ namespace ccf
 
         LedgerSecretsMap ledger_secrets;
         NetworkIdentity identity;
-        ServiceStatus service_status;
+        std::optional<ServiceStatus> service_status = std::nullopt;
 
-        bool operator==(const NetworkInfo& other) const
-        {
-          return public_only == other.public_only &&
-            last_recovered_signed_idx == other.last_recovered_signed_idx &&
-            consensus_type == other.consensus_type &&
-            ledger_secrets == other.ledger_secrets &&
-            service_status == other.service_status &&
-            identity == other.identity;
-        }
+        NetworkInfo() {}
 
-        bool operator!=(const NetworkInfo& other) const
-        {
-          return !(*this == other);
-        }
+        NetworkInfo(
+          bool public_only,
+          kv::Version last_recovered_signed_idx,
+          ConsensusType consensus_type,
+          const LedgerSecretsMap& ledger_secrets,
+          const NetworkIdentity& identity,
+          ServiceStatus service_status) :
+          public_only(public_only),
+          last_recovered_signed_idx(last_recovered_signed_idx),
+          consensus_type(consensus_type),
+          ledger_secrets(ledger_secrets),
+          identity(identity),
+          service_status(service_status)
+        {}
+
+        bool operator==(const NetworkInfo& other) const = default;
+        bool operator!=(const NetworkInfo& other) const = default;
       };
 
-      NetworkInfo network_info;
+      // Only set if the caller node is trusted
+      std::optional<NetworkInfo> network_info = std::nullopt;
     };
   };
 

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -123,8 +123,20 @@ namespace ccf
           service_status(service_status)
         {}
 
-        bool operator==(const NetworkInfo& other) const = default;
-        bool operator!=(const NetworkInfo& other) const = default;
+        bool operator==(const NetworkInfo& other) const
+        {
+          return public_only == other.public_only &&
+            last_recovered_signed_idx == other.last_recovered_signed_idx &&
+            consensus_type == other.consensus_type &&
+            ledger_secrets == other.ledger_secrets &&
+            identity == other.identity &&
+            service_status == other.service_status;
+        }
+
+        bool operator!=(const NetworkInfo& other) const
+        {
+          return !(*this == other);
+        }
       };
 
       // Only set if the caller node is trusted

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -203,13 +203,13 @@ namespace ccf
         node_status == NodeStatus::TRUSTED ||
         node_status == NodeStatus::LEARNER)
       {
-        rep.network_info = JoinNetworkNodeToNode::Out::NetworkInfo{
+        rep.network_info = JoinNetworkNodeToNode::Out::NetworkInfo(
           context.get_node_state().is_part_of_public_network(),
           context.get_node_state().get_last_recovered_signed_idx(),
           this->network.consensus_type,
           this->network.ledger_secrets->get(tx),
           *this->network.identity.get(),
-          service_status};
+          service_status);
       }
       return make_success(rep);
     }
@@ -300,14 +300,14 @@ namespace ccf
             JoinNetworkNodeToNode::Out rep;
             rep.node_status = joining_node_status;
             rep.node_id = existing_node_info->first;
-            rep.network_info = {
+            rep.network_info = JoinNetworkNodeToNode::Out::NetworkInfo(
               context.get_node_state().is_part_of_public_network(),
               context.get_node_state().get_last_recovered_signed_idx(),
               this->network.consensus_type,
               this->network.ledger_secrets->get(
                 args.tx, existing_node_info->second),
               *this->network.identity.get(),
-              active_service->status};
+              active_service->status);
             return make_success(rep);
           }
 
@@ -372,14 +372,14 @@ namespace ccf
             node_status == NodeStatus::TRUSTED ||
             node_status == NodeStatus::LEARNER)
           {
-            rep.network_info = {
+            rep.network_info = JoinNetworkNodeToNode::Out::NetworkInfo(
               context.get_node_state().is_part_of_public_network(),
               context.get_node_state().get_last_recovered_signed_idx(),
               this->network.consensus_type,
               this->network.ledger_secrets->get(
                 args.tx, existing_node_info->second),
               *this->network.identity.get(),
-              active_service->status};
+              active_service->status);
             return make_success(rep);
           }
           else if (node_status == NodeStatus::PENDING)

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -40,15 +40,17 @@ namespace ccf
   DECLARE_JSON_TYPE(NetworkIdentity)
   DECLARE_JSON_REQUIRED_FIELDS(NetworkIdentity, cert, priv_key)
 
-  DECLARE_JSON_TYPE(JoinNetworkNodeToNode::Out::NetworkInfo)
+  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(
+    JoinNetworkNodeToNode::Out::NetworkInfo)
   DECLARE_JSON_REQUIRED_FIELDS(
     JoinNetworkNodeToNode::Out::NetworkInfo,
     public_only,
     last_recovered_signed_idx,
     consensus_type,
     ledger_secrets,
-    identity,
-    service_status)
+    identity)
+  DECLARE_JSON_OPTIONAL_FIELDS(
+    JoinNetworkNodeToNode::Out::NetworkInfo, service_status)
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(JoinNetworkNodeToNode::Out)
   DECLARE_JSON_REQUIRED_FIELDS(JoinNetworkNodeToNode::Out, node_status, node_id)
   DECLARE_JSON_OPTIONAL_FIELDS(JoinNetworkNodeToNode::Out, network_info)

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -47,7 +47,8 @@ namespace ccf
     last_recovered_signed_idx,
     consensus_type,
     ledger_secrets,
-    identity)
+    identity,
+    service_status)
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(JoinNetworkNodeToNode::Out)
   DECLARE_JSON_REQUIRED_FIELDS(JoinNetworkNodeToNode::Out, node_status, node_id)
   DECLARE_JSON_OPTIONAL_FIELDS(JoinNetworkNodeToNode::Out, network_info)

--- a/src/node/rpc/test/node_frontend_test.cpp
+++ b/src/node/rpc/test/node_frontend_test.cpp
@@ -152,11 +152,12 @@ TEST_CASE("Add a node to an opening service")
     const auto response =
       parse_response_body<JoinNetworkNodeToNode::Out>(http_response);
 
-    require_ledger_secrets_equal(
-      response.network_info.ledger_secrets, network.ledger_secrets->get(tx));
-    CHECK(response.network_info.identity == *network.identity.get());
     CHECK(response.node_status == NodeStatus::TRUSTED);
-    CHECK(response.network_info.public_only == false);
+    CHECK(response.network_info.has_value());
+    require_ledger_secrets_equal(
+      response.network_info->ledger_secrets, network.ledger_secrets->get(tx));
+    CHECK(response.network_info->identity == *network.identity.get());
+    CHECK(response.network_info->public_only == false);
 
     const NodeId node_id = response.node_id;
     auto nodes = tx.rw(network.nodes);
@@ -183,11 +184,12 @@ TEST_CASE("Add a node to an opening service")
     const auto response =
       parse_response_body<JoinNetworkNodeToNode::Out>(http_response);
 
-    require_ledger_secrets_equal(
-      response.network_info.ledger_secrets,
-      network.ledger_secrets->get(tx, up_to_ledger_secret_seqno));
-    CHECK(response.network_info.identity == *network.identity.get());
     CHECK(response.node_status == NodeStatus::TRUSTED);
+    CHECK(response.network_info.has_value());
+    require_ledger_secrets_equal(
+      response.network_info->ledger_secrets,
+      network.ledger_secrets->get(tx, up_to_ledger_secret_seqno));
+    CHECK(response.network_info->identity == *network.identity.get());
   }
 
   INFO(
@@ -255,7 +257,7 @@ TEST_CASE("Add a node to an open service")
     const auto response =
       parse_response_body<JoinNetworkNodeToNode::Out>(http_response);
 
-    CHECK(response.network_info.identity.priv_key.empty());
+    CHECK(!response.network_info.has_value());
 
     auto node_id = response.node_id;
 
@@ -291,7 +293,7 @@ TEST_CASE("Add a node to an open service")
       parse_response_body<JoinNetworkNodeToNode::Out>(http_response);
 
     // The network secrets are still not available to the joining node
-    CHECK(response.network_info.identity.priv_key.empty());
+    CHECK(!response.network_info.has_value());
   }
 
   INFO("Trust node and attempt to join");
@@ -315,11 +317,12 @@ TEST_CASE("Add a node to an open service")
       parse_response_body<JoinNetworkNodeToNode::Out>(http_response);
 
     auto tx = network.tables->create_tx();
-    require_ledger_secrets_equal(
-      response.network_info.ledger_secrets,
-      network.ledger_secrets->get(tx, up_to_ledger_secret_seqno));
-    CHECK(response.network_info.identity == *network.identity.get());
     CHECK(response.node_status == NodeStatus::TRUSTED);
-    CHECK(response.network_info.public_only == true);
+    CHECK(response.network_info.has_value());
+    require_ledger_secrets_equal(
+      response.network_info->ledger_secrets,
+      network.ledger_secrets->get(tx, up_to_ledger_secret_seqno));
+    CHECK(response.network_info->identity == *network.identity.get());
+    CHECK(response.network_info->public_only == true);
   }
 }


### PR DESCRIPTION
The `service_status` field wasn't serialised in the `/node/join` response. Hopefully this doesn't break any BFT test but it might as I think all nodes join as `Follower` rather than `Learner` in BFT. 

Also updated the serialisation format for the `/node/join` response, using `std::optional` for the `NetworkInfo` struct which is only set when the node has been trusted. 