### PR TITLE
Versioned Sphinx to GitHub documentation links 

### DIFF
--- a/doc/architecture/raft_tla.rst
+++ b/doc/architecture/raft_tla.rst
@@ -6,12 +6,12 @@ CCF implements some modifications to Raft as it was originally proposed by Ongar
 
 The TLA+ specification models the intended behavior of Raft as it is modified for CCF. Below, we explain several core parts of the specification in more detail.
 
-You can find the full specification in the `CCF GitHub repository <https://github.com/microsoft/CCF/tree/main/tla>`_ and more information on TLA+ `here <http://lamport.azurewebsites.net/tla/tla.html>`_. Several good resources exist online, one good example is `this guide <https://www.learntla.com/introduction/about-this-guide/>`_.
+You can find the full specification in the :ccf_repo:`tla/` folder and more information on TLA+ `here <http://lamport.azurewebsites.net/tla/tla.html>`_. Several good resources exist online, one good example is `this guide <https://www.learntla.com/introduction/about-this-guide/>`_.
 
 
 Building blocks of the TLA+ spec
 --------------------------------
-The core model is maintained in the file `ccfraft.tla <https://github.com/microsoft/CCF/tree/main/tla/raft_spec/ccfraft.tla>`_ , however the constants defined in this file are controlled through the model check file `MCraft.tla <https://github.com/microsoft/CCF/tree/main/tla/raft_spec/MCraft.tla>`_ .
+The core model is maintained in the :ccf_repo:`tla/raft_spec/ccfraft.tla` file, however the constants defined in this file are controlled through the model check file :ccf_repo:`tla/raft_spec/MCraft.tla`.
 
 This file controls the constants as seen below. In addition to basic settings of how many nodes are to be model checked and their initial configuration, the model allows to place additional limitations on the state space of the program.
 

--- a/doc/build_apps/example.rst
+++ b/doc/build_apps/example.rst
@@ -51,7 +51,7 @@ The Logging application implements a trivial protocol, made up of four transacti
             "id": 100
         }
 
-The C++ implementation of the Logging application is located in the :ccf_repo:`samples/apps/logging` folder. It is discussed in detail on the following pages:
+The C++ implementation of the Logging application is located in the :ccf_repo:`samples/apps/logging/` folder. It is discussed in detail on the following pages:
 
 .. toctree::
    :maxdepth: 2

--- a/doc/build_apps/example.rst
+++ b/doc/build_apps/example.rst
@@ -51,7 +51,7 @@ The Logging application implements a trivial protocol, made up of four transacti
             "id": 100
         }
 
-The C++ implementation of the Logging application is located in the `src/apps <https://github.com/microsoft/CCF/tree/main/src/apps>`_ folder. It is discussed in detail on the following pages:
+The C++ implementation of the Logging application is located in the :ccf_repo:`samples/apps/logging` folder. It is discussed in detail on the following pages:
 
 .. toctree::
    :maxdepth: 2

--- a/doc/build_apps/js_app_bundle.rst
+++ b/doc/build_apps/js_app_bundle.rst
@@ -36,7 +36,7 @@ A bundle has the following folder structure:
 It consists of :ref:`metadata <build_apps/js_app_bundle:Metadata>` (``app.json``) and one or more :ref:`JavaScript modules <build_apps/js_app_bundle:JavaScript API>` (``src/``).
 JavaScript modules can `import <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import>`_ other modules using relative path names.
 
-You can find an example app bundle in the :ccf_repo:`tests/js-app-bundle` folder of the CCF git repository.
+You can find an example app bundle in the :ccf_repo:`tests/js-app-bundle/` folder of the CCF git repository.
 
 Metadata
 --------
@@ -119,7 +119,7 @@ Endpoint handlers
 
 An endpoint handler is an exported function that receives a :typedoc:interface:`Request <ccf-app/endpoints/Request>` object, returns a :typedoc:interface:`Response <ccf-app/endpoints/Response>` object, and is referenced in the ``app.json`` file of the app bundle (see above).
 
-See the following handler from the example app bundle in the :ccf_repo:`tests/js-app-bundle` folder of the CCF git repository. It validates the request body and returns the result of a mathematical operation:
+See the following handler from the example app bundle in the :ccf_repo:`tests/js-app-bundle/` folder of the CCF git repository. It validates the request body and returns the result of a mathematical operation:
 
 .. literalinclude:: ../../tests/js-app-bundle/src/math.js
    :language: js

--- a/doc/build_apps/js_app_bundle.rst
+++ b/doc/build_apps/js_app_bundle.rst
@@ -36,9 +36,7 @@ A bundle has the following folder structure:
 It consists of :ref:`metadata <build_apps/js_app_bundle:Metadata>` (``app.json``) and one or more :ref:`JavaScript modules <build_apps/js_app_bundle:JavaScript API>` (``src/``).
 JavaScript modules can `import <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import>`_ other modules using relative path names.
 
-You can find an example app bundle in the
-`tests/js-app-bundle <https://github.com/microsoft/CCF/tree/main/tests/js-app-bundle>`_
-folder of the CCF git repository.
+You can find an example app bundle in the :ccf_repo:`tests/js-app-bundle` folder of the CCF git repository.
 
 Metadata
 --------
@@ -99,9 +97,7 @@ Each endpoint object contains the following information:
   enforced - it will be inserted into the generated OpenAPI document for this service, but will not restrict the
   types of the endpoint's requests or responses.
 
-You can find an example metadata file at
-`tests/js-app-bundle/app.json <https://github.com/microsoft/CCF/tree/main/tests/js-app-bundle/app.json>`_
-in the CCF git repository.
+You can find an example metadata file at :ccf_repo:`tests/js-app-bundle/app.json` in the CCF git repository.
 
 JavaScript API
 --------------
@@ -123,10 +119,7 @@ Endpoint handlers
 
 An endpoint handler is an exported function that receives a :typedoc:interface:`Request <ccf-app/endpoints/Request>` object, returns a :typedoc:interface:`Response <ccf-app/endpoints/Response>` object, and is referenced in the ``app.json`` file of the app bundle (see above).
 
-See the following handler from the example app bundle in the
-`tests/js-app-bundle <https://github.com/microsoft/CCF/tree/main/tests/js-app-bundle>`_
-folder of the CCF git repository.
-It validates the request body and returns the result of a mathematical operation:
+See the following handler from the example app bundle in the :ccf_repo:`tests/js-app-bundle` folder of the CCF git repository. It validates the request body and returns the result of a mathematical operation:
 
 .. literalinclude:: ../../tests/js-app-bundle/src/math.js
    :language: js
@@ -307,7 +300,7 @@ Once :ref:`submitted and accepted <governance/proposals:Submitting a New Proposa
 Any existing application endpoints and JavaScript modules are removed.
 
 If you are using ``npm`` or similar to build your app it may make sense to convert your app into a proposal-ready JSON bundle during packaging.
-For an example of how this could be done, see `this example script <https://github.com/microsoft/CCF/tree/main/tests/npm-app/build_bundle.js>`_ from one of CCF's test applications, called by ``npm build`` from the corresponding `package.json <https://github.com/microsoft/CCF/tree/main/tests/npm-app/package.json>`_.
+For an example of how this could be done, see :ccf_repo:`tests/npm-app/build_bundle.js` from one of CCF's test applications, called by ``npm build`` from the corresponding :ccf_repo:`tests/npm-app/package.json`.
 
 Bytecode cache
 ~~~~~~~~~~~~~~

--- a/doc/build_apps/js_app_ts.rst
+++ b/doc/build_apps/js_app_ts.rst
@@ -3,7 +3,7 @@ TypeScript Application
 
 This guide shows how to build a TypeScript application using Node.js and npm.
 
-The source code for the example app can be found in the :ccf_repo:`tests/npm-app` folder of the CCF git repository.
+The source code for the example app can be found in the :ccf_repo:`tests/npm-app/` folder of the CCF git repository.
 
 Prerequisites
 -------------

--- a/doc/build_apps/js_app_ts.rst
+++ b/doc/build_apps/js_app_ts.rst
@@ -3,9 +3,7 @@ TypeScript Application
 
 This guide shows how to build a TypeScript application using Node.js and npm.
 
-The source code for the example app can be found in the
-`tests/npm-app <https://github.com/microsoft/CCF/tree/main/tests/npm-app>`_
-folder of the CCF git repository.
+The source code for the example app can be found in the :ccf_repo:`tests/npm-app` folder of the CCF git repository.
 
 Prerequisites
 -------------
@@ -90,7 +88,7 @@ An endpoint handler, here named ``abc``, has the following structure:
     export function abc(request: ccfapp.Request<AbcRequest>): ccfapp.Response<AbcResponse> {
         // access request details
         const data = request.body.json();
-        
+
         // process request
         // ...
 
@@ -117,7 +115,7 @@ The example also shows how an external library, here ``lodash``, is imported and
 .. warning::
     Even though request body schemas can be defined as part of the OpenAPI :ref:`metadata <build_apps/js_app_ts:Metadata>`,
     CCF does not validate incoming request data against those schemas.
-    It is up to the application to perform any necessary validation. 
+    It is up to the application to perform any necessary validation.
 
 .. tip::
     See the :typedoc:package:`ccf-app` package API documentation for how to access the Key-Value Store and other CCF functionality.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -200,27 +200,28 @@ breathe_default_project = "CCF"
 # Set up multiversion extension
 
 # Build tags from ccf-1.0.1x
-# smv_tag_whitelist = r"^ccf-(1\.\d+\.1\d+|2.*)$"
-smv_tag_whitelist = r"^ccf-1.0.16$"
+smv_tag_whitelist = r"^ccf-(1\.\d+\.1\d+|2.*)$"
 smv_branch_whitelist = r"^main$"
 smv_remote_whitelist = None
 smv_outputdir_format = "{ref.name}"
 
-# print(os.environ)
-print(sys.argv)
+# Intercept command line arguments passed by sphinx-multiversion to retrieve doc version.
+# This is a little hacky with sphinx-multiversion 0.2.4 and the `SPHINX_MULTIVERSION_NAME`
+# envvar should be used for further versions (release pending).
 docs_version = "main"
 for arg in sys.argv:
     if "smv_current_version=" in arg:
         docs_version = arg.split("=")[1]
-# docs_version = [arg for arg in sys.argv if "smv_current_version" in arg][0] or "main"
-# docs_version = foo or "main"
-print(f"Docs version: {docs_version}")
 
-# print(sys.flags)
+# :ccf_repo: directive can be used to create a versioned link to GitHub repo
+extlinks = {
+    "ccf_repo": (
+        f"https://github.com/microsoft/CCF/tree/{docs_version}/%s",
+        "%s",
+    )
+}
 
-extlinks = {"repo": (f"https://github.com/microsoft/CCF/tree/{docs_version}/%s", "%s")}
-
-# PyData theme options
+# Theme options
 
 html_logo = "_static/ccf.svg"
 html_favicon = "_static/favicon.ico"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -60,6 +60,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinxcontrib.openapi",
     "sphinx_panels",
+    "sphinx.ext.extlinks",
 ]
 
 autosectionlabel_prefix_document = True
@@ -199,10 +200,25 @@ breathe_default_project = "CCF"
 # Set up multiversion extension
 
 # Build tags from ccf-1.0.1x
-smv_tag_whitelist = r"^ccf-(1\.\d+\.1\d+|2.*)$"
+# smv_tag_whitelist = r"^ccf-(1\.\d+\.1\d+|2.*)$"
+smv_tag_whitelist = r"^ccf-1.0.16$"
 smv_branch_whitelist = r"^main$"
 smv_remote_whitelist = None
 smv_outputdir_format = "{ref.name}"
+
+# print(os.environ)
+print(sys.argv)
+docs_version = "main"
+for arg in sys.argv:
+    if "smv_current_version=" in arg:
+        docs_version = arg.split("=")[1]
+# docs_version = [arg for arg in sys.argv if "smv_current_version" in arg][0] or "main"
+# docs_version = foo or "main"
+print(f"Docs version: {docs_version}")
+
+# print(sys.flags)
+
+extlinks = {"repo": (f"https://github.com/microsoft/CCF/tree/{docs_version}/%s", "%s")}
 
 # PyData theme options
 

--- a/doc/governance/constitution.rst
+++ b/doc/governance/constitution.rst
@@ -7,7 +7,7 @@ The constitution for a CCF service is implemented as a set of JS scripts. These 
     - ``resolve``: This takes a proposal and the votes (the results of ballot scripts) which have been submitted against it, and determines whether the proposal should be accepted or rejected. In the simple case this might simply accept proposals after a majority of members have voted in favour. It could also examine member data to give each member a different role or weight, or have different thresholds for each action. This has read-only access to the KV.
     - ``apply``: This takes a proposal which has been accepted by ``resolve``, and should make the proposed changes to the service's state. For instance if the proposal added a new user this should extract their cert and data from the proposal and write them to the appropriate KV tables. This has full read-write access to the KV.
 
-Sample constitutions are available in the :ccf_repo:`samples/constitutions` folder and include the default implementation of ``apply`` which parses a JSON object from the proposal body, and then delegates the application of each action within the proposal to a named entry from ``actions.js``:
+Sample constitutions are available in the :ccf_repo:`samples/constitutions/` folder and include the default implementation of ``apply`` which parses a JSON object from the proposal body, and then delegates the application of each action within the proposal to a named entry from ``actions.js``:
 
 .. literalinclude:: ../../samples/constitutions/default/apply.js
     :language: js

--- a/doc/governance/constitution.rst
+++ b/doc/governance/constitution.rst
@@ -7,7 +7,7 @@ The constitution for a CCF service is implemented as a set of JS scripts. These 
     - ``resolve``: This takes a proposal and the votes (the results of ballot scripts) which have been submitted against it, and determines whether the proposal should be accepted or rejected. In the simple case this might simply accept proposals after a majority of members have voted in favour. It could also examine member data to give each member a different role or weight, or have different thresholds for each action. This has read-only access to the KV.
     - ``apply``: This takes a proposal which has been accepted by ``resolve``, and should make the proposed changes to the service's state. For instance if the proposal added a new user this should extract their cert and data from the proposal and write them to the appropriate KV tables. This has full read-write access to the KV.
 
-Sample constitutions are available in the `samples/constitutions directory <https://github.com/microsoft/CCF/tree/main/samples/constitutions>`_, for instance the default implementation of ``apply`` which parses a JSON object from the proposal body, and then delegates the application of each action within the proposal to a named entry from ``actions.js``:
+Sample constitutions are available in the :ccf_repo:`samples/constitutions` folder and include the default implementation of ``apply`` which parses a JSON object from the proposal body, and then delegates the application of each action within the proposal to a named entry from ``actions.js``:
 
 .. literalinclude:: ../../samples/constitutions/default/apply.js
     :language: js

--- a/doc/operations/start_network.rst
+++ b/doc/operations/start_network.rst
@@ -1,6 +1,8 @@
 Running a CCF Service
 =====================
 
+Does this work? :repo:`doc/conf.py`
+
 .. note:: Before creating a new network:
 
     - The :ref:`identity of the initial members of the consortium must be created <governance/adding_member:Generating Member Keys and Certificates>`.

--- a/doc/operations/start_network.rst
+++ b/doc/operations/start_network.rst
@@ -1,8 +1,6 @@
 Running a CCF Service
 =====================
 
-Does this work? :repo:`doc/conf.py`
-
 .. note:: Before creating a new network:
 
     - The :ref:`identity of the initial members of the consortium must be created <governance/adding_member:Generating Member Keys and Certificates>`.


### PR DESCRIPTION
Finally found a way to fix this, using the `extlinks` Sphinx extension and by intercepting the version argument passed by `sphinx-multiversion` to `sphinx-build`. Tested locally and it worked fine but we won't see it live in our docs until this is ported to the 1.x LTS branch and 1.0.17 is released. 