### PR TITLE
Python infra: Fix node ID gap in recovery

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Bonsensus
+Quack

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -127,13 +127,7 @@ class Network:
         else:
             self.consortium = existing_network.consortium
             self.users = existing_network.users
-            # When creating a new network from an existing one (e.g. for recovery),
-            # the node id of the nodes of the new network should start from the node
-            # id of the existing network, so that new nodes id match the ones in the
-            # nodes KV table
-            self.next_node_id = (
-                len(existing_network.nodes) + existing_network.next_node_id
-            )
+            self.next_node_id = existing_network.next_node_id
             self.txs = existing_network.txs
             self.jwt_issuer = existing_network.jwt_issuer
 


### PR DESCRIPTION
On recovery, the first node local ID was wrongly set to how many nodes were in the previous service + the next local ID to allocate. For example, when recovering a 3-node service (IDs: 0, 1 and 2), the first recovery node ID was 6 (instead of 3) 