### PR TITLE
Accept node deletion in 1.x LTS

### DIFF
--- a/src/node/hooks.h
+++ b/src/node/hooks.h
@@ -23,6 +23,12 @@ namespace ccf
     {
       for (const auto& [node_id, opt_ni] : w)
       {
+        if (!opt_ni.has_value())
+        {
+          // Deleted node will have already been retired (compatibility for 2.x)
+          continue;
+        }
+
         const auto& ni = opt_ni.value();
         switch (ni.status)
         {


### PR DESCRIPTION
In preparation for https://github.com/microsoft/CCF/pull/3409, 1.x nodes should be able to tolerate nodes being deleted from the KV store. 