### PR TITLE
Return after setting HTTP error codes

### DIFF
--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -129,6 +129,7 @@ namespace ccf
               HTTP_STATUS_INTERNAL_SERVER_ERROR,
               ccf::errors::InternalError,
               "RPC could not be redirected to unknown primary.");
+            return ctx->serialise_response();
           }
 
           auto nodes = tx.ro<Nodes>(Tables::NODES);

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -850,6 +850,7 @@ namespace ccf
           HTTP_STATUS_INTERNAL_SERVER_ERROR,
           ccf::errors::InternalError,
           "Node info not available");
+        return;
       };
       make_read_only_endpoint(
         "/network/nodes/self", HTTP_GET, get_self_node, no_auth_required)
@@ -869,6 +870,7 @@ namespace ccf
               HTTP_STATUS_INTERNAL_SERVER_ERROR,
               ccf::errors::InternalError,
               "Primary unknown");
+            return;
           }
 
           auto nodes = args.tx.ro(this->network.nodes);
@@ -893,6 +895,7 @@ namespace ccf
           HTTP_STATUS_INTERNAL_SERVER_ERROR,
           ccf::errors::InternalError,
           "Primary unknown");
+        return;
       };
       make_read_only_endpoint(
         "/network/nodes/primary", HTTP_GET, get_primary_node, no_auth_required)
@@ -918,6 +921,7 @@ namespace ccf
                 HTTP_STATUS_INTERNAL_SERVER_ERROR,
                 ccf::errors::InternalError,
                 "Primary unknown");
+              return;
             }
 
             auto nodes = args.tx.ro(this->network.nodes);


### PR DESCRIPTION
We were missing a few returns after setting HTTP error codes, which will result in less precise errors (eg - illegal optional access).