### PR TITLE
Verify peer hostname in join RPC

### DIFF
--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -414,7 +414,11 @@ namespace ccf
     {
       auto network_ca = std::make_shared<tls::CA>(config.join.service_cert);
       auto join_client_cert = std::make_unique<tls::Cert>(
-        network_ca, self_signed_node_cert, node_sign_kp->private_key_pem());
+        network_ca,
+        self_signed_node_cert,
+        node_sign_kp->private_key_pem(),
+        tls::Auth::auth_default,
+        config.join.target_rpc_address);
 
       // Create RPC client and connect to remote node
       auto join_client =


### PR DESCRIPTION
Now that we use OpenSSL, we can verify the hostname in the TLS handshake established between two nodes during the `GET /node/join` RPC. This is because mbedtls didn't support peer hostname verification when the peer hostname was an IP address (which is the case in most of our end-to-end tests). See https://github.com/microsoft/CCF/issues/552#issuecomment-555007565 for background info.



