### PR TITLE
Add white background to mermaid divs in dark theme docs

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -5,3 +5,9 @@
 img {
   margin: .3rem !important;
 }
+
+/* Insert white background rectangle for mermaid divs, so they are visible in dark theme */
+body[data-theme="dark"] .mermaid
+{
+  background-color: #ffffff
+}


### PR DESCRIPTION
There are various theming options for mermaid diagrams, but I couldn't find anyway to re-render them based on the current light theme/dark theme selection. Going with a simple hack suggested by @achamayou - Add a white background to all mermaid divs, so they remain readable.

Before:
![image](https://user-images.githubusercontent.com/6000239/151532899-f7b3e91b-34dc-48f6-8db0-ad9c150a9e4d.png)

After:
![image](https://user-images.githubusercontent.com/6000239/151532916-692debc6-0a8a-43fe-88b2-63280a077539.png)
