### PR TITLE
Add free-form `node_data` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Nodes now have a free-form `node_data` field, to match users and members. This can be set when the node is launched, or modified by governance, and is intended to store metadata about a node's deployment (eg - IDs of the pod/cluster it is running on).
+- Nodes now have a free-form `node_data` field, to match users and members. This can be set when the node is launched, or modified by governance. It is intended to store correlation IDs describing the node's deployment, such as a VM name or Pod identifier.
 
 ## [2.0.0-rc4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Nodes now have a free-form `node_data` field, to match users and members. This can be set when the node is launched, or modified by governance, and is intended to store metadata about a node's deployment (eg - IDs of the pod/cluster it is running on).
+
 ## [2.0.0-rc4]
 
 ### Added

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -249,7 +249,7 @@
     },
     "node_data_json_file": {
       "type": "string",
-      "description": "Path to file (JSON) containing initial node data"
+      "description": "Path to file (JSON) containing initial node data. It is intended to store correlation IDs describing the node's deployment, such as a VM name or Pod identifier."
     },
     "ledger": {
       "type": "object",

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -247,6 +247,10 @@
       },
       "description": "This section includes configuration for the node x509 identity certificate"
     },
+    "node_data_json_file": {
+      "type": "string",
+      "description": "Path to file (JSON) containing initial node data"
+    },
     "ledger": {
       "type": "object",
       "properties": {

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -240,6 +240,12 @@
       },
       "GetNode__NodeInfo": {
         "properties": {
+          "last_written": {
+            "$ref": "#/components/schemas/uint64"
+          },
+          "node_data": {
+            "$ref": "#/components/schemas/json"
+          },
           "node_id": {
             "$ref": "#/components/schemas/NodeId"
           },
@@ -257,7 +263,9 @@
           "node_id",
           "status",
           "primary",
-          "rpc_interfaces"
+          "rpc_interfaces",
+          "node_data",
+          "last_written"
         ],
         "type": "object"
       },
@@ -738,7 +746,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "2.14.1"
+    "version": "2.15.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/include/ccf/service/node_info.h
+++ b/include/ccf/service/node_info.h
@@ -56,6 +56,10 @@ namespace ccf
     /// Public key
     std::optional<crypto::Pem> public_key = std::nullopt;
 
+    /// Free-form user data, can be used to store operator correlation
+    /// IDs/labels for the node for example
+    nlohmann::json node_data = nullptr;
+
     /**
      * Fields below are deprecated
      */
@@ -75,7 +79,8 @@ namespace ccf
     ledger_secret_seqno,
     code_digest,
     certificate_signing_request,
-    public_key);
+    public_key,
+    node_data);
 }
 
 FMT_BEGIN_NAMESPACE

--- a/samples/constitutions/default/actions.js
+++ b/samples/constitutions/default/actions.js
@@ -907,7 +907,26 @@ const actions = new Map([
       }
     ),
   ],
-
+  [
+    "set_node_data",
+    new Action(
+      function (args) {
+        checkEntityId(args.node_id, "node_id");
+        checkType(args.node_data, "object?", "node_data");
+      },
+      function (args) {
+        let node_id = ccf.strToBuf(args.node_id);
+        let nodes_info = ccf.kv["public:ccf.gov.nodes.info"];
+        let node_info = nodes_info.get(node_id);
+        if (node_info === undefined) {
+          throw new Error(`Node ${node_id} does not exist`);
+        }
+        let ni = ccf.bufToJsonCompatible(node_info);
+        ni.node_data = args.node_data;
+        nodes_info.set(node_id, ccf.jsonCompatibleToBuf(ni));
+      }
+    ),
+  ],
   [
     "transition_node_to_trusted",
     new Action(

--- a/samples/constitutions/default/actions.js
+++ b/samples/constitutions/default/actions.js
@@ -912,7 +912,6 @@ const actions = new Map([
     new Action(
       function (args) {
         checkEntityId(args.node_id, "node_id");
-        checkType(args.node_data, "object?", "node_data");
       },
       function (args) {
         let node_id = ccf.strToBuf(args.node_id);

--- a/src/common/configuration.h
+++ b/src/common/configuration.h
@@ -133,6 +133,8 @@ struct StartupConfig : CCFConfig
   // Only if starting or recovering
   size_t initial_service_certificate_validity_days = 1;
 
+  nlohmann::json node_data = nullptr;
+
   struct Start
   {
     std::vector<ccf::NewMember> members;
@@ -177,6 +179,7 @@ DECLARE_JSON_REQUIRED_FIELDS(
   startup_host_time,
   snapshot_tx_interval,
   initial_service_certificate_validity_days,
+  node_data,
   start,
   join,
   recover);

--- a/src/host/configuration.h
+++ b/src/host/configuration.h
@@ -60,6 +60,9 @@ namespace host
     ds::TimeString slow_io_logging_threshold = {"10ms"};
     std::optional<std::string> node_client_interface = std::nullopt;
     ds::TimeString client_connection_timeout = {"2000ms"};
+    // TODO: This is a path to a file, for consistency with member data. But
+    // those should probably both be inlined now that we have JSON configs
+    std::optional<std::string> node_data_json_file = std::nullopt;
 
     struct OutputFiles
     {
@@ -210,6 +213,7 @@ namespace host
     slow_io_logging_threshold,
     node_client_interface,
     client_connection_timeout,
+    node_data_json_file,
     output_files,
     ledger,
     snapshots,

--- a/src/host/configuration.h
+++ b/src/host/configuration.h
@@ -60,8 +60,6 @@ namespace host
     ds::TimeString slow_io_logging_threshold = {"10ms"};
     std::optional<std::string> node_client_interface = std::nullopt;
     ds::TimeString client_connection_timeout = {"2000ms"};
-    // TODO: This is a path to a file, for consistency with member data. But
-    // those should probably both be inlined now that we have JSON configs
     std::optional<std::string> node_data_json_file = std::nullopt;
 
     struct OutputFiles

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -354,6 +354,12 @@ int main(int argc, char** argv)
     startup_config.worker_threads = config.worker_threads;
     startup_config.node_certificate = config.node_certificate;
 
+    if (config.node_data_json_file.has_value())
+    {
+      startup_config.node_data =
+        files::slurp_json(config.node_data_json_file.value());
+    }
+
     auto startup_host_time = std::chrono::system_clock::now();
     LOG_INFO_FMT("Startup host time: {}", startup_host_time);
 

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -670,6 +670,7 @@ namespace ccf
       join_params.startup_seqno = startup_seqno;
       join_params.certificate_signing_request = node_sign_kp->create_csr(
         config.node_certificate.subject_name, subject_alt_names);
+      join_params.node_data = config.node_data;
 
       LOG_DEBUG_FMT(
         "Sending join request to {}", config.join.target_rpc_address);
@@ -1741,6 +1742,7 @@ namespace ccf
       create_params.public_encryption_key = node_encrypt_kp->public_key_pem();
       create_params.code_digest = node_code_id;
       create_params.node_info_network = config.network;
+      create_params.node_data = config.node_data;
 
       const auto body = serdes::pack(create_params, serdes::Pack::Text);
 

--- a/src/node/rpc/call_types.h
+++ b/src/node/rpc/call_types.h
@@ -69,7 +69,8 @@ namespace ccf
       NodeStatus status;
       bool primary;
       ccf::NodeInfoNetwork::RpcInterfaces rpc_interfaces;
-      nlohmann::json node_data = nullptr;
+      nlohmann::json node_data;
+      ccf::SeqNo last_written;
     };
 
     using Out = NodeInfo;

--- a/src/node/rpc/call_types.h
+++ b/src/node/rpc/call_types.h
@@ -69,6 +69,7 @@ namespace ccf
       NodeStatus status;
       bool primary;
       ccf::NodeInfoNetwork::RpcInterfaces rpc_interfaces;
+      nlohmann::json node_data = nullptr;
     };
 
     using Out = NodeInfo;

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -60,6 +60,7 @@ namespace ccf
       crypto::Pem public_encryption_key;
       CodeDigest code_digest;
       NodeInfoNetwork node_info_network;
+      nlohmann::json node_data;
 
       // Only set on genesis transaction, but not on recovery
       std::optional<StartupConfig::Start> genesis_info = std::nullopt;
@@ -76,6 +77,7 @@ namespace ccf
       ConsensusType consensus_type = ConsensusType::CFT;
       std::optional<kv::Version> startup_seqno = std::nullopt;
       std::optional<crypto::Pem> certificate_signing_request = std::nullopt;
+      nlohmann::json node_data = nullptr;
     };
 
     struct Out

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -842,7 +842,7 @@ namespace ccf
         GetNodes::Out out;
 
         auto nodes = args.tx.ro(this->network.nodes);
-        nodes->foreach([this, host, port, status, &out](
+        nodes->foreach([this, host, port, status, &out, nodes](
                          const NodeId& nid, const NodeInfo& ni) {
           if (status.has_value() && status.value() != ni.status)
           {
@@ -877,7 +877,12 @@ namespace ccf
           }
 
           out.nodes.push_back(
-            {nid, ni.status, is_primary, ni.rpc_interfaces, ni.node_data});
+            {nid,
+             ni.status,
+             is_primary,
+             ni.rpc_interfaces,
+             ni.node_data,
+             nodes->get_version_of_previous_write(nid).value_or(0)});
           return true;
         });
 
@@ -934,7 +939,12 @@ namespace ccf
         }
         auto& ni = info.value();
         return make_success(GetNode::Out{
-          node_id, ni.status, is_primary, ni.rpc_interfaces, ni.node_data});
+          node_id,
+          ni.status,
+          is_primary,
+          ni.rpc_interfaces,
+          ni.node_data,
+          nodes->get_version_of_previous_write(node_id).value_or(0)});
       };
       make_read_only_endpoint(
         "/network/nodes/{node_id}",

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -347,7 +347,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
-      openapi_info.document_version = "2.14.1";
+      openapi_info.document_version = "2.15.0";
     }
 
     void init_handlers() override

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -281,7 +281,8 @@ namespace ccf
         ledger_secret_seqno,
         ds::to_hex(code_digest.data),
         in.certificate_signing_request,
-        client_public_key_pem};
+        client_public_key_pem,
+        in.node_data};
 
       // Because the certificate signature scheme is non-deterministic, only
       // self-signed node certificate is recorded in the node info table

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -876,7 +876,8 @@ namespace ccf
             is_primary = consensus->primary() == nid;
           }
 
-          out.nodes.push_back({nid, ni.status, is_primary, ni.rpc_interfaces});
+          out.nodes.push_back(
+            {nid, ni.status, is_primary, ni.rpc_interfaces, ni.node_data});
           return true;
         });
 
@@ -932,8 +933,8 @@ namespace ccf
           }
         }
         auto& ni = info.value();
-        return make_success(
-          GetNode::Out{node_id, ni.status, is_primary, ni.rpc_interfaces});
+        return make_success(GetNode::Out{
+          node_id, ni.status, is_primary, ni.rpc_interfaces, ni.node_data});
       };
       make_read_only_endpoint(
         "/network/nodes/{node_id}",

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -88,10 +88,15 @@ namespace ccf
     current_view,
     primary_id)
 
-  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(GetNode::NodeInfo)
+  DECLARE_JSON_TYPE(GetNode::NodeInfo)
   DECLARE_JSON_REQUIRED_FIELDS(
-    GetNode::NodeInfo, node_id, status, primary, rpc_interfaces)
-  DECLARE_JSON_OPTIONAL_FIELDS(GetNode::NodeInfo, node_data)
+    GetNode::NodeInfo,
+    node_id,
+    status,
+    primary,
+    rpc_interfaces,
+    node_data,
+    last_written)
 
   DECLARE_JSON_TYPE(GetNodes::Out)
   DECLARE_JSON_REQUIRED_FIELDS(GetNodes::Out, nodes)

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -28,7 +28,7 @@ namespace ccf
     consensus_type,
     startup_seqno)
   DECLARE_JSON_OPTIONAL_FIELDS(
-    JoinNetworkNodeToNode::In, certificate_signing_request)
+    JoinNetworkNodeToNode::In, certificate_signing_request, node_data)
 
   DECLARE_JSON_ENUM(
     ccf::IdentityType,
@@ -72,7 +72,8 @@ namespace ccf
     public_encryption_key,
     code_digest,
     node_info_network)
-  DECLARE_JSON_OPTIONAL_FIELDS(CreateNetworkNodeToNode::In, genesis_info)
+  DECLARE_JSON_OPTIONAL_FIELDS(
+    CreateNetworkNodeToNode::In, genesis_info, node_data);
 
   DECLARE_JSON_TYPE(GetCommit::Out)
   DECLARE_JSON_REQUIRED_FIELDS(GetCommit::Out, transaction_id)

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -88,9 +88,10 @@ namespace ccf
     current_view,
     primary_id)
 
-  DECLARE_JSON_TYPE(GetNode::NodeInfo)
+  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(GetNode::NodeInfo)
   DECLARE_JSON_REQUIRED_FIELDS(
     GetNode::NodeInfo, node_id, status, primary, rpc_interfaces)
+  DECLARE_JSON_OPTIONAL_FIELDS(GetNode::NodeInfo, node_data)
 
   DECLARE_JSON_TYPE(GetNodes::Out)
   DECLARE_JSON_REQUIRED_FIELDS(GetNodes::Out, nodes)

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -73,7 +73,7 @@ namespace ccf
     code_digest,
     node_info_network)
   DECLARE_JSON_OPTIONAL_FIELDS(
-    CreateNetworkNodeToNode::In, genesis_info, node_data);
+    CreateNetworkNodeToNode::In, genesis_info, node_data)
 
   DECLARE_JSON_TYPE(GetCommit::Out)
   DECLARE_JSON_REQUIRED_FIELDS(GetCommit::Out, transaction_id)

--- a/tests/config.jinja
+++ b/tests/config.jinja
@@ -14,6 +14,7 @@
     "curve_id": "{{ curve_id }}",
     "initial_validity_days": {{ initial_node_cert_validity_days }}
   },
+  "node_data_json_file": {{ node_data_json_file|tojson }},
   "command": {
     "type": "{{ start_type }}",
     "start":

--- a/tests/governance_js.py
+++ b/tests/governance_js.py
@@ -496,38 +496,6 @@ def test_actions(network, args):
     network.consortium.remove_member(node, new_member)
     network.consortium.remove_member(node, new_member)
 
-    # Set node data
-    with node.client(new_user.local_id) as c:
-        r = c.get("/node/network/nodes")
-        assert r.status_code == 200, (r.status_code, r.body.text())
-        original_nodes = {
-            node_info["node_id"]: node_info for node_info in r.body.json()["nodes"]
-        }
-        for _, node_info in original_nodes.items():
-            assert node_info["node_data"] == None, node_info
-        new_node_data = {"container_id": "foo", "age": 42}
-        target_node_id = node.node_id
-        network.consortium.set_node_data(node, target_node_id, new_node_data)
-        r = c.get("/node/network/nodes")
-        assert r.status_code == 200, (r.status_code, r.body.text())
-        new_nodes = {
-            node_info["node_id"]: node_info for node_info in r.body.json()["nodes"]
-        }
-        assert new_nodes.keys() == original_nodes.keys(), (
-            new_nodes.keys(),
-            original_nodes.keys(),
-        )
-        for node_id, node_info in new_nodes.items():
-            if node_id == target_node_id:
-                assert node_info["node_data"] == new_node_data, node_info
-                original_info = original_nodes[target_node_id]
-                assert node_info["last_written"] > original_info["last_written"], (
-                    node_info,
-                    original_info,
-                )
-            else:
-                assert node_info["node_data"] == None, node_info
-
     return network
 
 

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -648,6 +648,15 @@ class Consortium:
         proposal = self.get_any_active_member().propose(remote_node, proposal_body)
         return self.vote_using_majority(remote_node, proposal, careful_vote)
 
+    def set_node_data(self, remote_node, node_service_id, node_data):
+        proposal, careful_vote = self.make_proposal(
+            "set_node_data",
+            node_id=node_service_id,
+            node_data=node_data,
+        )
+        proposal = self.get_any_active_member().propose(remote_node, proposal)
+        return self.vote_using_majority(remote_node, proposal, careful_vote)
+
     def set_node_certificate_validity(
         self, remote_node, node_to_renew, valid_from, validity_period_days
     ):

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -190,9 +190,7 @@ class Network:
         self.next_node_id += 1
         return next_node_id
 
-    def create_node(
-        self, host, binary_dir=None, library_dir=None, node_port=0, version=None
-    ):
+    def create_node(self, host, binary_dir=None, library_dir=None, **kwargs):
         node_id = self._get_next_local_node_id()
         debug = (
             (str(node_id) in self.dbg_nodes) if self.dbg_nodes is not None else False
@@ -207,8 +205,7 @@ class Network:
             library_dir or self.library_dir,
             debug,
             perf,
-            node_port=node_port,
-            version=version,
+            **kwargs,
         )
         self.nodes.append(node)
         return node

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -103,6 +103,7 @@ class Node:
         perf=False,
         node_port=0,
         version=None,
+        node_data_json_file=None,
     ):
         self.local_node_id = local_node_id
         self.binary_dir = binary_dir
@@ -127,6 +128,7 @@ class Node:
         self.consensus = None
         self.certificate_valid_from = None
         self.certificate_validity_days = None
+        self.initial_node_data_json_file = node_data_json_file
 
         if os.getenv("CONTAINER_NODES"):
             self.remote_shim = infra.remote_shim.DockerShim
@@ -273,6 +275,7 @@ class Node:
             members_info=members_info,
             version=self.version,
             major_version=self.major_version,
+            node_data_json_file=self.initial_node_data_json_file,
             **kwargs,
         )
         self.remote.setup()

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -588,6 +588,7 @@ class CCFRemote(object):
         sig_ms_interval=None,
         jwt_key_refresh_interval_s=None,
         election_timeout_ms=None,
+        node_data_json_file=None,
         **kwargs,
     ):
         """
@@ -677,6 +678,7 @@ class CCFRemote(object):
                 signature_interval_duration=f"{sig_ms_interval}ms",
                 jwt_key_refresh_interval=f"{jwt_key_refresh_interval_s}s",
                 election_timeout=f"{election_timeout_ms}ms",
+                node_data_json_file=node_data_json_file,
                 **kwargs,
             )
 


### PR DESCRIPTION
Resolves #3644.

`node_data` can be passed at cchost startup time*, or via a `set_node_data` proposal. The objects returned in `/network/nodes` also include `last_written`, as a hint to when each node was added.

_\* The config argument is a top-level field named `node_data_json_file`. It's a path to a file for consistency with `member_data`. We could inline these now that we have a JSON config, rather than requiring them to be dumped to a separate file, but it's a more awkward change when migrating from 1.x to 2.x_

### TODO
- [x] CHANGELOG
- [x] Documented config schema