### PR TITLE
Update `nghttp2/nghttp2` to 1.47.0

### DIFF
--- a/3rdparty/exported/nghttp2/includes/nghttp2/nghttp2ver.h
+++ b/3rdparty/exported/nghttp2/includes/nghttp2/nghttp2ver.h
@@ -29,7 +29,7 @@
  * @macro
  * Version number of the nghttp2 library release
  */
-#define NGHTTP2_VERSION "1.46.0"
+#define NGHTTP2_VERSION "1.47.0"
 
 /**
  * @macro
@@ -37,6 +37,6 @@
  * release. This is a 24 bit number with 8 bits for major number, 8 bits
  * for minor and 8 bits for patch. Version 1.2.3 becomes 0x010203.
  */
-#define NGHTTP2_VERSION_NUM 0x012e00
+#define NGHTTP2_VERSION_NUM 0x012f00
 
 #endif /* NGHTTP2VER_H */

--- a/3rdparty/exported/nghttp2/nghttp2_buf.h
+++ b/3rdparty/exported/nghttp2/nghttp2_buf.h
@@ -99,7 +99,7 @@ void nghttp2_buf_free(nghttp2_buf *buf, nghttp2_mem *mem);
  * |new_cap|. If extensions took place, buffer pointers in |buf| will
  * change.
  *
- * This function returns 0 if it succeeds, or one of the followings
+ * This function returns 0 if it succeeds, or one of the following
  * negative error codes:
  *
  * NGHTTP2_ERR_NOMEM

--- a/3rdparty/exported/nghttp2/nghttp2_frame.c
+++ b/3rdparty/exported/nghttp2/nghttp2_frame.c
@@ -654,8 +654,6 @@ int nghttp2_frame_unpack_goaway_payload2(nghttp2_goaway *frame,
     var_gift_payloadlen = 0;
   }
 
-  payloadlen -= var_gift_payloadlen;
-
   if (!var_gift_payloadlen) {
     var_gift_payload = NULL;
   } else {

--- a/3rdparty/exported/nghttp2/nghttp2_frame.h
+++ b/3rdparty/exported/nghttp2/nghttp2_frame.h
@@ -46,7 +46,7 @@
 #define NGHTTP2_MAX_FRAME_SIZE_MIN (1 << 14)
 
 #define NGHTTP2_MAX_PAYLOADLEN 16384
-/* The one frame buffer length for tranmission.  We may use several of
+/* The one frame buffer length for transmission.  We may use several of
    them to support CONTINUATION.  To account for Pad Length field, we
    allocate extra 1 byte, which saves extra large memcopying. */
 #define NGHTTP2_FRAMEBUF_CHUNKLEN                                              \

--- a/3rdparty/exported/nghttp2/nghttp2_hd.c
+++ b/3rdparty/exported/nghttp2/nghttp2_hd.c
@@ -1263,6 +1263,8 @@ int nghttp2_hd_inflate_change_table_size(
     return NGHTTP2_ERR_INVALID_STATE;
   }
 
+  inflater->settings_hd_table_bufsize_max = settings_max_dynamic_table_size;
+
   /* It seems that encoder is not required to send dynamic table size
      update if the table size is not changed after applying
      SETTINGS_HEADER_TABLE_SIZE.  RFC 7541 is ambiguous here, but this
@@ -1275,13 +1277,12 @@ int nghttp2_hd_inflate_change_table_size(
     /* Remember minimum value, and validate that encoder sends the
        value less than or equal to this. */
     inflater->min_hd_table_bufsize_max = settings_max_dynamic_table_size;
+
+    inflater->ctx.hd_table_bufsize_max = settings_max_dynamic_table_size;
+
+    hd_context_shrink_table_size(&inflater->ctx, NULL);
   }
 
-  inflater->settings_hd_table_bufsize_max = settings_max_dynamic_table_size;
-
-  inflater->ctx.hd_table_bufsize_max = settings_max_dynamic_table_size;
-
-  hd_context_shrink_table_size(&inflater->ctx, NULL);
   return 0;
 }
 

--- a/3rdparty/exported/nghttp2/nghttp2_net.h
+++ b/3rdparty/exported/nghttp2/nghttp2_net.h
@@ -42,7 +42,7 @@
 #if defined(WIN32)
 /* Windows requires ws2_32 library for ntonl family functions.  We
    define inline functions for those function so that we don't have
-   dependeny on that lib. */
+   dependency on that lib. */
 
 #  ifdef _MSC_VER
 #    define STIN static __inline

--- a/3rdparty/exported/nghttp2/nghttp2_outbound_item.h
+++ b/3rdparty/exported/nghttp2/nghttp2_outbound_item.h
@@ -111,7 +111,7 @@ struct nghttp2_outbound_item {
      to this structure to avoid frequent memory allocation. */
   nghttp2_ext_frame_payload ext_frame_payload;
   nghttp2_aux_data aux_data;
-  /* The priority used in priority comparion.  Smaller is served
+  /* The priority used in priority comparison.  Smaller is served
      earlier.  For PING, SETTINGS and non-DATA frames (excluding
      response HEADERS frame) have dedicated cycle value defined above.
      For DATA frame, cycle is computed by taking into account of

--- a/3rdparty/exported/nghttp2/nghttp2_pq.h
+++ b/3rdparty/exported/nghttp2/nghttp2_pq.h
@@ -114,7 +114,7 @@ typedef int (*nghttp2_pq_item_cb)(nghttp2_pq_entry *item, void *arg);
 void nghttp2_pq_update(nghttp2_pq *pq, nghttp2_pq_item_cb fun, void *arg);
 
 /*
- * Applys |fun| to each item in |pq|.  The |arg| is passed as arg
+ * Applies |fun| to each item in |pq|.  The |arg| is passed as arg
  * parameter to callback function.  This function must not change the
  * ordering key.  If the return value from callback is nonzero, this
  * function returns 1 immediately without iterating remaining items.

--- a/3rdparty/exported/nghttp2/nghttp2_session.c
+++ b/3rdparty/exported/nghttp2/nghttp2_session.c
@@ -5341,7 +5341,7 @@ static ssize_t inbound_frame_compute_pad(nghttp2_inbound_frame *iframe) {
 
 /*
  * This function returns the effective payload length in the data of
- * length |readlen| when the remaning payload is |payloadleft|. The
+ * length |readlen| when the remaining payload is |payloadleft|. The
  * |payloadleft| does not include |readlen|. If padding was started
  * strictly before this data chunk, this function returns -1.
  */

--- a/3rdparty/exported/nghttp2/nghttp2_session.h
+++ b/3rdparty/exported/nghttp2/nghttp2_session.h
@@ -408,7 +408,7 @@ int nghttp2_session_add_rst_stream(nghttp2_session *session, int32_t stream_id,
                                    uint32_t error_code);
 
 /*
- * Adds PING frame. This is a convenient functin built on top of
+ * Adds PING frame. This is a convenient function built on top of
  * nghttp2_session_add_frame() to add PING easily.
  *
  * If the |opaque_data| is not NULL, it must point to 8 bytes memory

--- a/3rdparty/exported/nghttp2/nghttp2_stream.c
+++ b/3rdparty/exported/nghttp2/nghttp2_stream.c
@@ -33,7 +33,7 @@
 #include "nghttp2_frame.h"
 
 /* Maximum distance between any two stream's cycle in the same
-   prirority queue.  Imagine stream A's cycle is A, and stream B's
+   priority queue.  Imagine stream A's cycle is A, and stream B's
    cycle is B, and A < B.  The cycle is unsigned 32 bit integer, it
    may get overflow.  Because of how we calculate the next cycle
    value, if B - A is less than or equals to

--- a/3rdparty/exported/nghttp2/nghttp2_submit.c
+++ b/3rdparty/exported/nghttp2/nghttp2_submit.c
@@ -492,8 +492,6 @@ int nghttp2_session_set_local_window_size(nghttp2_session *session,
     return nghttp2_session_update_recv_stream_window_size(session, stream, 0,
                                                           1);
   }
-
-  return 0;
 }
 
 int nghttp2_submit_altsvc(nghttp2_session *session, uint8_t flags,

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -122,7 +122,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/nghttp2/nghttp2",
-          "commitHash": "7af0c508be9cbec407268e2f546f597d268c104e"
+          "commitHash": "d9f580c3cb419e77474da507eef20f1c81ecff32"
         }
       }
     },


### PR DESCRIPTION
Note that this library isn't currently included in CCF (requires `-DENABLE_HTTP2`, which is `OFF` by default). 