### PR TITLE
Fix logging host_level schema

### DIFF
--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -280,7 +280,7 @@
       "properties": {
         "host_level": {
           "type": "string",
-          "enum": ["info", "fail", "fatal"],
+          "enum": ["trace", "debug", "info", "fail", "fatal"],
           "default": "info",
           "description": "Logging level for the untrusted host. Note: while it is possible to set the host log level at startup, it is deliberately not possible to change the log level of the enclave without rebuilding it and changing its code identity."
         },

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -85,9 +85,8 @@ int main(int argc, char** argv)
   }
   catch (const std::exception& e)
   {
-    LOG_FAIL_FMT(
-      "Error parsing configuration file {}: {}", config_file_path, e.what());
-    return 1;
+    throw std::logic_error(fmt::format(
+      "Error parsing configuration file {}: {}", config_file_path, e.what()));
   }
 
   auto config_json = nlohmann::json(config);
@@ -96,11 +95,10 @@ int main(int argc, char** argv)
   auto schema_error_msg = json::validate_json(config_json, schema_json);
   if (schema_error_msg.has_value())
   {
-    LOG_FAIL_FMT(
+    throw std::logic_error(fmt::format(
       "Error validating JSON schema for configuration file {}: {}",
       config_file_path,
-      schema_error_msg.value());
-    return 1;
+      schema_error_msg.value()));
   }
 
   if (config.logging.format == host::LogFormat::JSON)


### PR DESCRIPTION
In #3446, I did not allow the log level "trace" and "debug" as valid values for the host log level, which meant node wouldn't start up when building CCF with `-DVERBLOSE_LOGGING=ON`. Even worse, the JSON validation error messages were not printed because the logger hadn't been setup, so we now raise an exception. 