### PR TITLE
GitHub Pages CI Job updates

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -31,6 +31,8 @@ jobs:
       # Only the main branch builds and publishes the versioned documentation.
       # This is because the configuration of the docs (e.g. theme) will change
       # over time and only the main branch should be source of trust/kept up to date.
+
+      # Only on main and not on PRs
       - script: |
           set -ex
           python3.8 -m venv env
@@ -42,26 +44,26 @@ jobs:
           sphinx-multiversion doc build/html
         displayName: Sphinx Multi-version
         condition: |
+          and(
+            not(eq(variables['Build.Reason'], 'PullRequest')),
+            eq(variables['Build.SourceBranch'], 'refs/heads/main')
+          )
+
+      # Only on PRs and not on main (e.g. release branch/tag)
+      - script: |
+          set -ex
+          python3.8 -m venv env
+          source env/bin/activate
+          pip install wheel
+          pip install -U -r doc/requirements.txt
+          pip install -U -e ./python
+          sphinx-build doc build/html
+        displayName: Sphinx Single-version
+        condition: |
           or(
             eq(variables['Build.Reason'], 'PullRequest'),
             not(eq(variables['Build.SourceBranch'], 'refs/heads/main'))
           )
-
-      # Only on PRs and not on main branch
-      # - script: |
-      #     set -ex
-      #     python3.8 -m venv env
-      #     source env/bin/activate
-      #     pip install wheel
-      #     pip install -U -r doc/requirements.txt
-      #     pip install -U -e ./python
-      #     sphinx-build doc build/html
-      #   displayName: Sphinx Single-version
-      #   condition: |
-      #     or(
-      #       eq(variables['Build.Reason'], 'PullRequest'),
-      #       not(eq(variables['Build.SourceBranch'], 'refs/heads/main'))
-      #     )
 
       - script: |
           set -ex

--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -28,6 +28,9 @@ jobs:
         parameters:
           cmake_args: ""
 
+      # Only the main branch builds and publishes the versioned documentation.
+      # This is because the configuration (e.g. theme) of the documentation
+      # may change over time and only the configuration on main should be updated.
       - script: |
           set -ex
           python3.8 -m venv env
@@ -36,15 +39,8 @@ jobs:
           pip install -U -r doc/requirements.txt
           pip install -U -e ./python
           pip install -U -r doc/historical_ccf_requirements.txt
-        displayName: Python venv
-
-      # Only the main branch builds and publishes the versioned documentation.
-      # This is because the configuration (e.g. theme) of the documentation
-      # may change over time and only the configuration on main should be updated.
-      - script: |
-          set -ex
           sphinx-multiversion doc build/html
-        displayName: Sphinx Multiversion
+        displayName: Sphinx Multi-version
         condition: |
           and(
             not(eq(variables['Build.Reason'], 'PullRequest')),
@@ -53,8 +49,13 @@ jobs:
 
       - script: |
           set -ex
+          python3.8 -m venv env
+          source env/bin/activate
+          pip install wheel
+          pip install -U -r doc/requirements.txt
+          pip install -U -e ./python
           sphinx-build doc build/html
-        displayName: Sphinx Main
+        displayName: Sphinx Single-version
         condition: |
           or(
             eq(variables['Build.Reason'], 'PullRequest'),

--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -36,8 +36,30 @@ jobs:
           pip install -U -r doc/requirements.txt
           pip install -U -e ./python
           pip install -U -r doc/historical_ccf_requirements.txt
+        displayName: Python venv
+
+      # Only the main branch builds and publishes the versioned documentation.
+      # This is because the configuration (e.g. theme) of the documentation
+      # may change over time and only the configuration on main should be updated.
+      - script: |
+          set -ex
           sphinx-multiversion doc build/html
-        displayName: Sphinx
+        displayName: Sphinx Multiversion
+        condition: |
+          and(
+            not(eq(variables['Build.Reason'], 'PullRequest')),
+            eq(variables['Build.SourceBranch'], 'refs/heads/main')
+          )
+
+      - script: |
+          set -ex
+          sphinx-build doc build/html
+        displayName: Sphinx Main
+        condition: |
+          or(
+            eq(variables['Build.Reason'], 'PullRequest'),
+            not(eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+          )
 
       - script: |
           set -ex
@@ -71,10 +93,7 @@ jobs:
         condition: |
           and(
             not(eq(variables['Build.Reason'], 'PullRequest')),
-            or(
-                eq(variables['Build.SourceBranch'], 'refs/heads/main'),
-                startsWith(variables['Build.SourceBranch'], 'refs/tags/ccf-')
-            )
+            eq(variables['Build.SourceBranch'], 'refs/heads/main')
           )
         workingDirectory: build/html
 

--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -29,8 +29,8 @@ jobs:
           cmake_args: ""
 
       # Only the main branch builds and publishes the versioned documentation.
-      # This is because the configuration (e.g. theme) of the documentation
-      # may change over time and only the configuration on main should be updated.
+      # This is because the configuration of the docs (e.g. theme) will change
+      # over time and only the main branch should be source of trust/kept up to date.
       - script: |
           set -ex
           python3.8 -m venv env
@@ -47,6 +47,7 @@ jobs:
             eq(variables['Build.SourceBranch'], 'refs/heads/main')
           )
 
+      # Only on PRs and not on main branch
       - script: |
           set -ex
           python3.8 -m venv env

--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -42,26 +42,26 @@ jobs:
           sphinx-multiversion doc build/html
         displayName: Sphinx Multi-version
         condition: |
-          and(
-            not(eq(variables['Build.Reason'], 'PullRequest')),
-            eq(variables['Build.SourceBranch'], 'refs/heads/main')
-          )
-
-      # Only on PRs and not on main branch
-      - script: |
-          set -ex
-          python3.8 -m venv env
-          source env/bin/activate
-          pip install wheel
-          pip install -U -r doc/requirements.txt
-          pip install -U -e ./python
-          sphinx-build doc build/html
-        displayName: Sphinx Single-version
-        condition: |
           or(
             eq(variables['Build.Reason'], 'PullRequest'),
             not(eq(variables['Build.SourceBranch'], 'refs/heads/main'))
           )
+
+      # Only on PRs and not on main branch
+      # - script: |
+      #     set -ex
+      #     python3.8 -m venv env
+      #     source env/bin/activate
+      #     pip install wheel
+      #     pip install -U -r doc/requirements.txt
+      #     pip install -U -e ./python
+      #     sphinx-build doc build/html
+      #   displayName: Sphinx Single-version
+      #   condition: |
+      #     or(
+      #       eq(variables['Build.Reason'], 'PullRequest'),
+      #       not(eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      #     )
 
       - script: |
           set -ex

--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -30,7 +30,8 @@ jobs:
 
       # Only the main branch builds and publishes the versioned documentation.
       # This is because the configuration of the docs (e.g. theme) will change
-      # over time and only the main branch should be source of trust/kept up to date.
+      # over time and only the main branch should be source of truth and be
+      # kept up to date.
 
       # Only on main and not on PRs
       - script: |

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -107,7 +107,9 @@ html_theme = "furo"
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    "announcement": 'CCF 2.0 release candidate <a href="https://github.com/microsoft/CCF/releases/tag/ccf-2.0.0-rc0"> is now available </a>'
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
- Do not publish documentation from release tags (we really only want to publish the documentation from `main` so that it always uses the latest theme, etc.).
- Only run `sphinx-build` (i.e. no multiversion) from pull requests (we don't need to re-build the whole versioned documentation, but only check that the documentation for the local checkout works). 