### PR TITLE
Remove the final MbedTLS references from the code

### DIFF
--- a/src/crypto/pem.h
+++ b/src/crypto/pem.h
@@ -13,8 +13,7 @@
 
 namespace crypto
 {
-  // Convenience class ensuring null termination of PEM-encoded certificates as
-  // required by mbedTLS
+  // Convenience class ensuring null termination of PEM-encoded certificates
   class Pem
   {
     std::string s;

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -378,7 +378,6 @@ void run_csr(bool corrupt_csr = false)
 
   std::vector<SubjectAltName> subject_alternative_names;
 
-  // mbedtls doesn't support parsing SAN from CSR
   if constexpr (std::is_same_v<T, KeyPair_OpenSSL>)
   {
     subject_alternative_names.push_back({"email:my-other-name", false});

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -378,19 +378,11 @@ void run_csr(bool corrupt_csr = false)
 
   std::vector<SubjectAltName> subject_alternative_names;
 
-  if constexpr (std::is_same_v<T, KeyPair_OpenSSL>)
-  {
-    subject_alternative_names.push_back({"email:my-other-name", false});
-    subject_alternative_names.push_back({"www.microsoft.com", false});
-    subject_alternative_names.push_back({"192.168.0.1", true});
-    valid_from = "20210311000000Z";
-    valid_to = "20230611235959Z";
-  }
-  else
-  {
-    valid_from = "20210311000000";
-    valid_to = "20230611235959";
-  }
+  subject_alternative_names.push_back({"email:my-other-name", false});
+  subject_alternative_names.push_back({"www.microsoft.com", false});
+  subject_alternative_names.push_back({"192.168.0.1", true});
+  valid_from = "20210311000000Z";
+  valid_to = "20230611235959Z";
 
   auto csr = kpm.create_csr(subject_name, subject_alternative_names);
 

--- a/src/enclave/tls_endpoint.h
+++ b/src/enclave/tls_endpoint.h
@@ -555,6 +555,7 @@ namespace enclave
     // emulate what MbedTLS used to do.
     // Now that we have removed it from the code, we can move the callbacks
     // above to handle BIOs directly and hopefully remove the complexity below.
+    // This work will be carried out in #3429.
     static long send_callback_openssl(
       BIO* b,
       int oper,

--- a/src/node/test/encryptor.cpp
+++ b/src/node/test/encryptor.cpp
@@ -228,7 +228,7 @@ TEST_CASE("Additional data")
     version,
     term));
 
-  // mbedtls 2.16+ does not produce plain text if decryption fails
+  // Check we do not produce plain text if decryption fails
   REQUIRE(decrypted_cipher2.empty());
 }
 

--- a/src/tls/cert.h
+++ b/src/tls/cert.h
@@ -60,9 +60,8 @@ namespace tls
       {
         // Peer hostname is only checked against peer certificate (SAN
         // extension) if it is set. This lets us connect to peers that present
-        // certificates with IPAddress in SAN field (mbedtls does not parse
-        // IPAddress in SAN field). This is OK since we check for peer CA
-        // endorsement.
+        // certificates with IPAddress in SAN field. This is OK since we check
+        // for peer CA endorsement.
         SSL_set1_host(ssl, peer_hostname->c_str());
       }
 

--- a/src/tls/test/main.cpp
+++ b/src/tls/test/main.cpp
@@ -92,10 +92,7 @@ int recv(void* ctx, uint8_t* buf, size_t len)
   return rc;
 }
 
-// These are OpenSSL callbacks that call onto the MbedTLS ones. They have the
-// same name but different signatures, so when using OpenSSL, these are the ones
-// that set_bio() will take, and call the ones above by using the correct
-// signature.
+// OpenSSL callbacks that call onto the pipe's ones
 template <int end>
 long send(
   BIO* b,
@@ -191,7 +188,6 @@ int handshake(Context* ctx)
         break;
 
       case TLS_ERR_NEED_CERT:
-      case TLS_ERR_PEER_VERIFY:
       {
         LOG_FAIL_FMT("Handshake error: {}", tls::error_string(rc));
         return 1;

--- a/src/tls/tls.h
+++ b/src/tls/tls.h
@@ -11,20 +11,17 @@
 //
 // Depending on the error, the connection needs to close with success, failure
 // or auth-failure.
-//
-// Some MbedTLS errors are not matched by OpenSSL, so we set some ridiculous
-// negative number that will never match. This allows us to place the macro as
-// a switch-case and not duplicate cases but also never match.
 #define TLS_READING -SSL_READING
 #define TLS_WRITING -SSL_WRITING
 #define TLS_ERR_WANT_READ -SSL_ERROR_WANT_READ
 #define TLS_ERR_WANT_WRITE -SSL_ERROR_WANT_WRITE
 #define TLS_ERR_CONN_CLOSE_NOTIFY -SSL_ERROR_ZERO_RETURN
 #define TLS_ERR_NEED_CERT -SSL_ERROR_WANT_X509_LOOKUP
-// No counterpart in OpenSSL
-#define TLS_ERR_CONN_RESET INT_MIN
-#define TLS_ERR_PEER_VERIFY INT_MIN + 1
-#define TLS_ERR_X509_VERIFY INT_MIN + 2
+// Specific error to check validity of certificate, not emitted by OpenSSL, but
+// by Context. We set to a bogus negative value that won't match any OpenSSL
+// error code.
+// Once we refactor the code to match the OpenSSL style we may not need this.
+#define TLS_ERR_X509_VERIFY INT_MIN
 
 #include "crypto/openssl/openssl_wrappers.h"
 

--- a/tests/infra/path.py
+++ b/tests/infra/path.py
@@ -61,7 +61,7 @@ def cert_bytes(cert_file_name):
                 chars.append(c)
             else:
                 break
-        # mbedtls demands null-terminated certs
+        # null-terminated certs, just in case
         return chars + [0]
 
 

--- a/tests/infra/path.py
+++ b/tests/infra/path.py
@@ -61,7 +61,7 @@ def cert_bytes(cert_file_name):
                 chars.append(c)
             else:
                 break
-        # null-terminated certs, just in case
+        # null-terminated certs, for compatibility
         return chars + [0]
 
 


### PR DESCRIPTION
This commit cleans up the final references to MbedTLS on the code,
making sure what's left is consistent with OpenSSL.

The only remaining references to "MbedTLS" are the ones that we
need to worry about when we work on #3429.