### PR TITLE
Fix issue with latest tag and release in progress

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Quack
+Quack Quack Quack


### PR DESCRIPTION
During a release, the release tag is created first, but the release itself isn't created until the CI has successfully run. This means that we should ignore existing tags that haven't yet got a release (like we already do for the `lts_compatibility` test). 