### PR TITLE
Add an Edit link in docs footer

### DIFF
--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -1,0 +1,11 @@
+{#-
+  This extends page.html from the Furo template to add an Edit on GitHub button to the footer.
+-#}
+{% extends "!page.html" %}
+{% block footer %}
+  {{ super() }}
+  <script>
+    var relatedInfo = document.querySelector(".related-information");
+    relatedInfo.insertAdjacentHTML("beforeend", '| <a class="muted-link" href="https://github.com/microsoft/CCF/edit/main/doc/{{ pagename }}{{ page_source_suffix }}" rel="nofollow">Edit</a>');
+  </script>
+{% endblock %}


### PR DESCRIPTION
Our docs were missing an "Edit on GitHub" button. I had a look for an off-the-shelf extension, but there don't seem to be any with clean config or that work directly with the Furo theme.

Instead I'm just inserting it manually into the footer, via a `<script>` tag that modifies the default footer.

If we want to fiddle with the template further we could put it elsewhere on the page, but it seems most naturally to be next to `Show Source`, which we have no control over with this theme.

Looks like this (hovering to show link destination):
![image](https://user-images.githubusercontent.com/6000239/149526610-62e659a2-2d42-43cb-8886-3a95b8b26580.png)
