### PR TITLE
Remove unused reserved memory option

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -63,13 +63,6 @@ if(ENABLE_2TX_RECONFIG)
   add_compile_definitions(ENABLE_2TX_RECONFIG)
 endif()
 
-option(DEBUG_CONFIG "Enable non-production options options to aid debugging"
-       OFF
-)
-if(DEBUG_CONFIG)
-  add_compile_definitions(DEBUG_CONFIG)
-endif()
-
 option(USE_NLJSON_KV_SERIALISER "Use nlohmann JSON as the KV serialiser" OFF)
 if(USE_NLJSON_KV_SERIALISER)
   add_compile_definitions(USE_NLJSON_KV_SERIALISER)

--- a/src/enclave/interface.h
+++ b/src/enclave/interface.h
@@ -32,14 +32,6 @@ struct EnclaveConfig
   ringbuffer::Offsets* from_enclave_buffer_offsets;
 
   oversized::WriterConfig writer_config = {};
-
-#ifdef DEBUG_CONFIG
-  struct DebugConfig
-  {
-    size_t memory_reserve_startup;
-  };
-  DebugConfig debug_config = {};
-#endif
 };
 
 struct CCFConfig

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -16,9 +16,6 @@
 static std::mutex create_lock;
 static std::atomic<enclave::Enclave*> e;
 
-#ifdef DEBUG_CONFIG
-static uint8_t* reserved_memory;
-#endif
 std::atomic<std::chrono::microseconds> logger::config::us =
   std::chrono::microseconds::zero();
 std::atomic<uint16_t> num_pending_threads = 0;
@@ -150,9 +147,6 @@ extern "C"
     }
 #endif
 
-#ifdef DEBUG_CONFIG
-    reserved_memory = new uint8_t[ec->debug_config.memory_reserve_startup];
-#endif
     enclave::Enclave* enclave;
 
     try

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -391,19 +391,6 @@ int main(int argc, char** argv)
       "Interval in seconds for JWT public signing key refresh.")
     ->capture_default_str();
 
-  size_t memory_reserve_startup = 0;
-  app
-    .add_option(
-      "--memory-reserve-startup",
-      memory_reserve_startup,
-#ifdef DEBUG_CONFIG
-      "Reserve unused memory inside the enclave, to simulate high memory use"
-#else
-      "Unused"
-#endif
-      )
-    ->capture_default_str();
-
   crypto::CurveID curve_id = crypto::CurveID::SECP384R1;
   std::vector<std::pair<std::string, crypto::CurveID>> curve_id_map = {
     {"secp384r1", crypto::CurveID::SECP384R1},
@@ -801,9 +788,6 @@ int main(int argc, char** argv)
     enclave_config.from_enclave_buffer_offsets = &from_enclave_offsets;
 
     enclave_config.writer_config = writer_config;
-#ifdef DEBUG_CONFIG
-    enclave_config.debug_config = {memory_reserve_startup};
-#endif
 
     CCFConfig ccf_config;
     ccf_config.consensus_config = {

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -94,7 +94,6 @@ class Network:
         "raft_election_timeout_ms",
         "bft_view_change_timeout_ms",
         "consensus",
-        "memory_reserve_startup",
         "log_format_json",
         "constitution",
         "join_timer",

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -563,7 +563,6 @@ class CCFRemote(object):
         bft_view_change_timeout_ms=5000,
         consensus="cft",
         worker_threads=0,
-        memory_reserve_startup=0,
         constitution=None,
         ledger_dir=None,
         read_only_ledger_dir=None,  # Read-only ledger dir to copy to node directory
@@ -670,9 +669,6 @@ class CCFRemote(object):
 
         if sig_ms_interval:
             cmd += [f"--sig-ms-interval={sig_ms_interval}"]
-
-        if memory_reserve_startup:
-            cmd += [f"--memory-reserve-startup={memory_reserve_startup}"]
 
         if ledger_chunk_bytes:
             cmd += [f"--ledger-chunk-bytes={ledger_chunk_bytes}"]


### PR DESCRIPTION
This was only enabled when the `DEBUG_CONFIG` CMake flag was set, which has been unused/untested for some time.