### PR TITLE
Restore edit on GitHub link

### DIFF
--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -1,12 +1,14 @@
 {#-
-  This extends page.html from the Furo template to add an Edit on GitHub button to the footer.
+  This extends page.html from the Furo template to add GitHub links.
 -#}
 {% extends "!page.html" %}
 {% block footer %}
   {{ super() }}
   <script>
+    // Edit this page, on GitHub
     var contentIconContainer = document.querySelector(".content-icon-container");
-    const content =`<div class="edit-this-page">
+    const editContent = `
+    <div class="edit-this-page">
       <a class="muted-link" href="https://github.com/{{ github_user }}/{{ github_repo }}/edit/{{ github_version }}/{{ doc_path }}{{ pagename }}{{ page_source_suffix }}">
         <svg viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
           <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
@@ -15,6 +17,16 @@
         </svg>
       </a>
     </div>`;
-    contentIconContainer.insertAdjacentHTML("afterbegin", content);
+    contentIconContainer.insertAdjacentHTML("afterbegin", editContent);
+
+    // Show GitHub repository home
+    var icons = document.querySelector(".icons")
+    const repoLinkContent = `
+    <a class="muted-link" href="https://github.com/{{ github_user }}/{{ github_repo }}" aria-label="On GitHub">
+      <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16">
+        <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
+      </svg>
+    </a>`;
+    icons.insertAdjacentHTML("beforeend", repoLinkContent);
   </script>
 {% endblock %}

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -5,7 +5,16 @@
 {% block footer %}
   {{ super() }}
   <script>
-    var relatedInfo = document.querySelector(".related-information");
-    relatedInfo.insertAdjacentHTML("beforeend", '| <a class="muted-link" href="https://github.com/microsoft/CCF/edit/main/doc/{{ pagename }}{{ page_source_suffix }}" rel="nofollow">Edit</a>');
+    var contentIconContainer = document.querySelector(".content-icon-container");
+    const content =`<div class="edit-this-page">
+      <a class="muted-link" href="https://github.com/{{ github_user }}/{{ github_repo }}/edit/{{ github_version }}/{{ doc_path }}{{ pagename }}{{ page_source_suffix }}">
+        <svg viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+          <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+          <path d="M4 20h4l10.5 -10.5a1.5 1.5 0 0 0 -4 -4l-10.5 10.5v4" />
+          <line x1="13.5" y1="6.5" x2="17.5" y2="10.5" />
+        </svg>
+      </a>
+    </div>`;
+    contentIconContainer.insertAdjacentHTML("afterbegin", content);
   </script>
 {% endblock %}

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -94,4 +94,3 @@ CCF Documentation
     contribute/index.rst
     architecture/index.rst
     research/index.rst
-    GitHub Repository <https://github.com/microsoft/CCF>


### PR DESCRIPTION
A recent update to the furo theme broke our hack that inserted an `Edit on GitHub` link to the footer. This restores that link, more closely matching the existing `Edit on GitHub` button that the theme inserts for RTD so that it's a) consistent with other sites, and b) less likely to break in future. This uses more of the `html_context` defined in `conf,py`, and less hard-coded URL elements.

The edit button is now this little pencil icon:
![image](https://user-images.githubusercontent.com/6000239/154118769-57b074cf-644f-4b41-b81d-5d0ea7f30bc8.png)

Additionally, this moves the link to the GitHub repo from the sidebar to an icon in the footer, again for consistency with other sites using this theme. Happy to revert that, if we prefer the verbose version in the sidebar.

Before:
![image](https://user-images.githubusercontent.com/6000239/154118547-0880a0e0-b68c-43d7-8c4c-f778fcedde34.png)

After:
![image](https://user-images.githubusercontent.com/6000239/154118669-9ccd0cb7-09ac-4ef9-8ed3-8a82f9d378b2.png)
