### PR TITLE
Update to doxygen 1.9.3

### DIFF
--- a/getting_started/setup_vm/roles/ccf_build/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_build/vars/common.yml
@@ -35,6 +35,6 @@ mbedtls_ver: "2.16.10"
 mbedtls_dir: "mbedtls-{{ mbedtls_ver }}"
 mbedtls_src: "{{ mbedtls_dir }}.tar.gz"
 
-doxygen_ver: "1.9.1"
+doxygen_ver: "1.9.3"
 doxygen_bin: "doxygen-{{ doxygen_ver }}.linux.bin.tar.gz"
 doxygen_url: "https://doxygen.nl/files/{{ doxygen_bin }}"


### PR DESCRIPTION
Since the latest doxygen update, the CodeQL job is failing (https://github.com/microsoft/CCF/runs/4712658927?check_suite_focus=true) as the Doxygen 1.9.1 binary is no longer available on their server. 

I cannot find a "latest" symlink but they seem to keep the latest two versions online and they only update twice a year so updating this version once a year doesn't seem too bad? 