### PR TITLE
Do not uninstall `curl` from `app_ci` docker image

### DIFF
--- a/docker/app_ci
+++ b/docker/app_ci
@@ -27,10 +27,10 @@ RUN ["/bin/bash", "-c", "mv *sgx_$(echo ${PSW_VERSION//./_})_${UBUNTU}_custom_ve
 
 COPY getting_started/setup_vm/ /setup_vm/
 RUN apt update \
-    && apt install -y ansible software-properties-common curl bsdmainutils dnsutils \
+    && apt install -y ansible software-properties-common bsdmainutils dnsutils \
     && cd setup_vm \
     && ansible-playbook app-dev.yml $extra_vars \
     && rm -rf /tmp/* \
-    && apt remove -y ansible software-properties-common curl \
+    && apt remove -y ansible software-properties-common \
     && apt -y autoremove \
     && apt -y clean

--- a/docker/app_run
+++ b/docker/app_run
@@ -27,10 +27,10 @@ RUN ["/bin/bash", "-c", "mv *sgx_$(echo ${PSW_VERSION//./_})_${UBUNTU}_custom_ve
 
 COPY getting_started/setup_vm/ /setup_vm/
 RUN apt update \
-    && apt install -y ansible software-properties-common curl bsdmainutils dnsutils \
+    && apt install -y ansible software-properties-common bsdmainutils dnsutils \
     && cd setup_vm \
     && ansible-playbook app-run.yml $extra_vars \
     && rm -rf /tmp/* \
-    && apt remove -y ansible software-properties-common curl \
+    && apt remove -y ansible software-properties-common \
     && apt -y autoremove \
     && apt -y clean

--- a/docker/app_run
+++ b/docker/app_run
@@ -27,10 +27,10 @@ RUN ["/bin/bash", "-c", "mv *sgx_$(echo ${PSW_VERSION//./_})_${UBUNTU}_custom_ve
 
 COPY getting_started/setup_vm/ /setup_vm/
 RUN apt update \
-    && apt install -y ansible software-properties-common bsdmainutils dnsutils \
+    && apt install -y ansible software-properties-common curl bsdmainutils dnsutils \
     && cd setup_vm \
     && ansible-playbook app-run.yml $extra_vars \
     && rm -rf /tmp/* \
-    && apt remove -y ansible software-properties-common \
+    && apt remove -y ansible software-properties-common curl \
     && apt -y autoremove \
     && apt -y clean


### PR DESCRIPTION
It is already installed as part of the `ccf_build` role here: https://github.com/microsoft/CCF/blob/c157123e284034d96ac66a26cfe1dbc26ec5aa9b/getting_started/setup_vm/roles/ccf_build/vars/common.yml#L23 

Note that we still do this in the `app_run` image as it is necessary to install the CCF debian package from GitHub.