### PR TITLE
Move `partitions_cft` to its own CTest configuration

### DIFF
--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -42,7 +42,7 @@ jobs:
       cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.debug.cmake_args }} ${{ parameters.build.NoSGX.cmake_args }}"
       suffix: "Instrumented"
       artifact_name: "NoSGX_Instrumented"
-      ctest_filter: '-LE "benchmark|perf|partitions"'
+      ctest_filter: '-LE "benchmark|perf"'
       ctest_timeout: "300"
       timeoutInMinutes: 120
 
@@ -53,7 +53,7 @@ jobs:
       cmake_args: "${{ parameters.build.common.cmake_args }} -DTLS_TEST=ON -DSHUFFLE_SUITE=ON -DENABLE_BFT=OFF"
       suffix: "Release"
       artifact_name: "SGX_Release"
-      ctest_filter: '-LE "benchmark|perf|rotation|partitions"'
+      ctest_filter: '-LE "benchmark|perf|rotation"'
 
   - template: common.yml
     parameters:
@@ -62,4 +62,4 @@ jobs:
       cmake_args: "${{ parameters.build.common.cmake_args }} -DTLS_TEST=ON -DSHUFFLE_SUITE=ON -DENABLE_BFT=OFF"
       suffix: "Release"
       artifact_name: "SGX_IceLake_Release"
-      ctest_filter: '-LE "benchmark|perf|rotation|partitions"'
+      ctest_filter: '-LE "benchmark|perf|rotation"'

--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -35,7 +35,7 @@ parameters:
     perf:
       ctest_args: '-L "benchmark|perf|vegeta"'
     release:
-      ctest_args: ''
+      ctest_args: ""
 
 jobs:
   # Debug

--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -29,13 +29,13 @@ parameters:
 
   test:
     NoSGX:
-      ctest_args: '-LE "benchmark|perf|tlstest|vegeta|partitions|suite"'
+      ctest_args: '-LE "benchmark|perf|tlstest|vegeta|suite"'
     SGX:
-      ctest_args: '-LE "benchmark|perf|tlstest|vegeta|partitions|suite"'
+      ctest_args: '-LE "benchmark|perf|tlstest|vegeta|suite"'
     perf:
       ctest_args: '-L "benchmark|perf|vegeta"'
     release:
-      ctest_args: '-LE "partitions"'
+      ctest_args: ''
 
 jobs:
   # Debug

--- a/.azure-pipelines-templates/test.yml
+++ b/.azure-pipelines-templates/test.yml
@@ -18,7 +18,7 @@ steps:
   - ${{ if ne(parameters.suffix, 'Perf') }}:
       - script: |
           set -ex
-          sudo bash -c "source env/bin/activate && ctest -VV --timeout ${{ parameters.ctest_timeout }} --no-compress-output -L partitions"
+          sudo bash -c "source env/bin/activate && ctest -VV --timeout ${{ parameters.ctest_timeout }} --no-compress-output -L partitions -C partitions"
         env:
           CTEST_TIMEOUT: "${{ parameters.ctest_timeout }}"
         condition: succeededOrFailed()

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -29,6 +29,6 @@ jobs:
       cmake_args: "-DCOMPILE_TARGETS=sgx -DWORKER_THREADS=2"
       suffix: "MultiThread"
       artifact_name: "MultiThread"
-      ctest_filter: '-LE "perf|partitions|bft"'
+      ctest_filter: '-LE "perf|bft"'
       ctest_timeout: "0" # No timeout
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -633,6 +633,7 @@ if(BUILD_TESTS)
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/partitions_test.py
     CONSENSUS cft
     LABEL partitions
+    CONFIGURATIONS partitions
     # Higher snapshot interval as the test currently assumes that no
     # transactions are emitted while partitions are up. To be removed when
     # https://github.com/microsoft/CCF/issues/2577 is implemented


### PR DESCRIPTION
As noted in #2996, we have a CTest test case which requires root permissions, meaning that new users trying a straight build-and-run will see errors. Instead of requiring them to provide root permissions, I think we should move that test to a standalone configuration so it is only run on-demand (by passing `-C partitions`).

Fixes #2996.