### PR TITLE
Build CI image from Open Enclave 0.17.6 pre-release

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -7,7 +7,7 @@ trigger:
 
 jobs:
   - job: build_and_publish_docs
-    container: ccfciteam/ccf-ci:oe0.17.5-2
+    container: ccfciteam/ccf-ci:oe0.17.6-pre0
     pool:
       vmImage: ubuntu-20.04
 

--- a/.azure-pipelines-v8.yml
+++ b/.azure-pipelines-v8.yml
@@ -20,7 +20,7 @@ parameters:
 
 jobs:
   - job: build_v8
-    container: ccfciteam/ccf-ci:oe0.17.5-2
+    container: ccfciteam/ccf-ci:oe0.17.6-pre0
     pool: 1es-dv4-focal
 
     strategy:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -27,11 +27,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfciteam/ccf-ci:oe0.17.5-2
+      image: ccfciteam/ccf-ci:oe0.17.6-pre0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.5-2
+      image: ccfciteam/ccf-ci:oe0.17.6-pre0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
 variables:

--- a/.daily.yml
+++ b/.daily.yml
@@ -23,11 +23,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfciteam/ccf-ci:oe0.17.5-2
+      image: ccfciteam/ccf-ci:oe0.17.6-pre0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache
 
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.5-2
+      image: ccfciteam/ccf-ci:oe0.17.6-pre0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-20.04
-    container: ccfciteam/ccf-ci:oe0.17.5-2
+    container: ccfciteam/ccf-ci:oe0.17.6-pre0
 
     steps:
       - name: Checkout repository

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -16,7 +16,7 @@ pr:
 resources:
   containers:
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.5-2
+      image: ccfciteam/ccf-ci:oe0.17.6-pre0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.stress.yml
+++ b/.stress.yml
@@ -21,7 +21,7 @@ schedules:
 resources:
   containers:
     - container: sgx
-      image: ccfciteam/ccf-ci:oe0.17.5-2
+      image: ccfciteam/ccf-ci:oe0.17.6-pre0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/getting_started/setup_vm/roles/openenclave/vars/common.yml
+++ b/getting_started/setup_vm/roles/openenclave/vars/common.yml
@@ -1,6 +1,6 @@
-oe_ver: "0.17.5"
+oe_ver: "0.17.6"
 # Usually the same, except for rc, where ver is -rc and ver_ is _rc
-oe_ver_: "0.17.5"
+oe_ver_: "0.17.6"
 
 # Source install
 workspace: "/tmp/"
@@ -11,7 +11,7 @@ oe_playbook: scripts/ansible/oe-contributors-acc-setup-no-driver.yml
 oe_build_opts: ""
 
 # Binary install
-oe_deb: "https://github.com/openenclave/openenclave/releases/download/v{{ oe_ver }}/Ubuntu_2004_open-enclave_{{ oe_ver_ }}_amd64.deb"
+oe_deb: "https://rosanstorage.blob.core.windows.net/oe-release-candidates-public/Ubuntu_2004_open-enclave_0.17.6_amd64.deb"
 
 # LVI mitigations
 oe_lvi_scripts_dir: "{{ oe_prefix }}/bin/scripts/lvi-mitigation"


### PR DESCRIPTION
Test Open Enclave 0.17.6 pre-release. Will not merge, a separate PR will be created for the upgrade to 0.17.6 final.