### PR TITLE
Convert is snapshot to entry type, cherry-pick #3275 to LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Internally, CCF now interprets the former `bool is_snapshot` field in ledger transactions as an `enum EntryType entry_type`. The values and their semantics remain identical for now, but will be extended in 2.0. This change is back-ported to provide a user-friendly error in the event that 1.x nodes attempt to read a ledger produced by 2.x nodes (#3275).
+
 ## [1.0.15]
 
 ### Changed

--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -42,6 +42,11 @@ class NodeStatus(Enum):
     RETIRED = "Retired"
 
 
+class EntryType(Enum):
+    WRITE_SET = 0
+    SNAPSHOT = 1
+
+
 def to_uint_64(buffer):
     return struct.unpack("@Q", buffer)[0]
 
@@ -94,7 +99,7 @@ class PublicDomain:
 
     _buffer: io.BytesIO
     _buffer_size: int
-    _is_snapshot: bool
+    _entry_type: EntryType
     _version: int
     _max_conflict_version: int
     _tables: dict
@@ -102,18 +107,21 @@ class PublicDomain:
     def __init__(self, buffer: io.BytesIO):
         self._buffer = buffer
         self._buffer_size = self._buffer.getbuffer().nbytes
-        self._is_snapshot = self._read_is_snapshot()
+        self._entry_type = self._read_entry_type()
         self._version = self._read_version()
         self._max_conflict_version = self._read_version()
 
-        if self._is_snapshot:
+        if self._entry_type == EntryType.SNAPSHOT:
             self._read_snapshot_header()
 
         self._tables = {}
         self._read()
 
-    def _read_is_snapshot(self):
-        return unpack(self._buffer, "<?")
+    def _read_entry_type(self):
+        val = unpack(self._buffer, "<B")
+        if val > EntryType.SNAPSHOT.value:
+            raise ValueError(f"Invalid EntryType: {val}")
+        return EntryType(val)
 
     def _read_version(self):
         return unpack(self._buffer, "<q")
@@ -171,7 +179,7 @@ class PublicDomain:
             records = {}
             self._tables[map_name] = records
 
-            if self._is_snapshot:
+            if self._entry_type == EntryType.SNAPSHOT:
                 # map snapshot version
                 self._read_version()
 

--- a/src/kv/generic_serialise_wrapper.h
+++ b/src/kv/generic_serialise_wrapper.h
@@ -24,7 +24,7 @@ namespace kv
     W* current_writer;
     TxID tx_id;
     Version max_conflict_version;
-    bool is_snapshot;
+    EntryType entry_type;
 
     std::shared_ptr<AbstractTxEncryptor> crypto_util;
 
@@ -59,14 +59,14 @@ namespace kv
       std::shared_ptr<AbstractTxEncryptor> e,
       const TxID& tx_id_,
       const Version& max_conflict_version_,
-      bool is_snapshot_ = false) :
+      EntryType entry_type_ = EntryType::WriteSet) :
       tx_id(tx_id_),
       max_conflict_version(max_conflict_version_),
-      is_snapshot(is_snapshot_),
+      entry_type(entry_type_),
       crypto_util(e)
     {
       set_current_domain(SecurityDomain::PUBLIC);
-      serialise_internal(is_snapshot);
+      serialise_internal(entry_type);
       serialise_internal(tx_id.version);
       serialise_internal(max_conflict_version);
     }
@@ -188,7 +188,7 @@ namespace kv
             serialised_hdr,
             encrypted_private_domain,
             tx_id,
-            is_snapshot))
+            entry_type))
       {
         throw KvSerialiserException(fmt::format(
           "Could not serialise transaction at seqno {}", tx_id.version));
@@ -223,7 +223,7 @@ namespace kv
     R private_reader;
     R* current_reader;
     std::vector<uint8_t> decrypted_buffer;
-    bool is_snapshot;
+    EntryType entry_type;
     Version version;
     Version max_conflict_version;
     std::shared_ptr<AbstractTxEncryptor> crypto_util;
@@ -233,7 +233,7 @@ namespace kv
     // domain have been read
     void read_public_header()
     {
-      is_snapshot = public_reader.template read_next<bool>();
+      entry_type = public_reader.template read_next<EntryType>();
       version = public_reader.template read_next<Version>();
       max_conflict_version = public_reader.template read_next<Version>();
     }

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -144,6 +144,16 @@ namespace kv
     APPLICATION
   };
 
+  enum class EntryType : uint8_t
+  {
+    WriteSet = 0,
+    Snapshot = 1
+  };
+
+  // EntryType must be backwards compatible with the older
+  // bool is_snapshot field
+  static_assert(sizeof(EntryType) == sizeof(bool));
+
   constexpr auto public_domain_prefix = "public:";
 
   static inline SecurityDomain get_security_domain(const std::string& name)
@@ -431,7 +441,7 @@ namespace kv
       std::vector<uint8_t>& serialised_header,
       std::vector<uint8_t>& cipher,
       const TxID& tx_id,
-      bool is_snapshot = false) = 0;
+      EntryType entry_type = EntryType::WriteSet) = 0;
     virtual bool decrypt(
       const std::vector<uint8_t>& cipher,
       const std::vector<uint8_t>& additional_data,

--- a/src/kv/raw_serialise.h
+++ b/src/kv/raw_serialise.h
@@ -73,6 +73,10 @@ namespace kv
           serialise_vector(entry);
         }
       }
+      else if constexpr (std::is_same_v<T, EntryType>)
+      {
+        serialise_entry(static_cast<uint8_t>(entry));
+      }
       else if constexpr (std::is_same_v<T, std::string>)
       {
         serialise_string(entry);
@@ -170,6 +174,15 @@ namespace kv
         serialized::write(data_, size_, data_ptr + entry_offset, entry_size);
 
         return ret;
+      }
+      else if constexpr (std::is_same_v<T, kv::EntryType>)
+      {
+        uint8_t entry_type = read_entry<uint8_t>();
+        if (entry_type > 1)
+          throw std::logic_error(
+            fmt::format("Invalid EntryType: {}", entry_type));
+
+        return kv::EntryType(entry_type);
       }
       else if constexpr (std::is_same_v<T, std::string>)
       {

--- a/src/kv/snapshot.h
+++ b/src/kv/snapshot.h
@@ -46,7 +46,7 @@ namespace kv
       // serialized.
       // Note: Snapshots are always taken at compacted state so version only is
       // unique enough to prevent IV reuse
-      KvStoreSerialiser serialiser(encryptor, {0, version}, version - 1, true);
+      KvStoreSerialiser serialiser(encryptor, {0, version}, version - 1, kv::EntryType::Snapshot);
 
       if (hash_at_snapshot.has_value())
       {

--- a/src/kv/snapshot.h
+++ b/src/kv/snapshot.h
@@ -46,7 +46,8 @@ namespace kv
       // serialized.
       // Note: Snapshots are always taken at compacted state so version only is
       // unique enough to prevent IV reuse
-      KvStoreSerialiser serialiser(encryptor, {0, version}, version - 1, kv::EntryType::Snapshot);
+      KvStoreSerialiser serialiser(
+        encryptor, {0, version}, version - 1, kv::EntryType::Snapshot);
 
       if (hash_at_snapshot.has_value())
       {

--- a/src/kv/test/null_encryptor.h
+++ b/src/kv/test/null_encryptor.h
@@ -16,7 +16,7 @@ namespace kv
       std::vector<uint8_t>& serialised_header,
       std::vector<uint8_t>& cipher,
       const TxID& tx_id,
-      bool is_snapshot = false) override
+      EntryType entry_type = EntryType::WriteSet) override
     {
       cipher = plain;
       return true;

--- a/src/node/test/encryptor.cpp
+++ b/src/node/test/encryptor.cpp
@@ -168,23 +168,21 @@ TEST_CASE("Ciphers at same seqno/term with and without snapshot are different")
   kv::Version version = 10;
   kv::Term term = 1;
 
-  bool is_snapshot = true;
   encryptor.encrypt(
     plain,
     additional_data,
     serialised_header,
     cipher,
     {term, version},
-    is_snapshot);
+    kv::EntryType::Snapshot);
 
-  is_snapshot = !is_snapshot;
   encryptor.encrypt(
     plain,
     additional_data,
     serialised_header2,
     cipher2,
     {term, version},
-    is_snapshot);
+    kv::EntryType::WriteSet);
 
   // Ciphers are different because IV is different
   REQUIRE(cipher != cipher2);


### PR DESCRIPTION
See #3275. Internally, CCF now interprets the former `bool is_snapshot` field in ledger transactions as an `enum EntryType entry_type`. The values and their semantics remain identical for now, but will be extended in 2.0. This change is back-ported to provide a user-friendly error in the event that 1.x nodes attempt to read a ledger produced by 2.x nodes (#3275).