### PR TITLE
Allow logging before enclave node creation to be seen

### DIFF
--- a/src/common/enclave_interface_types.h
+++ b/src/common/enclave_interface_types.h
@@ -35,7 +35,10 @@ enum CreateNodeStatus
   OpenSSLRDRANDInitFailed = 9,
 
   /** The reconfiguration method is not supported */
-  ReconfigurationMethodNotSupported = 10
+  ReconfigurationMethodNotSupported = 10,
+
+  /** Host and enclave versions must match */
+  VersionMismatch = 11
 };
 
 constexpr char const* create_node_result_to_str(CreateNodeStatus result)
@@ -86,6 +89,10 @@ constexpr char const* create_node_result_to_str(CreateNodeStatus result)
     {
       return "ReconfigurationMethodNotSupported";
     }
+    case CreateNodeStatus::VersionMismatch:
+    {
+      return "VersionMismatch";
+    }
     default:
     {
       return "Unknown CreateNodeStatus";
@@ -99,3 +106,18 @@ enum StartType
   Join = 2,
   Recover = 3,
 };
+
+constexpr char const* start_type_to_str(StartType type)
+{
+  switch (type)
+  {
+    case StartType::Start:
+      return "Start";
+    case StartType::Join:
+      return "Join";
+    case StartType::Recover:
+      return "Recover";
+    default:
+      return "Unknown StartType";
+  }
+}

--- a/src/enclave/ccf_v.h
+++ b/src/enclave/ccf_v.h
@@ -142,7 +142,18 @@ extern "C"
       start_type,
       num_worker_thread,
       time_location);
-    return OE_OK;
+
+    // Only return OE_OK when the error isn't OE related
+    switch (*status)
+    {
+      case CreateNodeStatus::OEAttesterInitFailed:
+      case CreateNodeStatus::OEVerifierInitFailed:
+      case CreateNodeStatus::EnclaveInitFailed:
+      case CreateNodeStatus::MemoryNotOutsideEnclave:
+        return OE_FAILURE;
+      default:
+        return OE_OK;
+    }
   }
 
   inline oe_result_t enclave_run(oe_enclave_t*, bool* _retval)

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -28,9 +28,9 @@ namespace enclave
   class Enclave
   {
   private:
-    ringbuffer::Circuit circuit;
-    ringbuffer::WriterFactory basic_writer_factory;
-    oversized::WriterFactory writer_factory;
+    std::unique_ptr<ringbuffer::Circuit> circuit;
+    std::unique_ptr<ringbuffer::WriterFactory> basic_writer_factory;
+    std::unique_ptr<oversized::WriterFactory> writer_factory;
     ccf::NetworkState network;
     ccf::ShareManager share_manager;
     std::shared_ptr<RPCMap> rpc_map;
@@ -88,30 +88,22 @@ namespace enclave
   public:
     Enclave(
       const EnclaveConfig& ec,
+      std::unique_ptr<ringbuffer::Circuit> circuit_,
+      std::unique_ptr<ringbuffer::WriterFactory> basic_writer_factory_,
+      std::unique_ptr<oversized::WriterFactory> writer_factory_,
       size_t sig_tx_interval,
       size_t sig_ms_interval,
       const consensus::Configuration& consensus_config,
       const CurveID& curve_id) :
-      circuit(
-        ringbuffer::BufferDef{
-          ec.to_enclave_buffer_start,
-          ec.to_enclave_buffer_size,
-          ec.to_enclave_buffer_offsets},
-        ringbuffer::BufferDef{
-          ec.from_enclave_buffer_start,
-          ec.from_enclave_buffer_size,
-          ec.from_enclave_buffer_offsets}),
-      basic_writer_factory(circuit),
-      writer_factory(basic_writer_factory, ec.writer_config),
+      circuit(std::move(circuit_)),
+      basic_writer_factory(std::move(basic_writer_factory_)),
+      writer_factory(std::move(writer_factory_)),
       network(consensus_config.type),
       share_manager(network),
       rpc_map(std::make_shared<RPCMap>()),
-      rpcsessions(std::make_shared<RPCSessions>(writer_factory, rpc_map))
+      rpcsessions(std::make_shared<RPCSessions>(*writer_factory, rpc_map))
     {
       ccf::initialize_oe();
-
-      logger::config::msg() = AdminMessage::log_msg;
-      logger::config::writer() = writer_factory.create_writer_to_outside();
 
       // From
       // https://software.intel.com/content/www/us/en/develop/articles/how-to-use-the-rdrand-engine-in-openssl-for-random-number-generation.html
@@ -121,29 +113,34 @@ namespace enclave
         ENGINE_init(rdrand_engine) != 1 ||
         ENGINE_set_default(rdrand_engine, ENGINE_METHOD_RAND) != 1)
       {
+        LOG_FAIL_FMT("Error creating OpenSSL's RDRAND engine");
         ENGINE_free(rdrand_engine);
         throw ccf::ccf_openssl_rdrand_init_error(
           "could not initialize RDRAND engine for OpenSSL");
       }
 
-      to_host = writer_factory.create_writer_to_outside();
+      to_host = writer_factory->create_writer_to_outside();
 
+      LOG_TRACE_FMT("Creating ledger secrets");
       network.ledger_secrets = std::make_shared<ccf::LedgerSecrets>();
 
+      LOG_TRACE_FMT("Creating node");
       node = std::make_unique<ccf::NodeState>(
-        writer_factory, network, rpcsessions, share_manager, curve_id);
+        *writer_factory, network, rpcsessions, share_manager, curve_id);
 
+      LOG_TRACE_FMT("Creating context");
       context = std::make_unique<NodeContext>();
       context->historical_state_cache =
         std::make_shared<ccf::historical::StateCache>(
           *network.tables,
           network.ledger_secrets,
-          writer_factory.create_writer_to_outside());
+          writer_factory->create_writer_to_outside());
       context->node_state = node.get();
       context->indexer = std::make_shared<ccf::indexing::Indexer>(
         std::make_shared<ccf::indexing::HistoricalTransactionFetcher>(
           context->historical_state_cache));
 
+      LOG_TRACE_FMT("Creating RPC actors / ffi");
       rpc_map->register_frontend<ccf::ActorsType::members>(
         std::make_unique<ccf::MemberRpcFrontend>(
           network, *context, share_manager));
@@ -156,6 +153,7 @@ namespace enclave
 
       ccf::js::register_ffi_plugins(ccfapp::get_js_plugins());
 
+      LOG_TRACE_FMT("Initialize node");
       node->initialize(
         consensus_config,
         rpc_map,
@@ -169,13 +167,15 @@ namespace enclave
     {
       if (rdrand_engine)
       {
+        LOG_TRACE_FMT("Finishing RDRAND engine");
         ENGINE_finish(rdrand_engine);
         ENGINE_free(rdrand_engine);
       }
+      LOG_TRACE_FMT("Shutting down enclave");
       ccf::shutdown_oe();
     }
 
-    bool create_new_node(
+    CreateNodeStatus create_new_node(
       StartType start_type_,
       StartupConfig&& ccf_config_,
       uint8_t* node_cert,
@@ -196,12 +196,14 @@ namespace enclave
       ccf::NodeCreateInfo r;
       try
       {
+        LOG_TRACE_FMT(
+          "Creating node with start_type {}", start_type_to_str(start_type));
         r = node->create(start_type, std::move(ccf_config_));
       }
       catch (const std::exception& e)
       {
         LOG_FAIL_FMT("Error starting node: {}", e.what());
-        return false;
+        return CreateNodeStatus::InternalError;
       }
 
       // Copy node and network certs out
@@ -211,7 +213,7 @@ namespace enclave
           "Insufficient space ({}) to copy node_cert out ({})",
           node_cert_size,
           r.self_signed_node_cert.size());
-        return false;
+        return CreateNodeStatus::InternalError;
       }
       ::memcpy(
         node_cert,
@@ -229,13 +231,13 @@ namespace enclave
             "Insufficient space ({}) to copy network_cert out ({})",
             network_cert_size,
             r.network_cert.size());
-          return false;
+          return CreateNodeStatus::InternalError;
         }
         ::memcpy(network_cert, r.network_cert.data(), r.network_cert.size());
         *network_cert_len = r.network_cert.size();
       }
 
-      return true;
+      return CreateNodeStatus::OK;
     }
 
     bool run_main()
@@ -420,7 +422,7 @@ namespace enclave
         while (!bp.get_finished())
         {
           // First, read some messages from the ringbuffer
-          auto read = bp.read_n(max_messages, circuit.read_from_outside());
+          auto read = bp.read_n(max_messages, circuit->read_from_outside());
 
           // Then, execute some thread messages
           size_t thread_msg = 0;

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -56,66 +56,96 @@ extern "C"
       return CreateNodeStatus::NodeAlreadyCreated;
     }
 
-    // Report enclave version to host
-    auto ccf_version_string = std::string(ccf::ccf_version);
-    if (ccf_version_string.size() > enclave_version_size)
-    {
-      return CreateNodeStatus::InternalError;
-    }
-
-    ::memcpy(
-      enclave_version, ccf_version_string.data(), ccf_version_string.size());
-    *enclave_version_len = ccf_version_string.size();
-
-    num_pending_threads = (uint16_t)num_worker_threads + 1;
-
-    if (
-      num_pending_threads >
-      threading::ThreadMessaging::thread_messaging.max_num_threads)
-    {
-      return CreateNodeStatus::TooManyThreads;
-    }
-
-    // Check that where we expect arguments to be in host-memory, they really
-    // are. lfence after these checks to prevent speculative execution
-    if (!oe_is_outside_enclave(time_location, sizeof(enclave::host_time)))
-    {
-      return CreateNodeStatus::MemoryNotOutsideEnclave;
-    }
-
-    enclave::host_time =
-      static_cast<decltype(enclave::host_time)>(time_location);
-
-    if (!oe_is_outside_enclave(enclave_config, sizeof(EnclaveConfig)))
-    {
-      return CreateNodeStatus::MemoryNotOutsideEnclave;
-    }
-
     EnclaveConfig ec = *static_cast<EnclaveConfig*>(enclave_config);
 
+    // Setup logger to allow enclave logs to reach the host before node is
+    // actually created
+    auto circuit = std::make_unique<ringbuffer::Circuit>(
+      ringbuffer::BufferDef{
+        ec.to_enclave_buffer_start,
+        ec.to_enclave_buffer_size,
+        ec.to_enclave_buffer_offsets},
+      ringbuffer::BufferDef{
+        ec.from_enclave_buffer_start,
+        ec.from_enclave_buffer_size,
+        ec.from_enclave_buffer_offsets});
+    auto basic_writer_factory =
+      std::make_unique<ringbuffer::WriterFactory>(*circuit);
+    auto writer_factory = std::make_unique<oversized::WriterFactory>(
+      *basic_writer_factory, ec.writer_config);
+
+    logger::config::msg() = AdminMessage::log_msg;
+    logger::config::writer() = writer_factory->create_writer_to_outside();
+
     {
+      // Report enclave version to host
+      auto ccf_version_string = std::string(ccf::ccf_version);
+      if (ccf_version_string.size() > enclave_version_size)
+      {
+        LOG_FAIL_FMT(
+          "Version mismatch: host {}, enclave {}",
+          ccf_version_string,
+          enclave_version);
+        return CreateNodeStatus::VersionMismatch;
+      }
+
+      ::memcpy(
+        enclave_version, ccf_version_string.data(), ccf_version_string.size());
+      *enclave_version_len = ccf_version_string.size();
+
+      num_pending_threads = (uint16_t)num_worker_threads + 1;
+
+      if (
+        num_pending_threads >
+        threading::ThreadMessaging::thread_messaging.max_num_threads)
+      {
+        LOG_FAIL_FMT("Too many threads: {}", num_pending_threads);
+        return CreateNodeStatus::TooManyThreads;
+      }
+
+      // Check that where we expect arguments to be in host-memory, they really
+      // are. lfence after these checks to prevent speculative execution
+      if (!oe_is_outside_enclave(time_location, sizeof(enclave::host_time)))
+      {
+        LOG_FAIL_FMT("Memory outside enclave: time_location");
+        return CreateNodeStatus::MemoryNotOutsideEnclave;
+      }
+
+      enclave::host_time =
+        static_cast<decltype(enclave::host_time)>(time_location);
+
+      if (!oe_is_outside_enclave(enclave_config, sizeof(EnclaveConfig)))
+      {
+        LOG_FAIL_FMT("Memory outside enclave: enclave_config");
+        return CreateNodeStatus::MemoryNotOutsideEnclave;
+      }
+
       // Check that ringbuffer memory ranges are entirely outside of the enclave
       if (!oe_is_outside_enclave(
             ec.to_enclave_buffer_start, ec.to_enclave_buffer_size))
       {
+        LOG_FAIL_FMT("Memory outside enclave: to_enclave buffer start");
         return CreateNodeStatus::MemoryNotOutsideEnclave;
       }
 
       if (!oe_is_outside_enclave(
             ec.from_enclave_buffer_start, ec.from_enclave_buffer_size))
       {
+        LOG_FAIL_FMT("Memory outside enclave: from_enclave buffer start");
         return CreateNodeStatus::MemoryNotOutsideEnclave;
       }
 
       if (!oe_is_outside_enclave(
             ec.to_enclave_buffer_offsets, sizeof(ringbuffer::Offsets)))
       {
+        LOG_FAIL_FMT("Memory outside enclave: to_enclave buffer offset");
         return CreateNodeStatus::MemoryNotOutsideEnclave;
       }
 
       if (!oe_is_outside_enclave(
             ec.from_enclave_buffer_offsets, sizeof(ringbuffer::Offsets)))
       {
+        LOG_FAIL_FMT("Memory outside enclave: from_enclave buffer offset");
         return CreateNodeStatus::MemoryNotOutsideEnclave;
       }
 
@@ -124,6 +154,7 @@ extern "C"
 
     if (!oe_is_outside_enclave(ccf_config, ccf_config_size))
     {
+      LOG_FAIL_FMT("Memory outside enclave: ccf_config");
       return CreateNodeStatus::MemoryNotOutsideEnclave;
     }
 
@@ -137,6 +168,7 @@ extern "C"
     // enclaves
     if (cc.consensus.type != ConsensusType::CFT)
     {
+      LOG_FAIL_FMT("BFT consensus disabled in release mode");
       return CreateNodeStatus::ConsensusNotAllowed;
     }
 #endif
@@ -149,6 +181,8 @@ extern "C"
       cc.start.service_configuration.reconfiguration_type.value() !=
         ReconfigurationType::ONE_TRANSACTION)
     {
+      LOG_FAIL_FMT(
+        "2TX reconfiguration is experimental, disabled in release mode");
       return CreateNodeStatus::ReconfigurationMethodNotSupported;
     }
 #endif
@@ -159,6 +193,9 @@ extern "C"
     {
       enclave = new enclave::Enclave(
         ec,
+        std::move(circuit),
+        std::move(basic_writer_factory),
+        std::move(writer_factory),
         cc.ledger_signatures.tx_count,
         cc.ledger_signatures.delay.count_ms(),
         cc.consensus,
@@ -181,17 +218,19 @@ extern "C"
       return CreateNodeStatus::EnclaveInitFailed;
     }
 
-    if (!enclave->create_new_node(
-          start_type,
-          std::move(cc),
-          node_cert,
-          node_cert_size,
-          node_cert_len,
-          network_cert,
-          network_cert_size,
-          network_cert_len))
+    auto status = enclave->create_new_node(
+      start_type,
+      std::move(cc),
+      node_cert,
+      node_cert_size,
+      node_cert_len,
+      network_cert,
+      network_cert_size,
+      network_cert_len);
+
+    if (status != CreateNodeStatus::OK)
     {
-      return CreateNodeStatus::InternalError;
+      return status;
     }
 
     e.store(enclave);

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -454,7 +454,7 @@ int main(int argc, char** argv)
 #endif
     }
 
-    enclave.create_node(
+    auto create_status = enclave.create_node(
       enclave_config,
       startup_config,
       node_cert,
@@ -462,6 +462,28 @@ int main(int argc, char** argv)
       config.command.type,
       config.worker_threads,
       time_updater->behaviour.get_value());
+
+    if (create_status != CreateNodeStatus::OK)
+    {
+      LOG_FAIL_FMT(
+        "An error occurred when creating CCF node: {}",
+        create_node_result_to_str(create_status));
+
+      // Pull all logs from the enclave via BufferProcessor `bp`
+      // and show any logs that came from the ring buffer during setup.
+      //
+      // `64` is an arbitrary number of log entries, `read_n` will stop
+      // before if there aren't any more to read. The `while` will keep
+      // reading if there are more.
+      while (bp.read_n(64, circuit.read_from_inside()))
+      {
+        // Do nothing here, read_n should process the left-over messages using
+        // the already registered handler for log entrie and print on out/err.
+      }
+
+      // This returns from main, stopping the program
+      return create_status;
+    }
 
     LOG_INFO_FMT("Created new node");
 


### PR DESCRIPTION
Before the enclave node is initialised, and the logger structure is
setup (sending logs through the ring buffer), any error ends up as
InternalError because we can't see the logs yet.

This commit changes that by creating the logging infrastructure before
the node is created (but after the ring buffer is setup), so that any
logs during that time, inside the enclave, can be flushed out and
displayed with the other error messages.

This allows us to be more verbose inside the enclave while constructing
the objects and creating the nodes, which helps debug the causes that
enclaves fail.

Extra work done to pass CreateNodeStatus around instead of throwing
exceptions, handling OE and CCF errors across enclave<->host barriers,
adding a new type of error (version mismatch) and adding a few traces
across the enclave constructor and node creations to help narrow issues
at a first glance.

Example: Creating a sandbox with the wrong parameter.

Command Line:
```
sandbox.sh -v \
  -p samples/apps/logging/liblogging \
  -n local://127.0.0.1:1234 \
  --subject_alt_names DNSName:foobar.azure.com
```

Note the alt-name is `DNSName` instead of `dNSName`. This will trigger
an error.

None of the output below was showing before this patch, on case of node
creation error, since the node still hadn't have time to setup the
writer and the host wasn't pulling any from the ring buffer.

Output:
```
[trace] ../src/enclave/enclave.h:108
  | Creating node
[trace] ../src/enclave/enclave.h:112
  | Creating context
[trace] ../src/enclave/enclave.h:121
  | Creating RPC actors / ffi
[trace] ./include/ccf/endpoint_registry.h:66
  | Parsed a templated endpoint: /log/private/raw_text/{id}
    became /log/private/raw_text/([^/]+)
[trace] ./include/ccf/endpoint_registry.h:69
  | Component names are: id
[trace] ../src/enclave/enclave.h:134
  | Initialize node
[debug] ../src/ds/state_machine.h:44
  | [NodeState] Advancing to state "Initialized" (from "Uninitialized")
[info ] ../src/enclave/rpc_sessions.h:164
  | Setting max open sessions on interface "primary_rpc_interface"
    (127.0.0.1:1234) to [1000, 1010]
[trace] ../src/enclave/enclave.h:177
  | Creating node with start_type Start
[fail ] ../src/enclave/enclave.h:182
  | Error starting node: SAN could not be parsed: DNSName:foobar.azure.com,
    must be (iPAddress|dNSName):VALUE
```

Fixes #857