### PR TITLE
Add option to skip verification ledger in `ccf.Ledger` Python module

### DIFF
--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -650,6 +650,9 @@ class Transaction(Entry):
             pos=self._tx_offset,
         )
 
+    def get_len(self) -> int:
+        return len(self.get_raw_tx())
+
     def get_tx_digest(self) -> bytes:
         claims_digest = self.get_public_domain().get_claims_digest()
         commit_evidence_digest = self.get_public_domain().get_commit_evidence_digest()
@@ -738,6 +741,9 @@ class Snapshot(Entry):
         if not self.is_committed():
             raise ValueError(f"Snapshot file {self._filename} is not yet committed")
         return len(self._filename.split(COMMITTED_FILE_SUFFIX)[1]) != 0
+
+    def get_len(self) -> int:
+        return self._file_size
 
 
 class LedgerChunk:

--- a/python/ccf/read_ledger.py
+++ b/python/ccf/read_ledger.py
@@ -82,7 +82,7 @@ def dump_entry(entry, table_filter, tables_format_rules):
     flags = entry.get_transaction_header().flags
     flags_msg = "" if flags == 0 else f", flags={hex(flags)}"
     LOG.success(
-        f"{indent(2)}seqno {public_transaction.get_seqno()} ({counted_string(public_tables, 'public table')}) [{len(entry.get_raw_tx())} bytes{flags_msg}]"
+        f"{indent(2)}seqno {public_transaction.get_seqno()} ({counted_string(public_tables, 'public table')}) [{entry.get_len()} bytes{flags_msg}]"
     )
 
     private_table_size = entry.get_private_domain_size()
@@ -116,51 +116,29 @@ def dump_entry(entry, table_filter, tables_format_rules):
                 )
 
 
-def run(args_, tables_format_rules=None):
-    parser = argparse.ArgumentParser(
-        description="Read CCF ledger or snapshot",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
-    parser.add_argument(
-        "paths", help="Path to ledger directories or snapshot file", nargs="+"
-    )
-    parser.add_argument(
-        "-s",
-        "--snapshot",
-        help="Indicates that the path to read is a snapshot",
-        action="store_true",
-    )
-    parser.add_argument(
-        "-t",
-        "--tables",
-        help="Regex filter for tables to display",
-        type=str,
-        default=".*",
-    )
-    parser.add_argument(
-        "--uncommitted", help="Also parse uncommitted ledger files", action="store_true"
-    )
-    args = parser.parse_args(args_)
-
-    table_filter = re.compile(args.tables)
+def run(
+    paths, is_snapshot=False, tables=".*", uncommitted=False, tables_format_rules=None
+):
 
     # Extend and compile rules
+    table_filter = re.compile(tables)
     tables_format_rules = tables_format_rules or []
     tables_format_rules.extend(default_tables_format_rules)
     tables_format_rules = [
         (re.compile(table_name_re), _) for (table_name_re, _) in tables_format_rules
     ]
 
-    if args.snapshot:
-        snapshot_file = args.paths[0]
+    if is_snapshot:
+        snapshot_file = paths[0]
         with ccf.ledger.Snapshot(snapshot_file) as snapshot:
             LOG.info(
                 f"Reading snapshot from {snapshot_file} ({'' if snapshot.is_committed() else 'un'}committed)"
             )
             dump_entry(snapshot, table_filter, tables_format_rules)
+        return True
     else:
-        ledger_dirs = args.paths
-        ledger = ccf.ledger.Ledger(ledger_dirs, committed_only=not args.uncommitted)
+        ledger_dirs = paths
+        ledger = ccf.ledger.Ledger(ledger_dirs, committed_only=not uncommitted)
 
         LOG.info(f"Reading ledger from {ledger_dirs}")
         LOG.info(f"Contains {counted_string(ledger, 'chunk')}")
@@ -193,5 +171,30 @@ if __name__ == "__main__":
         format="<level>{message}</level>",
     )
 
-    if not run(sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description="Read CCF ledger or snapshot",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "paths", help="Path to ledger directories or snapshot file", nargs="+"
+    )
+    parser.add_argument(
+        "-s",
+        "--snapshot",
+        help="Indicates that the path to read is a snapshot",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-t",
+        "--tables",
+        help="Regex filter for tables to display",
+        type=str,
+        default=".*",
+    )
+    parser.add_argument(
+        "--uncommitted", help="Also parse uncommitted ledger files", action="store_true"
+    )
+    args = parser.parse_args()
+
+    if not run(args.paths, args.snapshot, args.tables, args.uncommitted):
         sys.exit(1)

--- a/python/ccf/read_ledger.py
+++ b/python/ccf/read_ledger.py
@@ -117,7 +117,12 @@ def dump_entry(entry, table_filter, tables_format_rules):
 
 
 def run(
-    paths, is_snapshot=False, tables=".*", uncommitted=False, tables_format_rules=None
+    paths,
+    is_snapshot=False,
+    tables=".*",
+    uncommitted=False,
+    insecure_skip_verification=False,
+    tables_format_rules=None,
 ):
 
     # Extend and compile rules
@@ -138,7 +143,11 @@ def run(
         return True
     else:
         ledger_dirs = paths
-        ledger = ccf.ledger.Ledger(ledger_dirs, committed_only=not uncommitted)
+        ledger = ccf.ledger.Ledger(
+            ledger_dirs,
+            committed_only=not uncommitted,
+            insecure_skip_verification=insecure_skip_verification,
+        )
 
         LOG.info(f"Reading ledger from {ledger_dirs}")
         LOG.info(f"Contains {counted_string(ledger, 'chunk')}")
@@ -157,9 +166,12 @@ def run(
             LOG.success("Ledger verification complete")
             has_error = False
         finally:
-            LOG.info(
-                f"Found {ledger.signature_count()} signatures, and verified until {ledger.last_verified_txid()}"
-            )
+            if insecure_skip_verification:
+                LOG.warning(f"Skipped ledger integrity verification")
+            else:
+                LOG.info(
+                    f"Found {ledger.signature_count()} signatures, and verified until {ledger.last_verified_txid()}"
+                )
         return not has_error
 
 
@@ -194,7 +206,19 @@ if __name__ == "__main__":
     parser.add_argument(
         "--uncommitted", help="Also parse uncommitted ledger files", action="store_true"
     )
+    parser.add_argument(
+        "--insecure-skip-verification",
+        help="INSECURE: skip ledger Merkle tree integrity verification",
+        action="store_true",
+        default=False,
+    )
     args = parser.parse_args()
 
-    if not run(args.paths, args.snapshot, args.tables, args.uncommitted):
+    if not run(
+        args.paths,
+        args.snapshot,
+        args.tables,
+        args.uncommitted,
+        args.insecure_skip_verification,
+    ):
         sys.exit(1)

--- a/tests/governance.py
+++ b/tests/governance.py
@@ -472,9 +472,6 @@ if __name__ == "__main__":
         governance_history.run,
         package="samples/apps/logging/liblogging",
         nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-        # Higher snapshot interval as snapshots trigger new ledger chunks, which
-        # may result in latest chunk being partially written
-        snapshot_tx_interval=10000,
     )
 
     cr.run(2)


### PR DESCRIPTION
Verifying the integrity of a ledger when parsing it is useful by default, but we sometimes want to display the content of a single ledger file without having to parse all previous ledger files. This PR adds a new option to skip the integrity verification (also available via `read_ledger.py`). 

I understand there may be more subtle ways to do this so opening as a draft PR for discussion.

Also contains changes from #3534 