### PR TITLE
Disable suites in CI, leave them in Daily

### DIFF
--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -29,9 +29,9 @@ parameters:
 
   test:
     NoSGX:
-      ctest_args: '-LE "benchmark|perf|tlstest|vegeta|partitions"'
+      ctest_args: '-LE "benchmark|perf|tlstest|vegeta|partitions|suite"'
     SGX:
-      ctest_args: '-LE "benchmark|perf|tlstest|vegeta|partitions"'
+      ctest_args: '-LE "benchmark|perf|tlstest|vegeta|partitions|suite"'
     perf:
       ctest_args: '-L "benchmark|perf|vegeta"'
     release:


### PR DESCRIPTION
This is to save execution time, because suites only relatively rarely seem to catch errors that individual tests don't in CI.

They remain very useful though, because they've caught subtle problems more than once, so we do want to run them in Daily.