### PR TITLE
Update doxygen on 1.x

### DIFF
--- a/getting_started/setup_vm/roles/ccf_build/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_build/vars/common.yml
@@ -32,6 +32,6 @@ mbedtls_ver: "2.16.8"
 mbedtls_dir: "mbedtls-{{ mbedtls_ver }}"
 mbedtls_src: "{{ mbedtls_dir }}.tar.gz"
 
-doxygen_ver: "1.9.1"
+doxygen_ver: "1.9.3"
 doxygen_bin: "doxygen-{{ doxygen_ver }}.linux.bin.tar.gz"
 doxygen_url: "https://doxygen.nl/files/{{ doxygen_bin }}"


### PR DESCRIPTION
Same as #3355, for different reasons: the post-release containers building job fails because of this at the moment.