### PR TITLE
Historical adapter v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added `foreach_key` and `foreach_value` to C++ KV API, to iterate without deserializing both entries when only one is used (#2918).
+- `ccf::historical::adapter_v2` now returns 404, with either `TransactionPendingOrUnknown` or `TransactionInvalid`, rather than 400 when a user performs a historical query for a transaction id that is not committed.
 
 ### Changed
 
@@ -18,7 +19,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated `actions.js` constitution fragment to record service-endorsed node certificate on the `transition_node_to_trusted` action. The constitution should be updated using the existing `set_constitution` proposal (#2844).
 - Improved performance for lookup of path-templated endpoints (#2918).
 - Raised the minimum supported CMake version for building CCF to 3.16 (#2946).
-- `ccf::historical::adapter_v2` now returns 404, with either `TransactionPendingOrUnknown` or `TransactionInvalid`, rather than 400 when a user performs a historical query for a transaction id that is not committed.
 
 ## [2.0.0-dev3]
 

--- a/doc/build_apps/api.rst
+++ b/doc/build_apps/api.rst
@@ -86,7 +86,7 @@ Supporting Types
 Historical Queries
 ------------------
 
-.. doxygenfunction:: ccf::historical::adapter
+.. doxygenfunction:: ccf::historical::adapter_v2
    :project: CCF
 
 .. doxygenclass:: ccf::historical::AbstractStateCache

--- a/doc/build_apps/logging_cpp.rst
+++ b/doc/build_apps/logging_cpp.rst
@@ -181,7 +181,7 @@ This app can then define its own endpoints from a blank slate. If it wants to pr
 Historical Queries
 ~~~~~~~~~~~~~~~~~~
 
-This sample demonstrates how to define a historical query endpoint with the help of :cpp:func:`ccf::historical::adapter`.
+This sample demonstrates how to define a historical query endpoint with the help of :cpp:func:`ccf::historical::adapter_v2`.
 
 The handler passed to the adapter is very similar to a read-only endpoint definition, but receives a read-only :cpp:struct:`ccf::historical::State` rather than a transaction.
 

--- a/include/ccf/historical_queries_adapter.h
+++ b/include/ccf/historical_queries_adapter.h
@@ -50,7 +50,7 @@ namespace ccf::historical
     return tx_id_opt;
   }
 
-  static inline bool is_tx_committed(
+  static inline bool is_tx_committed_v1(
     kv::Consensus* consensus,
     ccf::View view,
     ccf::SeqNo seqno,
@@ -83,8 +83,147 @@ namespace ccf::historical
     return true;
   };
 
+  enum class HistoricalTxStatus
+  {
+    Error,
+    PendingOrUnknown,
+    Invalid,
+    Valid
+  };
+
+  using CheckHistoricalTxStatus = std::function<HistoricalTxStatus(
+    ccf::View view, ccf::SeqNo seqno, std::string& error_reason)>;
+
+  static inline HistoricalTxStatus is_tx_committed_v2(
+    kv::Consensus* consensus,
+    ccf::View view,
+    ccf::SeqNo seqno,
+    std::string& error_reason)
+  {
+    if (consensus == nullptr)
+    {
+      error_reason = "Node is not fully configured";
+      return HistoricalTxStatus::Error;
+    }
+
+    const auto tx_view = consensus->get_view(seqno);
+    const auto committed_seqno = consensus->get_committed_seqno();
+    const auto committed_view = consensus->get_view(committed_seqno);
+
+    const auto tx_status = ccf::evaluate_tx_status(
+      view, seqno, tx_view, committed_view, committed_seqno);
+    switch (tx_status)
+    {
+      case ccf::TxStatus::Unknown:
+      case ccf::TxStatus::Pending:
+        error_reason = fmt::format(
+          "Only committed transactions can be queried. Transaction {}.{} "
+          "is "
+          "{}",
+          view,
+          seqno,
+          ccf::tx_status_to_str(tx_status));
+        return HistoricalTxStatus::PendingOrUnknown;
+      case ccf::TxStatus::Invalid:
+        error_reason = fmt::format(
+          "Only committed transactions can be queried. Transaction {}.{} "
+          "is "
+          "{}",
+          view,
+          seqno,
+          ccf::tx_status_to_str(tx_status));
+        return HistoricalTxStatus::Invalid;
+      case ccf::TxStatus::Committed:;
+    }
+
+    return HistoricalTxStatus::Valid;
+  };
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
+
+  static ccf::endpoints::EndpointFunction adapter_v2(
+    const HandleHistoricalQuery& f,
+    AbstractStateCache& state_cache,
+    const CheckHistoricalTxStatus& available,
+    const TxIDExtractor& extractor = txid_from_header)
+  {
+    return [f, &state_cache, available, extractor](
+             endpoints::EndpointContext& args) {
+      // Extract the requested transaction ID
+      ccf::TxID target_tx_id;
+      {
+        const auto tx_id_opt = extractor(args);
+        if (tx_id_opt.has_value())
+        {
+          target_tx_id = tx_id_opt.value();
+        }
+        else
+        {
+          return;
+        }
+      }
+
+      // Check that the requested transaction ID is available
+      {
+        auto error_reason = fmt::format(
+          "Transaction {} is not available.", target_tx_id.to_str());
+        auto is_available =
+          available(target_tx_id.view, target_tx_id.seqno, error_reason);
+        switch (is_available)
+        {
+          case HistoricalTxStatus::Error:
+            args.rpc_ctx->set_error(
+              HTTP_STATUS_INTERNAL_SERVER_ERROR,
+              ccf::errors::TransactionPendingOrUnknown,
+              std::move(error_reason));
+            return;
+          case HistoricalTxStatus::PendingOrUnknown:
+            // Set header No-Cache
+            args.rpc_ctx->set_response_header(
+              http::headers::CACHE_CONTROL, "no-cache");
+            args.rpc_ctx->set_error(
+              HTTP_STATUS_NOT_FOUND,
+              ccf::errors::TransactionPendingOrUnknown,
+              std::move(error_reason));
+            return;
+          case HistoricalTxStatus::Invalid:
+            args.rpc_ctx->set_error(
+              HTTP_STATUS_NOT_FOUND,
+              ccf::errors::TransactionInvalid,
+              std::move(error_reason));
+            return;
+          case HistoricalTxStatus::Valid:;
+        }
+      }
+
+      // We need a handle to determine whether this request is the 'same' as a
+      // previous one. For simplicity we use target_tx_id.seqno. This means we
+      // keep a lot of state around for old requests! It should be cleaned up
+      // manually
+      const auto historic_request_handle = target_tx_id.seqno;
+
+      // Get a state at the target version from the cache, if it is present
+      auto historical_state =
+        state_cache.get_state_at(historic_request_handle, target_tx_id.seqno);
+      if (historical_state == nullptr)
+      {
+        args.rpc_ctx->set_response_status(HTTP_STATUS_ACCEPTED);
+        static constexpr size_t retry_after_seconds = 3;
+        args.rpc_ctx->set_response_header(
+          http::headers::RETRY_AFTER, retry_after_seconds);
+        args.rpc_ctx->set_response_header(
+          http::headers::CONTENT_TYPE, http::headervalues::contenttype::TEXT);
+        args.rpc_ctx->set_response_body(fmt::format(
+          "Historical transaction {} is not currently available.",
+          target_tx_id.to_str()));
+        return;
+      }
+
+      // Call the provided handler
+      f(args, historical_state);
+    };
+  }
 
   static ccf::endpoints::EndpointFunction adapter_v1(
     const HandleHistoricalQuery& f,
@@ -150,6 +289,9 @@ namespace ccf::historical
     };
   }
 
+  // These unversioned aliases are here for compatibility reasons,
+  // but the intention is to remove them come 2.0, and make all usage
+  // explicitly versioned
   static ccf::endpoints::EndpointFunction adapter(
     const HandleHistoricalQuery& f,
     AbstractStateCache& state_cache,
@@ -158,5 +300,8 @@ namespace ccf::historical
   {
     return adapter_v1(f, state_cache, available, extractor);
   }
+
+  const auto is_tx_committed = is_tx_committed_v1;
+
 #pragma clang diagnostic pop
 }

--- a/include/ccf/historical_queries_adapter.h
+++ b/include/ccf/historical_queries_adapter.h
@@ -173,12 +173,15 @@ namespace ccf::historical
         switch (is_available)
         {
           case HistoricalTxStatus::Error:
+          {
             args.rpc_ctx->set_error(
               HTTP_STATUS_INTERNAL_SERVER_ERROR,
               ccf::errors::TransactionPendingOrUnknown,
               std::move(error_reason));
             return;
+          }
           case HistoricalTxStatus::PendingOrUnknown:
+          {
             // Set header No-Cache
             args.rpc_ctx->set_response_header(
               http::headers::CACHE_CONTROL, "no-cache");
@@ -187,13 +190,19 @@ namespace ccf::historical
               ccf::errors::TransactionPendingOrUnknown,
               std::move(error_reason));
             return;
+          }
           case HistoricalTxStatus::Invalid:
+          {
             args.rpc_ctx->set_error(
               HTTP_STATUS_NOT_FOUND,
               ccf::errors::TransactionInvalid,
               std::move(error_reason));
             return;
-          case HistoricalTxStatus::Valid:;
+          }
+          case HistoricalTxStatus::Valid:
+          {
+            continue;
+          }
         }
       }
 

--- a/include/ccf/historical_queries_adapter.h
+++ b/include/ccf/historical_queries_adapter.h
@@ -86,7 +86,7 @@ namespace ccf::historical
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
 
-  static ccf::endpoints::EndpointFunction adapter(
+  static ccf::endpoints::EndpointFunction adapter_v1(
     const HandleHistoricalQuery& f,
     AbstractStateCache& state_cache,
     const CheckAvailability& available,
@@ -148,6 +148,15 @@ namespace ccf::historical
       // Call the provided handler
       f(args, historical_state);
     };
+  }
+
+  static ccf::endpoints::EndpointFunction adapter(
+    const HandleHistoricalQuery& f,
+    AbstractStateCache& state_cache,
+    const CheckAvailability& available,
+    const TxIDExtractor& extractor = txid_from_header)
+  {
+    return adapter_v1(f, state_cache, available, extractor);
   }
 #pragma clang diagnostic pop
 }

--- a/include/ccf/historical_queries_adapter.h
+++ b/include/ccf/historical_queries_adapter.h
@@ -201,7 +201,6 @@ namespace ccf::historical
           }
           case HistoricalTxStatus::Valid:
           {
-            continue;
           }
         }
       }
@@ -234,6 +233,8 @@ namespace ccf::historical
     };
   }
 
+  CCF_DEPRECATED(
+    "Will be removed in 2.0, switch to ccf::historical::adapter_v2")
   static ccf::endpoints::EndpointFunction adapter_v1(
     const HandleHistoricalQuery& f,
     AbstractStateCache& state_cache,
@@ -301,6 +302,8 @@ namespace ccf::historical
   // These unversioned aliases are here for compatibility reasons,
   // but the intention is to remove them come 2.0, and make all usage
   // explicitly versioned
+  CCF_DEPRECATED(
+    "Will be removed in 2.0, switch to ccf::historical::adapter_v2")
   static ccf::endpoints::EndpointFunction adapter(
     const HandleHistoricalQuery& f,
     AbstractStateCache& state_cache,

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -739,13 +739,13 @@ namespace loggingapp
 
       auto is_tx_committed =
         [this](ccf::View view, ccf::SeqNo seqno, std::string& error_reason) {
-          return ccf::historical::is_tx_committed(
+          return ccf::historical::is_tx_committed_v2(
             consensus, view, seqno, error_reason);
         };
       make_endpoint(
         "/log/private/historical",
         HTTP_GET,
-        ccf::historical::adapter(
+        ccf::historical::adapter_v2(
           get_historical, context.get_historical_state(), is_tx_committed),
         auth_policies)
         .set_auto_schema<void, LoggingGetHistorical::Out>()
@@ -799,7 +799,7 @@ namespace loggingapp
       make_endpoint(
         "/log/private/historical_receipt",
         HTTP_GET,
-        ccf::historical::adapter(
+        ccf::historical::adapter_v2(
           get_historical_with_receipt,
           context.get_historical_state(),
           is_tx_committed),

--- a/src/apps/js_generic/js_generic.cpp
+++ b/src/apps/js_generic/js_generic.cpp
@@ -228,11 +228,11 @@ namespace ccfapp
       {
         auto is_tx_committed =
           [this](ccf::View view, ccf::SeqNo seqno, std::string& error_reason) {
-            return ccf::historical::is_tx_committed(
+            return ccf::historical::is_tx_committed_v2(
               consensus, view, seqno, error_reason);
           };
 
-        ccf::historical::adapter(
+        ccf::historical::adapter_v2(
           [this, &props](
             ccf::endpoints::EndpointContext& endpoint_ctx,
             ccf::historical::StatePtr state) {

--- a/src/endpoints/common_endpoint_registry.cpp
+++ b/src/endpoints/common_endpoint_registry.cpp
@@ -226,30 +226,8 @@ namespace ccf
 
     auto is_tx_committed =
       [this](ccf::View view, ccf::SeqNo seqno, std::string& error_reason) {
-        if (consensus == nullptr)
-        {
-          error_reason = "Node is not fully configured";
-          return false;
-        }
-
-        const auto tx_view = consensus->get_view(seqno);
-        const auto committed_seqno = consensus->get_committed_seqno();
-        const auto committed_view = consensus->get_view(committed_seqno);
-
-        const auto tx_status = ccf::evaluate_tx_status(
-          view, seqno, tx_view, committed_view, committed_seqno);
-        if (tx_status != ccf::TxStatus::Committed)
-        {
-          error_reason = fmt::format(
-            "Only committed transactions can be queried. Transaction {}.{} is "
-            "{}",
-            view,
-            seqno,
-            ccf::tx_status_to_str(tx_status));
-          return false;
-        }
-
-        return true;
+        return ccf::historical::is_tx_committed(
+          consensus, view, seqno, error_reason);
       };
 
     auto get_receipt =

--- a/src/endpoints/common_endpoint_registry.cpp
+++ b/src/endpoints/common_endpoint_registry.cpp
@@ -226,7 +226,7 @@ namespace ccf
 
     auto is_tx_committed =
       [this](ccf::View view, ccf::SeqNo seqno, std::string& error_reason) {
-        return ccf::historical::is_tx_committed(
+        return ccf::historical::is_tx_committed_v2(
           consensus, view, seqno, error_reason);
       };
 
@@ -245,7 +245,7 @@ namespace ccf
     make_endpoint(
       "/receipt",
       HTTP_GET,
-      ccf::historical::adapter(
+      ccf::historical::adapter_v2(
         get_receipt,
         context.get_historical_state(),
         is_tx_committed,

--- a/src/http/http_consts.h
+++ b/src/http/http_consts.h
@@ -18,6 +18,7 @@ namespace http
     static constexpr auto LOCATION = "location";
     static constexpr auto RETRY_AFTER = "retry-after";
     static constexpr auto WWW_AUTHENTICATE = "www-authenticate";
+    static constexpr auto CACHE_CONTROL = "cache-control";
 
     static constexpr auto CCF_TX_ID = "x-ms-ccf-transaction-id";
   }

--- a/src/node/rpc/error.h
+++ b/src/node/rpc/error.h
@@ -69,6 +69,8 @@ namespace ccf
     ERROR(VoteNotFound)
     ERROR(VoteAlreadyExists)
     ERROR(NodeCannotHandleRequest)
+    ERROR(TransactionPendingOrUnknown)
+    ERROR(TransactionInvalid)
 
     // node-to-node (/join and /create):
     ERROR(ConsensusTypeMismatch)


### PR DESCRIPTION
Address #2640. This is essentially two changes:

1. Switch from 400 to 404, for historical transactions on requests that aren't committed (yet).
2. Give a different error reason for transaction ids that are invalid (forever) vs unknown/pending (so far, but may resolve).

TODO:

- [x] CHANGELOG