### PR TITLE
Redirect openenclave logging

### DIFF
--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -28,6 +28,15 @@ std::chrono::microseconds ccf::Channel::min_gap_between_initiation_attempts(
 
 extern "C"
 {
+  void open_enclave_logging_callback(
+    void* context,
+    oe_log_level_t level,
+    uint64_t thread_id,
+    const char* message)
+    {
+      LOG_INFO_FMT("OE: {}", message);
+    }
+
   CreateNodeStatus enclave_create_node(
     void* enclave_config,
     char* ccf_config,
@@ -74,6 +83,8 @@ extern "C"
       writer_factory->create_writer_to_outside());
     auto ringbuffer_logger = new_logger.get();
     logger::config::loggers().push_back(std::move(new_logger));
+
+    oe_enclave_log_set_callback(nullptr, &open_enclave_logging_callback);
 
     {
       // Report enclave version to host

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -33,9 +33,30 @@ extern "C"
     oe_log_level_t level,
     uint64_t thread_id,
     const char* message)
+  {
+    switch (level)
     {
-      LOG_INFO_FMT("OE: {}", message);
+      case OE_LOG_LEVEL_FATAL:
+        LOG_FATAL_FMT("OE: {}", message);
+        break;
+      case OE_LOG_LEVEL_ERROR:
+        LOG_FAIL_FMT("OE: {}", message);
+        break;
+      case OE_LOG_LEVEL_WARNING:
+        LOG_FAIL_FMT("OE: {}", message);
+        break;
+      case OE_LOG_LEVEL_INFO:
+        LOG_INFO_FMT("OE: {}", message);
+        break;
+      case OE_LOG_LEVEL_VERBOSE:
+        LOG_DEBUG_FMT("OE: {}", message);
+        break;
+      case OE_LOG_LEVEL_MAX:
+      case OE_LOG_LEVEL_NONE:
+        LOG_TRACE_FMT("OE: {}", message);
+        break;
     }
+  }
 
   CreateNodeStatus enclave_create_node(
     void* enclave_config,

--- a/src/enclave/oe_shim.h
+++ b/src/enclave/oe_shim.h
@@ -9,6 +9,9 @@
 
 #endif
 
+#  include <openenclave/log.h>
+#  include <openenclave/tracee.h>
+
 #ifndef VIRTUAL_ENCLAVE
 
 #  include <openenclave/edger8r/enclave.h> // For oe_lfence
@@ -41,6 +44,13 @@ OE_EXTERNC bool oe_is_outside_enclave(const void*, std::size_t)
 {
   return true;
 }
+
+OE_EXTERNC oe_result_t oe_enclave_log_set_callback(
+    void* context,
+    oe_enclave_log_callback_t callback)
+    {
+      return OE_OK;
+    }
 
 #  define oe_lfence() // nop
 

--- a/src/enclave/oe_shim.h
+++ b/src/enclave/oe_shim.h
@@ -9,8 +9,8 @@
 
 #endif
 
-#  include <openenclave/log.h>
-#  include <openenclave/tracee.h>
+#include <openenclave/log.h>
+#include <openenclave/tracee.h>
 
 #ifndef VIRTUAL_ENCLAVE
 
@@ -45,12 +45,11 @@ OE_EXTERNC bool oe_is_outside_enclave(const void*, std::size_t)
   return true;
 }
 
-OE_EXTERNC oe_result_t oe_enclave_log_set_callback(
-    void* context,
-    oe_enclave_log_callback_t callback)
-    {
-      return OE_OK;
-    }
+OE_EXTERNC oe_result_t
+oe_enclave_log_set_callback(void* context, oe_enclave_log_callback_t callback)
+{
+  return OE_OK;
+}
 
 #  define oe_lfence() // nop
 


### PR DESCRIPTION
Make use of newly added `oe_enclave_log_set_callback()` in Open Enclave 0.17.6 to redirect logs to the standard CCF mechanism.