### PR TITLE
Another fix for 'nobuiltins'

### DIFF
--- a/tests/nobuiltins.py
+++ b/tests/nobuiltins.py
@@ -5,7 +5,6 @@ from http import HTTPStatus
 import openapi_spec_validator
 from datetime import datetime, timezone
 import time
-import ccf.commit
 
 
 def test_nobuiltins_endpoints(network, args):

--- a/tests/nobuiltins.py
+++ b/tests/nobuiltins.py
@@ -5,32 +5,25 @@ from http import HTTPStatus
 import openapi_spec_validator
 from datetime import datetime, timezone
 import time
+import ccf.commit
 
 
 def test_nobuiltins_endpoints(network, args):
     primary, backups = network.find_nodes()
     with primary.client() as c:
-        timeout = 3
-        end_time = time.time() + timeout
-        found_stable_commit = False
+        # The rest of this test assumes the network's commit index is stable. This may
+        # not be true yet, as the setup transactions may not have committed. Do a fresh
+        # read to find the latest TxID, and wait for that to commit, before proceeding.
         r = c.get("/node/network")
         assert r.status_code == HTTPStatus.OK
-        target_view = r.view
-        target_seqno = r.seqno
-        assert target_view is not None
-        assert target_seqno is not None
-        while time.time() < end_time:
-            r = c.get("/node/commit")
-            assert r.status_code == HTTPStatus.OK
-            body_j = r.body.json()
-            tx_id = TxID.from_str(body_j["transaction_id"])
-            if tx_id.view == target_view and tx_id.seqno == target_seqno:
-                found_stable_commit = True
-                break
-            else:
-                time.sleep(0.1)
+        assert r.view is not None
+        assert r.seqno is not None
+        ccf.commit.wait_for_commit(c, seqno=r.seqno, view=r.view, timeout=3)
 
-        assert found_stable_commit, f"Failed to reach stable commit after {timeout}s"
+        r = c.get("/app/commit")
+        assert r.status_code == HTTPStatus.OK
+        body_j = r.body.json()
+        tx_id = TxID.from_str(body_j["transaction_id"])
 
         r = c.get("/app/node_summary")
         assert r.status_code == HTTPStatus.OK


### PR DESCRIPTION
Yet another attempt following #3146 and #3150, to fix what was originally a one-off CI failure.

~~The last fix only worked if the signature had happened before the `/node/network` read, otherwise the TxIDs would never actually match (despite indicating that the intended commit had occurred). Rather than re-implementing more of the commit tracking logic, we just reuse the existing `wait_for_commit`, and then do a final call to get the stable `/node/commit` value after that.~~

@jumaffre has pointed out that the network setup infra is already waiting for its changes to be globally committed. The increasing TxID is not caused by a slow commit, it comes from a snapshot being produced (every 10tx in all tests by default). We could increase the snapshot interval to avoid this, but I think it's better to say that the attempted assertion is invalid. Clients shouldn't assume that multiple independent calls to a service will return the same TxID just because _they_ are not doing anything - we think the service may still generate transactions itself (for signatures, or snapshots, or JWT refreshes, or other things in future). So all the client should assert is that this custom endpoint has returned a plausibly valid (maybe advanced) TxID.