### PR TITLE
js: turn crypto functions into plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,12 @@ add_custom_target(
 )
 
 # Add Logging app. Rebuilt/redefined here, rather than via add_subdirectory
-add_ccf_app(logging SRCS samples/apps/logging/logging.cpp)
+add_ccf_app(
+  logging
+  SRCS samples/apps/logging/logging.cpp
+  LINK_LIBS_ENCLAVE js_crypto.enclave
+  LINK_LIBS_VIRTUAL js_crypto.virtual
+)
 sign_app_library(
   logging.enclave ${CMAKE_CURRENT_SOURCE_DIR}/samples/apps/logging/oe_sign.conf
   ${CMAKE_CURRENT_BINARY_DIR}/signing_key.pem

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -349,28 +349,36 @@ set(CCF_NETWORK_TEST_ARGS -l ${TEST_HOST_LOGGING_LEVEL} --worker-threads
 )
 
 add_ccf_plugin(js_crypto SRCS ${CCF_DIR}/src/js/crypto.cpp)
-install(
-  TARGETS js_crypto.enclave
-  EXPORT ccf
-  DESTINATION lib
-)
-install(
-  TARGETS js_crypto.virtual
-  EXPORT ccf
-  DESTINATION lib
-)
+if("sgx" IN_LIST COMPILE_TARGETS)
+  install(
+    TARGETS js_crypto.enclave
+    EXPORT ccf
+    DESTINATION lib
+  )
+endif()
+if("virtual" IN_LIST COMPILE_TARGETS)
+  install(
+    TARGETS js_crypto.virtual
+    EXPORT ccf
+    DESTINATION lib
+  )
+endif()
 
 add_ccf_plugin(js_openenclave SRCS ${CCF_DIR}/src/js/openenclave.cpp)
-install(
-  TARGETS js_openenclave.enclave
-  EXPORT ccf
-  DESTINATION lib
-)
-install(
-  TARGETS js_openenclave.virtual
-  EXPORT ccf
-  DESTINATION lib
-)
+if("sgx" IN_LIST COMPILE_TARGETS)
+  install(
+    TARGETS js_openenclave.enclave
+    EXPORT ccf
+    DESTINATION lib
+  )
+endif()
+if("virtual" IN_LIST COMPILE_TARGETS)
+  install(
+    TARGETS js_openenclave.virtual
+    EXPORT ccf
+    DESTINATION lib
+  )
+endif()
 
 if("sgx" IN_LIST COMPILE_TARGETS)
   add_enclave_library(

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -348,36 +348,29 @@ set(CCF_NETWORK_TEST_ARGS -l ${TEST_HOST_LOGGING_LEVEL} --worker-threads
                           ${WORKER_THREADS}
 )
 
-if("sgx" IN_LIST COMPILE_TARGETS)
-  add_enclave_library(js_openenclave.enclave ${CCF_DIR}/src/js/openenclave.cpp)
-  use_oe_mbedtls(js_openenclave.enclave)
-  target_link_libraries(js_openenclave.enclave PUBLIC ccf.enclave)
-  add_lvi_mitigations(js_openenclave.enclave)
-  install(
-    TARGETS js_openenclave.enclave
-    EXPORT ccf
-    DESTINATION lib
-  )
-endif()
-if("virtual" IN_LIST COMPILE_TARGETS)
-  add_library(js_openenclave.virtual STATIC ${CCF_DIR}/src/js/openenclave.cpp)
-  add_san(js_openenclave.virtual)
-  target_link_libraries(js_openenclave.virtual PUBLIC ccf.virtual)
-  target_compile_options(js_openenclave.virtual PRIVATE ${COMPILE_LIBCXX})
-  target_compile_definitions(
-    js_openenclave.virtual PUBLIC INSIDE_ENCLAVE VIRTUAL_ENCLAVE
-                                  _LIBCPP_HAS_THREAD_API_PTHREAD
-  )
-  set_property(
-    TARGET js_openenclave.virtual PROPERTY POSITION_INDEPENDENT_CODE ON
-  )
-  use_client_mbedtls(js_openenclave.virtual)
-  install(
-    TARGETS js_openenclave.virtual
-    EXPORT ccf
-    DESTINATION lib
-  )
-endif()
+add_ccf_plugin(js_crypto SRCS ${CCF_DIR}/src/js/crypto.cpp)
+install(
+  TARGETS js_crypto.enclave
+  EXPORT ccf
+  DESTINATION lib
+)
+install(
+  TARGETS js_crypto.virtual
+  EXPORT ccf
+  DESTINATION lib
+)
+
+add_ccf_plugin(js_openenclave SRCS ${CCF_DIR}/src/js/openenclave.cpp)
+install(
+  TARGETS js_openenclave.enclave
+  EXPORT ccf
+  DESTINATION lib
+)
+install(
+  TARGETS js_openenclave.virtual
+  EXPORT ccf
+  DESTINATION lib
+)
 
 if("sgx" IN_LIST COMPILE_TARGETS)
   add_enclave_library(
@@ -420,8 +413,9 @@ add_ccf_app(
   js_generic
   SRCS ${CCF_DIR}/src/apps/js_generic/js_generic.cpp
   LINK_LIBS_ENCLAVE js_generic_base.enclave js_openenclave.enclave
-  LINK_LIBS_VIRTUAL js_generic_base.virtual js_openenclave.virtual INSTALL_LIBS
-                    ON
+                    js_crypto.enclave
+  LINK_LIBS_VIRTUAL js_generic_base.virtual js_openenclave.virtual
+                    js_crypto.virtual INSTALL_LIBS ON
 )
 sign_app_library(
   js_generic.enclave ${CCF_DIR}/src/apps/js_generic/oe_sign.conf

--- a/include/ccf/js_crypto_plugin.h
+++ b/include/ccf/js_crypto_plugin.h
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ccf/js_plugin.h"
+
+namespace ccf::js
+{
+  extern FFIPlugin crypto_plugin;
+}

--- a/js/ccf-app/src/crypto.ts
+++ b/js/ccf-app/src/crypto.ts
@@ -20,17 +20,17 @@ import { ccf } from "./global.js";
 /**
  * @inheritDoc CCF.generateAesKey
  */
-export const generateAesKey = ccf.generateAesKey;
+export const generateAesKey = ccf.crypto.generateAesKey;
 
 /**
  * @inheritDoc CCF.generateRsaKeyPair
  */
-export const generateRsaKeyPair = ccf.generateRsaKeyPair;
+export const generateRsaKeyPair = ccf.crypto.generateRsaKeyPair;
 
 /**
  * @inheritDoc CCF.wrapKey
  */
-export const wrapKey = ccf.wrapKey;
+export const wrapKey = ccf.crypto.wrapKey;
 
 /**
  * @inheritDoc CCF.crypto.verifySignature
@@ -40,17 +40,17 @@ export const verifySignature = ccf.crypto.verifySignature;
 /**
  * @inheritDoc CCF.digest
  */
-export const digest = ccf.digest;
+export const digest = ccf.crypto.digest;
 
 /**
  * @inheritDoc CCF.isValidX509CertBundle
  */
-export const isValidX509CertBundle = ccf.isValidX509CertBundle;
+export const isValidX509CertBundle = ccf.crypto.isValidX509CertBundle;
 
 /**
  * @inheritDoc CCF.isValidX509CertChain
  */
-export const isValidX509CertChain = ccf.isValidX509CertChain;
+export const isValidX509CertChain = ccf.crypto.isValidX509CertChain;
 
 export {
   WrapAlgoParams,

--- a/js/ccf-app/src/global.ts
+++ b/js/ccf-app/src/global.ts
@@ -227,54 +227,54 @@ export interface CCF {
    */
   bufToJsonCompatible<T extends JsonCompatible<T>>(v: ArrayBuffer): T;
 
-  /**
-   * Generate an AES key.
-   *
-   * @param size The length in bits of the key to generate. 128, 192, or 256.
-   */
-  generateAesKey(size: number): ArrayBuffer;
-
-  /**
-   * Generate an RSA key pair.
-   *
-   * @param size The length in bits of the RSA modulus. Minimum: 2048.
-   * @param exponent The public exponent. Default: 65537.
-   */
-  generateRsaKeyPair(size: number, exponent?: number): CryptoKeyPair;
-
-  /**
-   * Wraps a key using a wrapping key.
-   *
-   * Constraints on the `key` and `wrappingKey` parameters depend
-   * on the wrapping algorithm that is used (`wrapAlgo`).
-   */
-  wrapKey(
-    key: ArrayBuffer,
-    wrappingKey: ArrayBuffer,
-    wrapAlgo: WrapAlgoParams
-  ): ArrayBuffer;
-
-  /**
-   * Generate a digest (hash) of the given data.
-   */
-  digest(algorithm: DigestAlgorithm, data: ArrayBuffer): ArrayBuffer;
-
-  /**
-   * Returns whether a string is a PEM-encoded bundle of X.509 certificates.
-   *
-   * A bundle consists of one or more certificates.
-   * Certificates in the bundle do not have to be related to each other.
-   * Validation is only syntactical, properties like validity dates are not evaluated.
-   */
-  isValidX509CertBundle(pem: string): boolean;
-
-  /**
-   * Returns whether a certificate chain is valid given a set of trusted certificates.
-   * The chain and trusted certificates are PEM-encoded bundles of X.509 certificates.
-   */
-  isValidX509CertChain(chain: string, trusted: string): boolean;
-
   crypto: {
+    /**
+     * Generate an AES key.
+     *
+     * @param size The length in bits of the key to generate. 128, 192, or 256.
+     */
+    generateAesKey(size: number): ArrayBuffer;
+
+    /**
+     * Generate an RSA key pair.
+     *
+     * @param size The length in bits of the RSA modulus. Minimum: 2048.
+     * @param exponent The public exponent. Default: 65537.
+     */
+    generateRsaKeyPair(size: number, exponent?: number): CryptoKeyPair;
+
+    /**
+     * Wraps a key using a wrapping key.
+     *
+     * Constraints on the `key` and `wrappingKey` parameters depend
+     * on the wrapping algorithm that is used (`wrapAlgo`).
+     */
+    wrapKey(
+      key: ArrayBuffer,
+      wrappingKey: ArrayBuffer,
+      wrapAlgo: WrapAlgoParams
+    ): ArrayBuffer;
+
+    /**
+     * Generate a digest (hash) of the given data.
+     */
+    digest(algorithm: DigestAlgorithm, data: ArrayBuffer): ArrayBuffer;
+
+    /**
+     * Returns whether a string is a PEM-encoded bundle of X.509 certificates.
+     *
+     * A bundle consists of one or more certificates.
+     * Certificates in the bundle do not have to be related to each other.
+     * Validation is only syntactical, properties like validity dates are not evaluated.
+     */
+    isValidX509CertBundle(pem: string): boolean;
+
+    /**
+     * Returns whether a certificate chain is valid given a set of trusted certificates.
+     * The chain and trusted certificates are PEM-encoded bundles of X.509 certificates.
+     */
+    isValidX509CertChain(chain: string, trusted: string): boolean;
+
     /**
      * Returns whether digital signature is valid.
      *

--- a/js/ccf-app/test/polyfill.test.ts
+++ b/js/ccf-app/test/polyfill.test.ts
@@ -35,27 +35,27 @@ describe("polyfill", function () {
   });
   describe("generateAesKey", function () {
     it("generates a random AES key", function () {
-      assert.equal(ccf.generateAesKey(128).byteLength, 16);
-      assert.equal(ccf.generateAesKey(192).byteLength, 24);
-      assert.equal(ccf.generateAesKey(256).byteLength, 32);
-      assert.notDeepEqual(ccf.generateAesKey(256), ccf.generateAesKey(256));
+      assert.equal(ccf.crypto.generateAesKey(128).byteLength, 16);
+      assert.equal(ccf.crypto.generateAesKey(192).byteLength, 24);
+      assert.equal(ccf.crypto.generateAesKey(256).byteLength, 32);
+      assert.notDeepEqual(ccf.crypto.generateAesKey(256), ccf.crypto.generateAesKey(256));
     });
   });
   describe("generateRsaKeyPair", function () {
     it("generates a random RSA key pair", function () {
-      const pair = ccf.generateRsaKeyPair(2048);
+      const pair = ccf.crypto.generateRsaKeyPair(2048);
       assert.isTrue(pair.publicKey.startsWith("-----BEGIN PUBLIC KEY-----"));
       assert.isTrue(pair.privateKey.startsWith("-----BEGIN PRIVATE KEY-----"));
     });
   });
   describe("wrapKey", function () {
     it("performs RSA-OAEP wrapping correctly", function () {
-      const key = ccf.generateAesKey(128);
-      const wrappingKey = ccf.generateRsaKeyPair(2048);
+      const key = ccf.crypto.generateAesKey(128);
+      const wrappingKey = ccf.crypto.generateRsaKeyPair(2048);
       const wrapAlgo: RsaOaepParams = {
         name: "RSA-OAEP",
       };
-      const wrapped = ccf.wrapKey(
+      const wrapped = ccf.crypto.wrapKey(
         key,
         ccf.strToBuf(wrappingKey.publicKey),
         wrapAlgo
@@ -68,23 +68,23 @@ describe("polyfill", function () {
       assert.deepEqual(unwrapped, key);
     });
     it("performs AES-KWP wrapping correctly", function () {
-      const key = ccf.generateAesKey(128);
-      const wrappingKey = ccf.generateAesKey(256);
+      const key = ccf.crypto.generateAesKey(128);
+      const wrappingKey = ccf.crypto.generateAesKey(256);
       const wrapAlgo: AesKwpParams = {
         name: "AES-KWP",
       };
-      const wrapped = ccf.wrapKey(key, wrappingKey, wrapAlgo);
+      const wrapped = ccf.crypto.wrapKey(key, wrappingKey, wrapAlgo);
       const unwrapped = unwrapKey(wrapped, wrappingKey, wrapAlgo);
       assert.deepEqual(unwrapped, key);
     });
     it("performs RSA-OAEP-AES-KWP wrapping correctly", function () {
-      const key = ccf.generateAesKey(128);
-      const wrappingKey = ccf.generateRsaKeyPair(2048);
+      const key = ccf.crypto.generateAesKey(128);
+      const wrappingKey = ccf.crypto.generateRsaKeyPair(2048);
       const wrapAlgo: RsaOaepAesKwpParams = {
         name: "RSA-OAEP-AES-KWP",
         aesKeySize: 256,
       };
-      const wrapped = ccf.wrapKey(
+      const wrapped = ccf.crypto.wrapKey(
         key,
         ccf.strToBuf(wrappingKey.publicKey),
         wrapAlgo
@@ -215,7 +215,7 @@ describe("polyfill", function () {
       const data = "Hello world!";
       const expected =
         "c0535e4be2b79ffd93291305436bf889314e4a3faec05ecffcbb7df31ad9e51a";
-      const digest = ccf.digest("SHA-256", ccf.strToBuf(data));
+      const digest = ccf.crypto.digest("SHA-256", ccf.strToBuf(data));
       const actual = Buffer.from(digest).toString("hex");
       assert.equal(actual, expected);
     });
@@ -228,14 +228,14 @@ describe("polyfill", function () {
       }
       const pem1 = generateSelfSignedCert().cert;
       const pem2 = generateSelfSignedCert().cert;
-      assert.isTrue(ccf.isValidX509CertBundle(pem1));
-      assert.isTrue(ccf.isValidX509CertBundle(pem1 + "\n" + pem2));
+      assert.isTrue(ccf.crypto.isValidX509CertBundle(pem1));
+      assert.isTrue(ccf.crypto.isValidX509CertBundle(pem1 + "\n" + pem2));
     });
     it("returns false for invalid certs", function () {
       if (!supported) {
         this.skip();
       }
-      assert.isFalse(ccf.isValidX509CertBundle("garbage"));
+      assert.isFalse(ccf.crypto.isValidX509CertBundle("garbage"));
     });
   });
   describe("isValidX509CertChain", function (this) {
@@ -247,7 +247,7 @@ describe("polyfill", function () {
       const pems = generateCertChain(3);
       const chain = [pems[0], pems[1]].join("\n");
       const trusted = pems[2];
-      assert.isTrue(ccf.isValidX509CertChain(chain, trusted));
+      assert.isTrue(ccf.crypto.isValidX509CertChain(chain, trusted));
     });
     it("returns false for invalid cert chains", function () {
       if (!supported) {
@@ -256,7 +256,7 @@ describe("polyfill", function () {
       const pems = generateCertChain(3);
       const chain = pems[0];
       const trusted = pems[2];
-      assert.isFalse(ccf.isValidX509CertChain(chain, trusted));
+      assert.isFalse(ccf.crypto.isValidX509CertChain(chain, trusted));
     });
   });
   describe("kv", function () {

--- a/samples/apps/logging/CMakeLists.txt
+++ b/samples/apps/logging/CMakeLists.txt
@@ -6,7 +6,12 @@ cmake_minimum_required(VERSION 3.13)
 project(logging LANGUAGES C CXX)
 find_package(ccf REQUIRED)
 
-add_ccf_app(logging SRCS logging.cpp)
+add_ccf_app(
+  logging
+  SRCS logging.cpp
+  LINK_LIBS_ENCLAVE js_crypto.enclave
+  LINK_LIBS_VIRTUAL js_crypto.virtual
+)
 
 # Generate an ephemeral signing key
 add_custom_command(

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -10,6 +10,7 @@
 #include "ccf/app_interface.h"
 #include "ccf/historical_queries_adapter.h"
 #include "ccf/http_query.h"
+#include "ccf/js_crypto_plugin.h"
 #include "ccf/user_frontend.h"
 #include "ccf/version.h"
 
@@ -1203,6 +1204,11 @@ namespace ccfapp
     ccf::NetworkTables& nwt, ccfapp::AbstractNodeContext& context)
   {
     return make_shared<loggingapp::Logger>(nwt, context);
+  }
+
+  std::vector<ccf::js::FFIPlugin> get_js_plugins()
+  {
+    return {ccf::js::crypto_plugin};
   }
   // SNIPPET_END: app_interface
 }

--- a/samples/apps/nobuiltins/CMakeLists.txt
+++ b/samples/apps/nobuiltins/CMakeLists.txt
@@ -1,7 +1,12 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-add_ccf_app(nobuiltins SRCS nobuiltins.cpp)
+add_ccf_app(
+  nobuiltins
+  SRCS nobuiltins.cpp
+  LINK_LIBS_ENCLAVE js_crypto.enclave
+  LINK_LIBS_VIRTUAL js_crypto.virtual
+)
 
 # Generate an ephemeral signing key
 add_custom_command(

--- a/samples/apps/nobuiltins/nobuiltins.cpp
+++ b/samples/apps/nobuiltins/nobuiltins.cpp
@@ -3,6 +3,7 @@
 #include "ccf/app_interface.h"
 #include "ccf/base_endpoint_registry.h"
 #include "ccf/common_auth_policies.h"
+#include "ccf/js_crypto_plugin.h"
 #include "ccf/json_handler.h"
 #include "ds/json.h"
 #include "enclave/node_context.h"
@@ -348,5 +349,10 @@ namespace ccfapp
     ccf::NetworkTables& nwt, ccfapp::AbstractNodeContext& context)
   {
     return std::make_shared<nobuiltins::NoBuiltinsFrontend>(nwt, context);
+  }
+
+  std::vector<ccf::js::FFIPlugin> get_js_plugins()
+  {
+    return {ccf::js::crypto_plugin};
   }
 }

--- a/src/apps/js_generic/js_generic.cpp
+++ b/src/apps/js_generic/js_generic.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
 #include "ccf/app_interface.h"
+#include "ccf/js_crypto_plugin.h"
 #include "ccf/js_openenclave_plugin.h"
 #include "js_generic_base.h"
 
@@ -14,7 +15,7 @@ namespace ccfapp
 
   std::vector<ccf::js::FFIPlugin> get_js_plugins()
   {
-    return {ccf::js::openenclave_plugin};
+    return {ccf::js::crypto_plugin, ccf::js::openenclave_plugin};
   }
 
 } // namespace ccfapp

--- a/src/apps/smallbank/app/smallbank.cpp
+++ b/src/apps/smallbank/app/smallbank.cpp
@@ -3,6 +3,7 @@
 #include "apps/smallbank/smallbank_serializer.h"
 #include "apps/utils/metrics_tracker.h"
 #include "ccf/app_interface.h"
+#include "ccf/js_crypto_plugin.h"
 #include "ccf/user_frontend.h"
 
 #include <charconv>
@@ -470,5 +471,10 @@ namespace ccfapp
     NetworkTables& nwt, AbstractNodeContext& context)
   {
     return make_shared<SmallBank>(*nwt.tables, context);
+  }
+
+  std::vector<ccf::js::FFIPlugin> get_js_plugins()
+  {
+    return {ccf::js::crypto_plugin};
   }
 }

--- a/src/apps/smallbank/smallbank.cmake
+++ b/src/apps/smallbank/smallbank.cmake
@@ -25,7 +25,12 @@ else()
 endif()
 
 # SmallBank application
-add_ccf_app(smallbank SRCS ${CMAKE_CURRENT_LIST_DIR}/app/smallbank.cpp)
+add_ccf_app(
+  smallbank
+  SRCS ${CMAKE_CURRENT_LIST_DIR}/app/smallbank.cpp
+  LINK_LIBS_ENCLAVE js_crypto.enclave
+  LINK_LIBS_VIRTUAL js_crypto.virtual
+)
 sign_app_library(
   smallbank.enclave ${CMAKE_CURRENT_LIST_DIR}/app/oe_sign.conf
   ${CMAKE_CURRENT_BINARY_DIR}/signing_key.pem

--- a/src/apps/tpcc/app/tpcc.cpp
+++ b/src/apps/tpcc/app/tpcc.cpp
@@ -3,6 +3,7 @@
 #include "../tpcc_serializer.h"
 #include "apps/utils/metrics_tracker.h"
 #include "ccf/app_interface.h"
+#include "ccf/js_crypto_plugin.h"
 #include "ccf/user_frontend.h"
 #include "tpcc_setup.h"
 #include "tpcc_tables.h"
@@ -161,6 +162,11 @@ namespace ccfapp
     NetworkTables& nwt, AbstractNodeContext& context)
   {
     return make_shared<Tpcc>(*nwt.tables, context);
+  }
+
+  std::vector<ccf::js::FFIPlugin> get_js_plugins()
+  {
+    return {ccf::js::crypto_plugin};
   }
 }
 

--- a/src/apps/tpcc/tpcc.cmake
+++ b/src/apps/tpcc/tpcc.cmake
@@ -18,6 +18,8 @@ add_ccf_app(
   tpcc
   SRCS ${CMAKE_CURRENT_LIST_DIR}/app/tpcc.cpp
   INCLUDE_DIRS ${CCF_DIR}/3rdparty/test
+  LINK_LIBS_ENCLAVE js_crypto.enclave
+  LINK_LIBS_VIRTUAL js_crypto.virtual
 )
 sign_app_library(
   tpcc.enclave ${CMAKE_CURRENT_LIST_DIR}/app/oe_sign.conf

--- a/src/js/crypto.cpp
+++ b/src/js/crypto.cpp
@@ -509,10 +509,7 @@ namespace ccf::js
         JS_NewCFunction(
           ctx, js_generate_rsa_key_pair, "generateRsaKeyPair", 1));
       JS_SetPropertyStr(
-        ctx,
-        obj,
-        "wrapKey",
-        JS_NewCFunction(ctx, js_wrap_key, "wrapKey", 3));
+        ctx, obj, "wrapKey", JS_NewCFunction(ctx, js_wrap_key, "wrapKey", 3));
       JS_SetPropertyStr(
         ctx, obj, "digest", JS_NewCFunction(ctx, js_digest, "digest", 2));
       JS_SetPropertyStr(
@@ -528,10 +525,7 @@ namespace ccf::js
         JS_NewCFunction(
           ctx, js_is_valid_x509_cert_chain, "isValidX509CertChain", 2));
       JS_SetPropertyStr(
-        ctx,
-        obj,
-        "pemToId",
-        JS_NewCFunction(ctx, js_pem_to_id, "pemToId", 1));
+        ctx, obj, "pemToId", JS_NewCFunction(ctx, js_pem_to_id, "pemToId", 1));
     }
 
     JS_SetPropertyStr(

--- a/src/js/crypto.cpp
+++ b/src/js/crypto.cpp
@@ -499,37 +499,37 @@ namespace ccf::js
     {
       JS_SetPropertyStr(
         ctx,
-        crypto,
+        obj,
         "generateAesKey",
         JS_NewCFunction(ctx, js_generate_aes_key, "generateAesKey", 1));
       JS_SetPropertyStr(
         ctx,
-        crypto,
+        obj,
         "generateRsaKeyPair",
         JS_NewCFunction(
           ctx, js_generate_rsa_key_pair, "generateRsaKeyPair", 1));
       JS_SetPropertyStr(
         ctx,
-        crypto,
+        obj,
         "wrapKey",
         JS_NewCFunction(ctx, js_wrap_key, "wrapKey", 3));
       JS_SetPropertyStr(
-        ctx, crypto, "digest", JS_NewCFunction(ctx, js_digest, "digest", 2));
+        ctx, obj, "digest", JS_NewCFunction(ctx, js_digest, "digest", 2));
       JS_SetPropertyStr(
         ctx,
-        crypto,
+        obj,
         "isValidX509CertBundle",
         JS_NewCFunction(
           ctx, js_is_valid_x509_cert_bundle, "isValidX509CertBundle", 1));
       JS_SetPropertyStr(
         ctx,
-        crypto,
+        obj,
         "isValidX509CertChain",
         JS_NewCFunction(
           ctx, js_is_valid_x509_cert_chain, "isValidX509CertChain", 2));
       JS_SetPropertyStr(
         ctx,
-        crypto,
+        obj,
         "pemToId",
         JS_NewCFunction(ctx, js_pem_to_id, "pemToId", 1));
     }

--- a/src/js/wrap.cpp
+++ b/src/js/wrap.cpp
@@ -7,7 +7,6 @@
 #include "ds/logger.h"
 #include "enclave/rpc_context.h"
 #include "js/conv.cpp"
-#include "js/crypto.cpp"
 #include "js/no_plugins.cpp"
 #include "kv/untyped_map.h"
 #include "node/jwt.h"
@@ -1248,34 +1247,7 @@ namespace ccf::js
       "bufToJsonCompatible",
       JS_NewCFunction(
         ctx, js_buf_to_json_compatible, "bufToJsonCompatible", 1));
-    JS_SetPropertyStr(
-      ctx,
-      ccf,
-      "generateAesKey",
-      JS_NewCFunction(ctx, js_generate_aes_key, "generateAesKey", 1));
-    JS_SetPropertyStr(
-      ctx,
-      ccf,
-      "generateRsaKeyPair",
-      JS_NewCFunction(ctx, js_generate_rsa_key_pair, "generateRsaKeyPair", 1));
-    JS_SetPropertyStr(
-      ctx, ccf, "wrapKey", JS_NewCFunction(ctx, js_wrap_key, "wrapKey", 3));
-    JS_SetPropertyStr(
-      ctx, ccf, "digest", JS_NewCFunction(ctx, js_digest, "digest", 2));
-    JS_SetPropertyStr(
-      ctx,
-      ccf,
-      "isValidX509CertBundle",
-      JS_NewCFunction(
-        ctx, js_is_valid_x509_cert_bundle, "isValidX509CertBundle", 1));
-    JS_SetPropertyStr(
-      ctx,
-      ccf,
-      "isValidX509CertChain",
-      JS_NewCFunction(
-        ctx, js_is_valid_x509_cert_chain, "isValidX509CertChain", 2));
-    JS_SetPropertyStr(
-      ctx, ccf, "pemToId", JS_NewCFunction(ctx, js_pem_to_id, "pemToId", 1));
+
     JS_SetPropertyStr(
       ctx,
       ccf,
@@ -1285,12 +1257,6 @@ namespace ccf::js
 
     auto crypto = JS_NewObject(ctx);
     JS_SetPropertyStr(ctx, ccf, "crypto", crypto);
-
-    JS_SetPropertyStr(
-      ctx,
-      crypto,
-      "verifySignature",
-      JS_NewCFunction(ctx, js_verify_signature, "verifySignature", 4));
 
     if (txctx != nullptr)
     {


### PR DESCRIPTION
Feedback needed:
- I added a new `add_ccf_plugin` function to `ccf_app.cmake` which under the hood is not really plugin specific but just produces static enclave/virtual libraries linked against the `ccf` base library. Does this make sense?
- I had to opt in to the plugin in all apps as it is generally needed in (JS) constitutions. It seems a bit boilerplate-y given that likely all apps need it, though on the other hand it allows customization. Opinions?

TODO:
- Changelog entry
- Change JS sample apps / constitutions to use `ccf.crypto.*` instead of `ccf.*`