### PR TITLE
Python infra: improved test description

### DIFF
--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -16,7 +16,9 @@ def description(desc):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            LOG.success(desc)
+            LOG.opt(colors=True, depth=1).info(
+                f'<magenta>Test: {desc} {(kwargs or "")}</>'
+            )
             return func(*args, **kwargs)
 
         return wrapper


### PR DESCRIPTION
Finding where a test starts in a full CI run was tedious. We now colour the test name differently. We also include the list of `kwargs` arguments to the test, to differentiate the same test called with different arguments. 

![image](https://user-images.githubusercontent.com/42961061/134032437-da1508bd-d6de-43f0-87b2-e6ca400b4738.png)