### PR TITLE
Daily fix - export symbols in SAN build

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-quotidian wren
+quotidian when?

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -186,12 +186,13 @@ function(add_ccf_app name)
     )
 
     if(NOT SAN)
-      target_link_options(
-        ${virt_name}
-        PRIVATE
-        LINKER:--no-undefined,--undefined=enclave_create_node,--undefined=enclave_run
-      )
+      target_link_options(${virt_name} PRIVATE LINKER:--no-undefined)
     endif()
+
+    target_link_options(
+      ${virt_name} PRIVATE
+      LINKER:--undefined=enclave_create_node,--undefined=enclave_run
+    )
 
     set_property(TARGET ${virt_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
 


### PR DESCRIPTION
I broke the daily in #3419, as I wasn't applying the additional linker commands in virtual SAN builds.