### PR TITLE
Save exact version to `package.json`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -337,7 +337,7 @@ def config_inited(app, config):
             check=True,
         )
         subprocess.run(
-            ["npm", "install", "colors@1.4.0"],
+            ["npm", "install", "--save-exact", "colors@1.4.0"],
             cwd=js_pkg_dir,
             check=True,
         )


### PR DESCRIPTION
Resolving the issue that produced this: https://github.com/microsoft/CCF/pull/3386#discussion_r782272910

`conf.py` tries to install exactly `colors@1.4.0` when building all versions of our docs. But if you run `npm install colors@1.4.0`, it modifies `package.json` to make the version `^1.4.0`, which we absolutely don't want. The fix is a more precise argument `--save-exact`, which modifies `package.json` to (the current value) `1.4.0`, not `^1.4.0`.