### PR TITLE
Do not build doc pre-1.0.1x

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -198,8 +198,8 @@ breathe_default_project = "CCF"
 
 # Set up multiversion extension
 
-# Build tags from ccf-1.0.0
-smv_tag_whitelist = r"^ccf-(1\.\d+\.\d+|2.*)$"
+# Build tags from ccf-1.0.1x
+smv_tag_whitelist = r"^ccf-(1\.\d+\.1\d+|2.*)$"
 smv_branch_whitelist = r"^main$"
 smv_remote_whitelist = None
 smv_outputdir_format = "{ref.name}"


### PR DESCRIPTION
The doc job is starting to take quite a long time, and so it's tempting not to maintain documentation for older LTS releases, particularly since the changes from one LTS to the next are very small.

I think we also only should build the doc for the latest -dev, but that's quite a bit more difficult to do with regexps sadly.