### PR TITLE
Enable 2-tx reconfiguration with CFT

### DIFF
--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -15,7 +15,7 @@ parameters:
 
   build:
     common:
-      cmake_args: '-DCMAKE_C_COMPILER_LAUNCHER="ccache" -DCMAKE_CXX_COMPILER_LAUNCHER="ccache"'
+      cmake_args: '-DCMAKE_C_COMPILER_LAUNCHER="ccache" -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" -DENABLE_2TX_RECONFIG=ON'
     NoSGX:
       cmake_args: "-DCOMPILE_TARGETS=virtual"
     SGX:
@@ -25,7 +25,7 @@ parameters:
     perf:
       cmake_args: '-DBUILD_UNIT_TESTS=OFF -DBUILD_TPCC=ON -DDISTRIBUTE_PERF_TESTS="-n local://localhost -n local://localhost"'
     release:
-      cmake_args: "-DTLS_TEST=ON -DLONG_TESTS=ON -DENABLE_BFT=OFF"
+      cmake_args: "-DTLS_TEST=ON -DLONG_TESTS=ON -DENABLE_BFT=OFF -DENABLE_2TX_RECONFIG=OFF"
 
   test:
     NoSGX:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Added support for 2-transaction reconfiguration with CFT consensus (#3097), see [documentation](https://microsoft.github.io/CCF/main/overview/consensus/bft.html#two-transaction-reconfiguration).
+
 ### Changed
 
 - DNS resolution of client connections is now asynchronous.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added 
+
 - Added support for 2-transaction reconfiguration with CFT consensus (#3097), see [documentation](https://microsoft.github.io/CCF/main/overview/consensus/bft.html#two-transaction-reconfiguration).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-### Added 
+### Added
 
 - Added support for 2-transaction reconfiguration with CFT consensus (#3097), see [documentation](https://microsoft.github.io/CCF/main/overview/consensus/bft.html#two-transaction-reconfiguration).
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -699,11 +699,15 @@ if(BUILD_TESTS)
     ADDITIONAL_ARGS ${ROTATION_TEST_ARGS}
   )
 
+  set(RECONFIG_TEST_ARGS --ccf-version ${CCF_VERSION})
+  if(ENABLE_2TX_RECONFIG)
+    list(APPEND RECONFIG_TEST_ARGS --include-2tx-reconfig)
+  endif()
   add_e2e_test(
     NAME reconfiguration_test_cft
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/reconfiguration.py
     CONSENSUS cft
-    ADDITIONAL_ARGS --ccf-version ${CCF_VERSION}
+    ADDITIONAL_ARGS ${RECONFIG_TEST_ARGS}  
   )
 
   add_e2e_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,16 +624,20 @@ if(BUILD_TESTS)
     CONSENSUS cft
   )
 
+  # Higher snapshot interval as the test currently assumes that no
+  # transactions are emitted while partitions are up. To be removed when
+  # https://github.com/microsoft/CCF/issues/2577 is implemented
+  set(PARTITIONS_TEST_ARGS --snapshot-tx-interval 10000)
+  if(ENABLE_2TX_RECONFIG)
+    list(APPEND PARTITIONS_TEST_ARGS --include-2tx-reconfig)
+  endif()
   add_e2e_test(
     NAME partitions_cft
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/partitions_test.py
     CONSENSUS cft
     LABEL partitions
-    CONFIGURATIONS partitions
-    # Higher snapshot interval as the test currently assumes that no
-    # transactions are emitted while partitions are up. To be removed when
-    # https://github.com/microsoft/CCF/issues/2577 is implemented
-    ADDITIONAL_ARGS --snapshot-tx-interval 10000
+    CONFIGURATIONS partitions    
+    ADDITIONAL_ARGS ${PARTITIONS_TEST_ARGS}
   )
 
   if(NOT SAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -711,6 +711,8 @@ if(BUILD_TESTS)
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/reconfiguration.py
     CONSENSUS cft
     ADDITIONAL_ARGS --ccf-version ${CCF_VERSION} --reconfiguration-type 2tx
+    LABEL partitions
+    CONFIGURATIONS partitions
   )
 
   add_e2e_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,8 +624,8 @@ if(BUILD_TESTS)
     CONSENSUS cft
   )
 
-  # Higher snapshot interval as the test currently assumes that no
-  # transactions are emitted while partitions are up. To be removed when
+  # Higher snapshot interval as the test currently assumes that no transactions
+  # are emitted while partitions are up. To be removed when
   # https://github.com/microsoft/CCF/issues/2577 is implemented
   set(PARTITIONS_TEST_ARGS --snapshot-tx-interval 10000)
   if(ENABLE_2TX_RECONFIG)
@@ -636,7 +636,7 @@ if(BUILD_TESTS)
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/partitions_test.py
     CONSENSUS cft
     LABEL partitions
-    CONFIGURATIONS partitions    
+    CONFIGURATIONS partitions
     ADDITIONAL_ARGS ${PARTITIONS_TEST_ARGS}
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -711,9 +711,7 @@ if(ENABLE_2TX_RECONFIG)
     NAME reconfiguration_test_cft_2tx
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/reconfiguration.py
     CONSENSUS cft
-    ADDITIONAL_ARGS --ccf-version ${CCF_VERSION} --reconfiguration-type 2tx
-    LABEL partitions
-    CONFIGURATIONS partitions
+    ADDITIONAL_ARGS --ccf-version ${CCF_VERSION} --reconfiguration-type 2tx    
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,7 +520,7 @@ if(BUILD_TESTS)
     ADDITIONAL_ARGS
       --oe-binary
       ${OE_BINDIR}
-      --ledger-recovery-timeout
+      --ledger-read-timeout
       20
       --test-duration
       200

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -710,7 +710,7 @@ if(BUILD_TESTS)
     NAME reconfiguration_test_cft_2tx
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/reconfiguration.py
     CONSENSUS cft
-    ADDITIONAL_ARGS --ccf-version ${CCF_VERSION} --reconfiguration-type 2tx    
+    ADDITIONAL_ARGS --ccf-version ${CCF_VERSION} --reconfiguration-type 2tx
     CONFIGURATIONS partitions
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -707,7 +707,7 @@ if(BUILD_TESTS)
     NAME reconfiguration_test_cft
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/reconfiguration.py
     CONSENSUS cft
-    ADDITIONAL_ARGS ${RECONFIG_TEST_ARGS}  
+    ADDITIONAL_ARGS ${RECONFIG_TEST_ARGS}
   )
 
   add_e2e_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -710,8 +710,7 @@ if(BUILD_TESTS)
     NAME reconfiguration_test_cft_2tx
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/reconfiguration.py
     CONSENSUS cft
-    ADDITIONAL_ARGS --ccf-version ${CCF_VERSION} --reconfiguration-type 2tx
-    LABEL partitions
+    ADDITIONAL_ARGS --ccf-version ${CCF_VERSION} --reconfiguration-type 2tx    
     CONFIGURATIONS partitions
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -706,13 +706,16 @@ if(BUILD_TESTS)
     ADDITIONAL_ARGS --ccf-version ${CCF_VERSION}
   )
 
+if(ENABLE_2TX_RECONFIG)
   add_e2e_test(
     NAME reconfiguration_test_cft_2tx
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/reconfiguration.py
     CONSENSUS cft
     ADDITIONAL_ARGS --ccf-version ${CCF_VERSION} --reconfiguration-type 2tx
+    LABEL partitions
     CONFIGURATIONS partitions
   )
+endif()
 
   add_e2e_test(
     NAME election_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -706,15 +706,6 @@ if(BUILD_TESTS)
     ADDITIONAL_ARGS --ccf-version ${CCF_VERSION}
   )
 
-if(ENABLE_2TX_RECONFIG)
-  add_e2e_test(
-    NAME reconfiguration_test_cft_2tx
-    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/reconfiguration.py
-    CONSENSUS cft
-    ADDITIONAL_ARGS --ccf-version ${CCF_VERSION} --reconfiguration-type 2tx    
-  )
-endif()
-
   add_e2e_test(
     NAME election_test
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/election.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,7 +520,7 @@ if(BUILD_TESTS)
     ADDITIONAL_ARGS
       --oe-binary
       ${OE_BINDIR}
-      --ledger-read-timeout
+      --ledger-recovery-timeout
       20
       --test-duration
       200

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -707,6 +707,13 @@ if(BUILD_TESTS)
   )
 
   add_e2e_test(
+    NAME reconfiguration_test_cft_2tx
+    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/reconfiguration.py
+    CONSENSUS cft
+    ADDITIONAL_ARGS --ccf-version ${CCF_VERSION} --reconfiguration-type 2tx
+  )
+
+  add_e2e_test(
     NAME election_test
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/election.py
     CONSENSUS ${CONSENSUS_FILTER}

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -56,6 +56,11 @@ if(ENABLE_BFT)
   add_compile_definitions(ENABLE_BFT)
 endif()
 
+option(ENABLE_2TX_RECONFIG "Enable experimental 2-transaction reconfiguration" OFF)
+if(ENABLE_2TX_RECONFIG)
+  add_compile_definitions(ENABLE_2TX_RECONFIG)
+endif()
+
 option(DEBUG_CONFIG "Enable non-production options options to aid debugging"
        OFF
 )

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -56,7 +56,9 @@ if(ENABLE_BFT)
   add_compile_definitions(ENABLE_BFT)
 endif()
 
-option(ENABLE_2TX_RECONFIG "Enable experimental 2-transaction reconfiguration" OFF)
+option(ENABLE_2TX_RECONFIG "Enable experimental 2-transaction reconfiguration"
+       OFF
+)
 if(ENABLE_2TX_RECONFIG)
   add_compile_definitions(ENABLE_2TX_RECONFIG)
 endif()

--- a/doc/overview/consensus/1tx-reconfig.rst
+++ b/doc/overview/consensus/1tx-reconfig.rst
@@ -1,12 +1,9 @@
-Crash Fault Tolerance
-=====================
+One-transaction Reconfiguration
+===============================
+
+This describes the default reconfiguration scheme as currently implemented. When using CFT, CCF also supports :doc:`two-transaction reconfiguration <2tx-reconfig>`.
 
 Below, we only discuss changes to the original Raft implementation that are not trivial. For more information on Raft please see the original `Raft paper <https://www.usenix.org/system/files/conference/atc14/atc14-paper-ongaro.pdf>`_.
-
-One-transaction Reconfiguration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This describes the reconfiguration as currently implemented. Note, that the one-transaction reconfiguration is only valid for CFT.
 
 From a ledger and KV store perspective, reconfiguration is a single **reconfiguration transaction**. Any transaction that contains at least one write to ``public:ccf.gov.nodes.info`` setting a node's status to ``TRUSTED`` or ``RETIRED`` is such a reconfiguration transaction.
 

--- a/doc/overview/consensus/2tx-reconfig.rst
+++ b/doc/overview/consensus/2tx-reconfig.rst
@@ -1,15 +1,14 @@
-Byzantine Fault Tolerance
-=========================
+Two-transaction Reconfiguration
+===============================
 
-Below we discuss the reconfiguration as implemented for the BFT setting. Technically the two-transaction scheme is not specific to BFT. In fact, Ongaro and Ousterhout also described a two-transaction reconfiguration mechanism for Raft. As such, the two-transaction scheme as described below could also be used in CFT. However in BFT, the following properties are desirable: 
+Next to one-transaction reconfiguration, CCF also supports two-transaction reconfiguration, which has properties that are particularly desirable when used with the (experimental) Byzantine Fault Tolerance consensus algorithm. It is however also available to :doc:`CFT <1tx-reconfig>` networks and in fact, Ongaro and Ousterhout also describe a two-transaction reconfiguration mechanism for Raft. 
+
+In BFT, the following properties are desirable: 
 
 1. A reconfiguration only starts when the reconfiguration transaction is committed, so a reconfiguration attempt can never roll back.
-2. Reconfigurations are atomic. This creates room for additional conditions, such as checking that the byzantine reconfiguration (a multiple transaction protocol) is complete before proceeding to the new configuration.
+2. Reconfigurations are atomic. This creates room for additional conditions, such as checking that the Byzantine reconfiguration (a multiple transaction protocol) is complete before proceeding to the new configuration.
 
 BFT is under development and should not be enabled in a production environment. There is an open research question of `node identity with Byzantine nodes <https://github.com/microsoft/CCF/issues/893>`_.
-
-Two-transaction Reconfiguration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A two-transaction reconfiguration is triggered by the same mechanism as in one-transaction reconfiguration, i.e. a change to ``public:ccf.gov.nodes.info``. It does however not become active immediately. Joining nodes are held in a ``LEARNER`` state in which they receive copies of the ledger, but they are not taken into account in commit-level decisions or leader selection until a quorum of them has caught up. Nodes recognize that they are added to the network by observing the commit of the transaction that includes their own addition to ``public:ccf.gov.nodes.info``. This means that they have seen all preceding transactions up until their addition to the network. Similary, nodes that are to be retired recognize that their state is changed to ``RETIRING`` in ``public:ccf.gov.nodes.info``.
 

--- a/doc/overview/consensus/index.rst
+++ b/doc/overview/consensus/index.rst
@@ -10,7 +10,7 @@ Below, we give an overview over the nodes state machine in both settings and the
 CFT Consensus Protocol
 -----------------------
 
-The crash fault tolerant implementation in CCF is based on Raft. You can find more information on the Raft implementation in CCF :doc:`here <cft>`.
+The crash fault tolerant implementation in CCF is based on Raft. You can find more information on the Raft implementation of reconfiguration in CCF :doc:`here <1tx-reconfig>`.
 
 CFT parameters can be configured when starting up a network (see :doc:`here </operations/start_network>`). The parameters that can be set via the CLI are:
 
@@ -21,7 +21,7 @@ BFT Consensus Protocol
 ----------------------
 .. warning:: CCF with BFT is currently in development and should not be used in a production environment.
 
-More details on this mode is given :doc:`here <bft>`. There is an open research question of `node identity with Byzantine nodes <https://github.com/microsoft/CCF/issues/893>`_.
+More details on this mode is given :doc:`here <2tx-reconfig>`. There is an open research question of `node identity with Byzantine nodes <https://github.com/microsoft/CCF/issues/893>`_.
 
 By default CCF runs with CFT **and BFT is disabled on release versions**. To run CCF with BFT, CCF first needs to be :doc:`built from source </contribute/build_ccf>`. Then, the ``--consensus bft`` CLI argument must be provided when starting up the nodes (see :doc:`/operations/start_network` for starting up a network and nodes).
 
@@ -81,6 +81,8 @@ A node permanently transitions to ``Retired`` once it has observed commit reachi
 Note that because the rollback triggered when a node becomes aware of a new term never preserves unsigned transactions,
 and because RCI is always the first signature after RI, RI and RCI are always both rolled back if RCI itself is rolled back.
 
+Further information about the reconfiguration schemes:
+
 .. toctree::
-    cft
-    bft
+    1tx-reconfig
+    2tx-reconfig

--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -406,7 +406,11 @@ class LedgerValidator:
         # Note: A retired primary will still issue signature transactions until
         # its retirement is committed
         node_status = NodeStatus(tx_info.node_activity[tx_info.signing_node][0])
-        if node_status not in (NodeStatus.TRUSTED, NodeStatus.RETIRED):
+        if node_status not in (
+            NodeStatus.TRUSTED,
+            NodeStatus.RETIRING,
+            NodeStatus.RETIRED,
+        ):
             raise UntrustedNodeException(
                 f"The signing node {tx_info.signing_node} has unexpected status {node_status.value}"
             )

--- a/src/common/enclave_interface_types.h
+++ b/src/common/enclave_interface_types.h
@@ -32,7 +32,10 @@ enum CreateNodeStatus
   OEAttesterInitFailed = 8,
 
   /** OpenSSL RDRAND Init Failed */
-  OpenSSLRDRANDInitFailed = 9
+  OpenSSLRDRANDInitFailed = 9,
+
+  /** The reconfiguration method is not supported */
+  ReconfigurationMethodNotSupported = 10
 };
 
 constexpr char const* create_node_result_to_str(CreateNodeStatus result)

--- a/src/common/enclave_interface_types.h
+++ b/src/common/enclave_interface_types.h
@@ -82,6 +82,10 @@ constexpr char const* create_node_result_to_str(CreateNodeStatus result)
     {
       return "OpenSSLRDRANDInitFailed";
     }
+    case CreateNodeStatus::ReconfigurationMethodNotSupported:
+    {
+      return "ReconfigurationMethodNotSupported";
+    }
     default:
     {
       return "Unknown CreateNodeStatus";

--- a/src/consensus/aft/orc_requests.h
+++ b/src/consensus/aft/orc_requests.h
@@ -11,6 +11,8 @@
 
 namespace ccf
 {
+  size_t constexpr ORC_RPC_RETRY_INTERVAL_MS = 250;
+
   struct ObservedReconfigurationCommit
   {
     struct In
@@ -66,7 +68,7 @@ namespace ccf
     if (!submit_orc(msg->data.client, msg->data.from, msg->data.rid))
     {
       threading::ThreadMessaging::thread_messaging.add_task_after(
-        std::move(msg), std::chrono::milliseconds(250));
+        std::move(msg), std::chrono::milliseconds(ORC_RPC_RETRY_INTERVAL_MS));
     }
   }
 

--- a/src/consensus/aft/orc_requests.h
+++ b/src/consensus/aft/orc_requests.h
@@ -82,12 +82,13 @@ namespace ccf
   inline void schedule_submit_orc(
     std::shared_ptr<ccf::NodeClient> client,
     const ccf::NodeId& from,
-    kv::ReconfigurationId rid)
+    kv::ReconfigurationId rid,
+    bool delayed = false)
   {
     auto msg = std::make_unique<threading::Tmsg<AsyncORCTaskMsg>>(
       orc_cb, client, from, rid);
 
     threading::ThreadMessaging::thread_messaging.add_task_after(
-      std::move(msg), std::chrono::milliseconds(0));
+      std::move(msg), std::chrono::milliseconds(delayed ? 1000 : 0));
   }
 }

--- a/src/consensus/aft/orc_requests.h
+++ b/src/consensus/aft/orc_requests.h
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ds/thread_messaging.h"
+#include "kv/kv_types.h"
+#include "node/node_client.h"
+#include "node/rpc/serdes.h"
+
+namespace ccf
+{
+  struct ObservedReconfigurationCommit
+  {
+    struct In
+    {
+      ccf::NodeId from;
+      kv::ReconfigurationId reconfiguration_id;
+    };
+
+    using Out = void;
+  };
+
+  DECLARE_JSON_TYPE(ObservedReconfigurationCommit::In)
+  DECLARE_JSON_REQUIRED_FIELDS(
+    ObservedReconfigurationCommit::In, from, reconfiguration_id)
+
+  inline bool submit_orc(
+    std::shared_ptr<ccf::NodeClient> client,
+    const ccf::NodeId& from,
+    kv::ReconfigurationId rid)
+  {
+    LOG_DEBUG_FMT("Configurations: submit ORC for #{} from {}", rid, from);
+
+    ObservedReconfigurationCommit::In ps = {from, rid};
+
+    http::Request request(fmt::format(
+      "/{}/{}", ccf::get_actor_prefix(ccf::ActorsType::nodes), "orc"));
+    request.set_header(
+      http::headers::CONTENT_TYPE, http::headervalues::contenttype::JSON);
+
+    auto body = serdes::pack(ps, serdes::Pack::Text);
+    request.set_body(&body);
+    return client->make_request(request);
+  }
+
+  struct AsyncORCTaskMsg
+  {
+    AsyncORCTaskMsg(
+      std::shared_ptr<ccf::NodeClient> client_,
+      const ccf::NodeId& from_,
+      kv::ReconfigurationId rid_,
+      size_t retries_ = SIZE_MAX) :
+      client(client_),
+      from(from_),
+      rid(rid_),
+      retries(retries_)
+    {}
+
+    std::shared_ptr<ccf::NodeClient> client;
+    ccf::NodeId from;
+    kv::ReconfigurationId rid;
+    size_t retries;
+  };
+
+  inline void orc_cb(std::unique_ptr<threading::Tmsg<AsyncORCTaskMsg>> msg)
+  {
+    if (!submit_orc(msg->data.client, msg->data.from, msg->data.rid))
+    {
+      if (--msg->data.retries > 0)
+      {
+        threading::ThreadMessaging::thread_messaging.add_task_after(
+          std::move(msg), std::chrono::milliseconds(250));
+      }
+      else
+      {
+        LOG_DEBUG_FMT(
+          "Failed request; giving up as there are no more retries left");
+      }
+    }
+  }
+
+  inline void schedule_submit_orc(
+    std::shared_ptr<ccf::NodeClient> client,
+    const ccf::NodeId& from,
+    kv::ReconfigurationId rid)
+  {
+    auto msg = std::make_unique<threading::Tmsg<AsyncORCTaskMsg>>(
+      orc_cb, client, from, rid);
+
+    threading::ThreadMessaging::thread_messaging.add_task_after(
+      std::move(msg), std::chrono::milliseconds(0));
+  }
+}

--- a/src/consensus/aft/orc_requests.h
+++ b/src/consensus/aft/orc_requests.h
@@ -89,6 +89,6 @@ namespace ccf
       orc_cb, client, from, rid);
 
     threading::ThreadMessaging::thread_messaging.add_task_after(
-      std::move(msg), std::chrono::milliseconds(delayed ? 1000 : 0));
+      std::move(msg), std::chrono::milliseconds(delayed ? 2000 : 0));
   }
 }

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -652,17 +652,6 @@ namespace aft
                 "Configurations: observing own promotion, becoming a follower");
               replica_state = kv::ReplicaState::Follower;
             }
-
-            if (
-              nodes.find(nid) != nodes.end() &&
-              retirees.find(nid) != retirees.end() &&
-              new_retirees.find(nid) == new_retirees.end() &&
-              conf.find(nid) == conf.end())
-            {
-              // Final retirement of retiring node
-              retirees.erase(nid);
-              LOG_DEBUG_FMT("Configurations: {} is now retired", nid);
-            }
           }
         }
       }

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -771,6 +771,12 @@ namespace aft
         oit->second.size(),
         ncnodes.size(),
         rid);
+
+      // Note: Learners in the next configuration become trusted when there is
+      // quorum in the next configuration, i.e. they may become trusted in the
+      // nodes table before they are fully caught up and have submitted their
+      // own ORC.
+
       return oit->second.size() >= get_quorum(ncnodes.size());
     }
 

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -3384,6 +3384,8 @@ namespace aft
         }
         else
         {
+          bool retiring_primary = false;
+
           if (
             !is_retired() &&
             conf->nodes.find(state->my_node_id) != conf->nodes.end() &&
@@ -3392,10 +3394,12 @@ namespace aft
             auto rit = retirees.find(state->my_node_id);
             if (is_retiring() && rit != retirees.end() && rit->second <= idx)
             {
+              retiring_primary = is_primary();
               become_retired();
             }
             else if (!is_retiring())
             {
+              retiring_primary = is_primary();
               become_retiring();
             }
           }
@@ -3457,7 +3461,8 @@ namespace aft
                (is_retiring() &&
                 next->nodes.find(state->my_node_id) == next->nodes.end())))
             {
-              schedule_submit_orc(node_client, state->my_node_id, next->rid);
+              schedule_submit_orc(
+                node_client, state->my_node_id, next->rid, retiring_primary);
             }
             break;
           }

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -3343,7 +3343,6 @@ namespace aft
           else
           {
             if (
-              reconfiguration_type == ReconfigurationType::TWO_TRANSACTION &&
               !is_learner() && !is_retired() && node_client &&
               next->nodes.find(state->my_node_id) != next->nodes.end())
             {

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -546,24 +546,6 @@ namespace aft
       return offset;
     }
 
-    bool same_node_ids(
-      const kv::Configuration::Nodes& conf1,
-      const kv::Configuration::Nodes& conf2)
-    {
-      if (conf1.size() == conf2.size())
-      {
-        for (const auto& [nid, _] : conf1)
-        {
-          if (conf2.find(nid) == conf2.end())
-          {
-            return false;
-          }
-        }
-        return true;
-      }
-      return false;
-    }
-
   public:
     void add_configuration(
       Index idx,
@@ -656,7 +638,7 @@ namespace aft
         }
       }
 
-      if (!same_node_ids(conf, configurations.back().nodes))
+      if (conf != configurations.back().nodes)
       {
         uint32_t offset = get_bft_offset(conf);
         configurations.push_back({idx, std::move(conf), offset, 0});

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -41,6 +41,7 @@
 #include "node/resharing_tracker.h"
 #include "node/rpc/tx_status.h"
 #include "node/signatures.h"
+#include "orc_requests.h"
 #include "raft_types.h"
 
 #include <algorithm>
@@ -3456,7 +3457,7 @@ namespace aft
                (is_retiring() &&
                 next->nodes.find(state->my_node_id) == next->nodes.end())))
             {
-              node_client->schedule_submit_orc(state->my_node_id, next->rid);
+              schedule_submit_orc(node_client, state->my_node_id, next->rid);
             }
             break;
           }

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -730,7 +730,16 @@ namespace aft
     }
 
     // For more info about Observed Reconfiguration Commits see
-    // https://microsoft.github.io/CCF/main/overview/consensus/bft.html#two-transaction-reconfiguration
+    // https://microsoft.github.io/CCF/main/overview/consensus/2tx-reconfig.html
+    //
+    // Note that this call is not `const` and that it modifies `orc_sets`. This
+    // is safe, despite the fact that the primary may change or a
+    // reconfiguration may be (partially) rolled back, because the `orc_sets`
+    // are cleared upon entering/exiting the leader/follower replica states.
+    // This means that we never record spurious ORCs, while it is still
+    // guaranteed that we will eventuallky receive all of them, since all
+    // nodes keep re-submitting ORCs until they are able to switch to the next
+    // pending configuration.
     bool orc(kv::ReconfigurationId rid, const ccf::NodeId& node_id)
     {
       LOG_DEBUG_FMT(

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -721,6 +721,14 @@ namespace aft
       }
     }
 
+    void clear_orc_sets()
+    {
+      for (auto& [_, s] : orc_sets)
+      {
+        s.clear();
+      }
+    }
+
     // For more info about Observed Reconfiguration Commits see
     // https://microsoft.github.io/CCF/main/overview/consensus/bft.html#two-transaction-reconfiguration
     bool orc(kv::ReconfigurationId rid, const ccf::NodeId& node_id)
@@ -2918,6 +2926,8 @@ namespace aft
     {
       replica_state = kv::ReplicaState::Candidate;
       leader_id.reset();
+      clear_orc_sets();
+
       voted_for = state->my_node_id;
       votes_for_me.clear();
       state->current_view++;
@@ -3024,6 +3034,7 @@ namespace aft
       state->current_view = term;
       voted_for.reset();
       votes_for_me.clear();
+      clear_orc_sets();
 
       if (consensus_type == ConsensusType::BFT)
       {

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -149,7 +149,7 @@ namespace aft
     // Configurations
     std::list<Configuration> configurations;
     std::unordered_map<ccf::NodeId, NodeState> nodes;
-    std::unordered_map<ccf::NodeId, ccf::SeqNo> learners;
+    std::unordered_map<ccf::NodeId, ccf::SeqNo> learner_nodes;
     std::unordered_map<ccf::NodeId, ccf::SeqNo> retired_nodes;
     ReconfigurationType reconfiguration_type;
     bool require_identity_for_reconfig = false;
@@ -595,9 +595,9 @@ namespace aft
             fmt::join(new_learners, ", "));
           for (auto& id : new_learners)
           {
-            if (learners.find(id) == learners.end())
+            if (learner_nodes.find(id) == learner_nodes.end())
             {
-              learners[id] = idx;
+              learner_nodes[id] = idx;
             }
           }
         }
@@ -622,11 +622,11 @@ namespace aft
           {
             if (
               nodes.find(nid) != nodes.end() &&
-              learners.find(nid) != learners.end() &&
+              learner_nodes.find(nid) != learner_nodes.end() &&
               new_learners.find(nid) == new_learners.end())
             {
               // Promotion of known learner
-              learners.erase(nid);
+              learner_nodes.erase(nid);
             }
             if (is_learner() && nid == state->my_node_id)
             {
@@ -793,7 +793,7 @@ namespace aft
       }
       if (reconfiguration_type == ReconfigurationType::TWO_TRANSACTION)
       {
-        details.learners = learners;
+        details.learners = learner_nodes;
       }
       return details;
     }
@@ -3220,7 +3220,7 @@ namespace aft
       {
         if (
           (nodes.find(id) != nodes.end() &&
-           learners.find(id) == learners.end()) ||
+           learner_nodes.find(id) == learner_nodes.end()) ||
           (id == state->my_node_id && !is_learner()))
         {
           r++;
@@ -3399,7 +3399,7 @@ namespace aft
 
             for (auto& [nid, _] : next->nodes)
             {
-              learners.erase(nid);
+              learner_nodes.erase(nid);
             }
 
             for (auto& [nid, _] : conf->nodes)
@@ -3556,11 +3556,11 @@ namespace aft
 
       if (reconfiguration_type == ReconfigurationType::TWO_TRANSACTION)
       {
-        for (auto it = learners.begin(); it != learners.end();)
+        for (auto it = learner_nodes.begin(); it != learner_nodes.end();)
         {
           if (it->second > idx)
           {
-            it = learners.erase(it);
+            it = learner_nodes.erase(it);
           }
           else
           {

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -3451,7 +3451,11 @@ namespace aft
                 next->nodes.find(state->my_node_id) == next->nodes.end())))
             {
               schedule_submit_orc(
-                node_client, state->my_node_id, next->rid, retiring_primary);
+                node_client,
+                state->my_node_id,
+                next->rid,
+                retiring_primary ? 2 * election_timeout :
+                                   std::chrono::milliseconds(0));
             }
             break;
           }

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -737,7 +737,7 @@ namespace aft
     // reconfiguration may be (partially) rolled back, because the `orc_sets`
     // are cleared upon entering/exiting the leader/follower replica states.
     // This means that we never record spurious ORCs, while it is still
-    // guaranteed that we will eventuallky receive all of them, since all
+    // guaranteed that we will eventually receive all of them, since all
     // nodes keep re-submitting ORCs until they are able to switch to the next
     // pending configuration.
     bool orc(kv::ReconfigurationId rid, const ccf::NodeId& node_id)

--- a/src/consensus/aft/raft_consensus.h
+++ b/src/consensus/aft/raft_consensus.h
@@ -131,9 +131,9 @@ namespace aft
       ccf::SeqNo seqno,
       const Configuration::Nodes& conf,
       const std::unordered_set<ccf::NodeId>& learners = {},
-      const std::unordered_set<ccf::NodeId>& retirees = {}) override
+      const std::unordered_set<ccf::NodeId>& retired_nodes = {}) override
     {
-      aft->add_configuration(seqno, conf, learners, retirees);
+      aft->add_configuration(seqno, conf, learners, retired_nodes);
     }
 
     void record_signature(

--- a/src/consensus/aft/raft_consensus.h
+++ b/src/consensus/aft/raft_consensus.h
@@ -130,9 +130,10 @@ namespace aft
     void add_configuration(
       ccf::SeqNo seqno,
       const Configuration::Nodes& conf,
-      const std::unordered_set<ccf::NodeId>& learners = {}) override
+      const std::unordered_set<ccf::NodeId>& learners = {},
+      const std::unordered_set<ccf::NodeId>& retirees = {}) override
     {
-      aft->add_configuration(seqno, conf, learners);
+      aft->add_configuration(seqno, conf, learners, retirees);
     }
 
     void record_signature(

--- a/src/enclave/interface.h
+++ b/src/enclave/interface.h
@@ -16,6 +16,7 @@
 #include "kv/kv_types.h"
 #include "node/members.h"
 #include "node/node_info_network.h"
+#include "reconfiguration_type.h"
 #include "tls/tls.h"
 
 #include <chrono>
@@ -82,6 +83,7 @@ struct CCFConfig
 
   size_t initial_node_certificate_validity_period_days;
   std::string startup_host_time;
+  ReconfigurationType reconfiguration_type;
 };
 
 DECLARE_JSON_TYPE(CCFConfig::SignatureIntervals);
@@ -114,7 +116,8 @@ DECLARE_JSON_REQUIRED_FIELDS(
   jwt_key_refresh_interval_s,
   curve_id,
   initial_node_certificate_validity_period_days,
-  startup_host_time);
+  startup_host_time,
+  reconfiguration_type);
 DECLARE_JSON_OPTIONAL_FIELDS(
   CCFConfig, startup_snapshot_evidence_seqno_for_1_x);
 

--- a/src/enclave/interface.h
+++ b/src/enclave/interface.h
@@ -65,6 +65,7 @@ struct CCFConfig
     std::string constitution;
     size_t recovery_threshold;
     size_t max_allowed_node_cert_validity_days;
+    ReconfigurationType reconfiguration_type;
   };
   Genesis genesis = {};
 
@@ -83,7 +84,6 @@ struct CCFConfig
 
   size_t initial_node_certificate_validity_period_days;
   std::string startup_host_time;
-  ReconfigurationType reconfiguration_type;
 };
 
 DECLARE_JSON_TYPE(CCFConfig::SignatureIntervals);
@@ -96,7 +96,8 @@ DECLARE_JSON_REQUIRED_FIELDS(
   members_info,
   constitution,
   recovery_threshold,
-  max_allowed_node_cert_validity_days);
+  max_allowed_node_cert_validity_days,
+  reconfiguration_type);
 
 DECLARE_JSON_TYPE(CCFConfig::Joining);
 DECLARE_JSON_REQUIRED_FIELDS(
@@ -116,8 +117,7 @@ DECLARE_JSON_REQUIRED_FIELDS(
   jwt_key_refresh_interval_s,
   curve_id,
   initial_node_certificate_validity_period_days,
-  startup_host_time,
-  reconfiguration_type);
+  startup_host_time);
 DECLARE_JSON_OPTIONAL_FIELDS(
   CCFConfig, startup_snapshot_evidence_seqno_for_1_x);
 

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -141,6 +141,15 @@ extern "C"
     }
 #endif
 
+#ifndef ENABLE_2TX_RECONFIG
+    // 2-tx reconfiguration is currently experimental, disable it in release
+    // enclaves
+    if (cc.genesis.reconfiguration_type != ReconfigurationType::ONE_TRANSACTION)
+    {
+      return CreateNodeStatus::InternalError;
+    }
+#endif
+
 #ifdef DEBUG_CONFIG
     reserved_memory = new uint8_t[ec->debug_config.memory_reserve_startup];
 #endif

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -146,7 +146,7 @@ extern "C"
     // enclaves
     if (cc.genesis.reconfiguration_type != ReconfigurationType::ONE_TRANSACTION)
     {
-      return CreateNodeStatus::InternalError;
+      return CreateNodeStatus::ReconfigurationMethodNotSupported;
     }
 #endif
 

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -842,7 +842,6 @@ int main(int argc, char** argv)
 
     ccf_config.startup_host_time = crypto::OpenSSL::to_x509_time_string(
       std::chrono::system_clock::to_time_t(startup_host_time));
-    ccf_config.reconfiguration_type = reconfiguration_type;
     ccf_config.genesis.reconfiguration_type = reconfiguration_type;
 
     if (*start)

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -434,18 +434,6 @@ int main(int argc, char** argv)
   // depending on the subcommand.
   std::string network_cert_file = "networkcert.pem";
 
-  ReconfigurationType reconfiguration_type =
-    ReconfigurationType::ONE_TRANSACTION;
-  std::vector<std::pair<std::string, ReconfigurationType>>
-    reconfiguration_type_map{
-      {"1tx", ReconfigurationType::ONE_TRANSACTION},
-      {"2tx", ReconfigurationType::TWO_TRANSACTION}};
-  app
-    .add_option(
-      "--reconfiguration-type", reconfiguration_type, "Reconfiguration type")
-    ->transform(
-      CLI::CheckedTransformer(reconfiguration_type_map, CLI::ignore_case));
-
   auto start = app.add_subcommand("start", "Start new network");
   start->configurable();
 
@@ -494,6 +482,18 @@ int main(int argc, char** argv)
       "Maximum validity period (days) for certificates of trusted nodes")
     ->check(CLI::PositiveNumber)
     ->type_name("UINT");
+
+  ReconfigurationType reconfiguration_type =
+    ReconfigurationType::ONE_TRANSACTION;
+  std::vector<std::pair<std::string, ReconfigurationType>>
+    reconfiguration_type_map{
+      {"1tx", ReconfigurationType::ONE_TRANSACTION},
+      {"2tx", ReconfigurationType::TWO_TRANSACTION}};
+  start
+    ->add_option(
+      "--reconfiguration-type", reconfiguration_type, "Reconfiguration type")
+    ->transform(
+      CLI::CheckedTransformer(reconfiguration_type_map, CLI::ignore_case));
 
   auto join = app.add_subcommand("join", "Join existing network");
   join->configurable();
@@ -843,6 +843,7 @@ int main(int argc, char** argv)
     ccf_config.startup_host_time = crypto::OpenSSL::to_x509_time_string(
       std::chrono::system_clock::to_time_t(startup_host_time));
     ccf_config.reconfiguration_type = reconfiguration_type;
+    ccf_config.genesis.reconfiguration_type = reconfiguration_type;
 
     if (*start)
     {

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -9,6 +9,7 @@
 #include "ds/non_blocking.h"
 #include "ds/oversized.h"
 #include "enclave.h"
+#include "enclave/reconfiguration_type.h"
 #include "handle_ring_buffer.h"
 #include "load_monitor.h"
 #include "node_connections.h"
@@ -433,6 +434,18 @@ int main(int argc, char** argv)
   // depending on the subcommand.
   std::string network_cert_file = "networkcert.pem";
 
+  ReconfigurationType reconfiguration_type =
+    ReconfigurationType::ONE_TRANSACTION;
+  std::vector<std::pair<std::string, ReconfigurationType>>
+    reconfiguration_type_map{
+      {"1tx", ReconfigurationType::ONE_TRANSACTION},
+      {"2tx", ReconfigurationType::TWO_TRANSACTION}};
+  app
+    .add_option(
+      "--reconfiguration-type", reconfiguration_type, "Reconfiguration type")
+    ->transform(
+      CLI::CheckedTransformer(reconfiguration_type_map, CLI::ignore_case));
+
   auto start = app.add_subcommand("start", "Start new network");
   start->configurable();
 
@@ -829,6 +842,7 @@ int main(int argc, char** argv)
 
     ccf_config.startup_host_time = crypto::OpenSSL::to_x509_time_string(
       std::chrono::system_clock::to_time_t(startup_host_time));
+    ccf_config.reconfiguration_type = reconfiguration_type;
 
     if (*start)
     {

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -95,6 +95,11 @@ namespace kv
         hostname(hostname_),
         port(port_)
       {}
+
+      bool operator==(const NodeInfo& other) const
+      {
+        return hostname == other.hostname && port == other.port;
+      }
     };
 
     using Nodes = std::map<NodeId, NodeInfo>;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -173,7 +173,8 @@ namespace kv
     virtual void add_configuration(
       ccf::SeqNo seqno,
       const Configuration::Nodes& conf,
-      const std::unordered_set<NodeId>& learners = {}) = 0;
+      const std::unordered_set<NodeId>& learners = {},
+      const std::unordered_set<NodeId>& retirees = {}) = 0;
     virtual Configuration::Nodes get_latest_configuration() = 0;
     virtual Configuration::Nodes get_latest_configuration_unsafe() const = 0;
     virtual ConsensusDetails get_details() = 0;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -179,7 +179,7 @@ namespace kv
       ccf::SeqNo seqno,
       const Configuration::Nodes& conf,
       const std::unordered_set<NodeId>& learners = {},
-      const std::unordered_set<NodeId>& retirees = {}) = 0;
+      const std::unordered_set<NodeId>& retired_nodes = {}) = 0;
     virtual Configuration::Nodes get_latest_configuration() = 0;
     virtual Configuration::Nodes get_latest_configuration_unsafe() const = 0;
     virtual ConsensusDetails get_details() = 0;

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -149,7 +149,8 @@ namespace kv::test
     void add_configuration(
       ccf::SeqNo seqno,
       const Configuration::Nodes& conf,
-      const std::unordered_set<NodeId>& learners = {}) override
+      const std::unordered_set<NodeId>& learners = {},
+      const std::unordered_set<NodeId>& retirees = {}) override
     {}
 
     void reconfigure(

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -150,7 +150,7 @@ namespace kv::test
       ccf::SeqNo seqno,
       const Configuration::Nodes& conf,
       const std::unordered_set<NodeId>& learners = {},
-      const std::unordered_set<NodeId>& retirees = {}) override
+      const std::unordered_set<NodeId>& retired_nodes = {}) override
     {}
 
     void reconfigure(

--- a/src/node/hooks.h
+++ b/src/node/hooks.h
@@ -18,6 +18,7 @@ namespace ccf
     kv::Version version;
     std::map<NodeId, std::optional<NodeAddr>> cfg_delta;
     std::unordered_set<NodeId> learners;
+    std::unordered_set<NodeId> retirees;
 
   public:
     ConfigurationChangeHook(kv::Version version_, const Nodes::Write& w) :
@@ -44,6 +45,7 @@ namespace ccf
           case NodeStatus::RETIRED:
           {
             cfg_delta.try_emplace(node_id, std::nullopt);
+            retirees.insert(node_id);
             break;
           }
           case NodeStatus::LEARNER:
@@ -82,7 +84,8 @@ namespace ccf
       }
       if (!cfg_delta.empty())
       {
-        consensus->add_configuration(version, configuration, learners);
+        consensus->add_configuration(
+          version, configuration, learners, retirees);
       }
     }
   };

--- a/src/node/hooks.h
+++ b/src/node/hooks.h
@@ -56,7 +56,7 @@ namespace ccf
           }
           case NodeStatus::RETIRING:
           {
-            /* Nothing */
+            cfg_delta.try_emplace(node_id, std::nullopt);
             break;
           }
           default:

--- a/src/node/hooks.h
+++ b/src/node/hooks.h
@@ -18,7 +18,7 @@ namespace ccf
     kv::Version version;
     std::map<NodeId, std::optional<NodeAddr>> cfg_delta;
     std::unordered_set<NodeId> learners;
-    std::unordered_set<NodeId> retirees;
+    std::unordered_set<NodeId> retired_nodes;
 
   public:
     ConfigurationChangeHook(kv::Version version_, const Nodes::Write& w) :
@@ -45,7 +45,7 @@ namespace ccf
           case NodeStatus::RETIRED:
           {
             cfg_delta.try_emplace(node_id, std::nullopt);
-            retirees.insert(node_id);
+            retired_nodes.insert(node_id);
             break;
           }
           case NodeStatus::LEARNER:
@@ -85,7 +85,7 @@ namespace ccf
       if (!cfg_delta.empty())
       {
         consensus->add_configuration(
-          version, configuration, learners, retirees);
+          version, configuration, learners, retired_nodes);
       }
     }
   };

--- a/src/node/http_node_client.h
+++ b/src/node/http_node_client.h
@@ -62,7 +62,7 @@ namespace ccf
       {
         auto ser_res = ctx->serialise_response();
         std::string str((char*)ser_res.data(), ser_res.size());
-        LOG_FAIL_FMT("Request failed: {}", str);
+        LOG_DEBUG_FMT("Request failed: {}", str);
       }
 
       return rs == HTTP_STATUS_OK;

--- a/src/node/http_node_client.h
+++ b/src/node/http_node_client.h
@@ -59,17 +59,14 @@ namespace ccf
 
       auto rs = ctx->get_response_status();
 
-      if (
-        rs != HTTP_STATUS_OK &&
-        (!no_content_ok || rs != HTTP_STATUS_NO_CONTENT))
+      if (rs != HTTP_STATUS_OK)
       {
         auto ser_res = ctx->serialise_response();
         std::string str((char*)ser_res.data(), ser_res.size());
         LOG_FAIL_FMT("Request failed: {}", str);
       }
 
-      return rs == HTTP_STATUS_OK ||
-        (no_content_ok && rs == HTTP_STATUS_NO_CONTENT);
+      return rs == HTTP_STATUS_OK;
     }
 
     bool submit_orc(const NodeId& from, kv::ReconfigurationId rid) override

--- a/src/node/http_node_client.h
+++ b/src/node/http_node_client.h
@@ -3,9 +3,6 @@
 #pragma once
 
 #include "node/node_client.h"
-#include "node/rpc/node_call_types.h"
-#include "node/rpc/serdes.h"
-#include "node/rpc/serialization.h"
 
 #include <chrono>
 
@@ -25,7 +22,7 @@ namespace ccf
 
     virtual ~HTTPNodeClient() {}
 
-    inline bool make_request(http::Request& request)
+    virtual bool make_request(http::Request& request) override
     {
       const auto& node_cert = endorsed_node_cert.has_value() ?
         endorsed_node_cert.value() :
@@ -69,68 +66,6 @@ namespace ccf
       }
 
       return rs == HTTP_STATUS_OK;
-    }
-
-    bool submit_orc(const NodeId& from, kv::ReconfigurationId rid) override
-    {
-      LOG_DEBUG_FMT("Configurations: submit ORC for #{} from {}", rid, from);
-
-      ObservedReconfigurationCommit::In ps = {from, rid};
-
-      http::Request request(fmt::format(
-        "/{}/{}", ccf::get_actor_prefix(ccf::ActorsType::nodes), "orc"));
-      request.set_header(
-        http::headers::CONTENT_TYPE, http::headervalues::contenttype::JSON);
-
-      auto body = serdes::pack(ps, serdes::Pack::Text);
-      request.set_body(&body);
-      return make_request(request);
-    }
-
-    struct AsyncORCTaskMsg
-    {
-      AsyncORCTaskMsg(
-        HTTPNodeClient* client_,
-        const NodeId& from_,
-        kv::ReconfigurationId rid_,
-        size_t retries_ = SIZE_MAX) :
-        client(client_),
-        from(from_),
-        rid(rid_),
-        retries(retries_)
-      {}
-
-      HTTPNodeClient* client;
-      NodeId from;
-      kv::ReconfigurationId rid;
-      size_t retries;
-    };
-
-    static void orc_cb(std::unique_ptr<threading::Tmsg<AsyncORCTaskMsg>> msg)
-    {
-      if (!msg->data.client->submit_orc(msg->data.from, msg->data.rid))
-      {
-        if (--msg->data.retries > 0)
-        {
-          threading::ThreadMessaging::thread_messaging.add_task_after(
-            std::move(msg), std::chrono::milliseconds(250));
-        }
-        else
-        {
-          LOG_DEBUG_FMT(
-            "Failed request; giving up as there are no more retries left");
-        }
-      }
-    }
-
-    virtual void schedule_submit_orc(
-      const NodeId& from, kv::ReconfigurationId rid) override
-    {
-      auto msg = std::make_unique<threading::Tmsg<AsyncORCTaskMsg>>(
-        orc_cb, this, from, rid);
-
-      threading::ThreadMessaging::thread_messaging.add_task_after(
-        std::move(msg), std::chrono::milliseconds(0));
     }
   };
 }

--- a/src/node/http_node_client.h
+++ b/src/node/http_node_client.h
@@ -23,7 +23,7 @@ namespace ccf
 
     virtual ~HTTPNodeClient() {}
 
-    inline bool make_request(http::Request& request, bool no_content_ok = false)
+    inline bool make_request(http::Request& request)
     {
       const auto& node_cert = endorsed_node_cert.has_value() ?
         endorsed_node_cert.value() :
@@ -82,7 +82,7 @@ namespace ccf
 
       auto body = serdes::pack(ps, serdes::Pack::Text);
       request.set_body(&body);
-      return make_request(request, true);
+      return make_request(request);
     }
 
     struct AsyncORCTaskMsg

--- a/src/node/node_client.h
+++ b/src/node/node_client.h
@@ -30,9 +30,6 @@ namespace ccf
 
     virtual ~NodeClient() {}
 
-    virtual bool submit_orc(const NodeId& from, kv::ReconfigurationId rid) = 0;
-
-    virtual void schedule_submit_orc(
-      const NodeId& from, kv::ReconfigurationId rid) = 0;
+    virtual bool make_request(http::Request& request) = 0;
   };
 }

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -954,9 +954,8 @@ namespace ccf
       }
 
       auto service_config = tx.ro(network.config)->get();
-      auto reconfiguration_type = ReconfigurationType::ONE_TRANSACTION;
-      if (service_config->reconfiguration_type.has_value())
-        reconfiguration_type = service_config->reconfiguration_type.value();
+      auto reconfiguration_type = service_config->reconfiguration_type.value_or(
+        ReconfigurationType::ONE_TRANSACTION);
 
       setup_consensus(ServiceStatus::OPENING, reconfiguration_type, true);
       auto_refresh_jwt_keys();

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -13,6 +13,7 @@
 #include "ds/logger.h"
 #include "ds/net.h"
 #include "ds/state_machine.h"
+#include "enclave/reconfiguration_type.h"
 #include "enclave/rpc_sessions.h"
 #include "encryptor.h"
 #include "entities.h"
@@ -333,7 +334,11 @@ namespace ccf
             open_frontend(ActorsType::members);
           }
 
-          setup_consensus(ServiceStatus::OPENING, false, endorsed_node_cert);
+          setup_consensus(
+            ServiceStatus::OPENING,
+            config.genesis.reconfiguration_type,
+            false,
+            endorsed_node_cert);
 
           // Become the primary and force replication
           consensus->force_become_primary();
@@ -511,6 +516,8 @@ namespace ccf
             setup_consensus(
               resp.network_info->service_status.value_or(
                 ServiceStatus::OPENING),
+              resp.network_info->reconfiguration_type.value_or(
+                ReconfigurationType::ONE_TRANSACTION),
               resp.network_info->public_only,
               n2n_channels_cert);
             auto_refresh_jwt_keys();
@@ -946,7 +953,12 @@ namespace ccf
         progress_tracker->set_node_id(self);
       }
 
-      setup_consensus(ServiceStatus::OPENING, true);
+      auto service_config = tx.ro(network.config)->get();
+      auto reconfiguration_type = ReconfigurationType::ONE_TRANSACTION;
+      if (service_config->reconfiguration_type.has_value())
+        reconfiguration_type = service_config->reconfiguration_type.value();
+
+      setup_consensus(ServiceStatus::OPENING, reconfiguration_type, true);
       auto_refresh_jwt_keys();
 
       LOG_DEBUG_FMT(
@@ -1589,7 +1601,7 @@ namespace ccf
         genesis_info.configuration = {
           config.genesis.recovery_threshold,
           network.consensus_type,
-          config.reconfiguration_type,
+          config.genesis.reconfiguration_type,
           config.genesis.max_allowed_node_cert_validity_days};
         create_params.genesis_info = genesis_info;
       }
@@ -1936,6 +1948,7 @@ namespace ccf
 
     void setup_consensus(
       ServiceStatus service_status,
+      ReconfigurationType reconfiguration_type,
       bool public_only = false,
       const std::optional<crypto::Pem>& endorsed_node_certificate_ =
         std::nullopt)
@@ -1964,7 +1977,7 @@ namespace ccf
         rpc_map, node_sign_kp, self_signed_node_cert, endorsed_node_cert);
 
       kv::ReplicaState initial_state =
-        (network.consensus_type == ConsensusType::BFT &&
+        (reconfiguration_type == ReconfigurationType::TWO_TRANSACTION &&
          service_status == ServiceStatus::OPEN) ?
         kv::ReplicaState::Learner :
         kv::ReplicaState::Follower;
@@ -1989,7 +2002,7 @@ namespace ccf
         sig_tx_interval,
         public_only,
         initial_state,
-        config.reconfiguration_type);
+        reconfiguration_type);
 
       consensus = std::make_shared<RaftConsensusType>(
         std::move(raft), network.consensus_type);

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1585,14 +1585,11 @@ namespace ccf
           genesis_info.members_info.push_back(m_info);
         }
         genesis_info.constitution = config.genesis.constitution;
-        auto reconf_type = network.consensus_type == ConsensusType::BFT ?
-          ReconfigurationType::TWO_TRANSACTION :
-          ReconfigurationType::ONE_TRANSACTION;
 
         genesis_info.configuration = {
           config.genesis.recovery_threshold,
           network.consensus_type,
-          reconf_type,
+          config.reconfiguration_type,
           config.genesis.max_allowed_node_cert_validity_days};
         create_params.genesis_info = genesis_info;
       }
@@ -1993,7 +1990,8 @@ namespace ccf
         std::chrono::milliseconds(consensus_config.bft_view_change_timeout),
         sig_tx_interval,
         public_only,
-        initial_state);
+        initial_state,
+        config.reconfiguration_type);
 
       consensus = std::make_shared<RaftConsensusType>(
         std::move(raft), network.consensus_type);

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1949,17 +1949,15 @@ namespace ccf
         std::chrono::milliseconds(consensus_config.raft_election_timeout));
       auto shared_state = std::make_shared<aft::State>(self);
 
-      std::shared_ptr<ccf::SplitIdentityResharingTracker> resharing_tracker;
-
-      if (network.consensus_type == ConsensusType::BFT)
+      auto resharing_tracker = nullptr;
+      if (consensus_config.consensus_type == ConsensusType::BFT)
       {
-        resharing_tracker =
-          std::make_shared<ccf::SplitIdentityResharingTracker>(
-            shared_state,
-            rpc_map,
-            node_sign_kp,
-            self_signed_node_cert,
-            endorsed_node_cert);
+        std::make_shared<ccf::SplitIdentityResharingTracker>(
+          shared_state,
+          rpc_map,
+          node_sign_kp,
+          self_signed_node_cert,
+          endorsed_node_cert);
       }
 
       auto node_client = std::make_shared<HTTPNodeClient>(

--- a/src/node/rpc/error.h
+++ b/src/node/rpc/error.h
@@ -71,6 +71,7 @@ namespace ccf
     ERROR(NodeCannotHandleRequest)
     ERROR(TransactionPendingOrUnknown)
     ERROR(TransactionInvalid)
+    ERROR(PrimaryNotFound)
 
     // node-to-node (/join and /create):
     ERROR(ConsensusTypeMismatch)

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -109,8 +109,8 @@ namespace ccf
           }
         }
         ctx->set_error(
-          HTTP_STATUS_INTERNAL_SERVER_ERROR,
-          ccf::errors::InternalError,
+          HTTP_STATUS_SERVICE_UNAVAILABLE,
+          ccf::errors::PrimaryNotFound,
           "RPC could not be forwarded to unknown primary.");
         update_metrics(ctx, endpoint);
         return ctx->serialise_response();

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -186,15 +186,4 @@ namespace ccf
       size_t peak_allocated_heap_size = 0;
     };
   };
-
-  struct ObservedReconfigurationCommit
-  {
-    struct In
-    {
-      NodeId from;
-      kv::ReconfigurationId reconfiguration_id;
-    };
-
-    using Out = void;
-  };
 }

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 #include "ds/json_schema.h"
+#include "enclave/reconfiguration_type.h"
 #include "node/config.h"
 #include "node/identity.h"
 #include "node/ledger_secrets.h"
@@ -115,6 +116,7 @@ namespace ccf
         bool public_only = false;
         kv::Version last_recovered_signed_idx = kv::NoVersion;
         ConsensusType consensus_type = ConsensusType::CFT;
+        std::optional<ReconfigurationType> reconfiguration_type = std::nullopt;
 
         LedgerSecretsMap ledger_secrets;
         NetworkIdentity identity;
@@ -128,6 +130,7 @@ namespace ccf
           bool public_only,
           kv::Version last_recovered_signed_idx,
           ConsensusType consensus_type,
+          ReconfigurationType reconfiguration_type,
           const LedgerSecretsMap& ledger_secrets,
           const NetworkIdentity& identity,
           ServiceStatus service_status,
@@ -135,6 +138,7 @@ namespace ccf
           public_only(public_only),
           last_recovered_signed_idx(last_recovered_signed_idx),
           consensus_type(consensus_type),
+          reconfiguration_type(reconfiguration_type),
           ledger_secrets(ledger_secrets),
           identity(identity),
           service_status(service_status),
@@ -146,6 +150,7 @@ namespace ccf
           return public_only == other.public_only &&
             last_recovered_signed_idx == other.last_recovered_signed_idx &&
             consensus_type == other.consensus_type &&
+            reconfiguration_type == other.reconfiguration_type &&
             ledger_secrets == other.ledger_secrets &&
             identity == other.identity &&
             service_status == other.service_status &&

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -7,6 +7,7 @@
 #include "ccf/http_query.h"
 #include "ccf/json_handler.h"
 #include "ccf/version.h"
+#include "consensus/aft/orc_requests.h"
 #include "crypto/certs.h"
 #include "crypto/csr.h"
 #include "crypto/hash.h"

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -142,6 +142,13 @@ namespace ccf
       return duplicate_node_id;
     }
 
+    bool is_taking_part_in_acking(NodeStatus node_status)
+    {
+      return node_status == NodeStatus::TRUSTED ||
+        node_status == NodeStatus::LEARNER ||
+        node_status == NodeStatus::RETIRING;
+    }
+
     auto add_node(
       kv::Tx& tx,
       const std::vector<uint8_t>& node_der,
@@ -450,10 +457,7 @@ namespace ccf
           auto node_info = nodes->get(existing_node_info->node_id);
           auto node_status = node_info->status;
           rep.node_status = node_status;
-          if (
-            node_status == NodeStatus::TRUSTED ||
-            node_status == NodeStatus::LEARNER ||
-            node_status == NodeStatus::RETIRING)
+          if (is_taking_part_in_acking(node_status))
           {
             rep.network_info = JoinNetworkNodeToNode::Out::NetworkInfo(
               context.get_node_state().is_part_of_public_network(),

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -229,14 +229,13 @@ namespace ccf
 
       nodes->put(joining_node_id, node_info);
 
-      kv::NetworkConfiguration nc =
-        get_latest_network_configuration(network, tx);
-      nc.nodes.insert(joining_node_id);
-
       if (
         node_status == NodeStatus::TRUSTED ||
         node_status == NodeStatus::LEARNER)
       {
+        kv::NetworkConfiguration nc =
+          get_latest_network_configuration(network, tx);
+        nc.nodes.insert(joining_node_id);
         add_new_network_reconfiguration(network, tx, nc);
       }
 

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -1360,14 +1360,6 @@ namespace ccf
       auto orc_handler = [this](auto& args, const nlohmann::json& params) {
         const auto in = params.get<ObservedReconfigurationCommit::In>();
 
-        if (consensus == nullptr)
-        {
-          return make_error(
-            HTTP_STATUS_INTERNAL_SERVER_ERROR,
-            ccf::errors::ConsensusTypeMismatch,
-            fmt::format("No consensus"));
-        }
-
         if (consensus->type() != ConsensusType::BFT)
         {
           auto primary_id = consensus->primary();

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -270,10 +270,17 @@ namespace ccf
             joining_node_id, {endorsed_certificate.value()});
         }
 
+        auto config = tx.ro(network.config);
+        auto service_config = config->get();
+        auto reconfiguration_type = ReconfigurationType::ONE_TRANSACTION;
+        if (service_config->reconfiguration_type.has_value())
+          reconfiguration_type = service_config->reconfiguration_type.value();
+
         rep.network_info = JoinNetworkNodeToNode::Out::NetworkInfo{
           context.get_node_state().is_part_of_public_network(),
           context.get_node_state().get_last_recovered_signed_idx(),
           this->network.consensus_type,
+          reconfiguration_type,
           this->network.ledger_secrets->get(tx),
           *this->network.identity.get(),
           service_status,
@@ -356,6 +363,12 @@ namespace ccf
             "No service is available to accept new node.");
         }
 
+        auto config = args.tx.ro(network.config);
+        auto service_config = config->get();
+        auto reconfiguration_type = ReconfigurationType::ONE_TRANSACTION;
+        if (service_config->reconfiguration_type.has_value())
+          reconfiguration_type = service_config->reconfiguration_type.value();
+
         if (active_service->status == ServiceStatus::OPENING)
         {
           // If the service is opening, new nodes are trusted straight away
@@ -372,6 +385,7 @@ namespace ccf
               context.get_node_state().is_part_of_public_network(),
               context.get_node_state().get_last_recovered_signed_idx(),
               this->network.consensus_type,
+              reconfiguration_type,
               this->network.ledger_secrets->get(
                 args.tx, existing_node_info->ledger_secret_seqno),
               *this->network.identity.get(),
@@ -447,6 +461,7 @@ namespace ccf
               context.get_node_state().is_part_of_public_network(),
               context.get_node_state().get_last_recovered_signed_idx(),
               this->network.consensus_type,
+              reconfiguration_type,
               this->network.ledger_secrets->get(
                 args.tx, existing_node_info->ledger_secret_seqno),
               *this->network.identity.get(),

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -1410,7 +1410,7 @@ namespace ccf
           });
         }
 
-        return make_success();
+        return make_success(true);
       };
 
       make_endpoint(

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -57,13 +57,13 @@ namespace ccf
     public_only,
     last_recovered_signed_idx,
     consensus_type,
-    reconfiguration_type,
     ledger_secrets,
     identity)
   DECLARE_JSON_OPTIONAL_FIELDS(
     JoinNetworkNodeToNode::Out::NetworkInfo,
     service_status,
-    endorsed_certificate)
+    endorsed_certificate,
+    reconfiguration_type)
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(JoinNetworkNodeToNode::Out)
   DECLARE_JSON_REQUIRED_FIELDS(JoinNetworkNodeToNode::Out, node_status)
   DECLARE_JSON_OPTIONAL_FIELDS(

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -57,6 +57,7 @@ namespace ccf
     public_only,
     last_recovered_signed_idx,
     consensus_type,
+    reconfiguration_type,
     ledger_secrets,
     identity)
   DECLARE_JSON_OPTIONAL_FIELDS(

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -147,8 +147,4 @@ namespace ccf
 
   DECLARE_JSON_TYPE(UpdateResharing::In)
   DECLARE_JSON_REQUIRED_FIELDS(UpdateResharing::In, rid)
-
-  DECLARE_JSON_TYPE(ObservedReconfigurationCommit::In)
-  DECLARE_JSON_REQUIRED_FIELDS(
-    ObservedReconfigurationCommit::In, from, reconfiguration_id)
 }

--- a/src/runtime_config/default/actions.js
+++ b/src/runtime_config/default/actions.js
@@ -936,7 +936,8 @@ const actions = new Map([
         if (node !== undefined) {
           const node_obj = ccf.bufToJsonCompatible(node);
           node_obj.status =
-            serviceConfig.reconfiguration_type == "TwoTransaction"
+            serviceConfig.reconfiguration_type === "TwoTransaction" &&
+            node_obj.status !== "Pending"
               ? "Retiring"
               : "Retired";
           ccf.kv["public:ccf.gov.nodes.info"].set(

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -342,16 +342,15 @@ class Consortium:
             timeout=timeout,
         )
 
-        is_trusted = self._check_node_exists(remote_node, node_id, NodeStatus.TRUSTED)
-
         if self.reconfiguration_type == "2tx":
-            if not is_trusted and not self._check_node_exists(
+            # Note: the order of these checks is important
+            if not self._check_node_exists(
                 remote_node, node_id, NodeStatus.LEARNER
-            ):
+            ) and not self._check_node_exists(remote_node, node_id, NodeStatus.TRUSTED):
                 raise ValueError(
                     f"Node {node_id} does not exist in state {NodeStatus.TRUSTED} or {NodeStatus.LEARNER}"
                 )
-        elif not is_trusted:
+        elif not self._check_node_exists(remote_node, node_id, NodeStatus.TRUSTED):
             raise ValueError(
                 f"Node {node_id} does not exist in state {NodeStatus.TRUSTED}"
             )

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -33,6 +33,7 @@ class Consortium:
         curve=None,
         public_state=None,
         authenticate_session=True,
+        reconfiguration_type=None,
     ):
         self.common_dir = common_dir
         self.members = []
@@ -42,6 +43,7 @@ class Consortium:
         self.members = []
         self.recovery_threshold = None
         self.authenticate_session = authenticate_session
+        self.reconfiguration_type = reconfiguration_type
         # If a list of member IDs is passed in, generate fresh member identities.
         # Otherwise, recover the state of the consortium from the common directory
         # and the state of the service

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -323,8 +323,8 @@ class Consortium:
         )
 
         if not self._check_node_exists(
-            remote_node, node_id, NodeStatus.TRUSTED
-        ) and not self._check_node_exists(remote_node, node_id, NodeStatus.LEARNER):
+            remote_node, node_id, NodeStatus.LEARNER
+        ) and not self._check_node_exists(remote_node, node_id, NodeStatus.TRUSTED):
             raise ValueError(
                 f"Node {node_id} does not exist in state {NodeStatus.TRUSTED} or {NodeStatus.LEARNER}"
             )

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -317,18 +317,9 @@ class Consortium:
             timeout=timeout,
         )
 
-        if self.reconfiguration_type == "2tx":
-            # Note: the order of these checks is important
-            if not self._check_node_exists(
-                remote_node, node_id, NodeStatus.LEARNER
-            ) and not self._check_node_exists(remote_node, node_id, NodeStatus.TRUSTED):
-                raise ValueError(
-                    f"Node {node_id} does not exist in state {NodeStatus.TRUSTED} or {NodeStatus.LEARNER}"
-                )
-        elif not self._check_node_exists(remote_node, node_id, NodeStatus.TRUSTED):
-            raise ValueError(
-                f"Node {node_id} does not exist in state {NodeStatus.TRUSTED}"
-            )
+        self.wait_for_node_to_exist_in_store(
+            remote_node, node_id, timeout, NodeStatus.TRUSTED
+        )
 
     def remove_member(self, remote_node, member_to_remove):
         LOG.info(f"Retiring member {member_to_remove.local_id}")

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -362,6 +362,12 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         type=int,
         default=365,
     )
+    parser.add_argument(
+        "--reconfiguration-type",
+        help="Reconfiguration type",
+        default="1tx",
+        choices=("1tx", "2tx"),
+    )
 
     add(parser)
 

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -291,8 +291,8 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         default=3,
     )
     parser.add_argument(
-        "--ledger-read-timeout",
-        help="The maximum time (s) to read the ledger",
+        "--ledger-recovery-timeout",
+        help="On recovery, maximum timeout (s) while reading the ledger",
         type=int,
         default=30,
     )

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -291,8 +291,8 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         default=3,
     )
     parser.add_argument(
-        "--ledger-recovery-timeout",
-        help="On recovery, maximum timeout (s) while reading the ledger",
+        "--ledger-read-timeout",
+        help="The maximum time (s) to read the ledger",
         type=int,
         default=30,
     )

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -637,8 +637,6 @@ class Network:
     def trust_node(self, node, args, valid_from=None, validity_period_days=None):
         primary, _ = self.find_primary()
         try:
-            # Note: the time it takes for a learner to catch up is proportional
-            # to the ledger size; we may want to factor that into the timeout.
             if self.status is ServiceStatus.OPEN:
                 valid_from = valid_from or str(
                     infra.crypto.datetime_to_X509time(datetime.now())

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -110,6 +110,7 @@ class Network:
         "client_connection_timeout_ms",
         "initial_node_cert_validity_days",
         "max_allowed_node_cert_validity_days",
+        "reconfiguration_type",
     ]
 
     # Maximum delay (seconds) for updates to propagate from the primary to backups

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -637,6 +637,8 @@ class Network:
     def trust_node(self, node, args, valid_from=None, validity_period_days=None):
         primary, _ = self.find_primary()
         try:
+            # Note: the time it takes for a learner to catch up is proportional
+            # to the ledger size; we may want to factor that into the timeout.
             if self.status is ServiceStatus.OPEN:
                 valid_from = valid_from or str(
                     infra.crypto.datetime_to_X509time(datetime.now())

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -413,6 +413,7 @@ class Network:
             initial_members_info,
             args.participants_curve,
             authenticate_session=not args.disable_member_session_auth,
+            reconfiguration_type=args.reconfiguration_type,
         )
         initial_users = [
             f"user{user_id}" for user_id in list(range(max(0, args.initial_user_count)))

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -219,7 +219,7 @@ class Network:
         # Contact primary if no target node is set
         if target_node is None:
             target_node, _ = self.find_primary(
-                timeout=args.ledger_recovery_timeout if recovery else 3
+                timeout=args.ledger_read_timeout if recovery else 3
             )
         LOG.info(f"Joining from target node {target_node.local_node_id}")
 
@@ -321,7 +321,7 @@ class Network:
                         self.wait_for_state(
                             node,
                             infra.node.State.PART_OF_PUBLIC_NETWORK.value,
-                            timeout=args.ledger_recovery_timeout,
+                            timeout=args.ledger_read_timeout,
                         )
                 else:
                     # When a new service is started, initial nodes join without a snapshot
@@ -353,7 +353,7 @@ class Network:
         # Here, recovery nodes might still be catching up, and possibly swamp
         # the current primary which would not be able to serve user requests
         primary, _ = self.find_primary(
-            timeout=args.ledger_recovery_timeout if recovery else 3
+            timeout=args.ledger_read_timeout if recovery else 3
         )
         return primary
 
@@ -494,7 +494,7 @@ class Network:
             self.wait_for_state(
                 node,
                 infra.node.State.PART_OF_PUBLIC_NETWORK.value,
-                timeout=args.ledger_recovery_timeout,
+                timeout=args.ledger_read_timeout,
             )
         # Catch-up in recovery can take a long time, so extend this timeout
         self.wait_for_all_nodes_to_commit(primary=primary, timeout=20)
@@ -518,7 +518,7 @@ class Network:
             self.wait_for_state(
                 node,
                 infra.node.State.PART_OF_NETWORK.value,
-                timeout=args.ledger_recovery_timeout,
+                timeout=args.ledger_read_timeout,
             )
             self._wait_for_app_open(node)
 
@@ -637,18 +637,19 @@ class Network:
     def trust_node(self, node, args, valid_from=None, validity_period_days=None):
         primary, _ = self.find_primary()
         try:
-            # Note: the time it takes for a learner to catch up is proportional
-            # to the ledger size; we may want to factor that into the timeout.
             if self.status is ServiceStatus.OPEN:
                 valid_from = valid_from or str(
                     infra.crypto.datetime_to_X509time(datetime.now())
                 )
+                timeout = ceil(args.join_timer * 2 / 1000)
+                if args.reconfiguration_type == "2tx":
+                    timeout += args.ledger_read_timeout
                 self.consortium.trust_node(
                     primary,
                     node.node_id,
                     valid_from=valid_from,
                     validity_period_days=validity_period_days,
-                    timeout=ceil(args.join_timer * 2 / 1000),
+                    timeout=timeout,
                 )
             # Here, quote verification has already been run when the node
             # was added as pending. Only wait for the join timer for the

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -1084,7 +1084,8 @@ class Network:
         while time.time() < end_time:
             try:
                 return call(seqno)
-            except Exception:
+            except Exception as ex:
+                LOG.info(f"Exception: {ex}")
                 self.consortium.create_and_withdraw_large_proposal(node)
                 time.sleep(0.1)
         raise TimeoutError(

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -663,8 +663,8 @@ class Network:
         )
         self.wait_for_all_nodes_to_commit(primary=primary)
 
-    def retire_node(self, remote_node, node_to_retire):
-        self.consortium.retire_node(remote_node, node_to_retire)
+    def retire_node(self, remote_node, node_to_retire, timeout=10):
+        self.consortium.retire_node(remote_node, node_to_retire, timeout=timeout)
         self.nodes.remove(node_to_retire)
 
     def create_user(self, local_user_id, curve, record=True):

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -448,7 +448,6 @@ class Node:
     def session_auth(self, name=None):
         return {
             "session_auth": self.identity(name),
-            "ca": os.path.join(self.common_dir, "networkcert.pem"),
         }
 
     def signing_auth(self, name=None):
@@ -458,13 +457,23 @@ class Node:
         return self.remote.get_host()
 
     def client(
-        self, identity=None, signing_identity=None, interface_idx=None, **kwargs
+        self,
+        identity=None,
+        signing_identity=None,
+        interface_idx=None,
+        self_signed_ok=False,
+        **kwargs,
     ):
         if self.network_state == NodeNetworkState.stopped:
             raise RuntimeError(
                 f"Cannot create client for node {self.local_node_id} as node is stopped"
             )
-        akwargs = self.session_auth(identity)
+
+        if self_signed_ok:
+            akwargs = {"ca": ""}
+        else:
+            akwargs = {"ca": os.path.join(self.common_dir, "networkcert.pem")}
+        akwargs.update(self.session_auth(identity))
         akwargs.update(self.signing_auth(signing_identity))
         akwargs[
             "description"

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -446,15 +446,19 @@ class Node:
             )
 
     def session_auth(self, name=None):
-        return {
-            "session_auth": self.identity(name),
-        }
+        return {"session_auth": self.identity(name)}
 
     def signing_auth(self, name=None):
         return {"signing_auth": self.identity(name)}
 
     def get_public_rpc_host(self):
         return self.remote.get_host()
+
+    def session_ca(self, self_signed_ok):
+        if self_signed_ok:
+            return {"ca": ""}
+        else:
+            return {"ca": os.path.join(self.common_dir, "networkcert.pem")}
 
     def client(
         self,
@@ -469,10 +473,7 @@ class Node:
                 f"Cannot create client for node {self.local_node_id} as node is stopped"
             )
 
-        if self_signed_ok:
-            akwargs = {"ca": ""}
-        else:
-            akwargs = {"ca": os.path.join(self.common_dir, "networkcert.pem")}
+        akwargs = self.session_ca(self_signed_ok)
         akwargs.update(self.session_auth(identity))
         akwargs.update(self.signing_auth(signing_identity))
         akwargs[

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -584,6 +584,7 @@ class CCFRemote(object):
         major_version=None,
         include_addresses=True,
         additional_raw_node_args=None,
+        reconfiguration_type=None,
     ):
         """
         Run a ccf binary on a remote host.
@@ -713,6 +714,9 @@ class CCFRemote(object):
 
             if node_client_host:
                 cmd += [f"--node-client-interface={node_client_host}"]
+
+        if reconfiguration_type:
+            cmd += [f"--reconfiguration-type={reconfiguration_type}"]
 
         if additional_raw_node_args:
             for s in additional_raw_node_args:

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -751,8 +751,8 @@ class CCFRemote(object):
                         f"--max-allowed-node-cert-validity-days={max_allowed_node_cert_validity_days}"
                     ]
 
-            if reconfiguration_type:
-                cmd += [f"--reconfiguration-type={reconfiguration_type}"]
+                if reconfiguration_type and reconfiguration_type != "1tx":
+                    cmd += [f"--reconfiguration-type={reconfiguration_type}"]
 
         elif start_type == StartType.join:
             cmd += [

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -715,9 +715,6 @@ class CCFRemote(object):
             if node_client_host:
                 cmd += [f"--node-client-interface={node_client_host}"]
 
-        if reconfiguration_type:
-            cmd += [f"--reconfiguration-type={reconfiguration_type}"]
-
         if additional_raw_node_args:
             for s in additional_raw_node_args:
                 cmd += [str(s)]
@@ -753,6 +750,9 @@ class CCFRemote(object):
                     cmd += [
                         f"--max-allowed-node-cert-validity-days={max_allowed_node_cert_validity_days}"
                     ]
+
+            if reconfiguration_type:
+                cmd += [f"--reconfiguration-type={reconfiguration_type}"]
 
         elif start_type == StartType.join:
             cmd += [

--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -198,6 +198,9 @@ def test_learner_does_not_take_part(network, args):
 
 
 def run_2tx_reconfig_tests(args):
+    if not args.include_2tx_reconfig:
+        return
+
     local_args = args
 
     if args.reconfiguration_type != "2tx":
@@ -239,7 +242,14 @@ def run(args):
 
 if __name__ == "__main__":
 
-    args = infra.e2e_args.cli_args()
+    def add(parser):
+        parser.add_argument(
+            "--include-2tx-reconfig",
+            help="Include tests for the 2-transaction reconfiguration scheme",
+            action="store_true",
+        )
+
+    args = infra.e2e_args.cli_args(add)
     args.package = "samples/apps/logging/liblogging"
 
     args.nodes = infra.e2e_args.min_nodes(args, f=1)

--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -9,8 +9,12 @@ import suite.test_requirements as reqs
 from infra.checker import check_can_progress, check_does_not_progress
 import pprint
 from ccf.tx_status import TxStatus
+import ccf.ledger
 
 from loguru import logger as LOG
+
+from math import ceil
+from datetime import datetime
 
 
 @reqs.description("Invalid partitions are not allowed")
@@ -145,6 +149,74 @@ def test_isolate_and_reconnect_primary(network, args, **kwargs):
         assert status == TxStatus.Invalid, r
 
 
+@reqs.description("Add a learner, partition nodes, check that there is no progress")
+def test_learner_does_not_take_part(network, args):
+    primary, backups = network.find_nodes()
+    f_backups = backups[: network.get_f() + 1]
+
+    new_node = network.create_node("local://localhost")
+    network.join_node(new_node, args.package, args, from_snapshot=False)
+
+    with network.partitioner.partition(f_backups):
+
+        check_does_not_progress(primary, timeout=5)
+
+        try:
+            network.consortium.trust_node(
+                primary,
+                new_node.node_id,
+                timeout=ceil(args.join_timer * 2 / 1000),
+                valid_from=str(infra.crypto.datetime_to_X509time(datetime.now())),
+            )
+            new_node.wait_for_node_to_join(timeout=ceil(args.join_timer * 2 / 1000))
+            join_failed = False
+        except Exception:
+            join_failed = True
+
+        if not join_failed:
+            raise Exception("join succeeded unexpectedly")
+
+        with new_node.client(self_signed_ok=True) as c:
+            r = c.get("/node/network/nodes/self")
+            assert r.body.json()["status"] == "Learner"
+            r = c.get("/node/consensus")
+            assert new_node.node_id in r.body.json()["details"]["learners"]
+
+        # New node joins, but cannot be promoted to TRUSTED without f other backups
+
+        check_does_not_progress(primary, timeout=5)
+
+        with new_node.client(self_signed_ok=True) as c:
+            r = c.get("/node/network/nodes/self")
+            assert r.body.json()["status"] == "Learner"
+            r = c.get("/node/consensus")
+            assert new_node.node_id in r.body.json()["details"]["learners"]
+
+    network.wait_for_primary_unanimity()
+    primary, _ = network.find_nodes()
+    network.wait_for_all_nodes_to_commit(primary=primary)
+    check_can_progress(primary)
+
+
+def run_2tx_reconfig_tests(args):
+    local_args = args
+
+    if args.reconfiguration_type != "2tx":
+        local_args.reconfiguration_type = "2tx"
+
+    with infra.network.network(
+        local_args.nodes,
+        local_args.binary_dir,
+        local_args.debug_nodes,
+        local_args.perf_nodes,
+        pdb=local_args.pdb,
+        init_partitioner=True,
+    ) as network:
+        network.start_and_join(local_args)
+
+        test_learner_does_not_take_part(network, local_args)
+
+
 def run(args):
     txs = app.LoggingTxs("user0")
 
@@ -173,3 +245,4 @@ if __name__ == "__main__":
 
     args.nodes = infra.e2e_args.min_nodes(args, f=1)
     run(args)
+    run_2tx_reconfig_tests(args)

--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -9,7 +9,6 @@ import suite.test_requirements as reqs
 from infra.checker import check_can_progress, check_does_not_progress
 import pprint
 from ccf.tx_status import TxStatus
-import ccf.ledger
 
 from loguru import logger as LOG
 

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -562,12 +562,13 @@ def run_all(args):
 
 
 if __name__ == "__main__":
+
     def add(parser):
         parser.add_argument(
             "--include-2tx-reconfig",
             help="Include tests for the 2-transaction reconfiguration scheme",
             type=bool,
-            default=False
+            default=False,
         )
 
     cr = ConcurrentRunner(add)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -270,6 +270,7 @@ def test_version(network, args):
 
 
 @reqs.description("Replace a node on the same addresses")
+@reqs.can_kill_n_nodes(1)
 def test_node_replacement(network, args):
     primary, backups = network.find_nodes()
 
@@ -393,8 +394,6 @@ def test_retiring_nodes_emit_at_most_one_signature(network, args):
 
 @reqs.description("Adding a learner without snapshot")
 def test_learner_catches_up(network, args):
-    args.join_timer = args.join_timer * 2
-
     num_nodes_before = len(network.nodes)
     new_node = network.create_node("local://localhost")
     network.join_node(new_node, args.package, args, from_snapshot=False)
@@ -422,7 +421,8 @@ def test_learner_catches_up(network, args):
         print(rj)
         assert len(rj["details"]["configs"]) == 1
         c0 = rj["details"]["configs"][0]["nodes"]
-        assert len(c0) == num_nodes_before + 1 and new_node.node_id in c0
+        assert len(c0) == num_nodes_before + 1
+        assert new_node.node_id in c0
 
     return network
 
@@ -502,10 +502,12 @@ def run(args):
 
             test_node_filter(network, args)
             test_retiring_nodes_emit_at_most_one_signature(network, args)
-        else:
+
+        if args.reconfiguration_type == "2tx":
             test_learner_catches_up(network, args)
             # test_learner_does_not_take_part(network, args)
             test_retire_backup(network, args)
+
         test_node_certificates_validity_period(network, args)
         test_add_node_invalid_validity_period(network, args)
 

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -567,8 +567,7 @@ if __name__ == "__main__":
         parser.add_argument(
             "--include-2tx-reconfig",
             help="Include tests for the 2-transaction reconfiguration scheme",
-            type=bool,
-            default=False,
+            action="store_false"
         )
 
     cr = ConcurrentRunner(add)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -519,7 +519,7 @@ def run(args):
         args.perf_nodes,
         pdb=args.pdb,
         txs=txs,
-        init_partitioner=True,
+        init_partitioner=args.reconfiguration_type == "2tx",
     ) as network:
         network.start_and_join(args)
 

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -567,7 +567,7 @@ if __name__ == "__main__":
         parser.add_argument(
             "--include-2tx-reconfig",
             help="Include tests for the 2-transaction reconfiguration scheme",
-            action="store_false"
+            action="store_false",
         )
 
     cr = ConcurrentRunner(add)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -567,7 +567,7 @@ if __name__ == "__main__":
         parser.add_argument(
             "--include-2tx-reconfig",
             help="Include tests for the 2-transaction reconfiguration scheme",
-            action="store_false",
+            action="store_true",
         )
 
     cr = ConcurrentRunner(add)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -210,7 +210,7 @@ def test_retire_primary(network, args):
     pre_count = count_nodes(node_configs(network), network)
 
     primary, backup = network.find_primary_and_any_backup()
-    network.retire_node(primary, primary)
+    network.retire_node(primary, primary, timeout=15)
     # Query this backup to find the new primary. If we ask any other
     # node, then this backup may not know the new primary by the
     # time we call check_can_progress.

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -562,7 +562,15 @@ def run_all(args):
 
 
 if __name__ == "__main__":
-    cr = ConcurrentRunner()
+    def add(parser):
+        parser.add_argument(
+            "--include-2tx-reconfig",
+            help="Include tests for the 2-transaction reconfiguration scheme",
+            type=bool,
+            default=False
+        )
+
+    cr = ConcurrentRunner(add)
 
     cr.add(
         "1tx_reconfig",
@@ -572,12 +580,13 @@ if __name__ == "__main__":
         reconfiguration_type="1tx",
     )
 
-    cr.add(
-        "2tx_reconfig",
-        run,
-        package="samples/apps/logging/liblogging",
-        nodes=infra.e2e_args.min_nodes(cr.args, f=1),
-        reconfiguration_type="2tx",
-    )
+    if cr.args.include_2tx_reconfig:
+        cr.add(
+            "2tx_reconfig",
+            run,
+            package="samples/apps/logging/liblogging",
+            nodes=infra.e2e_args.min_nodes(cr.args, f=1),
+            reconfiguration_type="2tx",
+        )
 
     cr.run()

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -7,7 +7,6 @@ import infra.proc
 import infra.logging_app as app
 import suite.test_requirements as reqs
 import tempfile
-import time
 from shutil import copy
 import os
 from infra.checker import check_can_progress, check_does_not_progress

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -136,7 +136,7 @@ def test_share_resilience(network, args, from_snapshot=False):
         recovered_network.wait_for_state(
             node,
             infra.node.State.PART_OF_NETWORK.value,
-            timeout=args.ledger_recovery_timeout,
+            timeout=args.ledger_read_timeout,
         )
 
     recovered_network.consortium.check_for_service(

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -136,7 +136,7 @@ def test_share_resilience(network, args, from_snapshot=False):
         recovered_network.wait_for_state(
             node,
             infra.node.State.PART_OF_NETWORK.value,
-            timeout=args.ledger_read_timeout,
+            timeout=args.ledger_recovery_timeout,
         )
 
     recovered_network.consortium.check_for_service(

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -137,7 +137,7 @@ def recover(number_txs=5):
             new_network = func(*args, **kwargs)
             new_network.txs.verify(
                 network=new_network,
-                timeout=vargs.get("ledger_read_timeout"),
+                timeout=vargs.get("ledger_recovery_timeout"),
             )
             return new_network
 

--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -137,7 +137,7 @@ def recover(number_txs=5):
             new_network = func(*args, **kwargs)
             new_network.txs.verify(
                 network=new_network,
-                timeout=vargs.get("ledger_recovery_timeout"),
+                timeout=vargs.get("ledger_read_timeout"),
             )
             return new_network
 

--- a/tests/vegeta_stress.py
+++ b/tests/vegeta_stress.py
@@ -70,7 +70,7 @@ def run(args, additional_attack_args):
         sa = primary.session_auth("user0")
         attack_cmd += ["--cert", sa["session_auth"].cert]
         attack_cmd += ["--key", sa["session_auth"].key]
-        attack_cmd += ["--root-certs", sa["ca"]]
+        attack_cmd += ["--root-certs", primary.session_ca(False)["ca"]]
         attack_cmd += additional_attack_args
 
         attack_cmd_s = " ".join(attack_cmd)


### PR DESCRIPTION
Mainly passing an additional option through the various parts of the infrastructure.

The new `reconfiguration_test_cft_2tx` should probably be disabled or moved to the long/daily tests for now.