### PR TITLE
Bring default sig interval back up

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Hey there
+Hm

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -194,7 +194,7 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         "--sig-ms-interval",
         help="Milliseconds between signatures",
         type=int,
-        default=100,
+        default=500,
     )
     parser.add_argument(
         "--memory-reserve-startup",


### PR DESCRIPTION
The shorter interval leads to excessive snapshotting and join failures.