### PR TITLE
Add job to build CI containers

### DIFF
--- a/.github/workflows/ci-containers.yml
+++ b/.github/workflows/ci-containers.yml
@@ -1,9 +1,9 @@
 name: "Build and Publish CI Containers"
 
-on:  
+on:
   push:
     tags:
-      - 'ccf_ci_image/*'
+      - "ccf_ci_image/*"
 
 jobs:
   build:

--- a/.github/workflows/ci-containers.yml
+++ b/.github/workflows/ci-containers.yml
@@ -1,0 +1,26 @@
+name: "Build and Publish CI Containers"
+
+on:  
+  push:
+    tags:
+      - 'ccf_ci_image/*'
+
+jobs:
+  build:
+    name: "Build CI Containers"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Truncate ref
+        run: echo "##[set-output name=tag;]${GITHUB_REF#refs/tags/ccf_ci_image/}"
+        id: tref
+
+      - name: Build CCF CI container
+        run: docker build -f docker/ccf_ci . -t ccfciteam/ccf-ci:${{steps.tref.outputs.tag}}
+
+      - name: Log in
+        run: docker login -u amchamay -p ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Push CI container
+        run: docker push ccfciteam/ccf-ci:${{steps.tref.outputs.tag}}

--- a/doc/contribute/build_images.rst
+++ b/doc/contribute/build_images.rst
@@ -1,0 +1,10 @@
+CCF Build images
+================
+
+CCF build images are produced by running the `docker/app_ci <https://github.com/microsoft/CCF/blob/main/docker/ccf_ci>`_ Docker file,
+and pushed to `Docker Hub <https://hub.docker.com/r/ccfciteam/ccf-ci/tags>`_.
+
+Pushing a git tag of the form ``ccf_ci_image/$TAG`` will trigger a `workflow <https://github.com/microsoft/CCF/blob/main/.github/workflows/ci-containers.yml>`_
+that builds and pushes a ``ccfciteam/ccf-ci:$TAG`` image.
+
+That image can then be used in CI and CD pipelines.

--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -42,6 +42,13 @@ The CCF team welcome contributions to any part of the framework, including this 
 
     Design documentation.
 
+    ---
+
+    :fa:`cogs` :doc:`build_images`
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    CCF build images.
+
 .. toctree::
     :maxdepth: 1
     :hidden:
@@ -51,3 +58,4 @@ The CCF team welcome contributions to any part of the framework, including this 
     build_ccf
     release_ccf
     design/index
+    build_images


### PR DESCRIPTION
Attempt to solve #3303. Will trigger when a tag starting with `ccf_ci_image/$TAG` is pushed, and will create an image from this tag called `ccfciteam/ccf-ci:$TAG`.

Note: I know it says container**s**, and we only have the one CI container now, but I have a hunch this won't last and renaming GitHub CI flows is zero fun, since you can never delete the old ones.

Also note the deliberate absence of `:latest`, as opposed to releases, because I can't imagine ever using that happily.