### PR TITLE
JS FFI plugin interface with `openenclave` as first plugin

### DIFF
--- a/src/apps/js_generic/js_generic.cpp
+++ b/src/apps/js_generic/js_generic.cpp
@@ -269,8 +269,7 @@ namespace ccfapp
       js::TxContext txctx{&target_tx, js::TxAccess::APP};
 
       js::register_request_body_class(ctx);
-      js::populate_global_console(ctx);
-      js::populate_global_ccf(
+      js::populate_global(
         &txctx,
         endpoint_ctx.rpc_ctx.get(),
         transaction_id,
@@ -279,7 +278,6 @@ namespace ccfapp
         &context.get_node_state(),
         nullptr,
         ctx);
-      js::populate_global_openenclave(ctx);
 
       JSValue export_func;
       try

--- a/src/js/oe.cpp
+++ b/src/js/oe.cpp
@@ -13,6 +13,8 @@
 #else
 #  include <openenclave/host_verify.h>
 #endif
+#include "ccf/version.h"
+#include "js/plugin.h"
 
 namespace js
 {
@@ -172,4 +174,30 @@ namespace js
 
 #pragma clang diagnostic pop
 
+  static JSValue create_openenclave_obj(JSContext* ctx)
+  {
+    auto openenclave = JS_NewObject(ctx);
+
+    JS_SetPropertyStr(
+      ctx,
+      openenclave,
+      "verifyOpenEnclaveEvidence",
+      JS_NewCFunction(
+        ctx, js_verify_open_enclave_evidence, "verifyOpenEnclaveEvidence", 3));
+
+    return openenclave;
+  }
+
+  static void populate_global_openenclave(JSContext* ctx)
+  {
+    auto global_obj = JS_GetGlobalObject(ctx);
+    JS_SetPropertyStr(
+      ctx, global_obj, "openenclave", create_openenclave_obj(ctx));
+    JS_FreeValue(ctx, global_obj);
+  }
+
+  FFIPlugin openenclave_plugin = {
+    .name = "Open Enclave",
+    .ccf_version = ccf::ccf_version,
+    .extend = populate_global_openenclave};
 }

--- a/src/js/plugin.h
+++ b/src/js/plugin.h
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include <functional>
+#include <quickjs/quickjs.h>
+#include <string>
+
+namespace js
+{
+  struct FFIPlugin
+  {
+    std::string name;
+    std::string ccf_version;
+    std::function<void(JSContext* ctx)> extend;
+  };
+}

--- a/src/js/wrap.h
+++ b/src/js/wrap.h
@@ -6,6 +6,7 @@
 #include "ccf/tx.h"
 #include "ds/logger.h"
 #include "enclave/rpc_context.h"
+#include "js/plugin.h"
 #include "kv/kv_types.h"
 #include "node/network_state.h"
 #include "node/rpc/node_interface.h"
@@ -45,10 +46,10 @@ namespace js
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wc99-extensions"
 
+  void register_ffi_plugins();
   void register_class_ids();
   void register_request_body_class(JSContext* ctx);
-  void populate_global_console(JSContext* ctx);
-  void populate_global_ccf(
+  void populate_global(
     TxContext* txctx,
     enclave::RpcContext* rpc_ctx,
     const std::optional<ccf::TxID>& transaction_id,
@@ -57,7 +58,6 @@ namespace js
     ccf::AbstractNodeState* host_node_state,
     ccf::NetworkState* network_state,
     JSContext* ctx);
-  void populate_global_openenclave(JSContext* ctx);
 
   JSValue js_print(JSContext* ctx, JSValueConst, int argc, JSValueConst* argv);
   void js_dump_error(JSContext* ctx);

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -333,6 +333,7 @@ namespace ccf
         get_subject_alternative_names();
 
       js::register_class_ids();
+      js::register_ffi_plugins();
       self_signed_node_cert = create_self_signed_node_cert();
       accept_node_tls_connections();
       open_frontend(ActorsType::nodes);

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -208,8 +208,7 @@ namespace ccf
         js::Context context(rt);
         rt.add_ccf_classdefs();
         js::TxContext txctx{&tx, js::TxAccess::GOV_RO};
-        js::populate_global_console(context);
-        js::populate_global_ccf(
+        js::populate_global(
           &txctx,
           nullptr,
           std::nullopt,
@@ -255,10 +254,9 @@ namespace ccf
       {
         js::Runtime rt;
         js::Context js_context(rt);
-        js::populate_global_console(js_context);
         rt.add_ccf_classdefs();
         js::TxContext txctx{&tx, js::TxAccess::GOV_RO};
-        js::populate_global_ccf(
+        js::populate_global(
           &txctx,
           nullptr,
           std::nullopt,
@@ -367,10 +365,9 @@ namespace ccf
           {
             js::Runtime rt;
             js::Context js_context(rt);
-            js::populate_global_console(js_context);
             rt.add_ccf_classdefs();
             js::TxContext txctx{&tx, js::TxAccess::GOV_RW};
-            js::populate_global_ccf(
+            js::populate_global(
               &txctx,
               nullptr,
               std::nullopt,
@@ -880,7 +877,7 @@ namespace ccf
         js::Runtime rt;
         js::Context context(rt);
         rt.add_ccf_classdefs();
-        js::populate_global_ccf(
+        js::populate_global(
           nullptr,
           nullptr,
           std::nullopt,


### PR DESCRIPTION
This PR mostly defines the interface for JS FFI plugins, both for defining plugins and how to register them. The `openenclave` global is now such a plugin (which is currently hard-coded to be always registered), which meant moving more code into `oe.cpp`. The interface is very generic currently and a plugin can do anything to a `JSContext`.

- A plugin defines a human-readable name (used for logging only).
- A plugin includes the CCF version it was built against. If during registration it doesn't match the running version, an exception is thrown. Only exact matches are allowed.
- A plugin defines a function that extends an existing `JSContext` arbitrarily. The function doesn't receive any other arguments currently.
- Plugins are registered both in `js_generic` and for governance calls. Previously, governance would not expose the `openenclave` global. Is that ok?
- The `console` global is made available everywhere. Previously, the governance `validate` and `apply` calls did not have it, while `resolve` and `vote` did have it. Is that ok?


The next PR will look at how to deal with plugins at the build level. 