### PR TITLE
Raft ae on periodic

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -2679,12 +2679,12 @@ namespace aft
 
       if (r.success != AppendEntriesResponseType::OK)
       {
-        // Failed due to log inconsistency. Reset sent_idx and try again.
+        // Failed due to log inconsistency. Reset sent_idx, and try again soon.
         LOG_DEBUG_FMT(
           "Recv append entries response to {} from {}: failed",
           state->my_node_id,
           from);
-        send_append_entries(from, node->second.match_idx + 1);
+        node->second.sent_idx = node->second.match_idx;
         return;
       }
 

--- a/src/consensus/aft/test/committable_suffix.cpp
+++ b/src/consensus/aft/test/committable_suffix.cpp
@@ -442,6 +442,7 @@ DOCTEST_TEST_CASE("Retention of dead leader's commit")
     {
       // Only the first AppendEntries to B is kept, all other
       // AppendEntries are lost
+      rC.periodic(request_timeout);
       keep_first_for(node_idB, channelsC->messages);
       DOCTEST_REQUIRE(1 == dispatch_all(nodes, node_idC, channelsC->messages));
 

--- a/src/consensus/aft/test/main.cpp
+++ b/src/consensus/aft/test/main.cpp
@@ -712,6 +712,7 @@ DOCTEST_TEST_CASE("Recv append entries logic" * doctest::test_suite("multiple"))
     aer.success = aft::AppendEntriesResponseType::FAIL;
     const auto p = reinterpret_cast<uint8_t*>(&aer);
     receive_message(r1, r0, {p, p + sizeof(aer)});
+    r0.periodic(request_timeout);
     DOCTEST_REQUIRE(r0c->messages.size() == 1);
 
     // Only the third entry is deserialised
@@ -761,6 +762,7 @@ DOCTEST_TEST_CASE("Recv append entries logic" * doctest::test_suite("multiple"))
     aer.success = aft::AppendEntriesResponseType::FAIL;
     const auto p = reinterpret_cast<uint8_t*>(&aer);
     receive_message(r1, r0, {p, p + sizeof(aer)});
+    r0.periodic(request_timeout);
     DOCTEST_REQUIRE(r0c->messages.size() == 1);
 
     // Receive append entries (idx: 5, prev_idx: 3)
@@ -951,13 +953,11 @@ DOCTEST_TEST_CASE("Exceed append entries limit")
   auto aer = r2c->messages.front().second;
   r2c->messages.pop_front();
   receive_message(r2, r0, aer);
+  r0.periodic(request_timeout);
 
   DOCTEST_REQUIRE(r0c->messages.size() > num_small_entries_sent);
-  DOCTEST_REQUIRE(
-    r0c->messages.size() <= num_small_entries_sent + num_big_entries);
   auto sent_entries = dispatch_all(nodes, node_id0, r0c->messages);
   DOCTEST_REQUIRE(sent_entries > num_small_entries_sent);
-  DOCTEST_REQUIRE(sent_entries <= num_small_entries_sent + num_big_entries);
   DOCTEST_REQUIRE(r2.ledger->ledger.size() == individual_entries);
 }
 

--- a/tests/raft_scenarios/fancy_election
+++ b/tests/raft_scenarios/fancy_election
@@ -68,6 +68,7 @@ dispatch_one,1
 dispatch_one,2
 
 # Node 1 sends its committable suffix
+periodic_all,10
 dispatch_one,1
 
 # Node 2 ACKs all of that, advancing commit on Node 1

--- a/tests/raft_scenarios/suffix_collision
+++ b/tests/raft_scenarios/suffix_collision
@@ -66,5 +66,8 @@ dispatch_all
 periodic_all,10
 dispatch_all
 
+periodic_all,10
+dispatch_all
+
 state_all
 assert_state_sync


### PR DESCRIPTION
A quick-fix for part of #1451.

One kind of raft inefficiency we have seen several times during debugging audits, is an amplification attack caused by a single missed AE inside a long range:

```
Node 0     Node 1
AE 1 ->          
AE 2 ->          
AE 3 ->          
AE 4 ->          
AE 5 ->          
                  # AE 1 is lost
                  # 4 messages from 0 to 1
          -> AE 2
        <- NACK 2
          -> AE 3
        <- NACK 3
          -> AE 4
        <- NACK 4
          -> AE 5
        <- NACK 5
                  # 4 messages from 1 to 0
NACK 2 <-        
AE 1 ->          
AE 2 ->          
AE 3 ->          
AE 4 ->          
AE 5 ->          
NACK 3 <-        
AE 1 ->          
...
AE 5 ->          
NACK 4 <-        
AE 1 ->          
...
AE 5 ->          
NACK 5 <-        
AE 1 ->          
...
AE 5 ->          
                  # 25 messages from 0 to 1!     
```

And this cascades; if the first missed message was due to an overloaded socket, its likely we continue to drop messages as we increase load on the socket, and so on.

There's a possible mitigation from improving the Raft chunk size calculations, but the simpler solution is just _don't send AEs inline while processing NACKs_. Assume that NACKs aren't isolated - if we received one, we're likely to receive more. So don't respond straight away, continue to accumulate information. Send your best guess at a helpful AE range only on the next tick. This does introduce a slight delay, but it should be minimal/expected.

I am tempted to remove _all_ inline calls to `send_append_entries`, and only trigger it on ticks. Currently we try to immediately send AEs when a new node joins, and inside replicate. I think it should also be safe to queue these, and assume we have at least the same information (and maybe more!) slightly later, on the next tick. But that's a riskier change for no clear benefit, so I've avoided it for now.