### PR TITLE
[LTS 1.x] Port HTTP parsing/protocol tests (#3634) to 1.x

### DIFF
--- a/src/enclave/rpc_context.h
+++ b/src/enclave/rpc_context.h
@@ -213,7 +213,10 @@ namespace enclave
     {
       nlohmann::json body = ccf::ODataErrorResponse{
         ccf::ODataError{std::move(error.code), std::move(error.msg)}};
-      const auto s = body.dump();
+      // Set error_handler to replace, to avoid throwing if the error message
+      // contains non-UTF8 characters. Other args are default values
+      const auto s =
+        body.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace);
       set_response_status(error.status);
       set_response_body(std::vector<uint8_t>(s.begin(), s.end()));
       set_response_header(

--- a/src/http/http_parser.h
+++ b/src/http/http_parser.h
@@ -224,11 +224,10 @@ namespace http
       else if (err_no != HPE_OK)
       {
         throw std::runtime_error(fmt::format(
-          "HTTP parsing failed ({}: {}) around byte {} of fragment:\n{}",
+          "HTTP parsing failed ({}: {}) around byte {}",
           llhttp_errno_name(err_no),
           llhttp_get_error_reason(&parser),
-          llhttp_get_error_pos(&parser) - data_char,
-          std::string((char const*)data, size)));
+          llhttp_get_error_pos(&parser) - data_char));
       }
     }
 

--- a/src/http/test/http_test.cpp
+++ b/src/http/test/http_test.cpp
@@ -107,11 +107,11 @@ DOCTEST_TEST_CASE("Parsing fuzzing")
   http::SimpleRequestProcessor sp;
   http::RequestParser p(sp);
 
-#define ADD_HTTP_METHOD(NUM, NAME, STRING) HTTP_##NAME,
-  std::vector<llhttp_method> all_methods{HTTP_ALL_METHOD_MAP(ADD_HTTP_METHOD)};
-#undef HTTP_METHOD_GEN
+// #define ADD_HTTP_METHOD(NUM, NAME, STRING) HTTP_##NAME,
+//   std::vector<llhttp_method> all_methods{HTTP_ALL_METHOD_MAP(ADD_HTTP_METHOD)};
+// #undef ADD_HTTP_METHOD
 
-  for (auto method : all_methods)
+  for (auto method : {HTTP_POST, HTTP_GET, HTTP_PRI})
   {
     const auto orig_req = http::build_request(method, r);
 

--- a/src/http/test/http_test.cpp
+++ b/src/http/test/http_test.cpp
@@ -104,28 +104,24 @@ DOCTEST_TEST_CASE("Parsing fuzzing")
 {
   std::vector<uint8_t> r;
 
-  http::SimpleRequestProcessor sp;
-  http::RequestParser p(sp);
-
-// #define ADD_HTTP_METHOD(NUM, NAME, STRING) HTTP_##NAME,
-//   std::vector<llhttp_method> all_methods{HTTP_ALL_METHOD_MAP(ADD_HTTP_METHOD)};
-// #undef ADD_HTTP_METHOD
+#define ADD_HTTP_METHOD(NUM, NAME, STRING) HTTP_##NAME,
+  std::vector<llhttp_method> all_methods{HTTP_ALL_METHOD_MAP(ADD_HTTP_METHOD)};
+#undef ADD_HTTP_METHOD
 
   for (auto method : {HTTP_POST, HTTP_GET, HTTP_PRI})
   {
     const auto orig_req = http::build_request(method, r);
 
-    for (auto i = 0; i < orig_req.size(); ++i)
+    std::vector<char> replacements = {'\0', '\1'};
+    for (auto i : {0, 1, 2})
     {
-      std::vector<char> replacements;
-      replacements.push_back('\0');
-      replacements.push_back('\1');
-      replacements.push_back((i + 128) % 256);
       for (auto c : replacements)
       {
         auto req = orig_req;
         req[i] = c;
 
+        http::SimpleRequestProcessor sp;
+        http::RequestParser p(sp);
         DOCTEST_CHECK_THROWS(p.execute(req.data(), req.size()));
         DOCTEST_CHECK(sp.received.empty());
       }

--- a/src/http/test/http_test.cpp
+++ b/src/http/test/http_test.cpp
@@ -100,6 +100,39 @@ DOCTEST_TEST_CASE("Parsing error")
   DOCTEST_CHECK(sp.received.empty());
 }
 
+DOCTEST_TEST_CASE("Parsing fuzzing")
+{
+  std::vector<uint8_t> r;
+
+  http::SimpleRequestProcessor sp;
+  http::RequestParser p(sp);
+
+#define ADD_HTTP_METHOD(NUM, NAME, STRING) HTTP_##NAME,
+  std::vector<llhttp_method> all_methods{HTTP_ALL_METHOD_MAP(ADD_HTTP_METHOD)};
+#undef HTTP_METHOD_GEN
+
+  for (auto method : all_methods)
+  {
+    const auto orig_req = http::build_request(method, r);
+
+    for (auto i = 0; i < orig_req.size(); ++i)
+    {
+      std::vector<char> replacements;
+      replacements.push_back('\0');
+      replacements.push_back('\1');
+      replacements.push_back((i + 128) % 256);
+      for (auto c : replacements)
+      {
+        auto req = orig_req;
+        req[i] = c;
+
+        DOCTEST_CHECK_THROWS(p.execute(req.data(), req.size()));
+        DOCTEST_CHECK(sp.received.empty());
+      }
+    }
+  }
+}
+
 DOCTEST_TEST_CASE("Partial request")
 {
   http::SimpleRequestProcessor sp;

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1320,7 +1320,7 @@ def run_parsing_errors(args):
         pdb=args.pdb,
         txs=txs,
     ) as network:
-        network.start_and_open(args)
+        network.start_and_join(args)
 
         network = test_illegal(network, args, verify=args.package != "libjs_generic")
         network = test_protocols(network, args)

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -147,23 +147,10 @@ def test_protocols(network, args):
 
     common_options = [url, "-sS", "--cacert", ca_path]
 
-    # Check that websocket upgrade request is ignored
-    res = infra.proc.ccall(
-        "curl",
-        "--no-buffer",
-        "-H",
-        "Connection: Upgrade",
-        "-H",
-        "Upgrade: websocket",
-        "-w",
-        "\n%{http_code}",
-        *common_options,
-    )
-    assert res.returncode == 0, res.returncode
-    body = res.stdout.decode()
-    status_code = body.splitlines()[-1]
-    assert status_code == "200", body
-    expected_response_body = body[: body.rfind("\n")]
+    with primary.client("user0") as c:
+        r = c.get("/node/state")
+        assert r.status_code == http.HTTPStatus.OK, r.status_code
+        expected_response_body = r.body.text()
 
     # Test additional HTTP versions with curl
     for (protocol, expected_error) in (
@@ -196,10 +183,7 @@ def test_protocols(network, args):
         number_txs=1,
         on_backup=True,
     )
-    if verify:
-        network.txs.verify()
-    else:
-        LOG.warning("Skipping log messages verification")
+    network.txs.verify()
 
     return network
 
@@ -1289,34 +1273,34 @@ def run(args):
         )
         network = test_illegal(network, args, verify=args.package != "libjs_generic")
         network = test_protocols(network, args)
-        # network = test_large_messages(network, args)
-        # network = test_remove(network, args)
-        # network = test_forwarding_frontends(network, args)
-        # network = test_signed_escapes(network, args)
-        # network = test_user_data_ACL(network, args)
-        # network = test_cert_prefix(network, args)
-        # network = test_anonymous_caller(network, args)
-        # network = test_multi_auth(network, args)
-        # network = test_custom_auth(network, args)
-        # network = test_custom_auth_safety(network, args)
-        # network = test_raw_text(network, args)
-        # network = test_historical_query(network, args)
-        # network = test_historical_query_range(network, args)
-        # network = test_view_history(network, args)
-        # network = test_primary(network, args)
-        # network = test_network_node_info(network, args)
-        # network = test_metrics(network, args)
-        # network = test_memory(network, args)
-        # # BFT does not handle re-keying yet
-        # if args.consensus == "cft":
-        #     network = test_liveness(network, args)
-        #     network = test_rekey(network, args)
-        #     network = test_liveness(network, args)
-        #     network = test_random_receipts(network, args)
-        # if args.package == "liblogging":
-        #     network = test_ws(network, args)
-        #     network = test_receipts(network, args)
-        # network = test_historical_receipts(network, args)
+        network = test_large_messages(network, args)
+        network = test_remove(network, args)
+        network = test_forwarding_frontends(network, args)
+        network = test_signed_escapes(network, args)
+        network = test_user_data_ACL(network, args)
+        network = test_cert_prefix(network, args)
+        network = test_anonymous_caller(network, args)
+        network = test_multi_auth(network, args)
+        network = test_custom_auth(network, args)
+        network = test_custom_auth_safety(network, args)
+        network = test_raw_text(network, args)
+        network = test_historical_query(network, args)
+        network = test_historical_query_range(network, args)
+        network = test_view_history(network, args)
+        network = test_primary(network, args)
+        network = test_network_node_info(network, args)
+        network = test_metrics(network, args)
+        network = test_memory(network, args)
+        # BFT does not handle re-keying yet
+        if args.consensus == "cft":
+            network = test_liveness(network, args)
+            network = test_rekey(network, args)
+            network = test_liveness(network, args)
+            network = test_random_receipts(network, args)
+        if args.package == "liblogging":
+            network = test_ws(network, args)
+            network = test_receipts(network, args)
+        network = test_historical_receipts(network, args)
 
 
 if __name__ == "__main__":

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -62,7 +62,7 @@ def test(network, args, verify=True):
 def test_illegal(network, args, verify=True):
     primary, _ = network.find_primary()
 
-    cafile = os.path.join(network.common_dir, "service_cert.pem")
+    cafile = os.path.join(network.common_dir, "networkcert.pem")
     context = ssl.create_default_context(cafile=cafile)
     context.set_ecdh_curve(ccf.clients.get_curve(cafile).name)
     context.load_cert_chain(
@@ -140,10 +140,10 @@ def test_protocols(network, args):
     primary, _ = network.find_primary()
 
     primary_root = (
-        f"https://{primary.get_public_rpc_host()}:{primary.get_public_rpc_port()}"
+        f"https://{primary.pubhost}:{primary.pubport}"
     )
     url = f"{primary_root}/node/state"
-    ca_path = os.path.join(network.common_dir, "service_cert.pem")
+    ca_path = os.path.join(network.common_dir, "networkcert.pem")
 
     common_options = [url, "-sS", "--cacert", ca_path]
 
@@ -1288,35 +1288,35 @@ def run(args):
             verify=args.package != "libjs_generic",
         )
         network = test_illegal(network, args, verify=args.package != "libjs_generic")
-        network = test_protocols(network, args, verify=args.package != "libjs_generic")
-        network = test_large_messages(network, args)
-        network = test_remove(network, args)
-        network = test_forwarding_frontends(network, args)
-        network = test_signed_escapes(network, args)
-        network = test_user_data_ACL(network, args)
-        network = test_cert_prefix(network, args)
-        network = test_anonymous_caller(network, args)
-        network = test_multi_auth(network, args)
-        network = test_custom_auth(network, args)
-        network = test_custom_auth_safety(network, args)
-        network = test_raw_text(network, args)
-        network = test_historical_query(network, args)
-        network = test_historical_query_range(network, args)
-        network = test_view_history(network, args)
-        network = test_primary(network, args)
-        network = test_network_node_info(network, args)
-        network = test_metrics(network, args)
-        network = test_memory(network, args)
-        # BFT does not handle re-keying yet
-        if args.consensus == "cft":
-            network = test_liveness(network, args)
-            network = test_rekey(network, args)
-            network = test_liveness(network, args)
-            network = test_random_receipts(network, args)
-        if args.package == "liblogging":
-            network = test_ws(network, args)
-            network = test_receipts(network, args)
-        network = test_historical_receipts(network, args)
+        network = test_protocols(network, args)
+        # network = test_large_messages(network, args)
+        # network = test_remove(network, args)
+        # network = test_forwarding_frontends(network, args)
+        # network = test_signed_escapes(network, args)
+        # network = test_user_data_ACL(network, args)
+        # network = test_cert_prefix(network, args)
+        # network = test_anonymous_caller(network, args)
+        # network = test_multi_auth(network, args)
+        # network = test_custom_auth(network, args)
+        # network = test_custom_auth_safety(network, args)
+        # network = test_raw_text(network, args)
+        # network = test_historical_query(network, args)
+        # network = test_historical_query_range(network, args)
+        # network = test_view_history(network, args)
+        # network = test_primary(network, args)
+        # network = test_network_node_info(network, args)
+        # network = test_metrics(network, args)
+        # network = test_memory(network, args)
+        # # BFT does not handle re-keying yet
+        # if args.consensus == "cft":
+        #     network = test_liveness(network, args)
+        #     network = test_rekey(network, args)
+        #     network = test_liveness(network, args)
+        #     network = test_random_receipts(network, args)
+        # if args.package == "liblogging":
+        #     network = test_ws(network, args)
+        #     network = test_receipts(network, args)
+        # network = test_historical_receipts(network, args)
 
 
 if __name__ == "__main__":

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1338,4 +1338,5 @@ if __name__ == "__main__":
     args.initial_user_count = 4
     args.initial_member_count = 2
     run(args)
-    run_parsing_errors(args)
+    if args.consensus == "cft":
+        run_parsing_errors(args)

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -282,12 +282,13 @@ class Node:
             if self.pubport is None:
                 self.pubport = self.rpc_port
 
-    def stop(self):
+    def stop(self, *args, **kwargs):
         if self.remote and self.network_state is not NodeNetworkState.stopped:
             if self.suspended:
                 self.resume()
             self.network_state = NodeNetworkState.stopped
-            return self.remote.stop()
+            LOG.info(f"Stopping node {self.local_node_id}")
+            return self.remote.stop(*args, **kwargs)
         return [], []
 
     def is_stopped(self):


### PR DESCRIPTION
This is a cherry-pick of #3634 with some additional tweaks to work on the 1.x branch.

Before #3636, this e2e test triggered a crash - now it is a regression test confirming that the crash no longer occurs.

The main semantic change in this backport is that it does not test that WebSocket upgrades are ignored. On 1.x, some endpoints _may_ be WebSocket enabled, so this test would return a 405. WebSocket upgrades are still tested by other test cases on this branch, and remain disabled in main and 2.x.

Edit - this also includes the fixes to those tests from #3640.