### PR TITLE
Do we need the directory mount for /dev/sgx?

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -32,7 +32,7 @@ resources:
 
     - container: sgx
       image: ccfciteam/ccf-ci:oe0.17.2-psw-2.15
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision:/dev/sgx -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
 variables:
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/ccf-') }}:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -32,7 +32,7 @@ resources:
 
     - container: sgx
       image: ccfciteam/ccf-ci:oe0.17.2-psw-2.15
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision:/dev/sgx -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
 variables:
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/ccf-') }}:

--- a/.daily.yml
+++ b/.daily.yml
@@ -28,7 +28,7 @@ resources:
 
     - container: sgx
       image: ccfciteam/ccf-ci:oe0.17.2-psw-2.15
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:
   - template: .azure-pipelines-templates/daily-matrix.yml

--- a/.daily.yml
+++ b/.daily.yml
@@ -28,7 +28,7 @@ resources:
 
     - container: sgx
       image: ccfciteam/ccf-ci:oe0.17.2-psw-2.15
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision:/dev/sgx -v /dev/shm:/tmp/ccache
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/shm:/tmp/ccache
 
 jobs:
   - template: .azure-pipelines-templates/daily-matrix.yml

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -17,7 +17,7 @@ resources:
   containers:
     - container: sgx
       image: ccfciteam/ccf-ci:oe0.17.2-psw-2.15
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision:/dev/sgx -v /dev/shm:/tmp/ccache
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/shm:/tmp/ccache
 
 jobs:
   - template: .azure-pipelines-templates/common.yml

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -17,7 +17,7 @@ resources:
   containers:
     - container: sgx
       image: ccfciteam/ccf-ci:oe0.17.2-psw-2.15
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:
   - template: .azure-pipelines-templates/common.yml

--- a/.stress.yml
+++ b/.stress.yml
@@ -22,7 +22,7 @@ resources:
   containers:
     - container: sgx
       image: ccfciteam/ccf-ci:oe0.17.2-psw-2.15
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision:/dev/sgx -v /dev/shm:/tmp/ccache
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/shm:/tmp/ccache
 
 jobs:
   - template: .azure-pipelines-templates/stress-matrix.yml

--- a/.stress.yml
+++ b/.stress.yml
@@ -22,7 +22,7 @@ resources:
   containers:
     - container: sgx
       image: ccfciteam/ccf-ci:oe0.17.2-psw-2.15
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:
   - template: .azure-pipelines-templates/stress-matrix.yml

--- a/doc/build_apps/build_setup.rst
+++ b/doc/build_apps/build_setup.rst
@@ -27,11 +27,11 @@ The quickest way to get started building CCF applications is to use the CCF buil
 
 The container contains the latest release of CCF along with a complete build toolchain, and startup scripts.
 
-If your hardware does support SGX, and has the appropriate driver installed and loaded, then you will only need to expose the device to the container by passing ``--device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx`` when you start it. It can be run on hardware that does not support SGX, in which case you will want to use the virtual binaries, or build in `virtual mode`.
+If your hardware does support SGX, and has the appropriate driver installed and loaded, then you will only need to expose the device to the container by passing ``--device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision:/dev/sgx`` when you start it. It can be run on hardware that does not support SGX, in which case you will want to use the virtual binaries, or build in `virtual mode`.
 
 .. note::
 
-    - When running the build container on SGX-enabled hardware, pass the ``--device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx`` options to use SGX in the container.
+    - When running the build container on SGX-enabled hardware, pass the ``--device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision:/dev/sgx`` options to use SGX in the container.
     - `virtual` mode provides no security guarantee. It is only useful for development and prototyping.
 
 Visual Studio Code Setup


### PR DESCRIPTION
The answer is, yes we do, Open Enclave uses the `/dev/sgx/*` paths.

```
58: [get_driver_type /home/sgx/jenkins/ubuntuServer2004-release-build-trunk-215/build_target/PROD/label/Builder-UbuntuSrv20/label_exp/ubuntu64/linux-trunk-opensource/psw/urts/linux/edmm_utility.cpp:111] Failed to open Intel SGX device.
58: terminating with uncaught exception of type std::logic_error: Could not create enclave: OE_PLATFORM_ERROR
```