### PR TITLE
Enable auth e2e test in V8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -593,8 +593,18 @@ if(BUILD_TESTS)
     PYTHON_SCRIPT
       ${CMAKE_SOURCE_DIR}/tests/js-custom-authorization/custom_authorization.py
     CONSENSUS cft
-    ADDITIONAL_ARGS --js-app-bundle ${CMAKE_SOURCE_DIR}/tests
+    ADDITIONAL_ARGS --package libjs_generic --js-app-bundle ${CMAKE_SOURCE_DIR}/tests
   )
+
+  if(ENABLE_V8)
+    add_e2e_test(
+      NAME auth_v8
+      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/js-custom-authorization/custom_authorization.py
+      CONSENSUS cft
+      ADDITIONAL_ARGS
+        --package libjs_v8 --js-app-bundle ${CMAKE_SOURCE_DIR}/tests
+    )
+  endif()
 
   add_e2e_test(
     NAME launch_host_process_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -593,16 +593,18 @@ if(BUILD_TESTS)
     PYTHON_SCRIPT
       ${CMAKE_SOURCE_DIR}/tests/js-custom-authorization/custom_authorization.py
     CONSENSUS cft
-    ADDITIONAL_ARGS --package libjs_generic --js-app-bundle ${CMAKE_SOURCE_DIR}/tests
+    ADDITIONAL_ARGS --package libjs_generic --js-app-bundle
+                    ${CMAKE_SOURCE_DIR}/tests
   )
 
   if(ENABLE_V8)
     add_e2e_test(
       NAME auth_v8
-      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/js-custom-authorization/custom_authorization.py
+      PYTHON_SCRIPT
+        ${CMAKE_SOURCE_DIR}/tests/js-custom-authorization/custom_authorization.py
       CONSENSUS cft
-      ADDITIONAL_ARGS
-        --package libjs_v8 --js-app-bundle ${CMAKE_SOURCE_DIR}/tests
+      ADDITIONAL_ARGS --package libjs_v8 --js-app-bundle
+                      ${CMAKE_SOURCE_DIR}/tests
     )
   endif()
 

--- a/scripts/v8/fetch.sh
+++ b/scripts/v8/fetch.sh
@@ -5,6 +5,8 @@
 # Fetches the Universal Artifact from Azure that was built and published with
 # build.sh. Doesn't fetch if the tarball already exists.
 
+# NB: No way to list available artifacts/versions with the CLI.
+# View https://dev.azure.com/MSRC-CCF/CCF/_packaging?_a=feed&feed=V8 for current artifacts.
 SYNTAX="fetch.sh <version (ex. 9.4.146.17)> <mode (debug|release)> <target (virtual|sgx)> [-f(orce)]"
 if [ "$1" == "" ]; then
   echo "ERROR: Missing expected argument 'version'"
@@ -49,6 +51,14 @@ if command -v az > /dev/null; then
 else
   echo " + Installing the Azure Client..."
   sudo apt update && sudo apt install azure-cli -y
+fi
+
+## Check for the Azure DevOps extension
+if az extension show --name azure-devops > /dev/null; then
+  echo " + Azure DevOps extension already installed"
+else
+  echo " + Installing the Azure DevOps extension..."
+  az extension add --name azure-devops
 fi
 
 ## Login into Azure

--- a/src/apps/js_v8/tmpl/request.h
+++ b/src/apps/js_v8/tmpl/request.h
@@ -8,6 +8,7 @@
 
 using ccf::BaseEndpointRegistry;
 using ccf::endpoints::EndpointContext;
+using ccf::endpoints::EndpointDefinition;
 
 namespace ccf::v8_tmpl
 {
@@ -19,6 +20,7 @@ namespace ccf::v8_tmpl
 
     static v8::Local<v8::Object> wrap(
       v8::Local<v8::Context> context,
+      const EndpointDefinition* endpoint_def,
       EndpointContext* endpoint_ctx,
       BaseEndpointRegistry* endpoint_registry);
   };

--- a/src/apps/js_v8/v8_runner.cpp
+++ b/src/apps/js_v8/v8_runner.cpp
@@ -306,11 +306,6 @@ namespace ccf
     v8::Isolate::CreateParams create_params;
     create_params.array_buffer_allocator =
       v8::ArrayBuffer::Allocator::NewDefaultAllocator();
-
-    // Set constrained heap size to match QuickJS
-    const size_t max_heap_size = 100 * 1024 * 1024;
-    create_params.constraints.ConfigureDefaultsFromHeapSize(0, max_heap_size);
-
     isolate_ = v8::Isolate::New(create_params);
     // Note: Out-of-memory also calls the fatal error handler.
     isolate_->SetFatalErrorHandler(on_fatal_error);

--- a/src/apps/js_v8/v8_runner.cpp
+++ b/src/apps/js_v8/v8_runner.cpp
@@ -306,6 +306,11 @@ namespace ccf
     v8::Isolate::CreateParams create_params;
     create_params.array_buffer_allocator =
       v8::ArrayBuffer::Allocator::NewDefaultAllocator();
+
+    // Set constrained heap size to match QuickJS
+    const size_t max_heap_size = 100 * 1024 * 1024;
+    create_params.constraints.ConfigureDefaultsFromHeapSize(0, max_heap_size);
+
     isolate_ = v8::Isolate::New(create_params);
     // Note: Out-of-memory also calls the fatal error handler.
     isolate_->SetFatalErrorHandler(on_fatal_error);

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -7,7 +7,6 @@ import infra.e2e_args
 from infra.tx_status import TxStatus
 import infra.checker
 import infra.jwt_issuer
-import inspect
 import http
 from http.client import HTTPResponse
 import ssl
@@ -174,7 +173,7 @@ def test_large_messages(network, args):
             # pass but not others, and finding where does it fail).
             log_id = 40
             for p in range(10, 20) if args.consensus == "CFT" else range(10, 13):
-                long_msg = "X" * (2**p)
+                long_msg = "X" * (2 ** p)
                 check_commit(
                     c.post("/app/log/private", {"id": log_id, "msg": long_msg}),
                     result=True,

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -447,9 +447,7 @@ def test_multi_auth(network, args):
         LOG.info("Authenticate via second JWT token")
         jwt2 = jwt_issuer.issue_jwt(claims={"user": "Bob"})
 
-        with primary.client(
-            common_headers={"authorization": "Bearer " + jwt2}
-        ) as c:
+        with primary.client(common_headers={"authorization": "Bearer " + jwt2}) as c:
             r = c.get("/app/multi_auth")
             require_new_response(r)
 

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -173,7 +173,7 @@ def test_large_messages(network, args):
             # pass but not others, and finding where does it fail).
             log_id = 40
             for p in range(10, 20) if args.consensus == "CFT" else range(10, 13):
-                long_msg = "X" * (2 ** p)
+                long_msg = "X" * (2**p)
                 check_commit(
                     c.post("/app/log/private", {"id": log_id, "msg": long_msg}),
                     result=True,

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -364,102 +364,94 @@ def test_multi_auth(network, args):
     member = network.consortium.members[0]
 
     with primary.client(user.local_id) as c:
-        response = c.get("/app/api")
-        supported_methods = response.body.json()["paths"]
-        if "/multi_auth" in supported_methods.keys():
-            response_bodies = set()
+        response_bodies = set()
 
-            def require_new_response(r):
-                assert r.status_code == http.HTTPStatus.OK.value, r.status_code
-                r_body = r.body.text()
-                assert r_body not in response_bodies, r_body
-                response_bodies.add(r_body)
+        def require_new_response(r):
+            assert r.status_code == http.HTTPStatus.OK.value, r.status_code
+            r_body = r.body.text()
+            assert r_body not in response_bodies, r_body
+            response_bodies.add(r_body)
 
-            LOG.info("Anonymous, no auth")
-            with primary.client() as c:
-                r = c.get("/app/multi_auth")
-                require_new_response(r)
+        LOG.info("Anonymous, no auth")
+        with primary.client() as c:
+            r = c.get("/app/multi_auth")
+            require_new_response(r)
 
-            LOG.info("Authenticate as a user, via TLS cert")
-            with primary.client(user.local_id) as c:
-                r = c.get("/app/multi_auth")
-                require_new_response(r)
+        LOG.info("Authenticate as a user, via TLS cert")
+        with primary.client(user.local_id) as c:
+            r = c.get("/app/multi_auth")
+            require_new_response(r)
 
-            LOG.info("Authenticate as same user, now with user data")
-            network.consortium.set_user_data(
-                primary, user.service_id, {"some": ["interesting", "data", 42]}
-            )
-            with primary.client(user.local_id) as c:
-                r = c.get("/app/multi_auth")
-                require_new_response(r)
+        LOG.info("Authenticate as same user, now with user data")
+        network.consortium.set_user_data(
+            primary, user.service_id, {"some": ["interesting", "data", 42]}
+        )
+        with primary.client(user.local_id) as c:
+            r = c.get("/app/multi_auth")
+            require_new_response(r)
 
-            LOG.info("Authenticate as a different user, via TLS cert")
-            with primary.client("user1") as c:
-                r = c.get("/app/multi_auth")
-                require_new_response(r)
+        LOG.info("Authenticate as a different user, via TLS cert")
+        with primary.client("user1") as c:
+            r = c.get("/app/multi_auth")
+            require_new_response(r)
 
-            LOG.info("Authenticate as a member, via TLS cert")
-            with primary.client(member.local_id) as c:
-                r = c.get("/app/multi_auth")
-                require_new_response(r)
+        LOG.info("Authenticate as a member, via TLS cert")
+        with primary.client(member.local_id) as c:
+            r = c.get("/app/multi_auth")
+            require_new_response(r)
 
-            LOG.info("Authenticate as same member, now with user data")
-            network.consortium.set_member_data(
-                primary, member.service_id, {"distinct": {"arbitrary": ["data"]}}
-            )
-            with primary.client(member.local_id) as c:
-                r = c.get("/app/multi_auth")
-                require_new_response(r)
+        LOG.info("Authenticate as same member, now with user data")
+        network.consortium.set_member_data(
+            primary, member.service_id, {"distinct": {"arbitrary": ["data"]}}
+        )
+        with primary.client(member.local_id) as c:
+            r = c.get("/app/multi_auth")
+            require_new_response(r)
 
-            LOG.info("Authenticate as a different member, via TLS cert")
-            with primary.client("member1") as c:
-                r = c.get("/app/multi_auth")
-                require_new_response(r)
+        LOG.info("Authenticate as a different member, via TLS cert")
+        with primary.client("member1") as c:
+            r = c.get("/app/multi_auth")
+            require_new_response(r)
 
-            LOG.info("Authenticate as a user, via HTTP signature")
-            with primary.client(None, user.local_id) as c:
-                r = c.get("/app/multi_auth")
-                require_new_response(r)
+        LOG.info("Authenticate as a user, via HTTP signature")
+        with primary.client(None, user.local_id) as c:
+            r = c.get("/app/multi_auth")
+            require_new_response(r)
 
-            LOG.info("Authenticate as a member, via HTTP signature")
-            with primary.client(None, member.local_id) as c:
-                r = c.get("/app/multi_auth")
-                require_new_response(r)
+        LOG.info("Authenticate as a member, via HTTP signature")
+        with primary.client(None, member.local_id) as c:
+            r = c.get("/app/multi_auth")
+            require_new_response(r)
 
-            LOG.info("Authenticate as user2 but sign as user1")
-            with primary.client("user2", "user1") as c:
-                r = c.get("/app/multi_auth")
-                require_new_response(r)
+        LOG.info("Authenticate as user2 but sign as user1")
+        with primary.client("user2", "user1") as c:
+            r = c.get("/app/multi_auth")
+            require_new_response(r)
 
-            network.create_user("user5", args.participants_curve, record=False)
+        network.create_user("user5", args.participants_curve, record=False)
 
-            LOG.info("Authenticate as invalid user5 but sign as valid user3")
-            with primary.client("user5", "user3") as c:
-                r = c.get("/app/multi_auth")
-                require_new_response(r)
+        LOG.info("Authenticate as invalid user5 but sign as valid user3")
+        with primary.client("user5", "user3") as c:
+            r = c.get("/app/multi_auth")
+            require_new_response(r)
 
-            LOG.info("Authenticate via JWT token")
-            jwt_issuer = infra.jwt_issuer.JwtIssuer()
-            jwt_issuer.register(network)
-            jwt = jwt_issuer.issue_jwt(claims={"user": "Alice"})
+        LOG.info("Authenticate via JWT token")
+        jwt_issuer = infra.jwt_issuer.JwtIssuer()
+        jwt_issuer.register(network)
+        jwt = jwt_issuer.issue_jwt(claims={"user": "Alice"})
 
-            with primary.client() as c:
-                r = c.get("/app/multi_auth", headers={"authorization": "Bearer " + jwt})
-                require_new_response(r)
+        with primary.client() as c:
+            r = c.get("/app/multi_auth", headers={"authorization": "Bearer " + jwt})
+            require_new_response(r)
 
-            LOG.info("Authenticate via second JWT token")
-            jwt2 = jwt_issuer.issue_jwt(claims={"user": "Bob"})
+        LOG.info("Authenticate via second JWT token")
+        jwt2 = jwt_issuer.issue_jwt(claims={"user": "Bob"})
 
-            with primary.client(
-                common_headers={"authorization": "Bearer " + jwt2}
-            ) as c:
-                r = c.get("/app/multi_auth")
-                require_new_response(r)
-
-        else:
-            LOG.warning(
-                f"Skipping {inspect.currentframe().f_code.co_name} as application does not implement '/multi_auth'"
-            )
+        with primary.client(
+            common_headers={"authorization": "Bearer " + jwt2}
+        ) as c:
+            r = c.get("/app/multi_auth")
+            require_new_response(r)
 
     return network
 

--- a/tests/js-custom-authorization/custom_authorization.py
+++ b/tests/js-custom-authorization/custom_authorization.py
@@ -377,7 +377,6 @@ if __name__ == "__main__":
     cr.add(
         "authz",
         run,
-        package="libjs_generic",
         nodes=infra.e2e_args.nodes(cr.args, 1),
         js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-custom-authorization"),
     )
@@ -385,7 +384,6 @@ if __name__ == "__main__":
     cr.add(
         "limits",
         run_limits,
-        package="libjs_generic",
         nodes=infra.e2e_args.nodes(cr.args, 1),
         js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-limits"),
     )
@@ -393,7 +391,6 @@ if __name__ == "__main__":
     cr.add(
         "authn",
         run_authn,
-        package="libjs_generic",
         nodes=infra.e2e_args.nodes(cr.args, 1),
         js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-authentication"),
         initial_user_count=4,
@@ -403,7 +400,6 @@ if __name__ == "__main__":
     cr.add(
         "content_types",
         run_content_types,
-        package="libjs_generic",
         nodes=infra.e2e_args.nodes(cr.args, 1),
         js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-content-types"),
     )

--- a/tests/js-custom-authorization/custom_authorization.py
+++ b/tests/js-custom-authorization/custom_authorization.py
@@ -499,7 +499,6 @@ if __name__ == "__main__":
     cr.add(
         "request_object",
         run_request_object,
-        package="libjs_generic",
         nodes=infra.e2e_args.nodes(cr.args, 1),
         js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-api"),
     )

--- a/tests/js-custom-authorization/custom_authorization.py
+++ b/tests/js-custom-authorization/custom_authorization.py
@@ -47,8 +47,14 @@ def test_stack_size_limit(network, args):
         r = c.post("/app/recursive", body={"depth": 50})
         assert r.status_code == http.HTTPStatus.OK, r.status_code
 
+    depth_limit = 2000
+    if "v8" in args.package:
+        # Stack limit is not currently configured explicitly for V8 app.
+        # Default limit requires deeper recursion to hit.
+        depth_limit = 20000
+
     with primary.client("user0") as c:
-        r = c.post("/app/recursive", body={"depth": 2000})
+        r = c.post("/app/recursive", body={"depth": depth_limit})
         assert r.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR, r.status_code
 
     return network
@@ -60,6 +66,10 @@ def test_heap_size_limit(network, args):
 
     with primary.client("user0") as c:
         r = c.post("/app/alloc", body={"size": 5 * 1024 * 1024})
+        assert r.status_code == http.HTTPStatus.OK, r.status_code
+
+    with primary.client("user0") as c:
+        r = c.post("/app/alloc", body={"size": 50 * 1024 * 1024})
         assert r.status_code == http.HTTPStatus.OK, r.status_code
 
     with primary.client("user0") as c:


### PR DESCRIPTION
Part of #3314.

~~Draft for now, because this will need updating after #3498 is merged.~~ - This is done, the fields added to the QuickJS implementation in #3498 are now also implemented in V8.

~~Includes part of #3324 - setting max heap size to same as QuickJS, but hit the same barriers that issue notes on setting a stack limit. For now, we just test that _a_ (much larger) stack limit still applies to V8.~~ - Gave up on this. Seems even the heap constraint has some platform-dependence that I'm missing, so the CI behaviour is different than local. Just disabled the `limits` test in V8 for now, with a comment pointing at #3324.