### PR TITLE
Allow logging before enclave node creation to be seen

### DIFF
--- a/src/common/enclave_interface_types.h
+++ b/src/common/enclave_interface_types.h
@@ -35,7 +35,10 @@ enum CreateNodeStatus
   OpenSSLRDRANDInitFailed = 9,
 
   /** The reconfiguration method is not supported */
-  ReconfigurationMethodNotSupported = 10
+  ReconfigurationMethodNotSupported = 10,
+
+  /** Host and enclave versions must match */
+  VersionMismatch = 11
 };
 
 constexpr char const* create_node_result_to_str(CreateNodeStatus result)
@@ -86,6 +89,10 @@ constexpr char const* create_node_result_to_str(CreateNodeStatus result)
     {
       return "ReconfigurationMethodNotSupported";
     }
+    case CreateNodeStatus::VersionMismatch:
+    {
+      return "VersionMismatch";
+    }
     default:
     {
       return "Unknown CreateNodeStatus";
@@ -99,3 +106,18 @@ enum StartType
   Join = 2,
   Recover = 3,
 };
+
+constexpr char const* start_type_to_str(StartType type)
+{
+  switch (type)
+  {
+    case StartType::Start:
+      return "Start";
+    case StartType::Join:
+      return "Join";
+    case StartType::Recover:
+      return "Recover";
+    default:
+      return "Unknown StartType";
+  }
+}

--- a/src/enclave/ccf_v.h
+++ b/src/enclave/ccf_v.h
@@ -142,7 +142,18 @@ extern "C"
       start_type,
       num_worker_thread,
       time_location);
-    return OE_OK;
+
+    // Only return OE_OK when the error isn't OE related
+    switch (*status)
+    {
+      case CreateNodeStatus::OEAttesterInitFailed:
+      case CreateNodeStatus::OEVerifierInitFailed:
+      case CreateNodeStatus::EnclaveInitFailed:
+      case CreateNodeStatus::MemoryNotOutsideEnclave:
+        return OE_FAILURE;
+      default:
+        return OE_OK;
+    }
   }
 
   inline oe_result_t enclave_run(oe_enclave_t*, bool* _retval)

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -65,30 +65,22 @@ namespace enclave
   public:
     Enclave(
       const EnclaveConfig& ec,
+      ringbuffer::Circuit&& circuit,
+      ringbuffer::WriterFactory&& basic_writer_factory,
+      oversized::WriterFactory&& writer_factory,
       size_t sig_tx_interval,
       size_t sig_ms_interval,
       const consensus::Configuration& consensus_config,
       const CurveID& curve_id) :
-      circuit(
-        ringbuffer::BufferDef{
-          ec.to_enclave_buffer_start,
-          ec.to_enclave_buffer_size,
-          ec.to_enclave_buffer_offsets},
-        ringbuffer::BufferDef{
-          ec.from_enclave_buffer_start,
-          ec.from_enclave_buffer_size,
-          ec.from_enclave_buffer_offsets}),
-      basic_writer_factory(circuit),
-      writer_factory(basic_writer_factory, ec.writer_config),
+      circuit(std::move(circuit)),
+      basic_writer_factory(std::move(basic_writer_factory)),
+      writer_factory(std::move(writer_factory)),
       network(consensus_config.type),
       share_manager(network),
       rpc_map(std::make_shared<RPCMap>()),
       rpcsessions(std::make_shared<RPCSessions>(writer_factory, rpc_map))
     {
       ccf::initialize_oe();
-
-      logger::config::msg() = AdminMessage::log_msg;
-      logger::config::writer() = writer_factory.create_writer_to_outside();
 
       // From
       // https://software.intel.com/content/www/us/en/develop/articles/how-to-use-the-rdrand-engine-in-openssl-for-random-number-generation.html
@@ -98,6 +90,7 @@ namespace enclave
         ENGINE_init(rdrand_engine) != 1 ||
         ENGINE_set_default(rdrand_engine, ENGINE_METHOD_RAND) != 1)
       {
+        LOG_FAIL_FMT("Error creating OpenSSL's RDRAND engine");
         ENGINE_free(rdrand_engine);
         throw ccf::ccf_openssl_rdrand_init_error(
           "could not initialize RDRAND engine for OpenSSL");
@@ -105,11 +98,14 @@ namespace enclave
 
       to_host = writer_factory.create_writer_to_outside();
 
+      LOG_TRACE_FMT("Creating ledger secrets");
       network.ledger_secrets = std::make_shared<ccf::LedgerSecrets>();
 
+      LOG_TRACE_FMT("Creating node");
       node = std::make_unique<ccf::NodeState>(
         writer_factory, network, rpcsessions, share_manager, curve_id);
 
+      LOG_TRACE_FMT("Creating context");
       context = std::make_unique<NodeContext>();
       context->historical_state_cache =
         std::make_unique<ccf::historical::StateCache>(
@@ -118,6 +114,7 @@ namespace enclave
           writer_factory.create_writer_to_outside());
       context->node_state = node.get();
 
+      LOG_TRACE_FMT("Creating RPC actors / ffi");
       rpc_map->register_frontend<ccf::ActorsType::members>(
         std::make_unique<ccf::MemberRpcFrontend>(
           network, *context, share_manager));
@@ -130,6 +127,7 @@ namespace enclave
 
       ccf::js::register_ffi_plugins(ccfapp::get_js_plugins());
 
+      LOG_TRACE_FMT("Initialize node");
       node->initialize(
         consensus_config,
         rpc_map,
@@ -142,13 +140,15 @@ namespace enclave
     {
       if (rdrand_engine)
       {
+        LOG_TRACE_FMT("Finishing RDRAND engine");
         ENGINE_finish(rdrand_engine);
         ENGINE_free(rdrand_engine);
       }
+      LOG_TRACE_FMT("Shutting down enclave");
       ccf::shutdown_oe();
     }
 
-    bool create_new_node(
+    CreateNodeStatus create_new_node(
       StartType start_type_,
       StartupConfig&& ccf_config_,
       uint8_t* node_cert,
@@ -169,12 +169,14 @@ namespace enclave
       ccf::NodeCreateInfo r;
       try
       {
+        LOG_TRACE_FMT(
+          "Creating node with start_type {}", start_type_to_str(start_type));
         r = node->create(start_type, std::move(ccf_config_));
       }
       catch (const std::exception& e)
       {
         LOG_FAIL_FMT("Error starting node: {}", e.what());
-        return false;
+        return CreateNodeStatus::InternalError;
       }
 
       // Copy node and network certs out
@@ -184,7 +186,7 @@ namespace enclave
           "Insufficient space ({}) to copy node_cert out ({})",
           node_cert_size,
           r.self_signed_node_cert.size());
-        return false;
+        return CreateNodeStatus::InternalError;
       }
       ::memcpy(
         node_cert,
@@ -202,13 +204,13 @@ namespace enclave
             "Insufficient space ({}) to copy network_cert out ({})",
             network_cert_size,
             r.network_cert.size());
-          return false;
+          return CreateNodeStatus::InternalError;
         }
         ::memcpy(network_cert, r.network_cert.data(), r.network_cert.size());
         *network_cert_len = r.network_cert.size();
       }
 
-      return true;
+      return CreateNodeStatus::OK;
     }
 
     bool run_main()

--- a/src/host/enclave.h
+++ b/src/host/enclave.h
@@ -86,7 +86,7 @@ namespace host
       }
     }
 
-    void create_node(
+    CreateNodeStatus create_node(
       const EnclaveConfig& enclave_config,
       const StartupConfig& ccf_config,
       std::vector<uint8_t>& node_cert,
@@ -124,17 +124,9 @@ namespace host
         num_worker_thread,
         time_location);
 
-      if (err != OE_OK)
+      if (err != OE_OK || status != CreateNodeStatus::OK)
       {
-        throw std::logic_error(fmt::format(
-          "Failed to call in enclave_create_node: {}", oe_result_str(err)));
-      }
-
-      if (status != CreateNodeStatus::OK)
-      {
-        throw std::logic_error(fmt::format(
-          "An error occurred when creating CCF node: {}",
-          create_node_result_to_str(status)));
+        return status;
       }
 
       // Host and enclave versions must match. Otherwise the node may crash much
@@ -144,14 +136,17 @@ namespace host
         enclave_version_buf.begin() + enclave_version_len);
       if (ccf::ccf_version != enclave_version)
       {
-        throw std::logic_error(fmt::format(
+        LOG_FAIL_FMT(
           "Host/Enclave versions mismatch: {} != {}",
           ccf::ccf_version,
-          enclave_version));
+          enclave_version);
+        return CreateNodeStatus::VersionMismatch;
       }
 
       node_cert.resize(node_cert_len);
       network_cert.resize(network_cert_len);
+
+      return CreateNodeStatus::OK;
     }
 
     // Run a processor over this circuit inside the enclave - should be called


### PR DESCRIPTION
Before the enclave node is initialised, and the logger structure is
setup (sending logs through the ring buffer), any error ends up as
InternalError because we can't see the logs yet.

This commit changes that by creating the logging infrastructure before
the node is created (but after the ring buffer is setup), so that any
logs during that time, inside the enclave, can be flushed out and
displayed with the other error messages.

This allows us to be more verbose inside the enclave while constructing
the objects and creating the nodes, which helps debug the causes that
enclaves fail.

Extra work done to pass CreateNodeStatus around instead of throwing
exceptions, handling OE and CCF errors across enclave<->host barriers,
adding a new type of error (version mismatch) and adding a few traces
across the enclave constructor and node creations to help narrow issues
at a first glance.

Fixes #857