### PR TITLE
More TLS cleanups

### DIFF
--- a/src/enclave/tls_endpoint.h
+++ b/src/enclave/tls_endpoint.h
@@ -69,7 +69,7 @@ namespace enclave
     {
       execution_thread =
         threading::ThreadMessaging::get_execution_thread(session_id);
-      ctx->set_bio(this, send_callback_openssl, recv_callback_openssl, nullptr);
+      ctx->set_bio(this, send_callback_openssl, recv_callback_openssl);
     }
 
     ~TLSEndpoint()

--- a/src/tls/client.h
+++ b/src/tls/client.h
@@ -12,9 +12,7 @@ namespace tls
     std::shared_ptr<Cert> cert;
 
   public:
-    Client(std::shared_ptr<Cert> cert_, bool dtls = false) :
-      Context(true, dtls),
-      cert(cert_)
+    Client(std::shared_ptr<Cert> cert_) : Context(true), cert(cert_)
     {
       cert->use(ssl, cfg);
     }

--- a/src/tls/context.h
+++ b/src/tls/context.h
@@ -23,16 +23,13 @@ namespace tls
     crypto::OpenSSL::Unique_SSL ssl;
 
   public:
-    Context(bool client, bool dtls) :
-      cfg(
-        dtls ? (client ? DTLS_client_method() : DTLS_server_method()) :
-               (client ? TLS_client_method() : TLS_server_method())),
+    Context(bool client) :
+      cfg(client ? TLS_client_method() : TLS_server_method()),
       ssl(cfg)
     {
       // Require at least TLS 1.2, support up to 1.3
-      SSL_CTX_set_min_proto_version(
-        cfg, dtls ? DTLS1_2_VERSION : TLS1_2_VERSION);
-      SSL_set_min_proto_version(ssl, dtls ? DTLS1_2_VERSION : TLS1_2_VERSION);
+      SSL_CTX_set_min_proto_version(cfg, TLS1_2_VERSION);
+      SSL_set_min_proto_version(ssl, TLS1_2_VERSION);
 
       // Disable renegotiation to avoid DoS
       SSL_CTX_set_options(
@@ -79,11 +76,7 @@ namespace tls
 
     virtual ~Context() = default;
 
-    void set_bio(
-      void* cb_obj,
-      BIO_callback_fn_ex send,
-      BIO_callback_fn_ex recv,
-      BIO_callback_fn_ex dbg)
+    void set_bio(void* cb_obj, BIO_callback_fn_ex send, BIO_callback_fn_ex recv)
     {
       // Read/Write BIOs will be used by TLS
       BIO* rbio = BIO_new(BIO_s_mem());

--- a/src/tls/server.h
+++ b/src/tls/server.h
@@ -12,9 +12,7 @@ namespace tls
     std::shared_ptr<Cert> cert;
 
   public:
-    Server(std::shared_ptr<Cert> cert_, bool dtls = false) :
-      Context(false, dtls),
-      cert(cert_)
+    Server(std::shared_ptr<Cert> cert_) : Context(false), cert(cert_)
     {
       cert->use(ssl, cfg);
     }


### PR DESCRIPTION
When moving to OpenSSL, we left some options open for the day we
implement QUIC and need to reuse the TLS context.

However, while looking at QUIC implementation, we realised it doesn't
need some of the things we expected, for example, it doesn't support
DTLS.

There is an effort to port DTLS to QUIC [1], but that seems it's not
going anywhere, so we shouldn't wait for that to work, given this
is a simple cleanup. We can add later, of course.

[1] https://tools.ietf.org/id/draft-rescorla-quic-over-dtls-00.html

Also cleaning the debug BIO hook that is no longer used.