### PR TITLE
Add more ciphers and restrict elliptic curves in OpenSSL

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Trigger daily, please
+Trigger daily

--- a/src/tls/openssl/context.h
+++ b/src/tls/openssl/context.h
@@ -37,11 +37,13 @@ namespace tls
       // Disable renegotiation to avoid DoS
       SSL_CTX_set_options(
         cfg,
-        SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION |
+        SSL_OP_CIPHER_SERVER_PREFERENCE |
+          SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION |
           SSL_OP_NO_RENEGOTIATION);
       SSL_set_options(
         ssl,
-        SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION |
+        SSL_OP_CIPHER_SERVER_PREFERENCE |
+          SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION |
           SSL_OP_NO_RENEGOTIATION);
 
       // Set cipher for TLS 1.2 (TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)
@@ -49,8 +51,20 @@ namespace tls
       SSL_set_cipher_list(ssl, "ECDHE-ECDSA-AES128-GCM-SHA256");
 
       // Set cipher for TLS 1.3 (same as above)
-      SSL_CTX_set_ciphersuites(cfg, "TLS_AES_128_GCM_SHA256");
-      SSL_set_ciphersuites(ssl, "TLS_AES_128_GCM_SHA256");
+      SSL_CTX_set_ciphersuites(
+        cfg,
+        "TLS_AES_256_GCM_SHA384:"
+        "TLS_CHACHA20_POLY1305_SHA256:"
+        "TLS_AES_128_GCM_SHA256");
+      SSL_set_ciphersuites(
+        ssl,
+        "TLS_AES_256_GCM_SHA384:"
+        "TLS_CHACHA20_POLY1305_SHA256:"
+        "TLS_AES_128_GCM_SHA256");
+
+      // Restrict the curves to approved ones
+      SSL_CTX_set1_curves_list(cfg, "P-521:P-384");
+      SSL_set1_curves_list(ssl, "P-521:P-384");
 
       // Initialise connection
       if (client)

--- a/src/tls/openssl/context.h
+++ b/src/tls/openssl/context.h
@@ -54,12 +54,10 @@ namespace tls
       SSL_CTX_set_ciphersuites(
         cfg,
         "TLS_AES_256_GCM_SHA384:"
-        "TLS_CHACHA20_POLY1305_SHA256:"
         "TLS_AES_128_GCM_SHA256");
       SSL_set_ciphersuites(
         ssl,
         "TLS_AES_256_GCM_SHA384:"
-        "TLS_CHACHA20_POLY1305_SHA256:"
         "TLS_AES_128_GCM_SHA256");
 
       // Restrict the curves to approved ones


### PR DESCRIPTION
These are the approved ciphers and curves that we can support. The TLS
1.2 cipher remains the same for compatibility, but the TLS 1.3 cipher
suites is updated to include stronger ciphers.

Comparing the TLS Report, now that I know what to look for, this is now
on par with the previous report (same bit-rate, server-order, restricted
curves), but strictly better with TLS 1.3 and more, stronger approved
ciphers in 1.3.