### PR TITLE
Remove unused WriteSetWithClaims

### DIFF
--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -53,15 +53,11 @@ class NodeStatus(Enum):
 class EntryType(Enum):
     WRITE_SET = 0
     SNAPSHOT = 1
-    WRITE_SET_WITH_CLAIMS = 2
-    WRITE_SET_WITH_COMMIT_EVIDENCE = 3
-    WRITE_SET_WITH_COMMIT_EVIDENCE_AND_CLAIMS = 4
+    WRITE_SET_WITH_COMMIT_EVIDENCE = 2
+    WRITE_SET_WITH_COMMIT_EVIDENCE_AND_CLAIMS = 3
 
     def has_claims(self):
-        return self in (
-            EntryType.WRITE_SET_WITH_CLAIMS,
-            EntryType.WRITE_SET_WITH_COMMIT_EVIDENCE_AND_CLAIMS,
-        )
+        return self == EntryType.WRITE_SET_WITH_COMMIT_EVIDENCE_AND_CLAIMS
 
     def has_commit_evidence(self):
         return self in (

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -287,16 +287,14 @@ namespace kv
   {
     WriteSet = 0,
     Snapshot = 1,
-    WriteSetWithClaims = 2,
-    WriteSetWithCommitEvidence = 3,
-    WriteSetWithCommitEvidenceAndClaims = 4,
+    WriteSetWithCommitEvidence = 2,
+    WriteSetWithCommitEvidenceAndClaims = 3,
     MAX = WriteSetWithCommitEvidenceAndClaims
   };
 
   static bool has_claims(const EntryType& et)
   {
-    return et == EntryType::WriteSetWithClaims ||
-      et == EntryType::WriteSetWithCommitEvidenceAndClaims;
+    return et == EntryType::WriteSetWithCommitEvidenceAndClaims;
   }
 
   static bool has_commit_evidence(const EntryType& et)


### PR DESCRIPTION
WriteSetWithClaims was only ever used in a couple of dev releases, but there is no intention for it to be used in 2.0.0 final, now that every new-style transaction has commit evidence. As @letmaik suggested, we might as well remove it.