### PR TITLE
Cherry-pick #2550 to 1.x LTS

### DIFF
--- a/include/ccf/base_endpoint_registry.h
+++ b/include/ccf/base_endpoint_registry.h
@@ -152,5 +152,9 @@ namespace ccf
       kv::ReadOnlyTx& tx,
       const MemberId& member_id,
       crypto::Pem& member_cert_pem);
+
+    /** Get untrusted time from the host of the currently executing node.
+     */
+    ApiResult get_untrusted_host_time_v1(::timespec& time);
   };
 }

--- a/samples/apps/nobuiltins/nobuiltins.cpp
+++ b/samples/apps/nobuiltins/nobuiltins.cpp
@@ -51,6 +51,14 @@ namespace nobuiltins
   DECLARE_JSON_TYPE(TransactionIDResponse)
   DECLARE_JSON_REQUIRED_FIELDS(TransactionIDResponse, transaction_id)
 
+  struct TimeResponse
+  {
+    std::string timestamp;
+  };
+
+  DECLARE_JSON_TYPE(TimeResponse)
+  DECLARE_JSON_REQUIRED_FIELDS(TimeResponse, timestamp)
+
   // SNIPPET: registry_inheritance
   class NoBuiltinsRegistry : public ccf::BaseEndpointRegistry
   {
@@ -272,6 +280,50 @@ namespace nobuiltins
         .set_execute_outside_consensus(
           ccf::endpoints::ExecuteOutsideConsensus::Locally)
         .set_auto_schema<void, TransactionIDResponse>()
+        .install();
+
+      auto get_time = [this](auto& ctx, nlohmann::json&&) {
+        ::timespec time;
+        ccf::ApiResult result = get_untrusted_host_time_v1(time);
+        if (result != ccf::ApiResult::OK)
+        {
+          return ccf::make_error(
+            HTTP_STATUS_INTERNAL_SERVER_ERROR,
+            ccf::errors::InternalError,
+            fmt::format(
+              "Unable to get time: {}", ccf::api_result_to_str(result)));
+        }
+
+        std::tm calendar_time;
+        gmtime_r(&time.tv_sec, &calendar_time);
+
+        // 20 characters for a (timezoneless) ISO 8601 datetime, plus a
+        // terminating null
+        constexpr size_t buf_size = 21;
+        char buf[buf_size];
+        if (strftime(buf, buf_size, "%Y-%m-%dT%H:%M:%S", &calendar_time) == 0)
+        {
+          return ccf::make_error(
+            HTTP_STATUS_INTERNAL_SERVER_ERROR,
+            ccf::errors::InternalError,
+            fmt::format("Unable to format timestamp"));
+        }
+
+        // Build full time, with 6 decimals of sub-second precision, and a
+        // Python-friendly +00:00 UTC offset
+        TimeResponse response;
+        response.timestamp =
+          fmt::format("{}.{:06}+00:00", buf, time.tv_nsec / 1'000);
+        return ccf::make_success(response);
+      };
+      make_command_endpoint(
+        "current_time",
+        HTTP_GET,
+        ccf::json_command_adapter(get_time),
+        ccf::no_auth_required)
+        .set_execute_outside_consensus(
+          ccf::endpoints::ExecuteOutsideConsensus::Locally)
+        .set_auto_schema<void, TimeResponse>()
         .install();
     }
   };

--- a/src/endpoints/base_endpoint_registry.cpp
+++ b/src/endpoints/base_endpoint_registry.cpp
@@ -3,6 +3,7 @@
 
 #include "ccf/base_endpoint_registry.h"
 
+#include "enclave/enclave_time.h"
 #include "node/members.h"
 #include "node/users.h"
 
@@ -267,5 +268,16 @@ namespace ccf
       LOG_TRACE_FMT("{}", e.what());
       return ApiResult::InternalError;
     }
+  }
+
+  ApiResult BaseEndpointRegistry::get_untrusted_host_time_v1(::timespec& time)
+  {
+    const std::chrono::microseconds now_us = enclave::get_enclave_time();
+
+    constexpr auto us_per_s = 1'000'000;
+    time.tv_sec = now_us.count() / us_per_s;
+    time.tv_nsec = (now_us.count() % us_per_s) * 1'000;
+
+    return ApiResult::OK;
   }
 }

--- a/tests/nobuiltins.py
+++ b/tests/nobuiltins.py
@@ -5,6 +5,8 @@ import infra.network
 from ccf.tx_id import TxID
 from http import HTTPStatus
 import openapi_spec_validator
+from datetime import datetime, timezone
+import time
 
 
 def test_nobuiltins_endpoints(network, args):
@@ -31,6 +33,22 @@ def test_nobuiltins_endpoints(network, args):
         assert r.status_code == HTTPStatus.OK
         body_j = r.body.json()
         assert body_j["transaction_id"] == f"{tx_id}"
+
+        for i in range(3):
+            if i != 0:
+                time.sleep(1.5)
+            r = c.get("/app/current_time")
+            local_time = datetime.now(timezone.utc)
+            assert r.status_code == HTTPStatus.OK
+            body_j = r.body.json()
+            service_time = datetime.fromisoformat(body_j["timestamp"])
+            diff = (local_time - service_time).total_seconds()
+            # This intends to test that the reported time is "close enough"
+            # to the real current time. This is dependent on the skew between
+            # clocks on this executor and the target node, and the request
+            # latency (including Python IO and parsing). It may need to be
+            # more lenient
+            assert abs(diff) < 1, diff
 
         r = c.get("/app/all_nodes")
         assert r.status_code == HTTPStatus.OK


### PR DESCRIPTION
#2550 

Noticed this old PR still had the `1.x-todo` label. There was ongoing discussion about how this should be exposed to JS, so for now it is only a C++ API.