### PR TITLE
Fix `test_node_replacement` failure in `full_test_suite`

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Allo Allo
+Coin coin

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -121,7 +121,7 @@ class Network:
         if existing_network is None:
             self.consortium = None
             self.users = []
-            self.node_offset = 0
+            self.next_node_id = 0
             self.txs = txs
             self.jwt_issuer = jwt_issuer
         else:
@@ -131,8 +131,8 @@ class Network:
             # the node id of the nodes of the new network should start from the node
             # id of the existing network, so that new nodes id match the ones in the
             # nodes KV table
-            self.node_offset = (
-                len(existing_network.nodes) + existing_network.node_offset
+            self.next_node_id = (
+                len(existing_network.nodes) + existing_network.next_node_id
             )
             self.txs = existing_network.txs
             self.jwt_issuer = existing_network.jwt_issuer
@@ -169,9 +169,9 @@ class Network:
             self.create_node(host, version=self.version)
 
     def _get_next_local_node_id(self):
-        if len(self.nodes):
-            return self.nodes[-1].local_node_id + 1
-        return self.node_offset
+        next_node_id = self.next_node_id
+        self.next_node_id += 1
+        return next_node_id
 
     def create_node(
         self, host, binary_dir=None, library_dir=None, node_port=None, version=None

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -236,7 +236,7 @@ def test_version(network, args):
 
 
 @reqs.description("Replace a node on the same addresses")
-@reqs.at_least_n_nodes(3)  # Should be at_least_f_failures(1)
+@reqs.can_kill_n_nodes(1)
 def test_node_replacement(network, args):
     primary, backups = network.find_nodes()
 


### PR DESCRIPTION
Fix #2896 

The `test_node_replacement`, when chained after `test_kill_primary` failed consistently as the consensus couldn't make progress. This is because the `at_least_n_nodes(3)` requirement wasn't precise enough. In this case, the network was already degraded when the test started (4 trusted nodes but 1 is stopped) so the backup suspension at the end of the test meant that they were only 2 nodes left for consensus, which is less than the quorum of 3.

Also added a `--dry-run` option to the test suite, and tweaked the local node id logic in the infra so that node ids aren't re-used when a node is retired.
