### PR TITLE
Historical query perf improvements: Replace signature verification with GCM header check

### DIFF
--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -40,7 +40,7 @@ namespace kv::test
         replica.push_back(entry);
 
         // Simplification: all entries are replicated in the same term
-        view_history.update(std::get<0>(entry), 2);
+        view_history.update(std::get<0>(entry), 0);
       }
       return true;
     }
@@ -83,7 +83,7 @@ namespace kv::test
 
     std::pair<ccf::View, ccf::SeqNo> get_committed_txid() override
     {
-      return {2, 0};
+      return {0, 0};
     }
 
     std::optional<SignableTxIndices> get_signable_txid() override
@@ -123,12 +123,12 @@ namespace kv::test
 
     ccf::View get_view(ccf::SeqNo seqno) override
     {
-      return 2;
+      return 0;
     }
 
     ccf::View get_view() override
     {
-      return 2;
+      return 0;
     }
 
     std::vector<ccf::SeqNo> get_view_history(ccf::SeqNo seqno) override

--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -100,8 +100,10 @@ namespace ccf::historical
       std::vector<StoreDetailsPtr> requested_stores;
       std::chrono::milliseconds time_to_expiry;
 
+      bool include_receipts;
+
       // Entries from outside the requested range (such as the next signature)
-      // may be needed to trust this range. They are stored here, distinct from
+      // may be needed to produce receipts. They are stored here, distinct from
       // user-requested stores.
       std::optional<std::pair<ccf::SeqNo, StoreDetailsPtr>>
         supporting_signature;
@@ -180,8 +182,8 @@ namespace ccf::historical
         // If the final entry in the new range is known and not a signature,
         // then we may need a subsequent signature to support it (or an earlier
         // entry received out-of-order!) So start fetching subsequent entries to
-        // find supporting signature. Its possible this was the supporting entry
-        // we already had, or a signature in the range we already had, but
+        // find supporting signature. It's possible this was the supporting
+        // entry we already had, or a signature in the range we already had, but
         // working that out is tricky so be pessimistic and refetch instead.
         supporting_signature.reset();
         const auto last_details = get_store_details(last_requested_seqno);
@@ -200,30 +202,24 @@ namespace ccf::historical
         return ret;
       }
 
-      enum class UpdateTrustedResult
+      enum class PopulateReceiptsResult
       {
-        // Common result. The new seqno may have transitioned some entries to
-        // Trusted
+        // Common result. The new seqno may have added receipts for some entries
         Continue,
 
         // Occasional result. The new seqno was at the end of the sequence (or
         // an attempt at retrieving a trailing supporting signature), but we
-        // still have untrusted entries, so attempt to fetch the next
+        // still have receiptless entries, so attempt to fetch the next
         FetchNext,
-
-        // Error result. The new entry exposed a mismatch between a signature's
-        // claim at a certain seqno and the entry we received there. Invalidate
-        // entire request, it can be re-requested if necessary
-        Invalidated,
       };
 
-      UpdateTrustedResult update_trusted(ccf::SeqNo new_seqno)
+      PopulateReceiptsResult populate_receipts(ccf::SeqNo new_seqno)
       {
         auto new_details = get_store_details(new_seqno);
         if (new_details->is_signature)
         {
-          // Iterate through earlier indices. If this signature covers them (and
-          // the digests match), move them to Trusted
+          // Iterate through earlier indices. If this signature covers them
+          // then create a receipt for them
           const auto sig = get_signature(new_details->store);
           ccf::MerkleTreeHistory tree(get_tree(new_details->store).value());
 
@@ -234,45 +230,21 @@ namespace ccf::historical
               auto details = get_store_details(seqno);
               if (details != nullptr)
               {
-                if (details->current_stage == RequestStage::Untrusted)
-                {
-                  // Compare signed digest, from signature mini-tree, with
-                  // digest of the entry which was used to construct this store
-                  const auto& untrusted_digest = details->entry_digest;
-                  const auto trusted_digest = tree.get_leaf(seqno);
-                  if (trusted_digest != untrusted_digest)
-                  {
-                    LOG_FAIL_FMT(
-                      "Signature at {} has a different transaction at {} than "
-                      "previously received",
-                      new_seqno,
-                      seqno);
-
-                    // We trust the signature (since it comes from a trusted
-                    // node), and it disagrees with one of the entries we
-                    // previously retrieved and deserialised. This generally
-                    // means a malicious host gave us a bad transaction but a
-                    // good signature. Delete the entire original request
-                    // - if it is re-requested, maybe the host will give us a
-                    // valid pair of transaction+sig next time
-                    return UpdateTrustedResult::Invalidated;
-                  }
-
-                  auto proof = tree.get_proof(seqno);
-                  details->receipt = std::make_shared<TxReceipt>(
-                    sig->sig,
-                    proof.get_root(),
-                    proof.get_path(),
-                    sig->node,
-                    sig->cert);
-                  details->transaction_id = {sig->view, seqno};
-                  details->current_stage = RequestStage::Trusted;
-                }
+                auto proof = tree.get_proof(seqno);
+                details->receipt = std::make_shared<TxReceipt>(
+                  sig->sig,
+                  proof.get_root(),
+                  proof.get_path(),
+                  sig->node,
+                  sig->cert);
+                // TODO: I think we can set this earlier, since we derive this
+                // from GCM header during deserialisation?
+                details->transaction_id = {sig->view, seqno};
               }
             }
           }
         }
-        else if (new_details->current_stage == RequestStage::Untrusted)
+        else if (new_details->receipt == nullptr)
         {
           // Iterate through later indices, see if there's a signature that
           // covers this one
@@ -290,12 +262,6 @@ namespace ccf::historical
                 ccf::MerkleTreeHistory tree(get_tree(details->store).value());
                 if (tree.in_range(new_seqno))
                 {
-                  const auto trusted_digest = tree.get_leaf(new_seqno);
-                  if (trusted_digest != untrusted_digest)
-                  {
-                    return UpdateTrustedResult::Invalidated;
-                  }
-
                   auto proof = tree.get_proof(new_seqno);
                   details->receipt = std::make_shared<TxReceipt>(
                     sig->sig,
@@ -304,11 +270,10 @@ namespace ccf::historical
                     sig->node,
                     sig->cert);
                   details->transaction_id = {sig->view, new_seqno};
-                  new_details->current_stage = RequestStage::Trusted;
                 }
 
-                // Break here - if this signature doesn't cover us, no later one
-                // can
+                // Break here - if this signature doesn't cover us, no later
+                // one can
                 sig_seen = true;
                 break;
               }
@@ -324,12 +289,6 @@ namespace ccf::historical
               ccf::MerkleTreeHistory tree(get_tree(details->store).value());
               if (tree.in_range(new_seqno))
               {
-                const auto trusted_digest = tree.get_leaf(new_seqno);
-                if (trusted_digest != untrusted_digest)
-                {
-                  return UpdateTrustedResult::Invalidated;
-                }
-
                 auto proof = tree.get_proof(new_seqno);
                 details->receipt = std::make_shared<TxReceipt>(
                   sig->sig,
@@ -338,27 +297,26 @@ namespace ccf::historical
                   sig->node,
                   sig->cert);
                 details->transaction_id = {sig->view, new_seqno};
-                new_details->current_stage = RequestStage::Trusted;
               }
             }
           }
 
-          // If still untrusted, and this non-signature is the last requested
-          // seqno, or previous attempt at finding supporting signature, request
-          // the _next_ seqno to find supporting signature
-          if (new_details->current_stage == RequestStage::Untrusted)
+          // If still have no receipt, and this non-signature is the last
+          // requested seqno, or a previous attempt at finding supporting
+          // signature, request the _next_ seqno to find supporting signature
+          if (new_details->receipt == nullptr)
           {
             if (
               new_seqno == last_requested_seqno ||
               (supporting_signature.has_value() &&
                supporting_signature->first == new_seqno))
             {
-              return UpdateTrustedResult::FetchNext;
+              return PopulateReceiptsResult::FetchNext;
             }
           }
         }
 
-        return UpdateTrustedResult::Continue;
+        return PopulateReceiptsResult::Continue;
       }
     };
 
@@ -476,16 +434,9 @@ namespace ccf::historical
           details != nullptr &&
           details->current_stage == RequestStage::Fetching)
         {
-          if (is_signature)
-          {
-            // Signatures have already been verified by the time we get here, so
-            // we trust them already
-            details->current_stage = RequestStage::Trusted;
-          }
-          else
-          {
-            details->current_stage = RequestStage::Untrusted;
-          }
+          // Deserialisation includes a GCM integrity check, so all entries have
+          // been verified by the time we get here.
+          details->current_stage = RequestStage::Trusted;
 
           details->entry_digest = entry_digest;
 
@@ -497,7 +448,7 @@ namespace ccf::historical
           details->store = store;
 
           details->is_signature = is_signature;
-          if (is_signature)
+          if (is_signature && request.include_receipts)
           {
             // Construct a signature receipt
             const auto sig = get_signature(details->store);
@@ -507,27 +458,25 @@ namespace ccf::historical
             details->transaction_id = {sig->view, sig->seqno};
           }
 
-          const auto result = request.update_trusted(seqno);
-          switch (result)
+          if (request.include_receipts)
           {
-            case (Request::UpdateTrustedResult::Continue):
+            const auto result = request.populate_receipts(seqno);
+            switch (result)
             {
-              ++request_it;
-              break;
-            }
-            case (Request::UpdateTrustedResult::Invalidated):
-            {
-              request_it = requests.erase(request_it);
-              break;
-            }
-            case (Request::UpdateTrustedResult::FetchNext):
-            {
-              const auto next_seqno = seqno + 1;
-              fetch_entry_at(next_seqno);
-              request.supporting_signature =
-                std::make_pair(next_seqno, std::make_shared<StoreDetails>());
-              ++request_it;
-              break;
+              case (Request::PopulateReceiptsResult::Continue):
+              {
+                ++request_it;
+                break;
+              }
+              case (Request::PopulateReceiptsResult::FetchNext):
+              {
+                const auto next_seqno = seqno + 1;
+                fetch_entry_at(next_seqno);
+                request.supporting_signature =
+                  std::make_pair(next_seqno, std::make_shared<StoreDetails>());
+                ++request_it;
+                break;
+              }
             }
           }
         }
@@ -573,7 +522,8 @@ namespace ccf::historical
       RequestHandle handle,
       ccf::SeqNo start_seqno,
       size_t num_following_indices,
-      ExpiryDuration seconds_until_expiry)
+      ExpiryDuration seconds_until_expiry,
+      bool include_receipts)
     {
       std::lock_guard<std::mutex> guard(requests_lock);
 
@@ -589,6 +539,7 @@ namespace ccf::historical
       }
 
       Request& request = it->second;
+      request.include_receipts = include_receipts;
 
       // Update this Request to represent the currently requested range,
       // returning any newly requested indices
@@ -631,7 +582,9 @@ namespace ccf::historical
            ++seqno)
       {
         auto target_details = request.get_store_details(seqno);
-        if (target_details->current_stage == RequestStage::Trusted)
+        if (
+          target_details->current_stage == RequestStage::Trusted &&
+          (!request.include_receipts || target_details->receipt != nullptr))
         {
           // Have this store, associated txid and receipt and trust it - add it
           // to return list
@@ -713,7 +666,7 @@ namespace ccf::historical
       ExpiryDuration seconds_until_expiry) override
     {
       auto range =
-        get_store_range_internal(handle, seqno, 0, seconds_until_expiry);
+        get_store_range_internal(handle, seqno, 0, seconds_until_expiry, true);
 
       if (range.empty())
       {
@@ -739,7 +692,7 @@ namespace ccf::historical
 
       const auto tail_length = end_seqno - start_seqno;
       auto range = get_store_range_internal(
-        handle, start_seqno, tail_length, seconds_until_expiry);
+        handle, start_seqno, tail_length, seconds_until_expiry, false);
       std::vector<StorePtr> stores;
       for (size_t i = 0; i < range.size(); i++)
       {

--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -535,7 +535,7 @@ namespace ccf::historical
           start_seqno));
       }
 
-      const auto tail_length = end_seqno - start_seqno;
+      const auto num_following_indices = end_seqno - start_seqno;
 
       const auto ms_until_expiry =
         std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -237,8 +237,6 @@ namespace ccf::historical
                   proof.get_path(),
                   sig->node,
                   sig->cert);
-                // TODO: I think we can set this earlier, since we derive this
-                // from GCM header during deserialisation?
                 details->transaction_id = {sig->view, seqno};
               }
             }

--- a/src/node/test/historical_queries.cpp
+++ b/src/node/test/historical_queries.cpp
@@ -339,7 +339,8 @@ TEST_CASE("StateCache point queries")
       "entries");
     // NB: This is _a_ valid entry, but not at this seqno.
     REQUIRE(cache.get_state_at(low_handle, low_seqno) == nullptr);
-    REQUIRE_FALSE(cache.handle_ledger_entry(low_seqno, ledger.at(low_seqno + 1)));
+    REQUIRE_FALSE(
+      cache.handle_ledger_entry(low_seqno, ledger.at(low_seqno + 1)));
   }
 
   {

--- a/src/node/test/historical_queries.cpp
+++ b/src/node/test/historical_queries.cpp
@@ -516,8 +516,6 @@ TEST_CASE("StateCache range queries")
       REQUIRE(stores.empty());
     }
 
-    const auto proof_end = signing_version(range_end);
-
     // Cache is robust to receiving these out-of-order, so stress that by
     // submitting out-of-order
     std::vector<size_t> to_provide(1 + range_end - range_start);
@@ -532,17 +530,11 @@ TEST_CASE("StateCache range queries")
       provide_ledger_entry(seqno);
     }
 
-    // Then provide trailing proof after the requested indices
-    for (auto seqno = range_end + 1; seqno <= proof_end; ++seqno)
-    {
-      provide_ledger_entry(seqno);
-    }
-
     {
       auto stores = cache.get_store_range(this_handle, range_start, range_end);
       REQUIRE(!stores.empty());
 
-      const auto range_size = (range_end - range_start) + 1;
+      const auto range_size = to_provide.size();
       REQUIRE(stores.size() == range_size);
       for (size_t i = 0; i < stores.size(); ++i)
       {

--- a/src/node/test/historical_queries.cpp
+++ b/src/node/test/historical_queries.cpp
@@ -337,24 +337,9 @@ TEST_CASE("StateCache point queries")
     INFO(
       "Cache accepts _wrong_ requested entry, and the range of supporting "
       "entries");
-    // NB: This is _a_ valid entry, but not at this seqno. In fact this stage
-    // will accept anything that looks quite like a valid entry, even if it
-    // never came from a legitimate node - they should all fail at the signature
-    // check
+    // NB: This is _a_ valid entry, but not at this seqno.
     REQUIRE(cache.get_state_at(low_handle, low_seqno) == nullptr);
-    REQUIRE(cache.handle_ledger_entry(low_seqno, ledger.at(low_seqno + 1)));
-
-    // Count up to next signature
-    for (size_t i = low_seqno + 1; i < high_signature_transaction; ++i)
-    {
-      REQUIRE(provide_ledger_entry(i));
-      REQUIRE(cache.get_state_at(low_handle, low_seqno) == nullptr);
-    }
-
-    // Signature is good
-    REQUIRE(provide_ledger_entry(high_signature_transaction));
-    // Junk entry is still not available
-    REQUIRE(cache.get_state_at(low_handle, low_seqno) == nullptr);
+    REQUIRE_FALSE(cache.handle_ledger_entry(low_seqno, ledger.at(low_seqno + 1)));
   }
 
   {

--- a/tests/historical_query_perf.py
+++ b/tests/historical_query_perf.py
@@ -22,7 +22,7 @@ def test_historical_query_range(network, args):
 
     id_pattern = [id_a, id_a, id_a, id_b, id_b, id_c]
 
-    n_entries = 3001
+    n_entries = 10000
 
     jwt_issuer = infra.jwt_issuer.JwtIssuer()
     jwt_issuer.register(network)

--- a/tests/historical_query_perf.py
+++ b/tests/historical_query_perf.py
@@ -92,7 +92,7 @@ def test_historical_query_range(network, args):
     average_fetch_rate = (id_a_fetch_rate + id_b_fetch_rate + id_c_fetch_rate) / 3
 
     with cimetrics.upload.metrics(complete=False) as metrics:
-        upload_name = "Historical query (/s)"
+        upload_name = "Historical query (/s)^"
         LOG.debug(f"Uploading metric: {upload_name} = {average_fetch_rate}")
         metrics.put(upload_name, average_fetch_rate)
 

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -210,7 +210,7 @@ def run_code_upgrade_from(
             jwt_issuer.refresh_keys()
             # Note: /gov/jwt_keys/all endpoint was added in 2.x
             primary, _ = network.find_nodes()
-            if not primary.major_version or primary.version > 1:
+            if not primary.major_version or primary.major_version > 1:
                 jwt_issuer.wait_for_refresh(network)
             else:
                 time.sleep(3)


### PR DESCRIPTION
Signature verification is only required to confirm provenance. To confirm integrity, it is sufficient to validate the existing GCM header. Providence is not a meaningful property for nodes to confirm, instead they can return receipts which allow callers to check signatures + provenance if they wish.

An additional check which we didn't have to do previously but do now is explicitly confirming that each entry is a precursor to the current state, by checking its (integrity-protected) TxID matches the consensus' view history.

TODO:
- [x] The flow inside `historical_queries.h` is now over-complicated, since it only trusts each store once it has seen the following signature. This should be fixed.
- [x] We can go even faster by avoiding the signature fetch when the receipt is not requested. This requires some API change to indicate a request where the receipt is optional.