### PR TITLE
Add hooks for `kv::Set` and `kv::Value` and convert remaining service tables

### DIFF
--- a/src/consensus/aft/request.h
+++ b/src/consensus/aft/request.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "ds/json.h"
-#include "kv/map.h"
+#include "kv/value.h"
 #include "node/entities.h"
 
 #include <vector>
@@ -76,10 +76,7 @@ namespace aft
   DECLARE_JSON_TYPE(Request);
   DECLARE_JSON_REQUIRED_FIELDS(Request, rid, caller_cert, raw, frame_format);
 
-  // size_t is used as the key of the table. This key will always be 0 since we
-  // don't want to store the requests in the kv over time, we just want to get
-  // them into the ledger
-  using RequestsMap = kv::RawCopySerialisedMap<size_t, Request>;
+  using RequestsMap = kv::RawCopySerialisedValue<Request>;
 }
 
 namespace kv::serialisers

--- a/src/consensus/aft/revealed_nonces.h
+++ b/src/consensus/aft/revealed_nonces.h
@@ -39,6 +39,5 @@ namespace aft
   DECLARE_JSON_TYPE(RevealedNonces);
   DECLARE_JSON_REQUIRED_FIELDS(RevealedNonces, tx_id, nonces)
 
-  // Always recorded at key 0
-  using RevealedNoncesMap = ccf::ServiceMap<size_t, RevealedNonces>;
+  using RevealedNoncesMap = ccf::ServiceValue<RevealedNonces>;
 }

--- a/src/kv/deserialise.h
+++ b/src/kv/deserialise.h
@@ -551,7 +551,7 @@ namespace kv
       tx->set_change_list(std::move(changes), term);
 
       auto aft_requests = tx->rw<aft::RequestsMap>(ccf::Tables::AFT_REQUESTS);
-      auto req_v = aft_requests->get(0);
+      auto req_v = aft_requests->get();
       CCF_ASSERT(
         req_v.has_value(),
         "Deserialised append entry, but requests map is empty");
@@ -628,7 +628,7 @@ namespace kv
         tx->set_change_list(std::move(changes), term);
 
         auto aft_requests = tx->rw<aft::RequestsMap>(ccf::Tables::AFT_REQUESTS);
-        auto req_v = aft_requests->get(0);
+        auto req_v = aft_requests->get();
         CCF_ASSERT(
           req_v.has_value(),
           "Deserialised append entry, but requests map is empty");

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -170,7 +170,8 @@ TEST_CASE("sets and values")
 
   {
     INFO("kv::Set");
-    kv::Set<std::string> set("public:set");
+    using Set = kv::Set<std::string>;
+    Set set("public:set");
     constexpr auto k1 = "key1";
     constexpr auto k2 = "key2";
 
@@ -234,12 +235,96 @@ TEST_CASE("sets and values")
 
       REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
     }
+
+    {
+      INFO("Hooks");
+
+      kv_store.compact(kv_store.current_version()); // Flush global hook
+
+      std::vector<Set::Write> local_writes;
+      std::vector<Set::Write> global_writes;
+
+      auto map_hook =
+        [&](kv::Version v, const Set::Write& w) -> kv::ConsensusHookPtr {
+        local_writes.push_back(w);
+        return kv::ConsensusHookPtr(nullptr);
+      };
+      auto global_hook = [&](kv::Version v, const Set::Write& w) {
+        global_writes.push_back(w);
+      };
+
+      kv_store.set_map_hook(set.get_name(), set.wrap_map_hook(map_hook));
+      kv_store.set_global_hook(
+        set.get_name(), set.wrap_commit_hook(global_hook));
+
+      {
+        INFO("Insertion only");
+
+        auto tx = kv_store.create_tx();
+        auto set_handle = tx.rw(set);
+        set_handle->insert(k1);
+        set_handle->insert(k2);
+        set_handle->remove(k2);
+        REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+
+        REQUIRE(global_writes.size() == 0);
+        REQUIRE(local_writes.size() == 1);
+        const auto& latest_writes = local_writes.front();
+        REQUIRE(latest_writes.at(k1).has_value());
+        INFO("Local removals are not seen");
+        REQUIRE(latest_writes.size() == 1);
+        REQUIRE(latest_writes.find(k2) == latest_writes.end());
+
+        local_writes.clear();
+      }
+
+      {
+        INFO("Insertion and removal");
+
+        auto tx = kv_store.create_tx();
+        auto set_handle = tx.rw(set);
+        set_handle->remove(k1);
+        set_handle->insert(k2);
+        REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+
+        REQUIRE(local_writes.size() == 1);
+        const auto& latest_writes = local_writes.front();
+        REQUIRE(latest_writes.size() == 2);
+        REQUIRE(!latest_writes.at(k1).has_value());
+        REQUIRE(latest_writes.at(k2).has_value());
+
+        local_writes.clear();
+      }
+
+      {
+        INFO("Global hook");
+
+        auto tx = kv_store.create_tx();
+        auto set_handle = tx.rw(set);
+        set_handle->insert(k1);
+        REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+
+        kv_store.compact(kv_store.current_version());
+
+        REQUIRE(global_writes.size() == 4);
+        REQUIRE(global_writes.at(0).size() == 1);
+        REQUIRE(!global_writes.at(0).at(k1).has_value());
+        REQUIRE(global_writes.at(1).size() == 1);
+        REQUIRE(global_writes.at(1).at(k1).has_value());
+        REQUIRE(global_writes.at(2).size() == 2);
+        REQUIRE(!global_writes.at(2).at(k1).has_value());
+        REQUIRE(global_writes.at(2).at(k2).has_value());
+        REQUIRE(global_writes.at(3).size() == 1);
+        REQUIRE(global_writes.at(3).at(k1).has_value());
+      }
+    }
   }
 
   {
     INFO("kv::Value");
-    kv::Value<std::string> val1("public:value1");
-    kv::Value<std::string> val2("public:value2");
+    using Value = kv::Value<std::string>;
+    Value val1("public:value1");
+    Value val2("public:value2");
 
     const auto v1 = "hello";
     const auto v2 = "world";
@@ -295,6 +380,75 @@ TEST_CASE("sets and values")
       REQUIRE(!h1->has());
 
       REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+    }
+
+    {
+      INFO("Hooks");
+
+      kv_store.compact(kv_store.current_version()); // Flush global hook
+
+      std::vector<Value::Write> local_writes;
+      std::vector<Value::Write> global_writes;
+
+      auto map_hook =
+        [&](kv::Version v, const Value::Write& w) -> kv::ConsensusHookPtr {
+        local_writes.push_back(w);
+        return kv::ConsensusHookPtr(nullptr);
+      };
+      auto global_hook = [&](kv::Version v, const Value::Write& w) {
+        global_writes.push_back(w);
+      };
+
+      kv_store.set_map_hook(val1.get_name(), val1.wrap_map_hook(map_hook));
+      kv_store.set_global_hook(
+        val1.get_name(), val1.wrap_commit_hook(global_hook));
+
+      {
+        INFO("Local hook");
+
+        auto tx = kv_store.create_tx();
+        REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+        REQUIRE(local_writes.size() == 0); // Commit without puts
+
+        tx = kv_store.create_tx();
+        auto h1 = tx.rw(val1);
+        h1->put(v1);
+        h1->put(v2); // Override previous value
+        REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+
+        REQUIRE(global_writes.size() == 0);
+        REQUIRE(local_writes.size() == 1);
+        auto latest_writes = local_writes.front();
+        REQUIRE(latest_writes.value() == v2);
+        local_writes.clear();
+
+        tx = kv_store.create_tx();
+        h1 = tx.rw(val1);
+        h1->clear();
+        REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+
+        REQUIRE(local_writes.size() == 1);
+        latest_writes = local_writes.front();
+        REQUIRE(!latest_writes.has_value());
+        local_writes.clear();
+      }
+
+      {
+        INFO("Global hook");
+
+        auto tx = kv_store.create_tx();
+        auto h1 = tx.rw(val1);
+        h1->put(v3);
+        REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+
+        kv_store.compact(kv_store.current_version());
+
+        REQUIRE(global_writes.size() == 4);
+        REQUIRE(!global_writes.at(0).has_value());
+        REQUIRE(global_writes.at(1).value() == v2);
+        REQUIRE(!global_writes.at(2).has_value());
+        REQUIRE(global_writes.at(3).value() == v3);
+      }
     }
   }
 

--- a/src/kv/value.h
+++ b/src/kv/value.h
@@ -35,9 +35,40 @@ namespace kv
     using WriteOnlyHandle = kv::WriteableValueHandle<V, VSerialiser, Unit>;
     using Handle = kv::ValueHandle<V, VSerialiser, Unit>;
 
+    using Write = std::optional<V>;
+    using MapHook = MapHook<Write>;
+    using CommitHook = CommitHook<Write>;
+
     using ValueSerialiser = VSerialiser;
 
     using NamedHandleMixin::NamedHandleMixin;
+
+  private:
+    static Write deserialise_write(const kv::untyped::Write& w)
+    {
+      assert(w.size() == 1); // Value contains only one element
+      const auto& value = w.begin()->second;
+      if (!value.has_value())
+      {
+        return std::nullopt;
+      }
+      return VSerialiser::from_serialised(value.value());
+    }
+
+  public:
+    static kv::untyped::Map::CommitHook wrap_commit_hook(const CommitHook& hook)
+    {
+      return [hook](Version v, const kv::untyped::Write& w) {
+        hook(v, deserialise_write(w));
+      };
+    }
+
+    static kv::untyped::Map::MapHook wrap_map_hook(const MapHook& hook)
+    {
+      return [hook](Version v, const kv::untyped::Write& w) {
+        return hook(v, deserialise_write(w));
+      };
+    }
   };
 
   template <

--- a/src/kv/value.h
+++ b/src/kv/value.h
@@ -5,6 +5,7 @@
 #include "kv_types.h"
 #include "serialise_entry_blit.h"
 #include "serialise_entry_json.h"
+#include "unit.h"
 #include "value_handle.h"
 
 namespace kv

--- a/src/node/backup_signatures.h
+++ b/src/node/backup_signatures.h
@@ -29,6 +29,5 @@ namespace ccf
   DECLARE_JSON_TYPE(BackupSignatures);
   DECLARE_JSON_REQUIRED_FIELDS(BackupSignatures, view, seqno, root, signatures);
 
-  // Always recorded at key 0
-  using BackupSignaturesMap = ServiceMap<size_t, BackupSignatures>;
+  using BackupSignaturesMap = ServiceValue<BackupSignatures>;
 }

--- a/src/node/constitution.h
+++ b/src/node/constitution.h
@@ -6,5 +6,5 @@
 
 namespace ccf
 {
-  using Constitution = ServiceMap<size_t, std::string>;
+  using Constitution = ServiceValue<std::string>;
 }

--- a/src/node/genesis_gen.h
+++ b/src/node/genesis_gen.h
@@ -409,7 +409,7 @@ namespace ccf
 
     void set_constitution(const std::string& constitution)
     {
-      tx.rw(tables.constitution)->put(0, constitution);
+      tx.rw(tables.constitution)->put(constitution);
     }
 
     void trust_node_code_id(const CodeDigest& node_code_id)

--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -583,7 +583,7 @@ namespace ccf::historical
 
       // Construct description and decrypted secret
       auto previous_ledger_secret =
-        encrypted_past_ledger_secret->get(0)->previous_ledger_secret;
+        encrypted_past_ledger_secret->get()->previous_ledger_secret;
 
       auto recovered_ledger_secret = std::make_shared<LedgerSecret>(
         ccf::decrypt_previous_ledger_secret_raw(

--- a/src/node/ledger_secrets.h
+++ b/src/node/ledger_secrets.h
@@ -94,7 +94,7 @@ namespace ccf
       // require access to a tx object, which must take a dependency on the
       // secrets table.
       auto secrets = tx.ro<Secrets>(Tables::ENCRYPTED_LEDGER_SECRETS);
-      secrets->get(0);
+      secrets->get();
     }
 
   public:

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -861,7 +861,7 @@ namespace ccf
 
         if (ledger_idx == startup_snapshot_info->evidence_seqno)
         {
-          auto evidence = snapshot_evidence->get(0);
+          auto evidence = snapshot_evidence->get();
           if (!evidence.has_value())
           {
             throw std::logic_error("Invalid snapshot evidence");
@@ -1129,19 +1129,10 @@ namespace ccf
           [this](
             kv::Version version, const EncryptedLedgerSecretsInfo::Write& w)
             -> kv::ConsensusHookPtr {
-            if (w.size() > 1)
+            if (!w.has_value())
             {
               throw std::logic_error(fmt::format(
-                "Transaction contains {} writes to map {}, expected one",
-                w.size(),
-                network.encrypted_ledger_secrets.get_name()));
-            }
-
-            auto encrypted_ledger_secret_info = w.at(0);
-            if (!encrypted_ledger_secret_info.has_value())
-            {
-              throw std::logic_error(fmt::format(
-                "Removal from {} table",
+                "Unexpected removal from {} table",
                 network.encrypted_ledger_secrets.get_name()));
             }
 
@@ -1802,19 +1793,12 @@ namespace ccf
             -> kv::ConsensusHookPtr {
             LedgerSecretsMap restored_ledger_secrets;
 
-            if (w.size() > 1)
-            {
-              throw std::logic_error(fmt::format(
-                "Transaction contains {} writes to map {}, expected one",
-                w.size(),
-                network.secrets.get_name()));
-            }
-
-            auto ledger_secrets_for_nodes = w.at(0);
+            const auto& ledger_secrets_for_nodes = w;
             if (!ledger_secrets_for_nodes.has_value())
             {
               throw std::logic_error(fmt::format(
-                "Removal from {} table", network.secrets.get_name()));
+                "Unexpected removal from {} table",
+                network.secrets.get_name()));
             }
 
             for (const auto& [node_id, encrypted_ledger_secrets] :
@@ -1922,19 +1906,11 @@ namespace ccf
           [this](
             kv::Version version, const EncryptedLedgerSecretsInfo::Write& w)
             -> kv::ConsensusHookPtr {
-            if (w.size() > 1)
-            {
-              throw std::logic_error(fmt::format(
-                "Transaction contains {} writes to map {}, expected one",
-                w.size(),
-                network.encrypted_ledger_secrets.get_name()));
-            }
-
-            auto encrypted_ledger_secret_info = w.at(0);
+            auto encrypted_ledger_secret_info = w;
             if (!encrypted_ledger_secret_info.has_value())
             {
               throw std::logic_error(fmt::format(
-                "Removal from {} table",
+                "Unexpected removal from {} table",
                 network.encrypted_ledger_secrets.get_name()));
             }
 

--- a/src/node/progress_tracker_types.h
+++ b/src/node/progress_tracker_types.h
@@ -104,7 +104,7 @@ namespace ccf
       kv::CommittableTx tx(&store);
       auto backup_sig_view = tx.rw(backup_signatures);
 
-      backup_sig_view->put(0, sig_value);
+      backup_sig_view->put(sig_value);
       auto r = tx.commit();
       LOG_TRACE_FMT("Adding signatures to ledger, result:{}", r);
       CCF_ASSERT_FMT(
@@ -117,7 +117,7 @@ namespace ccf
     {
       kv::ReadOnlyTx tx(&store);
       auto sigs_tv = tx.ro(backup_signatures);
-      auto sigs = sigs_tv->get(0);
+      auto sigs = sigs_tv->get();
       if (!sigs.has_value())
       {
         LOG_FAIL_FMT("No signatures found in signatures map");
@@ -130,7 +130,7 @@ namespace ccf
     {
       kv::ReadOnlyTx tx(&store);
       auto new_views_tv = tx.ro(new_views);
-      return new_views_tv->get(0);
+      return new_views_tv->get();
     }
 
     void write_nonces(aft::RevealedNonces& nonces) override
@@ -138,7 +138,7 @@ namespace ccf
       kv::CommittableTx tx(&store);
       auto nonces_tv = tx.rw(revealed_nonces);
 
-      nonces_tv->put(0, nonces);
+      nonces_tv->put(nonces);
       auto r = tx.commit();
       if (r != kv::CommitResult::SUCCESS)
       {
@@ -157,7 +157,7 @@ namespace ccf
     {
       kv::ReadOnlyTx tx(&store);
       auto nonces_tv = tx.ro(revealed_nonces);
-      auto nonces = nonces_tv->get(0);
+      auto nonces = nonces_tv->get();
       if (!nonces.has_value())
       {
         LOG_FAIL_FMT("No signatures found in signatures map");
@@ -217,7 +217,7 @@ namespace ccf
       kv::CommittableTx tx(&store);
       auto new_views_tv = tx.rw(new_views);
 
-      new_views_tv->put(0, new_view);
+      new_views_tv->put(new_view);
       auto r = tx.commit();
       if (r != kv::CommitResult::SUCCESS)
       {

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -642,7 +642,6 @@ namespace ccf
       PreExec fn = [](kv::CommittableTx& tx, enclave::RpcContext& ctx) {
         auto aft_requests = tx.rw<aft::RequestsMap>(ccf::Tables::AFT_REQUESTS);
         aft_requests->put(
-          0,
           {tx.get_req_id(),
            ctx.session->caller_cert,
            ctx.get_serialised_request(),

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -865,7 +865,7 @@ namespace ccf
             "{:02x}", fmt::join(caller_identity.request_digest, ""));
         }
 
-        auto constitution = ctx.tx.ro(network.constitution)->get(0);
+        auto constitution = ctx.tx.ro(network.constitution)->get();
         if (!constitution.has_value())
         {
           ctx.rpc_ctx->set_error(
@@ -1207,7 +1207,7 @@ namespace ccf
             HTTP_STATUS_BAD_REQUEST, ccf::errors::InvalidResourceName, error);
         }
 
-        auto constitution = ctx.tx.ro(network.constitution)->get(0);
+        auto constitution = ctx.tx.ro(network.constitution)->get();
         if (!constitution.has_value())
         {
           return make_error(

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -546,7 +546,7 @@ TEST_CASE("process_bft")
 
   auto tx = bft_network.tables->create_tx();
   auto aft_requests = tx.rw<aft::RequestsMap>(ccf::Tables::AFT_REQUESTS);
-  auto request_value = aft_requests->get(0);
+  auto request_value = aft_requests->get();
   REQUIRE(request_value.has_value());
 
   aft::Request deserialised_req = request_value.value();

--- a/src/node/secret_broadcast.h
+++ b/src/node/secret_broadcast.h
@@ -43,7 +43,7 @@ namespace ccf
         secrets_for_nodes.emplace(nid, std::move(ledger_secrets_for_node));
       }
 
-      secrets->put(0, secrets_for_nodes);
+      secrets->put(secrets_for_nodes);
     }
 
     static void broadcast_new(
@@ -68,7 +68,7 @@ namespace ccf
         secrets_for_nodes.emplace(nid, std::move(ledger_secrets_for_node));
       }
 
-      secrets->put(0, secrets_for_nodes);
+      secrets->put(secrets_for_nodes);
     }
 
     static std::vector<uint8_t> decrypt(

--- a/src/node/secrets.h
+++ b/src/node/secrets.h
@@ -31,5 +31,5 @@ namespace ccf
 
   // This map is used to communicate encrypted ledger secrets from the primary
   // to the backups during recovery (past secrets) and re-keying (new secret)
-  using Secrets = ServiceMap<size_t, LedgerSecretsForNodes>;
+  using Secrets = ServiceValue<LedgerSecretsForNodes>;
 }

--- a/src/node/share_manager.h
+++ b/src/node/share_manager.h
@@ -154,7 +154,6 @@ namespace ccf
       auto wrapped_latest_ls = ls_wrapping_key.wrap(latest_ledger_secret);
       auto recovery_shares = tx.rw(network.shares);
       recovery_shares->put(
-        0,
         {wrapped_latest_ls,
          compute_encrypted_shares(tx, ls_wrapping_key),
          latest_ledger_secret->previous_secret_stored_version});
@@ -198,16 +197,15 @@ namespace ccf
 
         encrypted_previous_secret = encrypted_previous_ls.serialise();
         encrypted_ls->put(
-          0,
           {PreviousLedgerSecretInfo(
              std::move(encrypted_previous_secret),
              version_previous_secret,
-             encrypted_ls->get_version_of_previous_write(0)),
+             encrypted_ls->get_version_of_previous_write()),
            latest_ls_version});
       }
       else
       {
-        encrypted_ls->put(0, {std::nullopt, latest_ls_version});
+        encrypted_ls->put({std::nullopt, latest_ls_version});
       }
     }
 
@@ -330,7 +328,7 @@ namespace ccf
     std::optional<EncryptedShare> get_encrypted_share(
       kv::Tx& tx, const MemberId& member_id)
     {
-      auto recovery_shares_info = tx.rw(network.shares)->get(0);
+      auto recovery_shares_info = tx.rw(network.shares)->get();
       if (!recovery_shares_info.has_value())
       {
         throw std::logic_error(
@@ -359,7 +357,7 @@ namespace ccf
           "Could not find any ledger secrets in the ledger");
       }
 
-      auto recovery_shares_info = tx.ro(network.shares)->get(0);
+      auto recovery_shares_info = tx.ro(network.shares)->get();
       if (!recovery_shares_info.has_value())
       {
         throw std::logic_error(
@@ -392,7 +390,7 @@ namespace ccf
         current_ledger_secret_version.value(),
         std::make_shared<LedgerSecret>(
           std::move(restored_ls->raw_key),
-          encrypted_previous_ledger_secret->get_version_of_previous_write(0)));
+          encrypted_previous_ledger_secret->get_version_of_previous_write()));
       auto latest_ls = s.first->second;
 
       for (auto it = recovery_ledger_secrets.rbegin();

--- a/src/node/shares.h
+++ b/src/node/shares.h
@@ -107,14 +107,12 @@ namespace ccf
   // and can be deduced to the version at which the
   // EncryptedPastLedgerSecret map was updated.
 
-  // The key for this table is always 0. It is updated every time the member
-  // recovery shares are updated, e.g. when the recovery threshold is modified
-  // and when the ledger secret is updated
-  using RecoveryShares = ServiceMap<size_t, RecoverySharesInfo>;
+  // This table is updated every time the member recovery shares are updated,
+  // e.g. when the recovery threshold is modified and when the ledger secret is
+  // updated
+  using RecoveryShares = ServiceValue<RecoverySharesInfo>;
 
-  // The key for this table is always 0. It is updated every time the ledger
-  // secret is updated, e.g. at startup or on ledger rekey. It is not updated on
-  // a pure re-share.
-  using EncryptedLedgerSecretsInfo =
-    ServiceMap<size_t, EncryptedLedgerSecretInfo>;
+  // This table is updated every time the ledger secret is updated, e.g. at
+  // startup or on ledger rekey. It is not updated on a pure re-share.
+  using EncryptedLedgerSecretsInfo = ServiceValue<EncryptedLedgerSecretInfo>;
 }

--- a/src/node/snapshot_evidence.h
+++ b/src/node/snapshot_evidence.h
@@ -21,7 +21,5 @@ namespace ccf
   DECLARE_JSON_TYPE(SnapshotHash)
   DECLARE_JSON_REQUIRED_FIELDS(SnapshotHash, hash, version)
 
-  // As we only keep track of the latest snapshot, the key for the
-  // SnapshotEvidence table is always 0.
-  using SnapshotEvidence = ServiceMap<size_t, SnapshotHash>;
+  using SnapshotEvidence = ServiceValue<SnapshotHash>;
 }

--- a/src/node/snapshotter.h
+++ b/src/node/snapshotter.h
@@ -94,7 +94,7 @@ namespace ccf
       auto tx = store->create_tx();
       auto evidence = tx.rw<SnapshotEvidence>(Tables::SNAPSHOT_EVIDENCE);
       auto snapshot_hash = crypto::Sha256Hash(serialised_snapshot);
-      evidence->put(0, {snapshot_hash, snapshot_version});
+      evidence->put({snapshot_hash, snapshot_version});
 
       auto rc = tx.commit();
       if (rc != kv::CommitResult::SUCCESS)

--- a/src/node/view_change.h
+++ b/src/node/view_change.h
@@ -92,6 +92,5 @@ namespace ccf
   DECLARE_JSON_REQUIRED_FIELDS(
     ViewChangeConfirmation, view, primary_id, signature, view_change_messages);
 
-  // Always recorded at key 0
-  using NewViewsMap = ServiceMap<size_t, ViewChangeConfirmation>;
+  using NewViewsMap = ServiceValue<ViewChangeConfirmation>;
 }


### PR DESCRIPTION
Fairly standalone change, which will be required for adding hooks on the signatures table (as part of #2958). 

The `kv::Set` and `kv::Value` (introduced in #2599) didn't yet support local and global commit hooks. This PR adds support for those and also convert the remaining service tables to using `kv::Value`. 