### PR TITLE
`ledger.py` reports errors on non-contiguous ranges

### DIFF
--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -858,6 +858,8 @@ class Ledger:
                     try_add_chunk(chunk)
             elif os.path.isfile(p):
                 try_add_chunk(p)
+            else:
+                raise ValueError(f"{p} is not a ledger directory or ledger chunk")
 
         # Sorts the list based off the first number after ledger_ so that
         # the ledger is verified in sequence
@@ -865,6 +867,15 @@ class Ledger:
             ledger_files,
             key=lambda x: range_from_filename(x)[0],
         )
+
+        # If we do not have a single contiguous range, report an error
+        for file_a, file_b in zip(self._filenames[:-1], self._filenames[1:]):
+            range_a = range_from_filename(file_a)
+            range_b = range_from_filename(file_b)
+            if range_a[1] + 1 != range_b[0]:
+                raise ValueError(
+                    f"Ledger cannot parse non-contiguous chunks {file_a} and {file_b}"
+                )
 
         self._reset_iterators(insecure_skip_verification)
 

--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -872,7 +872,7 @@ class Ledger:
         for file_a, file_b in zip(self._filenames[:-1], self._filenames[1:]):
             range_a = range_from_filename(file_a)
             range_b = range_from_filename(file_b)
-            if range_a[1] + 1 != range_b[0]:
+            if range_a[1] is None or range_a[1] + 1 != range_b[0]:
                 raise ValueError(
                     f"Ledger cannot parse non-contiguous chunks {file_a} and {file_b}"
                 )


### PR DESCRIPTION
Fixes #3622.

As discussed in that issue, our viz/parsing tools are incorrect if we have duplicate transactions in multiple chunks. Detecting this duplication and if we have a complete range is hard in the presence of re-chunking and truncation, but we don't think "real" ledger dirs should ever have that much noise. So the simple solution is to demand a contiguous range, which we get from all existing single ledgers.