### PR TITLE
Pin pyparsing when we use cimetrics

### DIFF
--- a/tests/cimetrics_env.sh
+++ b/tests/cimetrics_env.sh
@@ -10,6 +10,7 @@ if [ ! -f "env/bin/activate" ]
 fi
 
 source env/bin/activate
-pip install -q -U cimetrics
+#pip install -q -U cimetrics
+pip install -q "pyparsing<3,>=2.0.2" cimetrics
 
 "$@"


### PR DESCRIPTION
We should be able to unwind this after the next release of packaging, but for now this is needed to get the perf CI working again.