### PR TITLE
Added ability to disable OE usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,9 +129,8 @@ if("virtual" IN_LIST COMPILE_TARGETS)
     ccf.virtual PUBLIC INSIDE_ENCLAVE VIRTUAL_ENCLAVE
                        _LIBCPP_HAS_THREAD_API_PTHREAD
   )
-  if (DISABLE_OE)
-    target_compile_definitions(
-        ccf.virtual PUBLIC PRIVATE DISABLE_OE)
+  if(DISABLE_OE)
+    target_compile_definitions(ccf.virtual PUBLIC DISABLE_OE)
   endif()
 
   target_compile_options(ccf.virtual PUBLIC ${COMPILE_LIBCXX})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,10 @@ if("virtual" IN_LIST COMPILE_TARGETS)
     ccf.virtual PUBLIC INSIDE_ENCLAVE VIRTUAL_ENCLAVE
                        _LIBCPP_HAS_THREAD_API_PTHREAD
   )
+  if (DISABLE_OE)
+    target_compile_definitions(
+        ccf.virtual PUBLIC PRIVATE DISABLE_OE)
+  endif()
 
   target_compile_options(ccf.virtual PUBLIC ${COMPILE_LIBCXX})
   add_warning_checks(ccf.virtual)
@@ -153,7 +157,7 @@ if("virtual" IN_LIST COMPILE_TARGETS)
            quickjs.host
            sss.host
            ccf_endpoints.host
-           openenclave::oehost
+           ${HOST_SIDE_VERIFIERS}
            ${CMAKE_THREAD_LIBS_INIT}
   )
 

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -18,7 +18,7 @@ set(DISABLE_OE
     False
     CACHE
       BOOL
-      "Disable the requirements for OE, but also to ability to verify OE attesation reports."
+      "Disable the requirement for OE, but also to ability to verify OE attestation reports."
 )
 
 set(IS_VALID_TARGET "FALSE")

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-if (NOT DISABLE_OE)
+if(NOT DISABLE_OE)
   set(ALLOWED_TARGETS "sgx;virtual")
 else()
   set(ALLOWED_TARGETS "virtual")
@@ -14,11 +14,10 @@ set(COMPILE_TARGETS
       "List of target compilation platforms. Choose from: ${ALLOWED_TARGETS}"
 )
 
-set(DISABLE_OE
-    False
-    CACHE
-      BOOL
-      "Disable the requirement for OE, but also to ability to verify OE attestation reports."
+option(
+  DISABLE_OE
+  "Disable the requirement for OE, but also to ability to verify OE attestation reports."
+  OFF
 )
 
 set(IS_VALID_TARGET "FALSE")
@@ -42,22 +41,24 @@ endif()
 
 set(HOST_SIDE_VERIFIERS)
 
-if (NOT DISABLE_OE)
+if(NOT DISABLE_OE)
   # Find OpenEnclave package
   find_package(OpenEnclave 0.17.5 CONFIG REQUIRED)
 
-  # As well as pulling in openenclave:: targets, this sets variables which can be
-  # used for our edge cases (eg - for virtual libraries). These do not follow the
-  # standard naming patterns, for example use OE_INCLUDEDIR rather than
+  # As well as pulling in openenclave:: targets, this sets variables which can
+  # be used for our edge cases (eg - for virtual libraries). These do not follow
+  # the standard naming patterns, for example use OE_INCLUDEDIR rather than
   # OpenEnclave_INCLUDE_DIRS
 
   set(OE_TARGET_LIBC openenclave::oelibc)
-  set(OE_TARGET_ENCLAVE_AND_STD openenclave::oeenclave openenclave::oelibcxx
-                                openenclave::oelibc openenclave::oecryptoopenssl
+  set(OE_TARGET_ENCLAVE_AND_STD
+      openenclave::oeenclave openenclave::oelibcxx openenclave::oelibc
+      openenclave::oecryptoopenssl
   )
   # These oe libraries must be linked in specific order
-  set(OE_TARGET_ENCLAVE_CORE_LIBS openenclave::oeenclave openenclave::oesnmalloc
-                                  openenclave::oecore openenclave::oesyscall
+  set(OE_TARGET_ENCLAVE_CORE_LIBS
+      openenclave::oeenclave openenclave::oesnmalloc openenclave::oecore
+      openenclave::oesyscall
   )
 
   list(APPEND HOST_SIDE_VERIFIERS openenclave::oehost)
@@ -259,10 +260,11 @@ function(add_host_library name)
   set(files ${PARSED_ARGS_UNPARSED_ARGUMENTS})
   add_library(${name} ${files})
   target_compile_options(${name} PUBLIC ${COMPILE_LIBCXX})
-  if (DISABLE_OE)
-    target_compile_definitions(
-        ${name} PUBLIC DISABLE_OE)
+  if(DISABLE_OE)
+    target_compile_definitions(${name} PUBLIC DISABLE_OE)
   endif()
-  target_link_libraries(${name} PUBLIC ${LINK_LIBCXX} -lgcc ${HOST_SIDE_VERIFIERS})
+  target_link_libraries(
+    ${name} PUBLIC ${LINK_LIBCXX} -lgcc ${HOST_SIDE_VERIFIERS}
+  )
   set_property(TARGET ${name} PROPERTY POSITION_INDEPENDENT_CODE ON)
 endfunction()

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -181,9 +181,8 @@ endif()
 function(add_unit_test name)
   add_executable(${name} ${CCF_DIR}/src/enclave/thread_local.cpp ${ARGN})
   target_compile_options(${name} PRIVATE ${COMPILE_LIBCXX})
-  if (DISABLE_OE)
-    target_compile_definitions(
-        ${name} PRIVATE DISABLE_OE)
+  if(DISABLE_OE)
+    target_compile_definitions(${name} PRIVATE DISABLE_OE)
   endif()
   target_include_directories(
     ${name} PRIVATE src ${CCFCRYPTO_INC} ${CCF_DIR}/3rdparty/test
@@ -193,9 +192,7 @@ function(add_unit_test name)
     ${name} PRIVATE ${LINK_LIBCXX} ccfcrypto.host ${HOST_SIDE_VERIFIERS}
   )
   if("virtual" IN_LIST COMPILE_TARGETS)
-    target_link_libraries(
-      ${name} PRIVATE ${CMAKE_THREAD_LIBS_INIT}
-    )
+    target_link_libraries(${name} PRIVATE ${CMAKE_THREAD_LIBS_INIT})
   endif()
   add_san(${name})
 
@@ -268,9 +265,8 @@ if("virtual" IN_LIST COMPILE_TARGETS)
   # Virtual Host Executable
   add_executable(cchost.virtual ${SNMALLOC_CPP} ${CCF_DIR}/src/host/main.cpp)
   target_compile_definitions(cchost.virtual PRIVATE -DVIRTUAL_ENCLAVE)
-  if (DISABLE_OE)
-    target_compile_definitions(
-        cchost.virtual PRIVATE DISABLE_OE)
+  if(DISABLE_OE)
+    target_compile_definitions(cchost.virtual PRIVATE DISABLE_OE)
   endif()
   target_compile_options(cchost.virtual PRIVATE ${COMPILE_LIBCXX})
   target_include_directories(
@@ -425,9 +421,8 @@ if("virtual" IN_LIST COMPILE_TARGETS)
     js_generic_base.virtual PUBLIC INSIDE_ENCLAVE VIRTUAL_ENCLAVE
                                    _LIBCPP_HAS_THREAD_API_PTHREAD
   )
-  if (DISABLE_OE)
-    target_compile_definitions(
-        js_generic_base.virtual PUBLIC DISABLE_OE)
+  if(DISABLE_OE)
+    target_compile_definitions(js_generic_base.virtual PUBLIC DISABLE_OE)
   endif()
   set_property(
     TARGET js_generic_base.virtual PROPERTY POSITION_INDEPENDENT_CODE ON

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -381,25 +381,23 @@ if("sgx" IN_LIST COMPILE_TARGETS)
   list(APPEND JS_PLUGINS_ENCLAVE js_openenclave.enclave)
 endif()
 if("virtual" IN_LIST COMPILE_TARGETS AND NOT DISABLE_OE)
-  if (NOT DISABLE_OE)
-    add_library(js_openenclave.virtual STATIC ${CCF_DIR}/src/js/openenclave.cpp)
-    add_san(js_openenclave.virtual)
-    target_link_libraries(js_openenclave.virtual PUBLIC ccf.virtual)
-    target_compile_options(js_openenclave.virtual PRIVATE ${COMPILE_LIBCXX})
-    target_compile_definitions(
-      js_openenclave.virtual PUBLIC INSIDE_ENCLAVE VIRTUAL_ENCLAVE
-                                    _LIBCPP_HAS_THREAD_API_PTHREAD
-    )
-    set_property(
-      TARGET js_openenclave.virtual PROPERTY POSITION_INDEPENDENT_CODE ON
-    )
-    install(
-      TARGETS js_openenclave.virtual
-      EXPORT ccf
-      DESTINATION lib
-    )
-    list(APPEND JS_PLUGINS_VIRTUAL js_openenclave.virtual)
-  endif()
+  add_library(js_openenclave.virtual STATIC ${CCF_DIR}/src/js/openenclave.cpp)
+  add_san(js_openenclave.virtual)
+  target_link_libraries(js_openenclave.virtual PUBLIC ccf.virtual)
+  target_compile_options(js_openenclave.virtual PRIVATE ${COMPILE_LIBCXX})
+  target_compile_definitions(
+    js_openenclave.virtual PUBLIC INSIDE_ENCLAVE VIRTUAL_ENCLAVE
+                                  _LIBCPP_HAS_THREAD_API_PTHREAD
+  )
+  set_property(
+    TARGET js_openenclave.virtual PROPERTY POSITION_INDEPENDENT_CODE ON
+  )
+  install(
+    TARGETS js_openenclave.virtual
+    EXPORT ccf
+    DESTINATION lib
+  )
+  list(APPEND JS_PLUGINS_VIRTUAL js_openenclave.virtual)
 endif()
 
 if("sgx" IN_LIST COMPILE_TARGETS)

--- a/src/apps/js_generic/js_generic.cpp
+++ b/src/apps/js_generic/js_generic.cpp
@@ -14,7 +14,11 @@ namespace ccfapp
 
   std::vector<ccf::js::FFIPlugin> get_js_plugins()
   {
+#if !defined(DISABLE_OE)
     return {ccf::js::openenclave_plugin};
+#else
+    return {};
+#endif
   }
 
 } // namespace ccfapp

--- a/src/common/mallinfo.h
+++ b/src/common/mallinfo.h
@@ -1,0 +1,10 @@
+#pragma once
+
+struct ccf_mallinfo_t
+{
+  size_t max_total_heap_size = 0;
+  size_t current_allocated_heap_size = 0;
+  size_t peak_allocated_heap_size = 0;
+};
+
+bool ccf_allocator_mallinfo(ccf_mallinfo_t& info);

--- a/src/common/mallinfo.h
+++ b/src/common/mallinfo.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+
 #pragma once
 
 struct ccf_mallinfo_t

--- a/src/enclave/oe_init.h
+++ b/src/enclave/oe_init.h
@@ -4,7 +4,7 @@
 
 #if defined(INSIDE_ENCLAVE) && !defined(VIRTUAL_ENCLAVE)
 #  include <openenclave/enclave.h>
-#else
+#elif !defined(DISABLE_OE)
 #  include <openenclave/host_verify.h>
 #endif
 #include "ds/ccf_exception.h"
@@ -23,6 +23,7 @@ namespace ccf
       }
     }
 #endif
+#if !defined(DISABLE_OE)
     {
       auto rc = oe_verifier_initialize();
       if (rc != OE_OK)
@@ -31,6 +32,7 @@ namespace ccf
           "Failed to initialise evidence verifier: {}", oe_result_str(rc)));
       }
     }
+#endif
   }
 
   void shutdown_oe()
@@ -38,7 +40,9 @@ namespace ccf
 #if !defined(VIRTUAL_ENCLAVE)
     oe_attester_shutdown();
 #endif
+#if !defined(DISABLE_OE)
     oe_verifier_shutdown();
+#endif
   }
 
 }

--- a/src/enclave/oe_shim.h
+++ b/src/enclave/oe_shim.h
@@ -14,6 +14,19 @@
 #  include <openenclave/edger8r/enclave.h> // For oe_lfence
 #  include <openenclave/enclave.h>
 
+bool ccf_allocator_mallinfo(ccf_mallinfo_t& info)
+{
+  oe_mallinfo_t oe_info;
+  if (oe_allocator_mallinfo(&oe_info) != OE_OK)
+  {
+    return false;
+  }
+  info.max_total_heap_size = oe_info.max_total_heap_size;
+  info.current_allocated_heap_size = oe_info.current_allocated_heap_size;
+  info.peak_allocated_heap_size = oe_info.peak_allocated_heap_size;
+  return true;
+}
+
 #else
 
 // Repeat or approximate a lot of OE definitions, so that the virtual library
@@ -44,12 +57,12 @@ OE_EXTERNC bool oe_is_outside_enclave(const void*, std::size_t)
 
 #  define oe_lfence() // nop
 
-OE_EXTERNC oe_result_t oe_allocator_mallinfo(oe_mallinfo_t* info)
+bool ccf_allocator_mallinfo(ccf_mallinfo_t& info)
 {
-  info->max_total_heap_size = std::numeric_limits<size_t>::max();
-  info->current_allocated_heap_size = 0;
-  info->peak_allocated_heap_size = 0;
-  return OE_OK;
+  info.max_total_heap_size = std::numeric_limits<size_t>::max();
+  info.current_allocated_heap_size = 0;
+  info.peak_allocated_heap_size = 0;
+  return true;
 }
 
 #endif

--- a/src/node/jwt.h
+++ b/src/node/jwt.h
@@ -13,7 +13,7 @@
 #if defined(INSIDE_ENCLAVE) && !defined(VIRTUAL_ENCLAVE)
 #  include <openenclave/attestation/verifier.h>
 #  include <openenclave/enclave.h>
-#elsif !defined(DISABLE_OE)
+#  elsif !defined(DISABLE_OE)
 #  include <openenclave/attestation/verifier.h>
 #  include <openenclave/host_verify.h>
 #endif

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 #include "common/configuration.h"
+#include "common/mallinfo.h"
 #include "ds/json_schema.h"
 #include "enclave/interface.h"
 #include "node/config.h"
@@ -12,7 +13,6 @@
 #include "node/service.h"
 
 #include <nlohmann/json.hpp>
-#include <openenclave/advanced/mallinfo.h>
 
 namespace ccf
 {
@@ -157,7 +157,7 @@ namespace ccf
 
     struct Out
     {
-      Out(const oe_mallinfo_t& info) :
+      Out(const ccf_mallinfo_t& info) :
         max_total_heap_size(info.max_total_heap_size),
         current_allocated_heap_size(info.current_allocated_heap_size),
         peak_allocated_heap_size(info.peak_allocated_heap_size)

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -1124,9 +1124,8 @@ namespace ccf
 // Do not attempt to call oe_allocator_mallinfo when used from
 // unit tests such as the frontend_test
 #ifdef INSIDE_ENCLAVE
-        oe_mallinfo_t info;
-        auto rc = oe_allocator_mallinfo(&info);
-        if (rc == OE_OK)
+        ccf_mallinfo_t info;
+        if (ccf_allocator_mallinfo(info))
         {
           MemoryUsage::Out mu(info);
           args.rpc_ctx->set_response_status(HTTP_STATUS_OK);


### PR DESCRIPTION
This is the starting point of a CCF variant which does not use any OE bits.
It only allows virtual mode and for now there is not alternative verifier in place for attestation reports.
This will enable exploration around porting CCF to other platforms without needing to first port OE.