### PR TITLE
Always use in-process attestation when calling oeutil

### DIFF
--- a/tests/infra/proc.py
+++ b/tests/infra/proc.py
@@ -6,11 +6,11 @@ from subprocess import run
 from loguru import logger as LOG
 
 
-def ccall(*args, path=None, log_output=True):
+def ccall(*args, path=None, log_output=True, env=None):
     suffix = f" [cwd: {path}]" if path else ""
     cmd = " ".join(args)
     LOG.info(f"{cmd}{suffix}")
-    result = run(args, capture_output=True, cwd=path, check=False)
+    result = run(args, capture_output=True, cwd=path, check=False, env=env)
     if result.stdout and log_output:
         LOG.debug("stdout: {}".format(result.stdout.decode().strip()))
     if result.stderr and log_output:

--- a/tests/jwt_test.py
+++ b/tests/jwt_test.py
@@ -157,7 +157,7 @@ def make_attested_cert(network, args):
     pubk = os.path.join(network.common_dir, "attested_enc_pubk.pem")
     der = os.path.join(network.common_dir, "oe_cert.der")
     infra.proc.ccall(
-        oeutil, "generate-evidence", "-f", "cert", privk, pubk, "-o", der
+        oeutil, "generate-evidence", "-f", "cert", privk, pubk, "-o", der, env={} # Unset env, to ensure in-process attestation is always used. This is the only thing we test
     ).check_returncode()
     pem = os.path.join(network.common_dir, "oe_cert.pem")
     infra.proc.ccall(

--- a/tests/jwt_test.py
+++ b/tests/jwt_test.py
@@ -157,7 +157,16 @@ def make_attested_cert(network, args):
     pubk = os.path.join(network.common_dir, "attested_enc_pubk.pem")
     der = os.path.join(network.common_dir, "oe_cert.der")
     infra.proc.ccall(
-        oeutil, "generate-evidence", "-f", "cert", privk, pubk, "-o", der, env={} # Unset env, to ensure in-process attestation is always used. This is the only thing we test
+        oeutil,
+        "generate-evidence",
+        "-f",
+        "cert",
+        privk,
+        pubk,
+        "-o",
+        der,
+        # To ensure in-process attestation is always used, clear the env to unset the SGX_AESM_ADDR variable
+        env={},
     ).check_returncode()
     pem = os.path.join(network.common_dir, "oe_cert.pem")
     infra.proc.ccall(


### PR DESCRIPTION
The `SGX_AESM_ADDR` environment variable affects whether in-process or out-of-process attestation is used. Specifically, in-proc is only used when this env var is unset. We only test in-proc attestation, and this is enforced on `cchost` as we explicitly wipe the environment whenever we invoke it.

This PR applies the same behaviour to invocations of `oeutil generate-evidence` (used in the `jwt_test`), to ensure they use the tested in-process attestation regardless of system-wide settings.

Some more pointers for anyone investigating this in future:
- [OE docs around in-proc vs out-of-proc selection](https://github.com/openenclave/openenclave/blob/753e3227b9721851d363f028e37e5431f2311ca3/docs/GettingStartedDocs/Contributors/SGX1GettingStarted.md#determine-call-path-for-sgx-quote-generation-in-attestation-sample)
- Files that may be setting this env-var for you:
  - `/etc/profile.d/linux-base-sgx.sh`
  - `/usr/lib/systemd/system-environment-generators/linux-base-sgx`