### PR TITLE
Fix for retirement index assertion upon becoming retiring

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -3116,7 +3116,10 @@ namespace aft
         "unexpected attempt to pull retirement_idx forward from {} to {}",
         retirement_idx.value(),
         state->commit_idx);
-      retirement_idx = state->commit_idx;
+      if (!retirement_idx.has_value())
+      {
+        retirement_idx = state->commit_idx;
+      }
     }
 
     void become_retired()

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -3111,9 +3111,11 @@ namespace aft
       leader_id.reset();
 
       CCF_ASSERT_FMT(
-        !retirement_idx.has_value(),
-        "retirement_idx already set to {}",
-        retirement_idx.value());
+        !retirement_idx.has_value() ||
+          retirement_idx.value() <= state->commit_idx,
+        "unexpected attempt to pull retirement_idx forward from {} to {}",
+        retirement_idx.value(),
+        state->commit_idx);
       retirement_idx = state->commit_idx;
     }
 


### PR DESCRIPTION
Fixes #3195.

The assertion was too strong. It's fine for a node to become `RETIRING` more than once (e.g. when it temporarily becomes leader/candidate/follower before become `RETIRED`). But, the second time around the commit index can't be any lower than the first time.