### PR TITLE
Add more request fields to JS API

### DIFF
--- a/js/ccf-app/src/endpoints.ts
+++ b/js/ccf-app/src/endpoints.ts
@@ -45,18 +45,50 @@ export interface Request<T extends JsonCompatible<T> = any> {
 
   /**
    * An object mapping URL path parameter names to their values.
+   * 
+   * GET /app/person/bob?fields=all, matched to /app/person/{name} => {"name": "bob"}
    */
   params: { [key: string]: string };
 
   /**
-   * The query string of the requested URL.
+   * The full original requested URL.
+   * 
+   * GET /app/person/bob?fields=all => "/app/person/bob?fields=all"
+   */
+  url: string;
+
+  /**
+   * The path component of the requested URL.
+   * 
+   * GET /app/person/bob?fields=all => "/app/person/bob"
+   */
+  path: string;
+
+  /**
+   * The endpoint name which matched requested URL, potentially containing path parameters.
+   * 
+   * GET /app/person/bob?fields=all => "/app/person/{name}"
+   */
+  route: string;
+
+  /**
+   * The query component of the requested URL.
+   * 
+   * GET /app/person/bob?fields=all => "fields=all"
    */
   query: string;
 
   /**
-   * The request path of the requested URL.
+   * The HTTP method of the request.
+   * 
+   * GET /app/person/bob?fields=all => "GET"
    */
-  path: string;
+  method: string;
+
+  /**
+   * Hostname extracted from Host header, or null if header is missing
+   */
+  hostname: string;
 
   /**
    * An object to access the request body in various ways.
@@ -228,7 +260,7 @@ export interface Response<T extends ResponseBodyType<T> = any> {
 export type EndpointFn<
   A extends JsonCompatible<A> = any,
   B extends ResponseBodyType<B> = any
-> = (request: Request<A>) => Response<B>;
+  > = (request: Request<A>) => Response<B>;
 
 /**
  * @inheritDoc CCF.rpc.setApplyWrites

--- a/js/ccf-app/src/endpoints.ts
+++ b/js/ccf-app/src/endpoints.ts
@@ -46,42 +46,42 @@ export interface Request<T extends JsonCompatible<T> = any> {
   /**
    * An object mapping URL path parameter names to their values.
    * 
-   * GET /app/person/bob?fields=all, matched to /app/person/{name} => {"name": "bob"}
+   * For example `GET /app/person/bob?fields=all` matched to `/app/person/{name}` becomes `{"name": "bob"}`
    */
   params: { [key: string]: string };
 
   /**
    * The full original requested URL.
    * 
-   * GET /app/person/bob?fields=all => "/app/person/bob?fields=all"
+   * For example `GET /app/person/bob?fields=all` becomes `"/app/person/bob?fields=all"`
    */
   url: string;
 
   /**
    * The path component of the requested URL.
    * 
-   * GET /app/person/bob?fields=all => "/app/person/bob"
+   * For example `GET /app/person/bob?fields=all` becomes `"/app/person/bob"`
    */
   path: string;
 
   /**
    * The endpoint name which matched requested URL, potentially containing path parameters.
    * 
-   * GET /app/person/bob?fields=all => "/app/person/{name}"
+   * For example `GET /app/person/bob?fields=all` becomes `"/app/person/{name}"`
    */
   route: string;
 
   /**
    * The query component of the requested URL.
    * 
-   * GET /app/person/bob?fields=all => "fields=all"
+   * For example `GET /app/person/bob?fields=all` becomes `"fields=all"`
    */
   query: string;
 
   /**
    * The HTTP method of the request.
    * 
-   * GET /app/person/bob?fields=all => "GET"
+   * For example `GET /app/person/bob?fields=all` becomes `"GET"`
    */
   method: string;
 

--- a/src/apps/js_generic/js_generic_base.cpp
+++ b/src/apps/js_generic/js_generic_base.cpp
@@ -30,6 +30,9 @@ namespace ccfapp
   class JSHandlers : public UserEndpointRegistry
   {
   private:
+    struct JSDynamicEndpoint : public ccf::endpoints::EndpointDefinition
+    {};
+
     NetworkTables& network;
     ccfapp::AbstractNodeContext& context;
     metrics::Tracker metrics_tracker;
@@ -155,13 +158,15 @@ namespace ccfapp
     }
 
     js::JSWrappedValue create_request_obj(
-      ccf::endpoints::EndpointContext& endpoint_ctx, js::Context& ctx)
+      const JSDynamicEndpoint* endpoint,
+      ccf::endpoints::EndpointContext& endpoint_ctx,
+      js::Context& ctx)
     {
       auto request = ctx.new_obj();
 
+      const auto& r_headers = endpoint_ctx.rpc_ctx->get_request_headers();
       auto headers = ctx.new_obj();
-      for (auto& [header_name, header_value] :
-           endpoint_ctx.rpc_ctx->get_request_headers())
+      for (auto& [header_name, header_value] : r_headers)
       {
         headers.set(
           header_name,
@@ -174,10 +179,41 @@ namespace ccfapp
         ctx.new_string_len(request_query.c_str(), request_query.size());
       request.set("query", query_str);
 
-      const auto request_path = endpoint_ctx.rpc_ctx->get_request_path();
+      const auto& request_path = endpoint_ctx.rpc_ctx->get_request_path();
       auto path_str =
         ctx.new_string_len(request_path.c_str(), request_path.size());
       request.set("path", path_str);
+
+      const auto& request_method = endpoint_ctx.rpc_ctx->get_request_verb();
+      auto method_str = ctx.new_string(request_method.c_str());
+      request.set("method", method_str);
+
+      const auto host_it = r_headers.find(http::headers::HOST);
+      if (host_it != r_headers.end())
+      {
+        const auto& request_hostname = host_it->second;
+        auto hostname_str =
+          ctx.new_string_len(request_hostname.c_str(), request_hostname.size());
+        request.set("hostname", hostname_str);
+      }
+      else
+      {
+        request.set("hostname", JS_NULL);
+      }
+
+      const auto request_route = endpoint->full_uri_path;
+      auto route_str =
+        ctx.new_string_len(request_route.c_str(), request_route.size());
+      request.set("route", route_str);
+
+      auto request_url = request_path;
+      if (!request_query.empty())
+      {
+        request_url = fmt::format("{}?{}", request_url, request_query);
+      }
+      auto url_str =
+        ctx.new_string_len(request_url.c_str(), request_url.size());
+      request.set("url", url_str);
 
       auto params = ctx.new_obj();
       for (auto& [param_name, param_value] :
@@ -200,10 +236,10 @@ namespace ccfapp
     }
 
     void execute_request(
-      const ccf::endpoints::EndpointProperties& props,
+      const JSDynamicEndpoint* endpoint,
       ccf::endpoints::EndpointContext& endpoint_ctx)
     {
-      if (props.mode == ccf::endpoints::Mode::Historical)
+      if (endpoint->properties.mode == ccf::endpoints::Mode::Historical)
       {
         auto is_tx_committed =
           [this](ccf::View view, ccf::SeqNo seqno, std::string& error_reason) {
@@ -212,26 +248,27 @@ namespace ccfapp
           };
 
         ccf::historical::adapter_v2(
-          [this, &props](
+          [this, endpoint](
             ccf::endpoints::EndpointContext& endpoint_ctx,
             ccf::historical::StatePtr state) {
             auto tx = state->store->create_tx();
             auto tx_id = state->transaction_id;
             auto receipt = state->receipt;
             assert(receipt);
-            do_execute_request(props, endpoint_ctx, &tx, tx_id, receipt);
+            do_execute_request(endpoint, endpoint_ctx, &tx, tx_id, receipt);
           },
           context.get_historical_state(),
           is_tx_committed)(endpoint_ctx);
       }
       else
       {
-        do_execute_request(props, endpoint_ctx, nullptr, std::nullopt, nullptr);
+        do_execute_request(
+          endpoint, endpoint_ctx, nullptr, std::nullopt, nullptr);
       }
     }
 
     void do_execute_request(
-      const ccf::endpoints::EndpointProperties& props,
+      const JSDynamicEndpoint* endpoint,
       ccf::endpoints::EndpointContext& endpoint_ctx,
       kv::Tx* historical_tx,
       const std::optional<ccf::TxID>& transaction_id,
@@ -264,6 +301,7 @@ namespace ccfapp
       js::JSWrappedValue export_func;
       try
       {
+        const auto& props = endpoint->properties;
         auto module_val =
           js::load_app_module(ctx, props.js_module.c_str(), &endpoint_ctx.tx);
         export_func =
@@ -279,7 +317,7 @@ namespace ccfapp
       }
 
       // Call exported function
-      auto request = create_request_obj(endpoint_ctx, ctx);
+      auto request = create_request_obj(endpoint, endpoint_ctx, ctx);
       auto val = ctx.call(export_func, {request});
 
       if (JS_IsException(val))
@@ -433,9 +471,6 @@ namespace ccfapp
       return;
     }
 
-    struct JSDynamicEndpoint : public ccf::endpoints::EndpointDefinition
-    {};
-
   public:
     JSHandlers(NetworkTables& network, AbstractNodeContext& context) :
       UserEndpointRegistry(context),
@@ -477,6 +512,8 @@ namespace ccfapp
         auto endpoint_def = std::make_shared<JSDynamicEndpoint>();
         endpoint_def->dispatch = key;
         endpoint_def->properties = it.value();
+        endpoint_def->full_uri_path = fmt::format(
+          "/{}{}", method_prefix, endpoint_def->dispatch.uri_path);
         instantiate_authn_policies(*endpoint_def);
         return endpoint_def;
       }
@@ -521,6 +558,8 @@ namespace ccfapp
 
                   auto endpoint = std::make_shared<JSDynamicEndpoint>();
                   endpoint->dispatch = other_key;
+                  endpoint->full_uri_path = fmt::format(
+                    "/{}{}", method_prefix, endpoint->dispatch.uri_path);
                   endpoint->properties = endpoints->get(other_key).value();
                   instantiate_authn_policies(*endpoint);
                   matches.push_back(endpoint);
@@ -584,7 +623,7 @@ namespace ccfapp
       auto endpoint = dynamic_cast<const JSDynamicEndpoint*>(e.get());
       if (endpoint != nullptr)
       {
-        execute_request(endpoint->properties, endpoint_ctx);
+        execute_request(endpoint, endpoint_ctx);
         return;
       }
 

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -533,7 +533,8 @@ class CCFClient:
         **kwargs,
     ):
         self.connection_timeout = connection_timeout
-        self.name = f"[{host}:{port}]"
+        self.hostname = f"{host}:{port}"
+        self.name = f"[{self.hostname}]"
         self.description = description or self.name
         self.is_connected = False
         self.auth = bool(session_auth)

--- a/tests/js-api/app.json
+++ b/tests/js-api/app.json
@@ -1,0 +1,56 @@
+{
+  "endpoints": {
+    "/echo": {
+      "post": {
+        "js_module": "endpoints.js",
+        "js_function": "echo",
+        "forwarding_required": "always",
+        "authn_policies": ["user_cert", "no_auth"],
+        "mode": "readonly",
+        "openapi": {}
+      },
+      "get": {
+        "js_module": "endpoints.js",
+        "js_function": "echo",
+        "forwarding_required": "always",
+        "authn_policies": ["user_cert", "no_auth"],
+        "mode": "readonly",
+        "openapi": {}
+      },
+      "delete": {
+        "js_module": "endpoints.js",
+        "js_function": "echo",
+        "forwarding_required": "always",
+        "authn_policies": ["user_cert", "no_auth"],
+        "mode": "readonly",
+        "openapi": {}
+      }
+    },
+    "/echo/{foo}": {
+      "post": {
+        "js_module": "endpoints.js",
+        "js_function": "echo",
+        "forwarding_required": "always",
+        "authn_policies": ["user_cert", "no_auth"],
+        "mode": "readonly",
+        "openapi": {}
+      },
+      "get": {
+        "js_module": "endpoints.js",
+        "js_function": "echo",
+        "forwarding_required": "always",
+        "authn_policies": ["user_cert", "no_auth"],
+        "mode": "readonly",
+        "openapi": {}
+      },
+      "delete": {
+        "js_module": "endpoints.js",
+        "js_function": "echo",
+        "forwarding_required": "always",
+        "authn_policies": ["user_cert", "no_auth"],
+        "mode": "readonly",
+        "openapi": {}
+      }
+    }
+  }
+}

--- a/tests/js-api/src/endpoints.js
+++ b/tests/js-api/src/endpoints.js
@@ -1,0 +1,3 @@
+export function echo(request) {
+  return { body: JSON.stringify(request) };
+}

--- a/tests/js-custom-authorization/custom_authorization.py
+++ b/tests/js-custom-authorization/custom_authorization.py
@@ -371,6 +371,91 @@ def run_content_types(args):
         network = test_unknown_path(network, args)
 
 
+@reqs.description("Test request object API")
+def test_request_object_api(network, args):
+    primary, _ = network.find_nodes()
+
+    def test_expectations(expected_fields, response):
+        assert response.status_code == http.HTTPStatus.OK, response
+        j = response.body.json()
+        for k, v in expected_fields.items():
+            ks = k.split(".")
+            current = j
+            for k_ in ks:
+                assert k_ in current, f"Missing field {k} from response body"
+                current = current[k_]
+            actual = current
+            assert (
+                v == actual
+            ), f"Mismatch at field {k}. Expected '{v}', response contains '{actual}'"
+            # LOG.success(f"{k} == {v}")
+
+    def test_url(expected_fields, client, base_url, query="", url_params=None):
+        url = base_url
+        expected_fields["route"] = base_url
+
+        if url_params is not None:
+            url = url.format(**url_params)
+
+        expected_fields["path"] = url
+
+        if len(query) > 0:
+            url += f"?{query}"
+
+        expected_fields["query"] = query
+        expected_fields["url"] = url
+
+        expected_fields["method"] = "GET"
+        test_expectations(expected_fields, client.get(url))
+        expected_fields["method"] = "POST"
+        test_expectations(expected_fields, client.post(url))
+        expected_fields["method"] = "DELETE"
+        test_expectations(expected_fields, client.delete(url))
+
+    def test_client(expected_fields, client):
+        test_url(
+            {**expected_fields, "hostname": f"{client.hostname}"},
+            client,
+            "/app/echo",
+        )
+        test_url(
+            {**expected_fields, "hostname": f"{client.hostname}"},
+            client,
+            "/app/echo",
+            query="a=42&b=hello_world",
+        )
+        test_url(
+            {**expected_fields, "hostname": f"{client.hostname}"},
+            client,
+            "/app/echo/{foo}",
+            url_params={"foo": "bar"},
+        )
+        test_url(
+            {**expected_fields, "hostname": f"{client.hostname}"},
+            client,
+            "/app/echo/{foo}",
+            query="a=42&b=hello_world",
+            url_params={"foo": "bar"},
+        )
+
+    user = network.users[0]
+    with primary.client(user.local_id) as c:
+        test_client({"caller.policy": "user_cert", "caller.id": user.service_id}, c)
+
+    with primary.client() as c:
+        test_client({"caller.policy": "no_auth"}, c)
+
+    return network
+
+
+def run_request_object(args):
+    with infra.network.network(
+        args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
+    ) as network:
+        network.start_and_join(args)
+        network = test_request_object_api(network, args)
+
+
 if __name__ == "__main__":
     cr = ConcurrentRunner()
 
@@ -406,6 +491,14 @@ if __name__ == "__main__":
         package="libjs_generic",
         nodes=infra.e2e_args.nodes(cr.args, 1),
         js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-content-types"),
+    )
+
+    cr.add(
+        "request_object",
+        run_request_object,
+        package="libjs_generic",
+        nodes=infra.e2e_args.nodes(cr.args, 1),
+        js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-api"),
     )
 
     cr.run()


### PR DESCRIPTION
Resolves #3092.

Exposing URL components as described in the issue/new docs.

@letmaik: I haven't implemented this for V8. I started to, but noticed all the other tests in `custom_authorization.py` are not currently running with V8, and fail when they do. What's the expected API parity here?