### PR TITLE
Simplify objects initialisation in `node_state.h`

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Quack Quack Quack
+Run the daily CI please.

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -354,6 +354,7 @@ namespace ccf
       setup_history();
       setup_progress_tracker();
       setup_snapshotter();
+      setup_encryptor();
 
       switch (start_type)
       {
@@ -371,7 +372,6 @@ namespace ccf
             open_frontend(ActorsType::members);
           }
 
-          setup_encryptor();
           setup_consensus(ServiceStatus::OPENING, false, endorsed_node_cert);
 
           // Become the primary and force replication
@@ -414,13 +414,6 @@ namespace ccf
 
           network.identity = std::make_unique<ReplicatedNetworkIdentity>(
             "CN=CCF Network", curve_id);
-
-          // It is necessary to give an encryptor to the store for it to
-          // deserialise the public domain when recovering the public ledger.
-          // Once the public recovery is complete, the existing encryptor is
-          // replaced with a new one initialised with the recovered ledger
-          // secrets.
-          setup_encryptor();
 
           bool from_snapshot = !config.startup_snapshot.empty();
           setup_recovery_hook();
@@ -550,7 +543,6 @@ namespace ccf
                 resp.network_info->endorsed_certificate.value();
             }
 
-            setup_encryptor();
             setup_consensus(
               resp.network_info->service_status.value_or(
                 ServiceStatus::OPENING),
@@ -954,7 +946,6 @@ namespace ccf
       }
 
       network.ledger_secrets->init(last_recovered_signed_idx + 1);
-      setup_encryptor();
 
       // Initialise snapshotter after public recovery
       snapshotter->init_after_public_recovery();

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1946,6 +1946,11 @@ namespace ccf
 
     void setup_history()
     {
+      if (history)
+      {
+        throw std::logic_error("History already initialised");
+      }
+
       history = std::make_shared<MerkleTxHistory>(
         *network.tables.get(),
         self,
@@ -1953,14 +1958,16 @@ namespace ccf
         sig_tx_interval,
         sig_ms_interval,
         true);
-
       network.tables->set_history(history);
     }
 
     void setup_encryptor()
     {
-      // This function makes use of ledger secrets and should be called once
-      // the node has joined the service
+      if (encryptor)
+      {
+        throw std::logic_error("Encryptor already initialised");
+      }
+
       encryptor = make_encryptor();
       network.tables->set_encryptor(encryptor);
     }
@@ -1973,7 +1980,6 @@ namespace ccf
     {
       setup_n2n_channels(endorsed_node_certificate_);
       setup_cmd_forwarder();
-      setup_tracker_store();
 
       auto request_tracker = std::make_shared<aft::RequestTracker>();
       auto view_change_tracker = std::make_unique<aft::ViewChangeTracker>(
@@ -2057,6 +2063,11 @@ namespace ccf
     {
       if (network.consensus_type == ConsensusType::BFT)
       {
+        if (progress_tracker)
+        {
+          throw std::logic_error("Progress tracker already initialised");
+        }
+
         setup_tracker_store();
         progress_tracker =
           std::make_shared<ccf::ProgressTracker>(tracker_store, self);
@@ -2066,6 +2077,10 @@ namespace ccf
 
     void setup_snapshotter()
     {
+      if (snapshotter)
+      {
+        throw std::logic_error("Snapshotter already initialised");
+      }
       snapshotter = std::make_shared<Snapshotter>(
         writer_factory, network.tables, config.snapshot_tx_interval);
     }

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -353,6 +353,7 @@ namespace ccf
 
       setup_history();
       setup_progress_tracker();
+      setup_snapshotter();
 
       switch (start_type)
       {
@@ -370,7 +371,6 @@ namespace ccf
             open_frontend(ActorsType::members);
           }
 
-          setup_snapshotter();
           setup_encryptor();
           setup_consensus(ServiceStatus::OPENING, false, endorsed_node_cert);
 
@@ -422,7 +422,6 @@ namespace ccf
           // secrets.
           setup_encryptor();
 
-          setup_snapshotter();
           bool from_snapshot = !config.startup_snapshot.empty();
           setup_recovery_hook();
 
@@ -551,7 +550,6 @@ namespace ccf
                 resp.network_info->endorsed_certificate.value();
             }
 
-            setup_snapshotter();
             setup_encryptor();
             setup_consensus(
               resp.network_info->service_status.value_or(

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -352,6 +352,7 @@ namespace ccf
 #endif
 
       setup_history();
+      setup_progress_tracker();
 
       switch (start_type)
       {
@@ -372,7 +373,6 @@ namespace ccf
           setup_snapshotter();
           setup_encryptor();
           setup_consensus(ServiceStatus::OPENING, false, endorsed_node_cert);
-          setup_progress_tracker();
 
           // Become the primary and force replication
           consensus->force_become_primary();
@@ -558,7 +558,6 @@ namespace ccf
                 ServiceStatus::OPENING),
               resp.network_info->public_only,
               n2n_channels_cert);
-            setup_progress_tracker();
             auto_refresh_jwt_keys();
 
             if (resp.network_info->public_only)
@@ -989,7 +988,6 @@ namespace ccf
       }
 
       setup_consensus(ServiceStatus::OPENING, true);
-      setup_progress_tracker();
       auto_refresh_jwt_keys();
 
       LOG_DEBUG_FMT(

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -351,6 +351,8 @@ namespace ccf
       }
 #endif
 
+      setup_history();
+
       switch (start_type)
       {
         case StartType::New:
@@ -371,7 +373,6 @@ namespace ccf
           setup_encryptor();
           setup_consensus(ServiceStatus::OPENING, false, endorsed_node_cert);
           setup_progress_tracker();
-          setup_history();
 
           // Become the primary and force replication
           consensus->force_become_primary();
@@ -413,8 +414,6 @@ namespace ccf
 
           network.identity = std::make_unique<ReplicatedNetworkIdentity>(
             "CN=CCF Network", curve_id);
-
-          setup_history();
 
           // It is necessary to give an encryptor to the store for it to
           // deserialise the public domain when recovering the public ledger.
@@ -560,7 +559,6 @@ namespace ccf
               resp.network_info->public_only,
               n2n_channels_cert);
             setup_progress_tracker();
-            setup_history();
             auto_refresh_jwt_keys();
 
             if (resp.network_info->public_only)


### PR DESCRIPTION
As touched on #2991, most objects (e.g. `history`, `encryptor`) were initialised in multiple places in `node_state.h` because the node ID (`self`) wasn't known until the node had joined or recovered the service. This is no longer the case since node IDs are now derived from the node's public key, so attempting to simplify this. 