### PR TITLE
Fetch and improve V8 build

### DIFF
--- a/.azure-pipelines-v8.yml
+++ b/.azure-pipelines-v8.yml
@@ -18,9 +18,11 @@ jobs:
           sudo apt update
           sudo apt install -y pkg-config
         displayName: "Install dependencies"
+        continueOnError: false
 
       - script: scripts/build-v8.sh $(VERSION) $(PUSH_ARTIFACT)
         displayName: "Build V8"
+        continueOnError: false
 
       - script: |
           # Universal Packages versions only take three sections X.Y.Z.
@@ -31,9 +33,10 @@ jobs:
           #   Ex: 9.4.146.17 -> 94.14617.$(Build.BuildId)
           export MINOR=$(echo $(VERSION) | cut -d "." -f 3,4 | sed 's/\.//')
           echo '##vso[task.setvariable variable=pkg-ver]'$MAJOR.$MINOR.$(Build.BuildId)
-          mv build-v8/v8.tar.xz $(Build.ArtifactStagingDirectory)/v8-$(pkg-ver).tar.xz
+          mv build-v8/v8-$(VERSION).tar.xz $(Build.ArtifactStagingDirectory)
         displayName: "Prepare Artifact Staging Directory"
         condition: eq(variables.pushArtifact, 'true')
+        continueOnError: false
 
       - task: UniversalPackages@0
         displayName: "Publish V8 Artifact"
@@ -41,7 +44,7 @@ jobs:
           command: publish
           publishDirectory: "$(Build.ArtifactStagingDirectory)"
           vstsFeedPublish: "CCF/V8"
-          vstsFeedPackagePublish: "ccf-v8-$(pkg-ver).tar.xz"
+          vstsFeedPackagePublish: "v8-monolith"
           versionOption: custom
           versionPublish: "$(pkg-ver)"
           packagePublishDescription: "CCF build of monolith V8"

--- a/scripts/build-v8.sh
+++ b/scripts/build-v8.sh
@@ -8,8 +8,7 @@ if [ "$1" == "" ]; then
   echo "$SYNTAX"
   exit 1
 fi
-EXPECTED_VERSION="$1"
-MAJOR_VERSION="${1%.*.*}"
+VERSION="$1"
 PUBLISH=false
 if [ "$2" != "" ]; then
   if [ "$2" == "true" ]; then
@@ -42,12 +41,10 @@ fi
 echo " + Fetching V8 on known stable branch..."
 fetch v8
 cd v8 || exit
-# This is known stable on all platforms according to omahaproxy.appspot.com
-CHECKOUT_BANCH="branch-heads/$MAJOR_VERSION"
-git checkout "$CHECKOUT_BANCH"
-VERSION=$(git show | grep -o "$EXPECTED_VERSION")
-if [ "$VERSION" != "$EXPECTED_VERSION" ]; then
-  echo "ERROR: Invalid version $VERSION for checkout $CHECKOUT_BANCH"
+# Check omahaproxy.appspot.com for known stable versions
+git checkout "refs/tags/$VERSION"
+if [ $? -ne 0 ]; then
+  echo "ERROR: Invalid version $VERSION for checkout"
   exit 1
 fi
 
@@ -94,5 +91,5 @@ fi
 # Creates in .../build-v8/ root
 if [ "$PUBLISH" == "true" ]; then
   echo " + Generate the tarball..."
-  tar Jcf ../v8.tar.xz install
+  tar Jcf ../v8-"$VERSION".tar.xz install
 fi

--- a/scripts/fetch-v8.sh
+++ b/scripts/fetch-v8.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+# Fetches the Universal Artifact from Azire that was built and published with
+# build-v8.sh. Doesn't fetch if the tarball already exists.
+
+SYNTAX="fetch-v8.sh <version (ex. 9.4.146.17)> [-f(orce)]"
+if [ "$1" == "" ]; then
+  echo "ERROR: Missing expected argument 'version'"
+  echo "$SYNTAX"
+  exit 1
+fi
+VERSION="$1"
+MAJOR_VERSION=$(echo "$VERSION" | cut -d "." -f 1,2 | sed 's/\.//')
+MINOR_VERSION=$(echo "$VERSION" | cut -d "." -f 3,4 | sed 's/\.//')
+PKG_VERSION="$MAJOR_VERSION.$MINOR_VERSION"
+
+## Check that the package exists, override with -f
+FORCE="$2"
+if [ -f v8-$"VERSION".tar.xz ] && [ "$FORCE" != "-f" ]; then
+  echo " + Tarball built/fetched already"
+  echo "   Use '-f' to force downloading the package again"
+  exit 0
+fi
+
+## Check for the Azure client
+if command -v az > /dev/null; then
+  echo " + Azure client already installed"
+else
+  echo " + Installing the Azure Client..."
+  sudo apt update && sudo apt install azure-cli -y
+fi
+
+## Login into Azure
+if az account list | grep -q MSRC; then
+  echo " + Already logged in"
+else
+  echo " + Login to Azure, follow instructions..."
+  az login
+fi
+
+## Fetch the file
+echo " + Fetch the tarball..."
+az artifacts universal download \
+  --organization https://dev.azure.com/MSRC-CCF \
+  --project CCF \
+  --scope project \
+  --feed V8 \
+  --name v8-monolith \
+  --version "$PKG_VERSION.*" \
+  --path .
+
+TARBALL="v8-$VERSION.tar.xz"
+if [ ! -f "$TARBALL" ]; then
+  echo "ERROR: Artifact download failed"
+  exit 1
+fi
+
+## Unpack on the same directory as it was built
+echo " + Unpack the tarball..."
+mkdir -p build-v8
+tar Jxf v8-"$VERSION".tar.xz -C build-v8


### PR DESCRIPTION
Adding a new script to fetch the pipeline artifact for using V8 into
CCF.

Mistakes on artifact naming have made it hard to get the right package.
When implementing the fetch script I realised the problem and have now
fixed in all three places: build-v8, pipeline, fetch-v8

Also, build now fetches the tag "$VERSION" instead of relying the
branch-head to be on the same version and failing.

A future addition would be to pass less info (ex. 9.4) and get the
script to fetch the head and figure out the version on its own.