### PR TITLE
Cherry-pick #3037 and #3041 to 1.x LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.11]
+
+### Changed
+
+- Improvements to the historical range query performance (#3041)
+
 ## [1.0.10]
 
 ### Dependency
@@ -930,6 +936,14 @@ Some discrepancies with the TR remain, and are being tracked under https://githu
 
 Initial pre-release
 
+[1.0.11]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.11
+[1.0.10]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.10
+[1.0.9]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.9
+[1.0.8]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.8
+[1.0.7]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.7
+[1.0.6]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.6
+[1.0.5]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.5
+[1.0.4]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.4
 [1.0.3]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.3
 [1.0.2]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.2
 [1.0.1]: https://github.com/microsoft/CCF/releases/tag/ccf-1.0.1

--- a/include/ccf/historical_queries_interface.h
+++ b/include/ccf/historical_queries_interface.h
@@ -144,12 +144,15 @@ namespace ccf::historical
     /** Retrieve a full state at a given seqno, including the Store, the TxID
      * assigned by consensus, and an offline-verifiable receipt for the Tx.
      */
-    virtual StatePtr get_state_at(RequestHandle handle, ccf::SeqNo seqno) = 0;
-
     virtual StatePtr get_state_at(
       RequestHandle handle,
       ccf::SeqNo seqno,
       ExpiryDuration seconds_until_expiry) = 0;
+
+    /** Same as @c get_state_at but uses default expiry value.
+     * @see get_state_at
+     */
+    virtual StatePtr get_state_at(RequestHandle handle, ccf::SeqNo seqno) = 0;
 
     /** Retrieve a range of Stores containing the state written at the given
      * indices.
@@ -179,6 +182,22 @@ namespace ccf::historical
      * @see get_store_range
      */
     virtual std::vector<StorePtr> get_store_range(
+      RequestHandle handle, ccf::SeqNo start_seqno, ccf::SeqNo end_seqno) = 0;
+
+    /** Retrieve a range of states at the given indices, including the Store,
+     * the TxID assigned by consensus, and an offline-verifiable receipt for
+     * the Tx.
+     */
+    virtual std::vector<StatePtr> get_state_range(
+      RequestHandle handle,
+      ccf::SeqNo start_seqno,
+      ccf::SeqNo end_seqno,
+      ExpiryDuration seconds_until_expiry) = 0;
+
+    /** Same as @c get_state_range but uses default expiry value.
+     * @see get_state_range
+     */
+    virtual std::vector<StatePtr> get_state_range(
       RequestHandle handle, ccf::SeqNo start_seqno, ccf::SeqNo end_seqno) = 0;
 
     /** Drop state for the given handle.

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -38,7 +38,7 @@ namespace kv::test
         replica.push_back(entry);
 
         // Simplification: all entries are replicated in the same term
-        view_history.update(std::get<0>(entry), 2);
+        view_history.update(std::get<0>(entry), 0);
       }
       return true;
     }
@@ -81,7 +81,7 @@ namespace kv::test
 
     std::pair<ccf::View, ccf::SeqNo> get_committed_txid() override
     {
-      return {2, 0};
+      return {0, 0};
     }
 
     std::optional<SignableTxIndices> get_signable_txid() override
@@ -121,12 +121,12 @@ namespace kv::test
 
     ccf::View get_view(ccf::SeqNo seqno) override
     {
-      return 2;
+      return 0;
     }
 
     ccf::View get_view() override
     {
-      return 2;
+      return 0;
     }
 
     std::vector<ccf::SeqNo> get_view_history(ccf::SeqNo seqno) override

--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -100,8 +100,10 @@ namespace ccf::historical
       std::vector<StoreDetailsPtr> requested_stores;
       std::chrono::milliseconds time_to_expiry;
 
+      bool include_receipts;
+
       // Entries from outside the requested range (such as the next signature)
-      // may be needed to trust this range. They are stored here, distinct from
+      // may be needed to produce receipts. They are stored here, distinct from
       // user-requested stores.
       std::optional<std::pair<ccf::SeqNo, StoreDetailsPtr>>
         supporting_signature;
@@ -180,8 +182,8 @@ namespace ccf::historical
         // If the final entry in the new range is known and not a signature,
         // then we may need a subsequent signature to support it (or an earlier
         // entry received out-of-order!) So start fetching subsequent entries to
-        // find supporting signature. Its possible this was the supporting entry
-        // we already had, or a signature in the range we already had, but
+        // find supporting signature. It's possible this was the supporting
+        // entry we already had, or a signature in the range we already had, but
         // working that out is tricky so be pessimistic and refetch instead.
         supporting_signature.reset();
         const auto last_details = get_store_details(last_requested_seqno);
@@ -200,30 +202,24 @@ namespace ccf::historical
         return ret;
       }
 
-      enum class UpdateTrustedResult
+      enum class PopulateReceiptsResult
       {
-        // Common result. The new seqno may have transitioned some entries to
-        // Trusted
+        // Common result. The new seqno may have added receipts for some entries
         Continue,
 
         // Occasional result. The new seqno was at the end of the sequence (or
         // an attempt at retrieving a trailing supporting signature), but we
-        // still have untrusted entries, so attempt to fetch the next
+        // still have receiptless entries, so attempt to fetch the next
         FetchNext,
-
-        // Error result. The new entry exposed a mismatch between a signature's
-        // claim at a certain seqno and the entry we received there. Invalidate
-        // entire request, it can be re-requested if necessary
-        Invalidated,
       };
 
-      UpdateTrustedResult update_trusted(ccf::SeqNo new_seqno)
+      PopulateReceiptsResult populate_receipts(ccf::SeqNo new_seqno)
       {
         auto new_details = get_store_details(new_seqno);
         if (new_details->is_signature)
         {
-          // Iterate through earlier indices. If this signature covers them (and
-          // the digests match), move them to Trusted
+          // Iterate through earlier indices. If this signature covers them
+          // then create a receipt for them
           const auto sig = get_signature(new_details->store);
           ccf::MerkleTreeHistory tree(get_tree(new_details->store).value());
 
@@ -234,41 +230,19 @@ namespace ccf::historical
               auto details = get_store_details(seqno);
               if (details != nullptr)
               {
-                if (details->current_stage == RequestStage::Untrusted)
-                {
-                  // Compare signed digest, from signature mini-tree, with
-                  // digest of the entry which was used to construct this store
-                  const auto& untrusted_digest = details->entry_digest;
-                  const auto trusted_digest = tree.get_leaf(seqno);
-                  if (trusted_digest != untrusted_digest)
-                  {
-                    LOG_FAIL_FMT(
-                      "Signature at {} has a different transaction at {} than "
-                      "previously received",
-                      new_seqno,
-                      seqno);
-
-                    // We trust the signature (since it comes from a trusted
-                    // node), and it disagrees with one of the entries we
-                    // previously retrieved and deserialised. This generally
-                    // means a malicious host gave us a bad transaction but a
-                    // good signature. Delete the entire original request
-                    // - if it is re-requested, maybe the host will give us a
-                    // valid pair of transaction+sig next time
-                    return UpdateTrustedResult::Invalidated;
-                  }
-
-                  auto proof = tree.get_proof(seqno);
-                  details->receipt = std::make_shared<TxReceipt>(
-                    sig->sig, proof.get_root(), proof.get_path(), sig->node);
-                  details->transaction_id = {sig->view, seqno};
-                  details->current_stage = RequestStage::Trusted;
-                }
+                auto proof = tree.get_proof(seqno);
+                details->receipt = std::make_shared<TxReceipt>(
+                  sig->sig,
+                  proof.get_root(),
+                  proof.get_path(),
+                  sig->node,
+                  sig->cert);
+                details->transaction_id = {sig->view, seqno};
               }
             }
           }
         }
-        else if (new_details->current_stage == RequestStage::Untrusted)
+        else if (new_details->receipt == nullptr)
         {
           // Iterate through later indices, see if there's a signature that
           // covers this one
@@ -286,21 +260,14 @@ namespace ccf::historical
                 ccf::MerkleTreeHistory tree(get_tree(details->store).value());
                 if (tree.in_range(new_seqno))
                 {
-                  const auto trusted_digest = tree.get_leaf(new_seqno);
-                  if (trusted_digest != untrusted_digest)
-                  {
-                    return UpdateTrustedResult::Invalidated;
-                  }
-
                   auto proof = tree.get_proof(new_seqno);
                   details->receipt = std::make_shared<TxReceipt>(
                     sig->sig, proof.get_root(), proof.get_path(), sig->node);
                   details->transaction_id = {sig->view, new_seqno};
-                  new_details->current_stage = RequestStage::Trusted;
                 }
 
-                // Break here - if this signature doesn't cover us, no later one
-                // can
+                // Break here - if this signature doesn't cover us, no later
+                // one can
                 sig_seen = true;
                 break;
               }
@@ -316,37 +283,30 @@ namespace ccf::historical
               ccf::MerkleTreeHistory tree(get_tree(details->store).value());
               if (tree.in_range(new_seqno))
               {
-                const auto trusted_digest = tree.get_leaf(new_seqno);
-                if (trusted_digest != untrusted_digest)
-                {
-                  return UpdateTrustedResult::Invalidated;
-                }
-
                 auto proof = tree.get_proof(new_seqno);
                 details->receipt = std::make_shared<TxReceipt>(
                   sig->sig, proof.get_root(), proof.get_path(), sig->node);
                 details->transaction_id = {sig->view, new_seqno};
-                new_details->current_stage = RequestStage::Trusted;
               }
             }
           }
 
-          // If still untrusted, and this non-signature is the last requested
-          // seqno, or previous attempt at finding supporting signature, request
-          // the _next_ seqno to find supporting signature
-          if (new_details->current_stage == RequestStage::Untrusted)
+          // If still have no receipt, and this non-signature is the last
+          // requested seqno, or a previous attempt at finding supporting
+          // signature, request the _next_ seqno to find supporting signature
+          if (new_details->receipt == nullptr)
           {
             if (
               new_seqno == last_requested_seqno ||
               (supporting_signature.has_value() &&
                supporting_signature->first == new_seqno))
             {
-              return UpdateTrustedResult::FetchNext;
+              return PopulateReceiptsResult::FetchNext;
             }
           }
         }
 
-        return UpdateTrustedResult::Continue;
+        return PopulateReceiptsResult::Continue;
       }
     };
 
@@ -372,64 +332,6 @@ namespace ccf::historical
           static_cast<consensus::Index>(seqno),
           consensus::LedgerRequestPurpose::HistoricalQuery);
       }
-    }
-
-    std::optional<ccf::NodeInfo> get_node_info(const ccf::NodeId& node_id)
-    {
-      // Current solution: Use current state of Nodes table from real store.
-      // This only works while entries are never deleted from this table, and
-      // makes no check that the signing node was active at the point it
-      // produced this signature
-      auto tx = source_store.create_read_only_tx();
-      auto nodes = tx.ro<ccf::Nodes>(ccf::Tables::NODES);
-      return nodes->get(node_id);
-    }
-
-    // Returns true if this is a valid signature that passes our verification
-    // checks
-    bool verify_signature(const StorePtr& sig_store, ccf::SeqNo sig_seqno)
-    {
-      const auto sig = get_signature(sig_store);
-      if (!sig.has_value())
-      {
-        LOG_FAIL_FMT("Signature at {}: Missing signature value", sig_seqno);
-        return false;
-      }
-
-      const auto tree_ = get_tree(sig_store);
-      if (!tree_.has_value())
-      {
-        LOG_FAIL_FMT("Signature at {}: Missing tree value", sig_seqno);
-        return false;
-      }
-
-      // Build tree from signature
-      ccf::MerkleTreeHistory tree(tree_.value());
-      const auto real_root = tree.get_root();
-      if (real_root != sig->root)
-      {
-        LOG_FAIL_FMT("Signature at {}: Invalid root", sig_seqno);
-        return false;
-      }
-
-      const auto node_info = get_node_info(sig->node);
-      if (!node_info.has_value())
-      {
-        LOG_FAIL_FMT(
-          "Signature at {}: Node {} is unknown", sig_seqno, sig->node);
-        return false;
-      }
-
-      auto verifier = crypto::make_verifier(node_info->cert);
-      const auto verified =
-        verifier->verify_hash(real_root.h, sig->sig, crypto::MDType::SHA256);
-      if (!verified)
-      {
-        LOG_FAIL_FMT("Signature at {}: Signature invalid", sig_seqno);
-        return false;
-      }
-
-      return true;
     }
 
     std::unique_ptr<LedgerSecretRecoveryInfo> fetch_supporting_secret_if_needed(
@@ -522,16 +424,9 @@ namespace ccf::historical
           details != nullptr &&
           details->current_stage == RequestStage::Fetching)
         {
-          if (is_signature)
-          {
-            // Signatures have already been verified by the time we get here, so
-            // we trust them already
-            details->current_stage = RequestStage::Trusted;
-          }
-          else
-          {
-            details->current_stage = RequestStage::Untrusted;
-          }
+          // Deserialisation includes a GCM integrity check, so all entries have
+          // been verified by the time we get here.
+          details->current_stage = RequestStage::Trusted;
 
           details->entry_digest = entry_digest;
 
@@ -543,7 +438,7 @@ namespace ccf::historical
           details->store = store;
 
           details->is_signature = is_signature;
-          if (is_signature)
+          if (is_signature && request.include_receipts)
           {
             // Construct a signature receipt
             const auto sig = get_signature(details->store);
@@ -553,27 +448,25 @@ namespace ccf::historical
             details->transaction_id = {sig->view, sig->seqno};
           }
 
-          const auto result = request.update_trusted(seqno);
-          switch (result)
+          if (request.include_receipts)
           {
-            case (Request::UpdateTrustedResult::Continue):
+            const auto result = request.populate_receipts(seqno);
+            switch (result)
             {
-              ++request_it;
-              break;
-            }
-            case (Request::UpdateTrustedResult::Invalidated):
-            {
-              request_it = requests.erase(request_it);
-              break;
-            }
-            case (Request::UpdateTrustedResult::FetchNext):
-            {
-              const auto next_seqno = seqno + 1;
-              fetch_entry_at(next_seqno);
-              request.supporting_signature =
-                std::make_pair(next_seqno, std::make_shared<StoreDetails>());
-              ++request_it;
-              break;
+              case (Request::PopulateReceiptsResult::Continue):
+              {
+                ++request_it;
+                break;
+              }
+              case (Request::PopulateReceiptsResult::FetchNext):
+              {
+                const auto next_seqno = seqno + 1;
+                fetch_entry_at(next_seqno);
+                request.supporting_signature =
+                  std::make_pair(next_seqno, std::make_shared<StoreDetails>());
+                ++request_it;
+                break;
+              }
             }
           }
         }
@@ -618,10 +511,21 @@ namespace ccf::historical
     std::vector<StatePtr> get_state_range_internal(
       RequestHandle handle,
       ccf::SeqNo start_seqno,
-      size_t num_following_indices,
-      ExpiryDuration seconds_until_expiry)
+      ccf::SeqNo end_seqno,
+      ExpiryDuration seconds_until_expiry,
+      bool include_receipts)
     {
       std::lock_guard<SpinLock> guard(requests_lock);
+
+      if (end_seqno < start_seqno)
+      {
+        throw std::logic_error(fmt::format(
+          "Invalid range for historical query: end {} is before start {}",
+          end_seqno,
+          start_seqno));
+      }
+
+      const auto num_following_indices = end_seqno - start_seqno;
 
       const auto ms_until_expiry =
         std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -635,6 +539,7 @@ namespace ccf::historical
       }
 
       Request& request = it->second;
+      request.include_receipts = include_receipts;
 
       // Update this Request to represent the currently requested range,
       // returning any newly requested indices
@@ -677,7 +582,9 @@ namespace ccf::historical
            ++seqno)
       {
         auto target_details = request.get_store_details(seqno);
-        if (target_details->current_stage == RequestStage::Trusted)
+        if (
+          target_details->current_stage == RequestStage::Trusted &&
+          (!request.include_receipts || target_details->receipt != nullptr))
         {
           // Have this store, associated txid and receipt and trust it - add it
           // to return list
@@ -773,8 +680,8 @@ namespace ccf::historical
       ccf::SeqNo end_seqno,
       ExpiryDuration seconds_until_expiry) override
     {
-      auto range =
-        get_state_range(handle, start_seqno, end_seqno, seconds_until_expiry);
+      auto range = get_state_range_internal(
+        handle, start_seqno, end_seqno, seconds_until_expiry, false);
       std::vector<StorePtr> stores;
       for (size_t i = 0; i < range.size(); i++)
       {
@@ -798,17 +705,8 @@ namespace ccf::historical
       ccf::SeqNo end_seqno,
       ExpiryDuration seconds_until_expiry) override
     {
-      if (end_seqno < start_seqno)
-      {
-        throw std::logic_error(fmt::format(
-          "Invalid range for historical query: end {} is before start {}",
-          end_seqno,
-          start_seqno));
-      }
-
-      const auto tail_length = end_seqno - start_seqno;
       auto range = get_state_range_internal(
-        handle, start_seqno, tail_length, seconds_until_expiry);
+        handle, start_seqno, end_seqno, seconds_until_expiry, true);
       return range;
     }
 
@@ -898,18 +796,44 @@ namespace ccf::historical
         return false;
       }
 
-      const auto is_signature =
-        deserialise_result == kv::ApplyResult::PASS_SIGNATURE;
-      if (is_signature)
       {
-        // This looks like a signature - check that we trust it
-        if (!verify_signature(store, seqno))
+        // Confirm this entry is from a precursor of the current state, and not
+        // a fork
+        const auto tx_id = store->current_txid();
+        if (tx_id.version != seqno)
         {
-          LOG_FAIL_FMT("Bad signature at {}", seqno);
-          delete_all_interested_requests(seqno);
+          LOG_FAIL_FMT(
+            "Corrupt ledger entry received - claims to be {} but is actually "
+            "{}.{}",
+            seqno,
+            tx_id.term,
+            tx_id.version);
+          return false;
+        }
+
+        auto consensus = source_store.get_consensus();
+        if (consensus == nullptr)
+        {
+          LOG_FAIL_FMT("No consensus on source store");
+          return false;
+        }
+
+        const auto actual_view = consensus->get_view(seqno);
+        if (actual_view != tx_id.term)
+        {
+          LOG_FAIL_FMT(
+            "Ledger entry comes from fork - contains {}.{} but this service "
+            "expected {}.{}",
+            tx_id.term,
+            tx_id.version,
+            actual_view,
+            seqno);
           return false;
         }
       }
+
+      const auto is_signature =
+        deserialise_result == kv::ApplyResult::PASS_SIGNATURE;
 
       LOG_DEBUG_FMT(
         "Processing historical store at {} ({})",

--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -61,8 +61,7 @@ namespace ccf::historical
 
       LedgerSecretRecoveryInfo(
         ccf::SeqNo target_seqno_, LedgerSecretPtr last_ledger_secret_) :
-        target_seqno(target_seqno_),
-        last_ledger_secret(last_ledger_secret_)
+        target_seqno(target_seqno_), last_ledger_secret(last_ledger_secret_)
       {}
     };
 
@@ -232,11 +231,7 @@ namespace ccf::historical
               {
                 auto proof = tree.get_proof(seqno);
                 details->receipt = std::make_shared<TxReceipt>(
-                  sig->sig,
-                  proof.get_root(),
-                  proof.get_path(),
-                  sig->node,
-                  sig->cert);
+                  sig->sig, proof.get_root(), proof.get_path(), sig->node);
                 details->transaction_id = {sig->view, seqno};
               }
             }
@@ -453,13 +448,11 @@ namespace ccf::historical
             const auto result = request.populate_receipts(seqno);
             switch (result)
             {
-              case (Request::PopulateReceiptsResult::Continue):
-              {
+              case (Request::PopulateReceiptsResult::Continue): {
                 ++request_it;
                 break;
               }
-              case (Request::PopulateReceiptsResult::FetchNext):
-              {
+              case (Request::PopulateReceiptsResult::FetchNext): {
                 const auto next_seqno = seqno + 1;
                 fetch_entry_at(next_seqno);
                 request.supporting_signature =

--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -615,7 +615,7 @@ namespace ccf::historical
       return true;
     }
 
-    std::vector<StatePtr> get_store_range_internal(
+    std::vector<StatePtr> get_state_range_internal(
       RequestHandle handle,
       ccf::SeqNo start_seqno,
       size_t num_following_indices,
@@ -748,19 +748,12 @@ namespace ccf::historical
       return get_store_at(handle, seqno, default_expiry_duration);
     }
 
-    StatePtr get_state_at(RequestHandle handle, ccf::SeqNo seqno) override
-    {
-      return get_state_at(handle, seqno, default_expiry_duration);
-    }
-
     StatePtr get_state_at(
       RequestHandle handle,
       ccf::SeqNo seqno,
       ExpiryDuration seconds_until_expiry) override
     {
-      auto range =
-        get_store_range_internal(handle, seqno, 0, seconds_until_expiry);
-
+      auto range = get_state_range(handle, seqno, seqno, seconds_until_expiry);
       if (range.empty())
       {
         return nullptr;
@@ -769,23 +762,19 @@ namespace ccf::historical
       return range[0];
     }
 
+    StatePtr get_state_at(RequestHandle handle, ccf::SeqNo seqno) override
+    {
+      return get_state_at(handle, seqno, default_expiry_duration);
+    }
+
     std::vector<StorePtr> get_store_range(
       RequestHandle handle,
       ccf::SeqNo start_seqno,
       ccf::SeqNo end_seqno,
       ExpiryDuration seconds_until_expiry) override
     {
-      if (end_seqno < start_seqno)
-      {
-        throw std::logic_error(fmt::format(
-          "Invalid range for historical query: end {} is before start {}",
-          end_seqno,
-          start_seqno));
-      }
-
-      const auto tail_length = end_seqno - start_seqno;
-      auto range = get_store_range_internal(
-        handle, start_seqno, tail_length, seconds_until_expiry);
+      auto range =
+        get_state_range(handle, start_seqno, end_seqno, seconds_until_expiry);
       std::vector<StorePtr> stores;
       for (size_t i = 0; i < range.size(); i++)
       {
@@ -800,6 +789,35 @@ namespace ccf::historical
       ccf::SeqNo end_seqno) override
     {
       return get_store_range(
+        handle, start_seqno, end_seqno, default_expiry_duration);
+    }
+
+    std::vector<StatePtr> get_state_range(
+      RequestHandle handle,
+      ccf::SeqNo start_seqno,
+      ccf::SeqNo end_seqno,
+      ExpiryDuration seconds_until_expiry) override
+    {
+      if (end_seqno < start_seqno)
+      {
+        throw std::logic_error(fmt::format(
+          "Invalid range for historical query: end {} is before start {}",
+          end_seqno,
+          start_seqno));
+      }
+
+      const auto tail_length = end_seqno - start_seqno;
+      auto range = get_state_range_internal(
+        handle, start_seqno, tail_length, seconds_until_expiry);
+      return range;
+    }
+
+    std::vector<StatePtr> get_state_range(
+      RequestHandle handle,
+      ccf::SeqNo start_seqno,
+      ccf::SeqNo end_seqno) override
+    {
+      return get_state_range(
         handle, start_seqno, end_seqno, default_expiry_duration);
     }
 

--- a/src/node/rpc/test/node_stub.h
+++ b/src/node/rpc/test/node_stub.h
@@ -154,6 +154,23 @@ namespace ccf
       return {};
     }
 
+    std::vector<historical::StatePtr> get_state_range(
+      historical::RequestHandle handle,
+      ccf::SeqNo start_seqno,
+      ccf::SeqNo end_seqno,
+      historical::ExpiryDuration seconds_until_expiry)
+    {
+      return {};
+    }
+
+    std::vector<historical::StatePtr> get_state_range(
+      historical::RequestHandle handle,
+      ccf::SeqNo start_seqno,
+      ccf::SeqNo end_seqno)
+    {
+      return {};
+    }
+
     bool drop_request(historical::RequestHandle handle)
     {
       return true;

--- a/src/node/test/historical_queries.cpp
+++ b/src/node/test/historical_queries.cpp
@@ -335,24 +335,10 @@ TEST_CASE("StateCache point queries")
     INFO(
       "Cache accepts _wrong_ requested entry, and the range of supporting "
       "entries");
-    // NB: This is _a_ valid entry, but not at this seqno. In fact this stage
-    // will accept anything that looks quite like a valid entry, even if it
-    // never came from a legitimate node - they should all fail at the signature
-    // check
+    // NB: This is _a_ valid entry, but not at this seqno.
     REQUIRE(cache.get_state_at(low_handle, low_seqno) == nullptr);
-    REQUIRE(cache.handle_ledger_entry(low_seqno, ledger.at(low_seqno + 1)));
-
-    // Count up to next signature
-    for (size_t i = low_seqno + 1; i < high_signature_transaction; ++i)
-    {
-      REQUIRE(provide_ledger_entry(i));
-      REQUIRE(cache.get_state_at(low_handle, low_seqno) == nullptr);
-    }
-
-    // Signature is good
-    REQUIRE(provide_ledger_entry(high_signature_transaction));
-    // Junk entry is still not available
-    REQUIRE(cache.get_state_at(low_handle, low_seqno) == nullptr);
+    REQUIRE_FALSE(
+      cache.handle_ledger_entry(low_seqno, ledger.at(low_seqno + 1)));
   }
 
   {
@@ -528,8 +514,6 @@ TEST_CASE("StateCache range queries")
       REQUIRE(stores.empty());
     }
 
-    const auto proof_end = signing_version(range_end);
-
     // Cache is robust to receiving these out-of-order, so stress that by
     // submitting out-of-order
     std::vector<size_t> to_provide(1 + range_end - range_start);
@@ -544,17 +528,11 @@ TEST_CASE("StateCache range queries")
       provide_ledger_entry(seqno);
     }
 
-    // Then provide trailing proof after the requested indices
-    for (auto seqno = range_end + 1; seqno <= proof_end; ++seqno)
-    {
-      provide_ledger_entry(seqno);
-    }
-
     {
       auto stores = cache.get_store_range(this_handle, range_start, range_end);
       REQUIRE(!stores.empty());
 
-      const auto range_size = (range_end - range_start) + 1;
+      const auto range_size = to_provide.size();
       REQUIRE(stores.size() == range_size);
       for (size_t i = 0; i < stores.size(); ++i)
       {


### PR DESCRIPTION
#3041 - Historical query performance improvement
#3037 - Supporting API standardisation (not strictly required, but makes the above a simpler merge)

Also added missing links to `CHANGELOG.md`.