### PR TITLE
Remove `enclave` namespace

### DIFF
--- a/include/ccf/endpoint_context.h
+++ b/include/ccf/endpoint_context.h
@@ -7,7 +7,6 @@
 #include <functional>
 #include <memory>
 
-// TODO: include?
 namespace ccf
 {
   class RpcContext;

--- a/include/ccf/endpoint_context.h
+++ b/include/ccf/endpoint_context.h
@@ -7,7 +7,8 @@
 #include <functional>
 #include <memory>
 
-namespace enclave
+// TODO: include?
+namespace ccf
 {
   class RpcContext;
 }
@@ -23,13 +24,13 @@ namespace ccf::endpoints
   struct CommandEndpointContext
   {
     CommandEndpointContext(
-      const std::shared_ptr<enclave::RpcContext>& r,
+      const std::shared_ptr<ccf::RpcContext>& r,
       std::unique_ptr<AuthnIdentity>&& c) :
       rpc_ctx(r),
       caller(std::move(c))
     {}
 
-    std::shared_ptr<enclave::RpcContext> rpc_ctx;
+    std::shared_ptr<ccf::RpcContext> rpc_ctx;
     std::unique_ptr<AuthnIdentity> caller;
 
     template <typename T>
@@ -55,7 +56,7 @@ namespace ccf::endpoints
   struct EndpointContext : public CommandEndpointContext
   {
     EndpointContext(
-      const std::shared_ptr<enclave::RpcContext>& r,
+      const std::shared_ptr<ccf::RpcContext>& r,
       std::unique_ptr<AuthnIdentity>&& c,
       kv::Tx& t) :
       CommandEndpointContext(r, std::move(c)),
@@ -70,7 +71,7 @@ namespace ccf::endpoints
   struct ReadOnlyEndpointContext : public CommandEndpointContext
   {
     ReadOnlyEndpointContext(
-      const std::shared_ptr<enclave::RpcContext>& r,
+      const std::shared_ptr<ccf::RpcContext>& r,
       std::unique_ptr<AuthnIdentity>&& c,
       kv::ReadOnlyTx& t) :
       CommandEndpointContext(r, std::move(c)),

--- a/include/ccf/endpoint_registry.h
+++ b/include/ccf/endpoint_registry.h
@@ -110,7 +110,7 @@ namespace ccf::endpoints
 
     template <typename T>
     bool get_path_param(
-      const enclave::PathParams& params,
+      const ccf::PathParams& params,
       const std::string& param_name,
       T& value,
       std::string& error)
@@ -137,7 +137,7 @@ namespace ccf::endpoints
 
     template <>
     bool get_path_param(
-      const enclave::PathParams& params,
+      const ccf::PathParams& params,
       const std::string& param_name,
       std::string& value,
       std::string& error)
@@ -245,13 +245,13 @@ namespace ccf::endpoints
     virtual void init_handlers();
 
     virtual EndpointDefinitionPtr find_endpoint(
-      kv::Tx&, enclave::RpcContext& rpc_ctx);
+      kv::Tx&, ccf::RpcContext& rpc_ctx);
 
     virtual void execute_endpoint(
       EndpointDefinitionPtr e, EndpointContext& args);
 
     virtual std::set<RESTVerb> get_allowed_verbs(
-      kv::Tx&, const enclave::RpcContext& rpc_ctx);
+      kv::Tx&, const ccf::RpcContext& rpc_ctx);
 
     virtual void report_ambiguous_templated_path(
       const std::string& path,

--- a/include/ccf/endpoints/authentication/authentication_types.h
+++ b/include/ccf/endpoints/authentication/authentication_types.h
@@ -8,7 +8,8 @@
 #include <nlohmann/json.hpp>
 #include <string>
 
-namespace enclave
+// TODO: include?
+namespace ccf
 {
   class RpcContext;
 }
@@ -31,11 +32,11 @@ namespace ccf
 
     virtual std::unique_ptr<AuthnIdentity> authenticate(
       kv::ReadOnlyTx& tx,
-      const std::shared_ptr<enclave::RpcContext>& ctx,
+      const std::shared_ptr<ccf::RpcContext>& ctx,
       std::string& error_reason) = 0;
 
     virtual void set_unauthenticated_error(
-      std::shared_ptr<enclave::RpcContext>& ctx, std::string&& error_reason);
+      std::shared_ptr<ccf::RpcContext>& ctx, std::string&& error_reason);
 
     virtual std::optional<OpenAPISecuritySchema> get_openapi_security_schema()
       const = 0;

--- a/include/ccf/endpoints/authentication/authentication_types.h
+++ b/include/ccf/endpoints/authentication/authentication_types.h
@@ -8,7 +8,6 @@
 #include <nlohmann/json.hpp>
 #include <string>
 
-// TODO: include?
 namespace ccf
 {
   class RpcContext;

--- a/include/ccf/endpoints/authentication/cert_auth.h
+++ b/include/ccf/endpoints/authentication/cert_auth.h
@@ -31,7 +31,7 @@ namespace ccf
 
     std::unique_ptr<AuthnIdentity> authenticate(
       kv::ReadOnlyTx& tx,
-      const std::shared_ptr<enclave::RpcContext>& ctx,
+      const std::shared_ptr<ccf::RpcContext>& ctx,
       std::string& error_reason) override;
 
     std::optional<OpenAPISecuritySchema> get_openapi_security_schema()
@@ -54,7 +54,7 @@ namespace ccf
 
     std::unique_ptr<AuthnIdentity> authenticate(
       kv::ReadOnlyTx& tx,
-      const std::shared_ptr<enclave::RpcContext>& ctx,
+      const std::shared_ptr<ccf::RpcContext>& ctx,
       std::string& error_reason) override;
 
     std::optional<OpenAPISecuritySchema> get_openapi_security_schema()
@@ -74,7 +74,7 @@ namespace ccf
   public:
     std::unique_ptr<AuthnIdentity> authenticate(
       kv::ReadOnlyTx& tx,
-      const std::shared_ptr<enclave::RpcContext>& ctx,
+      const std::shared_ptr<ccf::RpcContext>& ctx,
       std::string& error_reason) override;
 
     std::optional<OpenAPISecuritySchema> get_openapi_security_schema()

--- a/include/ccf/endpoints/authentication/empty_auth.h
+++ b/include/ccf/endpoints/authentication/empty_auth.h
@@ -18,11 +18,11 @@ namespace ccf
 
     std::unique_ptr<AuthnIdentity> authenticate(
       kv::ReadOnlyTx&,
-      const std::shared_ptr<enclave::RpcContext>&,
+      const std::shared_ptr<ccf::RpcContext>&,
       std::string&) override;
 
     void set_unauthenticated_error(
-      std::shared_ptr<enclave::RpcContext>&, std::string&&) override;
+      std::shared_ptr<ccf::RpcContext>&, std::string&&) override;
 
     std::optional<OpenAPISecuritySchema> get_openapi_security_schema()
       const override

--- a/include/ccf/endpoints/authentication/jwt_auth.h
+++ b/include/ccf/endpoints/authentication/jwt_auth.h
@@ -27,11 +27,11 @@ namespace ccf
 
     std::unique_ptr<AuthnIdentity> authenticate(
       kv::ReadOnlyTx& tx,
-      const std::shared_ptr<enclave::RpcContext>& ctx,
+      const std::shared_ptr<ccf::RpcContext>& ctx,
       std::string& error_reason) override;
 
     void set_unauthenticated_error(
-      std::shared_ptr<enclave::RpcContext>& ctx,
+      std::shared_ptr<ccf::RpcContext>& ctx,
       std::string&& error_reason) override;
 
     std::optional<OpenAPISecuritySchema> get_openapi_security_schema()

--- a/include/ccf/endpoints/authentication/sig_auth.h
+++ b/include/ccf/endpoints/authentication/sig_auth.h
@@ -35,11 +35,11 @@ namespace ccf
 
     std::unique_ptr<AuthnIdentity> authenticate(
       kv::ReadOnlyTx& tx,
-      const std::shared_ptr<enclave::RpcContext>& ctx,
+      const std::shared_ptr<ccf::RpcContext>& ctx,
       std::string& error_reason) override;
 
     void set_unauthenticated_error(
-      std::shared_ptr<enclave::RpcContext>& ctx,
+      std::shared_ptr<ccf::RpcContext>& ctx,
       std::string&& error_reason) override;
 
     std::optional<OpenAPISecuritySchema> get_openapi_security_schema()
@@ -78,11 +78,11 @@ namespace ccf
 
     std::unique_ptr<AuthnIdentity> authenticate(
       kv::ReadOnlyTx& tx,
-      const std::shared_ptr<enclave::RpcContext>& ctx,
+      const std::shared_ptr<ccf::RpcContext>& ctx,
       std::string& error_reason) override;
 
     void set_unauthenticated_error(
-      std::shared_ptr<enclave::RpcContext>& ctx,
+      std::shared_ptr<ccf::RpcContext>& ctx,
       std::string&& error_reason) override;
 
     std::optional<OpenAPISecuritySchema> get_openapi_security_schema()

--- a/include/ccf/json_handler.h
+++ b/include/ccf/json_handler.h
@@ -67,21 +67,21 @@ namespace ccf
     char const* pack_to_content_type(serdes::Pack p);
 
     serdes::Pack detect_json_pack(
-      const std::shared_ptr<enclave::RpcContext>& ctx);
+      const std::shared_ptr<ccf::RpcContext>& ctx);
 
     serdes::Pack get_response_pack(
-      const std::shared_ptr<enclave::RpcContext>& ctx,
+      const std::shared_ptr<ccf::RpcContext>& ctx,
       serdes::Pack request_pack = serdes::Pack::Text);
 
     nlohmann::json get_params_from_body(
-      const std::shared_ptr<enclave::RpcContext>& ctx, serdes::Pack pack);
+      const std::shared_ptr<ccf::RpcContext>& ctx, serdes::Pack pack);
 
     std::pair<serdes::Pack, nlohmann::json> get_json_params(
-      const std::shared_ptr<enclave::RpcContext>& ctx);
+      const std::shared_ptr<ccf::RpcContext>& ctx);
 
     void set_response(
       JsonAdapterResponse&& res,
-      std::shared_ptr<enclave::RpcContext>& ctx,
+      std::shared_ptr<ccf::RpcContext>& ctx,
       serdes::Pack request_packing);
   }
 

--- a/include/ccf/json_handler.h
+++ b/include/ccf/json_handler.h
@@ -66,8 +66,7 @@ namespace ccf
 
     char const* pack_to_content_type(serdes::Pack p);
 
-    serdes::Pack detect_json_pack(
-      const std::shared_ptr<ccf::RpcContext>& ctx);
+    serdes::Pack detect_json_pack(const std::shared_ptr<ccf::RpcContext>& ctx);
 
     serdes::Pack get_response_pack(
       const std::shared_ptr<ccf::RpcContext>& ctx,

--- a/include/ccf/rpc_context.h
+++ b/include/ccf/rpc_context.h
@@ -13,7 +13,7 @@
 
 #include <vector>
 
-namespace enclave
+namespace ccf
 {
   static constexpr size_t InvalidSessionId = std::numeric_limits<size_t>::max();
   using ListenInterfaceID = std::string;

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -52,7 +52,7 @@ namespace loggingapp
   public:
     std::unique_ptr<ccf::AuthnIdentity> authenticate(
       kv::ReadOnlyTx&,
-      const std::shared_ptr<enclave::RpcContext>& ctx,
+      const std::shared_ptr<ccf::RpcContext>& ctx,
       std::string& error_reason) override
     {
       const auto& headers = ctx->get_request_headers();

--- a/src/apps/js_generic/js_generic_base.cpp
+++ b/src/apps/js_generic/js_generic_base.cpp
@@ -489,7 +489,7 @@ namespace ccfapp
     }
 
     ccf::endpoints::EndpointDefinitionPtr find_endpoint(
-      kv::Tx& tx, enclave::RpcContext& rpc_ctx) override
+      kv::Tx& tx, ccf::RpcContext& rpc_ctx) override
     {
       const auto method = rpc_ctx.get_method();
       const auto verb = rpc_ctx.get_request_verb();
@@ -577,7 +577,7 @@ namespace ccfapp
     }
 
     std::set<RESTVerb> get_allowed_verbs(
-      kv::Tx& tx, const enclave::RpcContext& rpc_ctx) override
+      kv::Tx& tx, const ccf::RpcContext& rpc_ctx) override
     {
       const auto method = rpc_ctx.get_method();
 

--- a/src/apps/js_v8/js_v8_base.cpp
+++ b/src/apps/js_v8/js_v8_base.cpp
@@ -318,7 +318,7 @@ namespace ccfapp
     }
 
     ccf::endpoints::EndpointDefinitionPtr find_endpoint(
-      kv::Tx& tx, enclave::RpcContext& rpc_ctx) override
+      kv::Tx& tx, ccf::RpcContext& rpc_ctx) override
     {
       const auto method = rpc_ctx.get_method();
       const auto verb = rpc_ctx.get_request_verb();
@@ -406,7 +406,7 @@ namespace ccfapp
     }
 
     std::set<RESTVerb> get_allowed_verbs(
-      kv::Tx& tx, const enclave::RpcContext& rpc_ctx) override
+      kv::Tx& tx, const ccf::RpcContext& rpc_ctx) override
     {
       const auto method = rpc_ctx.get_method();
 

--- a/src/apps/js_v8/tmpl/ccf_global.cpp
+++ b/src/apps/js_v8/tmpl/ccf_global.cpp
@@ -56,9 +56,9 @@ namespace ccf::v8_tmpl
       get_internal_field(obj, InternalField::StateCache));
   }
 
-  static enclave::RpcContext* unwrap_rpc_context(v8::Local<v8::Object> obj)
+  static ccf::RpcContext* unwrap_rpc_context(v8::Local<v8::Object> obj)
   {
-    return static_cast<enclave::RpcContext*>(
+    return static_cast<ccf::RpcContext*>(
       get_internal_field(obj, InternalField::RpcContext));
   }
 
@@ -649,7 +649,7 @@ namespace ccf::v8_tmpl
   static void get_rpc(
     v8::Local<v8::Name> name, const v8::PropertyCallbackInfo<v8::Value>& info)
   {
-    enclave::RpcContext* rpc_ctx = unwrap_rpc_context(info.Holder());
+    ccf::RpcContext* rpc_ctx = unwrap_rpc_context(info.Holder());
     v8::Local<v8::Context> context = info.GetIsolate()->GetCurrentContext();
 
     v8::Local<v8::Value> value = Rpc::wrap(context, rpc_ctx);
@@ -726,7 +726,7 @@ namespace ccf::v8_tmpl
     ccf::historical::StatePtr* historical_state,
     ccf::BaseEndpointRegistry* endpoint_registry,
     ccf::historical::AbstractStateCache* state_cache,
-    enclave::RpcContext* rpc_ctx)
+    ccf::RpcContext* rpc_ctx)
   {
     v8::Isolate* isolate = context->GetIsolate();
     v8::EscapableHandleScope handle_scope(isolate);

--- a/src/apps/js_v8/tmpl/ccf_global.h
+++ b/src/apps/js_v8/tmpl/ccf_global.h
@@ -22,7 +22,7 @@ namespace ccf::v8_tmpl
       ccf::historical::StatePtr* historical_state,
       ccf::BaseEndpointRegistry* endpoint_registry,
       ccf::historical::AbstractStateCache* state_cache,
-      enclave::RpcContext* rpc_ctx);
+      ccf::RpcContext* rpc_ctx);
   };
 
 } // namespace ccf::v8_tmpl

--- a/src/apps/js_v8/tmpl/rpc.cpp
+++ b/src/apps/js_v8/tmpl/rpc.cpp
@@ -13,9 +13,9 @@ namespace ccf::v8_tmpl
     END
   };
 
-  static enclave::RpcContext* unwrap_rpc_context(v8::Local<v8::Object> obj)
+  static ccf::RpcContext* unwrap_rpc_context(v8::Local<v8::Object> obj)
   {
-    return static_cast<enclave::RpcContext*>(
+    return static_cast<ccf::RpcContext*>(
       get_internal_field(obj, InternalField::RpcContext));
   }
 
@@ -23,7 +23,7 @@ namespace ccf::v8_tmpl
   {
     v8::Isolate* isolate = info.GetIsolate();
     v8::Local<v8::Context> context = isolate->GetCurrentContext();
-    enclave::RpcContext* rpc_ctx = unwrap_rpc_context(info.Holder());
+    ccf::RpcContext* rpc_ctx = unwrap_rpc_context(info.Holder());
 
     if (info.Length() != 1)
     {
@@ -62,7 +62,7 @@ namespace ccf::v8_tmpl
   }
 
   v8::Local<v8::Object> Rpc::wrap(
-    v8::Local<v8::Context> context, enclave::RpcContext* rpc_ctx)
+    v8::Local<v8::Context> context, ccf::RpcContext* rpc_ctx)
   {
     v8::Isolate* isolate = context->GetIsolate();
     v8::EscapableHandleScope handle_scope(isolate);

--- a/src/apps/js_v8/tmpl/rpc.h
+++ b/src/apps/js_v8/tmpl/rpc.h
@@ -15,7 +15,7 @@ namespace ccf::v8_tmpl
     static v8::Local<v8::ObjectTemplate> create_template(v8::Isolate* isolate);
 
     static v8::Local<v8::Object> wrap(
-      v8::Local<v8::Context> context, enclave::RpcContext* rpc_ctx);
+      v8::Local<v8::Context> context, ccf::RpcContext* rpc_ctx);
   };
 
 } // namespace ccf::v8_tmpl

--- a/src/enclave/client_endpoint.h
+++ b/src/enclave/client_endpoint.h
@@ -5,7 +5,7 @@
 #include "http/http_builder.h"
 #include "tls/msg_types.h"
 
-namespace enclave
+namespace ccf
 {
   class ClientEndpoint
   {

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -27,7 +27,7 @@
 
 #include <openssl/engine.h>
 
-namespace enclave
+namespace ccf
 {
   class Enclave
   {
@@ -257,7 +257,7 @@ namespace enclave
             threading::ThreadMessaging::thread_messaging.set_finished();
           });
 
-        last_tick_time = enclave::get_enclave_time();
+        last_tick_time = ccf::get_enclave_time();
 
         DISPATCHER_SET_MESSAGE_HANDLER(
           bp,
@@ -268,7 +268,7 @@ namespace enclave
             RINGBUFFER_WRITE_MESSAGE(
               AdminMessage::work_stats, to_host, j.dump());
 
-            const auto time_now = enclave::get_enclave_time();
+            const auto time_now = ccf::get_enclave_time();
             ringbuffer_logger->set_time(time_now);
 
             const auto elapsed_ms =
@@ -435,7 +435,7 @@ namespace enclave
           // messages were executed, idle
           if (read == 0 && thread_msg == 0)
           {
-            const auto time_now = enclave::get_enclave_time();
+            const auto time_now = ccf::get_enclave_time();
             static std::chrono::microseconds idling_start_time;
 
             if (consecutive_idles == 0)

--- a/src/enclave/enclave_time.cpp
+++ b/src/enclave/enclave_time.cpp
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #include "enclave/enclave_time.h"
 
-namespace enclave
+namespace ccf
 {
   std::atomic<std::chrono::microseconds>* host_time = nullptr;
   std::chrono::microseconds last_value(0);

--- a/src/enclave/enclave_time.h
+++ b/src/enclave/enclave_time.h
@@ -5,7 +5,7 @@
 #include <atomic>
 #include <chrono>
 
-namespace enclave
+namespace ccf
 {
   extern std::atomic<std::chrono::microseconds>* host_time;
   extern std::chrono::microseconds last_value;

--- a/src/enclave/endpoint.h
+++ b/src/enclave/endpoint.h
@@ -4,7 +4,7 @@
 
 #include <vector>
 
-namespace enclave
+namespace ccf
 {
   class Endpoint : public std::enable_shared_from_this<Endpoint>
   {

--- a/src/enclave/forwarder_types.h
+++ b/src/enclave/forwarder_types.h
@@ -4,7 +4,7 @@
 
 #include <vector>
 
-namespace enclave
+namespace ccf
 {
   class RpcContext;
 
@@ -21,7 +21,7 @@ namespace enclave
     virtual ~AbstractForwarder() {}
 
     virtual bool forward_command(
-      std::shared_ptr<enclave::RpcContext> rpc_ctx,
+      std::shared_ptr<ccf::RpcContext> rpc_ctx,
       const ccf::NodeId& to,
       const std::vector<uint8_t>& caller_cert) = 0;
   };

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -147,8 +147,7 @@ extern "C"
         return CreateNodeStatus::MemoryNotOutsideEnclave;
       }
 
-      ccf::host_time =
-        static_cast<decltype(ccf::host_time)>(time_location);
+      ccf::host_time = static_cast<decltype(ccf::host_time)>(time_location);
 
       // Check that ringbuffer memory ranges are entirely outside of the enclave
       if (!oe_is_outside_enclave(

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -15,7 +15,7 @@
 
 // the central enclave object
 static std::mutex create_lock;
-static std::atomic<enclave::Enclave*> e;
+static std::atomic<ccf::Enclave*> e;
 
 std::atomic<uint16_t> num_pending_threads = 0;
 std::atomic<uint16_t> num_complete_threads = 0;
@@ -106,7 +106,7 @@ extern "C"
     auto writer_factory = std::make_unique<oversized::WriterFactory>(
       *basic_writer_factory, ec.writer_config);
 
-    auto new_logger = std::make_unique<enclave::RingbufferLogger>(
+    auto new_logger = std::make_unique<ccf::RingbufferLogger>(
       writer_factory->create_writer_to_outside());
     auto ringbuffer_logger = new_logger.get();
     logger::config::loggers().push_back(std::move(new_logger));
@@ -141,14 +141,14 @@ extern "C"
 
       // Check that where we expect arguments to be in host-memory, they really
       // are. lfence after these checks to prevent speculative execution
-      if (!oe_is_outside_enclave(time_location, sizeof(enclave::host_time)))
+      if (!oe_is_outside_enclave(time_location, sizeof(ccf::host_time)))
       {
         LOG_FAIL_FMT("Memory outside enclave: time_location");
         return CreateNodeStatus::MemoryNotOutsideEnclave;
       }
 
-      enclave::host_time =
-        static_cast<decltype(enclave::host_time)>(time_location);
+      ccf::host_time =
+        static_cast<decltype(ccf::host_time)>(time_location);
 
       // Check that ringbuffer memory ranges are entirely outside of the enclave
       if (!oe_is_outside_enclave(
@@ -217,11 +217,11 @@ extern "C"
     }
 #endif
 
-    enclave::Enclave* enclave = nullptr;
+    ccf::Enclave* enclave = nullptr;
 
     try
     {
-      enclave = new enclave::Enclave(
+      enclave = new ccf::Enclave(
         ec,
         std::move(circuit),
         std::move(basic_writer_factory),

--- a/src/enclave/ringbuffer_logger.h
+++ b/src/enclave/ringbuffer_logger.h
@@ -4,7 +4,7 @@
 
 #include "ccf/ds/logger.h"
 
-namespace enclave
+namespace ccf
 {
   class RingbufferLogger : public logger::AbstractLogger
   {

--- a/src/enclave/rpc_handler.h
+++ b/src/enclave/rpc_handler.h
@@ -15,7 +15,7 @@ namespace kv
   class CommittableTx;
 }
 
-namespace enclave
+namespace ccf
 {
   class RpcHandler
   {

--- a/src/enclave/rpc_map.h
+++ b/src/enclave/rpc_map.h
@@ -5,12 +5,12 @@
 #include "ccf/actors.h"
 #include "rpc_handler.h"
 
-namespace enclave
+namespace ccf
 {
   class RPCMap
   {
   private:
-    std::unordered_map<ccf::ActorsType, std::shared_ptr<RpcHandler>> map;
+    std::unordered_map<ccf::ActorsType, std::shared_ptr<ccf::RpcHandler>> map;
     std::map<std::string, ccf::ActorsType> actors_map;
 
   public:

--- a/src/enclave/rpc_sessions.h
+++ b/src/enclave/rpc_sessions.h
@@ -17,7 +17,7 @@
 #include <limits>
 #include <unordered_map>
 
-namespace enclave
+namespace ccf
 {
   using ServerEndpointImpl = http::HTTPServerEndpoint;
   using ClientEndpointImpl = http::HTTPClientEndpoint;
@@ -56,14 +56,14 @@ namespace enclave
     // the enclave via create_client().
     std::atomic<tls::ConnID> next_client_session_id = -1;
 
-    class NoMoreSessionsEndpointImpl : public enclave::TLSEndpoint
+    class NoMoreSessionsEndpointImpl : public ccf::TLSEndpoint
     {
     public:
       NoMoreSessionsEndpointImpl(
         tls::ConnID session_id,
         ringbuffer::AbstractWriterFactory& writer_factory,
         std::unique_ptr<tls::Context> ctx) :
-        enclave::TLSEndpoint(session_id, writer_factory, std::move(ctx))
+        ccf::TLSEndpoint(session_id, writer_factory, std::move(ctx))
       {}
 
       static void recv_cb(std::unique_ptr<threading::Tmsg<SendRecvMsg>> msg)

--- a/src/enclave/tls_endpoint.h
+++ b/src/enclave/tls_endpoint.h
@@ -13,7 +13,7 @@
 
 #include <exception>
 
-namespace enclave
+namespace ccf
 {
   class TLSEndpoint : public Endpoint
   {

--- a/src/endpoints/authentication/authentication_types.cpp
+++ b/src/endpoints/authentication/authentication_types.cpp
@@ -8,7 +8,7 @@
 namespace ccf
 {
   void AuthnPolicy::set_unauthenticated_error(
-    std::shared_ptr<enclave::RpcContext>& ctx, std::string&& error_reason)
+    std::shared_ptr<ccf::RpcContext>& ctx, std::string&& error_reason)
   {
     ctx->set_error(
       HTTP_STATUS_UNAUTHORIZED,

--- a/src/endpoints/authentication/cert_auth.cpp
+++ b/src/endpoints/authentication/cert_auth.cpp
@@ -12,7 +12,7 @@ namespace ccf
 {
   std::unique_ptr<AuthnIdentity> UserCertAuthnPolicy::authenticate(
     kv::ReadOnlyTx& tx,
-    const std::shared_ptr<enclave::RpcContext>& ctx,
+    const std::shared_ptr<ccf::RpcContext>& ctx,
     std::string& error_reason)
   {
     const auto& caller_cert = ctx->session->caller_cert;
@@ -32,7 +32,7 @@ namespace ccf
 
   std::unique_ptr<AuthnIdentity> MemberCertAuthnPolicy::authenticate(
     kv::ReadOnlyTx& tx,
-    const std::shared_ptr<enclave::RpcContext>& ctx,
+    const std::shared_ptr<ccf::RpcContext>& ctx,
     std::string& error_reason)
   {
     const auto& caller_cert = ctx->session->caller_cert;
@@ -52,7 +52,7 @@ namespace ccf
 
   std::unique_ptr<AuthnIdentity> NodeCertAuthnPolicy::authenticate(
     kv::ReadOnlyTx& tx,
-    const std::shared_ptr<enclave::RpcContext>& ctx,
+    const std::shared_ptr<ccf::RpcContext>& ctx,
     std::string& error_reason)
   {
     auto node_caller_id =

--- a/src/endpoints/authentication/empty_auth.cpp
+++ b/src/endpoints/authentication/empty_auth.cpp
@@ -6,13 +6,13 @@
 namespace ccf
 {
   std::unique_ptr<AuthnIdentity> EmptyAuthnPolicy::authenticate(
-    kv::ReadOnlyTx&, const std::shared_ptr<enclave::RpcContext>&, std::string&)
+    kv::ReadOnlyTx&, const std::shared_ptr<ccf::RpcContext>&, std::string&)
   {
     return std::make_unique<EmptyAuthnIdentity>();
   }
 
   void EmptyAuthnPolicy::set_unauthenticated_error(
-    std::shared_ptr<enclave::RpcContext>&, std::string&&)
+    std::shared_ptr<ccf::RpcContext>&, std::string&&)
   {
     throw std::logic_error("Should not happen");
   }

--- a/src/endpoints/authentication/jwt_auth.cpp
+++ b/src/endpoints/authentication/jwt_auth.cpp
@@ -11,7 +11,7 @@ namespace ccf
 {
   std::unique_ptr<AuthnIdentity> JwtAuthnPolicy::authenticate(
     kv::ReadOnlyTx& tx,
-    const std::shared_ptr<enclave::RpcContext>& ctx,
+    const std::shared_ptr<ccf::RpcContext>& ctx,
     std::string& error_reason)
   {
     const auto& headers = ctx->get_request_headers();
@@ -49,7 +49,7 @@ namespace ccf
   }
 
   void JwtAuthnPolicy::set_unauthenticated_error(
-    std::shared_ptr<enclave::RpcContext>& ctx, std::string&& error_reason)
+    std::shared_ptr<ccf::RpcContext>& ctx, std::string&& error_reason)
   {
     ctx->set_error(
       HTTP_STATUS_UNAUTHORIZED,

--- a/src/endpoints/authentication/sig_auth.cpp
+++ b/src/endpoints/authentication/sig_auth.cpp
@@ -13,7 +13,7 @@
 namespace ccf
 {
   static std::optional<SignedReq> parse_signed_request(
-    const std::shared_ptr<enclave::RpcContext>& ctx)
+    const std::shared_ptr<ccf::RpcContext>& ctx)
   {
     return http::HttpSignatureVerifier::parse(
       ctx->get_request_verb().c_str(),
@@ -57,7 +57,7 @@ namespace ccf
 
   std::unique_ptr<AuthnIdentity> UserSignatureAuthnPolicy::authenticate(
     kv::ReadOnlyTx& tx,
-    const std::shared_ptr<enclave::RpcContext>& ctx,
+    const std::shared_ptr<ccf::RpcContext>& ctx,
     std::string& error_reason)
   {
     std::optional<SignedReq> signed_request = std::nullopt;
@@ -108,7 +108,7 @@ namespace ccf
   }
 
   void UserSignatureAuthnPolicy::set_unauthenticated_error(
-    std::shared_ptr<enclave::RpcContext>& ctx, std::string&& error_reason)
+    std::shared_ptr<ccf::RpcContext>& ctx, std::string&& error_reason)
   {
     ctx->set_error(
       HTTP_STATUS_UNAUTHORIZED,
@@ -140,7 +140,7 @@ namespace ccf
 
   std::unique_ptr<AuthnIdentity> MemberSignatureAuthnPolicy::authenticate(
     kv::ReadOnlyTx& tx,
-    const std::shared_ptr<enclave::RpcContext>& ctx,
+    const std::shared_ptr<ccf::RpcContext>& ctx,
     std::string& error_reason)
   {
     std::optional<SignedReq> signed_request = std::nullopt;
@@ -196,7 +196,7 @@ namespace ccf
   }
 
   void MemberSignatureAuthnPolicy::set_unauthenticated_error(
-    std::shared_ptr<enclave::RpcContext>& ctx, std::string&& error_reason)
+    std::shared_ptr<ccf::RpcContext>& ctx, std::string&& error_reason)
   {
     ctx->set_error(
       HTTP_STATUS_UNAUTHORIZED,

--- a/src/endpoints/base_endpoint_registry.cpp
+++ b/src/endpoints/base_endpoint_registry.cpp
@@ -274,7 +274,7 @@ namespace ccf
 
   ApiResult BaseEndpointRegistry::get_untrusted_host_time_v1(::timespec& time)
   {
-    const std::chrono::microseconds now_us = enclave::get_enclave_time();
+    const std::chrono::microseconds now_us = ccf::get_enclave_time();
 
     constexpr auto us_per_s = 1'000'000;
     time.tv_sec = now_us.count() / us_per_s;

--- a/src/endpoints/endpoint_registry.cpp
+++ b/src/endpoints/endpoint_registry.cpp
@@ -210,7 +210,7 @@ namespace ccf::endpoints
   void EndpointRegistry::init_handlers() {}
 
   EndpointDefinitionPtr EndpointRegistry::find_endpoint(
-    kv::Tx&, enclave::RpcContext& rpc_ctx)
+    kv::Tx&, ccf::RpcContext& rpc_ctx)
   {
     auto method = rpc_ctx.get_method();
 
@@ -296,7 +296,7 @@ namespace ccf::endpoints
   }
 
   std::set<RESTVerb> EndpointRegistry::get_allowed_verbs(
-    kv::Tx& tx, const enclave::RpcContext& rpc_ctx)
+    kv::Tx& tx, const ccf::RpcContext& rpc_ctx)
   {
     auto method = rpc_ctx.get_method();
 

--- a/src/endpoints/json_handler.cpp
+++ b/src/endpoints/json_handler.cpp
@@ -34,7 +34,7 @@ namespace ccf
     }
 
     serdes::Pack detect_json_pack(
-      const std::shared_ptr<enclave::RpcContext>& ctx)
+      const std::shared_ptr<ccf::RpcContext>& ctx)
     {
       std::optional<serdes::Pack> packing = std::nullopt;
 
@@ -73,7 +73,7 @@ namespace ccf
     }
 
     serdes::Pack get_response_pack(
-      const std::shared_ptr<enclave::RpcContext>& ctx,
+      const std::shared_ptr<ccf::RpcContext>& ctx,
       serdes::Pack request_pack)
     {
       const auto accept_it = ctx->get_request_header(http::headers::ACCEPT);
@@ -108,13 +108,13 @@ namespace ccf
     }
 
     nlohmann::json get_params_from_body(
-      const std::shared_ptr<enclave::RpcContext>& ctx, serdes::Pack pack)
+      const std::shared_ptr<ccf::RpcContext>& ctx, serdes::Pack pack)
     {
       return serdes::unpack(ctx->get_request_body(), pack);
     }
 
     std::pair<serdes::Pack, nlohmann::json> get_json_params(
-      const std::shared_ptr<enclave::RpcContext>& ctx)
+      const std::shared_ptr<ccf::RpcContext>& ctx)
     {
       const auto pack = detect_json_pack(ctx);
 
@@ -136,7 +136,7 @@ namespace ccf
 
     void set_response(
       JsonAdapterResponse&& res,
-      std::shared_ptr<enclave::RpcContext>& ctx,
+      std::shared_ptr<ccf::RpcContext>& ctx,
       serdes::Pack request_packing)
     {
       auto error = std::get_if<ErrorDetails>(&res);

--- a/src/endpoints/json_handler.cpp
+++ b/src/endpoints/json_handler.cpp
@@ -33,8 +33,7 @@ namespace ccf
       }
     }
 
-    serdes::Pack detect_json_pack(
-      const std::shared_ptr<ccf::RpcContext>& ctx)
+    serdes::Pack detect_json_pack(const std::shared_ptr<ccf::RpcContext>& ctx)
     {
       std::optional<serdes::Pack> packing = std::nullopt;
 
@@ -73,8 +72,7 @@ namespace ccf
     }
 
     serdes::Pack get_response_pack(
-      const std::shared_ptr<ccf::RpcContext>& ctx,
-      serdes::Pack request_pack)
+      const std::shared_ptr<ccf::RpcContext>& ctx, serdes::Pack request_pack)
     {
       const auto accept_it = ctx->get_request_header(http::headers::ACCEPT);
       if (accept_it.has_value())

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -542,7 +542,7 @@ int main(int argc, char** argv)
       }
       catch (const std::exception& e)
       {
-        LOG_FAIL_FMT("Exception in enclave::run: {}", e.what());
+        LOG_FAIL_FMT("Exception in ccf::run: {}", e.what());
 
         // This exception should be rethrown, probably aborting the process, but
         // we sleep briefly to allow more outbound messages to be processed. If

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -14,7 +14,7 @@
 
 namespace http
 {
-  class HTTPEndpoint : public enclave::TLSEndpoint
+  class HTTPEndpoint : public ccf::TLSEndpoint
   {
   protected:
     http::Parser& p;
@@ -104,18 +104,18 @@ namespace http
   private:
     http::RequestParser request_parser;
 
-    std::shared_ptr<enclave::RPCMap> rpc_map;
-    std::shared_ptr<enclave::RpcHandler> handler;
-    std::shared_ptr<enclave::SessionContext> session_ctx;
+    std::shared_ptr<ccf::RPCMap> rpc_map;
+    std::shared_ptr<ccf::RpcHandler> handler;
+    std::shared_ptr<ccf::SessionContext> session_ctx;
     int64_t session_id;
-    enclave::ListenInterfaceID interface_id;
+    ccf::ListenInterfaceID interface_id;
     size_t request_index = 0;
 
   public:
     HTTPServerEndpoint(
-      std::shared_ptr<enclave::RPCMap> rpc_map,
+      std::shared_ptr<ccf::RPCMap> rpc_map,
       int64_t session_id,
-      const enclave::ListenInterfaceID& interface_id,
+      const ccf::ListenInterfaceID& interface_id,
       ringbuffer::AbstractWriterFactory& writer_factory,
       std::unique_ptr<tls::Context> ctx) :
       HTTPEndpoint(request_parser, session_id, writer_factory, std::move(ctx)),
@@ -146,11 +146,11 @@ namespace http
       {
         if (session_ctx == nullptr)
         {
-          session_ctx = std::make_shared<enclave::SessionContext>(
+          session_ctx = std::make_shared<ccf::SessionContext>(
             session_id, peer_cert(), interface_id);
         }
 
-        std::shared_ptr<enclave::RpcContext> rpc_ctx = nullptr;
+        std::shared_ptr<ccf::RpcContext> rpc_ctx = nullptr;
         try
         {
           rpc_ctx = std::make_shared<HttpRpcContext>(
@@ -227,7 +227,7 @@ namespace http
   };
 
   class HTTPClientEndpoint : public HTTPEndpoint,
-                             public enclave::ClientEndpoint,
+                             public ccf::ClientEndpoint,
                              public http::ResponseProcessor
   {
   private:

--- a/src/http/http_rpc_context.h
+++ b/src/http/http_rpc_context.h
@@ -9,8 +9,7 @@
 
 namespace http
 {
-  inline static std::optional<std::string> extract_actor(
-    ccf::RpcContext& ctx)
+  inline static std::optional<std::string> extract_actor(ccf::RpcContext& ctx)
   {
     const auto path = ctx.get_method();
 

--- a/src/http/http_rpc_context.h
+++ b/src/http/http_rpc_context.h
@@ -10,7 +10,7 @@
 namespace http
 {
   inline static std::optional<std::string> extract_actor(
-    enclave::RpcContext& ctx)
+    ccf::RpcContext& ctx)
   {
     const auto path = ctx.get_method();
 
@@ -56,7 +56,7 @@ namespace http
     return error({status, code, std::move(msg)});
   }
 
-  class HttpRpcContext : public enclave::RpcContext
+  class HttpRpcContext : public ccf::RpcContext
   {
   private:
     size_t request_index;
@@ -72,7 +72,7 @@ namespace http
     http::HeaderMap request_headers = {};
 
     std::vector<uint8_t> request_body = {};
-    enclave::PathParams path_params = {};
+    ccf::PathParams path_params = {};
 
     std::vector<uint8_t> serialised_request = {};
 
@@ -116,7 +116,7 @@ namespace http
   public:
     HttpRpcContext(
       size_t request_index_,
-      std::shared_ptr<enclave::SessionContext> s,
+      std::shared_ptr<ccf::SessionContext> s,
       llhttp_method verb_,
       const std::string_view& url_,
       const http::HeaderMap& headers_,
@@ -168,7 +168,7 @@ namespace http
       return query;
     }
 
-    virtual enclave::PathParams& get_request_path_params() override
+    virtual ccf::PathParams& get_request_path_params() override
     {
       return path_params;
     }
@@ -291,10 +291,10 @@ namespace http
   };
 }
 
-namespace enclave
+namespace ccf
 {
-  inline std::shared_ptr<RpcContext> make_rpc_context(
-    std::shared_ptr<enclave::SessionContext> s,
+  inline std::shared_ptr<ccf::RpcContext> make_rpc_context(
+    std::shared_ptr<ccf::SessionContext> s,
     const std::vector<uint8_t>& packed,
     const std::vector<uint8_t>& raw_bft = {})
   {
@@ -317,8 +317,8 @@ namespace enclave
       0, s, msg.method, msg.url, msg.headers, msg.body, packed, raw_bft);
   }
 
-  inline std::shared_ptr<enclave::RpcContext> make_fwd_rpc_context(
-    std::shared_ptr<enclave::SessionContext> s,
+  inline std::shared_ptr<ccf::RpcContext> make_fwd_rpc_context(
+    std::shared_ptr<ccf::SessionContext> s,
     const std::vector<uint8_t>& packed,
     ccf::FrameFormat frame_format,
     const std::vector<uint8_t>& raw_bft = {})

--- a/src/js/wrap.cpp
+++ b/src/js/wrap.cpp
@@ -765,7 +765,7 @@ namespace ccf::js
     }
 
     auto rpc_ctx =
-      static_cast<enclave::RpcContext*>(JS_GetOpaque(this_val, rpc_class_id));
+      static_cast<ccf::RpcContext*>(JS_GetOpaque(this_val, rpc_class_id));
 
     if (rpc_ctx == nullptr)
     {
@@ -792,7 +792,7 @@ namespace ccf::js
     }
 
     auto rpc_ctx =
-      static_cast<enclave::RpcContext*>(JS_GetOpaque(this_val, rpc_class_id));
+      static_cast<ccf::RpcContext*>(JS_GetOpaque(this_val, rpc_class_id));
 
     if (rpc_ctx == nullptr)
     {
@@ -1456,7 +1456,7 @@ namespace ccf::js
   JSValue create_ccf_obj(
     TxContext* txctx,
     TxContext* historical_txctx,
-    enclave::RpcContext* rpc_ctx,
+    ccf::RpcContext* rpc_ctx,
     const std::optional<ccf::TxID>& transaction_id,
     ccf::TxReceiptPtr receipt,
     ccf::AbstractGovernanceEffects* gov_effects,
@@ -1749,7 +1749,7 @@ namespace ccf::js
   void populate_global_ccf(
     TxContext* txctx,
     TxContext* historical_txctx,
-    enclave::RpcContext* rpc_ctx,
+    ccf::RpcContext* rpc_ctx,
     const std::optional<ccf::TxID>& transaction_id,
     ccf::TxReceiptPtr receipt,
     ccf::AbstractGovernanceEffects* gov_effects,
@@ -1782,7 +1782,7 @@ namespace ccf::js
   void populate_global(
     TxContext* txctx,
     TxContext* historical_txctx,
-    enclave::RpcContext* rpc_ctx,
+    ccf::RpcContext* rpc_ctx,
     const std::optional<ccf::TxID>& transaction_id,
     ccf::TxReceiptPtr receipt,
     ccf::AbstractGovernanceEffects* gov_effects,

--- a/src/js/wrap.h
+++ b/src/js/wrap.h
@@ -169,7 +169,7 @@ namespace ccf::js
   void populate_global(
     TxContext* txctx,
     TxContext* historical_txctx,
-    enclave::RpcContext* rpc_ctx,
+    ccf::RpcContext* rpc_ctx,
     const std::optional<ccf::TxID>& transaction_id,
     ccf::TxReceiptPtr receipt,
     ccf::AbstractGovernanceEffects* gov_effects,

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -366,7 +366,7 @@ namespace ccf
       else if (status.check(INITIATED))
       {
         const auto time_since_initiated =
-          enclave::get_enclave_time() - last_initiation_time;
+          ccf::get_enclave_time() - last_initiation_time;
         if (time_since_initiated >= min_gap_between_initiation_attempts)
         {
           // If this node attempts to initiate too early when the peer node
@@ -833,7 +833,7 @@ namespace ccf
       // status.expect(INACTIVE);
       status.advance(INITIATED);
 
-      last_initiation_time = enclave::get_enclave_time();
+      last_initiation_time = ccf::get_enclave_time();
 
       send_key_exchange_init();
     }

--- a/src/node/http_node_client.h
+++ b/src/node/http_node_client.h
@@ -12,7 +12,7 @@ namespace ccf
   {
   public:
     HTTPNodeClient(
-      std::shared_ptr<enclave::RPCMap> rpc_map,
+      std::shared_ptr<ccf::RPCMap> rpc_map,
       crypto::KeyPairPtr node_sign_kp,
       const crypto::Pem& self_signed_node_cert_,
       const std::optional<crypto::Pem>& endorsed_node_cert_) :
@@ -34,9 +34,9 @@ namespace ccf
 
       std::vector<uint8_t> packed = request.build_request();
 
-      auto node_session = std::make_shared<enclave::SessionContext>(
-        enclave::InvalidSessionId, node_cert.raw());
-      auto ctx = enclave::make_rpc_context(node_session, packed);
+      auto node_session = std::make_shared<ccf::SessionContext>(
+        ccf::InvalidSessionId, node_cert.raw());
+      auto ctx = ccf::make_rpc_context(node_session, packed);
       ctx->execute_on_node = false;
 
       const auto actor_opt = http::extract_actor(*ctx);

--- a/src/node/jwt_key_auto_refresh.h
+++ b/src/node/jwt_key_auto_refresh.h
@@ -20,8 +20,8 @@ namespace ccf
     size_t refresh_interval_s;
     NetworkState& network;
     std::shared_ptr<kv::Consensus> consensus;
-    std::shared_ptr<enclave::RPCSessions> rpcsessions;
-    std::shared_ptr<enclave::RPCMap> rpc_map;
+    std::shared_ptr<ccf::RPCSessions> rpcsessions;
+    std::shared_ptr<ccf::RPCMap> rpc_map;
     crypto::KeyPairPtr node_sign_kp;
     crypto::Pem node_cert;
     std::atomic_size_t attempts;
@@ -31,8 +31,8 @@ namespace ccf
       size_t refresh_interval_s,
       NetworkState& network,
       const std::shared_ptr<kv::Consensus>& consensus,
-      const std::shared_ptr<enclave::RPCSessions>& rpcsessions,
-      const std::shared_ptr<enclave::RPCMap>& rpc_map,
+      const std::shared_ptr<ccf::RPCSessions>& rpcsessions,
+      const std::shared_ptr<ccf::RPCMap>& rpc_map,
       const crypto::KeyPairPtr& node_sign_kp,
       const crypto::Pem& node_cert) :
       refresh_interval_s(refresh_interval_s),
@@ -118,9 +118,9 @@ namespace ccf
 
       auto packed = request.build_request();
 
-      auto node_session = std::make_shared<enclave::SessionContext>(
-        enclave::InvalidSessionId, node_cert.raw());
-      auto ctx = enclave::make_rpc_context(node_session, packed);
+      auto node_session = std::make_shared<ccf::SessionContext>(
+        ccf::InvalidSessionId, node_cert.raw());
+      auto ctx = ccf::make_rpc_context(node_session, packed);
 
       const auto actor_opt = http::extract_actor(*ctx);
       if (!actor_opt.has_value())

--- a/src/node/node_client.h
+++ b/src/node/node_client.h
@@ -11,14 +11,14 @@ namespace ccf
   class NodeClient
   {
   protected:
-    std::shared_ptr<enclave::RPCMap> rpc_map;
+    std::shared_ptr<ccf::RPCMap> rpc_map;
     crypto::KeyPairPtr node_sign_kp;
     const crypto::Pem& self_signed_node_cert;
     const std::optional<crypto::Pem>& endorsed_node_cert = std::nullopt;
 
   public:
     NodeClient(
-      std::shared_ptr<enclave::RPCMap> rpc_map_,
+      std::shared_ptr<ccf::RPCMap> rpc_map_,
       crypto::KeyPairPtr node_sign_kp_,
       const crypto::Pem& self_signed_node_cert_,
       const std::optional<crypto::Pem>& endorsed_node_cert_) :

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -154,11 +154,11 @@ namespace ccf
     NetworkState& network;
 
     std::shared_ptr<kv::Consensus> consensus;
-    std::shared_ptr<enclave::RPCMap> rpc_map;
+    std::shared_ptr<ccf::RPCMap> rpc_map;
     std::shared_ptr<ccf::indexing::Indexer> indexer;
     std::shared_ptr<NodeToNode> n2n_channels;
     std::shared_ptr<Forwarder<NodeToNode>> cmd_forwarder;
-    std::shared_ptr<enclave::RPCSessions> rpcsessions;
+    std::shared_ptr<ccf::RPCSessions> rpcsessions;
 
     std::shared_ptr<kv::TxHistory> history;
     std::shared_ptr<kv::AbstractTxEncryptor> encryptor;
@@ -245,7 +245,7 @@ namespace ccf
     NodeState(
       ringbuffer::AbstractWriterFactory& writer_factory,
       NetworkState& network,
-      std::shared_ptr<enclave::RPCSessions> rpcsessions,
+      std::shared_ptr<ccf::RPCSessions> rpcsessions,
       ShareManager& share_manager,
       crypto::CurveID curve_id_) :
       sm("NodeState", NodeStartupState::uninitialized),
@@ -283,8 +283,8 @@ namespace ccf
     //
     void initialize(
       const consensus::Configuration& consensus_config_,
-      std::shared_ptr<enclave::RPCMap> rpc_map_,
-      std::shared_ptr<enclave::AbstractRPCResponder> rpc_sessions_,
+      std::shared_ptr<ccf::RPCMap> rpc_map_,
+      std::shared_ptr<ccf::AbstractRPCResponder> rpc_sessions_,
       std::shared_ptr<ccf::indexing::Indexer> indexer_,
       size_t sig_tx_interval_,
       size_t sig_ms_interval_)
@@ -1781,9 +1781,9 @@ namespace ccf
 
     bool send_create_request(const std::vector<uint8_t>& packed)
     {
-      auto node_session = std::make_shared<enclave::SessionContext>(
-        enclave::InvalidSessionId, self_signed_node_cert.raw());
-      auto ctx = enclave::make_rpc_context(node_session, packed);
+      auto node_session = std::make_shared<ccf::SessionContext>(
+        ccf::InvalidSessionId, self_signed_node_cert.raw());
+      auto ctx = ccf::make_rpc_context(node_session, packed);
 
       ctx->is_create_request = true;
 

--- a/src/node/resharing.h
+++ b/src/node/resharing.h
@@ -70,7 +70,7 @@ namespace ccf
 
     SplitIdentityResharingTracker(
       std::shared_ptr<aft::State> shared_state_,
-      std::shared_ptr<enclave::RPCMap> rpc_map_,
+      std::shared_ptr<ccf::RPCMap> rpc_map_,
       crypto::KeyPairPtr node_sign_kp_,
       const crypto::Pem& self_signed_node_cert_,
       const std::optional<crypto::Pem>& endorsed_node_cert_) :
@@ -196,7 +196,7 @@ namespace ccf
     {
       UpdateResharingTaskMsg(
         kv::ReconfigurationId rid_,
-        std::shared_ptr<enclave::RPCMap> rpc_map_,
+        std::shared_ptr<ccf::RPCMap> rpc_map_,
         crypto::KeyPairPtr node_sign_kp_,
         const crypto::Pem& node_cert_,
         size_t retries_ = 10) :
@@ -208,7 +208,7 @@ namespace ccf
       {}
 
       kv::ReconfigurationId rid;
-      std::shared_ptr<enclave::RPCMap> rpc_map;
+      std::shared_ptr<ccf::RPCMap> rpc_map;
       crypto::KeyPairPtr node_sign_kp;
       const crypto::Pem& node_cert;
       size_t retries;
@@ -216,7 +216,7 @@ namespace ccf
 
   protected:
     std::shared_ptr<aft::State> shared_state;
-    std::shared_ptr<enclave::RPCMap> rpc_map;
+    std::shared_ptr<ccf::RPCMap> rpc_map;
     crypto::KeyPairPtr node_sign_kp;
     const crypto::Pem& self_signed_node_cert;
     const std::optional<crypto::Pem>& endorsed_node_cert;
@@ -226,7 +226,7 @@ namespace ccf
 
     static inline bool make_request(
       http::Request& request,
-      std::shared_ptr<enclave::RPCMap> rpc_map,
+      std::shared_ptr<ccf::RPCMap> rpc_map,
       crypto::KeyPairPtr node_sign_kp,
       const crypto::Pem& node_cert)
     {
@@ -235,9 +235,9 @@ namespace ccf
 
       http::sign_request(request, node_sign_kp, key_id);
       std::vector<uint8_t> packed = request.build_request();
-      auto node_session = std::make_shared<enclave::SessionContext>(
-        enclave::InvalidSessionId, node_cert.raw());
-      auto ctx = enclave::make_rpc_context(node_session, packed);
+      auto node_session = std::make_shared<ccf::SessionContext>(
+        ccf::InvalidSessionId, node_cert.raw());
+      auto ctx = ccf::make_rpc_context(node_session, packed);
 
       const auto actor_opt = http::extract_actor(*ctx);
       if (!actor_opt.has_value())
@@ -270,7 +270,7 @@ namespace ccf
 
     static inline bool request_update_resharing(
       kv::ReconfigurationId rid,
-      std::shared_ptr<enclave::RPCMap> rpc_map,
+      std::shared_ptr<ccf::RPCMap> rpc_map,
       crypto::KeyPairPtr node_sign_kp,
       const crypto::Pem& node_cert)
     {

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -16,16 +16,16 @@ namespace ccf
     virtual ~ForwardedRpcHandler() {}
 
     virtual std::vector<uint8_t> process_forwarded(
-      std::shared_ptr<enclave::RpcContext> fwd_ctx) = 0;
+      std::shared_ptr<ccf::RpcContext> fwd_ctx) = 0;
   };
 
   template <typename ChannelProxy>
-  class Forwarder : public enclave::AbstractForwarder
+  class Forwarder : public AbstractForwarder
   {
   private:
-    std::weak_ptr<enclave::AbstractRPCResponder> rpcresponder;
+    std::weak_ptr<ccf::AbstractRPCResponder> rpcresponder;
     std::shared_ptr<ChannelProxy> n2n_channels;
-    std::weak_ptr<enclave::RPCMap> rpc_map;
+    std::weak_ptr<ccf::RPCMap> rpc_map;
     ConsensusType consensus_type;
     NodeId self;
 
@@ -33,9 +33,9 @@ namespace ccf
 
   public:
     Forwarder(
-      std::weak_ptr<enclave::AbstractRPCResponder> rpcresponder,
+      std::weak_ptr<ccf::AbstractRPCResponder> rpcresponder,
       std::shared_ptr<ChannelProxy> n2n_channels,
-      std::weak_ptr<enclave::RPCMap> rpc_map_,
+      std::weak_ptr<ccf::RPCMap> rpc_map_,
       ConsensusType consensus_type_) :
       rpcresponder(rpcresponder),
       n2n_channels(n2n_channels),
@@ -49,7 +49,7 @@ namespace ccf
     }
 
     bool forward_command(
-      std::shared_ptr<enclave::RpcContext> rpc_ctx,
+      std::shared_ptr<ccf::RpcContext> rpc_ctx,
       const NodeId& to,
       const std::vector<uint8_t>& caller_cert) override
     {
@@ -83,7 +83,7 @@ namespace ccf
         to, NodeMsgType::forwarded_msg, plain, msg);
     }
 
-    std::shared_ptr<enclave::RpcContext> recv_forwarded_command(
+    std::shared_ptr<ccf::RpcContext> recv_forwarded_command(
       const NodeId& from, const uint8_t* data, size_t size)
     {
       std::pair<ForwardedHeader, std::vector<uint8_t>> r;
@@ -116,13 +116,13 @@ namespace ccf
       }
       std::vector<uint8_t> raw_request = serialized::read(data_, size_, size_);
 
-      auto session = std::make_shared<enclave::SessionContext>(
-        client_session_id, caller_cert);
+      auto session =
+        std::make_shared<ccf::SessionContext>(client_session_id, caller_cert);
       session->is_forwarded = true;
 
       try
       {
-        return enclave::make_fwd_rpc_context(
+        return ccf::make_fwd_rpc_context(
           session, raw_request, r.first.frame_format);
       }
       catch (const std::exception& err)
@@ -196,7 +196,7 @@ namespace ccf
         {
           case ForwardedMsg::forwarded_cmd:
           {
-            std::shared_ptr<enclave::RPCMap> rpc_map_shared = rpc_map.lock();
+            std::shared_ptr<ccf::RPCMap> rpc_map_shared = rpc_map.lock();
             if (rpc_map_shared)
             {
               auto ctx = recv_forwarded_command(from, data, size);

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -23,7 +23,7 @@
 
 namespace ccf
 {
-  class RpcFrontend : public enclave::RpcHandler, public ForwardedRpcHandler
+  class RpcFrontend : public RpcHandler, public ForwardedRpcHandler
   {
   protected:
     kv::Store& tables;
@@ -34,7 +34,7 @@ namespace ccf
     bool is_open_ = false;
 
     kv::Consensus* consensus;
-    std::shared_ptr<enclave::AbstractForwarder> cmd_forwarder;
+    std::shared_ptr<AbstractForwarder> cmd_forwarder;
     kv::TxHistory* history;
 
     size_t sig_tx_interval = 5000;
@@ -43,7 +43,7 @@ namespace ccf
     crypto::Pem* service_identity = nullptr;
 
     using PreExec =
-      std::function<void(kv::CommittableTx& tx, enclave::RpcContext& ctx)>;
+      std::function<void(kv::CommittableTx& tx, ccf::RpcContext& ctx)>;
 
     void update_consensus()
     {
@@ -63,7 +63,7 @@ namespace ccf
     }
 
     void update_metrics(
-      const std::shared_ptr<enclave::RpcContext>& ctx,
+      const std::shared_ptr<ccf::RpcContext>& ctx,
       const endpoints::EndpointDefinitionPtr& endpoint)
     {
       int cat = ctx->get_response_status() / 100;
@@ -79,7 +79,7 @@ namespace ccf
     }
 
     std::optional<std::vector<uint8_t>> forward(
-      std::shared_ptr<enclave::RpcContext> ctx,
+      std::shared_ptr<ccf::RpcContext> ctx,
       kv::ReadOnlyTx& tx,
       const endpoints::EndpointDefinitionPtr& endpoint)
     {
@@ -127,7 +127,7 @@ namespace ccf
     }
 
     std::optional<std::vector<uint8_t>> process_command(
-      std::shared_ptr<enclave::RpcContext> ctx,
+      std::shared_ptr<ccf::RpcContext> ctx,
       kv::CommittableTx& tx,
       const PreExec& pre_exec = {},
       kv::Version prescribed_commit_version = kv::NoVersion,
@@ -423,7 +423,7 @@ namespace ccf
     }
 
     void set_cmd_forwarder(
-      std::shared_ptr<enclave::AbstractForwarder> cmd_forwarder_) override
+      std::shared_ptr<AbstractForwarder> cmd_forwarder_) override
     {
       cmd_forwarder = cmd_forwarder_;
     }
@@ -470,7 +470,7 @@ namespace ccf
     }
 
     void set_root_on_proposals(
-      const enclave::RpcContext& ctx, kv::CommittableTx& tx)
+      const ccf::RpcContext& ctx, kv::CommittableTx& tx)
     {
       if (
         ctx.get_request_path() == "/gov/proposals" &&
@@ -501,7 +501,7 @@ namespace ccf
      * to-be-executed by consensus), else the response (may contain error)
      */
     std::optional<std::vector<uint8_t>> process(
-      std::shared_ptr<enclave::RpcContext> ctx) override
+      std::shared_ptr<ccf::RpcContext> ctx) override
     {
       update_consensus();
 
@@ -529,7 +529,7 @@ namespace ccf
      * @return Serialised reply to send back to forwarder node
      */
     std::vector<uint8_t> process_forwarded(
-      std::shared_ptr<enclave::RpcContext> ctx) override
+      std::shared_ptr<ccf::RpcContext> ctx) override
     {
       if (!ctx->session->is_forwarded)
       {

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -472,9 +472,7 @@ namespace ccf
     }
 
     bool get_member_id_from_path(
-      const ccf::PathParams& params,
-      MemberId& member_id,
-      std::string& error)
+      const ccf::PathParams& params, MemberId& member_id, std::string& error)
     {
       return get_path_param(params, "member_id", member_id.value(), error);
     }

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -464,7 +464,7 @@ namespace ccf
     }
 
     bool get_proposal_id_from_path(
-      const enclave::PathParams& params,
+      const ccf::PathParams& params,
       ProposalId& proposal_id,
       std::string& error)
     {
@@ -472,7 +472,7 @@ namespace ccf
     }
 
     bool get_member_id_from_path(
-      const enclave::PathParams& params,
+      const ccf::PathParams& params,
       MemberId& member_id,
       std::string& error)
     {

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -473,12 +473,12 @@ auto user_session =
   make_shared<ccf::SessionContext>(ccf::InvalidSessionId, user_caller_der);
 auto backup_user_session =
   make_shared<ccf::SessionContext>(ccf::InvalidSessionId, user_caller_der);
-auto invalid_session = make_shared<ccf::SessionContext>(
-  ccf::InvalidSessionId, invalid_caller_der);
-auto member_session = make_shared<ccf::SessionContext>(
-  ccf::InvalidSessionId, member_caller_der);
-auto anonymous_session = make_shared<ccf::SessionContext>(
-  ccf::InvalidSessionId, anonymous_caller_der);
+auto invalid_session =
+  make_shared<ccf::SessionContext>(ccf::InvalidSessionId, invalid_caller_der);
+auto member_session =
+  make_shared<ccf::SessionContext>(ccf::InvalidSessionId, member_caller_der);
+auto anonymous_session =
+  make_shared<ccf::SessionContext>(ccf::InvalidSessionId, anonymous_caller_der);
 
 UserId user_id;
 

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -469,16 +469,16 @@ auto invalid_caller_der = crypto::make_verifier(invalid_caller) -> cert_der();
 
 auto anonymous_caller_der = std::vector<uint8_t>();
 
-auto user_session = make_shared<enclave::SessionContext>(
-  enclave::InvalidSessionId, user_caller_der);
-auto backup_user_session = make_shared<enclave::SessionContext>(
-  enclave::InvalidSessionId, user_caller_der);
-auto invalid_session = make_shared<enclave::SessionContext>(
-  enclave::InvalidSessionId, invalid_caller_der);
-auto member_session = make_shared<enclave::SessionContext>(
-  enclave::InvalidSessionId, member_caller_der);
-auto anonymous_session = make_shared<enclave::SessionContext>(
-  enclave::InvalidSessionId, anonymous_caller_der);
+auto user_session =
+  make_shared<ccf::SessionContext>(ccf::InvalidSessionId, user_caller_der);
+auto backup_user_session =
+  make_shared<ccf::SessionContext>(ccf::InvalidSessionId, user_caller_der);
+auto invalid_session = make_shared<ccf::SessionContext>(
+  ccf::InvalidSessionId, invalid_caller_der);
+auto member_session = make_shared<ccf::SessionContext>(
+  ccf::InvalidSessionId, member_caller_der);
+auto anonymous_session = make_shared<ccf::SessionContext>(
+  ccf::InvalidSessionId, anonymous_caller_der);
 
 UserId user_id;
 
@@ -543,7 +543,7 @@ TEST_CASE("process with signatures")
     constexpr auto rpc_name = "/this_rpc_doesnt_exist";
     const auto invalid_call = create_simple_request(rpc_name);
     const auto serialized_call = invalid_call.build_request();
-    auto rpc_ctx = enclave::make_rpc_context(user_session, serialized_call);
+    auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_call);
 
     const auto serialized_response = frontend.process(rpc_ctx).value();
     auto response = parse_response(serialized_response);
@@ -558,9 +558,9 @@ TEST_CASE("process with signatures")
     const auto serialized_signed_call = signed_call.build_request();
 
     auto simple_rpc_ctx =
-      enclave::make_rpc_context(user_session, serialized_simple_call);
+      ccf::make_rpc_context(user_session, serialized_simple_call);
     auto signed_rpc_ctx =
-      enclave::make_rpc_context(user_session, serialized_signed_call);
+      ccf::make_rpc_context(user_session, serialized_signed_call);
 
     INFO("Unsigned RPC");
     {
@@ -585,9 +585,9 @@ TEST_CASE("process with signatures")
     const auto serialized_signed_call = signed_call.build_request();
 
     auto simple_rpc_ctx =
-      enclave::make_rpc_context(user_session, serialized_simple_call);
+      ccf::make_rpc_context(user_session, serialized_simple_call);
     auto signed_rpc_ctx =
-      enclave::make_rpc_context(user_session, serialized_signed_call);
+      ccf::make_rpc_context(user_session, serialized_signed_call);
 
     INFO("Unsigned RPC");
     {
@@ -619,11 +619,11 @@ TEST_CASE("process with caller")
     const auto simple_call = create_simple_request("/empty_function_no_auth");
     const auto serialized_simple_call = simple_call.build_request();
     auto authenticated_rpc_ctx =
-      enclave::make_rpc_context(user_session, serialized_simple_call);
+      ccf::make_rpc_context(user_session, serialized_simple_call);
     auto invalid_rpc_ctx =
-      enclave::make_rpc_context(invalid_session, serialized_simple_call);
+      ccf::make_rpc_context(invalid_session, serialized_simple_call);
     auto anonymous_rpc_ctx =
-      enclave::make_rpc_context(anonymous_session, serialized_simple_call);
+      ccf::make_rpc_context(anonymous_session, serialized_simple_call);
 
     INFO("Valid authentication");
     {
@@ -658,11 +658,11 @@ TEST_CASE("process with caller")
     const auto simple_call = create_simple_request("/empty_function");
     const auto serialized_simple_call = simple_call.build_request();
     auto authenticated_rpc_ctx =
-      enclave::make_rpc_context(user_session, serialized_simple_call);
+      ccf::make_rpc_context(user_session, serialized_simple_call);
     auto invalid_rpc_ctx =
-      enclave::make_rpc_context(invalid_session, serialized_simple_call);
+      ccf::make_rpc_context(invalid_session, serialized_simple_call);
     auto anonymous_rpc_ctx =
-      enclave::make_rpc_context(anonymous_session, serialized_simple_call);
+      ccf::make_rpc_context(anonymous_session, serialized_simple_call);
 
     INFO("Valid authentication");
     {
@@ -708,7 +708,7 @@ TEST_CASE("No certs table")
 
   INFO("Authenticated caller");
   {
-    auto rpc_ctx = enclave::make_rpc_context(user_session, serialized_call);
+    auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_call);
     std::vector<uint8_t> serialized_response =
       frontend.process(rpc_ctx).value();
     auto response = parse_response(serialized_response);
@@ -717,8 +717,7 @@ TEST_CASE("No certs table")
 
   INFO("Anonymous caller");
   {
-    auto rpc_ctx =
-      enclave::make_rpc_context(anonymous_session, serialized_call);
+    auto rpc_ctx = ccf::make_rpc_context(anonymous_session, serialized_call);
     std::vector<uint8_t> serialized_response =
       frontend.process(rpc_ctx).value();
     auto response = parse_response(serialized_response);
@@ -741,7 +740,7 @@ TEST_CASE("Member caller")
   SUBCASE("valid caller")
   {
     auto member_rpc_ctx =
-      enclave::make_rpc_context(member_session, serialized_call);
+      ccf::make_rpc_context(member_session, serialized_call);
     std::vector<uint8_t> serialized_response =
       frontend.process(member_rpc_ctx).value();
     auto response = parse_response(serialized_response);
@@ -750,7 +749,7 @@ TEST_CASE("Member caller")
 
   SUBCASE("invalid caller")
   {
-    auto rpc_ctx = enclave::make_rpc_context(user_session, serialized_call);
+    auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_call);
     std::vector<uint8_t> serialized_response =
       frontend.process(rpc_ctx).value();
     auto response = parse_response(serialized_response);
@@ -774,7 +773,7 @@ TEST_CASE("JsonWrappedEndpointFunction")
       echo_call.set_body(serialized_body.data(), serialized_body.size());
       const auto serialized_call = echo_call.build_request();
 
-      auto rpc_ctx = enclave::make_rpc_context(user_session, serialized_call);
+      auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_call);
       auto response = parse_response(frontend.process(rpc_ctx).value());
       CHECK(response.status == HTTP_STATUS_OK);
 
@@ -797,7 +796,7 @@ TEST_CASE("JsonWrappedEndpointFunction")
 
       const auto serialized_call = echo_call.build_request();
 
-      auto rpc_ctx = enclave::make_rpc_context(user_session, serialized_call);
+      auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_call);
       auto response = parse_response(frontend.process(rpc_ctx).value());
       CHECK(response.status == HTTP_STATUS_OK);
 
@@ -811,7 +810,7 @@ TEST_CASE("JsonWrappedEndpointFunction")
       const auto get_caller = create_simple_request("/get_caller", pack_type);
       const auto serialized_call = get_caller.build_request();
 
-      auto rpc_ctx = enclave::make_rpc_context(user_session, serialized_call);
+      auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_call);
       auto response = parse_response(frontend.process(rpc_ctx).value());
       CHECK(response.status == HTTP_STATUS_OK);
 
@@ -825,7 +824,7 @@ TEST_CASE("JsonWrappedEndpointFunction")
     auto dont_fail = create_simple_request("/failable");
     const auto serialized_call = dont_fail.build_request();
 
-    auto rpc_ctx = enclave::make_rpc_context(user_session, serialized_call);
+    auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_call);
     auto response = parse_response(frontend.process(rpc_ctx).value());
     CHECK(response.status == HTTP_STATUS_OK);
   }
@@ -846,7 +845,7 @@ TEST_CASE("JsonWrappedEndpointFunction")
       fail.set_body(serialized_body.data(), serialized_body.size());
       const auto serialized_call = fail.build_request();
 
-      auto rpc_ctx = enclave::make_rpc_context(user_session, serialized_call);
+      auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_call);
       auto response = parse_response(frontend.process(rpc_ctx).value());
       CHECK(response.status == err);
       CHECK(
@@ -877,7 +876,7 @@ TEST_CASE("Restricted verbs")
     {
       http::Request get("get_only", verb);
       const auto serialized_get = get.build_request();
-      auto rpc_ctx = enclave::make_rpc_context(user_session, serialized_get);
+      auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_get);
       const auto serialized_response = frontend.process(rpc_ctx).value();
       const auto response = parse_response(serialized_response);
       if (verb == HTTP_GET)
@@ -897,7 +896,7 @@ TEST_CASE("Restricted verbs")
     {
       http::Request post("post_only", verb);
       const auto serialized_post = post.build_request();
-      auto rpc_ctx = enclave::make_rpc_context(user_session, serialized_post);
+      auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_post);
       const auto serialized_response = frontend.process(rpc_ctx).value();
       const auto response = parse_response(serialized_response);
       if (verb == HTTP_POST)
@@ -918,7 +917,7 @@ TEST_CASE("Restricted verbs")
       http::Request put_or_delete("put_or_delete", verb);
       const auto serialized_put_or_delete = put_or_delete.build_request();
       auto rpc_ctx =
-        enclave::make_rpc_context(user_session, serialized_put_or_delete);
+        ccf::make_rpc_context(user_session, serialized_put_or_delete);
       const auto serialized_response = frontend.process(rpc_ctx).value();
       const auto response = parse_response(serialized_response);
       if (verb == HTTP_PUT || verb == HTTP_DELETE)
@@ -984,8 +983,7 @@ TEST_CASE("Explicit commitability")
       request.set_body(&serialized_body);
 
       const auto serialized_request = request.build_request();
-      auto rpc_ctx =
-        enclave::make_rpc_context(user_session, serialized_request);
+      auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_request);
       const auto serialized_response = frontend.process(rpc_ctx).value();
       const auto response = parse_response(serialized_response);
 
@@ -1020,8 +1018,7 @@ TEST_CASE("Explicit commitability")
         request.set_body(&serialized_body);
 
         const auto serialized_request = request.build_request();
-        auto rpc_ctx =
-          enclave::make_rpc_context(user_session, serialized_request);
+        auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_request);
         const auto serialized_response = frontend.process(rpc_ctx).value();
         const auto response = parse_response(serialized_response);
 
@@ -1054,7 +1051,7 @@ TEST_CASE("Alternative endpoints")
     auto command = create_simple_request("/command");
     const auto serialized_command = command.build_request();
 
-    auto rpc_ctx = enclave::make_rpc_context(user_session, serialized_command);
+    auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_command);
     auto response = parse_response(frontend.process(rpc_ctx).value());
     CHECK(response.status == HTTP_STATUS_OK);
   }
@@ -1064,8 +1061,7 @@ TEST_CASE("Alternative endpoints")
     http::Request read_only("read_only", verb);
     const auto serialized_read_only = read_only.build_request();
 
-    auto rpc_ctx =
-      enclave::make_rpc_context(user_session, serialized_read_only);
+    auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_read_only);
     auto response = parse_response(frontend.process(rpc_ctx).value());
     CHECK(response.status == HTTP_STATUS_OK);
   }
@@ -1081,7 +1077,7 @@ TEST_CASE("Templated paths")
     auto request = create_simple_request("/fin/fang/foom");
     const auto serialized_request = request.build_request();
 
-    auto rpc_ctx = enclave::make_rpc_context(user_session, serialized_request);
+    auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_request);
     auto response = parse_response(frontend.process(rpc_ctx).value());
     CHECK(response.status == HTTP_STATUS_OK);
 
@@ -1100,7 +1096,7 @@ TEST_CASE("Templated paths")
     auto request = create_simple_request("/users/1/address");
     const auto serialized_request = request.build_request();
 
-    auto rpc_ctx = enclave::make_rpc_context(user_session, serialized_request);
+    auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_request);
     auto response = parse_response(frontend.process(rpc_ctx).value());
     CHECK(response.status == HTTP_STATUS_OK);
 
@@ -1127,8 +1123,7 @@ TEST_CASE("Signed read requests can be executed on backup")
 
   auto signed_call = create_signed_request(user_caller);
   auto serialized_signed_call = signed_call.build_request();
-  auto rpc_ctx =
-    enclave::make_rpc_context(user_session, serialized_signed_call);
+  auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_signed_call);
   auto response = parse_response(frontend.process(rpc_ctx).value());
   CHECK(response.status == HTTP_STATUS_OK);
 }
@@ -1147,8 +1142,8 @@ TEST_CASE("Forwarding" * doctest::test_suite("forwarding"))
   network_primary.tables->set_consensus(primary_consensus);
 
   auto channel_stub = std::make_shared<ChannelStubProxy>();
-  auto rpc_responder = std::weak_ptr<enclave::AbstractRPCResponder>();
-  auto rpc_map = std::weak_ptr<enclave::RPCMap>();
+  auto rpc_responder = std::weak_ptr<ccf::AbstractRPCResponder>();
+  auto rpc_map = std::weak_ptr<ccf::RPCMap>();
   auto backup_forwarder = std::make_shared<Forwarder<ChannelStubProxy>>(
     rpc_responder, channel_stub, rpc_map, ConsensusType::CFT);
   auto backup_consensus = std::make_shared<kv::test::BackupStubConsensus>();
@@ -1157,9 +1152,8 @@ TEST_CASE("Forwarding" * doctest::test_suite("forwarding"))
   auto simple_call = create_simple_request();
   auto serialized_call = simple_call.build_request();
 
-  auto backup_ctx =
-    enclave::make_rpc_context(backup_user_session, serialized_call);
-  auto ctx = enclave::make_rpc_context(user_session, serialized_call);
+  auto backup_ctx = ccf::make_rpc_context(backup_user_session, serialized_call);
+  auto ctx = ccf::make_rpc_context(user_session, serialized_call);
 
   {
     INFO("Backup frontend without forwarder does not forward");
@@ -1262,7 +1256,7 @@ TEST_CASE("Forwarding" * doctest::test_suite("forwarding"))
     auto signed_call = create_signed_request(user_caller);
     auto serialized_signed_call = signed_call.build_request();
     auto signed_ctx =
-      enclave::make_rpc_context(user_session, serialized_signed_call);
+      ccf::make_rpc_context(user_session, serialized_signed_call);
     const auto r = user_frontend_backup.process(signed_ctx);
     REQUIRE(!r.has_value());
     REQUIRE(channel_stub->size() == 1);
@@ -1309,8 +1303,8 @@ TEST_CASE("Nodefrontend forwarding" * doctest::test_suite("forwarding"))
   auto primary_consensus = std::make_shared<kv::test::PrimaryStubConsensus>();
   network_primary.tables->set_consensus(primary_consensus);
 
-  auto rpc_responder = std::weak_ptr<enclave::AbstractRPCResponder>();
-  auto rpc_map = std::weak_ptr<enclave::RPCMap>();
+  auto rpc_responder = std::weak_ptr<ccf::AbstractRPCResponder>();
+  auto rpc_map = std::weak_ptr<ccf::RPCMap>();
   auto backup_forwarder = std::make_shared<Forwarder<ChannelStubProxy>>(
     rpc_responder, channel_stub, rpc_map, ConsensusType::CFT);
   node_frontend_backup.set_cmd_forwarder(backup_forwarder);
@@ -1320,9 +1314,9 @@ TEST_CASE("Nodefrontend forwarding" * doctest::test_suite("forwarding"))
   auto write_req = create_simple_request();
   auto serialized_call = write_req.build_request();
 
-  auto node_session = std::make_shared<enclave::SessionContext>(
-    enclave::InvalidSessionId, node_caller.raw());
-  auto ctx = enclave::make_rpc_context(node_session, serialized_call);
+  auto node_session = std::make_shared<ccf::SessionContext>(
+    ccf::InvalidSessionId, node_caller.raw());
+  auto ctx = ccf::make_rpc_context(node_session, serialized_call);
   const auto r = node_frontend_backup.process(ctx);
   REQUIRE(!r.has_value());
   REQUIRE(channel_stub->size() == 1);
@@ -1355,8 +1349,8 @@ TEST_CASE("Userfrontend forwarding" * doctest::test_suite("forwarding"))
   auto primary_consensus = std::make_shared<kv::test::PrimaryStubConsensus>();
   network_primary.tables->set_consensus(primary_consensus);
 
-  auto rpc_responder = std::weak_ptr<enclave::AbstractRPCResponder>();
-  auto rpc_map = std::weak_ptr<enclave::RPCMap>();
+  auto rpc_responder = std::weak_ptr<ccf::AbstractRPCResponder>();
+  auto rpc_map = std::weak_ptr<ccf::RPCMap>();
   auto backup_forwarder = std::make_shared<Forwarder<ChannelStubProxy>>(
     rpc_responder, channel_stub, rpc_map, ConsensusType::CFT);
   user_frontend_backup.set_cmd_forwarder(backup_forwarder);
@@ -1366,7 +1360,7 @@ TEST_CASE("Userfrontend forwarding" * doctest::test_suite("forwarding"))
   auto write_req = create_simple_request();
   auto serialized_call = write_req.build_request();
 
-  auto ctx = enclave::make_rpc_context(user_session, serialized_call);
+  auto ctx = ccf::make_rpc_context(user_session, serialized_call);
   const auto r = user_frontend_backup.process(ctx);
   REQUIRE(!r.has_value());
   REQUIRE(channel_stub->size() == 1);
@@ -1403,8 +1397,8 @@ TEST_CASE("Memberfrontend forwarding" * doctest::test_suite("forwarding"))
   auto primary_consensus = std::make_shared<kv::test::PrimaryStubConsensus>();
   network_primary.tables->set_consensus(primary_consensus);
 
-  auto rpc_responder = std::weak_ptr<enclave::AbstractRPCResponder>();
-  auto rpc_map = std::weak_ptr<enclave::RPCMap>();
+  auto rpc_responder = std::weak_ptr<ccf::AbstractRPCResponder>();
+  auto rpc_map = std::weak_ptr<ccf::RPCMap>();
   auto backup_forwarder = std::make_shared<Forwarder<ChannelStubProxy>>(
     rpc_responder, channel_stub, rpc_map, ConsensusType::CFT);
   member_frontend_backup.set_cmd_forwarder(backup_forwarder);
@@ -1414,7 +1408,7 @@ TEST_CASE("Memberfrontend forwarding" * doctest::test_suite("forwarding"))
   auto write_req = create_simple_request();
   auto serialized_call = write_req.build_request();
 
-  auto ctx = enclave::make_rpc_context(member_session, serialized_call);
+  auto ctx = ccf::make_rpc_context(member_session, serialized_call);
   const auto r = member_frontend_backup.process(ctx);
   REQUIRE(!r.has_value());
   REQUIRE(channel_stub->size() == 1);
@@ -1494,7 +1488,7 @@ TEST_CASE("Retry on conflict")
     size_t retry_count = ccf_max_attempts - 1;
     req.set_header("test-retry-count", fmt::format("{}", retry_count));
     auto serialized_call = req.build_request();
-    auto rpc_ctx = enclave::make_rpc_context(user_session, serialized_call);
+    auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_call);
 
     auto response = parse_response(frontend.process(rpc_ctx).value());
     CHECK(response.status == HTTP_STATUS_OK);
@@ -1510,7 +1504,7 @@ TEST_CASE("Retry on conflict")
     size_t retry_count = ccf_max_attempts + 1;
     req.set_header("test-retry-count", fmt::format("{}", retry_count));
     auto serialized_call = req.build_request();
-    auto rpc_ctx = enclave::make_rpc_context(user_session, serialized_call);
+    auto rpc_ctx = ccf::make_rpc_context(user_session, serialized_call);
 
     auto response = parse_response(frontend.process(rpc_ctx).value());
     CHECK(response.status == HTTP_STATUS_SERVICE_UNAVAILABLE);

--- a/src/node/rpc/test/frontend_test_infra.h
+++ b/src/node/rpc/test/frontend_test_infra.h
@@ -110,9 +110,9 @@ auto frontend_process(
   const std::vector<uint8_t>& serialized_request,
   const crypto::Pem& caller)
 {
-  auto session = std::make_shared<enclave::SessionContext>(
-    enclave::InvalidSessionId, crypto::make_verifier(caller)->cert_der());
-  auto rpc_ctx = enclave::make_rpc_context(session, serialized_request);
+  auto session = std::make_shared<ccf::SessionContext>(
+    ccf::InvalidSessionId, crypto::make_verifier(caller)->cert_der());
+  auto rpc_ctx = ccf::make_rpc_context(session, serialized_request);
   http::extract_actor(*rpc_ctx);
   auto serialized_response = frontend.process(rpc_ctx);
 

--- a/src/node/rpc/test/node_frontend_test.cpp
+++ b/src/node/rpc/test/node_frontend_test.cpp
@@ -55,9 +55,9 @@ TResponse frontend_process(
   r.set_body(&body);
   auto serialise_request = r.build_request();
 
-  auto session = std::make_shared<enclave::SessionContext>(
-    enclave::InvalidSessionId, caller.raw());
-  auto rpc_ctx = enclave::make_rpc_context(session, serialise_request);
+  auto session = std::make_shared<ccf::SessionContext>(
+    ccf::InvalidSessionId, caller.raw());
+  auto rpc_ctx = ccf::make_rpc_context(session, serialise_request);
   auto serialised_response = frontend.process(rpc_ctx);
 
   CHECK(serialised_response.has_value());

--- a/src/node/rpc/test/node_frontend_test.cpp
+++ b/src/node/rpc/test/node_frontend_test.cpp
@@ -55,8 +55,8 @@ TResponse frontend_process(
   r.set_body(&body);
   auto serialise_request = r.build_request();
 
-  auto session = std::make_shared<ccf::SessionContext>(
-    ccf::InvalidSessionId, caller.raw());
+  auto session =
+    std::make_shared<ccf::SessionContext>(ccf::InvalidSessionId, caller.raw());
   auto rpc_ctx = ccf::make_rpc_context(session, serialise_request);
   auto serialised_response = frontend.process(rpc_ctx);
 

--- a/src/node/test/channels.cpp
+++ b/src/node/test/channels.cpp
@@ -18,7 +18,7 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 
-namespace enclave
+namespace ccf
 {
   std::atomic<std::chrono::microseconds>* host_time = nullptr;
   std::chrono::microseconds last_value(0);


### PR DESCRIPTION
As part of #3654, we want to rename `enclave::RpcContext` to `ccf::RpcContext`. We could do this purely for the public types, and keep some internal types under `enclave::`. But I think `enclave::` is an unhelpful namespace name that we intend to abolish in future, as part of #3580, so I've taken the opportunity to remove it wholesale now. This makes the diff far _simpler_; it's just a blind rename, rather than a per-instance rename to recognise a new namespace boundary! That's all this PR does, and any more interesting semantic changes will be PR'd separately.