### PR TITLE
Take individual chunk files in ledger parsing tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - The C++ types used to define public governance tables are now exposed in public headers. Any C++ applications reading these tables should update their include paths (ie - `#include "service/tables/nodes.h"` => `#include "ccf/service/tables/nodes.h"`) (#3608).
 - `TxReceipt::describe()` has been replaced with `ccf::describe_receipt()`. Includes of the private `node/tx_receipt.h` from C++ applications should be removed (#3610).
+- Python `ccf.read_ledger` and `ccf.ledger_viz` tools now accept paths to individual ledger chunks, to avoid parsing the entire ledger.
 
 ## [2.0.0-rc2]
 

--- a/python/ccf/ledger_viz.py
+++ b/python/ccf/ledger_viz.py
@@ -99,7 +99,12 @@ def main():
         description="Visualise content of CCF ledger",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument("paths", help="Path to ledger directories", nargs="+")
+    parser.add_argument(
+        "paths",
+        help="Path to ledger directories or ledger chunks. "
+        "Note that parsing individual ledger chunks requires the additional --insecure-skip-verification option",
+        nargs="+",
+    )
     parser.add_argument(
         "--uncommitted", help="Also parse uncommitted ledger files", action="store_true"
     )
@@ -115,8 +120,8 @@ def main():
     )
     args = parser.parse_args()
 
-    ledger_dirs = args.paths
-    ledger = ccf.ledger.Ledger(ledger_dirs, committed_only=not args.uncommitted)
+    ledger_paths = args.paths
+    ledger = ccf.ledger.Ledger(ledger_paths, committed_only=not args.uncommitted)
 
     l = DefaultLiner(args.write_views, args.split_views)
     l.help()

--- a/python/ccf/read_ledger.py
+++ b/python/ccf/read_ledger.py
@@ -142,14 +142,14 @@ def run(
             dump_entry(snapshot, table_filter, tables_format_rules)
         return True
     else:
-        ledger_dirs = paths
+        ledger_paths = paths
         ledger = ccf.ledger.Ledger(
-            ledger_dirs,
+            ledger_paths,
             committed_only=not uncommitted,
             insecure_skip_verification=insecure_skip_verification,
         )
 
-        LOG.info(f"Reading ledger from {ledger_dirs}")
+        LOG.info(f"Reading ledger from {ledger_paths}")
         LOG.info(f"Contains {counted_string(ledger, 'chunk')}")
 
         try:
@@ -188,7 +188,10 @@ if __name__ == "__main__":
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
-        "paths", help="Path to ledger directories or snapshot file", nargs="+"
+        "paths",
+        help="Path to ledger directories, ledger chunks, or snapshot file. "
+        "Note that parsing individual ledger chunks requires the additional --insecure-skip-verification option",
+        nargs="+",
     )
     parser.add_argument(
         "-s",


### PR DESCRIPTION
Looking at #3616, with #3618, I realised our CLI is still a little awkward, since it requires complete directories. Obviously it's possible to copy the target chunk file/files to a separate directory to parse with `--insecure-skip-validation`, but it seems easier if we just handle that conversion ourselves.

So wherever these classes/CLIs expect a ledger directory, they'll now also accept a specific ledger chunk.

![image](https://user-images.githubusercontent.com/6000239/156207800-24bcbb0d-af74-4f58-b086-9663dd20a262.png)

Note this does make it easier to specify non-contiguous chunks, but that was already possible with the directory approach.