### PR TITLE
Convert `build_bundle.js` to use CommonJS

### DIFF
--- a/tests/npm-app/build_bundle.js
+++ b/tests/npm-app/build_bundle.js
@@ -1,15 +1,15 @@
-import { readdirSync, statSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+const fs = require("fs");
+const path = require("path");
 
 const args = process.argv.slice(2);
 
 const getAllFiles = function (dirPath, arrayOfFiles) {
   arrayOfFiles = arrayOfFiles || [];
 
-  const files = readdirSync(dirPath);
+  const files = fs.readdirSync(dirPath);
   for (const file of files) {
-    const filePath = join(dirPath, file);
-    if (statSync(filePath).isDirectory()) {
+    const filePath = path.join(dirPath, file);
+    if (fs.statSync(filePath).isDirectory()) {
       arrayOfFiles = getAllFiles(filePath, arrayOfFiles);
     } else {
       arrayOfFiles.push(filePath);
@@ -25,10 +25,10 @@ const removePrefix = function (s, prefix) {
 
 const rootDir = args[0];
 
-const metadataPath = join(rootDir, "app.json");
-const metadata = JSON.parse(readFileSync(metadataPath, "utf-8"));
+const metadataPath = path.join(rootDir, "app.json");
+const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf-8"));
 
-const srcDir = join(rootDir, "src");
+const srcDir = path.join(rootDir, "src");
 const allFiles = getAllFiles(srcDir);
 
 // The trailing / is included so that it is trimmed in removePrefix.
@@ -38,11 +38,11 @@ const toTrim = srcDir + "/";
 const modules = allFiles.map(function (filePath) {
   return {
     name: removePrefix(filePath, toTrim),
-    module: readFileSync(filePath, "utf-8"),
+    module: fs.readFileSync(filePath, "utf-8"),
   };
 });
 
-const bundlePath = join(args[0], "bundle.json");
+const bundlePath = path.join(args[0], "bundle.json");
 const bundle = {
   metadata: metadata,
   modules: modules,
@@ -50,4 +50,4 @@ const bundle = {
 console.log(
   `Writing bundle containing ${modules.length} modules to ${bundlePath}`
 );
-writeFileSync(bundlePath, JSON.stringify(bundle));
+fs.writeFileSync(bundlePath, JSON.stringify(bundle));

--- a/tests/npm-app/package.json
+++ b/tests/npm-app/package.json
@@ -4,7 +4,7 @@
     "build": "del-cli -f dist/ && rollup --config && cp app.json dist/ && node build_bundle.js dist/",
     "bundle": "node build_bundle.js dist"
   },
-  "type": "module",
+  "type": "commonjs",
   "dependencies": {
     "@microsoft/ccf-app": "file:../../js/ccf-app",
     "js-base64": "^3.5.2",


### PR DESCRIPTION
The `import` syntax was only recently supported in `node` (v12), so does not work in the node that is available in our Docker containers (v10). To avoid compile errors, I've rewritten it to use the older `require` syntax, so it should work across more `node` versions.