### PR TITLE
Format with Black v22.1.0

### DIFF
--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -156,7 +156,7 @@ def test_large_messages(network, args):
             # pass but not others, and finding where does it fail).
             log_id = 40
             for p in range(10, 20) if args.consensus == "CFT" else range(10, 13):
-                long_msg = "X" * (2 ** p)
+                long_msg = "X" * (2**p)
                 check_commit(
                     c.post("/app/log/private", {"id": log_id, "msg": long_msg}),
                     result=True,


### PR DESCRIPTION
A new version of Black was [just released](https://black.readthedocs.io/en/stable/change_log.html#id1). It contains exactly one breaking change for our code:

> Remove spaces around power operators if both operands are simple (#2726)

I think we want to stick with the latest version (especially since it's finally non-Beta!), but this kind of behaviour change is extremely annoying (and will likely break on our next `release/1.x` build...).