### PR TITLE
1tx to 2tx reconfiguration migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added endpoint to obtain service configuration via `/node/service-configuration` (#3251)
+- Added endpoint to obtain service configuration via `/node/service/configuration` (#3251)
 
 ### Changed
 

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -74,6 +74,9 @@
           "membership_state": {
             "$ref": "#/components/schemas/MembershipState"
           },
+          "reconfiguration_type": {
+            "$ref": "#/components/schemas/ReconfigurationType"
+          },
           "retirement_phase": {
             "$ref": "#/components/schemas/RetirementPhase"
           }
@@ -666,7 +669,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "2.7.0"
+    "version": "2.7.1"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -1012,7 +1012,7 @@
         }
       }
     },
-    "/service-configuration": {
+    "/service/configuration": {
       "get": {
         "responses": {
           "200": {

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -719,6 +719,7 @@ namespace aft
       {
         details.acks[k] = v.match_idx;
       }
+      details.reconfiguration_type = reconfiguration_type;
       if (reconfiguration_type == ReconfigurationType::TWO_TRANSACTION)
       {
         details.learners = learner_nodes;
@@ -2529,6 +2530,16 @@ namespace aft
             node_info.second.hostname,
             node_info.second.port);
         }
+      }
+    }
+
+  public:
+    void update_parameters(kv::ConsensusParameters& params)
+    {
+      reconfiguration_type = params.reconfiguration_type;
+      if (reconfiguration_type == TWO_TRANSACTION && !node_client)
+      {
+        throw std::logic_error("missing node client");
       }
     }
   };

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -2536,14 +2536,9 @@ namespace aft
   public:
     void update_parameters(kv::ConsensusParameters& params)
     {
-      if (reconfiguration_type == params.reconfiguration_type)
-      {
-        return;
-      }
-      if (params.reconfiguration_type == TWO_TRANSACTION && !node_client)
-      {
-        throw std::logic_error("missing node client");
-      }
+      CCF_ASSERT_FMT(
+        params.reconfiguration_type != TWO_TRANSACTION || node_client,
+        "Bug; all enclaves that support 2tx reconfig must have node_clients");
       reconfiguration_type = params.reconfiguration_type;
     }
   };

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -2536,6 +2536,8 @@ namespace aft
   public:
     void update_parameters(kv::ConsensusParameters& params)
     {
+      // This should only be called when the state->lock is held, so we do not
+      // acquire the lock here.
       CCF_ASSERT_FMT(
         params.reconfiguration_type != TWO_TRANSACTION || node_client,
         "Bug; all enclaves that support 2tx reconfig must have node_clients");

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -2536,11 +2536,15 @@ namespace aft
   public:
     void update_parameters(kv::ConsensusParameters& params)
     {
-      reconfiguration_type = params.reconfiguration_type;
-      if (reconfiguration_type == TWO_TRANSACTION && !node_client)
+      if (reconfiguration_type == params.reconfiguration_type)
+      {
+        return;
+      }
+      if (params.reconfiguration_type == TWO_TRANSACTION && !node_client)
       {
         throw std::logic_error("missing node client");
       }
+      reconfiguration_type = params.reconfiguration_type;
     }
   };
 }

--- a/src/consensus/aft/raft_consensus.h
+++ b/src/consensus/aft/raft_consensus.h
@@ -172,6 +172,11 @@ namespace aft
       return aft->get_latest_configuration_unsafe();
     }
 
+    virtual void update_parameters(kv::ConsensusParameters& params) override
+    {
+      return aft->update_parameters(params);
+    }
+
     kv::ConsensusDetails get_details() override
     {
       return aft->get_details();

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -8,6 +8,7 @@
 #include "crypto/pem.h"
 #include "ds/nonstd.h"
 #include "enclave/consensus_type.h"
+#include "enclave/reconfiguration_type.h"
 #include "node/identity.h"
 #include "node/resharing_types.h"
 #include "serialiser_declare.h"
@@ -194,13 +195,18 @@ namespace kv
     std::optional<LeadershipState> leadership_state;
     std::optional<RetirementPhase> retirement_phase;
     std::optional<std::unordered_map<ccf::NodeId, ccf::SeqNo>> learners;
+    std::optional<ReconfigurationType> reconfiguration_type;
   };
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(ConsensusDetails);
   DECLARE_JSON_REQUIRED_FIELDS(
     ConsensusDetails, configs, acks, membership_state);
   DECLARE_JSON_OPTIONAL_FIELDS(
-    ConsensusDetails, learners, leadership_state, retirement_phase);
+    ConsensusDetails,
+    reconfiguration_type,
+    learners,
+    leadership_state,
+    retirement_phase);
 
   struct NetworkConfiguration
   {
@@ -215,6 +221,11 @@ namespace kv
 
   DECLARE_JSON_TYPE(kv::NetworkConfiguration);
   DECLARE_JSON_REQUIRED_FIELDS(kv::NetworkConfiguration, rid, nodes);
+
+  struct ConsensusParameters
+  {
+    ReconfigurationType reconfiguration_type;
+  };
 
   class ConfigurableConsensus
   {
@@ -241,6 +252,7 @@ namespace kv
       const crypto::Pem& node_cert) = 0;
     virtual void record_serialised_tree(
       kv::Version version, const std::vector<uint8_t>& tree) = 0;
+    virtual void update_parameters(ConsensusParameters& params) = 0;
   };
 
   class ConsensusHook

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -196,6 +196,8 @@ namespace kv::test
       return {};
     }
 
+    virtual void update_parameters(kv::ConsensusParameters& params) override {}
+
     ConsensusDetails get_details() override
     {
       return ConsensusDetails{{}, {}, MembershipState::Active};

--- a/src/node/hooks.h
+++ b/src/node/hooks.h
@@ -172,7 +172,7 @@ namespace ccf
   inline void service_configuration_commit_hook(
     kv::Version version,
     const ccf::Configuration::Write& w,
-    std::shared_ptr<kv::Consensus> consensus)
+    const std::shared_ptr<kv::Consensus>& consensus)
   {
     LOG_DEBUG_FMT("Service configuration update hook");
     assert(w.has_value());

--- a/src/node/hooks.h
+++ b/src/node/hooks.h
@@ -169,28 +169,17 @@ namespace ccf
     }
   };
 
-  class ServiceConfigurationUpdateHook : public kv::ConsensusHook
+  inline void service_configuration_commit_hook(
+    kv::Version version,
+    const ccf::Configuration::Write& w,
+    std::shared_ptr<kv::Consensus> consensus)
   {
-    kv::Version version;
-    ServiceConfiguration new_service_config;
-
-  public:
-    ServiceConfigurationUpdateHook(
-      kv::Version version_, const Configuration::Write& w)
-    {
-      assert(w.has_value());
-      version = version_;
-      new_service_config = w.value();
-    }
-
-    void call(kv::ConfigurableConsensus* consensus) override
-    {
-      LOG_DEBUG_FMT("Service configuration update hook");
-      kv::ConsensusParameters cp;
-      cp.reconfiguration_type =
-        new_service_config.reconfiguration_type.value_or(
-          ReconfigurationType::ONE_TRANSACTION);
-      consensus->update_parameters(cp);
-    }
-  };
+    LOG_DEBUG_FMT("Service configuration update hook");
+    assert(w.has_value());
+    auto new_service_config = w.value();
+    kv::ConsensusParameters cp;
+    cp.reconfiguration_type = new_service_config.reconfiguration_type.value_or(
+      ReconfigurationType::ONE_TRANSACTION);
+    consensus->update_parameters(cp);
+  }
 }

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -2025,10 +2025,10 @@ namespace ccf
 
       network.tables->set_global_hook(
         network.config.get_name(),
-        network.config.wrap_map_hook(
-          [](kv::Version version, const Configuration::Write& w)
-            -> kv::ConsensusHookPtr {
-            return std::make_unique<ServiceConfigurationUpdateHook>(version, w);
+        network.config.wrap_commit_hook(
+          [c = this->consensus](
+            kv::Version version, const Configuration::Write& w) {
+            service_configuration_commit_hook(version, w, c);
           }));
 
       setup_basic_hooks();

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -2023,6 +2023,14 @@ namespace ccf
             return std::make_unique<SerialisedMerkleTreeHook>(version, w);
           }));
 
+      network.tables->set_map_hook(
+        network.config.get_name(),
+        network.config.wrap_map_hook(
+          [](kv::Version version, const Configuration::Write& w)
+            -> kv::ConsensusHookPtr {
+            return std::make_unique<ServiceConfigurationUpdateHook>(version, w);
+          }));
+
       setup_basic_hooks();
     }
 

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -2023,7 +2023,7 @@ namespace ccf
             return std::make_unique<SerialisedMerkleTreeHook>(version, w);
           }));
 
-      network.tables->set_map_hook(
+      network.tables->set_global_hook(
         network.config.get_name(),
         network.config.wrap_map_hook(
           [](kv::Version version, const Configuration::Write& w)

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -320,7 +320,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
-      openapi_info.document_version = "2.7.0";
+      openapi_info.document_version = "2.7.1";
     }
 
     void init_handlers() override

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -1457,7 +1457,7 @@ namespace ccf
         };
 
       make_endpoint(
-        "/service-configuration",
+        "/service/configuration",
         HTTP_GET,
         json_adapter(service_config_handler),
         no_auth_required)

--- a/src/runtime_config/default/actions.js
+++ b/src/runtime_config/default/actions.js
@@ -1060,4 +1060,29 @@ const actions = new Map([
       }
     ),
   ],
+  [
+    "migrate_service_to_2tx_reconfig",
+    new Action(
+      function (args) {},
+      function (args) {
+        const rawConfig = ccf.kv["public:ccf.gov.service.config"].get(
+          getSingletonKvKey()
+        );
+        if (rawConfig === undefined) {
+          throw new Error("Service configuration could not be found");
+        }
+        const serviceConfig = ccf.bufToJsonCompatible(rawConfig);
+        if (serviceConfig.reconfiguration_type != "OneTransaction") {
+          throw new Error(
+            "Service does not use one-transaction reconfiguration."
+          );
+        }
+        serviceConfig.reconfiguration_type = "TwoTransaction";
+        ccf.kv["public:ccf.gov.service.config"].set(
+          getSingletonKvKey(),
+          ccf.jsonCompatibleToBuf(serviceConfig)
+        );
+      }
+    ),
+  ],
 ]);

--- a/src/runtime_config/default/actions.js
+++ b/src/runtime_config/default/actions.js
@@ -255,8 +255,13 @@ function updateServiceConfig(new_config) {
     config.reconfiguration_type = new_config.reconfiguration_type;
   }
 
-  if (new_config.recovery_threshold !== undefined) {
+  let need_recovery_threshold_refresh = false;
+  if (
+    new_config.recovery_threshold !== undefined &&
+    new_config.recovery_threshold !== config.recovery_threshold
+  ) {
     config.recovery_threshold = new_config.recovery_threshold;
+    need_recovery_threshold_refresh = true;
   }
 
   ccf.kv[service_config_table].set(
@@ -265,7 +270,7 @@ function updateServiceConfig(new_config) {
   );
 
   // All ok, run triggers
-  if (new_config.recovery_threshold !== undefined) {
+  if (need_recovery_threshold_refresh) {
     ccf.node.triggerRecoverySharesRefresh();
   }
 }

--- a/src/runtime_config/default/actions.js
+++ b/src/runtime_config/default/actions.js
@@ -197,6 +197,79 @@ function setNodeCertificateValidityPeriod(
   );
 }
 
+function checkRecoveryThreshold(config, new_config) {
+  const from = config.recovery_threshold;
+  const to = new_config.recovery_threshold;
+  if (to === undefined || from === to) {
+    return;
+  }
+
+  const service_info = "public:ccf.gov.service.info";
+  const rawService = ccf.kv[service_info].get(getSingletonKvKey());
+  if (rawService === undefined) {
+    throw new Error("Service information could not be found");
+  }
+
+  const service = ccf.bufToJsonCompatible(rawService);
+
+  if (service.status === "WaitingForRecoveryShares") {
+    throw new Error(
+      `Cannot set recovery threshold if service is ${service.status}`
+    );
+  } else if (service.status === "Open") {
+    let activeRecoveryMembersCount = getActiveRecoveryMembersCount();
+    if (new_config.recovery_threshold > activeRecoveryMembersCount) {
+      throw new Error(
+        `Cannot set recovery threshold to ${new_config.recovery_threshold}: recovery threshold would be greater than the number of recovery members ${activeRecoveryMembersCount}`
+      );
+    }
+  }
+}
+
+function checkReconfigurationType(config, new_config) {
+  const from = config.reconfiguration_type;
+  const to = new_config.reconfiguration_type;
+  if (from !== to && to !== undefined) {
+    if (!(from === "OneTransaction" && to === "TwoTransaction")) {
+      throw new Error(
+        `Cannot change reconfiguration type from ${from} to ${to}.`
+      );
+    }
+  }
+}
+
+function updateServiceConfig(new_config) {
+  const service_config_table = "public:ccf.gov.service.config";
+  const rawConfig = ccf.kv[service_config_table].get(getSingletonKvKey());
+  if (rawConfig === undefined) {
+    throw new Error("Service configuration could not be found");
+  }
+  let config = ccf.bufToJsonCompatible(rawConfig);
+
+  // First run all checks
+  checkReconfigurationType(config, new_config);
+  checkRecoveryThreshold(config, new_config);
+
+  // Then all updates
+  if (new_config.reconfiguration_type !== undefined) {
+    config.reconfiguration_type = new_config.reconfiguration_type;
+  }
+
+  if (new_config.recovery_threshold !== undefined) {
+    config.recovery_threshold = new_config.recovery_threshold;
+  }
+
+  ccf.kv[service_config_table].set(
+    getSingletonKvKey(),
+    ccf.jsonCompatibleToBuf(config)
+  );
+
+  // All ok, run triggers
+  if (new_config.recovery_threshold !== undefined) {
+    ccf.node.triggerRecoverySharesRefresh();
+  }
+}
+
 const actions = new Map([
   [
     "set_constitution",
@@ -422,48 +495,7 @@ const actions = new Map([
         checkBounds(args.recovery_threshold, 1, 254, "threshold");
       },
       function (args) {
-        const rawConfig = ccf.kv["public:ccf.gov.service.config"].get(
-          getSingletonKvKey()
-        );
-        if (rawConfig === undefined) {
-          throw new Error("Service configuration could not be found");
-        }
-
-        let config = ccf.bufToJsonCompatible(rawConfig);
-
-        if (args.recovery_threshold === config.recovery_threshold) {
-          return; // No effect
-        }
-
-        const rawService = ccf.kv["public:ccf.gov.service.info"].get(
-          getSingletonKvKey()
-        );
-        if (rawService === undefined) {
-          throw new Error("Service information could not be found");
-        }
-
-        const service = ccf.bufToJsonCompatible(rawService);
-
-        if (service.status === "WaitingForRecoveryShares") {
-          throw new Error(
-            `Cannot set recovery threshold if service is ${service.status}`
-          );
-        } else if (service.status === "Open") {
-          let activeRecoveryMembersCount = getActiveRecoveryMembersCount();
-          if (args.recovery_threshold > activeRecoveryMembersCount) {
-            throw new Error(
-              `Cannot set recovery threshold to ${args.recovery_threshold}: recovery threshold would be greater than the number of recovery members ${activeRecoveryMembersCount}`
-            );
-          }
-        }
-
-        config.recovery_threshold = args.recovery_threshold;
-        ccf.kv["public:ccf.gov.service.config"].set(
-          getSingletonKvKey(),
-          ccf.jsonCompatibleToBuf(config)
-        );
-
-        ccf.node.triggerRecoverySharesRefresh();
+        updateServiceConfig(args);
       }
     ),
   ],
@@ -1064,36 +1096,19 @@ const actions = new Map([
     "set_service_configuration",
     new Action(
       function (args) {
-        checkType(args.reconfiguration_type, "string?", "reconfiguration type");
-      },
-      function (args) {
-        const rawConfig = ccf.kv["public:ccf.gov.service.config"].get(
-          getSingletonKvKey()
-        );
-        if (rawConfig === undefined) {
-          throw new Error("Service configuration could not be found");
-        }
-        const serviceConfig = ccf.bufToJsonCompatible(rawConfig);
-        if (
-          args.reconfiguration_type !== undefined &&
-          serviceConfig.reconfiguration_type !== args.reconfiguration_type
-        ) {
-          if (
-            !(
-              serviceConfig.reconfiguration_type === "OneTransaction" &&
-              args.reconfiguration_type === "TwoTransaction"
-            )
-          ) {
+        for (var key in args) {
+          if (key !== "reconfiguration_type" && key !== "recovery_threshold") {
             throw new Error(
-              `Cannot change reconfiguration type from ${serviceConfig.reconfiguration_type} to ${args.reconfiguration_type}.`
+              `Cannot change ${key} via set_service_configuration.`
             );
           }
-          serviceConfig.reconfiguration_type = args.reconfiguration_type;
         }
-        ccf.kv["public:ccf.gov.service.config"].set(
-          getSingletonKvKey(),
-          ccf.jsonCompatibleToBuf(serviceConfig)
-        );
+        checkType(args.reconfiguration_type, "string?", "reconfiguration type");
+        checkType(args.recovery_threshold, "integer?", "recovery threshold");
+        checkBounds(args.recovery_threshold, 1, 254, "recovery threshold");
+      },
+      function (args) {
+        updateServiceConfig(args);
       }
     ),
   ],

--- a/src/runtime_config/default/actions.js
+++ b/src/runtime_config/default/actions.js
@@ -255,24 +255,18 @@ function updateServiceConfig(new_config) {
     config.reconfiguration_type = new_config.reconfiguration_type;
   }
 
-  let need_recovery_threshold_refresh = false;
   if (
     new_config.recovery_threshold !== undefined &&
     new_config.recovery_threshold !== config.recovery_threshold
   ) {
     config.recovery_threshold = new_config.recovery_threshold;
-    need_recovery_threshold_refresh = true;
+    ccf.node.triggerRecoverySharesRefresh();
   }
 
   ccf.kv[service_config_table].set(
     getSingletonKvKey(),
     ccf.jsonCompatibleToBuf(config)
   );
-
-  // All ok, run triggers
-  if (need_recovery_threshold_refresh) {
-    ccf.node.triggerRecoverySharesRefresh();
-  }
 }
 
 const actions = new Map([

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -613,3 +613,20 @@ class Consortium:
             self.wait_for_node_to_exist_in_store(
                 remote_node, n.node_id, timeout, NodeStatus.TRUSTED
             )
+
+    def submit_2tx_migration_proposal(self, remote_node, timeout=10):
+        proposal_body = {
+            "actions": [
+                {
+                    "name": "set_service_configuration",
+                    "args": {"reconfiguration_type": "TwoTransaction"},
+                }
+            ]
+        }
+        proposal = self.get_any_active_member().propose(remote_node, proposal_body)
+        self.vote_using_majority(
+            remote_node,
+            proposal,
+            {"ballot": "export function vote (proposal, proposer_id) { return true }"},
+            timeout=timeout,
+        )

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -627,8 +627,6 @@ def check_2tx_ledger(ledger_paths, learner_id):
 
     ledger = ccf.ledger.Ledger(ledger_paths, committed_only=True)
 
-    LOG.info(f"LEARNER ID: {learner_id}")
-
     for chunk in ledger:
         for tr in chunk:
             tables = tr.get_public_domain().get_tables()

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -15,7 +15,6 @@ import infra.crypto
 from datetime import datetime
 from infra.checker import check_can_progress
 from infra.runner import ConcurrentRunner
-from ccf.tx_id import TxID
 
 from loguru import logger as LOG
 

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -717,7 +717,6 @@ def run_migration_tests(args):
         new_node = network.create_node("local://localhost")
         network.join_node(new_node, args.package, args, from_snapshot=False)
         network.trust_node(new_node, args)
-        network.wait_for_all_nodes_to_commit(primary)
 
         config_after = get_current_config(network)
         nodes_after = get_current_nodes_table(network)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -625,7 +625,7 @@ def check_2tx_ledger(ledger_paths, learner_id):
     learner_at = 0
     trusted_at = 0
 
-    ledger = ccf.ledger.Ledger(ledger_paths, committed_only=True)
+    ledger = ccf.ledger.Ledger(ledger_paths, committed_only=False)
 
     for chunk in ledger:
         for tr in chunk:
@@ -665,11 +665,6 @@ def run_migration_tests(args):
         network.start_and_join(args)
         primary, _ = network.find_primary()
 
-        nodes_before = get_current_nodes_table(network)
-        for n in network.nodes:
-            assert n.node_id in nodes_before
-            assert nodes_before[n.node_id]["status"] == "Trusted"
-
         # Check that the service config agrees that this is a 1tx network
         with primary.client() as c:
             s = c.get("/node/service/configuration").body.json()
@@ -704,9 +699,6 @@ def run_migration_tests(args):
 
         ledger_paths = primary.remote.ledger_paths()
         learner_id = new_node.node_id
-
-        # Force ledger flush of all transactions so far.
-        network.get_latest_ledger_public_state()
 
     check_2tx_ledger(ledger_paths, learner_id)
 


### PR DESCRIPTION
Here's a sketch of how we could do 1tx to 2tx reconfiguration migration. Not necessarily intended to be merged, just a basis for discussion on how we want to do things. 

I think adding a hook on the service config table is a good idea in general, even if all we want to do is to reject any unwanted updates.