### PR TITLE
Fix for async DNS resolution request cleanup

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-hey there
+hey there good lookin

--- a/src/host/dns.h
+++ b/src/host/dns.h
@@ -4,10 +4,14 @@
 
 #include "../ds/logger.h"
 
+#include <unordered_set>
 #include <uv.h>
 
 namespace asynchost
 {
+  static std::unordered_set<uv_getaddrinfo_t*> pending_resolve_requests;
+  static std::mutex pending_resolve_requests_mtx;
+
   class DNS
   {
   public:
@@ -31,6 +35,11 @@ namespace asynchost
 
       if (async)
       {
+        {
+          std::unique_lock<std::mutex> guard(pending_resolve_requests_mtx);
+          pending_resolve_requests.insert(resolver);
+        }
+
         if (
           (rc = uv_getaddrinfo(
              uv_default_loop(),
@@ -46,6 +55,10 @@ namespace asynchost
             host,
             service,
             uv_strerror(rc));
+          {
+            std::unique_lock<std::mutex> guard(pending_resolve_requests_mtx);
+            pending_resolve_requests.erase(resolver);
+          }
           delete resolver;
           return false;
         }

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -148,6 +148,18 @@ namespace asynchost
 
     ~TCPImpl()
     {
+      {
+        std::unique_lock<std::mutex> guard(pending_resolve_requests_mtx);
+        for (auto& req : pending_resolve_requests)
+        {
+          // The UV request objects can stay, but if there are any references
+          // to `this` left, we need to remove them.
+          if (req->data == this)
+          {
+            req->data = nullptr;
+          }
+        }
+      }
       if (addr_base != nullptr)
       {
         uv_freeaddrinfo(addr_base);
@@ -589,7 +601,15 @@ namespace asynchost
 
     static void on_resolved(uv_getaddrinfo_t* req, int rc, struct addrinfo*)
     {
-      static_cast<TCPImpl*>(req->data)->on_resolved(req, rc);
+      {
+        std::unique_lock<std::mutex> guard(pending_resolve_requests_mtx);
+        pending_resolve_requests.erase(req);
+      }
+
+      if (req->data)
+      {
+        static_cast<TCPImpl*>(req->data)->on_resolved(req, rc);
+      }
     }
 
     void on_resolved(uv_getaddrinfo_t* req, int rc)

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -601,10 +601,8 @@ namespace asynchost
 
     static void on_resolved(uv_getaddrinfo_t* req, int rc, struct addrinfo*)
     {
-      {
-        std::unique_lock<std::mutex> guard(pending_resolve_requests_mtx);
-        pending_resolve_requests.erase(req);
-      }
+      std::unique_lock<std::mutex> guard(pending_resolve_requests_mtx);
+      pending_resolve_requests.erase(req);
 
       if (req->data)
       {


### PR DESCRIPTION
Here is an overly cautious fix for the cleanup of DNS resolution request objects. We probably don't stricly need `pending_resolve_requests` to be global, but I believe the lock on it is necessary. The key change here is that we run over all pending resolution requests in `~TCPImpl` and we set all references to `this` to `nullptr`, so that we can skip the callback when it fires later. 

Fixes #3491.