### PR TITLE
Remove docs references to old `networkcert.pem`

### DIFF
--- a/doc/audit/receipts.rst
+++ b/doc/audit/receipts.rst
@@ -11,7 +11,7 @@ This means that the request may return ``202 Accepted`` at first, with a suggest
 
 .. code-block:: bash
 
-    $ curl -X GET "https://<ccf-node-address>/app/receipt?transaction_id=2.643" --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem
+    $ curl -X GET "https://<ccf-node-address>/app/receipt?transaction_id=2.643" --cacert service_cert.pem --key user0_privk.pem --cert user0_cert.pem
 
     {'cert': '-----BEGIN CERTIFICATE-----\n'
             'MIIBzjCCAVSgAwIBAgIQGR/ue9CFspRa/g6jSMHFYjAKBggqhkjOPQQDAzAWMRQw\n'
@@ -39,7 +39,7 @@ Note that receipts over signature transactions are a special case, for example:
 
 .. code-block:: bash
 
-    $ curl -X GET "https://<ccf-node-address>/app/receipt?transaction_id=2.35" --cacert networkcert.pem --key user0_privk.pem --cert user0_cert.pem
+    $ curl -X GET "https://<ccf-node-address>/app/receipt?transaction_id=2.35" --cacert service_cert.pem --key user0_privk.pem --cert user0_cert.pem
 
     {'leaf': 'fdc977c49d3a8bdf986176984e9432a09b5f6fe0c04e0b1c2dd177c03fdca9ec',
      'node_id': '06fef62c80b6471c7005c1b114166fd1b0e077845f5ad544ad4eea4fb1d31f78',


### PR DESCRIPTION
The default name for this file is now `service_cert.pem`. I believe this is the last reference to the old name in the docs.