### PR TITLE
Infra split network start and open

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-chirp tv
+chirp chirp

--- a/tests/code_update.py
+++ b/tests/code_update.py
@@ -182,7 +182,7 @@ def run(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
         test_verify_quotes(network, args)
         test_add_node_with_bad_code(network, args)

--- a/tests/committable.py
+++ b/tests/committable.py
@@ -42,7 +42,7 @@ def run(args):
     with infra.network.network(
         hosts, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         primary, backups = network.find_nodes()
 
         # Suspend three of the backups to prevent commit

--- a/tests/connections.py
+++ b/tests/connections.py
@@ -72,7 +72,7 @@ def run(args):
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
         check = infra.checker.Checker()
-        network.start_and_join(args)
+        network.start_and_open(args)
         primary, _ = network.find_nodes()
 
         caps = interface_caps(primary.local_node_id)

--- a/tests/e2e_batched.py
+++ b/tests/e2e_batched.py
@@ -62,7 +62,7 @@ def run(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
         network = test(network, args, batch_size=1)
         network = test(network, args, batch_size=10)
@@ -94,7 +94,7 @@ def run_to_destruction(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
         LOG.warning("About to issue transactions until destruction")
         try:

--- a/tests/e2e_common_endpoints.py
+++ b/tests/e2e_common_endpoints.py
@@ -163,7 +163,7 @@ def run(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
         network = test_primary(network, args)
         network = test_network_node_info(network, args)

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -173,7 +173,7 @@ def test_large_messages(network, args):
             # pass but not others, and finding where does it fail).
             log_id = 40
             for p in range(10, 20) if args.consensus == "CFT" else range(10, 13):
-                long_msg = "X" * (2**p)
+                long_msg = "X" * (2 ** p)
                 check_commit(
                     c.post("/app/log/private", {"id": log_id, "msg": long_msg}),
                     result=True,
@@ -1313,7 +1313,7 @@ def run(args):
         pdb=args.pdb,
         txs=txs,
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
         network = test(network, args)
         network = test_illegal(network, args)

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -124,7 +124,7 @@ def run_file_operations(args):
         ) as network:
 
             args.common_read_only_ledger_dir = tmp_dir
-            network.start_and_join(args)
+            network.start_and_open(args)
 
             test_save_committed_ledger_files(network, args)
             test_parse_snapshot_file(network, args)
@@ -140,7 +140,7 @@ def run_tls_san_checks(args):
         pdb=args.pdb,
     ) as network:
         args.common_read_only_ledger_dir = None  # Reset from previous test
-        network.start_and_join(args)
+        network.start_and_open(args)
 
         LOG.info("Check SAN value in TLS certificate")
         dummy_san = "*.dummy.com"

--- a/tests/e2e_suite.py
+++ b/tests/e2e_suite.py
@@ -80,7 +80,7 @@ def run(args):
     )
 
     if not args.dry_run:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
     LOG.info(f"Running {len(chosen_suite)} tests for {args.test_duration} seconds")
 

--- a/tests/e2e_tutorial.py
+++ b/tests/e2e_tutorial.py
@@ -11,7 +11,7 @@ def run(args):
     ) as network:
         for node in network.nodes:
             node.curl = True
-        network.start_and_join(args)
+        network.start_and_open(args)
         primary, _ = network.find_primary()
 
     uncommitted_ledger_dir, committed_ledger_dirs = list(primary.get_ledger())

--- a/tests/election.py
+++ b/tests/election.py
@@ -49,7 +49,7 @@ def run(args):
     ) as network:
         check = infra.checker.Checker()
 
-        network.start_and_join(args)
+        network.start_and_open(args)
         current_view = None
         primary, current_view = network.find_primary()
 

--- a/tests/governance.py
+++ b/tests/governance.py
@@ -394,7 +394,7 @@ def gov(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         network.consortium.set_authenticate_session(args.authenticate_session)
         test_create_endpoint(network, args)
         test_consensus_status(network, args)
@@ -415,7 +415,7 @@ def js_gov(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         governance_js.test_proposal_validation(network, args)
         governance_js.test_proposal_storage(network, args)
         governance_js.test_proposal_withdrawal(network, args)

--- a/tests/governance_history.py
+++ b/tests/governance_history.py
@@ -153,7 +153,7 @@ def run(args):
         pdb=args.pdb,
         txs=txs,
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         primary, _ = network.find_primary()
 
         ledger_directories = primary.remote.ledger_paths()

--- a/tests/historical_query_perf.py
+++ b/tests/historical_query_perf.py
@@ -141,7 +141,7 @@ def run(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
         network = test_historical_query_range(network, args)
 

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -95,7 +95,7 @@ def run(get_command, args):
     with infra.network.network(
         hosts, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         primary, backups = network.find_nodes()
 
         command_args = get_command_args(args, get_command)

--- a/tests/js-custom-authorization/custom_authorization.py
+++ b/tests/js-custom-authorization/custom_authorization.py
@@ -35,7 +35,7 @@ def run(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         network = test_custom_auth(network, args)
 
 
@@ -80,7 +80,7 @@ def run_limits(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         network = test_stack_size_limit(network, args)
         network = test_heap_size_limit(network, args)
 
@@ -214,7 +214,7 @@ def run_authn(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         network = test_jwt_auth(network, args)
         network = test_multi_auth(network, args)
         network = test_role_based_access(network, args)
@@ -371,7 +371,7 @@ def run_content_types(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         network = test_content_types(network, args)
         network = test_accept_header(network, args)
         network = test_supported_methods(network, args)
@@ -459,7 +459,7 @@ def run_request_object(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         network = test_request_object_api(network, args)
 
 

--- a/tests/js-launch-host-process/host_process.py
+++ b/tests/js-launch-host-process/host_process.py
@@ -74,7 +74,7 @@ def run(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         network = test_host_process_launch(network, args)
         network = test_host_process_launch_many(network, args)
 

--- a/tests/js-modules/modules.py
+++ b/tests/js-modules/modules.py
@@ -607,7 +607,7 @@ def run(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         network = test_module_import(network, args)
         network = test_dynamic_module_import(network, args)
         network = test_bytecode_cache(network, args)

--- a/tests/jwt_test.py
+++ b/tests/jwt_test.py
@@ -501,7 +501,7 @@ def run_auto(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         test_jwt_endpoint(network, args)
         test_jwt_without_key_policy(network, args)
         if args.enclave_type != "virtual":
@@ -520,7 +520,7 @@ def run_manual(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         test_jwt_key_initial_refresh(network, args)
 
         # Check that initial refresh also works on backups
@@ -534,7 +534,7 @@ def run_ca_cert(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         ca_certs.test_cert_store(network, args)
 
 

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -196,7 +196,7 @@ def run_code_upgrade_from(
             jwt_issuer=jwt_issuer,
             version=from_version,
         ) as network:
-            network.start_and_join(args, node_container_image=from_container_image)
+            network.start_and_open(args, node_container_image=from_container_image)
 
             old_nodes = network.get_joined_nodes()
             primary, _ = network.find_primary()
@@ -433,7 +433,7 @@ def run_ledger_compatibility_since_first(args, local_branch, use_snapshot):
                 if idx == 0:
                     LOG.info(f"Starting new service (version: {version})")
                     network = infra.network.Network(**network_args)
-                    network.start_and_join(args)
+                    network.start_and_open(args)
                 else:
                     LOG.info(f"Recovering service (new version: {version})")
                     network = infra.network.Network(

--- a/tests/memberclient.py
+++ b/tests/memberclient.py
@@ -232,7 +232,7 @@ def run(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
         network = test_missing_signature_header(network, args)
         network = test_corrupted_signature(network, args)

--- a/tests/membership.py
+++ b/tests/membership.py
@@ -123,7 +123,7 @@ def service_startups(args):
     args.initial_operator_count = 1
     with infra.network.network(args.nodes, args.binary_dir, pdb=args.pdb) as network:
         try:
-            network.start_and_join(args)
+            network.start_and_open(args)
             assert False, "Service cannot be opened with no recovery members"
         except AssertionError:
             primary, _ = network.find_primary()
@@ -141,7 +141,7 @@ def service_startups(args):
     args.initial_recovery_member_count = 1
     args.initial_operator_count = 2
     with infra.network.network(args.nodes, args.binary_dir, pdb=args.pdb) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
     LOG.info(
         "Starting service with a recovery operator member, a recovery non-operator member and a non-recovery non-operator member"
@@ -150,7 +150,7 @@ def service_startups(args):
     args.initial_recovery_member_count = 2
     args.initial_operator_count = 1
     with infra.network.network(args.nodes, args.binary_dir, pdb=args.pdb) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
 
 def recovery_shares_scenario(args):
@@ -163,7 +163,7 @@ def recovery_shares_scenario(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
         # Membership changes trigger re-sharing and re-keying and are
         # only supported with CFT

--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -307,7 +307,7 @@ def run_2tx_reconfig_tests(args):
         pdb=local_args.pdb,
         init_partitioner=True,
     ) as network:
-        network.start_and_join(local_args)
+        network.start_and_open(local_args)
 
         test_learner_does_not_take_part(network, local_args)
 
@@ -324,7 +324,7 @@ def run(args):
         txs=txs,
         init_partitioner=True,
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
         test_invalid_partitions(network, args)
         test_partition_majority(network, args)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -555,7 +555,7 @@ def run(args):
         pdb=args.pdb,
         txs=txs,
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
         test_version(network, args)
 
@@ -600,7 +600,7 @@ def run_join_old_snapshot(args):
             pdb=args.pdb,
             txs=txs,
         ) as network:
-            network.start_and_join(args)
+            network.start_and_open(args)
             primary, _ = network.find_primary()
 
             # First, retrieve and save one committed snapshot
@@ -731,7 +731,7 @@ def run_migration_tests(args):
         args.perf_nodes,
         pdb=args.pdb,
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         test_migration_2tx_reconfiguration(network, args)
         primary, _ = network.find_primary()
         new_node = network.nodes[-1]

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -157,7 +157,7 @@ def run(args):
         pdb=args.pdb,
         txs=txs,
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
         for i in range(args.recovery):
             # Issue transactions which will required historical ledger queries recovery

--- a/tests/rotation.py
+++ b/tests/rotation.py
@@ -12,7 +12,7 @@ def run(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
         # Replace primary repeatedly and check the network still operates
         LOG.info(f"Retiring primary {args.rotation_retirements} times")

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -96,7 +96,7 @@ def run(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         primary, _ = network.find_primary()
 
         check = infra.checker.Checker()
@@ -149,7 +149,7 @@ def run_nobuiltins(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         nobuiltins.test_nobuiltins_endpoints(network, args)
 
 

--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -66,7 +66,7 @@ def run(args):
             )
             network.recover(args)
         else:
-            network.start_and_join(args)
+            network.start_and_open(args)
 
         nodes = network.get_joined_nodes()
         max_len = max([len(str(node.local_node_id)) for node in nodes])

--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -91,7 +91,7 @@ def run(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
         test(network, args)
 
 

--- a/tests/vegeta_stress.py
+++ b/tests/vegeta_stress.py
@@ -30,7 +30,7 @@ def run(args, additional_attack_args):
         args.perf_nodes,
         pdb=args.pdb,
     ) as network:
-        network.start_and_join(args)
+        network.start_and_open(args)
 
         primary, _ = network.find_primary()
         primary_hostname = (


### PR DESCRIPTION
Very minor change to the Python infra: rename `network.start_and_join` to `network.start_and_open` and split to two separate functions: `start` that deals with starting nodes (i.e. operations) and `open` to open the service to users (i.e. governance). 