### PR TITLE
[Do not merge] Test Open Enclave 0.17.2 pre-release

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -7,7 +7,7 @@ trigger:
 
 jobs:
   - job: build_and_publish_docs
-    container: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+    container: ccfciteam/ccf-ci:oe0.17.2-pre
     pool:
       vmImage: ubuntu-20.04
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -27,11 +27,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+      image: ccfciteam/ccf-ci:oe0.17.2-pre
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+      image: ccfciteam/ccf-ci:oe0.17.2-pre
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
 variables:

--- a/.daily.yml
+++ b/.daily.yml
@@ -23,11 +23,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+      image: ccfciteam/ccf-ci:oe0.17.2-pre
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache
 
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+      image: ccfciteam/ccf-ci:oe0.17.2-pre
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 *
 !getting_started
 !docker
-
+!open-enclave_0.17.2_amd64.deb

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-20.04
-    container: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+    container: ccfciteam/ccf-ci:oe0.17.2-pre
 
     steps:
       - name: Checkout repository

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -16,7 +16,7 @@ pr:
 resources:
   containers:
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+      image: ccfciteam/ccf-ci:oe0.17.2-pre
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.stress.yml
+++ b/.stress.yml
@@ -21,7 +21,7 @@ schedules:
 resources:
   containers:
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+      image: ccfciteam/ccf-ci:oe0.17.2-pre
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/docker/ccf_ci
+++ b/docker/ccf_ci
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y wget gnupg
 RUN ["/bin/bash", "-c", "wget -r -l1 --no-parent -nd -A *sgx_$(echo ${PSW_VERSION//./_})_${UBUNTU}_custom_version.cfg https://download.01.org/intel-sgx/sgx_repo/ubuntu/apt_preference_files/"]
 RUN ["/bin/bash", "-c", "mv *sgx_$(echo ${PSW_VERSION//./_})_${UBUNTU}_custom_version.cfg /etc/apt/preferences.d/intel-sgx.pref"]
 
+COPY open-enclave_0.17.2_amd64.deb /open-enclave_0.17.2_amd64.deb
 COPY getting_started/setup_vm/ /setup_vm/
 RUN apt update \
     && apt install -y ansible software-properties-common bsdmainutils dnsutils \

--- a/getting_started/setup_vm/roles/openenclave/vars/common.yml
+++ b/getting_started/setup_vm/roles/openenclave/vars/common.yml
@@ -11,7 +11,7 @@ oe_playbook: scripts/ansible/oe-contributors-acc-setup-no-driver.yml
 oe_build_opts: ""
 
 # Binary install
-oe_deb: "https://github.com/openenclave/openenclave/releases/download/v{{ oe_ver }}/Ubuntu_2004_open-enclave_{{ oe_ver_ }}_amd64.deb"
+oe_deb: "/open-enclave_0.17.2_amd64.deb"
 
 # LVI mitigations
 oe_lvi_scripts_dir: "{{ oe_prefix }}/bin/scripts/lvi-mitigation"


### PR DESCRIPTION
Once 0.17.2 is released officially, a follow-up PR will pick it up on `main`, and will be cherry picked to `release/1.x` for release as `1.0.10`.