### PR TITLE
Reduce size of CCF logo on `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Confidential Consortium Framework
 
-<img alt="ccf" align="right" src="https://microsoft.github.io/CCF/main/_images/ccf.svg" width="300">
+<img alt="ccf" align="right" src="https://microsoft.github.io/CCF/main/_images/ccf.svg" width="250">
 
 [![Docs](https://img.shields.io/badge/Docs-succeeded-green)](https://microsoft.github.io/CCF)
 


### PR DESCRIPTION
Things seem to have gone funky lately:
![image](https://user-images.githubusercontent.com/42961061/138859659-18b02357-8e66-4953-9369-b82a2d3b5b0d.png)
