### PR TITLE
Change '/api' endpoint to be read-only

### DIFF
--- a/src/endpoints/common_endpoint_registry.cpp
+++ b/src/endpoints/common_endpoint_registry.cpp
@@ -192,7 +192,8 @@ namespace ccf
           fmt::format("Error code: {}", ccf::api_result_to_str(result)));
       }
     };
-    make_read_only_endpoint("/api", HTTP_GET, json_read_only_adapter(openapi), no_auth_required)
+    make_read_only_endpoint(
+      "/api", HTTP_GET, json_read_only_adapter(openapi), no_auth_required)
       .set_auto_schema<void, GetAPI::Out>()
       .install();
 

--- a/src/endpoints/common_endpoint_registry.cpp
+++ b/src/endpoints/common_endpoint_registry.cpp
@@ -192,7 +192,7 @@ namespace ccf
           fmt::format("Error code: {}", ccf::api_result_to_str(result)));
       }
     };
-    make_endpoint("/api", HTTP_GET, json_adapter(openapi), no_auth_required)
+    make_read_only_endpoint("/api", HTTP_GET, json_read_only_adapter(openapi), no_auth_required)
       .set_auto_schema<void, GetAPI::Out>()
       .install();
 


### PR DESCRIPTION
Noticed that `/api` was not callable when there is no known primary, because the node attempts to forward it. This is unnecessary - it is read-only, and should be marked as such.