### PR TITLE
Bump daily timeout

### DIFF
--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -43,7 +43,7 @@ jobs:
       suffix: "Instrumented"
       artifact_name: "NoSGX_Instrumented"
       ctest_filter: '-LE "benchmark|perf"'
-      ctest_timeout: "300"
+      ctest_timeout: "360"
       timeoutInMinutes: 120
 
   - template: common.yml

--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -43,7 +43,7 @@ jobs:
       suffix: "Instrumented"
       artifact_name: "NoSGX_Instrumented"
       ctest_filter: '-LE "benchmark|perf"'
-      ctest_timeout: "360"
+      ctest_timeout: "600"
       timeoutInMinutes: 120
 
   - template: common.yml

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1214,7 +1214,7 @@ def test_receipts(network, args):
 @reqs.description("Validate random receipts")
 @reqs.supports_methods("receipt", "log/private")
 @reqs.at_least_n_nodes(2)
-def test_random_receipts(network, args, lts=False):
+def test_random_receipts(network, args, lts=True):
     primary, _ = network.find_primary_and_any_backup()
 
     common = os.listdir(network.common_dir)
@@ -1325,7 +1325,7 @@ def run(args):
             network = test_liveness(network, args)
             network = test_rekey(network, args)
             network = test_liveness(network, args)
-            network = test_random_receipts(network, args)
+            network = test_random_receipts(network, args, False)
         if args.package == "samples/apps/logging/liblogging":
             network = test_receipts(network, args)
         network = test_historical_receipts(network, args)


### PR DESCRIPTION
lts_compatibility was getting close to 300, and now exceeds it because receipt verification has become more expensive as a result of #2991.