### PR TITLE
add small doc amendment + change run.sh in setup_vm

### DIFF
--- a/doc/build_apps/create_vm.rst
+++ b/doc/build_apps/create_vm.rst
@@ -4,8 +4,9 @@ Create Azure SGX VM
 :term:`Azure Confidential Compute` (ACC) offers SGX-enabled `DC`_-series VMs, which can be deployed like other Azure SKUs.
 Note that `DC`_ SKUs can only be configured as `Gen2`_ VMs, and so only `Gen2`_ compatible VM images can be used.
 
-.. note:: If you use `Visual Studio Code <https://code.visualstudio.com/>`_, you can install and set up the `Remote - SSH <https://code.visualstudio.com/docs/remote/ssh-tutorial>`_ extension to connect to your SGX-enabled VM.
+Your ACC VM must be deployed with Ubuntu 16.04 or 18.04 and then upgraded to Ubuntu 20.04 using `do-release-upgrade` before CCF can be installed.
 
+.. note:: If you use `Visual Studio Code <https://code.visualstudio.com/>`_, you can install and set up the `Remote - SSH <https://code.visualstudio.com/docs/remote/ssh-tutorial>`_ extension to connect to your SGX-enabled VM.
 
 .. _`DC`: https://docs.microsoft.com/en-us/azure/virtual-machines/dcv2-series
 .. _`Gen2`: https://docs.microsoft.com/en-us/azure/virtual-machines/generation-2

--- a/getting_started/setup_vm/run.sh
+++ b/getting_started/setup_vm/run.sh
@@ -4,8 +4,6 @@
 
 set -ex
 
-sudo apt-get update
-sudo apt install software-properties-common
-sudo add-apt-repository -y --update ppa:ansible/ansible
-sudo apt install ansible -y
+sudo apt install python3-pip
+pip install ansible-base
 ansible-playbook "$@"

--- a/getting_started/setup_vm/run.sh
+++ b/getting_started/setup_vm/run.sh
@@ -4,6 +4,10 @@
 
 set -ex
 
-sudo apt install python3-pip
+# Install ansible-base rather than ansible because service_facts
+# is broken on Ubuntu 20.04 with the default apt package.
+# See https://github.com/ansible/ansible/issues/68536 (fixed in ansible >= 2.10)
+sudo apt-get update
+sudo apt install -y python3-pip
 pip install ansible-base
 ansible-playbook "$@"

--- a/getting_started/setup_vm/run.sh
+++ b/getting_started/setup_vm/run.sh
@@ -4,11 +4,8 @@
 
 set -ex
 
-# Install ansible-base rather than ansible because service_facts
-# is broken on Ubuntu 20.04 with the default apt package.
-# See https://github.com/ansible/ansible/issues/68536 (fixed in ansible >= 2.10)
 sudo apt-get update
 sudo apt install software-properties-common
 sudo add-apt-repository -y --update ppa:ansible/ansible
-sudo apt install ansible-base -y
+sudo apt install ansible -y
 ansible-playbook "$@"


### PR DESCRIPTION
Added a clear instruction to docs to upgrade the Azure CC VM to Ubuntu 20.04 using `do-release-upgrade`.

Changed `run.sh` to install `python3-pip` and then `ansible-base` via pip. This is because `ansible-base` can no longer be found in Ubuntu 20's `ppa:ansible/ansible` apt repository.