### PR TITLE
Tweak arg names and behaviour of ConcurrentRunner

### DIFF
--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -265,7 +265,7 @@ class ConcurrentRunner:
 
         if self.args.N:
             for thread in self.threads:
-                print(thread)
+                print(thread.name)
             return
 
         if self.args.R:

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -234,11 +234,15 @@ class ConcurrentRunner:
         def add(parser):
             parser.add_argument(
                 "-N",
-                help="List all sub-tests",
+                "--show-only",
+                help="List all sub-tests without executing",
                 action="store_true",
             )
             parser.add_argument(
-                "-R", help="Run sub-tests whose name includes this string"
+                "-R",
+                "--regex",
+                help="Run sub-tests whose name includes this string",
+                metavar="<string>",
             )
             if add_options:
                 add_options(parser)
@@ -263,15 +267,15 @@ class ConcurrentRunner:
         }
         LOG.configure(**config)
 
-        if self.args.N:
+        if self.args.regex:
+            self.threads = [
+                thread for thread in self.threads if self.args.regex in thread.name
+            ]
+
+        if self.args.show_only:
             for thread in self.threads:
                 print(thread.name)
             return
-
-        if self.args.R:
-            self.threads = [
-                thread for thread in self.threads if self.args.R in thread.name
-            ]
 
         if max_concurrent is None:
             max_concurrent = len(self.threads)


### PR DESCRIPTION
Giving these args long names for readability:

```
python ... --help
...
  -N, --show-only       List all sub-tests without executing (default: False)
  -R <string>, --regex <string>
                        Run sub-tests whose name includes this string (default: None)
```

<sub>(Sure it's not really a regex, but it's `-R` to match the CTest argument which _is_ a `--regex`, so I think that's what it's _called_ even if it's not what it _does_?)</sub>

Also printing just the thread name rather than the raw thread object, and filtering before printing to match CTest. Compare:

Old
```
python ... -R cpp -N
...
<Thread(js, initial)>
<Thread(cpp, initial)>
```

New
```
python ... -R cpp -N
...
cpp
```