### PR TITLE
Log early messages from a separate thread

### DIFF
--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -460,17 +460,12 @@ int main(int argc, char** argv)
     LOG_INFO_FMT("Initialising enclave: enclave_create_node");
     std::atomic<bool> ecall_completed = false;
     auto flush_outbound = [&]() {
-      while (true)
+      do
       {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
         bp.read_all(circuit.read_from_inside());
-
-        if (ecall_completed)
-        {
-          break;
-        }
-      }
+      } while (!ecall_completed);
     };
     std::thread flusher_thread(flush_outbound);
     auto create_status = enclave.create_node(


### PR DESCRIPTION
Companion to #3612, and follow-up to #3413.

If the `create_node` ECALL blocks, we currently get very little debugging information. This adds a separate thread flushing the outbound ringbuffer while that ECALL executes, so we will get more precise `LOG_` output indicating the point where the code blocked.