### PR TITLE
Channels fix: Resolve lts_compatibility test failures

### DIFF
--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -406,6 +406,10 @@ namespace ccf
       {
         // Whatever else we _were_ doing, we've received a valid init from them
         // - reset to use it
+        if (status.check(ESTABLISHED))
+        {
+          kex_ctx.reset();
+        }
         peer_cert = cert;
         peer_cv = verifier;
       }

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -406,7 +406,6 @@ namespace ccf
       {
         // Whatever else we _were_ doing, we've received a valid init from them
         // - reset to use it
-        kex_ctx.reset();
         peer_cert = cert;
         peer_cv = verifier;
       }

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -629,10 +629,6 @@ namespace ccf
               "Node has now joined the network as node {}: {}",
               self,
               (resp.network_info->public_only ? "public only" : "all domains"));
-
-            // TODO: Remove this before committing
-            LOG_FAIL_FMT("Sleeping for an extremely long time!");
-            std::this_thread::sleep_for(std::chrono::milliseconds(200));
           }
           else if (resp.node_status == NodeStatus::PENDING)
           {

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -629,6 +629,10 @@ namespace ccf
               "Node has now joined the network as node {}: {}",
               self,
               (resp.network_info->public_only ? "public only" : "all domains"));
+
+            // TODO: Remove this before committing
+            LOG_FAIL_FMT("Sleeping for an extremely long time!");
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
           }
           else if (resp.node_status == NodeStatus::PENDING)
           {

--- a/src/tls/key_exchange.h
+++ b/src/tls/key_exchange.h
@@ -158,23 +158,23 @@ namespace tls
         throw std::runtime_error("Missing peer key share");
       }
 
-      int rc = mbedtls_ecdh_read_public(ctx.get(), ks.p, ks.n);
-      if (rc != 0)
-      {
-        throw std::logic_error(error_string(rc));
-      }
-
       peer_key_share = {ks.p, ks.p + ks.n};
     }
 
     std::vector<uint8_t> compute_shared_secret()
     {
+      int rc = mbedtls_ecdh_read_public(ctx.get(), peer_key_share.data(), peer_key_share.size());
+      if (rc != 0)
+      {
+        throw std::logic_error(error_string(rc));
+      }
+
       crypto::EntropyPtr entropy = crypto::create_entropy();
 
       // Should only be called once, when peer public has been loaded.
       std::vector<uint8_t> shared_secret(len_shared_secret);
       size_t len;
-      int rc = mbedtls_ecdh_calc_secret(
+      rc = mbedtls_ecdh_calc_secret(
         ctx.get(),
         &len,
         shared_secret.data(),

--- a/src/tls/key_exchange.h
+++ b/src/tls/key_exchange.h
@@ -163,10 +163,15 @@ namespace tls
 
     std::vector<uint8_t> compute_shared_secret()
     {
-      int rc = mbedtls_ecdh_read_public(ctx.get(), peer_key_share.data(), peer_key_share.size());
-      if (rc != 0)
+      int rc;
+      if (peer_key_share.size() > 0)
       {
-        throw std::logic_error(error_string(rc));
+        rc = mbedtls_ecdh_read_public(
+          ctx.get(), peer_key_share.data(), peer_key_share.size());
+        if (rc != 0)
+        {
+          throw std::logic_error(error_string(rc));
+        }
       }
 
       crypto::EntropyPtr entropy = crypto::create_entropy();


### PR DESCRIPTION
Since #2801 we've had a high rate of failures in the `lts_compatibility` build. After investigating the logs I believe I've found the root cause. Opening as a PR with a forced repro initially, and then I'll add the resolution.

A healthy join of a new-node to old-node looks like this:
```
35:10.928 |03|       Node has now joined the network as node n[3=1735]: all domains (node_state.h:578)
35:10.967 |00| Initiating node channel with 3=1735. (channels.h:713)
35:11.035 |00| Node channel with 3=1735 is now established. (channels.h:690)
35:11.059 |03|       Node channel with n[0=2f90] is now established. (channels.h:732)
```

The failures we're seeing look like this:
```
35:17.470 |04|         Node has now joined the network as node n[4=e75f]: all domains (node_state.h:578)
35:17.508 |00| Initiating node channel with 4=e75f. (channels.h:713)
35:17.614 |00| Initiating node channel with 4=e75f. (channels.h:713)
35:17.625 |00| Node channel with 4=e75f is now established. (channels.h:690)
35:17.636 |04|         <- n[0=2f90] (WAITING_FOR_FINAL): Peer certificate verification failed (channels.h:548)
35:17.636 |04|         Node channel with n[0=2f90] cannot receive authenticated message: not established, status=WAITING_FOR_FINAL (channels.h:833)
35:17.636 |04|         Dropped invalid message from n[0=2f90] (raft.h:1001)
```

The key diagnostic is that repeated `Initiating node channel` from Node 0. It attempts to initiate many times before the node is ready, but if it makes multiple attempts late enough (when the target is actually listening and processing them), then they get out-of-sync.

Looking at another repro with verbose logs, this is what's happening on the receiving node (trimmed and [DESCRIBED] for readability):
```
09:37.515 |03|       <- n[1=29e7] (INACTIVE): recv_key_exchange_init(945 bytes, false) (channels.h:337)
09:37.518 |03|       <- n[1=29e7] (INACTIVE): New peer certificate: [CERT FOR NODE 0] (channels.h:661)
09:37.518 |03|       <- n[1=29e7] (INACTIVE): Verifying peer signature with peer certificate serial [CERT FOR NODE 0] (channels.h:676)
09:37.523 |03|       <- n[1=29e7] (INACTIVE): recv_key_exchange_init: version=1 ks=[NODE 0'S KEY SHARE] sig=[SIG A] pc=[CERT FOR NODE 0] salt=[SALT FROM NODE 0] (channels.h:420)
09:37.523 |03|       [Channel to n[1=29e7]] Advancing to state WAITING_FOR_FINAL (from INACTIVE) (state_machine.h:44)
09:37.525 |03|       -> n[1=29e7] (WAITING_FOR_FINAL): send_key_exchange_response: oks=[MY KEY SHARE A], serialised_signed_share=[SIGNED [MY KEY SHARE A]] (channels.h:263)
09:37.525 |03|       <- n[1=29e7] (WAITING_FOR_FINAL): recv_key_exchange_init(946 bytes, false) (channels.h:337)
09:37.528 |03|       <- n[1=29e7] (WAITING_FOR_FINAL): New peer certificate: [CERT FOR NODE 0] (channels.h:661)
09:37.528 |03|       <- n[1=29e7] (WAITING_FOR_FINAL): Verifying peer signature with peer certificate serial [CERT FOR NODE 0] (channels.h:676)
09:37.533 |03|       <- n[1=29e7] (WAITING_FOR_FINAL): recv_key_exchange_init: version=1 ks=[NODE 0'S KEY SHARE] sig=[SIG B] pc=[CERT FOR NODE 0] salt=[SALT FROM NODE 0] (channels.h:420)
09:37.533 |03|       [Channel to n[1=29e7]] Advancing to state WAITING_FOR_FINAL (from WAITING_FOR_FINAL) (state_machine.h:44)
09:37.536 |03|       -> n[1=29e7] (WAITING_FOR_FINAL): send_key_exchange_response: oks=[MY KEY SHARE B], serialised_signed_share=[SIGNED [MY KEY SHARE B]] (channels.h:263)
```

In short, the peer makes multiple initiation attempts with the same key share (ie, same context), while the new code resets its context (regenerates its _own_ key share) every time it receives. The fix is to stick with the old context for local state, potentially using a new share from _their_ end, and only ingest it destructively when we come to deriving the shared secret.