### PR TITLE
Switch from in-sub-executors to standard 1ES pool

### DIFF
--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -8,7 +8,7 @@ parameters:
       pool: 1es-dcv2-focal
     SGXIceLake:
       container: sgx
-      pool: 1es-dcv3-focal-2
+      pool: 1es-dcv3-focal
 
   build:
     common:


### PR DESCRIPTION
Shadow sub has received quota, switching to the same recommended setup we use for Coffee Lake,