### PR TITLE
Shim fixes for channel connection failures

### DIFF
--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -196,9 +196,12 @@ namespace ccf
         // successful
         *local_nonce = recv_nonce.nonce;
 
-        // Now safe to forget the key establishment context - we've successfully
-        // decrypted something from the peer
-        kex_ctx.free_ctx();
+        if (!key_exchange_in_progress)
+        {
+          // Now safe to forget the key establishment context - we've
+          // successfully decrypted something from the peer
+          kex_ctx.free_ctx();
+        }
       }
 
       size_t num_messages = send_nonce + recv_nonce.nonce;


### PR DESCRIPTION
Opening as a Draft because I'd like to run this through the CI a few times.

This includes 2 quick-fixes for channel connection issues that are also covered by #2801. In particular, they create nodes that are able to successfully co-exist with nodes built from #2801, so if this makes a release then #2801 should be able to pass the `lts_compatibility` test. Whether we actually want to make that multi-step release is another question - it would force (or at least strongly encourage) users to include this intermediate release in their upgrade path, where I believe other than this we're happy for them to skip releases? Though I guess we don't claim that's safe in the compatibility report.

The 2 fixes, commented inline but described further here:
- If a node is in `WAITING_FOR_FINAL` and receives an `init` message, reset and obey the `init`. This was one of the stalls of the current channels code, historically only seen with channel-closure but possible in any real deployment with message loss. When Node A processes an `init` message from Node B and sends a `response`, it enters state `WAITING_FOR_FINAL`. If that `response` is lost, Node A is stuck in this state forever. Post-#2801, Node A would periodically try to re-send that `response`, and also allow fresh initiation attempts from Node B to take precedence (sending a _new_ `response` applicable to B's latest context). This PR has a simple fix to get the latter behaviour but not the former, which means that if the peer has the #2801 behaviour (resending and re-attempting new establishments), this node will at least accept them, though it would not re-initiate itself.
- When a node receives a `response` message, it derives its encryption key and (in current code) discards the key exchange context it had built. It sends a `final` message allowing the peer to do the same. However, if that `final` message is never received, then the peer cannot successfully encrypt/decrypt over this channel, the channel appears `ESTABLISHED` on one end but does not allow communication. If the peer is running #2801, that peer will indicate that it thinks the connection is incomplete by re-sending the `response` message. The old code is unable to process it because it has discarded its key exchange context. This PR changes that so the context is retained, after it's been used locally (but we can't be sure that we'll never need it again), so that we successfully process duplicate `response` messages. Then only once we've successfully decrypted a message over a channel (thus confirming that the peer has finished with the context) do we discard it locally.

I haven't added any tests of this behaviour, other than locally running against the #2801 branch. I think this change transposes the possible connection failures rather than fully resolving them (ie - if the transport layer actually produces _duplicate_ `response` messages, we re-generate our end of the channel and can't talk to the peer?), but I think that's a necessary stepping stone.