### PR TITLE
Remove use of GithHub API for `lts_compatibility` test

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -14,7 +14,6 @@ jobs:
     steps:
       - checkout: self
         clean: true
-        fetchDepth: 10000
 
       - script: |
           set -ex

--- a/.azure-pipelines-templates/common.yml
+++ b/.azure-pipelines-templates/common.yml
@@ -12,7 +12,6 @@ jobs:
 
       - checkout: self
         clean: true
-        fetchDepth: 10000
 
       - template: cmake.yml
         parameters:

--- a/tests/infra/github.py
+++ b/tests/infra/github.py
@@ -92,10 +92,10 @@ class Repository:
     def __init__(self):
         self.g = git.cmd.Git()
         self.tags = [
-            tag.split("/")[-1]
+            tag.split("tags/")[-1]
             for tag in self.g.ls_remote(REMOTE_URL).split("\n")
-            if f"tags/{TAG_RELEASE_PREFIX}1" in tag
-        ]  # TODO: Remove 1
+            if f"tags/{TAG_RELEASE_PREFIX}" in tag
+        ]
         self.release_branches = [
             branch.split("heads/")[-1]
             for branch in self.g.ls_remote(REMOTE_URL).split("\n")

--- a/tests/infra/github.py
+++ b/tests/infra/github.py
@@ -79,8 +79,13 @@ def get_debian_package_url_from_tag_name(tag_name):
     return f'{REMOTE_URL}/releases/download/{tag_name}/{tag_name.replace("-", "_")}{DEBIAN_PACKAGE_EXTENSION}'
 
 
-def has_release_for_tag_name(tag):
-    return requests.get(f"{REMOTE_URL}/releases/tag/{tag}").status_code == 200
+def has_release_for_tag_name(tag_name):
+    return (
+        requests.head(
+            get_debian_package_url_from_tag_name(tag_name), allow_redirects=True
+        ).status_code
+        == 200
+    )
 
 
 class Repository:

--- a/tests/infra/github.py
+++ b/tests/infra/github.py
@@ -74,6 +74,10 @@ def get_major_version_from_branch_name(branch_name):
     )
 
 
+def get_debian_package_url_from_tag_name(tag_name):
+    return f'https://github.com/{REPOSITORY_NAME}/releases/download/{tag_name}/{tag_name.replace("-", "_")}_amd64.deb'
+
+
 class Repository:
     """
     Helper class to verify CCF operations compatibility described at
@@ -170,11 +174,12 @@ class Repository:
         release = self.get_release_for_tag(tag)
 
         install_directory = f"{INSTALL_DIRECTORY_PREFIX}{stripped_tag}"
-        debian_package_url = [
-            a.browser_download_url
-            for a in release.get_assets()
-            if re.match(f"ccf_{stripped_tag}{DEBIAN_PACKAGE_EXTENSION}", a.name)
-        ][0]
+        # debian_package_url = [
+        #     a.browser_download_url
+        #     for a in release.get_assets()
+        #     if re.match(f"ccf_{stripped_tag}{DEBIAN_PACKAGE_EXTENSION}", a.name)
+        # ][0]
+        debian_package_url = get_debian_package_url_from_tag_name(tag.name)
 
         debian_package_name = debian_package_url.split("/")[-1]
         download_path = os.path.join(DOWNLOAD_FOLDER_NAME, debian_package_name)

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -419,7 +419,6 @@ def run_ledger_compatibility_since_first(args, local_branch, use_snapshot):
 
 if __name__ == "__main__":
 
-    # TODO: Add option for repo directory
     def add(parser):
         parser.add_argument("--check-ledger-compatibility", action="store_true")
         parser.add_argument(
@@ -448,7 +447,7 @@ if __name__ == "__main__":
     compatibility_report = {}
     compatibility_report["version"] = args.ccf_version
     compatibility_report["live compatibility"] = {}
-    latest_lts_version = run_live_compatibility_with_latest(args, repo, "release/1.x")
+    latest_lts_version = run_live_compatibility_with_latest(args, repo, env.branch)
     following_lts_version = run_live_compatibility_with_following(
         args, repo, env.branch
     )

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -419,6 +419,7 @@ def run_ledger_compatibility_since_first(args, local_branch, use_snapshot):
 
 if __name__ == "__main__":
 
+    # TODO: Add option for repo directory
     def add(parser):
         parser.add_argument("--check-ledger-compatibility", action="store_true")
         parser.add_argument(

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -310,7 +310,7 @@ def run_ledger_compatibility_since_first(args, local_branch, use_snapshot):
     repo = infra.github.Repository()
     lts_releases = repo.get_lts_releases()
 
-    LOG.info(f"LTS releases: {[r[1].name for r in lts_releases.items()]}")
+    LOG.info(f"LTS releases: {[r[1] for r in lts_releases.items()]}")
 
     lts_versions = []
 
@@ -448,7 +448,7 @@ if __name__ == "__main__":
     compatibility_report = {}
     compatibility_report["version"] = args.ccf_version
     compatibility_report["live compatibility"] = {}
-    latest_lts_version = run_live_compatibility_with_latest(args, repo, env.branch)
+    latest_lts_version = run_live_compatibility_with_latest(args, repo, "release/1.x")
     following_lts_version = run_live_compatibility_with_following(
         args, repo, env.branch
     )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,5 +8,5 @@ openapi-spec-validator
 PyJWT
 docutils
 python-iptables
-PyGithub
 py-spy
+GitPython


### PR DESCRIPTION
As we somehow cannot use GitHub token to prevent the GitHub API throttle (see #2779), this PR removes the use of the GitHub API and replaces it with plain old Git. 