### PR TITLE
Distinguish different kinds of EntityID in OpenAPI

### DIFF
--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -55,11 +55,6 @@
         },
         "type": "array"
       },
-      "EntityId": {
-        "format": "hex",
-        "pattern": "^[a-f0-9]{64}$",
-        "type": "string"
-      },
       "GetCode__Out": {
         "properties": {
           "versions": {
@@ -201,6 +196,11 @@
         ],
         "type": "object"
       },
+      "NodeId": {
+        "format": "hex",
+        "pattern": "^[a-f0-9]{64}$",
+        "type": "string"
+      },
       "Receipt": {
         "properties": {
           "cert": {
@@ -213,7 +213,7 @@
             "$ref": "#/components/schemas/Receipt__LeafComponents"
           },
           "node_id": {
-            "$ref": "#/components/schemas/EntityId"
+            "$ref": "#/components/schemas/NodeId"
           },
           "proof": {
             "$ref": "#/components/schemas/Receipt__Element_array"
@@ -310,7 +310,7 @@
   "info": {
     "description": "This CCF sample app implements a simple logging application, securely recording messages at client-specified IDs. It demonstrates most of the features available to CCF apps.",
     "title": "CCF Sample Logging App",
-    "version": "1.8.0"
+    "version": "1.9.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -87,29 +87,6 @@
         },
         "type": "array"
       },
-      "EntityId": {
-        "format": "hex",
-        "pattern": "^[a-f0-9]{64}$",
-        "type": "string"
-      },
-      "EntityId_to_Failure": {
-        "additionalProperties": {
-          "$ref": "#/components/schemas/Failure"
-        },
-        "type": "object"
-      },
-      "EntityId_to_boolean": {
-        "additionalProperties": {
-          "$ref": "#/components/schemas/boolean"
-        },
-        "type": "object"
-      },
-      "EntityId_to_string": {
-        "additionalProperties": {
-          "$ref": "#/components/schemas/string"
-        },
-        "type": "object"
-      },
       "Failure": {
         "properties": {
           "reason": {
@@ -208,6 +185,34 @@
         ],
         "type": "object"
       },
+      "MemberId": {
+        "format": "hex",
+        "pattern": "^[a-f0-9]{64}$",
+        "type": "string"
+      },
+      "MemberId_to_Failure": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/Failure"
+        },
+        "type": "object"
+      },
+      "MemberId_to_boolean": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/boolean"
+        },
+        "type": "object"
+      },
+      "MemberId_to_string": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/string"
+        },
+        "type": "object"
+      },
+      "NodeId": {
+        "format": "hex",
+        "pattern": "^[a-f0-9]{64}$",
+        "type": "string"
+      },
       "Pem": {
         "type": "string"
       },
@@ -225,22 +230,22 @@
       "ProposalInfo": {
         "properties": {
           "ballots": {
-            "$ref": "#/components/schemas/EntityId_to_string"
+            "$ref": "#/components/schemas/MemberId_to_string"
           },
           "failure": {
             "$ref": "#/components/schemas/Failure"
           },
           "final_votes": {
-            "$ref": "#/components/schemas/EntityId_to_boolean"
+            "$ref": "#/components/schemas/MemberId_to_boolean"
           },
           "proposer_id": {
-            "$ref": "#/components/schemas/EntityId"
+            "$ref": "#/components/schemas/MemberId"
           },
           "state": {
             "$ref": "#/components/schemas/ProposalState"
           },
           "vote_failures": {
-            "$ref": "#/components/schemas/EntityId_to_Failure"
+            "$ref": "#/components/schemas/MemberId_to_Failure"
           }
         },
         "required": [
@@ -262,16 +267,16 @@
             "$ref": "#/components/schemas/string"
           },
           "proposer_id": {
-            "$ref": "#/components/schemas/EntityId"
+            "$ref": "#/components/schemas/MemberId"
           },
           "state": {
             "$ref": "#/components/schemas/ProposalState"
           },
           "vote_failures": {
-            "$ref": "#/components/schemas/EntityId_to_Failure"
+            "$ref": "#/components/schemas/MemberId_to_Failure"
           },
           "votes": {
-            "$ref": "#/components/schemas/EntityId_to_boolean"
+            "$ref": "#/components/schemas/MemberId_to_boolean"
           }
         },
         "required": [
@@ -305,7 +310,7 @@
             "$ref": "#/components/schemas/Receipt__LeafComponents"
           },
           "node_id": {
-            "$ref": "#/components/schemas/EntityId"
+            "$ref": "#/components/schemas/NodeId"
           },
           "proof": {
             "$ref": "#/components/schemas/Receipt__Element_array"
@@ -431,7 +436,7 @@
   "info": {
     "description": "This API is used to submit and query proposals which affect CCF's public governance tables.",
     "title": "CCF Governance API",
-    "version": "2.6.0"
+    "version": "2.7.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -23,7 +23,7 @@
             "$ref": "#/components/schemas/uint64"
           },
           "nodes": {
-            "$ref": "#/components/schemas/EntityId_to_Configuration__NodeInfo"
+            "$ref": "#/components/schemas/NodeId_to_Configuration__NodeInfo"
           },
           "rid": {
             "$ref": "#/components/schemas/uint64"
@@ -67,7 +67,7 @@
       "ConsensusDetails": {
         "properties": {
           "acks": {
-            "$ref": "#/components/schemas/EntityId_to_uint64"
+            "$ref": "#/components/schemas/NodeId_to_uint64"
           },
           "configs": {
             "$ref": "#/components/schemas/Configuration_array"
@@ -76,7 +76,7 @@
             "$ref": "#/components/schemas/LeadershipState"
           },
           "learners": {
-            "$ref": "#/components/schemas/EntityId_to_uint64"
+            "$ref": "#/components/schemas/NodeId_to_uint64"
           },
           "membership_state": {
             "$ref": "#/components/schemas/MembershipState"
@@ -172,23 +172,6 @@
         },
         "type": "array"
       },
-      "EntityId": {
-        "format": "hex",
-        "pattern": "^[a-f0-9]{64}$",
-        "type": "string"
-      },
-      "EntityId_to_Configuration__NodeInfo": {
-        "additionalProperties": {
-          "$ref": "#/components/schemas/Configuration__NodeInfo"
-        },
-        "type": "object"
-      },
-      "EntityId_to_uint64": {
-        "additionalProperties": {
-          "$ref": "#/components/schemas/uint64"
-        },
-        "type": "object"
-      },
       "GetCode__Out": {
         "properties": {
           "versions": {
@@ -238,7 +221,7 @@
             "$ref": "#/components/schemas/uint64"
           },
           "primary_id": {
-            "$ref": "#/components/schemas/EntityId"
+            "$ref": "#/components/schemas/NodeId"
           },
           "service_certificate": {
             "$ref": "#/components/schemas/Pem"
@@ -258,7 +241,7 @@
       "GetNode__NodeInfo": {
         "properties": {
           "node_id": {
-            "$ref": "#/components/schemas/EntityId"
+            "$ref": "#/components/schemas/NodeId"
           },
           "primary": {
             "$ref": "#/components/schemas/boolean"
@@ -315,7 +298,7 @@
             "$ref": "#/components/schemas/uint64"
           },
           "node_id": {
-            "$ref": "#/components/schemas/EntityId"
+            "$ref": "#/components/schemas/NodeId"
           },
           "recovery_target_seqno": {
             "$ref": "#/components/schemas/uint64"
@@ -431,6 +414,23 @@
         ],
         "type": "object"
       },
+      "NodeId": {
+        "format": "hex",
+        "pattern": "^[a-f0-9]{64}$",
+        "type": "string"
+      },
+      "NodeId_to_Configuration__NodeInfo": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/Configuration__NodeInfo"
+        },
+        "type": "object"
+      },
+      "NodeId_to_uint64": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/uint64"
+        },
+        "type": "object"
+      },
       "NodeInfoNetwork_v2__NetInterface": {
         "properties": {
           "bind_address": {
@@ -490,7 +490,7 @@
             "$ref": "#/components/schemas/string"
           },
           "node_id": {
-            "$ref": "#/components/schemas/EntityId"
+            "$ref": "#/components/schemas/NodeId"
           },
           "raw": {
             "$ref": "#/components/schemas/base64string"
@@ -528,7 +528,7 @@
             "$ref": "#/components/schemas/Receipt__LeafComponents"
           },
           "node_id": {
-            "$ref": "#/components/schemas/EntityId"
+            "$ref": "#/components/schemas/NodeId"
           },
           "proof": {
             "$ref": "#/components/schemas/Receipt__Element_array"
@@ -738,7 +738,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "2.13.0"
+    "version": "2.14.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/include/ccf/entity_id.h
+++ b/include/ccf/entity_id.h
@@ -95,7 +95,9 @@ namespace ccf
     else
     {
       throw JsonParseError(fmt::format(
-        "{} should be hex-encoded string: {}", FmtExtender::ID_LABEL, j.dump()));
+        "{} should be hex-encoded string: {}",
+        FmtExtender::ID_LABEL,
+        j.dump()));
     }
   }
 

--- a/include/ccf/entity_id.h
+++ b/include/ccf/entity_id.h
@@ -94,15 +94,15 @@ namespace ccf
     }
     else
     {
-      throw JsonParseError(
-        fmt::format("Entity id should be hex-encoded string: {}", j.dump()));
+      throw JsonParseError(fmt::format(
+        "{} should be hex-encoded string: {}", FmtExtender::ID_LABEL, j.dump()));
     }
   }
 
   template <typename FmtExtender>
   inline std::string schema_name(const EntityId<FmtExtender>&)
   {
-    return "EntityId";
+    return FmtExtender::ID_LABEL;
   }
 
   template <typename FmtExtender>
@@ -125,6 +125,8 @@ namespace ccf
     {
       return fmt::format("m[{}]", core);
     }
+
+    static constexpr auto ID_LABEL = "MemberId";
   };
   using MemberId = EntityId<MemberIdFormatter>;
 
@@ -134,6 +136,8 @@ namespace ccf
     {
       return fmt::format("u[{}]", core);
     }
+
+    static constexpr auto ID_LABEL = "UserId";
   };
   using UserId = EntityId<UserIdFormatter>;
 
@@ -143,6 +147,8 @@ namespace ccf
     {
       return fmt::format("n[{}]", core);
     }
+
+    static constexpr auto ID_LABEL = "NodeId";
   };
   using NodeId = EntityId<NodeIdFormatter>;
 }

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -188,7 +188,7 @@ namespace loggingapp
         "This CCF sample app implements a simple logging application, securely "
         "recording messages at client-specified IDs. It demonstrates most of "
         "the features available to CCF apps.";
-      openapi_info.document_version = "1.8.0";
+      openapi_info.document_version = "1.9.0";
 
       index_per_public_key = std::make_shared<RecordsIndexingStrategy>(
         PUBLIC_RECORDS, context, 10000, 20);

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -486,7 +486,7 @@ namespace ccf
       openapi_info.description =
         "This API is used to submit and query proposals which affect CCF's "
         "public governance tables.";
-      openapi_info.document_version = "2.6.0";
+      openapi_info.document_version = "2.7.0";
     }
 
     static std::optional<MemberId> get_caller_member_id(

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -324,7 +324,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
-      openapi_info.document_version = "2.13.0";
+      openapi_info.document_version = "2.14.0";
     }
 
     void init_handlers() override


### PR DESCRIPTION
While looking at our OpenAPI documents, I noticed that we report IDs for Members, Users, and Nodes as the same type (`EntityID`). This is losing some information, and makes the OpenAPI less descriptive. This plugs in a per-instance name to the OpenAPI.