### PR TITLE
Disable LVI mitigations in Debug builds

### DIFF
--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -21,7 +21,7 @@ parameters:
     SGX:
       cmake_args: "-DCOMPILE_TARGETS=sgx"
     debug:
-      cmake_args: "-DCMAKE_BUILD_TYPE=Debug"
+      cmake_args: "-DCMAKE_BUILD_TYPE=Debug -DLVI_MITIGATIONS=OFF"
     perf:
       cmake_args: '-DBUILD_UNIT_TESTS=OFF -DBUILD_TPCC=ON -DDISTRIBUTE_PERF_TESTS="-n local://localhost -n local://localhost"'
     release:


### PR DESCRIPTION
We currently have these mitigations enabled in debug, which slows down both building and running test in CI. This isn't useful.

The remain on:

- by default, because it's the safe choice
- in Release builds, Perf test builds and in the Daily everywhere

Debug build, as in SGX CI, without mitigations:

real    2m43.526s
user    16m14.244s
sys     0m54.846s

With:

real    3m55.891s
user    17m45.885s
sys     0m56.196s