### PR TITLE
Force makefile generator on mbedtls build

### DIFF
--- a/getting_started/setup_vm/roles/ccf_build/tasks/install.yml
+++ b/getting_started/setup_vm/roles/ccf_build/tasks/install.yml
@@ -32,7 +32,7 @@
 
 - name: Build mbedtls
   shell: |
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON ..
+    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON ..
     make
   args:
     chdir: "{{ workspace }}/mbedtls-{{ mbedtls_dir }}/build"


### PR DESCRIPTION
My environment had an override for the default generator do be ninja and
the ansible-playbook failed. This forces the generator, regardless of
what your default is.

Fixes #2993