### PR TITLE
Skip perf tests in tag release job

### DIFF
--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -37,7 +37,7 @@ parameters:
     perf:
       ctest_args: '-L "benchmark|perf|vegeta"'
     release:
-      ctest_args: ""
+      ctest_args: '-LE "benchmark|perf"'
 
 jobs:
   # Debug


### PR DESCRIPTION
The `SGX Release` job we run in the Daily CI is different than the `SGX Release` we run for actual releases. The latter included more tests, in particular the perf tests, which increase the run time and take us over the 60m total limit. This removes those perf tests -there's already an `SGX Perf` job in the same run, which gets similar results (and from build args consistent with other perf tests, if slightly different than the release artifact).