### PR TITLE
Open Enclave upgrade 0.17.2

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -7,7 +7,7 @@ trigger:
 
 jobs:
   - job: build_and_publish_docs
-    container: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+    container: ccfciteam/ccf-ci:oe0.17.2
     pool:
       vmImage: ubuntu-20.04
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -27,11 +27,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+      image: ccfciteam/ccf-ci:oe0.17.2
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+      image: ccfciteam/ccf-ci:oe0.17.2
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
 variables:

--- a/.daily.yml
+++ b/.daily.yml
@@ -23,11 +23,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+      image: ccfciteam/ccf-ci:oe0.17.2
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache
 
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+      image: ccfciteam/ccf-ci:oe0.17.2
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-20.04
-    container: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+    container: ccfciteam/ccf-ci:oe0.17.2
 
     steps:
       - name: Checkout repository

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -16,7 +16,7 @@ pr:
 resources:
   containers:
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+      image: ccfciteam/ccf-ci:oe0.17.2
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.stress.yml
+++ b/.stress.yml
@@ -21,7 +21,7 @@ schedules:
 resources:
   containers:
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.1-focal-lite
+      image: ccfciteam/ccf-ci:oe0.17.2
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Improved performance for lookup of path-templated endpoints (#2918).
 - Raised the minimum supported CMake version for building CCF to 3.16 (#2946).
 
+### Dependency
+
+- Upgrade OpenEnclave from 0.17.1 to 0.17.2
+
 ## [2.0.0-dev3]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Dependency
 
-- Upgrade OpenEnclave from 0.17.1 to 0.17.2
+- Upgrade OpenEnclave from 0.17.1 to 0.17.2 (#2992)
 
 ## [2.0.0-dev3]
 

--- a/getting_started/setup_vm/roles/openenclave/vars/common.yml
+++ b/getting_started/setup_vm/roles/openenclave/vars/common.yml
@@ -1,6 +1,6 @@
-oe_ver: "0.17.1"
+oe_ver: "0.17.2"
 # Usually the same, except for rc, where ver is -rc and ver_ is _rc
-oe_ver_: "0.17.1"
+oe_ver_: "0.17.2"
 
 # Source install
 workspace: "/tmp/"


### PR DESCRIPTION
To be cherry-picked on LTS. This minor release of Open Enclave picks up the latest OpenSSL (1.1.1l) and its CVE fixes.

Open Enclave release notes: https://github.com/openenclave/openenclave/releases/tag/v0.17.2
OpenSSL release notes: https://www.openssl.org/news/openssl-1.1.1-notes.html 