### PR TITLE
Correct `scurl.sh` args in doc samples

### DIFF
--- a/doc/governance/accept_recovery.rst
+++ b/doc/governance/accept_recovery.rst
@@ -22,7 +22,7 @@ A member proposes to recover the network and other members can vote on the propo
         ]
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert --key member1_privk --cert member1_cert --data-binary @transition_service_to_open.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert.pem --signing-key member1_privk.pem --signing-cert member1_cert.pem --data-binary @transition_service_to_open.json -H "content-type: application/json"
     {
         "ballot_count": 0,
         "proposal_id": "1b7cae1585077104e99e1860ad740efe28ebd498dbf9988e0e7b299e720c5377",
@@ -30,7 +30,7 @@ A member proposes to recover the network and other members can vote on the propo
         "state": "Open"
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals/1b7cae1585077104e99e1860ad740efe28ebd498dbf9988e0e7b299e720c5377/ballots --cacert service_cert --key member2_privk --cert member2_cert --data-binary @vote_accept.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals/1b7cae1585077104e99e1860ad740efe28ebd498dbf9988e0e7b299e720c5377/ballots --cacert service_cert.pem --signing-key member2_privk.pem --signing-cert member2_cert.pem --data-binary @vote_accept.json -H "content-type: application/json"
     {
         "ballot_count": 1,
         "proposal_id": "1b7cae1585077104e99e1860ad740efe28ebd498dbf9988e0e7b299e720c5377",
@@ -38,7 +38,7 @@ A member proposes to recover the network and other members can vote on the propo
         "state": "Open"
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals/1b7cae1585077104e99e1860ad740efe28ebd498dbf9988e0e7b299e720c5377/ballots --cacert service_cert --key member3_privk --cert member3_cert --data-binary @vote_accept.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals/1b7cae1585077104e99e1860ad740efe28ebd498dbf9988e0e7b299e720c5377/ballots --cacert service_cert.pem --signing-key member3_privk.pem --signing-cert member3_cert.pem --data-binary @vote_accept.json -H "content-type: application/json"
     {
         "ballot_count": 2,
         "proposal_id": "1b7cae1585077104e99e1860ad740efe28ebd498dbf9988e0e7b299e720c5377",
@@ -61,15 +61,15 @@ The recovery share retrieval, decryption and submission steps can be convenientl
 
 .. code-block:: bash
 
-    $ submit_recovery_share.sh https://<ccf-node-address> --member-enc-privk member0_enc_privk.pem --cert member0_cert
-    --key member0_privk --cacert service_cert
+    $ submit_recovery_share.sh https://<ccf-node-address> --member-enc-privk member0_enc_privk.pem --cert member0_cert.pem
+    --key member0_privk.pem --cacert service_cert.pem
     HTTP/1.1 200 OK
     content-type: text/plain
     x-ms-ccf-transaction-id: 4.28
     1/2 recovery shares successfully submitted.
 
-    $ submit_recovery_share.sh https://<ccf-node-address> --member-enc-privk member1_enc_privk.pem --cert member1_cert
-    --key member1_privk --cacert service_cert
+    $ submit_recovery_share.sh https://<ccf-node-address> --member-enc-privk member1_enc_privk.pem --cert member1_cert.pem
+    --key member1_privk.pem --cacert service_cert.pem
     HTTP/1.1 200 OK
     content-type: text/plain
     x-ms-ccf-transaction-id: 4.30

--- a/doc/governance/adding_member.rst
+++ b/doc/governance/adding_member.rst
@@ -65,7 +65,7 @@ Then, the new member should sign the state digest returned by the ``/gov/ack/upd
 
 .. code-block:: bash
 
-    $ scurl.sh https://<ccf-node-address>/gov/ack  --cacert service_cert.pem --key new_member_privk.pem --cert new_member_cert.pem --header "Content-Type: application/json" --data-binary '{"state_digest": <...>}'
+    $ scurl.sh https://<ccf-node-address>/gov/ack  --cacert service_cert.pem --signing-key new_member_privk.pem --signing-cert new_member_cert.pem --header "Content-Type: application/json" --data-binary '{"state_digest": <...>}'
     true
 
 Once the command completes, the new member becomes active and can take part in governance operations (e.g. creating a new proposal or voting for an existing one).

--- a/doc/governance/common_member_operations.rst
+++ b/doc/governance/common_member_operations.rst
@@ -70,7 +70,7 @@ To limit the scope of key compromise, members of the consortium can refresh the 
         ]
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert --key member1_privk --cert member1_cert --data-binary @trigger_ledger_rekey.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert.pem --signing-key member1_privk.pem --signing-cert member1_cert.pem --data-binary @trigger_ledger_rekey.json -H "content-type: application/json"
     {
         "ballot_count": 0,
         "proposal_id": "2f739d154b8cddacd7fc6d03cc8d4d20626e477ec4b1af10a74c670bb38bed5e",
@@ -78,7 +78,7 @@ To limit the scope of key compromise, members of the consortium can refresh the 
         "state": "Open"
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals/2f739d154b8cddacd7fc6d03cc8d4d20626e477ec4b1af10a74c670bb38bed5e/ballots --cacert service_cert --key member2_privk --cert member2_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals/2f739d154b8cddacd7fc6d03cc8d4d20626e477ec4b1af10a74c670bb38bed5e/ballots --cacert service_cert.pem --signing-key member2_privk.pem --signing-cert member2_cert.pem --data-binary @vote_accept_1.json -H "content-type: application/json"
     {
         "ballot_count": 1,
         "proposal_id": "2f739d154b8cddacd7fc6d03cc8d4d20626e477ec4b1af10a74c670bb38bed5e",
@@ -86,7 +86,7 @@ To limit the scope of key compromise, members of the consortium can refresh the 
         "state": "Open"
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals/2f739d154b8cddacd7fc6d03cc8d4d20626e477ec4b1af10a74c670bb38bed5e/ballots --cacert service_cert --key member3_privk --cert member3_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals/2f739d154b8cddacd7fc6d03cc8d4d20626e477ec4b1af10a74c670bb38bed5e/ballots --cacert service_cert.pem --signing-key member3_privk --signing-cert member3_cert.pem --data-binary @vote_accept_1.json -H "content-type: application/json"
     {
         "ballot_count": 2,
         "proposal_id": "2f739d154b8cddacd7fc6d03cc8d4d20626e477ec4b1af10a74c670bb38bed5e",
@@ -119,7 +119,7 @@ The number of member shares required to restore the private ledger (``recovery_t
         ]
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert --key member1_privk --cert member1_cert --data-binary @set_recovery_threshold.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert.pem --signing-key member1_privk.pem --signing-cert member1_cert.pem --data-binary @set_recovery_threshold.json -H "content-type: application/json"
     {
         "ballot_count": 0,
         "proposal_id": "b9c08b3861395eca904d913427dcb436136e277cf4712eb14e9e9cddf9d231a8",
@@ -127,7 +127,7 @@ The number of member shares required to restore the private ledger (``recovery_t
         "state": "Open"
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals/b9c08b3861395eca904d913427dcb436136e277cf4712eb14e9e9cddf9d231a8/ballots --cacert service_cert --key member2_privk --cert member2_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals/b9c08b3861395eca904d913427dcb436136e277cf4712eb14e9e9cddf9d231a8/ballots --cacert service_cert.pem --signing-key member2_privk.pem --signing-cert member2_cert.pem --data-binary @vote_accept_1.json -H "content-type: application/json"
     {
         "ballot_count": 1,
         "proposal_id": "b9c08b3861395eca904d913427dcb436136e277cf4712eb14e9e9cddf9d231a8",
@@ -136,7 +136,7 @@ The number of member shares required to restore the private ledger (``recovery_t
     }
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals/b9c08b3861395eca904d913427dcb436136e277cf4712eb14e9e9cddf9d231a8/ballots --cacert service_cert --key member3_privk --cert member3_cert --data-binary @vote_accept_1.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals/b9c08b3861395eca904d913427dcb436136e277cf4712eb14e9e9cddf9d231a8/ballots --cacert service_cert.pem --signing-key member3_privk.pem --signing-cert member3_cert.pem --data-binary @vote_accept_1.json -H "content-type: application/json"
     {
         "ballot_count": 2,
         "proposal_id": "b9c08b3861395eca904d913427dcb436136e277cf4712eb14e9e9cddf9d231a8",

--- a/doc/governance/open_network.rst
+++ b/doc/governance/open_network.rst
@@ -25,7 +25,7 @@ Then, the certificates of trusted users should be registered in CCF via the memb
         ]
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert --key member0_privk --cert member0_cert --data-binary @add_user.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert.pem --key member0_privk --cert member0_cert --data-binary @set_user.json -H "content-type: application/json"
     {
         "ballot_count": 0,
         "proposal_id": "f665047e3d1eb184a7b7921944a8ab543cfff117aab5b6358dc87f9e70278253",
@@ -42,7 +42,7 @@ Other members are then allowed to vote for the proposal, using the proposal id r
         "ballot": "export function vote (proposal, proposerId) { return true }"
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals/f665047e3d1eb184a7b7921944a8ab543cfff117aab5b6358dc87f9e70278253/ballots --cacert service_cert --key member1_privk --cert member1_cert --data-binary @vote_accept.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals/f665047e3d1eb184a7b7921944a8ab543cfff117aab5b6358dc87f9e70278253/ballots --cacert service_cert.pem --key member1_privk --cert member1_cert --data-binary @vote_accept.json -H "content-type: application/json"
     {
         "ballot_count": 1,
         "proposal_id": "f665047e3d1eb184a7b7921944a8ab543cfff117aab5b6358dc87f9e70278253",
@@ -55,7 +55,7 @@ Other members are then allowed to vote for the proposal, using the proposal id r
         "ballot": "export function vote (proposal, proposerId) { return proposerId == \"2af6cb6c0af07818186f7ef7151061174c3cb74b4a4c30a04a434f0c2b00a8c0\" }"
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals/f665047e3d1eb184a7b7921944a8ab543cfff117aab5b6358dc87f9e70278253/ballots --cacert service_cert --key member2_privk --cert member2_cert --data-binary @vote_conditional.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals/f665047e3d1eb184a7b7921944a8ab543cfff117aab5b6358dc87f9e70278253/ballots --cacert service_cert.pem --key member2_privk --cert member2_cert --data-binary @vote_conditional.json -H "content-type: application/json"
     {
         "ballot_count": 2,
         "proposal_id": "f665047e3d1eb184a7b7921944a8ab543cfff117aab5b6358dc87f9e70278253",
@@ -135,7 +135,7 @@ Once users are added to the opening network, members should create a proposal to
         ]
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert --key member0_privk --cert member0_cert --data-binary @transition_service_to_open.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert.pem --key member0_privk --cert member0_cert --data-binary @transition_service_to_open.json -H "content-type: application/json"
     {
         "ballot_count": 0,
         "proposal_id": "77374e16de0b2d61f58aec84d01e6218205d19c9401d2df127d893ce62576b81",

--- a/doc/governance/open_network.rst
+++ b/doc/governance/open_network.rst
@@ -25,7 +25,7 @@ Then, the certificates of trusted users should be registered in CCF via the memb
         ]
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert.pem --key member0_privk --cert member0_cert --data-binary @set_user.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert.pem --signing-key member0_privk.pem --signing-cert member0_cert.pem --data-binary @set_user.json -H "content-type: application/json"
     {
         "ballot_count": 0,
         "proposal_id": "f665047e3d1eb184a7b7921944a8ab543cfff117aab5b6358dc87f9e70278253",
@@ -42,7 +42,7 @@ Other members are then allowed to vote for the proposal, using the proposal id r
         "ballot": "export function vote (proposal, proposerId) { return true }"
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals/f665047e3d1eb184a7b7921944a8ab543cfff117aab5b6358dc87f9e70278253/ballots --cacert service_cert.pem --key member1_privk --cert member1_cert --data-binary @vote_accept.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals/f665047e3d1eb184a7b7921944a8ab543cfff117aab5b6358dc87f9e70278253/ballots --cacert service_cert.pem --signing-key member1_privk.pem --signing-cert member1_cert.pem --data-binary @vote_accept.json -H "content-type: application/json"
     {
         "ballot_count": 1,
         "proposal_id": "f665047e3d1eb184a7b7921944a8ab543cfff117aab5b6358dc87f9e70278253",
@@ -55,7 +55,7 @@ Other members are then allowed to vote for the proposal, using the proposal id r
         "ballot": "export function vote (proposal, proposerId) { return proposerId == \"2af6cb6c0af07818186f7ef7151061174c3cb74b4a4c30a04a434f0c2b00a8c0\" }"
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals/f665047e3d1eb184a7b7921944a8ab543cfff117aab5b6358dc87f9e70278253/ballots --cacert service_cert.pem --key member2_privk --cert member2_cert --data-binary @vote_conditional.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals/f665047e3d1eb184a7b7921944a8ab543cfff117aab5b6358dc87f9e70278253/ballots --cacert service_cert.pem --signing-key member2_privk.pem --signing-cert member2_cert.pem --data-binary @vote_conditional.json -H "content-type: application/json"
     {
         "ballot_count": 2,
         "proposal_id": "f665047e3d1eb184a7b7921944a8ab543cfff117aab5b6358dc87f9e70278253",
@@ -135,7 +135,7 @@ Once users are added to the opening network, members should create a proposal to
         ]
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert.pem --key member0_privk --cert member0_cert --data-binary @transition_service_to_open.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert.pem --signing-key member0_privk.pem --signing-cert member0_cert.pem --data-binary @transition_service_to_open.json -H "content-type: application/json"
     {
         "ballot_count": 0,
         "proposal_id": "77374e16de0b2d61f58aec84d01e6218205d19c9401d2df127d893ce62576b81",

--- a/doc/governance/proposals.rst
+++ b/doc/governance/proposals.rst
@@ -264,7 +264,7 @@ For example, ``member1`` may submit a proposal to add a new member (``member4``)
       ]
     }
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert --key member1_privk --cert member1_cert --data-binary @add_member.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals --cacert service_cert.pem --signing-key member1_privk.pem --signing-cert member1_cert.pem --data-binary @add_member.json -H "content-type: application/json"
     {
       "ballot_count": 0,
       "proposal_id": "d4ec2de82267f97d3d1b464020af0bd3241f1bedf769f0fee73cd00f08e9c7fd",
@@ -288,7 +288,7 @@ Here a new proposal has successfully been created, and nobody has yet voted for 
 
 
     # Member 1 approves the proposal (votes in favour: 1/3)
-    $ scurl.sh https://<ccf-node-address>/gov/proposals/d4ec2de82267f97d3d1b464020af0bd3241f1bedf769f0fee73cd00f08e9c7fd/ballots --cacert service_cert --key member1_privk --cert member1_cert --data-binary @vote_accept.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals/d4ec2de82267f97d3d1b464020af0bd3241f1bedf769f0fee73cd00f08e9c7fd/ballots --cacert service_cert.pem --signing-key member1_privk.pem --signing-cert member1_cert.pem --data-binary @vote_accept.json -H "content-type: application/json"
     {
       "ballot_count": 1,
       "proposal_id": "d4ec2de82267f97d3d1b464020af0bd3241f1bedf769f0fee73cd00f08e9c7fd",
@@ -298,7 +298,7 @@ Here a new proposal has successfully been created, and nobody has yet voted for 
 
 
     # Member 2 rejects the proposal (votes in favour: 1/3)
-    $ scurl.sh https://<ccf-node-address>/gov/proposals/d4ec2de82267f97d3d1b464020af0bd3241f1bedf769f0fee73cd00f08e9c7fd/ballots --cacert service_cert --key member2_privk --cert member2_cert --data-binary @vote_reject.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals/d4ec2de82267f97d3d1b464020af0bd3241f1bedf769f0fee73cd00f08e9c7fd/ballots --cacert service_cert.pem --signing-key member2_privk.pem --signing-cert member2_cert.pem --data-binary @vote_reject.json -H "content-type: application/json"
     {
       "ballot_count": 2,
       "proposal_id": "d4ec2de82267f97d3d1b464020af0bd3241f1bedf769f0fee73cd00f08e9c7fd",
@@ -307,7 +307,7 @@ Here a new proposal has successfully been created, and nobody has yet voted for 
     }
 
     # Member 3 accepts the proposal (votes in favour: 2/3)
-    $ scurl.sh https://<ccf-node-address>/gov/proposals/d4ec2de82267f97d3d1b464020af0bd3241f1bedf769f0fee73cd00f08e9c7fd/ballots --cacert service_cert --key member3_privk --cert member3_cert --data-binary @vote_accept.json -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals/d4ec2de82267f97d3d1b464020af0bd3241f1bedf769f0fee73cd00f08e9c7fd/ballots --cacert service_cert.pem --signing-key member3_privk.pem --signing-cert member3_cert.pem --data-binary @vote_accept.json -H "content-type: application/json"
     {
       "ballot_count": 3,
       "proposal_id": "d4ec2de82267f97d3d1b464020af0bd3241f1bedf769f0fee73cd00f08e9c7fd",
@@ -328,7 +328,7 @@ The details of pending proposals, can be queried from the service by calling :ht
 
 .. code-block:: bash
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals/d4ec2de82267f97d3d1b464020af0bd3241f1bedf769f0fee73cd00f08e9c7fd --cacert service_cert.pem --key member3_privk.pem --cert member3_cert.pem -H "content-type: application/json" -X GET
+    $ scurl.sh https://<ccf-node-address>/gov/proposals/d4ec2de82267f97d3d1b464020af0bd3241f1bedf769f0fee73cd00f08e9c7fd --cacert service_cert.pem --signing-key member3_privk.pem --signing-cert member3_cert.pem -H "content-type: application/json" -X GET
     {
       "ballots": {
         "0d8866bf4623a685963f3c087cd6fdcdf48fc483d774f7fc28bf428e31755aaa": "export function vote (proposal, proposerId) { return true }",
@@ -351,7 +351,7 @@ At any stage during the voting process, before the proposal is accepted, the pro
 
 .. code-block:: bash
 
-    $ scurl.sh https://<ccf-node-address>/gov/proposals/d4ec2de82267f97d3d1b464020af0bd3241f1bedf769f0fee73cd00f08e9c7fd/withdraw --cacert service_cert.pem --key member1_privk.pem --cert member1_cert.pem -H "content-type: application/json"
+    $ scurl.sh https://<ccf-node-address>/gov/proposals/d4ec2de82267f97d3d1b464020af0bd3241f1bedf769f0fee73cd00f08e9c7fd/withdraw --cacert service_cert.pem --signing-key member1_privk.pem --signing-cert member1_cert.pem -H "content-type: application/json"
     {
       "ballot_count": 1,
       "proposal_id": "d4ec2de82267f97d3d1b464020af0bd3241f1bedf769f0fee73cd00f08e9c7fd",

--- a/doc/use_apps/issue_commands.rst
+++ b/doc/use_apps/issue_commands.rst
@@ -34,6 +34,8 @@ In some situations CCF requires signed requests, for example for member votes.
 The signing scheme is compatible with the `IETF HTTP Signatures draft RFC <https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-08>`_,
 and supports the `ecdsa-sha256` as well as `hs2019` signing algorithms as described in the later `draft 12 <https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12>`_
 We provide a wrapper script (``scurl.sh``) around ``curl`` to submit signed requests from the command line.
+This passes most args verbatim to ``curl``, but expects additional ``--signing-cert`` and ``--signing-key`` args which specify the identity used to sign the request.
+These are distinct from the ``--cert`` and ``--key`` args which are passed to ``curl`` as the client TLS identity, and may specify a different identity.
 
 CCF identifies the signing identity for a request via the SHA-256 digest of its certificate (DER encoded), represented as a hex string.
 That value must be set in the ``keyId`` field of the ``Authorization`` HTTP header for a signed request.

--- a/python/utils/scurl.sh
+++ b/python/utils/scurl.sh
@@ -33,9 +33,11 @@ for item in "$@" ; do
         next_is_command=false
     fi
     if [ "$next_is_privk" == true ]; then
+        privk=$item
         next_is_privk=false
     fi
     if [ "$next_is_cert" == true ]; then
+        cert=$item
         next_is_cert=false
     fi
     if [ "$next_is_signing_privk" == true ]; then
@@ -78,12 +80,23 @@ for item in "$@" ; do
     fwd_args+=("$item")
 done
 
+has_required_args=true
 if [ -z "$signing_cert" ]; then
-    echo "Error: No signing certificate found in arguments (--signing-cert)"
-    exit 1
+    echo "Error: No signing certificate found in arguments (--signing-cert)."
+    if [ ! -z "$cert" ]; then
+        echo "  Did you mean: --signing-cert $cert?"
+    fi
+    has_required_args=false
 fi
 if [ -z "$signing_privk" ] && [ "$is_print_digest_to_sign" == false ]; then
-    echo "Error: No signing private key found in arguments (--signing-key)"
+    echo "Error: No signing private key found in arguments (--signing-key)."
+    if [ ! -z "$privk" ]; then
+        echo "  Did you mean: --signing-key $privk?"
+    fi
+    has_required_args=false
+fi
+
+if [ "$has_required_args" == false ]; then
     exit 1
 fi
 


### PR DESCRIPTION
As pointed out in #3540, our docs samples describing `scurl.sh` pass the wrong arguments - `--cert` and `--key` rather than `--signing-cert` and `--signing-key`.

I've done a pass to fix these sample commands, and also clarified that the arguments are files (I think they should be `service_cert.pem` or `<service_cert>`, but not `service_cert` - I opted for the former).

Also tweaked the error message when these args are missing, if `--cert`/`--key` are passed, to point users towards the fix.

(As an alternative approach, I tried tweaking `scurl.sh` to use `--cert` as default `--signing-cert` when `--signing-cert` is not specified. This is a small diff, and may reduce friction, but re-using/re-interpreting `curl`'s arguments is very different from adding our own, so I think this approach is safer)