### PR TITLE
Fix decoding of public keys in DER format

### DIFF
--- a/src/crypto/openssl/public_key.cpp
+++ b/src/crypto/openssl/public_key.cpp
@@ -31,8 +31,8 @@ namespace crypto
 
   PublicKey_OpenSSL::PublicKey_OpenSSL(const std::vector<uint8_t>& der)
   {
-    const unsigned char* pp = der.data();
-    key = d2i_PublicKey(EVP_PKEY_EC, &key, &pp, der.size());
+    Unique_BIO buf(der);
+    key = d2i_PUBKEY_bio(buf, &key);
     if (!key)
     {
       throw new std::runtime_error("Could not read DER");

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -8,6 +8,7 @@
 #include "crypto/key_wrap.h"
 #include "crypto/mbedtls/entropy.h"
 #include "crypto/mbedtls/key_pair.h"
+#include "crypto/mbedtls/public_key.h"
 #include "crypto/mbedtls/rsa_key_pair.h"
 #include "crypto/mbedtls/symmetric_key.h"
 #include "crypto/mbedtls/verifier.h"
@@ -726,5 +727,28 @@ TEST_CASE("x509 time")
       auto converted_time_t = crypto::OpenSSL::to_time_t(asn1_time);
       REQUIRE(converted_time_t == adjusted_time_t);
     }
+  }
+}
+
+TEST_CASE("check equality of DER encodings")
+{
+  {
+    KeyPair_OpenSSL key_ossl(CurveID::SECP384R1);
+    auto der_ossl = key_ossl.public_key_der();
+    PublicKey_mbedTLS pub_mbed(der_ossl);
+    auto der_mbed = pub_mbed.public_key_der();
+    REQUIRE(der_ossl == der_mbed);
+    PublicKey_OpenSSL pub_ossl(pub_mbed.public_key_der());
+    REQUIRE(der_mbed == der_ossl);
+  }
+
+  {
+    KeyPair_mbedTLS key_mbed(CurveID::SECP384R1);
+    auto der_mbed = key_mbed.public_key_der();
+    PublicKey_OpenSSL pub_ossl(der_mbed);
+    auto der_ossl = pub_ossl.public_key_der();
+    REQUIRE(der_ossl == der_mbed);
+    PublicKey_mbedTLS pub_mbed(pub_ossl.public_key_der());
+    REQUIRE(der_mbed == der_ossl);
   }
 }


### PR DESCRIPTION
This fixes the decoding of DER-encoded public keys. Our OpenSSL-based implementation used the wrong function and could not decode keys from mbedTLS, which we need/want for LTS compatibility reasons. The new test now checks that both implementations produce identical DER encodings and that they can decode each other's keys.