### PR TITLE
V8 pipeline publishing artifact

### DIFF
--- a/.azure-pipelines-v8.yml
+++ b/.azure-pipelines-v8.yml
@@ -1,0 +1,48 @@
+trigger:
+  batch: false
+
+variables:
+  pushArtifact: $(PUSH_ARTIFACT)
+  pkg-ver: $(VERSION)
+
+jobs:
+  - job: build_v8
+    container: ccfciteam/ccf-ci:oe0.17.2-docker-cli
+    pool: 1es-dv4-focal
+
+    steps:
+      - checkout: self
+        clean: true
+
+      - script: |
+          sudo apt update
+          sudo apt install -y pkg-config
+        displayName: "Install dependencies"
+
+      - script: scripts/build-v8.sh $(VERSION) $(PUSH_ARTIFACT)
+        displayName: "Build V8"
+
+      - script: |
+          # Universal Packages versions only take three sections X.Y.Z.
+          # V8 versions have four sections, with the first two as the chromium version.
+          #   Ex: 9.4.146.17 (Chromium version 94)
+          export MAJOR=$(echo $(VERSION) | cut -d "." -f 1,2 | sed 's/\.//')
+          # We also want our build version to increment, so we also join the last two.
+          #   Ex: 9.4.146.17 -> 94.14617.$(Build.BuildId)
+          export MINOR=$(echo $(VERSION) | cut -d "." -f 3,4 | sed 's/\.//')
+          echo '##vso[task.setvariable variable=pkg-ver]'$MAJOR.$MINOR.$(Build.BuildId)
+          mv build-v8/v8.tar.xz $(Build.ArtifactStagingDirectory)/v8-$(pkg-ver).tar.xz
+        displayName: "Prepare Artifact Staging Directory"
+        condition: eq(variables.pushArtifact, 'true')
+
+      - task: UniversalPackages@0
+        displayName: "Publish V8 Artifact"
+        inputs:
+          command: publish
+          publishDirectory: '$(Build.ArtifactStagingDirectory)'
+          vstsFeedPublish: 'CCF/V8'
+          vstsFeedPackagePublish: 'ccf-v8-$(pkg-ver).tar.xz'
+          versionOption: custom
+          versionPublish: '$(pkg-ver)'
+          packagePublishDescription: 'CCF build of monolith V8'
+        condition: eq(variables.pushArtifact, 'true')

--- a/.azure-pipelines-v8.yml
+++ b/.azure-pipelines-v8.yml
@@ -39,10 +39,10 @@ jobs:
         displayName: "Publish V8 Artifact"
         inputs:
           command: publish
-          publishDirectory: '$(Build.ArtifactStagingDirectory)'
-          vstsFeedPublish: 'CCF/V8'
-          vstsFeedPackagePublish: 'ccf-v8-$(pkg-ver).tar.xz'
+          publishDirectory: "$(Build.ArtifactStagingDirectory)"
+          vstsFeedPublish: "CCF/V8"
+          vstsFeedPackagePublish: "ccf-v8-$(pkg-ver).tar.xz"
           versionOption: custom
-          versionPublish: '$(pkg-ver)'
-          packagePublishDescription: 'CCF build of monolith V8'
+          versionPublish: "$(pkg-ver)"
+          packagePublishDescription: "CCF build of monolith V8"
         condition: eq(variables.pushArtifact, 'true')

--- a/scripts/build-v8.sh
+++ b/scripts/build-v8.sh
@@ -5,7 +5,7 @@
 SYNTAX="build-v8.sh <version (ex. 9.4.146.17)> [publish (true|false)]"
 if [ "$1" == "" ]; then
   echo "ERROR: Missing expected argument 'version'"
-  echo $SYNTAX
+  echo "$SYNTAX"
   exit 1
 fi
 EXPECTED_VERSION="$1"
@@ -16,7 +16,7 @@ if [ "$2" != "" ]; then
     PUBLISH="$2"
   elif [ "$2" != "false" ]; then
     echo "ERROR: Publis can only be 'true' or 'false'"
-    echo $SYNTAX
+    echo "$SYNTAX"
     exit 1
   fi
 fi
@@ -24,24 +24,27 @@ fi
 echo " + Cleaning up environment..."
 rm -rf build-v8
 mkdir build-v8
-cd build-v8
+# This should never fail but CI lint requires it
+cd build-v8 || exit
 
 echo " + Checking V8 build dependencies..."
 git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 export PATH=$PATH:$PWD/depot_tools
-if [ "$(which gn)" == "" ] ||
-   [ "$(which fetch)" == "" ] ||
-   [ "$(which gclient)" == "" ]; then
+if command -v gn > /dev/null &&
+   command -v fetch > /dev/null &&
+   command -v gclient > /dev/null; then
+  echo "depot_tools installation successful"
+else
   echo "ERROR: depot_tools installation unsuccessful"
   exit 1
 fi
 
 echo " + Fetching V8 on known stable branch..."
 fetch v8
-cd v8
+cd v8 || exit
 # This is known stable on all platforms according to omahaproxy.appspot.com
-CHECKOUT_BANCH=branch-heads/$MAJOR_VERSION
-git checkout $CHECKOUT_BANCH
+CHECKOUT_BANCH="branch-heads/$MAJOR_VERSION"
+git checkout "$CHECKOUT_BANCH"
 VERSION=$(git show | grep -o "$EXPECTED_VERSION")
 if [ "$VERSION" != "$EXPECTED_VERSION" ]; then
   echo "ERROR: Invalid version $VERSION for checkout $CHECKOUT_BANCH"

--- a/scripts/build-v8.sh
+++ b/scripts/build-v8.sh
@@ -15,7 +15,7 @@ if [ "$2" != "" ]; then
   if [ "$2" == "true" ]; then
     PUBLISH="$2"
   elif [ "$2" != "false" ]; then
-    echo "ERROR: Publis can only be 'true' or 'false'"
+    echo "ERROR: Publish can only be 'true' or 'false'"
     echo "$SYNTAX"
     exit 1
   fi

--- a/scripts/build-v8.sh
+++ b/scripts/build-v8.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+SYNTAX="build-v8.sh <version (ex. 9.4.146.17)> [publish (true|false)]"
+if [ "$1" == "" ]; then
+  echo "ERROR: Missing expected argument 'version'"
+  echo $SYNTAX
+  exit 1
+fi
+EXPECTED_VERSION="$1"
+MAJOR_VERSION="${1%.*.*}"
+PUBLISH=false
+if [ "$2" != "" ]; then
+  if [ "$2" == "true" ]; then
+    PUBLISH="$2"
+  elif [ "$2" != "false" ]; then
+    echo "ERROR: Publis can only be 'true' or 'false'"
+    echo $SYNTAX
+    exit 1
+  fi
+fi
+
+echo " + Cleaning up environment..."
+rm -rf build-v8
+mkdir build-v8
+cd build-v8
+
+echo " + Checking V8 build dependencies..."
+git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+export PATH=$PATH:$PWD/depot_tools
+if [ "$(which gn)" == "" ] ||
+   [ "$(which fetch)" == "" ] ||
+   [ "$(which gclient)" == "" ]; then
+  echo "ERROR: depot_tools installation unsuccessful"
+  exit 1
+fi
+
+echo " + Fetching V8 on known stable branch..."
+fetch v8
+cd v8
+# This is known stable on all platforms according to omahaproxy.appspot.com
+CHECKOUT_BANCH=branch-heads/$MAJOR_VERSION
+git checkout $CHECKOUT_BANCH
+VERSION=$(git show | grep -o "$EXPECTED_VERSION")
+if [ "$VERSION" != "$EXPECTED_VERSION" ]; then
+  echo "ERROR: Invalid version $VERSION for checkout $CHECKOUT_BANCH"
+  exit 1
+fi
+
+echo " + Install build dependencies..."
+./build/install-build-deps.sh --quick-check --no-arm --no-nacl --syms
+gclient sync -D
+
+echo " + Build V8 monolith mode..."
+# This is a mash of options from v8/infra/mb/mb_config.pyl
+OUT_DIR="out.gn/x64.debug"
+gn gen "$OUT_DIR" --args='v8_monolithic=true is_component_build=false v8_use_external_startup_data=false use_custom_libcxx=false is_debug=true v8_enable_backtrace=true use_lld=true target_cpu="x64" use_goma=false'
+ninja -C "$OUT_DIR" v8_monolith
+if [ ! -f "$OUT_DIR/obj/libv8_monolith.a" ]; then
+  echo "ERROR: Compilation unsuccessful, bailing out"
+  exit 1
+fi
+
+echo " + Create install dir..."
+mkdir -p install/lib
+cp -rv include install
+cp -v "$OUT_DIR"/icudtl.dat install/lib
+cp -rv "$OUT_DIR"/obj/*.a install/lib
+cp -rv "$OUT_DIR"/obj/third_party/icu/*.a install/lib
+du -sh install
+
+# Always test, even when we don't want to publish
+echo " + Test install..."
+COMPILER=third_party/llvm-build/Release+Asserts/bin/clang++
+$COMPILER -fuse-ld=lld -Iinstall -Iinstall/include samples/hello-world.cc -o hello_world -ldl -lv8_monolith -Linstall/lib -pthread -std=c++14 -DV8_COMPRESS_POINTERS
+OUTPUT="$(./hello_world | grep "3 + 4 = 7")"
+if [ "$OUTPUT" == "" ]; then
+  echo "ERROR: Hello World test failed"
+  exit 1
+fi
+
+$COMPILER -fuse-ld=lld -Iinstall -Iinstall/include samples/process.cc -o process -ldl -lv8_monolith -Linstall/lib -pthread -std=c++14 -DV8_COMPRESS_POINTERS
+OUTPUT="$(./process samples/count-hosts.js | grep "yahoo.com: 3")"
+if [ "$OUTPUT" == "" ]; then
+  echo "ERROR: Process test failed"
+  exit 1
+fi
+
+# Only generate tarball if asked to publish
+# Creates in .../build-v8/ root
+if [ "$PUBLISH" == "true" ]; then
+  echo " + Generate the tarball..."
+  tar Jcf ../v8.tar.xz install
+fi


### PR DESCRIPTION
Creating a script to build V8 and a pipeline config to run that,
publishing an artifact with the monolith version (ready for embedding).

The pipeline has two build options:
 * VERSION (mandatory): ex. 9.4.146.17
 * PUSH_ARTIFACT: true|false

We only need to publish the artifact once, but we can continue to build
making sure the build still works with the expected version, which it
won't if the version is updated upstream.

The version of the artifact needs to be changed due to Universal
Packages' constraints. It can only accept three sections, but with the
four from V8 and one from our builds, we'd have five.

Given that the first two sections in V8's version is the Chrome version
(ex. 9.4 -> 94), we join them. We also need to join the two last ones,
so that we can add a build ID.

The final versioning scheme is:
 * 9.4.146.17  ->  94.14617.$BuildId

This does create the problem where 14.617 and 146.17 yield the same
version on our side, but our builds of V8 will probably be few and far
between that we can worry about that when it stops us from progressing.

To download the latest 94.14617, use version "94.14617.*", or even the
latest 94, just use "94.*".

Example of a run publishing results: [#20210928.4](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=33424&view=logs&j=87e1acf2-5cf1-59b7-1e41-180861913346)
[Artifact published](https://dev.azure.com/MSRC-CCF/CCF/_packaging?_a=package&feed=V8&package=ccf-v8-94.14617.33424.tar.xz&protocolType=UPack&version=94.14617.33424)

Example of a run not publishing results: [#20210928.5](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=33425&view=logs&j=87e1acf2-5cf1-59b7-1e41-180861913346)