### PR TITLE
Tweak `test_add_as_many_pending_nodes` reconfiguration test case

### DIFF
--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -213,17 +213,17 @@ def test_add_as_many_pending_nodes(network, args):
         network.join_node(new_node, args.package, args, from_snapshot=False)
         new_nodes.append(new_node)
 
+    # Stop the retired nodes so they don't linger in the background and interfere
+    # with subsequent tests
+    for new_node in new_nodes:
+        new_node.stop()
+
     check_can_progress(primary)
 
     for new_node in new_nodes:
         network.retire_node(primary, new_node)
 
     wait_for_reconfiguration_to_complete(network)
-
-    # Stop the retired nodes so they don't linger in the background and interfere
-    # with subsequent tests
-    for new_node in new_nodes:
-        new_node.stop()
 
     return network
 
@@ -549,6 +549,8 @@ def run(args):
         test_node_certificates_validity_period(network, args)
         test_add_node_invalid_validity_period(network, args)
 
+    # TODO: When the test is stopped, make sure we can read all ledgers!
+
 
 def run_join_old_snapshot(args):
     txs = app.LoggingTxs("user0")
@@ -728,14 +730,14 @@ if __name__ == "__main__":
         reconfiguration_type="OneTransaction",
     )
 
-    if cr.args.include_2tx_reconfig:
-        cr.add(
-            "2tx_reconfig",
-            run,
-            package="samples/apps/logging/liblogging",
-            nodes=infra.e2e_args.min_nodes(cr.args, f=1),
-            reconfiguration_type="TwoTransaction",
-        )
+    # if cr.args.include_2tx_reconfig:
+    #     cr.add(
+    #         "2tx_reconfig",
+    #         run,
+    #         package="samples/apps/logging/liblogging",
+    #         nodes=infra.e2e_args.min_nodes(cr.args, f=1),
+    #         reconfiguration_type="TwoTransaction",
+    #     )
 
     cr.add(
         "migration",

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -200,7 +200,7 @@ def test_add_node_from_snapshot(
 @reqs.description("Adding as many pending nodes as current number of nodes")
 @reqs.supports_methods("log/private")
 def test_add_as_many_pending_nodes(network, args):
-    # Should not change the raft consensus rules (i.e. majority)
+    # Killing pending nodes should not change the raft consensus rules
     primary, _ = network.find_primary()
     number_new_nodes = len(network.nodes)
     LOG.info(
@@ -213,13 +213,14 @@ def test_add_as_many_pending_nodes(network, args):
         network.join_node(new_node, args.package, args, from_snapshot=False)
         new_nodes.append(new_node)
 
-    # Stop the retired nodes so they don't linger in the background and interfere
-    # with subsequent tests
     for new_node in new_nodes:
         new_node.stop()
 
+    # Even though pending nodes (half the number of nodes) are stopped,
+    # service can still make progress
     check_can_progress(primary)
 
+    # Cleanup killed pending nodes
     for new_node in new_nodes:
         network.retire_node(primary, new_node)
 
@@ -549,8 +550,6 @@ def run(args):
         test_node_certificates_validity_period(network, args)
         test_add_node_invalid_validity_period(network, args)
 
-    # TODO: When the test is stopped, make sure we can read all ledgers!
-
 
 def run_join_old_snapshot(args):
     txs = app.LoggingTxs("user0")
@@ -730,14 +729,14 @@ if __name__ == "__main__":
         reconfiguration_type="OneTransaction",
     )
 
-    # if cr.args.include_2tx_reconfig:
-    #     cr.add(
-    #         "2tx_reconfig",
-    #         run,
-    #         package="samples/apps/logging/liblogging",
-    #         nodes=infra.e2e_args.min_nodes(cr.args, f=1),
-    #         reconfiguration_type="TwoTransaction",
-    #     )
+    if cr.args.include_2tx_reconfig:
+        cr.add(
+            "2tx_reconfig",
+            run,
+            package="samples/apps/logging/liblogging",
+            nodes=infra.e2e_args.min_nodes(cr.args, f=1),
+            reconfiguration_type="TwoTransaction",
+        )
 
     cr.add(
         "migration",


### PR DESCRIPTION
Noticed this while investigating #2320 

The existing `test_add_as_many_pending_nodes` test aims to test that pending nodes do not participate in consensus. However, it only stopped the nodes at the end of the test, once they are retired, instead of stopping them early and verifying that the service can still make progress. 