### PR TITLE
Tweak printing of legend for `ledger_viz`

### DIFF
--- a/python/ccf/ledger_viz.py
+++ b/python/ccf/ledger_viz.py
@@ -64,9 +64,9 @@ class DefaultLiner(Liner):
 
     def help(self):
         print(
-            " ".join(
+            " | ".join(
                 [
-                    f"{category}: {cs(' ', 'White', bg_colour)}"
+                    f"{category} {cs(' ', 'White', bg_colour)}"
                     for category, bg_colour in self._bg_colour_mapping.items()
                 ]
             )


### PR DESCRIPTION
I keep misreading the key printed by `ledger_viz`.

![image](https://user-images.githubusercontent.com/6000239/140151926-b9e62c1a-2543-43f6-987b-0e5d9a57c4ac.png)

At a glance, I find the word "Signature", and the colour right next to it is red, so the initial read is that Signatures are red. I think the problem is that the `: ` spacer introduces more distance between the key and its value, than the ` ` separator between entries.

This changes the separator so that my feeble brain can read it at a glance.

![image](https://user-images.githubusercontent.com/6000239/140154553-9962f7e5-a0ca-480a-882e-0accbc64a552.png)
