### PR TITLE
Fix #2 for nobuiltins - wait for stable commit from a real TxID

### DIFF
--- a/tests/nobuiltins.py
+++ b/tests/nobuiltins.py
@@ -13,14 +13,22 @@ def test_nobuiltins_endpoints(network, args):
         timeout = 3
         end_time = time.time() + timeout
         found_stable_commit = False
+        r = c.get("/node/network")
+        assert r.status_code == HTTPStatus.OK
+        target_view = r.view
+        target_seqno = r.seqno
+        assert target_view is not None
+        assert target_seqno is not None
         while time.time() < end_time:
-            r = c.get("/app/commit")
+            r = c.get("/node/commit")
             assert r.status_code == HTTPStatus.OK
             body_j = r.body.json()
             tx_id = TxID.from_str(body_j["transaction_id"])
-            if tx_id.view == r.view and tx_id.seqno == r.seqno:
+            if tx_id.view == target_view and tx_id.seqno == target_seqno:
                 found_stable_commit = True
                 break
+            else:
+                time.sleep(0.1)
 
         assert found_stable_commit, f"Failed to reach stable commit after {timeout}s"
 


### PR DESCRIPTION
#3146 was wrong, and relied on `/commit` returning a `tx_id` header (which it normally doesn't, but does one-off on service open!)

This is a correction to that; call an endpoint which reliably does KV reads, to find the service's current tail.