### PR TITLE
Fix `full_test_suite` node replacement

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Run the daily CI please!?
+Run the daily CI please.

--- a/tests/infra/jwt_issuer.py
+++ b/tests/infra/jwt_issuer.py
@@ -10,6 +10,7 @@ from contextlib import AbstractContextManager
 import tempfile
 import json
 import time
+from ccf.log_capture import flush_info
 from loguru import logger as LOG
 
 
@@ -179,12 +180,15 @@ class JwtIssuer:
         end_time = time.time() + timeout
         with primary.client(network.consortium.get_any_active_member().local_id) as c:
             while time.time() < end_time:
-                r = c.get("/gov/jwt_keys/all")
+                logs = []
+                r = c.get("/gov/jwt_keys/all", log_capture=logs)
                 assert r.status_code == 200, r
                 stored_cert = r.body.json()[kid]
                 if self.cert_pem == stored_cert:
+                    flush_info(logs)
                     return
                 time.sleep(0.1)
+        flush_info(logs)
         raise TimeoutError(
             f"JWT public signing keys were not refreshed after {timeout}s"
         )

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -156,6 +156,7 @@ class Network:
         self.dbg_nodes = dbg_nodes
         self.perf_nodes = perf_nodes
         self.version = version
+        self.args = None
 
         # Requires admin privileges
         self.partitioner = (
@@ -279,6 +280,7 @@ class Network:
         read_only_ledger_dir=None,
         snapshot_dir=None,
     ):
+        self.args = args
         hosts = self.hosts
 
         if not args.package:
@@ -686,6 +688,9 @@ class Network:
 
     def get_stopped_nodes(self):
         return [node for node in self.nodes if node.is_stopped()]
+
+    def get_f(self):
+        return infra.e2e_args.max_f(self.args, len(self.nodes))
 
     def wait_for_state(self, node, state, timeout=3):
         end_time = time.time() + timeout

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -684,6 +684,9 @@ class Network:
     def get_joined_nodes(self):
         return [node for node in self.nodes if node.is_joined()]
 
+    def get_stopped_nodes(self):
+        return [node for node in self.nodes if node.is_stopped()]
+
     def wait_for_state(self, node, state, timeout=3):
         end_time = time.time() + timeout
         while time.time() < end_time:

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -258,9 +258,7 @@ def test_node_replacement(network, args):
     assert replacement_node.node_port == node_to_replace.node_port
     assert replacement_node.rpc_port == node_to_replace.rpc_port
 
-    allowed_to_suspend_count = infra.e2e_args.max_f(args, len(network.nodes)) - len(
-        network.get_stopped_nodes()
-    )
+    allowed_to_suspend_count = network.get_f() - len(network.get_stopped_nodes())
     backups_to_suspend = backups[:allowed_to_suspend_count]
     LOG.info(
         f"Suspending {len(backups_to_suspend)} other nodes to make progress depend on the replacement"

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -258,18 +258,18 @@ def test_node_replacement(network, args):
     assert replacement_node.node_port == node_to_replace.node_port
     assert replacement_node.rpc_port == node_to_replace.rpc_port
 
-    f = infra.e2e_args.max_f(args, len(network.nodes)) - len(
+    allowed_to_suspend_count = infra.e2e_args.max_f(args, len(network.nodes)) - len(
         network.get_stopped_nodes()
     )
-    f_backups = backups[:f]
+    backups_to_suspend = backups[:allowed_to_suspend_count]
     LOG.info(
-        f"Suspending {len(f_backups)} other nodes to make progress depend on the replacement"
+        f"Suspending {len(backups_to_suspend)} other nodes to make progress depend on the replacement"
     )
-    for other_backup in f_backups:
+    for other_backup in backups_to_suspend:
         other_backup.suspend()
     # Confirm the network can make progress
     check_can_progress(primary)
-    for other_backup in f_backups:
+    for other_backup in backups_to_suspend:
         other_backup.resume()
 
     return network

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -5,7 +5,7 @@ from ccf.ledger import NodeStatus
 import functools
 
 from loguru import logger as LOG
-from math import ceil
+import infra.e2e_args
 
 
 class TestRequirementsNotMet(Exception):
@@ -112,10 +112,10 @@ def can_kill_n_nodes(nodes_to_kill_count):
             )
             running_nodes_count = len(network.get_joined_nodes())
             would_leave_nodes_count = running_nodes_count - nodes_to_kill_count
-            minimum_nodes_to_run_count = ceil((trusted_nodes_count + 1) / 2)
-            if args.consensus == "cft" and (
-                would_leave_nodes_count < minimum_nodes_to_run_count
-            ):
+            minimum_nodes_to_run_count = trusted_nodes_count - infra.e2e_args.max_f(
+                args, trusted_nodes_count
+            )
+            if would_leave_nodes_count < minimum_nodes_to_run_count:
                 raise TestRequirementsNotMet(
                     f"Cannot kill {nodes_to_kill_count} node(s) as the network would not be able to make progress"
                     f" (would leave {would_leave_nodes_count} nodes but requires {minimum_nodes_to_run_count} nodes to make progress) "

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -1,11 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-from ccf.ledger import NodeStatus
 import functools
 
 from loguru import logger as LOG
-import infra.e2e_args
 
 
 class TestRequirementsNotMet(Exception):

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -99,27 +99,17 @@ def sufficient_recovery_member_count():
 
 def can_kill_n_nodes(nodes_to_kill_count):
     def check(network, args, *nargs, **kwargs):
-        primary, _ = network.find_primary()
-        with primary.client() as c:
-            r = c.get("/node/network/nodes")
-
-            trusted_nodes_count = len(
-                [
-                    node
-                    for node in r.body.json()["nodes"]
-                    if node["status"] == NodeStatus.TRUSTED.value
-                ]
+        running_nodes_count = len(network.get_joined_nodes())
+        would_leave_nodes_count = running_nodes_count - nodes_to_kill_count
+        minimum_nodes_to_run_count = network.nodes - network.get_f()
+        LOG.info(
+            f"{running_nodes_count}/{network.nodes} nodes running, with f={network.get_f()}, trying to kill {nodes_to_kill_count}"
+        )
+        if would_leave_nodes_count < minimum_nodes_to_run_count:
+            raise TestRequirementsNotMet(
+                f"Cannot kill {nodes_to_kill_count} node(s) as the network would not be able to make progress"
+                f" (would leave {would_leave_nodes_count} nodes but requires {minimum_nodes_to_run_count} nodes to make progress) "
             )
-            running_nodes_count = len(network.get_joined_nodes())
-            would_leave_nodes_count = running_nodes_count - nodes_to_kill_count
-            minimum_nodes_to_run_count = trusted_nodes_count - infra.e2e_args.max_f(
-                args, trusted_nodes_count
-            )
-            if would_leave_nodes_count < minimum_nodes_to_run_count:
-                raise TestRequirementsNotMet(
-                    f"Cannot kill {nodes_to_kill_count} node(s) as the network would not be able to make progress"
-                    f" (would leave {would_leave_nodes_count} nodes but requires {minimum_nodes_to_run_count} nodes to make progress) "
-                )
 
     return ensure_reqs(check)
 


### PR DESCRIPTION
The `reconfiguration.test_node_replacement` failed with the seed `SHUFFLE_SUITE_SEED=1633506379` because the test didn't take into account nodes that were previously killed. 