### PR TITLE
Remove an mbedTLS include

### DIFF
--- a/src/crypto/curve.h
+++ b/src/crypto/curve.h
@@ -6,7 +6,6 @@
 #include "ds/json.h"
 #include "ds/logger.h"
 
-#include <mbedtls/ecp.h>
 #include <openssl/evp.h>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
Predictably, I failed to remove one mbedTLS `#include`. Interestingly, this wasn't caught in any CI runs, but during the CodeQL build (https://github.com/microsoft/CCF/runs/4857169154?check_suite_focus=true) after merging my changes into `main`.