### PR TITLE
Skip LTS download if it already exists locally

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-cluck cluck
+cluck cluck!

--- a/tests/infra/github.py
+++ b/tests/infra/github.py
@@ -25,6 +25,7 @@ DEBIAN_PACKAGE_EXTENSION = "_amd64.deb"
 INSTALL_DIRECTORY_PREFIX = "ccf_install_"
 INSTALL_DIRECTORY_SUB_PATH = "opt/ccf"
 DOWNLOAD_FOLDER_NAME = "downloads"
+INSTALL_SUCCESS_FILE = "test_github_infra_installed"
 
 # Note: Releases are identified by tag since releases are not necessarily named, but all
 # releases are tagged
@@ -190,7 +191,18 @@ class Repository:
     def install_release(self, tag):
         stripped_tag = strip_release_tag_name(tag)
         install_directory = f"{INSTALL_DIRECTORY_PREFIX}{stripped_tag}"
+        install_path = os.path.abspath(
+            os.path.join(install_directory, INSTALL_DIRECTORY_SUB_PATH)
+        )
         debian_package_url = get_debian_package_url_from_tag_name(tag)
+        installed_file_path = os.path.join(install_path, INSTALL_SUCCESS_FILE)
+
+        # Skip downloading release if it already exists
+        if os.path.isfile(installed_file_path):
+            LOG.info(
+                f"Using existing release {stripped_tag} already installed at {install_path}"
+            )
+            return stripped_tag, install_path
 
         debian_package_name = debian_package_url.split("/")[-1]
         download_path = os.path.join(DOWNLOAD_FOLDER_NAME, debian_package_name)
@@ -206,9 +218,9 @@ class Repository:
         install_cmd = ["dpkg-deb", "-R", download_path, install_directory]
         assert infra.proc.ccall(*install_cmd).returncode == 0, "Installation failed"
 
-        install_path = os.path.abspath(
-            os.path.join(install_directory, INSTALL_DIRECTORY_SUB_PATH)
-        )
+        # Write new file to avoid having to download install again
+        open(os.path.join(install_path, INSTALL_SUCCESS_FILE), "w+")
+
         LOG.info(f"CCF release {stripped_tag} successfully installed at {install_path}")
         return stripped_tag, install_path
 

--- a/tests/infra/github.py
+++ b/tests/infra/github.py
@@ -219,7 +219,7 @@ class Repository:
         assert infra.proc.ccall(*install_cmd).returncode == 0, "Installation failed"
 
         # Write new file to avoid having to download install again
-        open(os.path.join(install_path, INSTALL_SUCCESS_FILE), "w+")
+        open(os.path.join(install_path, INSTALL_SUCCESS_FILE), "w+", encoding="utf-8")
 
         LOG.info(f"CCF release {stripped_tag} successfully installed at {install_path}")
         return stripped_tag, install_path


### PR DESCRIPTION
We've started to hit this new error in the Daily pipeline: https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=38267&view=logs&j=e982d093-d12a-5a2d-1a1d-0c6d38b8823f&t=8be5454d-0d8f-51e4-7372-58df022e9ebc&l=31963

This is because we download LTS releases many times in a row when running the `lts_compatibility_*` end-to-end test. 

The infra will now skip the release download from GitHub and use the local install if this one already exists.