### PR TITLE
Infra: Consider multiple read-only ledger directories

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Tiggerrr!
+Tiggerrr

--- a/tests/e2e_tutorial.py
+++ b/tests/e2e_tutorial.py
@@ -22,10 +22,11 @@ def run(args):
         rc = infra.proc.ccall(*cmd).returncode
         assert rc == 0, f"Failed to run tutorial script: {rc}"
 
+    _, committed_ledger_dirs = primary.get_ledger()
     cmd = [
         "python",
         args.ledger_tutorial,
-        primary.get_ledger()[1],
+        committed_ledger_dirs[0],
     ]
     rc = infra.proc.ccall(*cmd).returncode
     assert rc == 0, f"Failed to run tutorial script: {rc}"

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -210,7 +210,7 @@ class Network:
         recovery=False,
         ledger_dir=None,
         copy_ledger_read_only=False,
-        read_only_ledger_dirs=[],
+        read_only_ledger_dirs=None,
         from_snapshot=False,
         snapshot_dir=None,
     ):
@@ -221,11 +221,11 @@ class Network:
             )
         LOG.info(f"Joining from target node {target_node.local_node_id}")
 
-        committed_ledger_dirs = read_only_ledger_dirs
+        committed_ledger_dirs = read_only_ledger_dirs or []
         current_ledger_dir = ledger_dir
 
         # By default, only copy historical ledger if node is started from snapshot
-        if read_only_ledger_dirs and (from_snapshot or copy_ledger_read_only):
+        if not committed_ledger_dirs and (from_snapshot or copy_ledger_read_only):
             LOG.info(f"Copying ledger from target node {target_node.local_node_id}")
             current_ledger_dir, committed_ledger_dirs = target_node.get_ledger()
 
@@ -274,7 +274,7 @@ class Network:
         args,
         recovery=False,
         ledger_dir=None,
-        read_only_ledger_dirs=[],
+        read_only_ledger_dirs=None,
         snapshot_dir=None,
     ):
         self.args = args
@@ -443,7 +443,7 @@ class Network:
         self,
         args,
         ledger_dir,
-        committed_ledger_dirs=[],
+        committed_ledger_dirs=None,
         snapshot_dir=None,
         common_dir=None,
     ):

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -210,7 +210,7 @@ class Network:
         recovery=False,
         ledger_dir=None,
         copy_ledger_read_only=False,
-        read_only_ledger_dir=None,
+        read_only_ledger_dirs=[],
         from_snapshot=False,
         snapshot_dir=None,
     ):
@@ -221,15 +221,13 @@ class Network:
             )
         LOG.info(f"Joining from target node {target_node.local_node_id}")
 
-        committed_ledger_dir = read_only_ledger_dir
+        committed_ledger_dirs = read_only_ledger_dirs
         current_ledger_dir = ledger_dir
 
         # By default, only copy historical ledger if node is started from snapshot
-        if read_only_ledger_dir is None and (from_snapshot or copy_ledger_read_only):
+        if read_only_ledger_dirs and (from_snapshot or copy_ledger_read_only):
             LOG.info(f"Copying ledger from target node {target_node.local_node_id}")
-            current_ledger_dir, committed_ledger_dir = target_node.get_ledger(
-                include_read_only_dirs=True
-            )
+            current_ledger_dir, committed_ledger_dirs = target_node.get_ledger()
 
         if from_snapshot:
             # Only retrieve snapshot from target node if the snapshot directory is not
@@ -259,7 +257,7 @@ class Network:
             target_rpc_address=f"{target_node.get_public_rpc_host()}:{target_node.rpc_port}",
             snapshot_dir=snapshot_dir,
             ledger_dir=current_ledger_dir,
-            read_only_ledger_dir=committed_ledger_dir,
+            read_only_ledger_dirs=committed_ledger_dirs,
             **forwarded_args,
         )
 
@@ -276,7 +274,7 @@ class Network:
         args,
         recovery=False,
         ledger_dir=None,
-        read_only_ledger_dir=None,
+        read_only_ledger_dirs=[],
         snapshot_dir=None,
     ):
         self.args = args
@@ -312,7 +310,7 @@ class Network:
                             label=args.label,
                             common_dir=self.common_dir,
                             ledger_dir=ledger_dir,
-                            read_only_ledger_dir=read_only_ledger_dir,
+                            read_only_ledger_dirs=read_only_ledger_dirs,
                             snapshot_dir=snapshot_dir,
                             **forwarded_args,
                         )
@@ -330,7 +328,7 @@ class Network:
                         recovery=recovery,
                         ledger_dir=ledger_dir,
                         from_snapshot=snapshot_dir is not None,
-                        read_only_ledger_dir=read_only_ledger_dir,
+                        read_only_ledger_dirs=read_only_ledger_dirs,
                         snapshot_dir=snapshot_dir,
                     )
             except Exception:
@@ -445,7 +443,7 @@ class Network:
         self,
         args,
         ledger_dir,
-        committed_ledger_dir=None,
+        committed_ledger_dirs=[],
         snapshot_dir=None,
         common_dir=None,
     ):
@@ -459,15 +457,13 @@ class Network:
         self.common_dir = common_dir or get_common_folder_name(
             args.workspace, args.label
         )
-        ledger_dirs = [ledger_dir]
-        if committed_ledger_dir:
-            ledger_dirs.append(committed_ledger_dir)
+        ledger_dirs = [ledger_dir, *committed_ledger_dirs]
 
         primary = self._start_all_nodes(
             args,
             recovery=True,
             ledger_dir=ledger_dir,
-            read_only_ledger_dir=committed_ledger_dir,
+            read_only_ledger_dirs=committed_ledger_dirs,
             snapshot_dir=snapshot_dir,
         )
 
@@ -542,52 +538,39 @@ class Network:
         LOG.info("All nodes stopped")
 
         if not skip_verification:
-            longest_ledger_seqno = 0
-            most_up_to_date_node = None
-            committed_ledger_dirs = {}
-
-            for node in self.nodes:
-                # Find stopped node with longest ledger
-                _, committed_ledger_dir = node.get_ledger(include_read_only_dirs=True)
-                ledger_end_seqno = 0
-                for ledger_file in os.listdir(committed_ledger_dir):
-                    end_seqno = infra.node.get_committed_ledger_end_seqno(ledger_file)
-                    if end_seqno > ledger_end_seqno:
-                        ledger_end_seqno = end_seqno
-
-                if ledger_end_seqno > longest_ledger_seqno:
-                    longest_ledger_seqno = ledger_end_seqno
-                    most_up_to_date_node = node
-                committed_ledger_dirs[node.local_node_id] = [
-                    committed_ledger_dir,
-                    ledger_end_seqno,
-                ]
-
             # Verify that all ledger files on stopped nodes exist on most up-to-date node
             # and are identical
-            if most_up_to_date_node:
-                longest_ledger_dir, _ = committed_ledger_dirs[
-                    most_up_to_date_node.local_node_id
-                ]
-                for node_id, (committed_ledger_dir, _) in (
-                    l
-                    for l in committed_ledger_dirs.items()
-                    if not l[0] == most_up_to_date_node.node_id
-                ):
-                    for ledger_file in os.listdir(committed_ledger_dir):
-                        if ledger_file not in os.listdir(longest_ledger_dir):
-                            raise Exception(
-                                f"Ledger file on node {node_id} does not exist on most up-to-date node {most_up_to_date_node.local_node_id}: {ledger_file}"
-                            )
-                        if infra.path.compute_file_checksum(
-                            os.path.join(longest_ledger_dir, ledger_file)
-                        ) != infra.path.compute_file_checksum(
-                            os.path.join(committed_ledger_dir, ledger_file)
-                        ):
-                            raise Exception(
-                                f"Ledger file checksums between node {node_id} and most up-to-date node {most_up_to_date_node.node_id} did not match: {ledger_file}"
-                            )
+            longest_ledger_node = None
+            nodes_ledger = {}
 
+            longest_ledger_seqno = 0
+            for node in self.nodes:
+                _, committed = node.get_ledger()
+                last_seqno = Ledger(committed).get_latest_public_state()[1]
+                nodes_ledger[node.local_node_id] = [committed, last_seqno]
+                if last_seqno > longest_ledger_seqno:
+                    longest_ledger_seqno = last_seqno
+                    longest_ledger_node = node
+
+            if longest_ledger_node:
+
+                def list_files_in_dirs_with_checksums(dirs):
+                    return [
+                        (f, infra.path.compute_file_checksum(os.path.join(d, f)))
+                        for d in dirs
+                        for f in os.listdir(d)
+                    ]
+
+                longest_ledger_dirs, _ = nodes_ledger[longest_ledger_node.local_node_id]
+                longest_ledger_files = list_files_in_dirs_with_checksums(
+                    longest_ledger_dirs
+                )
+                for node_id, (ledger_dirs, _) in nodes_ledger.items():
+                    ledger_files = list_files_in_dirs_with_checksums(ledger_dirs)
+                    if not set(ledger_files).issubset(longest_ledger_files):
+                        raise Exception(
+                            f"Ledger files on node {node_id} do not match files on most up-to-date node {longest_ledger_node.local_node_id}: {ledger_files}, expected subset of {longest_ledger_files}"
+                        )
                 LOG.success(
                     f"Verified ledger files consistency on all {len(self.nodes)} stopped nodes"
                 )

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -10,7 +10,7 @@ import infra.path
 import infra.proc
 import infra.node
 import infra.consortium
-from ccf.ledger import NodeStatus, Ledger
+from ccf.ledger import NodeStatus, Ledger, COMMITTED_FILE_SUFFIX
 from ccf.tx_status import TxStatus
 from ccf.tx_id import TxID
 import random
@@ -545,9 +545,9 @@ class Network:
 
             longest_ledger_seqno = 0
             for node in self.nodes:
-                _, committed = node.get_ledger()
-                last_seqno = Ledger(committed).get_latest_public_state()[1]
-                nodes_ledger[node.local_node_id] = [committed, last_seqno]
+                ledger = node.remote.ledger_paths()
+                last_seqno = Ledger(ledger).get_latest_public_state()[1]
+                nodes_ledger[node.local_node_id] = [ledger, last_seqno]
                 if last_seqno > longest_ledger_seqno:
                     longest_ledger_seqno = last_seqno
                     longest_ledger_node = node
@@ -559,6 +559,7 @@ class Network:
                         (f, infra.path.compute_file_checksum(os.path.join(d, f)))
                         for d in dirs
                         for f in os.listdir(d)
+                        if f.endswith(COMMITTED_FILE_SUFFIX)
                     ]
 
                 longest_ledger_dirs, _ = nodes_ledger[longest_ledger_node.local_node_id]

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -400,12 +400,12 @@ class Node:
         assert ledger.last_committed_chunk_range[1] >= seqno
         return ledger.get_latest_public_state()
 
-    def get_ledger(self, include_read_only_dirs=False):
+    def get_ledger(self):
         """
         Triage committed and un-committed (i.e. current) ledger files
         """
         main_ledger_dir, read_only_ledger_dirs = self.remote.get_ledger(
-            f"{self.local_node_id}.ledger", include_read_only_dirs
+            f"{self.local_node_id}.ledger"
         )
 
         current_ledger_dir = os.path.join(
@@ -429,7 +429,7 @@ class Node:
                 if is_file_committed(f):
                     infra.path.copy_dir(os.path.join(ro_dir, f), committed_ledger_dir)
 
-        return current_ledger_dir, committed_ledger_dir
+        return current_ledger_dir, [committed_ledger_dir]
 
     def get_snapshots(self):
         return self.remote.get_snapshots()

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -840,8 +840,8 @@ class CCFRemote(object):
 
     def ledger_paths(self):
         paths = [os.path.join(self.remote.root, self.ledger_dir_name)]
-        if self.read_only_ledger_dir_name is not None:
-            paths += [os.path.join(self.remote.root, self.read_only_ledger_dir_name)]
+        for read_only_ledger_dir_name in self.read_only_ledger_dirs_names:
+            paths += [os.path.join(self.remote.root, read_only_ledger_dir_name)]
         return paths
 
     def get_logs(self, tail_lines_len=DEFAULT_TAIL_LINES_LEN):

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -564,7 +564,7 @@ class CCFRemote(object):
         worker_threads=0,
         constitution=None,
         ledger_dir=None,
-        read_only_ledger_dir=None,  # Read-only ledger dir to copy to node directory
+        read_only_ledger_dirs=[],  # Read-only ledger dirs to copy to node directory
         common_read_only_ledger_dir=None,  # Read-only ledger dir for all nodes
         log_format_json=None,
         binary_dir=".",
@@ -607,12 +607,10 @@ class CCFRemote(object):
             else f"{local_node_id}.ledger"
         )
 
-        self.read_only_ledger_dir = read_only_ledger_dir
-        self.read_only_ledger_dir_name = (
-            os.path.basename(self.read_only_ledger_dir)
-            if self.read_only_ledger_dir
-            else None
-        )
+        self.read_only_ledger_dirs = read_only_ledger_dirs
+        self.read_only_ledger_dirs_names = []
+        for d in self.read_only_ledger_dirs:
+            self.read_only_ledger_dirs_names.append(os.path.basename(d))
         self.common_read_only_ledger_dir = common_read_only_ledger_dir
 
         self.snapshot_dir = os.path.normpath(snapshot_dir) if snapshot_dir else None
@@ -681,9 +679,11 @@ class CCFRemote(object):
         if jwt_key_refresh_interval_s:
             cmd += [f"--jwt-key-refresh-interval-s={jwt_key_refresh_interval_s}"]
 
-        if self.read_only_ledger_dir is not None:
-            cmd += [f"--read-only-ledger-dir={self.read_only_ledger_dir_name}"]
-            data_files += [os.path.join(self.common_dir, self.read_only_ledger_dir)]
+        for dir_names in self.read_only_ledger_dirs_names:
+            cmd += [f"--read-only-ledger-dir={dir_names}"]
+
+        for dirs in self.read_only_ledger_dirs:
+            data_files += [os.path.join(self.common_dir, dirs)]
 
         if self.common_read_only_ledger_dir is not None:
             cmd += [f"--read-only-ledger-dir={self.common_read_only_ledger_dir}"]
@@ -808,22 +808,15 @@ class CCFRemote(object):
     def set_perf(self):
         self.remote.set_perf()
 
-    # For now, it makes sense to default include_read_only_dirs to False
-    # but when nodes started from snapshots are fully supported in the test
-    # suite, this argument will probably default to True (or be deleted entirely)
-    def get_ledger(self, ledger_dir_name, include_read_only_dirs=False):
+    def get_ledger(self, ledger_dir_name):
         self.remote.get(
             self.ledger_dir_name, self.common_dir, target_name=ledger_dir_name
         )
         read_only_ledger_dirs = []
-        if include_read_only_dirs and self.read_only_ledger_dir is not None:
-            read_only_ledger_dir_name = (
-                f"{ledger_dir_name}.ro"
-                if ledger_dir_name
-                else self.read_only_ledger_dir
-            )
+        for read_only_ledger_dir in self.read_only_ledger_dirs:
+            read_only_ledger_dir_name = f"{read_only_ledger_dir}.ro"
             self.remote.get(
-                os.path.basename(self.read_only_ledger_dir),
+                os.path.basename(read_only_ledger_dir),
                 self.common_dir,
                 target_name=read_only_ledger_dir_name,
             )

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -564,7 +564,7 @@ class CCFRemote(object):
         worker_threads=0,
         constitution=None,
         ledger_dir=None,
-        read_only_ledger_dirs=[],  # Read-only ledger dirs to copy to node directory
+        read_only_ledger_dirs=None,  # Read-only ledger dirs to copy to node directory
         common_read_only_ledger_dir=None,  # Read-only ledger dir for all nodes
         log_format_json=None,
         binary_dir=".",
@@ -607,7 +607,7 @@ class CCFRemote(object):
             else f"{local_node_id}.ledger"
         )
 
-        self.read_only_ledger_dirs = read_only_ledger_dirs
+        self.read_only_ledger_dirs = read_only_ledger_dirs or []
         self.read_only_ledger_dirs_names = []
         for d in self.read_only_ledger_dirs:
             self.read_only_ledger_dirs_names.append(os.path.basename(d))
@@ -814,15 +814,13 @@ class CCFRemote(object):
         )
         read_only_ledger_dirs = []
         for read_only_ledger_dir in self.read_only_ledger_dirs:
-            read_only_ledger_dir_name = f"{read_only_ledger_dir}.ro"
+            name = f"{read_only_ledger_dir}.ro"
             self.remote.get(
                 os.path.basename(read_only_ledger_dir),
                 self.common_dir,
-                target_name=read_only_ledger_dir_name,
+                target_name=name,
             )
-            read_only_ledger_dirs.append(
-                os.path.join(self.common_dir, read_only_ledger_dir_name)
-            )
+            read_only_ledger_dirs.append(os.path.join(self.common_dir, name))
         return (os.path.join(self.common_dir, ledger_dir_name), read_only_ledger_dirs)
 
     def get_snapshots(self):

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -424,9 +424,7 @@ def run_ledger_compatibility_since_first(args, local_branch, use_snapshot):
                 snapshot_dir = (
                     network.get_committed_snapshots(primary) if use_snapshot else None
                 )
-                ledger_dir, committed_ledger_dir = primary.get_ledger(
-                    include_read_only_dirs=True
-                )
+                ledger_dir, committed_ledger_dir = primary.get_ledger()
                 network.stop_all_nodes(skip_verification=True)
 
                 # Check that ledger and snapshots can be parsed

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -96,8 +96,6 @@ def test_share_resilience(network, args, from_snapshot=False):
 
     current_ledger_dir, committed_ledger_dirs = old_primary.get_ledger()
 
-    LOG.error(current_ledger_dir)
-
     recovered_network = infra.network.Network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, network
     )

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -56,9 +56,7 @@ def test(network, args, from_snapshot=False, split_ledger=False):
 
     network.stop_all_nodes()
 
-    current_ledger_dir, committed_ledger_dirs = old_primary.get_ledger(
-        include_read_only_dirs=True
-    )
+    current_ledger_dir, committed_ledger_dirs = old_primary.get_ledger()
 
     if split_ledger:
         # Test that ledger files can be arbitrarily split and that recovery
@@ -96,9 +94,7 @@ def test_share_resilience(network, args, from_snapshot=False):
 
     network.stop_all_nodes()
 
-    current_ledger_dir, committed_ledger_dirs = old_primary.get_ledger(
-        include_read_only_dirs=True
-    )
+    current_ledger_dir, committed_ledger_dirs = old_primary.get_ledger()
 
     LOG.error(current_ledger_dir)
 

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -56,7 +56,7 @@ def test(network, args, from_snapshot=False, split_ledger=False):
 
     network.stop_all_nodes()
 
-    current_ledger_dir, committed_ledger_dir = old_primary.get_ledger(
+    current_ledger_dir, committed_ledger_dirs = old_primary.get_ledger(
         include_read_only_dirs=True
     )
 
@@ -66,7 +66,10 @@ def test(network, args, from_snapshot=False, split_ledger=False):
         # Note: For real operations, it would be best practice to use a separate
         # output directory
         split_all_ledger_files_in_dir(current_ledger_dir, current_ledger_dir)
-        split_all_ledger_files_in_dir(committed_ledger_dir, committed_ledger_dir)
+        if committed_ledger_dirs:
+            split_all_ledger_files_in_dir(
+                committed_ledger_dirs[0], committed_ledger_dirs[0]
+            )
 
     recovered_network = infra.network.Network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, network
@@ -74,7 +77,7 @@ def test(network, args, from_snapshot=False, split_ledger=False):
     recovered_network.start_in_recovery(
         args,
         ledger_dir=current_ledger_dir,
-        committed_ledger_dir=committed_ledger_dir,
+        committed_ledger_dirs=committed_ledger_dirs,
         snapshot_dir=snapshot_dir,
     )
     recovered_network.recover(args)
@@ -90,11 +93,14 @@ def test_share_resilience(network, args, from_snapshot=False):
     snapshot_dir = None
     if from_snapshot:
         snapshot_dir = network.get_committed_snapshots(old_primary)
-    current_ledger_dir, committed_ledger_dir = old_primary.get_ledger(
+
+    network.stop_all_nodes()
+
+    current_ledger_dir, committed_ledger_dirs = old_primary.get_ledger(
         include_read_only_dirs=True
     )
 
-    network.stop_all_nodes()
+    LOG.error(current_ledger_dir)
 
     recovered_network = infra.network.Network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, network
@@ -102,7 +108,7 @@ def test_share_resilience(network, args, from_snapshot=False):
     recovered_network.start_in_recovery(
         args,
         ledger_dir=current_ledger_dir,
-        committed_ledger_dir=committed_ledger_dir,
+        committed_ledger_dirs=committed_ledger_dirs,
         snapshot_dir=snapshot_dir,
     )
     primary, _ = recovered_network.find_primary()


### PR DESCRIPTION
Part of #2612 

Minor change to consider multiple read-only ledger directories as opposed to just one as CCF nodes accept an arbitrary number of them but the infra only coped with one so far. 