### PR TITLE
Add `GET /gov/members` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Snapshot generation no longer causes a node crash if the snapshot is larger than the ring buffer message size (`memory.max_msg_size`). Instead, the generation of the large snapshot is skipped (#3603).
 
+### Added
+
+- New `GET /gov/members` endpoint which returns details of all members from the KV (#3615).
+
 ### Changed
 
 - The C++ types used to define public governance tables are now exposed in public headers. Any C++ applications reading these tables should update their include paths (ie - `#include "service/tables/nodes.h"` => `#include "ccf/service/tables/nodes.h"`) (#3608).

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -98,6 +98,12 @@
         },
         "type": "object"
       },
+      "EntityId_to_FullMemberDetails": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/FullMemberDetails"
+        },
+        "type": "object"
+      },
       "EntityId_to_boolean": {
         "additionalProperties": {
           "$ref": "#/components/schemas/boolean"
@@ -121,6 +127,29 @@
         },
         "required": [
           "reason"
+        ],
+        "type": "object"
+      },
+      "FullMemberDetails": {
+        "properties": {
+          "cert": {
+            "$ref": "#/components/schemas/Pem"
+          },
+          "member_data": {
+            "$ref": "#/components/schemas/json"
+          },
+          "public_encryption_key": {
+            "$ref": "#/components/schemas/Pem"
+          },
+          "status": {
+            "$ref": "#/components/schemas/MemberStatus"
+          }
+        },
+        "required": [
+          "status",
+          "member_data",
+          "cert",
+          "public_encryption_key"
         ],
         "type": "object"
       },
@@ -207,6 +236,13 @@
           "cert"
         ],
         "type": "object"
+      },
+      "MemberStatus": {
+        "enum": [
+          "Accepted",
+          "Active"
+        ],
+        "type": "string"
       },
       "Pem": {
         "type": "string"
@@ -431,7 +467,7 @@
   "info": {
     "description": "This API is used to submit and query proposals which affect CCF's public governance tables.",
     "title": "CCF Governance API",
-    "version": "2.6.0"
+    "version": "2.7.0"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -578,6 +614,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetTxStatus__Out"
+                }
+              }
+            },
+            "description": "Default response description"
+          }
+        }
+      }
+    },
+    "/gov/members": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityId_to_FullMemberDetails"
                 }
               }
             },

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -73,9 +73,9 @@ namespace ccf
     crypto::Pem cert;
     std::optional<crypto::Pem> public_encryption_key;
   };
-  DECLARE_JSON_TYPE(FullMemberDetails)
+  DECLARE_JSON_TYPE(FullMemberDetails);
   DECLARE_JSON_REQUIRED_FIELDS(
-    FullMemberDetails, status, member_data, cert, public_encryption_key)
+    FullMemberDetails, status, member_data, cert, public_encryption_key);
 
   class MemberEndpoints : public CommonEndpointRegistry
   {

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -495,7 +495,7 @@ namespace ccf
       openapi_info.description =
         "This API is used to submit and query proposals which affect CCF's "
         "public governance tables.";
-      openapi_info.document_version = "2.6.0";
+      openapi_info.document_version = "2.7.0";
     }
 
     static std::optional<MemberId> get_caller_member_id(
@@ -1422,6 +1422,7 @@ namespace ccf
 
 #pragma clang diagnostic pop
 
+      using AllMemberDetails = std::map<ccf::MemberId, FullMemberDetails>;
       auto get_all_members =
         [this](endpoints::ReadOnlyEndpointContext& ctx, nlohmann::json&&) {
           auto members = ctx.tx.ro<ccf::MemberInfo>(ccf::Tables::MEMBER_INFO);
@@ -1431,7 +1432,7 @@ namespace ccf
             ctx.tx.ro<ccf::MemberPublicEncryptionKeys>(
               ccf::Tables::MEMBER_ENCRYPTION_PUBLIC_KEYS);
 
-          std::map<ccf::MemberId, FullMemberDetails> response;
+          AllMemberDetails response;
 
           members->foreach(
             [&response, member_certs, member_public_encryption_keys](
@@ -1464,7 +1465,7 @@ namespace ccf
         HTTP_GET,
         json_read_only_adapter(get_all_members),
         ccf::no_auth_required)
-        .set_auto_schema<void, FullMemberDetails>()
+        .set_auto_schema<void, AllMemberDetails>()
         .install();
     }
   };

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -68,6 +68,15 @@ namespace ccf
   DECLARE_JSON_TYPE(KeyIdInfo)
   DECLARE_JSON_REQUIRED_FIELDS(KeyIdInfo, issuer, cert)
 
+  struct FullMemberDetails : public ccf::MemberDetails
+  {
+    crypto::Pem cert;
+    std::optional<crypto::Pem> public_encryption_key;
+  };
+  DECLARE_JSON_TYPE(FullMemberDetails)
+  DECLARE_JSON_REQUIRED_FIELDS(
+    FullMemberDetails, status, member_data, cert, public_encryption_key)
+
   class MemberEndpoints : public CommonEndpointRegistry
   {
   private:
@@ -1415,23 +1424,47 @@ namespace ccf
 
       auto get_all_members =
         [this](endpoints::ReadOnlyEndpointContext& ctx, nlohmann::json&&) {
-          auto members = ctx.tx.ro(this->network.member_info);
+          auto members = ctx.tx.ro<ccf::MemberInfo>(ccf::Tables::MEMBER_INFO);
+          auto member_certs =
+            ctx.tx.ro<ccf::MemberCerts>(ccf::Tables::MEMBER_CERTS);
+          auto member_public_encryption_keys =
+            ctx.tx.ro<ccf::MemberPublicEncryptionKeys>(
+              ccf::Tables::MEMBER_ENCRYPTION_PUBLIC_KEYS);
 
-          nlohmann::json response_body = nlohmann::json::object();
+          std::map<ccf::MemberId, FullMemberDetails> response;
 
-          members->foreach([&response_body](const auto& k, const auto& v) {
-            response_body[k] = v;
-            return true;
-          });
+          members->foreach(
+            [&response, member_certs, member_public_encryption_keys](
+              const auto& k, const auto& v) {
+              FullMemberDetails md;
+              md.status = v.status;
+              md.member_data = v.member_data;
 
-          return make_success(response_body);
+              const auto cert = member_certs->get(k);
+              if (cert.has_value())
+              {
+                md.cert = cert.value();
+              }
+
+              const auto public_encryption_key =
+                member_public_encryption_keys->get(k);
+              if (public_encryption_key.has_value())
+              {
+                md.public_encryption_key = public_encryption_key.value();
+              }
+
+              response[k] = md;
+              return true;
+            });
+
+          return make_success(response);
         };
       make_read_only_endpoint(
         "/members",
         HTTP_GET,
         json_read_only_adapter(get_all_members),
         ccf::no_auth_required)
-        .set_auto_schema<void, void>() // TODO
+        .set_auto_schema<void, FullMemberDetails>()
         .install();
     }
   };

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -1412,6 +1412,27 @@ namespace ccf
         .install();
 
 #pragma clang diagnostic pop
+
+      auto get_all_members =
+        [this](endpoints::ReadOnlyEndpointContext& ctx, nlohmann::json&&) {
+          auto members = ctx.tx.ro(this->network.member_info);
+
+          nlohmann::json response_body = nlohmann::json::object();
+
+          members->foreach([&response_body](const auto& k, const auto& v) {
+            response_body[k] = v;
+            return true;
+          });
+
+          return make_success(response_body);
+        };
+      make_read_only_endpoint(
+        "/members",
+        HTTP_GET,
+        json_read_only_adapter(get_all_members),
+        ccf::no_auth_required)
+        .set_auto_schema<void, void>() // TODO
+        .install();
     }
   };
 

--- a/tests/governance.py
+++ b/tests/governance.py
@@ -234,7 +234,7 @@ def test_all_members(network, args):
         assert response_details["member_data"] == member.member_data
         if member.is_recovery_member:
             recovery_enc_key = open(
-                member.member_info["encryption_public_key_file"]
+                member.member_info["encryption_public_key_file"], encoding="utf-8"
             ).read()
             assert response_details["public_encryption_key"] == recovery_enc_key
         else:

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -106,7 +106,8 @@ class Member:
             os.path.join(self.common_dir, self.member_info["certificate_file"]),
             encoding="utf-8",
         ) as c:
-            self.service_id = infra.crypto.compute_cert_der_hash_hex_from_pem(c.read())
+            self.cert = c.read()
+            self.service_id = infra.crypto.compute_cert_der_hash_hex_from_pem(self.cert)
 
         LOG.info(f"Member {self.local_id} created: {self.service_id}")
 


### PR DESCRIPTION
Resolves #3615.

Sample response:
```
$ curl -k https://127.0.0.1:8000/gov/members | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1272  100  1272    0     0   124k      0 --:--:-- --:--:-- --:--:--  124k
{
  "ae5b09279cdbec24d0e94b7a4cf2f2654da1a101be8a299c8da3179bdf370bbc": {
    "cert": "-----BEGIN CERTIFICATE-----\nMIIBtjCCATygAwIBAgIUOq1HvRmQIXLu9gBMtF6MKxQXHM0wCgYIKoZIzj0EAwMw\nEjEQMA4GA1UEAwwHbWVtYmVyMDAeFw0yMjAzMDExMTQzMThaFw0yMzAzMDExMTQz\nMThaMBIxEDAOBgNVBAMMB21lbWJlcjAwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAARF\nnMUOQ3/Nq8PNGfSosV4JujMDBvcfBnCXYoNs6S/i6Hre35COiuR48kok/QVX16bJ\naioX2wVwtdxwBQUwVBChUBLXNeRegGphw+8s/s3qSMTWwRb3Kte6JHkmK/++hyWj\nUzBRMB0GA1UdDgQWBBR0/SjlakLHzEcwANCaUkRkT8vvoTAfBgNVHSMEGDAWgBR0\n/SjlakLHzEcwANCaUkRkT8vvoTAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMD\nA2gAMGUCMCm5ddT4yXRJcbqvxQvKD4n4C/tgTO5Vi5VL+jc1/ZdWV2VVYM95XkHX\ne9pWTcWfTwIxAPPNfh0Khw5mYGOQgX06agJdfzKq4mnLvwII6to7c6gSIxmxpuHQ\n2MEqMInuhs0QrA==\n-----END CERTIFICATE-----\n",
    "member_data": null,
    "public_encryption_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0sh2kHh6DDmfgoMrmmy7\nRUfsIodwr0tMrdQ2qddBJCUi5+4RwwdlPny5rq4d+O8PucX1fogt97sABoh5SN+P\niaD5OF0Er+7j2d9nKhECRQbKipdCLgi4dRfByZAfEgqPQRe+txxYm49tQAYjoIqj\n/WoMiq2VdP878RXraJr7T1rVVEkpolkx6opo3JDVgPrQ3SH6i5f3ya1dFvCjoHT9\ns72D/0iGIqITgb8POg99QVZJKTbnh0yDwK0vz42mjzepK1n198wfN/aTJkv6WyZ7\nK4wP4slVnADJEES3npQSnEICPV/hb9RoRXgQuxx3PIqAfHA+OK8JJ+czIq0/R51K\nSQIDAQAB\n-----END PUBLIC KEY-----\n",
    "status": "Active"
  }
}
```

Note that this aims to be a clear summary, to avoid confusion. So for instance it always includes a `member_data` field, potentially containing `null`, rather than omitting the field for brevity.