### PR TITLE
Fix recovery threshold update proposal action

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-squeak.
+cluck cluck

--- a/src/runtime_config/default/actions.js
+++ b/src/runtime_config/default/actions.js
@@ -255,18 +255,23 @@ function updateServiceConfig(new_config) {
     config.reconfiguration_type = new_config.reconfiguration_type;
   }
 
+  let need_recovery_threshold_refresh = false;
   if (
     new_config.recovery_threshold !== undefined &&
     new_config.recovery_threshold !== config.recovery_threshold
   ) {
     config.recovery_threshold = new_config.recovery_threshold;
-    ccf.node.triggerRecoverySharesRefresh();
+    need_recovery_threshold_refresh = true;
   }
 
   ccf.kv[service_config_table].set(
     getSingletonKvKey(),
     ccf.jsonCompatibleToBuf(config)
   );
+
+  if (need_recovery_threshold_refresh) {
+    ccf.node.triggerRecoverySharesRefresh();
+  }
 }
 
 const actions = new Map([


### PR DESCRIPTION
I believe the regression was introduced in #3198 because of my comment (https://github.com/microsoft/CCF/pull/3198#discussion_r760363198): even if the proposal execution is atomic, `triggerRecoverySharesRefresh()` needs to read the `kv::Tx`'s own writes to find out the latest value of the recovery threshold.