### PR TITLE
Pin mistune to pre-2.x to fix doc build

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -11,3 +11,6 @@ furo
 # docutils 0.18.0 causes "AttributeError: 'Values' object
 # has no attribute 'section_self_link'" error when building doc
 docutils==0.17.*
+# mistune 2.0.0-rc1 causes "AttributeError: module 'mistune'
+# has no attribute 'BlockGrammar'" error when building doc
+mistune<2.0.0


### PR DESCRIPTION
See broken doc build https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=37978&view=results under https://github.com/microsoft/CCF/pull/3284 for details.

```
Running Sphinx v4.3.1

Exception occurred:
  File "/__w/1/s/env/lib/python3.8/site-packages/m2r.py", line 59, in <module>
    class RestBlockGrammar(mistune.BlockGrammar):
AttributeError: module 'mistune' has no attribute 'BlockGrammar'
```