### PR TITLE
Fix retirement bugs in 2tx reconfig

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -3089,7 +3089,10 @@ namespace aft
         rollback(last_committable_index());
       }
 
-      if (!is_retiring() && !is_retired())
+      if (
+        !is_retired() &&
+        !(is_retiring() && retirement_idx.has_value() &&
+          retirement_idx.value() <= state->commit_idx))
       {
         is_new_follower = true;
 
@@ -3097,7 +3100,10 @@ namespace aft
         {
           replica_state = kv::ReplicaState::Follower;
           LOG_INFO_FMT(
-            "Becoming follower {}: {}", state->my_node_id, state->current_view);
+            "Becoming follower {}: {}.{}",
+            state->my_node_id,
+            state->current_view,
+            state->commit_idx);
         }
       }
     }

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1200,11 +1200,7 @@ namespace aft
           }
         }
       }
-      else if (
-        consensus_type != ConsensusType::BFT &&
-        replica_state != kv::ReplicaState::Retired &&
-        replica_state != kv::ReplicaState::Retiring &&
-        replica_state != kv::ReplicaState::Learner)
+      else if (consensus_type != ConsensusType::BFT)
       {
         if (
           can_endorse_primary() && ticking &&
@@ -3060,6 +3056,7 @@ namespace aft
     bool can_endorse_primary()
     {
       return replica_state != kv::ReplicaState::Retired &&
+        replica_state != kv::ReplicaState::Retiring &&
         replica_state != kv::ReplicaState::Learner;
     }
 
@@ -3089,22 +3086,16 @@ namespace aft
         rollback(last_committable_index());
       }
 
-      if (
-        !is_retired() &&
-        !(is_retiring() && retirement_idx.has_value() &&
-          retirement_idx.value() <= state->commit_idx))
-      {
-        is_new_follower = true;
+      is_new_follower = true;
 
-        if (can_endorse_primary())
-        {
-          replica_state = kv::ReplicaState::Follower;
-          LOG_INFO_FMT(
-            "Becoming follower {}: {}.{}",
-            state->my_node_id,
-            state->current_view,
-            state->commit_idx);
-        }
+      if (can_endorse_primary())
+      {
+        replica_state = kv::ReplicaState::Follower;
+        LOG_INFO_FMT(
+          "Becoming follower {}: {}.{}",
+          state->my_node_id,
+          state->current_view,
+          state->commit_idx);
       }
     }
 

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -3056,7 +3056,6 @@ namespace aft
     bool can_endorse_primary()
     {
       return replica_state != kv::ReplicaState::Retired &&
-        replica_state != kv::ReplicaState::Retiring &&
         replica_state != kv::ReplicaState::Learner;
     }
 
@@ -3088,7 +3087,7 @@ namespace aft
 
       is_new_follower = true;
 
-      if (can_endorse_primary())
+      if (can_endorse_primary() && replica_state != kv::ReplicaState::Retiring)
       {
         replica_state = kv::ReplicaState::Follower;
         LOG_INFO_FMT(

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -220,6 +220,11 @@ def test_add_as_many_pending_nodes(network, args):
 
     wait_for_reconfiguration_to_complete(network)
 
+    # Stop the retired nodes so they don't linger in the background and interfere
+    # with subsequent tests
+    for new_node in new_nodes:
+        new_node.stop()
+
     return network
 
 

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -616,8 +616,7 @@ if __name__ == "__main__":
         reconfiguration_type="1tx",
     )
 
-    # Turned off while #3184 is in progress
-    if cr.args.include_2tx_reconfig and False:
+    if cr.args.include_2tx_reconfig:
         cr.add(
             "2tx_reconfig",
             run,


### PR DESCRIPTION
This fixes a bug in the retirement logic for 2tx reconfiguration. A node would not revert to being a follower after it's change to `RETIRING` was rolled back. It does so with this fix, but it now triggers a long series of elections, sometimes ending up in a situation where it rejects append entries for a long time (possibly forever).

Also adds a function to wait for reconfiguration completion in tests to avoid tests interfering with each other.