### PR TITLE
Updated js_generic and the ts package to include the request path in the request object.

### DIFF
--- a/js/ccf-app/src/endpoints.ts
+++ b/js/ccf-app/src/endpoints.ts
@@ -228,7 +228,7 @@ export interface Response<T extends ResponseBodyType<T> = any> {
 export type EndpointFn<
   A extends JsonCompatible<A> = any,
   B extends ResponseBodyType<B> = any
-> = (request: Request<A>) => Response<B>;
+  > = (request: Request<A>) => Response<B>;
 
 /**
  * @inheritDoc CCF.rpc.setApplyWrites

--- a/js/ccf-app/src/endpoints.ts
+++ b/js/ccf-app/src/endpoints.ts
@@ -228,7 +228,7 @@ export interface Response<T extends ResponseBodyType<T> = any> {
 export type EndpointFn<
   A extends JsonCompatible<A> = any,
   B extends ResponseBodyType<B> = any
-  > = (request: Request<A>) => Response<B>;
+> = (request: Request<A>) => Response<B>;
 
 /**
  * @inheritDoc CCF.rpc.setApplyWrites

--- a/js/ccf-app/src/endpoints.ts
+++ b/js/ccf-app/src/endpoints.ts
@@ -54,6 +54,11 @@ export interface Request<T extends JsonCompatible<T> = any> {
   query: string;
 
   /**
+   * The request path of the requested URL.
+   */
+  path: string;
+
+  /**
    * An object to access the request body in various ways.
    */
   body: Body<T>;
@@ -223,7 +228,7 @@ export interface Response<T extends ResponseBodyType<T> = any> {
 export type EndpointFn<
   A extends JsonCompatible<A> = any,
   B extends ResponseBodyType<B> = any
-> = (request: Request<A>) => Response<B>;
+  > = (request: Request<A>) => Response<B>;
 
 /**
  * @inheritDoc CCF.rpc.setApplyWrites

--- a/src/apps/js_generic/js_generic_base.cpp
+++ b/src/apps/js_generic/js_generic_base.cpp
@@ -174,6 +174,11 @@ namespace ccfapp
         ctx.new_string_len(request_query.c_str(), request_query.size());
       request.set("query", query_str);
 
+      const auto request_path = endpoint_ctx.rpc_ctx->get_request_path();
+      auto path_str =
+        ctx.new_string_len(request_path.c_str(), request_path.size());
+      request.set("path", path_str);
+
       auto params = ctx.new_obj();
       for (auto& [param_name, param_value] :
            endpoint_ctx.rpc_ctx->get_request_path_params())


### PR DESCRIPTION
The current js_generic implementation does not expose the current request path in the request object that is presented via the TS package.  The issue is mentioned in #3092.  This PR has the changes for both the core js_generic code and the TS package. 