### PR TITLE
Corrections from JWT key PR

### DIFF
--- a/doc/build_apps/auth/jwt.rst
+++ b/doc/build_apps/auth/jwt.rst
@@ -184,8 +184,8 @@ In this case, ``key_filter`` must be set to ``sgx`` such that only those certifi
 Extracting JWT metrics
 ----------------------
 
-CCF tracks JWT key auto-refresh that were attempted and succeeded.
+CCF tracks JWT key auto-refresh attempts and successes.
 This can be used to identify errors, for example when the number of attempts doesn't match the number of successes.
-For each issuer, that has auto-refresh enabled, CCF tracks an attempt for each try, and eventually a success, if the update completes.
+For each issuer that has auto-refresh enabled, CCF tracks an attempt for each try, and eventually a success, if the update completes.
 
-To query those numbers, use the RPC API on node endpoint `/jwt_metrics` as described `here <https://microsoft.github.io/CCF/main/operations/operator_rpc_api.html#get--jwt_metrics)`_.
+Operators can query those numbers via the :http:GET:`/jwt_metrics` endpoint.

--- a/doc/build_apps/auth/jwt.rst
+++ b/doc/build_apps/auth/jwt.rst
@@ -184,7 +184,8 @@ In this case, ``key_filter`` must be set to ``sgx`` such that only those certifi
 Extracting JWT metrics
 ----------------------
 
-CCF tracks the number of JWT queries that were attempted and succeeded. This can be used to identify errors, for example when the number of attempts doesn't match the number of successes.
-Each attempt, for each key on each issuer, is tracked as an attempt, and eventually a success, if the update completes.
+CCF tracks JWT key auto-refresh that were attempted and succeeded.
+This can be used to identify errors, for example when the number of attempts doesn't match the number of successes.
+For each issuer, that has auto-refresh enabled, CCF tracks an attempt for each try, and eventually a success, if the update completes.
 
 To query those numbers, use the RPC API on node endpoint `/jwt_metrics` as described `here <https://microsoft.github.io/CCF/main/operations/operator_rpc_api.html#get--jwt_metrics)`_.

--- a/doc/build_apps/auth/jwt.rst
+++ b/doc/build_apps/auth/jwt.rst
@@ -187,4 +187,4 @@ Extracting JWT metrics
 CCF tracks the number of JWT queries that were attempted and succeeded. This can be used to identify errors, for example when the number of attempts doesn't match the number of successes.
 Each attempt, for each key on each issuer, is tracked as an attempt, and eventually a success, if the update completes.
 
-To query those numbers, use the RPC API on node endpoint `/jwt_metrics` as described [here](https://microsoft.github.io/CCF/main/operations/operator_rpc_api.html#get--jwt_metrics).
+To query those numbers, use the RPC API on node endpoint `/jwt_metrics` as described `here <https://microsoft.github.io/CCF/main/operations/operator_rpc_api.html#get--jwt_metrics)`_.

--- a/src/node/jwt_key_auto_refresh.h
+++ b/src/node/jwt_key_auto_refresh.h
@@ -276,9 +276,6 @@ namespace ccf
       jwt_issuers->foreach([this, &ca_cert_bundles](
                              const JwtIssuer& issuer,
                              const JwtIssuerMetadata& metadata) {
-        // Increment attempts
-        attempts++;
-
         if (!metadata.auto_refresh)
         {
           LOG_DEBUG_FMT(
@@ -287,6 +284,10 @@ namespace ccf
             issuer);
           return true;
         }
+
+        // Increment attempts, only when auto-refresh is enabled.
+        attempts++;
+
         LOG_DEBUG_FMT(
           "JWT key auto-refresh: Refreshing keys for issuer '{}'", issuer);
         auto& ca_cert_bundle_name = metadata.ca_cert_bundle_name.value();


### PR DESCRIPTION
This corrects the comments in #3445 after it was merged.

* Rewords the doc paragraph a bit to include auto-refresh.
* Makes clear that each attempt is an issuer, not a key.
* Fixes the MD vs RST format for links.
* Only records an attempt for issuers that have auto-refresh enabled.