### PR TITLE
Never rollback initial ledger secrets

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Triggerrr
+Tiggerrr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - DNS resolution of client connections is now asynchronous.
 
+### Fixed
+
+- Fixed issue with new node startup which could get stuck if an election was triggered while catching up (#3169).
+
 ## [2.0.0-dev5]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed issue with new node startup which could get stuck if an election was triggered while catching up (#3169).
+- Fixed issue with join nodes which could get stuck if an election was triggered while catching up (#3169).
 
 ## [2.0.0-dev5]
 

--- a/js/ccf-app/package.json
+++ b/js/ccf-app/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "test": "cross-env TS_NODE_PROJECT=test/tsconfig.json mocha --loader=ts-node/esm test/**/*.test.ts",
     "docs": "typedoc",
-    "docs:serve": "rm -rf html && concurrently \"typedoc --watch --preserveWatchOutput\" \"serve html\""
+    "docs:watch": "rm -rf html && typedoc --watch --preserveWatchOutput"
   },
   "author": "Microsoft",
   "license": "Apache-2.0",
@@ -23,11 +23,9 @@
     "@types/node": "14.17.27",
     "@types/node-forge": "^0.9.7",
     "chai": "^4.3.4",
-    "concurrently": "^6.0.0",
     "cross-env": "^7.0.3",
-    "mocha": "^8.3.2",
+    "mocha": "^9.1.3",
     "node-forge": "^0.10.0",
-    "serve": "^11.3.2",
     "ts-node": "^9.1.1",
     "typedoc": "^0.20.34",
     "typescript": "4.2.4"

--- a/src/node/ledger_secrets.h
+++ b/src/node/ledger_secrets.h
@@ -27,6 +27,9 @@ namespace ccf
 
     // Set once when the LedgerSecrets are initialised. This prevents a backup
     // node to rollback not-yet-applicable ledger secrets when catching up.
+    // All rollback that would result in the removal of some of these secrets
+    // would imply that the transaction that added the node itself was rolled
+    // back.
     kv::Version initial_latest_ledger_secret_version = 0;
 
     std::optional<LedgerSecretsMap::iterator> last_used_secret_it =

--- a/src/node/ledger_secrets.h
+++ b/src/node/ledger_secrets.h
@@ -25,6 +25,10 @@ namespace ccf
     std::mutex lock;
     LedgerSecretsMap ledger_secrets;
 
+    // Set once when the LedgerSecrets are initialised. This prevents a backup
+    // node to rollback not-yet-applicable ledger secrets when catching up.
+    kv::Version initial_latest_ledger_secret_version = 0;
+
     std::optional<LedgerSecretsMap::iterator> last_used_secret_it =
       std::nullopt;
 
@@ -105,6 +109,7 @@ namespace ccf
       std::lock_guard<std::mutex> guard(lock);
 
       ledger_secrets.emplace(initial_version, make_ledger_secret());
+      initial_latest_ledger_secret_version = initial_version;
     }
 
     void init_from_map(LedgerSecretsMap&& ledger_secrets_)
@@ -115,6 +120,7 @@ namespace ccf
         ledger_secrets.empty(), "Should only init an empty LedgerSecrets");
 
       ledger_secrets = std::move(ledger_secrets_);
+      initial_latest_ledger_secret_version = ledger_secrets.rbegin()->first;
     }
 
     void adjust_previous_secret_stored_version(kv::Version version)
@@ -281,7 +287,9 @@ namespace ccf
       while (ledger_secrets.size() > 1)
       {
         auto k = ledger_secrets.rbegin();
-        if (k->first <= version)
+        if (
+          k->first <= version ||
+          k->first <= initial_latest_ledger_secret_version)
         {
           break;
         }
@@ -290,8 +298,9 @@ namespace ccf
         ledger_secrets.erase(k->first);
       }
 
-      // Assume that the next operation will use the first non-rollbacked secret
-      last_used_secret_it = std::prev(ledger_secrets.end());
+      // Invalidate last used ledger secret iterator. Next key usage will need
+      // to find the appropriate key on the slow path.
+      last_used_secret_it = std::nullopt;
     }
   };
 }

--- a/src/node/test/encryptor.cpp
+++ b/src/node/test/encryptor.cpp
@@ -356,6 +356,18 @@ TEST_CASE("Backup catchup from many ledger secrets")
         backup_store
           .deserialize(*std::get<1>(next_entry.value()), ConsensusType::CFT)
           ->apply() == kv::ApplyResult::PASS);
+
+      auto tx_id = backup_store.current_txid();
+      tx_id.version--;
+      // While catching up, assume the backup rolls back (e.g. because of an
+      // election)
+      backup_store.rollback(tx_id, backup_store.commit_view());
+
+      REQUIRE(
+        backup_store
+          .deserialize(*std::get<1>(next_entry.value()), ConsensusType::CFT)
+          ->apply() == kv::ApplyResult::PASS);
+
       next_entry = consensus->pop_oldest_entry();
     }
   }

--- a/tests/infra/github.py
+++ b/tests/infra/github.py
@@ -15,10 +15,6 @@ from setuptools.extern.packaging.version import Version  # type: ignore
 from loguru import logger as LOG
 
 
-# Optional. May be useful to avoid GitHub's low rate limits for unauthenticated clients
-# https://docs.github.com/en/rest/reference/rate-limit
-ENV_VAR_GITHUB_AUTH_TOKEN_NAME = "LTS_COMPATIBILITY_GH_TOKEN"
-
 REPOSITORY_NAME = "microsoft/CCF"
 REMOTE_URL = f"https://github.com/{REPOSITORY_NAME}"
 BRANCH_RELEASE_PREFIX = "release/"


### PR DESCRIPTION
When a backup node joins a service, it is given the entire history of ledger secrets so far (part of the `/node/join` response). If an election is triggered when the node is catching up, the node will rollback its store, which will cause the ledger secrets to be rolled back too. This is incorrect since the backup will need the ledger secrets to decrypt further entries, once the catch up phase is complete.

For example, if a new node joined without a snapshot and received the ledger secrets at seqnos `{1, 10}`, caught up till `5` at which point an election was triggered (new joiner's store is rolled back at `5`, ledger secrets at now `{1}`), it wouldn't have been able to deserialise entries from `10` onwards.

We now protect the initial ledger secrets received in the `/node/join` response so that they cannot be rolled back. 