### PR TITLE
Change docs CSS to make text in JSON samples visible

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -5,3 +5,5 @@
 img {
   margin: .3rem !important;
 }
+
+body[data-theme="dark"] .highlight .s2 { background-color: #303030 } /* Literal.String.Double */

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -5,5 +5,3 @@
 img {
   margin: .3rem !important;
 }
-
-body[data-theme="dark"] .highlight .s2 { background-color: #303030 } /* Literal.String.Double */

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -93,7 +93,7 @@ language = "en"
 exclude_patterns = []
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "colorful"
+pygments_style = "zenburn"
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
I use the dark theme on our docs, and noticed that strings in highlighted sections (such as JSON strings) have a weirdly light background, which makes them hard to read. This tweaks the CSS for those highlights, hopefully without breaking anything else.

Before:
![image](https://user-images.githubusercontent.com/6000239/151394257-c8776aac-55a5-4a12-a73b-25d06d629785.png)

After:
![image](https://user-images.githubusercontent.com/6000239/151394303-9b302b65-6413-400d-a77e-b797be4fd052.png)
