### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/ccf-app" # Location of package manifests
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "pip"
+    directory: "/python" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Try to see if using dependabot.yml can help keep our npm and python packages' dependencies in sync better.