### PR TITLE
Run election tests concurrently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -702,13 +702,13 @@ if(BUILD_TESTS)
     ADDITIONAL_ARGS --ccf-version ${CCF_VERSION}
   )
 
-  foreach(CONSENSUS ${CONSENSUSES})
-    add_e2e_test(
-      NAME election_test_${CONSENSUS}
-      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/election.py
-      CONSENSUS ${CONSENSUS}
-    )
+  add_e2e_test(
+    NAME election_test
+    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/election.py
+    CONSENSUS cft
+  )
 
+  foreach(CONSENSUS ${CONSENSUSES})
     add_e2e_test(
       NAME vegeta_stress_${CONSENSUS}
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/vegeta_stress.py

--- a/tests/election.py
+++ b/tests/election.py
@@ -8,6 +8,8 @@ import infra.proc
 import infra.e2e_args
 import infra.checker
 import suite.test_requirements as reqs
+from infra.runner import ConcurrentRunner
+import copy
 
 from loguru import logger as LOG
 
@@ -92,8 +94,27 @@ def run(args):
 
 if __name__ == "__main__":
 
-    args = infra.e2e_args.cli_args()
-    args.package = "liblogging"
-    args.nodes = infra.e2e_args.min_nodes(args, f=1)
-    args.raft_election_timeout_ms = 500
-    run(args)
+    cr = ConcurrentRunner()
+
+    args = copy.deepcopy(cr.args)
+
+    args.consensus = "cft"
+    cr.add(
+        "cft",
+        run,
+        package="liblogging",
+        nodes=infra.e2e_args.min_nodes(args, f=1),
+        raft_election_timeout_ms=500,
+        consensus="cft",
+    )
+
+    args.consensus = "bft"
+    cr.add(
+        "bft",
+        run,
+        package="liblogging",
+        nodes=infra.e2e_args.min_nodes(args, f=1),
+        consensus="bft",
+    )
+
+    cr.run()


### PR DESCRIPTION
Slightly more test concurrency, slight speedup.