### PR TITLE
Add 2.0 announcement in docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -107,7 +107,9 @@ html_theme = "furo"
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    "announcement": 'CCF 2.0 release candidate <a href="https://github.com/microsoft/CCF/releases/tag/ccf-2.0.0-rc0"> is now available </a>'
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42961061/152127410-44fcea3c-1b14-4233-9e34-461ca6bbeb31.png)

Note that this does not hardcode this for any specific version of the docs and can be removed/modified at any point.