### PR TITLE
Cherry-pick #2852 to 1.x LTS

### DIFF
--- a/src/consensus/aft/impl/state.h
+++ b/src/consensus/aft/impl/state.h
@@ -68,10 +68,28 @@ namespace aft
       return (it - views.begin());
     }
 
+    kv::Version start_of_view(ccf::View view)
+    {
+      if (view > views.size() || view == InvalidView)
+      {
+        return kv::NoVersion;
+      }
+
+      return views[view - 1];
+    }
+
     std::vector<kv::Version> get_history_until(
       kv::Version idx = std::numeric_limits<kv::Version>::max())
     {
       return {views.begin(), std::upper_bound(views.begin(), views.end(), idx)};
+    }
+
+    void rollback(kv::Version idx)
+    {
+      auto it = upper_bound(views.begin(), views.end(), idx);
+      views.erase(it, views.end());
+      LOG_DEBUG_FMT(
+        "Resulting views from rollback: {}", fmt::join(views, ", "));
     }
   };
 

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -145,6 +145,12 @@ namespace aft
 
   struct AppendEntriesResponse : RaftHeader
   {
+    // This term and idx usually refer to the tail of the sender's log. The
+    // exception is in a rejection because of a mismatching suffix, in which
+    // case this describes the latest point that the local node believes may
+    // still match the leader's (which may be from an old term!). In either case
+    // this can be treated as the latest possible matching index for this
+    // follower.
     Term term;
     Index last_log_idx;
     AppendEntriesResponseType success;


### PR DESCRIPTION
#2852 

The first part of this (#2835) was already merged (#2841). This is the improved fix, minus unnecessary (and conflicting) unit test changes.