### PR TITLE
Fix cleanup of custom claims

### DIFF
--- a/src/js/openenclave.cpp
+++ b/src/js/openenclave.cpp
@@ -34,6 +34,17 @@ namespace ccf::js
     }
   };
 
+  struct CustomClaims
+  {
+    oe_claim_t* data = nullptr;
+    size_t length = 0;
+
+    ~CustomClaims()
+    {
+      oe_free_custom_claims(data, length);
+    }
+  };
+
   static JSValue js_verify_open_enclave_evidence(
     JSContext* ctx, JSValueConst, int argc, JSValueConst* argv)
   {
@@ -119,7 +130,7 @@ namespace ccf::js
 
       if (claim_name == OE_CLAIM_CUSTOM_CLAIMS_BUFFER)
       {
-        Claims custom_claims;
+        CustomClaims custom_claims;
         rc = oe_deserialize_custom_claims(
           claim.value,
           claim.value_size,

--- a/src/node/quote.h
+++ b/src/node/quote.h
@@ -59,6 +59,17 @@ namespace ccf
     }
   };
 
+  struct CustomClaims
+  {
+    oe_claim_t* data = nullptr;
+    size_t length = 0;
+
+    ~CustomClaims()
+    {
+      oe_free_custom_claims(data, length);
+    }
+  };
+
   struct SerialisedClaims
   {
     uint8_t* buffer = nullptr;
@@ -138,7 +149,7 @@ namespace ccf
         else if (claim_name == OE_CLAIM_CUSTOM_CLAIMS_BUFFER)
         {
           // Find sgx report data in custom claims
-          Claims custom_claims;
+          CustomClaims custom_claims;
           rc = oe_deserialize_custom_claims(
             claim.value,
             claim.value_size,


### PR DESCRIPTION
OE custom claims were cleaned up using `oe_free_claims` instead of `oe_free_custom_claims`, which technically resulted in a memory leak and the error message reported in #3571. 

Fixes #3571