### PR TITLE
A more basic LTS test

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Run the daily CI please!
+Run the daily CI please?


### PR DESCRIPTION
Recent LTS compatibility failures (eg. https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=33677&view=results) seem to be caused by an assumption in the test that nodes resuming from suspension will not cause an election.

This seems to have been mostly the case pre-new channels but not any more. This change is simplifying the test somewhat, to retire old nodes and trigger transactions after they've gone.

What it does _not_ do is guarantee that we go through a situation where a primary running new code is replicating to nodes running old code successfully, but is closer to how a code upgrade is probably run. If we want to reliably test that particular mixed scenario, all I can think of is to force the election to come down the way we want by tweaking timeouts.

As @eddyashton suggested, this runs the risk of blocking the network, if new nodes start too slowly (they could be forever behind, calling elections before old nodes have a chance to do so).