### PR TITLE
Remove BFT timeouts options

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Tiggerrr
+Tiggerrr!

--- a/doc/overview/consensus/index.rst
+++ b/doc/overview/consensus/index.rst
@@ -5,7 +5,7 @@ CCF supports multiple consensus protocols.
 
 The default consensus protocol for CCF is Crash Fault Tolerance (:term:`CFT`) and there is an experimental option of enabling Byzantine Fault Tolerance (:term:`BFT`).
 
-Below, we give an overview over the nodes state machine in both settings and the retirement mechanics that apply across the two protocols. 
+Below, we give an overview over the nodes state machine in both settings and the retirement mechanics that apply across the two protocols.
 
 CFT Consensus Protocol
 -----------------------
@@ -24,12 +24,6 @@ BFT Consensus Protocol
 More details on this mode is given :doc:`here <2tx-reconfig>`. There is an open research question of `node identity with Byzantine nodes <https://github.com/microsoft/CCF/issues/893>`_.
 
 By default CCF runs with CFT **and BFT is disabled on release versions**. To run CCF with BFT, CCF first needs to be :doc:`built from source </contribute/build_ccf>`. Then, the ``--consensus bft`` CLI argument must be provided when starting up the nodes (see :doc:`/operations/start_network` for starting up a network and nodes).
-
-BFT parameters can be configured when starting up a network (see :doc:`here </operations/start_network>`). The parameters that can be set via the CLI are:
-
-- ``bft-view-change-timeout-ms`` is the BFT view change timeout in milliseconds. If a backup does not receive the pre-prepare message for a request forwarded to the primary after this timeout, the backup triggers a view change.
-- ``bft-status-interval-ms`` is the BFT status timer interval in milliseconds. All BFT nodes send messages containing their status to all other known nodes at regular intervals defined by this timer interval.
-
 
 Replica State Machine
 ---------------------

--- a/src/consensus/consensus_types.h
+++ b/src/consensus/consensus_types.h
@@ -13,17 +13,10 @@ namespace consensus
     ConsensusType consensus_type;
     size_t raft_request_timeout;
     size_t raft_election_timeout;
-    size_t bft_view_change_timeout;
-    size_t bft_status_interval;
   };
   DECLARE_JSON_TYPE(Configuration);
   DECLARE_JSON_REQUIRED_FIELDS(
-    Configuration,
-    consensus_type,
-    raft_request_timeout,
-    raft_election_timeout,
-    bft_view_change_timeout,
-    bft_status_interval);
+    Configuration, consensus_type, raft_request_timeout, raft_election_timeout);
 
 #pragma pack(push, 1)
   template <typename T>

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -304,27 +304,6 @@ int main(int argc, char** argv)
       "a new election.")
     ->capture_default_str();
 
-  size_t bft_view_change_timeout = 5000;
-  app
-    .add_option(
-      "--bft-view-change-timeout-ms",
-      bft_view_change_timeout,
-      "bft view change timeout in milliseconds. If a backup does not receive "
-      "the pre-prepare message for a request forwarded to the primary after "
-      "this timeout, the backup triggers a new view change.")
-    ->capture_default_str();
-
-  size_t bft_status_interval = 100;
-  app
-    .add_option(
-      "--bft-status-interval-ms",
-      bft_status_interval,
-      "bft status timer interval in milliseconds. All bft nodes send "
-      "messages "
-      "containing their status to all other known nodes at regular intervals "
-      "defined by this timer interval.")
-    ->capture_default_str();
-
   size_t client_connection_timeout = 2000;
   app
     .add_option(
@@ -807,11 +786,7 @@ int main(int argc, char** argv)
 
     CCFConfig ccf_config;
     ccf_config.consensus_config = {
-      consensus,
-      raft_timeout,
-      raft_election_timeout,
-      bft_view_change_timeout,
-      bft_status_interval};
+      consensus, raft_timeout, raft_election_timeout};
     ccf_config.signature_intervals = {sig_tx_interval, sig_ms_interval};
 
     ccf_config.node_info_network.node_address = {

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1997,7 +1997,7 @@ namespace ccf
         node_client,
         std::chrono::milliseconds(consensus_config.raft_request_timeout),
         std::chrono::milliseconds(consensus_config.raft_election_timeout),
-        std::chrono::milliseconds(consensus_config.bft_view_change_timeout),
+        std::chrono::milliseconds(consensus_config.raft_election_timeout),
         sig_tx_interval,
         public_only,
         initial_state,

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -208,12 +208,6 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         default=4000,
     )
     parser.add_argument(
-        "--bft-view-change-timeout-ms",
-        help="bft maximum view change timeout for each node in the network",
-        type=int,
-        default=5000,
-    )
-    parser.add_argument(
         "--consensus",
         help="Consensus",
         default="cft",

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -92,7 +92,6 @@ class Network:
         "sig_tx_interval",
         "sig_ms_interval",
         "raft_election_timeout_ms",
-        "bft_view_change_timeout_ms",
         "consensus",
         "memory_reserve_startup",
         "log_format_json",
@@ -339,11 +338,7 @@ class Network:
                 LOG.exception("Failed to start node {}".format(node.local_node_id))
                 raise
 
-        self.election_duration = (
-            args.bft_view_change_timeout_ms / 1000
-            if args.consensus == "bft"
-            else args.raft_election_timeout_ms / 1000
-        )
+        self.election_duration = args.raft_election_timeout_ms / 1000
         # After an election timeout, we need some additional roundtrips to complete before
         # the nodes _observe_ that an election has occurred
         self.observed_election_duration = self.election_duration + 1

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -633,7 +633,6 @@ class CCFRemote(object):
         bin_path = os.path.join(".", os.path.basename(self.BIN))
         enclave_path = os.path.join(".", os.path.basename(lib_path))
 
-
         cmd = [
             bin_path,
             f"--enclave-file={enclave_path}",

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -560,7 +560,6 @@ class CCFRemote(object):
         sig_tx_interval=5000,
         sig_ms_interval=1000,
         raft_election_timeout_ms=1000,
-        bft_view_change_timeout_ms=5000,
         consensus="cft",
         worker_threads=0,
         memory_reserve_startup=0,
@@ -634,11 +633,6 @@ class CCFRemote(object):
         bin_path = os.path.join(".", os.path.basename(self.BIN))
         enclave_path = os.path.join(".", os.path.basename(lib_path))
 
-        election_timeout_arg = (
-            f"--bft-view-change-timeout-ms={bft_view_change_timeout_ms}"
-            if consensus == "bft"
-            else f"--raft-election-timeout-ms={raft_election_timeout_ms}"
-        )
 
         cmd = [
             bin_path,
@@ -651,7 +645,7 @@ class CCFRemote(object):
             f"--snapshot-dir={self.snapshot_dir_name}",
             f"--node-cert-file={self.pem}",
             f"--host-log-level={host_log_level}",
-            election_timeout_arg,
+            f"--raft-election-timeout-ms={raft_election_timeout_ms}",
             f"--consensus={consensus}",
             f"--worker-threads={worker_threads}",
         ]


### PR DESCRIPTION
The BFT status interval was unused and we now use the Raft election timeout for BFT view changes as well.