### PR TITLE
Cherry-pick #2923 to 1.x LTS

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -5,6 +5,12 @@ trigger:
       - main
       - "refs/tags/ccf-*"
 
+pr:
+  batch: true
+  branches:
+    include:
+    - main
+
 jobs:
   - job: build_and_publish_docs
     container: ccfciteam/ccf-ci:oe0.17.1-focal

--- a/js/ccf-app/package.json
+++ b/js/ccf-app/package.json
@@ -30,6 +30,6 @@
     "serve": "^11.3.2",
     "ts-node": "^9.1.1",
     "typedoc": "^0.20.34",
-    "typescript": "^4.2.3"
+    "typescript": "4.2.4"
   }
 }

--- a/tests/js-modules/modules.py
+++ b/tests/js-modules/modules.py
@@ -190,8 +190,11 @@ def test_npm_app(network, args):
 
     LOG.info("Building npm app")
     app_dir = os.path.join(PARENT_DIR, "npm-app")
-    subprocess.run(["npm", "install"], cwd=app_dir, check=True)
-    subprocess.run(["npm", "run", "build"], cwd=app_dir, check=True)
+    assert infra.proc.ccall("npm", "install", path=app_dir).returncode == 0
+    assert (
+        infra.proc.ccall("npm", "run", "build", "--verbose", path=app_dir).returncode
+        == 0
+    )
 
     LOG.info("Deploying npm app")
     bundle_dir = os.path.join(app_dir, "dist")

--- a/tests/npm-app/package.json
+++ b/tests/npm-app/package.json
@@ -24,6 +24,6 @@
     "http-server": "^0.12.3",
     "rollup": "^2.41.0",
     "tslib": "^2.0.1",
-    "typescript": "^4.2.0"
+    "typescript": "4.2.4"
   }
 }


### PR DESCRIPTION
Cherry-picking #2923, to fix `modules_test` in the CI of the 1.x branch.