### PR TITLE
[LTS] Correct reporting of missing `cchost` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Removed erroneous "Start command should be start|join|recover" message on node startup.
 
 ## [1.0.14]
 

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -771,6 +771,11 @@ int main(int argc, char** argv)
       LOG_INFO_FMT("Creating new node - recover");
       start_type = StartType::Recover;
     }
+    else
+    {
+      LOG_FATAL_FMT("Start command should be start|join|recover. Exiting.");
+      return static_cast<int>(CLI::ExitCodes::ValidationError);
+    }
 
     if (*join || *recover)
     {
@@ -802,10 +807,6 @@ int main(int argc, char** argv)
         LOG_INFO_FMT(
           "No snapshot found: Node will replay all historical transactions");
       }
-    }
-    else
-    {
-      LOG_FATAL_FMT("Start command should be start|join|recover. Exiting.");
     }
 
     if (consensus == ConsensusType::BFT)


### PR DESCRIPTION
### NB: This is targetting the LTS branch.

Noticed that this else was in the wrong place, so it is [always printed](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=35699&view=logs&j=5435e0ac-25e5-5426-50be-61b0d0ea8d34&t=cf4e34b3-24ee-5d97-0df9-ba9302d9fe90&l=28232) on `start` nodes, and doesn't actually exit when it says it does. Fixing both of those directly on the LTS branch.