### PR TITLE
Make `--skip-checks` an optional arg to `set_ca_cert_bundle` proposal

### DIFF
--- a/python/ccf/proposal_generator.py
+++ b/python/ccf/proposal_generator.py
@@ -272,7 +272,9 @@ def set_recovery_threshold(threshold: int, **kwargs):
 
 
 @cli_proposal
-def set_ca_cert_bundle(cert_bundle_name, cert_bundle_path, skip_checks=False, **kwargs):
+def set_ca_cert_bundle(
+    cert_bundle_name, cert_bundle_path, skip_checks: bool = False, **kwargs
+):
     with open(cert_bundle_path, encoding="utf-8") as f:
         cert_bundle_pem = f.read()
 


### PR DESCRIPTION
Noticed while doing some manual testing that this arg was missing a type annotation, and as a result wasn't correctly exposed to the CLI, and was actually listed as a required arg.

Before:
```
$ python ../python/ccf/proposal_generator.py set_ca_cert_bundle --help
usage: proposal_generator.py set_ca_cert_bundle [-h] cert_bundle_name cert_bundle_path skip_checks

positional arguments:
  cert_bundle_name
  cert_bundle_path
  skip_checks

optional arguments:
  -h, --help        show this help message and exit

$ python ../python/ccf/proposal_generator.py set_ca_cert_bundle ./foo ./bar
usage: proposal_generator.py set_ca_cert_bundle [-h] cert_bundle_name cert_bundle_path skip_checks
proposal_generator.py set_ca_cert_bundle: error: the following arguments are required: skip_checks
```

After:
```
$ python ../python/ccf/proposal_generator.py set_ca_cert_bundle --help
usage: proposal_generator.py set_ca_cert_bundle [-h] [--skip-checks] cert_bundle_name cert_bundle_path

positional arguments:
  cert_bundle_name
  cert_bundle_path

optional arguments:
  -h, --help        show this help message and exit
  --skip-checks

$ python ../python/ccf/proposal_generator.py set_ca_cert_bundle ./foo ./bar
[No error about missing arg]
```