### PR TITLE
Revert "Remove unused WriteSetWithClaims"

### DIFF
--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -53,11 +53,15 @@ class NodeStatus(Enum):
 class EntryType(Enum):
     WRITE_SET = 0
     SNAPSHOT = 1
-    WRITE_SET_WITH_COMMIT_EVIDENCE = 2
-    WRITE_SET_WITH_COMMIT_EVIDENCE_AND_CLAIMS = 3
+    WRITE_SET_WITH_CLAIMS = 2
+    WRITE_SET_WITH_COMMIT_EVIDENCE = 3
+    WRITE_SET_WITH_COMMIT_EVIDENCE_AND_CLAIMS = 4
 
     def has_claims(self):
-        return self == EntryType.WRITE_SET_WITH_COMMIT_EVIDENCE_AND_CLAIMS
+        return self in (
+            EntryType.WRITE_SET_WITH_CLAIMS,
+            EntryType.WRITE_SET_WITH_COMMIT_EVIDENCE_AND_CLAIMS,
+        )
 
     def has_commit_evidence(self):
         return self in (

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -287,14 +287,16 @@ namespace kv
   {
     WriteSet = 0,
     Snapshot = 1,
-    WriteSetWithCommitEvidence = 2,
-    WriteSetWithCommitEvidenceAndClaims = 3,
+    WriteSetWithClaims = 2,
+    WriteSetWithCommitEvidence = 3,
+    WriteSetWithCommitEvidenceAndClaims = 4,
     MAX = WriteSetWithCommitEvidenceAndClaims
   };
 
   static bool has_claims(const EntryType& et)
   {
-    return et == EntryType::WriteSetWithCommitEvidenceAndClaims;
+    return et == EntryType::WriteSetWithClaims ||
+      et == EntryType::WriteSetWithCommitEvidenceAndClaims;
   }
 
   static bool has_commit_evidence(const EntryType& et)


### PR DESCRIPTION
Reverts microsoft/CCF#3485 - This change is incompatible with 1.0.18, and would require a remapped 1.0.19. The minor code simplification isn't worth the extra hassle and risk.