### PR TITLE
Update endorsed node certificate on global hook

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Trigger
+Trigger trigger

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -62,17 +62,13 @@ namespace ccf
     {
       NodeId node_id;
       crypto::Pem certificate_signing_request;
+      crypto::Pem node_endorsed_certificate;
       crypto::Pem public_key;
       crypto::Pem network_cert;
       QuoteInfo quote_info;
       crypto::Pem public_encryption_key;
       CodeDigest code_digest;
       NodeInfoNetwork node_info_network;
-      std::string node_cert_valid_from;
-      size_t initial_node_cert_validity_period_days;
-
-      // Only set if node does _not_ require endorsement by the service
-      std::optional<crypto::Pem> node_cert = std::nullopt;
 
       // Only set on genesis transaction, but not on recovery
       std::optional<StartupConfig::Start> genesis_info = std::nullopt;

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -1201,23 +1201,9 @@ namespace ccf
           g.set_constitution(in.genesis_info->constitution);
         }
 
-        if (!in.node_cert.has_value())
-        {
-          auto endorsed_certificates =
-            ctx.tx.rw(network.node_endorsed_certificates);
-          endorsed_certificates->put(
-            in.node_id,
-            crypto::create_endorsed_cert(
-              in.certificate_signing_request,
-              in.node_cert_valid_from,
-              in.initial_node_cert_validity_period_days,
-              this->network.identity->priv_key,
-              this->network.identity->cert));
-        }
-        else
-        {
-          node_info.cert = in.node_cert.value();
-        }
+        auto endorsed_certificates =
+          ctx.tx.rw(network.node_endorsed_certificates);
+        endorsed_certificates->put(in.node_id, in.node_endorsed_certificate);
 
         g.add_node(in.node_id, node_info);
 

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -74,16 +74,14 @@ namespace ccf
     CreateNetworkNodeToNode::In,
     node_id,
     certificate_signing_request,
+    node_endorsed_certificate,
     public_key,
     network_cert,
     quote_info,
     public_encryption_key,
     code_digest,
-    node_info_network,
-    node_cert_valid_from,
-    initial_node_cert_validity_period_days)
-  DECLARE_JSON_OPTIONAL_FIELDS(
-    CreateNetworkNodeToNode::In, node_cert, genesis_info)
+    node_info_network)
+  DECLARE_JSON_OPTIONAL_FIELDS(CreateNetworkNodeToNode::In, genesis_info)
 
   DECLARE_JSON_TYPE(GetCommit::Out)
   DECLARE_JSON_REQUIRED_FIELDS(GetCommit::Out, transaction_id)

--- a/tests/governance.py
+++ b/tests/governance.py
@@ -269,6 +269,9 @@ def test_each_node_cert_renewal(network, args):
                         expected_exception is None
                     ), "Proposal should have not succeeded"
 
+                # Node certificate is updated on global commit hook
+                network.wait_for_all_nodes_to_commit(primary)
+
                 node_cert_tls_after = node.get_tls_certificate_pem()
                 assert (
                     node_cert_tls_before != node_cert_tls_after


### PR DESCRIPTION
Resolves #2893 

This was the last item in the node certificate renewal work stream: because transactions can be rolled back, nodes shouldn't present the renewed endorsed certificate until the renewal has been (globally) committed. This is mostly trivial, except for the very first transaction that needs to know about the endorsed certificate before the first signature is emitted (since endorsed node certificates are currently recorded in the signature). 

Also remove a few unused BFT-specific code paths here and there.