### PR TITLE
Test fix - install package so that jinja's PackageLoader works

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Every Day
+All Day

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -63,7 +63,7 @@ fi
 python3.8 -m venv env
 # shellcheck source=/dev/null
 source env/bin/activate
-python -m pip install ../../../python
+python -m pip install -e ../../../python
 python ../../../python/tutorial.py ./workspace/sandbox_common/
 
 # Test Python package CLI


### PR DESCRIPTION
#3229 broke the Daily: https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=37140&view=logs&j=5435e0ac-25e5-5426-50be-61b0d0ea8d34&t=20753e5b-87ba-5bdc-0f17-d34c09f927a7&l=291

I believe that's because of this missing `-e`. Running Daily on this PR to confirm.