### PR TITLE
Fix TLS certificate verification

### DIFF
--- a/src/enclave/rpc_sessions.h
+++ b/src/enclave/rpc_sessions.h
@@ -191,9 +191,10 @@ namespace enclave
 
       // Caller authentication is done by each frontend by looking up
       // the caller's certificate in the relevant store table. The caller
-      // certificate does not have to be signed by a known CA (nullptr).
-      cert =
-        std::make_shared<tls::Cert>(nullptr, cert_, pk, std::nullopt, false);
+      // certificate does not have to be signed by a known CA (nullptr) and
+      // verification is not required here.
+      cert = std::make_shared<tls::Cert>(
+        nullptr, cert_, pk, std::nullopt, /*auth_required ==*/false);
     }
 
     void accept(tls::ConnID id, const ListenInterfaceID& listen_interface_id)

--- a/src/enclave/rpc_sessions.h
+++ b/src/enclave/rpc_sessions.h
@@ -192,7 +192,8 @@ namespace enclave
       // Caller authentication is done by each frontend by looking up
       // the caller's certificate in the relevant store table. The caller
       // certificate does not have to be signed by a known CA (nullptr).
-      cert = std::make_shared<tls::Cert>(nullptr, cert_, pk, false);
+      cert =
+        std::make_shared<tls::Cert>(nullptr, cert_, pk, std::nullopt, false);
     }
 
     void accept(tls::ConnID id, const ListenInterfaceID& listen_interface_id)

--- a/src/enclave/rpc_sessions.h
+++ b/src/enclave/rpc_sessions.h
@@ -192,7 +192,7 @@ namespace enclave
       // Caller authentication is done by each frontend by looking up
       // the caller's certificate in the relevant store table. The caller
       // certificate does not have to be signed by a known CA (nullptr).
-      cert = std::make_shared<tls::Cert>(nullptr, cert_, pk, tls::auth_default);
+      cert = std::make_shared<tls::Cert>(nullptr, cert_, pk, false);
     }
 
     void accept(tls::ConnID id, const ListenInterfaceID& listen_interface_id)

--- a/src/node/jwt_key_auto_refresh.h
+++ b/src/node/jwt_key_auto_refresh.h
@@ -245,7 +245,7 @@ namespace ccf
       auto jwks_url_port = !jwks_url.port.empty() ? jwks_url.port : "443";
 
       auto ca_cert = std::make_shared<tls::Cert>(
-        ca, std::nullopt, std::nullopt, true, jwks_url.host);
+        ca, std::nullopt, std::nullopt, /*auth_required=*/true, jwks_url.host);
 
       LOG_DEBUG_FMT(
         "JWT key auto-refresh: Requesting JWKS at https://{}:{}{}",

--- a/src/node/jwt_key_auto_refresh.h
+++ b/src/node/jwt_key_auto_refresh.h
@@ -245,7 +245,7 @@ namespace ccf
       auto jwks_url_port = !jwks_url.port.empty() ? jwks_url.port : "443";
 
       auto ca_cert = std::make_shared<tls::Cert>(
-        ca, std::nullopt, std::nullopt, tls::auth_required, jwks_url.host);
+        ca, std::nullopt, std::nullopt, true, jwks_url.host);
 
       LOG_DEBUG_FMT(
         "JWT key auto-refresh: Requesting JWKS at https://{}:{}{}",
@@ -311,11 +311,7 @@ namespace ccf
 
         auto ca = std::make_shared<tls::CA>(ca_cert_bundle_pem.value());
         auto ca_cert = std::make_shared<tls::Cert>(
-          ca,
-          std::nullopt,
-          std::nullopt,
-          tls::auth_required,
-          metadata_url.host);
+          ca, std::nullopt, std::nullopt, true, metadata_url.host);
 
         LOG_DEBUG_FMT(
           "JWT key auto-refresh: Requesting OpenID metadata at https://{}:{}{}",

--- a/src/node/jwt_key_auto_refresh.h
+++ b/src/node/jwt_key_auto_refresh.h
@@ -311,7 +311,7 @@ namespace ccf
 
         auto ca = std::make_shared<tls::CA>(ca_cert_bundle_pem.value());
         auto ca_cert = std::make_shared<tls::Cert>(
-          ca, std::nullopt, std::nullopt, true, metadata_url.host);
+          ca, std::nullopt, std::nullopt, /*auth_required=*/true, metadata_url.host);
 
         LOG_DEBUG_FMT(
           "JWT key auto-refresh: Requesting OpenID metadata at https://{}:{}{}",

--- a/src/node/jwt_key_auto_refresh.h
+++ b/src/node/jwt_key_auto_refresh.h
@@ -245,7 +245,7 @@ namespace ccf
       auto jwks_url_port = !jwks_url.port.empty() ? jwks_url.port : "443";
 
       auto ca_cert = std::make_shared<tls::Cert>(
-        ca, std::nullopt, std::nullopt, /*auth_required=*/true, jwks_url.host);
+        ca, std::nullopt, std::nullopt, jwks_url.host);
 
       LOG_DEBUG_FMT(
         "JWT key auto-refresh: Requesting JWKS at https://{}:{}{}",
@@ -311,7 +311,7 @@ namespace ccf
 
         auto ca = std::make_shared<tls::CA>(ca_cert_bundle_pem.value());
         auto ca_cert = std::make_shared<tls::Cert>(
-          ca, std::nullopt, std::nullopt, /*auth_required=*/true, metadata_url.host);
+          ca, std::nullopt, std::nullopt, metadata_url.host);
 
         LOG_DEBUG_FMT(
           "JWT key auto-refresh: Requesting OpenID metadata at https://{}:{}{}",

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -416,7 +416,6 @@ namespace ccf
         network_ca,
         self_signed_node_cert,
         node_sign_kp->private_key_pem(),
-        /*auth_required=*/true,
         config.join.target_rpc_address);
 
       // Create RPC client and connect to remote node

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -416,7 +416,7 @@ namespace ccf
         network_ca,
         self_signed_node_cert,
         node_sign_kp->private_key_pem(),
-        tls::Auth::auth_required,
+        true,
         config.join.target_rpc_address);
 
       // Create RPC client and connect to remote node

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -416,7 +416,7 @@ namespace ccf
         network_ca,
         self_signed_node_cert,
         node_sign_kp->private_key_pem(),
-        true,
+        /*auth_required=*/true,
         config.join.target_rpc_address);
 
       // Create RPC client and connect to remote node

--- a/src/tls/README.md
+++ b/src/tls/README.md
@@ -65,6 +65,3 @@ mimic the MbedTLS implementation, including:
 
 As discussed above, the error handling is slightly different and promotes
 verbose code in OpenSSL's side.
-
-Another example is `verify_result` and `get_verify_error` that is very long
-in the OpenSSL implementation and two one-liners in MbedTLS.

--- a/src/tls/ca.h
+++ b/src/tls/ca.h
@@ -13,13 +13,6 @@ using namespace crypto::OpenSSL;
 
 namespace tls
 {
-  enum Auth
-  {
-    auth_default,
-    auth_none,
-    auth_required
-  };
-
   class CA
   {
   private:

--- a/src/tls/cert.h
+++ b/src/tls/cert.h
@@ -58,10 +58,7 @@ namespace tls
     {
       if (peer_hostname.has_value())
       {
-        // Peer hostname is only checked against peer certificate (SAN
-        // extension) if it is set. This lets us connect to peers that present
-        // certificates with IPAddress in SAN field. This is OK since we check
-        // for peer CA endorsement.
+        // Peer hostname for SNI
         SSL_set_tlsext_host_name(ssl, peer_hostname->c_str());
       }
 

--- a/src/tls/context.h
+++ b/src/tls/context.h
@@ -123,7 +123,7 @@ namespace tls
       }
 
       // So does x509 validation
-      if (verify_result() != 0)
+      if (!peer_cert_ok())
       {
         return TLS_ERR_X509_VERIFY;
       }
@@ -185,292 +185,14 @@ namespace tls
       return SSL_shutdown(ssl);
     }
 
-    // This is a hack to make it work like MBedTLS (with negative return
-    // values as error), and to differentiate in get_verify_error if the error
-    // is because we don't have a peer cert or something else.
-    // We may find that this is unnecessary (alongside all of the error messages
-    // in get_verify_error), but that's a cleanup that will need a bit more
-    // research.
-#define TLS_ERR_X509_NO_PEER_CERT -1
-#define TLS_ERR_X509_INVALID_RESULT -2
-
-    int verify_result()
+    bool peer_cert_ok()
     {
-      if (SSL_get_verify_result(ssl) == X509_V_OK)
-      {
-        // Verify can return OK when no certificate is presented
-        // We want that to be an error
-        X509* cert = SSL_get_peer_certificate(ssl);
-        if (cert)
-        {
-          X509_free(cert);
-          return 0;
-        }
-        else
-        {
-          return TLS_ERR_X509_NO_PEER_CERT;
-        }
-      }
-      return TLS_ERR_X509_INVALID_RESULT;
+      return SSL_get_verify_result(ssl) == X509_V_OK;
     }
 
     std::string get_verify_error()
     {
-      int rc = verify_result();
-      if (rc == TLS_ERR_X509_NO_PEER_CERT)
-      {
-        return "Certificate verify error: No peer certificate";
-      }
-
-      switch (rc)
-      {
-        case X509_V_ERR_UNSPECIFIED:
-          return "Unspecified error; should not happen.";
-
-        case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT:
-          return "The issuer certificate of a looked up certificate could not "
-                 "be found. This normally means the list of trusted "
-                 "certificates is not complete.";
-
-        case X509_V_ERR_UNABLE_TO_GET_CRL:
-          return "The CRL of a certificate could not be found.";
-
-        case X509_V_ERR_UNABLE_TO_DECRYPT_CERT_SIGNATURE:
-          return "The certificate signature could not be decrypted. This means "
-                 "that the actual signature value could not be determined "
-                 "rather than it not matching the expected value";
-
-        case X509_V_ERR_UNABLE_TO_DECRYPT_CRL_SIGNATURE:
-          return "The CRL signature could not be decrypted: this means that "
-                 "the actual signature value could not be determined rather "
-                 "than it not matching the expected value. Unused.";
-
-        case X509_V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY:
-          return "The public key in the certificate SubjectPublicKeyInfo could "
-                 "not be read.";
-
-        case X509_V_ERR_CERT_SIGNATURE_FAILURE:
-          return "The signature of the certificate is invalid.";
-
-        case X509_V_ERR_CRL_SIGNATURE_FAILURE:
-          return "The signature of the certificate is invalid.";
-
-        case X509_V_ERR_CERT_NOT_YET_VALID:
-          return "The certificate is not yet valid: the notBefore date is "
-                 "after the current time.";
-
-        case X509_V_ERR_CERT_HAS_EXPIRED:
-          return "The certificate has expired: that is the notAfter date is "
-                 "before the current time.";
-
-        case X509_V_ERR_CRL_NOT_YET_VALID:
-          return "The CRL is not yet valid.";
-
-        case X509_V_ERR_CRL_HAS_EXPIRED:
-          return "The CRL has expired.";
-
-        case X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD:
-          return "The certificate notBefore field contains an invalid time.";
-
-        case X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD:
-          return "The certificate notAfter field contains an invalid time.";
-
-        case X509_V_ERR_ERROR_IN_CRL_LAST_UPDATE_FIELD:
-          return "The CRL lastUpdate field contains an invalid time.";
-
-        case X509_V_ERR_ERROR_IN_CRL_NEXT_UPDATE_FIELD:
-          return "The CRL nextUpdate field contains an invalid time.";
-
-        case X509_V_ERR_OUT_OF_MEM:
-          return "An error occurred trying to allocate memory. This should "
-                 "never happen.";
-
-        case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
-          return "The passed certificate is self-signed and the same "
-                 "certificate cannot be found in the list of trusted "
-                 "certificates.";
-
-        case X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN:
-          return "The certificate chain could be built up using the untrusted "
-                 "certificates but the root could not be found locally.";
-
-        case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY:
-          return "The issuer certificate could not be found: this occurs if "
-                 "the issuer certificate of an untrusted certificate cannot be "
-                 "found.";
-
-        case X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE:
-          return "No signatures could be verified because the chain contains "
-                 "only one certificate and it is not self signed.";
-
-        case X509_V_ERR_CERT_CHAIN_TOO_LONG:
-          return "The certificate chain length is greater than the supplied "
-                 "maximum depth. Unused.";
-
-        case X509_V_ERR_CERT_REVOKED:
-          return "The certificate has been revoked.";
-
-        case X509_V_ERR_INVALID_CA:
-          return "A CA certificate is invalid. Either it is not a CA or its "
-                 "extensions are not consistent with the supplied purpose.";
-
-        case X509_V_ERR_PATH_LENGTH_EXCEEDED:
-          return "The basicConstraints pathlength parameter has been exceeded.";
-
-        case X509_V_ERR_INVALID_PURPOSE:
-          return "The supplied certificate cannot be used for the specified "
-                 "purpose.";
-
-        case X509_V_ERR_CERT_UNTRUSTED:
-          return "The root CA is not marked as trusted for the specified "
-                 "purpose.";
-
-        case X509_V_ERR_CERT_REJECTED:
-          return "The root CA is marked to reject the specified purpose.";
-
-        case X509_V_ERR_SUBJECT_ISSUER_MISMATCH:
-          return "Not used as of OpenSSL 1.1.0 as a result of the deprecation "
-                 "of the -issuer_checks option.";
-
-        case X509_V_ERR_AKID_SKID_MISMATCH:
-          return "Not used as of OpenSSL 1.1.0 as a result of the deprecation "
-                 "of the -issuer_checks option.";
-
-        case X509_V_ERR_AKID_ISSUER_SERIAL_MISMATCH:
-          return "Not used as of OpenSSL 1.1.0 as a result of the deprecation "
-                 "of the -issuer_checks option.";
-
-        case X509_V_ERR_KEYUSAGE_NO_CERTSIGN:
-          return "Not used as of OpenSSL 1.1.0 as a result of the deprecation "
-                 "of the -issuer_checks option.";
-
-        case X509_V_ERR_UNABLE_TO_GET_CRL_ISSUER:
-          return "Unable to get CRL issuer certificate.";
-
-        case X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION:
-          return "Unhandled critical extension.";
-
-        case X509_V_ERR_KEYUSAGE_NO_CRL_SIGN:
-          return "Key usage does not include CRL signing.";
-
-        case X509_V_ERR_UNHANDLED_CRITICAL_CRL_EXTENSION:
-          return "Unhandled critical CRL extension.";
-
-        case X509_V_ERR_INVALID_NON_CA:
-          return "Invalid non-CA certificate has CA markings.";
-
-        case X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED:
-          return "Proxy path length constraint exceeded.";
-
-        case X509_V_ERR_KEYUSAGE_NO_DIGITAL_SIGNATURE:
-          return "Key usage does not include digital signature.";
-
-        case X509_V_ERR_PROXY_CERTIFICATES_NOT_ALLOWED:
-          return "Proxy certificates not allowed";
-
-        case X509_V_ERR_INVALID_EXTENSION:
-          return "Invalid or inconsistent certificate extension.";
-
-        case X509_V_ERR_INVALID_POLICY_EXTENSION:
-          return "Invalid or inconsistent certificate policy extension.";
-
-        case X509_V_ERR_NO_EXPLICIT_POLICY:
-          return "No explicit policy.";
-
-        case X509_V_ERR_DIFFERENT_CRL_SCOPE:
-          return "Different CRL scope.";
-
-        case X509_V_ERR_UNSUPPORTED_EXTENSION_FEATURE:
-          return "Unsupported extension feature.";
-
-        case X509_V_ERR_UNNESTED_RESOURCE:
-          return "RFC 3779 resource not subset of parent's resources.";
-
-        case X509_V_ERR_PERMITTED_VIOLATION:
-          return "Permitted subtree violation.";
-
-        case X509_V_ERR_EXCLUDED_VIOLATION:
-          return "Excluded subtree violation.";
-
-        case X509_V_ERR_SUBTREE_MINMAX:
-          return "Name constraints minimum and maximum not supported.";
-
-        case X509_V_ERR_APPLICATION_VERIFICATION:
-          return "Application verification failure. Unused.";
-
-        case X509_V_ERR_UNSUPPORTED_CONSTRAINT_TYPE:
-          return "Unsupported name constraint type.";
-
-        case X509_V_ERR_UNSUPPORTED_CONSTRAINT_SYNTAX:
-          return "Unsupported or invalid name constraint syntax.";
-
-        case X509_V_ERR_UNSUPPORTED_NAME_SYNTAX:
-          return "Unsupported or invalid name syntax.";
-
-        case X509_V_ERR_CRL_PATH_VALIDATION_ERROR:
-          return "CRL path validation error.";
-
-        case X509_V_ERR_PATH_LOOP:
-          return "Path loop.";
-
-        case X509_V_ERR_SUITE_B_INVALID_VERSION:
-          return "Suite B: certificate version invalid.";
-
-        case X509_V_ERR_SUITE_B_INVALID_ALGORITHM:
-          return "Suite B: invalid public key algorithm.";
-
-        case X509_V_ERR_SUITE_B_INVALID_CURVE:
-          return "Suite B: invalid ECC curve.";
-
-        case X509_V_ERR_SUITE_B_INVALID_SIGNATURE_ALGORITHM:
-          return "Suite B: invalid signature algorithm.";
-
-        case X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED:
-          return "Suite B: curve not allowed for this LOS.";
-
-        case X509_V_ERR_SUITE_B_CANNOT_SIGN_P_384_WITH_P_256:
-          return "Suite B: cannot sign P-384 with P-256.";
-
-        case X509_V_ERR_HOSTNAME_MISMATCH:
-          return "Hostname mismatch.";
-
-        case X509_V_ERR_EMAIL_MISMATCH:
-          return "Email address mismatch.";
-
-        case X509_V_ERR_IP_ADDRESS_MISMATCH:
-          return "IP address mismatch.";
-
-        case X509_V_ERR_DANE_NO_MATCH:
-          return "DANE TLSA authentication is enabled";
-
-        case X509_V_ERR_EE_KEY_TOO_SMALL:
-          return "EE certificate key too weak.";
-
-        case X509_V_ERR_INVALID_CALL:
-          return "nvalid certificate verification context.";
-
-        case X509_V_ERR_STORE_LOOKUP:
-          return "Issuer certificate lookup error.";
-
-        case X509_V_ERR_NO_VALID_SCTS:
-          return "Certificate Transparency required";
-
-        case X509_V_ERR_PROXY_SUBJECT_NAME_VIOLATION:
-          return "Proxy subject name violation.";
-
-        case X509_V_ERR_OCSP_VERIFY_NEEDED:
-          return "Returned by the verify callback to indicate an OCSP "
-                 "verification is needed.";
-
-        case X509_V_ERR_OCSP_VERIFY_FAILED:
-          return "Returned by the verify callback to indicate OCSP "
-                 "verification failed.";
-
-        case X509_V_ERR_OCSP_CERT_UNKNOWN:
-          return "Returned by the verify callback to indicate that the "
-                 "certificate is not recognized by the OCSP responder.";
-      }
-      return "";
+      return X509_verify_cert_error_string(SSL_get_verify_result(ssl));
     }
 
     virtual std::string host()
@@ -480,7 +202,10 @@ namespace tls
 
     std::vector<uint8_t> peer_cert()
     {
-      // Get the certificate into a BIO as DER
+      // CodeQL complains that we don't verify the peer certificate. We don't
+      // need to do that because it's been verified before and we use
+      // SSL_get_peer_certificate just to extract it from the context.
+
       crypto::OpenSSL::Unique_X509 cert(
         SSL_get_peer_certificate(ssl), /*check_null=*/false);
       if (!cert)

--- a/src/tls/test/main.cpp
+++ b/src/tls/test/main.cpp
@@ -270,7 +270,8 @@ NetworkCA get_ca()
 }
 
 /// Creates a tls::Cert with a new CA using a new self-signed Pem certificate.
-unique_ptr<tls::Cert> get_dummy_cert(NetworkCA& net_ca, string name, Auth auth)
+unique_ptr<tls::Cert> get_dummy_cert(
+  NetworkCA& net_ca, string name, bool auth_required)
 {
   // Create a CA with a self-signed certificate
   auto ca = make_unique<tls::CA>(CBuffer(net_ca.cert.str()));
@@ -286,7 +287,7 @@ unique_ptr<tls::Cert> get_dummy_cert(NetworkCA& net_ca, string name, Auth auth)
 
   // Create a tls::Cert with the CA, the signed certificate and the private key
   auto pk = kp->private_key_pem();
-  return make_unique<Cert>(move(ca), crt, pk, auth);
+  return make_unique<Cert>(move(ca), crt, pk, auth_required);
 }
 
 /// Helper to write past the maximum buffer (16k)
@@ -414,8 +415,8 @@ TEST_CASE("unverified handshake")
   auto ca = get_ca();
 
   // Create bogus certificate
-  auto server_cert = get_dummy_cert(ca, "server", auth_none);
-  auto client_cert = get_dummy_cert(ca, "client", auth_none);
+  auto server_cert = get_dummy_cert(ca, "server", false);
+  auto client_cert = get_dummy_cert(ca, "client", false);
 
   LOG_INFO_FMT("TEST: unverified handshake");
 
@@ -441,8 +442,8 @@ TEST_CASE("unverified communication")
   auto ca = get_ca();
 
   // Create bogus certificate
-  auto server_cert = get_dummy_cert(ca, "server", auth_none);
-  auto client_cert = get_dummy_cert(ca, "client", auth_none);
+  auto server_cert = get_dummy_cert(ca, "server", false);
+  auto client_cert = get_dummy_cert(ca, "client", false);
 
   LOG_INFO_FMT("TEST: unverified communication");
 
@@ -463,8 +464,8 @@ TEST_CASE("verified handshake")
   auto ca = get_ca();
 
   // Create bogus certificate
-  auto server_cert = get_dummy_cert(ca, "server", auth_required);
-  auto client_cert = get_dummy_cert(ca, "client", auth_required);
+  auto server_cert = get_dummy_cert(ca, "server", true);
+  auto client_cert = get_dummy_cert(ca, "client", true);
 
   LOG_INFO_FMT("TEST: verified handshake");
 
@@ -490,8 +491,8 @@ TEST_CASE("verified communication")
   auto ca = get_ca();
 
   // Create bogus certificate
-  auto server_cert = get_dummy_cert(ca, "server", auth_required);
-  auto client_cert = get_dummy_cert(ca, "client", auth_required);
+  auto server_cert = get_dummy_cert(ca, "server", true);
+  auto client_cert = get_dummy_cert(ca, "client", true);
 
   LOG_INFO_FMT("TEST: verified communication");
 
@@ -517,8 +518,8 @@ TEST_CASE("large message")
   auto ca = get_ca();
 
   // Create bogus certificate
-  auto server_cert = get_dummy_cert(ca, "server", auth_required);
-  auto client_cert = get_dummy_cert(ca, "client", auth_required);
+  auto server_cert = get_dummy_cert(ca, "server", true);
+  auto client_cert = get_dummy_cert(ca, "client", true);
 
   LOG_INFO_FMT("TEST: large message");
 
@@ -544,8 +545,8 @@ TEST_CASE("very large message")
   auto ca = get_ca();
 
   // Create bogus certificate
-  auto server_cert = get_dummy_cert(ca, "server", auth_required);
-  auto client_cert = get_dummy_cert(ca, "client", auth_required);
+  auto server_cert = get_dummy_cert(ca, "server", true);
+  auto client_cert = get_dummy_cert(ca, "client", true);
 
   LOG_INFO_FMT("TEST: very large message");
 

--- a/src/tls/test/main.cpp
+++ b/src/tls/test/main.cpp
@@ -5,6 +5,7 @@
 #include "crypto/verifier.h"
 #include "tls/tls.h"
 
+#include <exception>
 #include <openssl/err.h>
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "ds/buffer.h"
@@ -170,9 +171,9 @@ long recv(
 
 /// Performs a TLS handshake, looping until there's nothing more to read/write.
 /// Returns 0 on success, throws a runtime error with SSL error str on failure.
-int handshake(Context* ctx)
+int handshake(Context* ctx, bool& keep_going)
 {
-  while (true)
+  while (keep_going)
   {
     int rc = ctx->handshake();
 
@@ -213,6 +214,8 @@ int handshake(Context* ctx)
       }
     }
   }
+
+  return 0;
 }
 
 struct NetworkCA
@@ -344,24 +347,52 @@ void run_test_case(
   client.set_bio(
     &pipe, send<TestPipe::CLIENT>, recv<TestPipe::CLIENT>, nullptr);
 
+  bool keep_going = true;
+  std::optional<std::runtime_error> client_exception, server_exception;
+
   // Create a thread for the client handshake
-  thread client_thread([&client]() {
+  thread client_thread([&client, &keep_going, &client_exception]() {
     LOG_INFO_FMT("Client handshake");
-    if (handshake(&client))
-      throw runtime_error("Client handshake error");
+    try
+    {
+      if (handshake(&client, keep_going))
+        throw runtime_error("Client handshake error");
+    }
+    catch (std::runtime_error& ex)
+    {
+      keep_going = false;
+      client_exception = ex;
+    }
   });
 
   // Create a thread for the server handshake
-  thread server_thread([&server]() {
+  thread server_thread([&server, &keep_going, &server_exception]() {
     LOG_INFO_FMT("Server handshake");
-    if (handshake(&server))
-      throw runtime_error("Server handshake error");
+    try
+    {
+      if (handshake(&server, keep_going))
+        throw runtime_error("Server handshake error");
+    }
+    catch (std::runtime_error& ex)
+    {
+      keep_going = false;
+      server_exception = ex;
+    }
   });
 
   // Join threads
   client_thread.join();
   server_thread.join();
   LOG_INFO_FMT("Handshake completed");
+
+  if (client_exception)
+  {
+    throw *client_exception;
+  }
+  if (server_exception)
+  {
+    throw *server_exception;
+  }
 
   // The rest of the communication is deterministic and easy to simulate
   // so we take them out of the thread, to guarantee there will be bytes
@@ -478,6 +509,106 @@ TEST_CASE("verified handshake")
     0,
     move(server_cert),
     move(client_cert));
+}
+
+TEST_CASE("self-signed server certificate")
+{
+  auto kp = crypto::make_key_pair();
+  auto pk = kp->private_key_pem();
+  auto crt = generate_self_signed_cert(kp, "CN=server");
+  auto server_cert = make_unique<Cert>(nullptr, crt, pk);
+
+  // Create a CA
+  auto ca = get_ca();
+  auto client_cert = get_dummy_cert(ca, "client");
+
+  // Client expected to complain about self-signedness.
+  REQUIRE_THROWS_WITH_AS(
+    run_test_case(
+      0,
+      (const uint8_t*)"",
+      0,
+      (const uint8_t*)"",
+      0,
+      move(server_cert),
+      move(client_cert)),
+    "Client handshake error",
+    std::runtime_error);
+}
+
+TEST_CASE("server certificate from different CA")
+{
+  auto server_ca = get_ca();
+  auto server_cert = get_dummy_cert(server_ca, "server");
+
+  auto client_ca = get_ca();
+  auto client_cert = get_dummy_cert(client_ca, "client");
+
+  // Client expected to complain
+  REQUIRE_THROWS_WITH_AS(
+    run_test_case(
+      0,
+      (const uint8_t*)"",
+      0,
+      (const uint8_t*)"",
+      0,
+      move(server_cert),
+      move(client_cert)),
+    "Client handshake error",
+    std::runtime_error);
+}
+
+TEST_CASE("self-signed client certificate")
+{
+  auto server_ca = get_ca();
+  auto server_cert = get_dummy_cert(server_ca, "server", false);
+
+  auto kp = crypto::make_key_pair();
+  auto pk = kp->private_key_pem();
+  auto crt = generate_self_signed_cert(kp, "CN=server");
+
+  // With verification enabled, the client is expected to complain.
+  auto client_cert = make_unique<Cert>(nullptr, crt, pk);
+
+  REQUIRE_THROWS_WITH_AS(
+    run_test_case(
+      0,
+      (const uint8_t*)"",
+      0,
+      (const uint8_t*)"",
+      0,
+      move(server_cert),
+      move(client_cert)),
+    "Client handshake error",
+    std::runtime_error);
+
+  // Without verification enabled on the client, the server should complain.
+  server_cert = get_dummy_cert(server_ca, "server");
+  client_cert = make_unique<Cert>(nullptr, crt, pk, std::nullopt, false);
+
+  REQUIRE_THROWS_WITH_AS(
+    run_test_case(
+      0,
+      (const uint8_t*)"",
+      0,
+      (const uint8_t*)"",
+      0,
+      move(server_cert),
+      move(client_cert)),
+    "Server handshake error",
+    std::runtime_error);
+
+  // Neither, neither.
+  server_cert = get_dummy_cert(server_ca, "server", false);
+  client_cert = make_unique<Cert>(nullptr, crt, pk, std::nullopt, false);
+  REQUIRE_NOTHROW(run_test_case(
+    0,
+    (const uint8_t*)"",
+    0,
+    (const uint8_t*)"",
+    0,
+    move(server_cert),
+    move(client_cert)));
 }
 
 TEST_CASE("verified communication")

--- a/src/tls/test/main.cpp
+++ b/src/tls/test/main.cpp
@@ -271,7 +271,7 @@ NetworkCA get_ca()
 
 /// Creates a tls::Cert with a new CA using a new self-signed Pem certificate.
 unique_ptr<tls::Cert> get_dummy_cert(
-  NetworkCA& net_ca, string name, bool auth_required)
+  NetworkCA& net_ca, string name, bool auth_required = true)
 {
   // Create a CA with a self-signed certificate
   auto ca = make_unique<tls::CA>(CBuffer(net_ca.cert.str()));
@@ -287,7 +287,7 @@ unique_ptr<tls::Cert> get_dummy_cert(
 
   // Create a tls::Cert with the CA, the signed certificate and the private key
   auto pk = kp->private_key_pem();
-  return make_unique<Cert>(move(ca), crt, pk, auth_required);
+  return make_unique<Cert>(move(ca), crt, pk, std::nullopt, auth_required);
 }
 
 /// Helper to write past the maximum buffer (16k)
@@ -464,8 +464,8 @@ TEST_CASE("verified handshake")
   auto ca = get_ca();
 
   // Create bogus certificate
-  auto server_cert = get_dummy_cert(ca, "server", true);
-  auto client_cert = get_dummy_cert(ca, "client", true);
+  auto server_cert = get_dummy_cert(ca, "server");
+  auto client_cert = get_dummy_cert(ca, "client");
 
   LOG_INFO_FMT("TEST: verified handshake");
 
@@ -491,8 +491,8 @@ TEST_CASE("verified communication")
   auto ca = get_ca();
 
   // Create bogus certificate
-  auto server_cert = get_dummy_cert(ca, "server", true);
-  auto client_cert = get_dummy_cert(ca, "client", true);
+  auto server_cert = get_dummy_cert(ca, "server");
+  auto client_cert = get_dummy_cert(ca, "client");
 
   LOG_INFO_FMT("TEST: verified communication");
 
@@ -518,8 +518,8 @@ TEST_CASE("large message")
   auto ca = get_ca();
 
   // Create bogus certificate
-  auto server_cert = get_dummy_cert(ca, "server", true);
-  auto client_cert = get_dummy_cert(ca, "client", true);
+  auto server_cert = get_dummy_cert(ca, "server");
+  auto client_cert = get_dummy_cert(ca, "client");
 
   LOG_INFO_FMT("TEST: large message");
 
@@ -545,8 +545,8 @@ TEST_CASE("very large message")
   auto ca = get_ca();
 
   // Create bogus certificate
-  auto server_cert = get_dummy_cert(ca, "server", true);
-  auto client_cert = get_dummy_cert(ca, "client", true);
+  auto server_cert = get_dummy_cert(ca, "server");
+  auto client_cert = get_dummy_cert(ca, "client");
 
   LOG_INFO_FMT("TEST: very large message");
 


### PR DESCRIPTION
Fixes one of the two CodeQL security reports reported recently (both are spurious). Also fixes #3432.