### PR TITLE
Fix HTTP fuzzing tests to produce consistently invalid requests

### DIFF
--- a/src/http/test/http_test.cpp
+++ b/src/http/test/http_test.cpp
@@ -106,28 +106,24 @@ DOCTEST_TEST_CASE("Parsing fuzzing")
 {
   std::vector<uint8_t> r;
 
-  http::SimpleRequestProcessor sp;
-  http::RequestParser p(sp);
-
 #define ADD_HTTP_METHOD(NUM, NAME, STRING) HTTP_##NAME,
   std::vector<llhttp_method> all_methods{HTTP_ALL_METHOD_MAP(ADD_HTTP_METHOD)};
-#undef HTTP_METHOD_GEN
+#undef ADD_HTTP_METHOD
 
   for (auto method : all_methods)
   {
     const auto orig_req = http::build_request(method, r);
 
-    for (auto i = 0; i < orig_req.size(); ++i)
+    std::vector<char> replacements = {'\0', '\1'};
+    for (auto i : {0, 1, 2})
     {
-      std::vector<char> replacements;
-      replacements.push_back('\0');
-      replacements.push_back('\1');
-      replacements.push_back((i + 128) % 256);
       for (auto c : replacements)
       {
         auto req = orig_req;
         req[i] = c;
 
+        http::SimpleRequestProcessor sp;
+        http::RequestParser p(sp);
         DOCTEST_CHECK_THROWS(p.execute(req.data(), req.size()));
         DOCTEST_CHECK(sp.received.empty());
       }

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1402,39 +1402,52 @@ def run(args):
         network.start_and_open(args)
 
         network = test(network, args)
-        network = test_illegal(network, args)
-        # TODO
-        # network = test_protocols(network, args)
-        # network = test_large_messages(network, args)
-        # network = test_remove(network, args)
-        # network = test_clear(network, args)
-        # network = test_record_count(network, args)
-        # network = test_forwarding_frontends(network, args)
-        # network = test_signed_escapes(network, args)
-        # network = test_user_data_ACL(network, args)
-        # network = test_cert_prefix(network, args)
-        # network = test_anonymous_caller(network, args)
-        # network = test_multi_auth(network, args)
-        # network = test_custom_auth(network, args)
-        # network = test_custom_auth_safety(network, args)
-        # network = test_raw_text(network, args)
-        # network = test_historical_query(network, args)
-        # network = test_historical_query_range(network, args)
-        # network = test_view_history(network, args)
-        # network = test_metrics(network, args)
-        # # BFT does not handle re-keying yet
-        # if args.consensus == "CFT":
-        #     network = test_liveness(network, args)
-        #     network = test_rekey(network, args)
-        #     network = test_liveness(network, args)
-        #     network = test_random_receipts(network, args, False)
-        # if args.package == "samples/apps/logging/liblogging":
-        #     network = test_receipts(network, args)
-        #     network = test_historical_query_sparse(network, args)
-        # if "v8" not in args.package:
-        #     network = test_historical_receipts(network, args)
-        #     network = test_historical_receipts_with_claims(network, args)
+        network = test_protocols(network, args)
+        network = test_large_messages(network, args)
+        network = test_remove(network, args)
+        network = test_clear(network, args)
+        network = test_record_count(network, args)
+        network = test_forwarding_frontends(network, args)
+        network = test_signed_escapes(network, args)
+        network = test_user_data_ACL(network, args)
+        network = test_cert_prefix(network, args)
+        network = test_anonymous_caller(network, args)
+        network = test_multi_auth(network, args)
+        network = test_custom_auth(network, args)
+        network = test_custom_auth_safety(network, args)
+        network = test_raw_text(network, args)
+        network = test_historical_query(network, args)
+        network = test_historical_query_range(network, args)
+        network = test_view_history(network, args)
+        network = test_metrics(network, args)
+        # BFT does not handle re-keying yet
+        if args.consensus == "CFT":
+            network = test_liveness(network, args)
+            network = test_rekey(network, args)
+            network = test_liveness(network, args)
+            network = test_random_receipts(network, args, False)
+        if args.package == "samples/apps/logging/liblogging":
+            network = test_receipts(network, args)
+            network = test_historical_query_sparse(network, args)
+        if "v8" not in args.package:
+            network = test_historical_receipts(network, args)
+            network = test_historical_receipts_with_claims(network, args)
 
+
+def run_illegal(args):
+    txs = app.LoggingTxs("user0")
+    with infra.network.network(
+        args.nodes,
+        args.binary_dir,
+        args.debug_nodes,
+        args.perf_nodes,
+        pdb=args.pdb,
+        txs=txs,
+    ) as network:
+        network.start_and_open(args)
+
+        network = test_illegal(network, args)
+        network.ignore_error_pattern_on_shutdown("Error parsing HTTP request")
 
 if __name__ == "__main__":
     cr = ConcurrentRunner()
@@ -1474,6 +1487,21 @@ if __name__ == "__main__":
     cr.add(
         "common",
         e2e_common_endpoints.run,
+        package="samples/apps/logging/liblogging",
+        nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+    )
+
+    # Run illegal traffic tests in separate runner, where we can swallow unhelpful error logs
+    cr.add(
+        "js_illegal",
+        run_illegal,
+        package="libjs_generic",
+        nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+    )
+
+    cr.add(
+        "cpp_illegal",
+        run_illegal,
         package="samples/apps/logging/liblogging",
         nodes=infra.e2e_args.max_nodes(cr.args, f=0),
     )

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -156,7 +156,11 @@ def test_illegal(network, args):
     send_bad_raw_content(b"POST /node/\xff HTTP/2.0\r\n\r\n")
 
     for _ in range(40):
-        content = bytes(random.randint(0, 255) for _ in range(random.randrange(1, 40)))
+        content = bytes(random.randint(0, 255) for _ in range(random.randrange(1, 2)))
+        # If we've accidentally produced something that might look like a valid HTTP request prefix, mangle it further
+        first_byte = content[0]
+        if first_byte >= ord('A') and first_byte <= ord('Z') or first_byte == ord('\r') or first_byte == ord('\n'):
+            content = b'\00' + content
         send_bad_raw_content(content)
 
     def send_corrupt_variations(content):
@@ -1399,36 +1403,37 @@ def run(args):
 
         network = test(network, args)
         network = test_illegal(network, args)
-        network = test_protocols(network, args)
-        network = test_large_messages(network, args)
-        network = test_remove(network, args)
-        network = test_clear(network, args)
-        network = test_record_count(network, args)
-        network = test_forwarding_frontends(network, args)
-        network = test_signed_escapes(network, args)
-        network = test_user_data_ACL(network, args)
-        network = test_cert_prefix(network, args)
-        network = test_anonymous_caller(network, args)
-        network = test_multi_auth(network, args)
-        network = test_custom_auth(network, args)
-        network = test_custom_auth_safety(network, args)
-        network = test_raw_text(network, args)
-        network = test_historical_query(network, args)
-        network = test_historical_query_range(network, args)
-        network = test_view_history(network, args)
-        network = test_metrics(network, args)
-        # BFT does not handle re-keying yet
-        if args.consensus == "CFT":
-            network = test_liveness(network, args)
-            network = test_rekey(network, args)
-            network = test_liveness(network, args)
-            network = test_random_receipts(network, args, False)
-        if args.package == "samples/apps/logging/liblogging":
-            network = test_receipts(network, args)
-            network = test_historical_query_sparse(network, args)
-        if "v8" not in args.package:
-            network = test_historical_receipts(network, args)
-            network = test_historical_receipts_with_claims(network, args)
+        # TODO
+        # network = test_protocols(network, args)
+        # network = test_large_messages(network, args)
+        # network = test_remove(network, args)
+        # network = test_clear(network, args)
+        # network = test_record_count(network, args)
+        # network = test_forwarding_frontends(network, args)
+        # network = test_signed_escapes(network, args)
+        # network = test_user_data_ACL(network, args)
+        # network = test_cert_prefix(network, args)
+        # network = test_anonymous_caller(network, args)
+        # network = test_multi_auth(network, args)
+        # network = test_custom_auth(network, args)
+        # network = test_custom_auth_safety(network, args)
+        # network = test_raw_text(network, args)
+        # network = test_historical_query(network, args)
+        # network = test_historical_query_range(network, args)
+        # network = test_view_history(network, args)
+        # network = test_metrics(network, args)
+        # # BFT does not handle re-keying yet
+        # if args.consensus == "CFT":
+        #     network = test_liveness(network, args)
+        #     network = test_rekey(network, args)
+        #     network = test_liveness(network, args)
+        #     network = test_random_receipts(network, args, False)
+        # if args.package == "samples/apps/logging/liblogging":
+        #     network = test_receipts(network, args)
+        #     network = test_historical_query_sparse(network, args)
+        # if "v8" not in args.package:
+        #     network = test_historical_receipts(network, args)
+        #     network = test_historical_receipts_with_claims(network, args)
 
 
 if __name__ == "__main__":

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -159,8 +159,13 @@ def test_illegal(network, args):
         content = bytes(random.randint(0, 255) for _ in range(random.randrange(1, 2)))
         # If we've accidentally produced something that might look like a valid HTTP request prefix, mangle it further
         first_byte = content[0]
-        if first_byte >= ord('A') and first_byte <= ord('Z') or first_byte == ord('\r') or first_byte == ord('\n'):
-            content = b'\00' + content
+        if (
+            first_byte >= ord("A")
+            and first_byte <= ord("Z")
+            or first_byte == ord("\r")
+            or first_byte == ord("\n")
+        ):
+            content = b"\00" + content
         send_bad_raw_content(content)
 
     def send_corrupt_variations(content):
@@ -1448,6 +1453,7 @@ def run_parsing_errors(args):
         network = test_illegal(network, args)
         network = test_protocols(network, args)
         network.ignore_error_pattern_on_shutdown("Error parsing HTTP request")
+
 
 if __name__ == "__main__":
     cr = ConcurrentRunner()

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1402,7 +1402,6 @@ def run(args):
         network.start_and_open(args)
 
         network = test(network, args)
-        network = test_protocols(network, args)
         network = test_large_messages(network, args)
         network = test_remove(network, args)
         network = test_clear(network, args)
@@ -1434,7 +1433,7 @@ def run(args):
             network = test_historical_receipts_with_claims(network, args)
 
 
-def run_illegal(args):
+def run_parsing_errors(args):
     txs = app.LoggingTxs("user0")
     with infra.network.network(
         args.nodes,
@@ -1447,6 +1446,7 @@ def run_illegal(args):
         network.start_and_open(args)
 
         network = test_illegal(network, args)
+        network = test_protocols(network, args)
         network.ignore_error_pattern_on_shutdown("Error parsing HTTP request")
 
 if __name__ == "__main__":
@@ -1494,14 +1494,14 @@ if __name__ == "__main__":
     # Run illegal traffic tests in separate runner, where we can swallow unhelpful error logs
     cr.add(
         "js_illegal",
-        run_illegal,
+        run_parsing_errors,
         package="libjs_generic",
         nodes=infra.e2e_args.max_nodes(cr.args, f=0),
     )
 
     cr.add(
         "cpp_illegal",
-        run_illegal,
+        run_parsing_errors,
         package="samples/apps/logging/liblogging",
         nodes=infra.e2e_args.max_nodes(cr.args, f=0),
     )

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -620,7 +620,9 @@ class Network:
                 LOG.warning(f"  {pattern}")
 
         for node in self.nodes:
-            _, fatal_errors = node.stop(ignore_error_patterns=self.ignore_error_patterns)
+            _, fatal_errors = node.stop(
+                ignore_error_patterns=self.ignore_error_patterns
+            )
             if fatal_errors:
                 fatal_error_found = True
 

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -387,13 +387,13 @@ class Node:
                     # In the infra, public RPC port is always the same as local RPC port
                     rpc_interface.public_port = rpc_interface.port
 
-    def stop(self):
+    def stop(self, *args, **kwargs):
         if self.remote and self.network_state is not NodeNetworkState.stopped:
             if self.suspended:
                 self.resume()
             self.network_state = NodeNetworkState.stopped
             LOG.info(f"Stopping node {self.local_node_id}")
-            return self.remote.stop()
+            return self.remote.stop(*args, **kwargs)
         return [], []
 
     def is_stopped(self):

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -52,7 +52,7 @@ def sftp_session(hostname):
 DEFAULT_TAIL_LINES_LEN = 10
 
 
-def log_errors(out_path, err_path, tail_lines_len=DEFAULT_TAIL_LINES_LEN):
+def log_errors(out_path, err_path, tail_lines_len=DEFAULT_TAIL_LINES_LEN, ignore_error_patterns=None):
     error_filter = ["[fail ]", "[fatal]", "Atom leak", "atom leakage"]
     error_lines = []
     try:
@@ -62,8 +62,15 @@ def log_errors(out_path, err_path, tail_lines_len=DEFAULT_TAIL_LINES_LEN):
                 stripped_line = line.rstrip()
                 tail_lines.append(stripped_line)
                 if any(x in stripped_line for x in error_filter):
-                    LOG.error("{}: {}".format(out_path, stripped_line))
-                    error_lines.append(stripped_line)
+                    ignore = False
+                    if ignore_error_patterns is not None:
+                        for pattern in ignore_error_patterns:
+                            if pattern in stripped_line:
+                                ignore = True
+                                break
+                    if not ignore:
+                        LOG.error("{}: {}".format(out_path, stripped_line))
+                        error_lines.append(stripped_line)
         if error_lines:
             LOG.info(
                 "{} errors found, printing end of output for context:", len(error_lines)
@@ -265,7 +272,9 @@ class SSHRemote(CmdMixin):
                 raise ValueError(self.root)
         return files
 
-    def get_logs(self, tail_lines_len=DEFAULT_TAIL_LINES_LEN):
+    def get_logs(
+        self, tail_lines_len=DEFAULT_TAIL_LINES_LEN, ignore_error_patterns=None
+    ):
         with sftp_session(self.hostname) as session:
             for filepath in (self.err, self.out):
                 try:
@@ -285,6 +294,7 @@ class SSHRemote(CmdMixin):
             os.path.join(self.common_dir, "{}_{}_out".format(self.hostname, self.name)),
             os.path.join(self.common_dir, "{}_{}_err".format(self.hostname, self.name)),
             tail_lines_len=tail_lines_len,
+            ignore_error_patterns=ignore_error_patterns,
         )
 
     def start(self):
@@ -325,7 +335,7 @@ class SSHRemote(CmdMixin):
         if stdout.channel.recv_exit_status() != 0:
             raise RuntimeError(f"Could not resume remote {self.name} from suspension!")
 
-    def stop(self):
+    def stop(self, ignore_error_patterns=None):
         """
         Disconnect the client, and therefore shut down the command as well.
         """
@@ -333,7 +343,7 @@ class SSHRemote(CmdMixin):
         (
             errors,
             fatal_errors,
-        ) = self.get_logs()
+        ) = self.get_logs(ignore_error_patterns=ignore_error_patterns)
         self.client.close()
         self.proc_client.close()
         return errors, fatal_errors
@@ -478,10 +488,17 @@ class LocalRemote(CmdMixin):
     def resume(self):
         self.proc.send_signal(signal.SIGCONT)
 
-    def get_logs(self, tail_lines_len=DEFAULT_TAIL_LINES_LEN):
-        return log_errors(self.out, self.err, tail_lines_len=tail_lines_len)
+    def get_logs(
+        self, tail_lines_len=DEFAULT_TAIL_LINES_LEN, ignore_error_patterns=None
+    ):
+        return log_errors(
+            self.out,
+            self.err,
+            tail_lines_len=tail_lines_len,
+            ignore_error_patterns=ignore_error_patterns,
+        )
 
-    def stop(self):
+    def stop(self, ignore_error_patterns=None):
         """
         Disconnect the client, and therefore shut down the command as well.
         """
@@ -497,7 +514,7 @@ class LocalRemote(CmdMixin):
                 self.stdout.close()
             if self.stderr:
                 self.stderr.close()
-            return self.get_logs()
+            return self.get_logs(ignore_error_patterns=ignore_error_patterns)
 
     def setup(self):
         """
@@ -872,10 +889,10 @@ class CCFRemote(object):
     def debug_node_cmd(self):
         return self.remote.debug_node_cmd()
 
-    def stop(self):
+    def stop(self, *args, **kwargs):
         errors, fatal_errors = [], []
         try:
-            errors, fatal_errors = self.remote.stop()
+            errors, fatal_errors = self.remote.stop(*args, **kwargs)
         except Exception:
             LOG.exception("Failed to shut down {} cleanly".format(self.local_node_id))
         return errors, fatal_errors
@@ -922,8 +939,12 @@ class CCFRemote(object):
             paths += [os.path.join(self.remote.root, read_only_ledger_dir_name)]
         return paths
 
-    def get_logs(self, tail_lines_len=DEFAULT_TAIL_LINES_LEN):
-        return self.remote.get_logs(tail_lines_len=tail_lines_len)
+    def get_logs(
+        self, tail_lines_len=DEFAULT_TAIL_LINES_LEN, ignore_error_patterns=None
+    ):
+        return self.remote.get_logs(
+            tail_lines_len=tail_lines_len, ignore_error_patterns=ignore_error_patterns
+        )
 
     def get_host(self):
         return self.pub_host

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -52,7 +52,12 @@ def sftp_session(hostname):
 DEFAULT_TAIL_LINES_LEN = 10
 
 
-def log_errors(out_path, err_path, tail_lines_len=DEFAULT_TAIL_LINES_LEN, ignore_error_patterns=None):
+def log_errors(
+    out_path,
+    err_path,
+    tail_lines_len=DEFAULT_TAIL_LINES_LEN,
+    ignore_error_patterns=None,
+):
     error_filter = ["[fail ]", "[fatal]", "Atom leak", "atom leakage"]
     error_lines = []
     try:

--- a/tests/infra/remote_shim.py
+++ b/tests/infra/remote_shim.py
@@ -197,13 +197,13 @@ class DockerShim(infra.remote.CCFRemote):
     def get_host(self):
         return self.container_ip
 
-    def stop(self):
+    def stop(self, *args, **kwargs):
         try:
             self.container.stop()
             LOG.info(f"Stopped container {self.container.name}")
         except docker.errors.NotFound:
             pass
-        return self.remote.get_logs()
+        return self.remote.get_logs(*args, **kwargs)
 
     def suspend(self):
         self.container.pause()


### PR DESCRIPTION
This fixes a bug in #3634, which was producing occasional time-outs in the CI.

One of the new e2e HTTP fuzzing tests produced random data, and assumed this would be unparseable. However, if the random data was, for instance, a single byte containing an ASCII `P`, that would not produce a parsing error. This is a valid prefix for a HTTP request, so the parser would pause, expecting more data. This test now checks (very broadly!) for similar cases, and appends a null-byte to ensure the data is malformed. We'd like a smarter fuzzer here that can determine whether requests are valid or invalid, but for now we're generating reliably-invalid requests.

Some adjacent cleanup:
- Moving the illegal tests to a separate runner, and plumbing through an option to swallow the output they produce in node logs. We don't want to hide this when it appears in most tests, but localised here it can be ignored.
- Fixing the HTTP parsing unit test. The unit test I added recently was actually failing because the parser still held garbage from a previous run. Creating a fresh parser each time shows that the generation had the same hole as described above - sometimes it generated valid HTTP prefixes, and assumes they are garbage. I've reduced the scope of this unit test, so it reliably generates garbage.