### PR TITLE
Re-enable ledger consistency verification

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -32,8 +32,9 @@ jobs:
       # This is because the configuration of the docs (e.g. theme) will change
       # over time and only the main branch should be source of truth and be
       # kept up to date.
-
+      #
       # Only on main and not on PRs
+      # Note: override remote whitelist to detect release branches on remote
       - script: |
           set -ex
           python3.8 -m venv env
@@ -42,7 +43,7 @@ jobs:
           pip install -U -r doc/requirements.txt
           pip install -U -e ./python
           pip install -U -r doc/historical_ccf_requirements.txt
-          sphinx-multiversion doc build/html
+          sphinx-multiversion -D smv_remote_whitelist=origin doc build/html
         displayName: Sphinx Multi-version
         condition: |
           and(

--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-obey!
+trigger

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -587,9 +587,7 @@ class Network:
                 fatal_error_found = True
 
         LOG.info("All nodes stopped")
-
-        if not skip_verification:
-            self.check_ledger_files_identical()
+        self.check_ledger_files_identical()
 
         if fatal_error_found:
             if self.ignoring_shutdown_errors:

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -88,6 +88,7 @@ def run(get_command, args):
 
     args.initial_user_count = 3
     args.sig_ms_interval = 1000  # Set to cchost default value
+    args.ledger_chunk_bytes = "5MB"  # Set to cchost default value
 
     LOG.info("Starting nodes on {}".format(hosts))
 


### PR DESCRIPTION
The ledger consistency verification run at the end of all end-to-end tests seems to be skipped for most cases. I want to make sure this is still working, and measure any eventual impact on the total duration of our tests. 