### PR TITLE
Fix partitions_test

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Run the daily CI please?
+Run the daily CI please!?

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -30,6 +30,9 @@ logging.getLogger("paramiko").setLevel(logging.WARNING)
 # JOIN_TIMEOUT should be greater than the worst case quote verification time (~ 25 secs)
 JOIN_TIMEOUT = 40
 
+# If it takes a node n seconds to call an election, how long should we wait for an election to succeed?
+DEFAULT_TIMEOUT_MULTIPLIER = 3
+
 COMMON_FOLDER = "common"
 
 
@@ -874,7 +877,9 @@ class Network:
                     pprint.pprint(r.body.json())
         assert expected == commits, f"Multiple commit values: {commits}"
 
-    def wait_for_new_primary(self, old_primary, nodes=None, timeout_multiplier=2):
+    def wait_for_new_primary(
+        self, old_primary, nodes=None, timeout_multiplier=DEFAULT_TIMEOUT_MULTIPLIER
+    ):
         # We arbitrarily pick twice the election duration to protect ourselves against the somewhat
         # but not that rare cases when the first round of election fails (short timeout are particularly susceptible to this)
         timeout = self.observed_election_duration * timeout_multiplier
@@ -916,7 +921,10 @@ class Network:
         raise error(f"A new primary was not elected after {timeout} seconds")
 
     def wait_for_new_primary_in(
-        self, expected_node_ids, nodes=None, timeout_multiplier=2
+        self,
+        expected_node_ids,
+        nodes=None,
+        timeout_multiplier=DEFAULT_TIMEOUT_MULTIPLIER,
     ):
         # We arbitrarily pick twice the election duration to protect ourselves against the somewhat
         # but not that rare cases when the first round of election fails (short timeout are particularly susceptible to this)
@@ -945,7 +953,9 @@ class Network:
         flush_info(logs, None)
         raise error(f"A new primary was not elected after {timeout} seconds")
 
-    def wait_for_primary_unanimity(self, timeout_multiplier=2, min_view=None):
+    def wait_for_primary_unanimity(
+        self, timeout_multiplier=DEFAULT_TIMEOUT_MULTIPLIER, min_view=None
+    ):
         timeout = self.observed_election_duration * timeout_multiplier
         LOG.info(f"Waiting up to {timeout}s for all nodes to agree on the primary")
         end_time = time.time() + timeout

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -143,6 +143,7 @@ class Network:
         self.library_dir = library_dir
         self.common_dir = None
         self.election_duration = None
+        self.observed_election_duration = None
         self.key_generator = os.path.join(binary_dir, self.KEY_GEN)
         self.share_script = os.path.join(binary_dir, self.SHARE_SCRIPT)
         if not os.path.isfile(self.key_generator):

--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -65,9 +65,7 @@ def test_partition_majority(network, args):
         except TimeoutError:
             LOG.info("No new primary, as expected")
             with primary.client() as c:
-                res = c.get(
-                    "/node/network"
-                )  # Well-known read-only endpoint
+                res = c.get("/node/network")  # Well-known read-only endpoint
                 body = res.body.json()
                 initial_view = body["current_view"]
 

--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -65,10 +65,11 @@ def test_partition_majority(network, args):
         except TimeoutError:
             LOG.info("No new primary, as expected")
             with primary.client() as c:
-                resp = c.get(
-                    "/node/network/nodes/self"
+                res = c.get(
+                    "/node/network"
                 )  # Well-known read-only endpoint
-                initial_view = resp.view
+                body = res.body.json()
+                initial_view = body["current_view"]
 
     # The partitioned nodes will have called elections, increasing their view.
     # When the partition is lifted, the nodes must elect a new leader, in at least this


### PR DESCRIPTION
Fix for recent failure in Daily: https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=33725&view=logs&j=5435e0ac-25e5-5426-50be-61b0d0ea8d34&t=a2a8c6c1-1b13-59a7-596c-97d4f22a6857&l=214

The main issue was that `wait_for_primary_unanimity` wasn't working as intended. Additionally, while looking at this, we realised that we were waiting unnecessarily long for all of our election timeouts, as we doubled them twice. The base election duration should be 1 election + some roundtrips for it, then the multiplier correctly waits for N such elections.