### PR TITLE
Client connections resolve DNS asynchronously

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-And it was all yellow!
+Canary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- DNS resolution of client connections is now asynchronous.
+
 ## [2.0.0-dev5]
 
 ### Added

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -193,7 +193,7 @@ namespace asynchost
         }
         else
         {
-          resolve(this->host, this->service, false);
+          resolve(this->host, this->service, true);
         }
       }
     }
@@ -254,7 +254,7 @@ namespace asynchost
       else
       {
         assert_status(FRESH, CONNECTING_RESOLVING);
-        return resolve(host, service, false);
+        return resolve(host, service, true);
       }
 
       return true;
@@ -277,7 +277,7 @@ namespace asynchost
           // Try again, starting with DNS.
           LOG_DEBUG_FMT("Reconnect from DNS");
           status = CONNECTING_RESOLVING;
-          return resolve(host, service, false);
+          return resolve(host, service, true);
         }
 
         case DISCONNECTED:


### PR DESCRIPTION
DNS resolution was made synchronous in https://github.com/microsoft/CCF/pull/70 for listening sockets, but isn't necessary for client connections, which could stall the host thread if the DNS resolution takes too long, causing spurious elections. 

FYI, using the `socket_getaddrinfo` CLI, I've managed to hit ~4sec stall for DNS resolution in rare cases, running 

```bash
$ for ITER in {1..1000}; do time socket_getaddrinfo invaliddomain${ITER}.invaliddomain${ITER}.invaliddomain${ITER} 12345; done
...
Cannot getaddrinfo() - Name or service not known

real    0m3.976s
user    0m0.012s
sys     0m0.004s
...
```
