### PR TITLE
Revert "Reduce signature interval to 100ms in e2e tests"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -820,7 +820,7 @@ if(BUILD_TESTS)
       NAME reconfiguration_test_${CONSENSUS}
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/reconfiguration.py
       CONSENSUS ${CONSENSUS}
-      ADDITIONAL_ARGS --ccf-version ${CCF_VERSION} --sig-ms-interval 1000
+      ADDITIONAL_ARGS --ccf-version ${CCF_VERSION}
     )
 
   endforeach()

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -194,7 +194,7 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         "--sig-ms-interval",
         help="Milliseconds between signatures",
         type=int,
-        default=100,
+        default=1000,
     )
     parser.add_argument(
         "--memory-reserve-startup",


### PR DESCRIPTION
Reverts microsoft/CCF#2920