### PR TITLE
Dump consensus progress when commit times out

### DIFF
--- a/python/ccf/commit.py
+++ b/python/ccf/commit.py
@@ -3,6 +3,7 @@
 
 import http
 import time
+import pprint
 
 from typing import Optional, List
 
@@ -47,4 +48,6 @@ def wait_for_commit(
         else:
             time.sleep(0.1)
     flush_info(logs, log_capture, 1)
-    raise TimeoutError("Timed out waiting for commit")
+    raise TimeoutError(
+        f'Timed out waiting for commit: {pprint.pformat(client.get("/node/consensus").body.json())}'
+    )

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -101,7 +101,7 @@ namespace kv
 
     ccf::SeqNo idx;
     Nodes nodes;
-    uint32_t bft_offset;
+    uint32_t bft_offset = 0;
     ReconfigurationId rid;
   };
 
@@ -137,8 +137,9 @@ namespace kv
      {ReplicaState::Learner, "Learner"},
      {ReplicaState::Retiring, "Retiring"}});
 
-  DECLARE_JSON_TYPE(Configuration);
-  DECLARE_JSON_REQUIRED_FIELDS(Configuration, idx, nodes, bft_offset, rid);
+  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(Configuration);
+  DECLARE_JSON_REQUIRED_FIELDS(Configuration, idx, nodes, rid);
+  DECLARE_JSON_OPTIONAL_FIELDS(Configuration, bft_offset);
 
   struct ConsensusDetails
   {


### PR DESCRIPTION
Also remove `bft_offset` from consensus configuration serialisation if it is unset. 