### PR TITLE
Remove unused method

### DIFF
--- a/src/consensus/aft/raft_consensus.h
+++ b/src/consensus/aft/raft_consensus.h
@@ -195,8 +195,6 @@ namespace aft
       aft->enable_all_domains();
     }
 
-    void emit_signature() override {}
-
     ConsensusType type() override
     {
       return consensus_type;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -509,7 +509,6 @@ namespace kv
 
     virtual void enable_all_domains() {}
 
-    virtual void emit_signature() = 0;
     virtual ConsensusType type() = 0;
   };
 

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -207,11 +207,6 @@ namespace kv::test
       const ccf::ResharingResult& result) override
     {}
 
-    void emit_signature() override
-    {
-      return;
-    }
-
     ConsensusType type() override
     {
       return consensus_type;


### PR DESCRIPTION
We used to have `emit_signature` in both `Consensus` and `History`. Now the only used implementation is in `History`, so we can remove this vestigial method from `Consensus`.