### PR TITLE
Print signal a node was terminated by

### DIFF
--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -489,6 +489,10 @@ class LocalRemote(CmdMixin):
         if self.proc:
             self.proc.terminate()
             self.proc.wait(10)
+            exit_code = self.proc.returncode
+            if exit_code is not None and exit_code < 0:
+                signal_str = signal.strsignal(-exit_code)
+                LOG.error(f"{self.hostname} exited with signal: {signal_str}")
             if self.stdout:
                 self.stdout.close()
             if self.stderr:


### PR DESCRIPTION
New log output if a node was killed by a signal:
```
43: 11:27:26.261 | ERROR    | infra.remote:stop:495 - 127.6.188.245 exited with signal: Segmentation fault
```

Fixes #3331.