### PR TITLE
Always run txs.verify() in e2e_logging test

### DIFF
--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -47,7 +47,7 @@ def verify_receipt(receipt, network_cert, check_endorsement=True):
 @reqs.description("Running transactions against logging app")
 @reqs.supports_methods("log/private", "log/public")
 @reqs.at_least_n_nodes(2)
-def test(network, args, verify=True):
+def test(network, args):
     network.txs.issue(
         network=network,
         number_txs=1,
@@ -57,10 +57,7 @@ def test(network, args, verify=True):
         number_txs=1,
         on_backup=True,
     )
-    if verify:
-        network.txs.verify()
-    else:
-        LOG.warning("Skipping log messages verification")
+    network.txs.verify()
 
     return network
 
@@ -68,7 +65,7 @@ def test(network, args, verify=True):
 @reqs.description("Protocol-illegal traffic")
 @reqs.supports_methods("log/private", "log/public")
 @reqs.at_least_n_nodes(2)
-def test_illegal(network, args, verify=True):
+def test_illegal(network, args):
     primary, _ = network.find_primary()
 
     def send_bad_raw_content(content):
@@ -109,10 +106,7 @@ def test_illegal(network, args, verify=True):
         number_txs=1,
         on_backup=True,
     )
-    if verify:
-        network.txs.verify()
-    else:
-        LOG.warning("Skipping log messages verification")
+    network.txs.verify()
 
     return network
 
@@ -1406,8 +1400,8 @@ def run(args):
     ) as network:
         network.start_and_join(args)
 
-        network = test(network, args, verify=args.package != "libjs_generic")
-        network = test_illegal(network, args, verify=args.package != "libjs_generic")
+        network = test(network, args)
+        network = test_illegal(network, args)
         network = test_large_messages(network, args)
         network = test_remove(network, args)
         network = test_clear(network, args)


### PR DESCRIPTION
At some point verification wasn't supported in js_generic due to missing receipt endpoints, but this is not the case anymore.