### PR TITLE
Explicitly copy doxygen HTML output

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1183,7 +1183,7 @@ GENERATE_HTML          = YES
 # The default directory is: html.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_OUTPUT            = doxygen_html
+HTML_OUTPUT            = html
 
 # The HTML_FILE_EXTENSION tag can be used to specify the file extension for each
 # generated HTML page (for example: .htm, .php, .asp).

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -398,7 +398,7 @@ def setup(app):
         app.connect("config-inited", config_inited)
 
     doc_dir = pathlib.Path(app.srcdir)  # CCF/doc/
-    root_dir = os.path.abspath(doc_dir / "..")  # CCF/
+    root_dir = pathlib.Path(os.path.abspath(doc_dir / ".."))  # CCF/
     out_dir = pathlib.Path(app.outdir) # CCF/build/html
 
     # import ccf python package to generate docs for this version
@@ -409,9 +409,9 @@ def setup(app):
     breathe_projects["CCF"] = str(doc_dir / breathe_projects["CCF"])
     if not os.environ.get("SKIP_DOXYGEN"):
         subprocess.run(["doxygen"], cwd=root_dir, check=True)
-        doxygen_html_src = "doxygen/html"
+        doxygen_html_src = str(root_dir / "doxygen/html")
         doxygen_html_dest = str(out_dir / "doxygen")
-        subprocess.run(["cp", "-r", doxygen_html_src, doxygen_html_dest])
+        subprocess.run(["cp", "-r", doxygen_html_src, doxygen_html_dest], check=True)
 
     # configuration generator
     input_file_path = doc_dir / "host_config_schema/cchost_config.json"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -132,7 +132,7 @@ html_css_files = [
 
 html_js_files = ["https://kit.fontawesome.com/c75a35380d.js"]
 
-html_extra_path = ["../doxygen/"]
+html_extra_path = []
 
 # -- Options for HTMLHelp output ---------------------------------------------
 
@@ -399,6 +399,7 @@ def setup(app):
 
     doc_dir = pathlib.Path(app.srcdir)  # CCF/doc/
     root_dir = os.path.abspath(doc_dir / "..")  # CCF/
+    out_dir = pathlib.Path(app.outdir) # CCF/build/html
 
     # import ccf python package to generate docs for this version
     python_path = os.path.abspath(doc_dir / "../python")
@@ -408,6 +409,9 @@ def setup(app):
     breathe_projects["CCF"] = str(doc_dir / breathe_projects["CCF"])
     if not os.environ.get("SKIP_DOXYGEN"):
         subprocess.run(["doxygen"], cwd=root_dir, check=True)
+        doxygen_html_src = "doxygen/html"
+        doxygen_html_dest = str(out_dir / "doxygen")
+        subprocess.run(["cp", "-r", doxygen_html_src, doxygen_html_dest])
 
     # configuration generator
     input_file_path = doc_dir / "host_config_schema/cchost_config.json"

--- a/doc/contribute/onboarding.rst
+++ b/doc/contribute/onboarding.rst
@@ -95,4 +95,4 @@ Note that this diagram deliberately does not represent host-to-enclave communica
 Doxygen
 -------
 
-Doxygen description of the codebase is available `here </doxygen_html>`__.
+Doxygen description of the codebase is available `here <../doxygen/index.html>`_.


### PR DESCRIPTION
Fix for #3513.

@jumaffre noticed that this hadn't actually worked - the `html_extra_path` is checked before Doxygen is run, and on the current branch. So it worked locally, since I'd previously run `doxygen`, but not in CI/with `sphinx-multiversion`. Instead, we just copy the Doxygen html output to the Sphinx output directory, and add an appropriate relative link to it.