### PR TITLE
Fix memory leaks and cycles

### DIFF
--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -217,7 +217,7 @@ extern "C"
     }
 #endif
 
-    enclave::Enclave* enclave;
+    enclave::Enclave* enclave = nullptr;
 
     try
     {
@@ -249,15 +249,25 @@ extern "C"
       return CreateNodeStatus::EnclaveInitFailed;
     }
 
-    auto status = enclave->create_new_node(
-      start_type,
-      std::move(cc),
-      node_cert,
-      node_cert_size,
-      node_cert_len,
-      service_cert,
-      service_cert_size,
-      service_cert_len);
+    CreateNodeStatus status = EnclaveInitFailed;
+
+    try
+    {
+      status = enclave->create_new_node(
+        start_type,
+        std::move(cc),
+        node_cert,
+        node_cert_size,
+        node_cert_len,
+        service_cert,
+        service_cert_size,
+        service_cert_len);
+    }
+    catch (...)
+    {
+      delete enclave;
+      throw;
+    }
 
     if (status != CreateNodeStatus::OK)
     {


### PR DESCRIPTION
This fixes `shared_ptr` cycles via `RPCMap` and `RPCResponder` causing a bunch of memory to be leaked. Also fixes a direct leak of the `Enclave` object during shutdown. We use `std::weak_ptr` very sparingly so I wouldn't be surprised if there are a bunch of other cycles elsewhere. 