### PR TITLE
Fix handling of public addresses in sandbox script

### DIFF
--- a/tests/infra/interfaces.py
+++ b/tests/infra/interfaces.py
@@ -88,11 +88,19 @@ class HostSpec:
     @staticmethod
     def from_str(s):
         protocol, address = s.split("://")
+        pub_host, pub_port = None, None
+        if "," in address:
+            address, published_address = address.split(",")
+            pub_host, pub_port = split_address(published_address)
         host, port = split_address(address)
         return HostSpec(
             rpc_interfaces={
                 PRIMARY_RPC_INTERFACE: RPCInterface(
-                    protocol=protocol, host=host, port=port
+                    protocol=protocol,
+                    host=host,
+                    port=port,
+                    public_host=pub_host,
+                    public_port=pub_port,
                 )
             }
         )


### PR DESCRIPTION
To support calls like `sandbox.sh -v -n local://0.0.0.0:8000,127.0.0.1:8000 -p samples/apps/logging/liblogging.virtual.so`