### PR TITLE
Update GcmHeader types

### DIFF
--- a/include/ccf/crypto/sha256_hash.h
+++ b/include/ccf/crypto/sha256_hash.h
@@ -6,6 +6,8 @@
 
 #include <array>
 #include <span>
+#define FMT_HEADER_ONLY
+#include <fmt/format.h>
 
 namespace crypto
 {

--- a/include/ccf/crypto/symmetric_key.h
+++ b/include/ccf/crypto/symmetric_key.h
@@ -4,7 +4,11 @@
 
 #include "ccf/ds/buffer.h"
 #include "ds/serialized.h"
-#include "ds/thread_messaging.h"
+
+// TODO: Move to cpp?
+#define FMT_HEADER_ONLY
+#include <fmt/format.h>
+#include <vector>
 
 namespace crypto
 {
@@ -121,30 +125,12 @@ namespace crypto
     GcmHeader<> hdr;
     std::vector<uint8_t> cipher;
 
-    GcmCipher() {}
-    GcmCipher(size_t size) : cipher(size) {}
+    GcmCipher();
+    GcmCipher(size_t size);
 
-    std::vector<uint8_t> serialise()
-    {
-      std::vector<uint8_t> serial;
-      auto space = GcmHeader<>::RAW_DATA_SIZE + cipher.size();
-      serial.resize(space);
+    std::vector<uint8_t> serialise();
 
-      auto data_ = serial.data();
-      serialized::write(data_, space, hdr.tag, sizeof(hdr.tag));
-      serialized::write(data_, space, hdr.iv, sizeof(hdr.iv));
-      serialized::write(data_, space, cipher.data(), cipher.size());
-
-      return serial;
-    }
-
-    void deserialise(const std::vector<uint8_t>& serial)
-    {
-      auto size = serial.size();
-      auto data_ = serial.data();
-      hdr = serialized::read(data_, size, GcmHeader<>::RAW_DATA_SIZE);
-      cipher = serialized::read(data_, size, size);
-    }
+    void deserialise(const std::vector<uint8_t>& serial);
   };
 
   class KeyAesGcm
@@ -169,6 +155,7 @@ namespace crypto
       CBuffer aad,
       uint8_t* plain) const = 0;
 
+    // Key size in bits
     virtual size_t key_size() const = 0;
   };
 

--- a/include/ccf/crypto/symmetric_key.h
+++ b/include/ccf/crypto/symmetric_key.h
@@ -44,7 +44,7 @@ namespace crypto
     //   GcmHeader(data.data(), data.size())
     // {}
 
-    size_t raw_size() const
+    size_t serialised_size() const
     {
       return sizeof(tag) + iv.size();
     }
@@ -67,7 +67,7 @@ namespace crypto
 
     std::vector<uint8_t> serialise()
     {
-      auto space = raw_size();
+      auto space = serialised_size();
       std::vector<uint8_t> serial_hdr(space);
 
       auto data_ = serial_hdr.data();

--- a/include/ccf/crypto/symmetric_key.h
+++ b/include/ccf/crypto/symmetric_key.h
@@ -12,7 +12,8 @@
 
 namespace crypto
 {
-  constexpr size_t GCM_SIZE_KEY = 32;
+  constexpr size_t GCM_DEFAULT_KEY_SIZE = 32;
+
   constexpr size_t GCM_SIZE_TAG = 16;
   constexpr size_t GCM_SIZE_IV = 12;
 

--- a/src/crypto/symmetric_key.cpp
+++ b/src/crypto/symmetric_key.cpp
@@ -16,12 +16,12 @@ namespace crypto
   std::vector<uint8_t> GcmCipher::serialise()
   {
     std::vector<uint8_t> serial;
-    auto space = GcmHeader<>::RAW_DATA_SIZE + cipher.size();
+    auto space = hdr.raw_size() + cipher.size();
     serial.resize(space);
 
     auto data_ = serial.data();
     serialized::write(data_, space, hdr.tag, sizeof(hdr.tag));
-    serialized::write(data_, space, hdr.iv, sizeof(hdr.iv));
+    serialized::write(data_, space, hdr.iv.data(), hdr.iv.size());
     serialized::write(data_, space, cipher.data(), cipher.size());
 
     return serial;
@@ -29,10 +29,10 @@ namespace crypto
 
   void GcmCipher::deserialise(const std::vector<uint8_t>& serial)
   {
+    auto data = serial.data();
     auto size = serial.size();
-    auto data_ = serial.data();
-    hdr = serialized::read(data_, size, GcmHeader<>::RAW_DATA_SIZE);
-    cipher = serialized::read(data_, size, size);
+    hdr.deserialise(data, size);
+    cipher = serialized::read(data, size, size);
   }
 
   std::unique_ptr<KeyAesGcm> make_key_aes_gcm(CBuffer rawKey)

--- a/src/crypto/symmetric_key.cpp
+++ b/src/crypto/symmetric_key.cpp
@@ -16,7 +16,7 @@ namespace crypto
   std::vector<uint8_t> GcmCipher::serialise()
   {
     std::vector<uint8_t> serial;
-    auto space = hdr.raw_size() + cipher.size();
+    auto space = hdr.serialised_size() + cipher.size();
     serial.resize(space);
 
     auto data_ = serial.data();

--- a/src/crypto/test/bench.cpp
+++ b/src/crypto/test/bench.cpp
@@ -96,7 +96,7 @@ template <MDType M, size_t NContents>
 static void benchmark_hmac(picobench::state& s)
 {
   const auto contents = make_contents<NContents>();
-  const auto key = crypto::create_entropy()->random(crypto::GCM_SIZE_KEY);
+  const auto key = crypto::create_entropy()->random(crypto::GCM_DEFAULT_KEY_SIZE);
 
   s.start_timer();
   for (auto _ : s)

--- a/src/crypto/test/bench.cpp
+++ b/src/crypto/test/bench.cpp
@@ -96,7 +96,8 @@ template <MDType M, size_t NContents>
 static void benchmark_hmac(picobench::state& s)
 {
   const auto contents = make_contents<NContents>();
-  const auto key = crypto::create_entropy()->random(crypto::GCM_DEFAULT_KEY_SIZE);
+  const auto key =
+    crypto::create_entropy()->random(crypto::GCM_DEFAULT_KEY_SIZE);
 
   s.start_timer();
   for (auto _ : s)

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -499,7 +499,7 @@ TEST_CASE("CKM_RSA_AES_KEY_WRAP")
 TEST_CASE("AES-GCM convenience functions")
 {
   EntropyPtr entropy = create_entropy();
-  std::vector<uint8_t> key = entropy->random(GCM_SIZE_KEY);
+  std::vector<uint8_t> key = entropy->random(GCM_DEFAULT_KEY_SIZE);
   auto encrypted = aes_gcm_encrypt(key, contents);
   auto decrypted = aes_gcm_decrypt(key, encrypted);
   REQUIRE(decrypted == contents);

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -438,10 +438,18 @@ TEST_CASE("ExtendedIv0")
   unsigned char rawP[100];
   memset(rawP, 'x', sizeof(rawP));
   Buffer p{rawP, sizeof(rawP)};
-  // test large IV
-  GcmHeader h(1234);
 
-  // TODO: This only tests a null IV?
+  // test large IV
+  using LargeIVGcmHeader = FixedSizeGcmHeader<1234>;
+  LargeIVGcmHeader h;
+
+  SUBCASE("Null IV") {}
+
+  SUBCASE("Random IV")
+  {
+    h.set_random_iv();
+  }
+
   k->encrypt(h.get_iv(), p, nullb, p.p, h.tag);
 
   auto k2 = crypto::make_key_aes_gcm(get_raw_key());

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -425,7 +425,7 @@ TEST_CASE("Create sign and verify certificates")
   } while (corrupt_csr);
 }
 
-static const vector<uint8_t>& getRawKey()
+static const vector<uint8_t>& get_raw_key()
 {
   static const vector<uint8_t> v(16, '$');
   return v;
@@ -433,23 +433,24 @@ static const vector<uint8_t>& getRawKey()
 
 TEST_CASE("ExtendedIv0")
 {
-  auto k = crypto::make_key_aes_gcm(getRawKey());
+  auto k = crypto::make_key_aes_gcm(get_raw_key());
   // setup plain text
   unsigned char rawP[100];
   memset(rawP, 'x', sizeof(rawP));
   Buffer p{rawP, sizeof(rawP)};
   // test large IV
-  GcmHeader<1234> h;
+  GcmHeader h(1234);
+
+  // TODO: This only tests a null IV?
   k->encrypt(h.get_iv(), p, nullb, p.p, h.tag);
 
-  auto k2 = crypto::make_key_aes_gcm(getRawKey());
+  auto k2 = crypto::make_key_aes_gcm(get_raw_key());
   REQUIRE(k2->decrypt(h.get_iv(), h.tag, p, nullb, p.p));
 }
 
 TEST_CASE("AES Key wrap with padding")
 {
-  auto key = getRawKey();
-  GcmHeader<1234> h;
+  auto key = get_raw_key();
   std::vector<uint8_t> aad(123, 'y');
 
   std::vector<uint8_t> key_to_wrap = create_entropy()->random(997);
@@ -465,7 +466,7 @@ TEST_CASE("AES Key wrap with padding")
 
 TEST_CASE("CKM_RSA_PKCS_OAEP")
 {
-  auto key = getRawKey();
+  auto key = get_raw_key();
 
   auto rsa_kp = make_rsa_key_pair();
   auto rsa_pk = make_rsa_public_key(rsa_kp->public_key_pem());

--- a/src/indexing/enclave_lfs_access.h
+++ b/src/indexing/enclave_lfs_access.h
@@ -107,8 +107,7 @@ namespace ccf::indexing
       crypto::GcmCipher gcm(contents.size());
 
       // Use a random IV for each call
-      auto iv = entropy_src->random(crypto::GCM_SIZE_IV);
-      gcm.hdr.set_iv(iv.data(), iv.size());
+      gcm.hdr.set_random_iv();
 
       encryption_key->encrypt(
         gcm.hdr.get_iv(), contents, nullb, gcm.cipher.data(), gcm.hdr.tag);
@@ -127,8 +126,8 @@ namespace ccf::indexing
     {
       // Generate a fresh random key. Only this specific instance, in this
       // enclave, can read these files!
-      encryption_key =
-        crypto::make_key_aes_gcm(entropy_src->random(crypto::GCM_DEFAULT_KEY_SIZE));
+      encryption_key = crypto::make_key_aes_gcm(
+        entropy_src->random(crypto::GCM_DEFAULT_KEY_SIZE));
     }
 
     void register_message_handlers(

--- a/src/indexing/enclave_lfs_access.h
+++ b/src/indexing/enclave_lfs_access.h
@@ -128,7 +128,7 @@ namespace ccf::indexing
       // Generate a fresh random key. Only this specific instance, in this
       // enclave, can read these files!
       encryption_key =
-        crypto::make_key_aes_gcm(entropy_src->random(crypto::GCM_SIZE_KEY));
+        crypto::make_key_aes_gcm(entropy_src->random(crypto::GCM_DEFAULT_KEY_SIZE));
     }
 
     void register_message_handlers(

--- a/src/kv/encryptor.h
+++ b/src/kv/encryptor.h
@@ -30,7 +30,10 @@ namespace kv
 
       hdr.set_iv_seq(tx_id.version);
       hdr.set_iv_term(tx_id.term);
-      hdr.set_iv_snapshot(entry_type == EntryType::Snapshot);
+      if (entry_type == EntryType::Snapshot)
+      {
+        hdr.set_iv_is_snapshot();
+      }
     }
 
   public:

--- a/src/kv/encryptor.h
+++ b/src/kv/encryptor.h
@@ -41,12 +41,14 @@ namespace kv
 
     size_t get_header_length() override
     {
-      return S::RAW_DATA_SIZE;
+      return S::serialised_size();
     }
 
     uint64_t get_term(const uint8_t* data, size_t size) override
     {
-      return S(data, size).get_term();
+      S s;
+      s.deserialise(data, size);
+      return s.get_term();
     }
 
     /**

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -920,11 +920,10 @@ namespace ccf
       const uint8_t* data_ = data;
       size_t size_ = size;
 
-      // TODO: sizeof here is wrong! Probably raw_size?
-      serialized::skip(data_, size_, (size_ - sizeof(GcmHdr)));
       GcmHdr hdr;
+      serialized::skip(data_, size_, (size_ - hdr.serialised_size()));
       hdr.deserialise(data_, size_);
-      size -= sizeof(GcmHdr);
+      size -= hdr.serialised_size();
 
       if (!verify_or_decrypt(hdr, {data, size}))
       {

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -13,6 +13,7 @@
 #include "ds/hex.h"
 #include "ds/serialized.h"
 #include "ds/state_machine.h"
+#include "ds/thread_messaging.h"
 #include "enclave/enclave_time.h"
 #include "entities.h"
 #include "node_types.h"
@@ -59,7 +60,7 @@ namespace ccf
 
   static inline RecvNonce get_nonce(const GcmHdr& header)
   {
-    return RecvNonce(header.get_iv_int());
+    return *reinterpret_cast<const RecvNonce*>(header.iv);
   }
 
   enum ChannelStatus
@@ -193,7 +194,7 @@ namespace ccf
     {
       status.expect(ESTABLISHED);
 
-      RecvNonce recv_nonce(header.get_iv_int());
+      auto recv_nonce = *reinterpret_cast<const RecvNonce*>(header.iv);
       auto tid = recv_nonce.tid;
       assert(tid < threading::ThreadMessaging::max_num_threads);
 
@@ -847,7 +848,8 @@ namespace ccf
         (size_t)nonce.nonce);
 
       GcmHdr gcm_hdr;
-      gcm_hdr.set_iv_seq(nonce.get_val());
+      const auto nonce_n = nonce.get_val();
+      gcm_hdr.set_iv((const uint8_t*)&nonce_n, sizeof(nonce_n));
 
       std::vector<uint8_t> cipher(plain.n);
       assert(send_key);

--- a/src/node/encryptor.h
+++ b/src/node/encryptor.h
@@ -8,6 +8,45 @@
 
 namespace ccf
 {
-  using NodeEncryptor =
-    kv::TxEncryptor<ccf::LedgerSecrets, crypto::GcmHeader<crypto::GCM_SIZE_IV>>;
+  struct TxGcmHeader : public crypto::GcmHeader<crypto::GCM_SIZE_IV>
+  {
+    using Base = crypto::GcmHeader<crypto::GCM_SIZE_IV>;
+    using Base::Base;
+
+    // 12 bytes IV with 8 LSB are unique sequence number
+    // and 4 MSB are 4 LSB of term (with last bit indicating a snapshot)
+    constexpr static uint8_t IV_DELIMITER = 8;
+
+    void set_iv_seq(uint64_t seq)
+    {
+      *reinterpret_cast<uint64_t*>(iv) = seq;
+    }
+
+    void set_iv_term(uint64_t term)
+    {
+      if (term > 0x7FFFFFFF)
+      {
+        throw std::logic_error(fmt::format(
+          "term should fit in 31 bits of IV. Value is: 0x{0:x}", term));
+      }
+
+      *reinterpret_cast<uint32_t*>(iv + IV_DELIMITER) =
+        static_cast<uint32_t>(term);
+    }
+
+    uint64_t get_term() const
+    {
+      return *reinterpret_cast<const uint32_t*>(iv + IV_DELIMITER);
+    }
+
+    // TODO: This should be toggling a bit, based on is_snapshot
+    void set_iv_snapshot(bool is_snapshot)
+    {
+      // Set very last bit in IV
+      iv[crypto::GCM_SIZE_IV - 1] |=
+        (is_snapshot << ((sizeof(uint8_t) * 8) - 1));
+    }
+  };
+
+  using NodeEncryptor = kv::TxEncryptor<ccf::LedgerSecrets, TxGcmHeader>;
 }

--- a/src/node/encryptor.h
+++ b/src/node/encryptor.h
@@ -39,12 +39,10 @@ namespace ccf
       return *reinterpret_cast<const uint32_t*>(iv + IV_DELIMITER);
     }
 
-    // TODO: This should be toggling a bit, based on is_snapshot
-    void set_iv_snapshot(bool is_snapshot)
+    void set_iv_is_snapshot()
     {
       // Set very last bit in IV
-      iv[crypto::GCM_SIZE_IV - 1] |=
-        (is_snapshot << ((sizeof(uint8_t) * 8) - 1));
+      iv[crypto::GCM_SIZE_IV - 1] |= (1 << ((sizeof(uint8_t) * 8) - 1));
     }
   };
 

--- a/src/node/ledger_secret.h
+++ b/src/node/ledger_secret.h
@@ -76,7 +76,7 @@ namespace ccf
   inline LedgerSecretPtr make_ledger_secret()
   {
     return std::make_shared<LedgerSecret>(
-      crypto::create_entropy()->random(crypto::GCM_SIZE_KEY));
+      crypto::create_entropy()->random(crypto::GCM_DEFAULT_KEY_SIZE));
   }
 
   inline std::vector<uint8_t> decrypt_previous_ledger_secret_raw(

--- a/src/node/share_manager.h
+++ b/src/node/share_manager.h
@@ -20,7 +20,7 @@ namespace ccf
   class LedgerSecretWrappingKey
   {
   private:
-    static constexpr auto KZ_KEY_SIZE = crypto::GCM_SIZE_KEY;
+    static constexpr auto KZ_KEY_SIZE = crypto::GCM_DEFAULT_KEY_SIZE;
     std::vector<uint8_t> data; // Referred to as "kz" in TR
     bool has_wrapped = false;
 

--- a/src/node/share_manager.h
+++ b/src/node/share_manager.h
@@ -195,8 +195,7 @@ namespace ccf
 
         crypto::GcmCipher encrypted_previous_ls(
           previous_ledger_secret->second->raw_key.size());
-        auto iv = crypto::create_entropy()->random(crypto::GCM_SIZE_IV);
-        encrypted_previous_ls.hdr.set_iv(iv.data(), iv.size());
+        encrypted_previous_ls.hdr.set_random_iv();
 
         latest_ledger_secret->key->encrypt(
           encrypted_previous_ls.hdr.get_iv(),
@@ -226,8 +225,7 @@ namespace ccf
       // Submitted recovery shares are encrypted with the latest ledger secret.
       crypto::GcmCipher encrypted_submitted_share(submitted_share.size());
 
-      auto iv = crypto::create_entropy()->random(crypto::GCM_SIZE_IV);
-      encrypted_submitted_share.hdr.set_iv(iv.data(), iv.size());
+      encrypted_submitted_share.hdr.set_random_iv();
 
       current_ledger_secret->key->encrypt(
         encrypted_submitted_share.hdr.get_iv(),

--- a/src/node/test/channels.cpp
+++ b/src/node/test/channels.cpp
@@ -305,8 +305,7 @@ TEST_CASE("Client/Server key exchange")
     initiator_signature = msgs[0].data();
 
     auto md = msgs[1].data();
-    GcmHdr hdr;
-    REQUIRE(md.size() == msg.size() + hdr.serialised_size());
+    REQUIRE(md.size() == msg.size() + GcmHdr::serialised_size());
     REQUIRE(memcmp(md.data(), msg.data(), msg.size()) == 0);
 
     queued_msg = msgs[1]; // save for later

--- a/src/node/test/channels.cpp
+++ b/src/node/test/channels.cpp
@@ -305,7 +305,8 @@ TEST_CASE("Client/Server key exchange")
     initiator_signature = msgs[0].data();
 
     auto md = msgs[1].data();
-    REQUIRE(md.size() == msg.size() + sizeof(GcmHdr));
+    GcmHdr hdr;
+    REQUIRE(md.size() == msg.size() + hdr.serialised_size());
     REQUIRE(memcmp(md.data(), msg.data(), msg.size()) == 0);
 
     queued_msg = msgs[1]; // save for later


### PR DESCRIPTION
Side effect of #3569 was introducing a new public-header-includes-private chain from `symmetric_key.h`. This was because `GcmHeader` was templated on the `IV_SIZE`, so the implementation details need to be public. I've refactored that so `GcmHeader` is no longer templated (but still fixed-size by construction), and derived a supporting type for the users that still want statically known IV sizes.

Additionally I've simplified this public interface a little, moving the Tx-encryption specifics (interpreting the IV as a seqno + term + snapshot-bit) out of the public definition, and closer to where it's used.