### PR TITLE
Move split ledger test

### DIFF
--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -199,7 +199,9 @@ def test_split_ledger_on_stopped_network(primary, args):
         )
 
     # Check that the split ledger can be read successfully
-    ccf.ledger.Ledger([current_ledger_dir] + committed_ledger_dirs, committed_only=False)
+    ccf.ledger.Ledger(
+        [current_ledger_dir] + committed_ledger_dirs, committed_only=False
+    )
 
 
 def run_file_operations(args):

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -199,7 +199,7 @@ def test_split_ledger_on_stopped_network(primary, args):
         )
 
     # Check that the split ledger can be read successfully
-    ccf.ledger.Ledger([current_ledger_dir] + committed_ledger_dirs, False)
+    ccf.ledger.Ledger([current_ledger_dir] + committed_ledger_dirs, committed_only=False)
 
 
 def run_file_operations(args):

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -14,7 +14,7 @@ import ipaddress
 import infra.interfaces
 import infra.path
 import infra.proc
-
+import random
 
 from loguru import logger as LOG
 
@@ -149,6 +149,59 @@ def test_forced_snapshot(network, args):
     raise RuntimeError("Could not find matching snapshot file")
 
 
+def split_all_ledger_files_in_dir(input_dir, output_dir):
+    # A ledger file can only be split at a seqno that contains a signature
+    # (so that all files end on a signature that verifies their integrity).
+    # We first detect all signature transactions in a ledger file and truncate
+    # at any one (but not the last one, which would have no effect) at random.
+    for ledger_file in os.listdir(input_dir):
+        sig_seqnos = []
+
+        if ledger_file.endswith(ccf.ledger.RECOVERY_FILE_SUFFIX):
+            # Ignore recovery files
+            continue
+
+        ledger_file_path = os.path.join(input_dir, ledger_file)
+        ledger_chunk = ccf.ledger.LedgerChunk(ledger_file_path, ledger_validator=None)
+        for transaction in ledger_chunk:
+            public_domain = transaction.get_public_domain()
+            if ccf.ledger.SIGNATURE_TX_TABLE_NAME in public_domain.get_tables().keys():
+                sig_seqnos.append(public_domain.get_seqno())
+
+        if len(sig_seqnos) <= 1:
+            # A chunk may not contain enough signatures to be worth truncating
+            continue
+
+        # Ignore last signature, which would result in a no-op split
+        split_seqno = random.choice(sig_seqnos[:-1])
+
+        assert ccf.split_ledger.run(
+            [ledger_file_path, str(split_seqno), f"--output-dir={output_dir}"]
+        ), f"Ledger file {ledger_file_path} was not split at {split_seqno}"
+        LOG.info(
+            f"Ledger file {ledger_file_path} was successfully split at {split_seqno}"
+        )
+        LOG.debug(f"Deleting input ledger file {ledger_file_path}")
+        os.remove(ledger_file_path)
+
+
+@reqs.description("Split ledger")
+def test_split_ledger_on_stopped_network(primary, args):
+    # Test that ledger files can be arbitrarily split.
+    # Note: For real operations, it would be best practice to use a separate
+    # output directory
+
+    current_ledger_dir, committed_ledger_dirs = primary.get_ledger()
+    split_all_ledger_files_in_dir(current_ledger_dir, current_ledger_dir)
+    if committed_ledger_dirs:
+        split_all_ledger_files_in_dir(
+            committed_ledger_dirs[0], committed_ledger_dirs[0]
+        )
+
+    # Check that the split ledger can be read successfully
+    ccf.ledger.Ledger([current_ledger_dir] + committed_ledger_dirs, False)
+
+
 def run_file_operations(args):
     with tempfile.TemporaryDirectory() as tmp_dir:
         txs = app.LoggingTxs("user0")
@@ -168,6 +221,11 @@ def run_file_operations(args):
             test_parse_snapshot_file(network, args)
             test_forced_ledger_chunk(network, args)
             test_forced_snapshot(network, args)
+
+            primary, _ = network.find_primary()
+            network.stop_all_nodes()
+
+            test_split_ledger_on_stopped_network(primary, args)
 
 
 def run_tls_san_checks(args):

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -6,7 +6,6 @@ import infra.node
 import infra.logging_app as app
 import infra.checker
 import suite.test_requirements as reqs
-import ccf.split_ledger
 import ccf.ledger
 import os
 import json
@@ -493,8 +492,6 @@ checked. Note that the key for each logging message is unique (per table).
 
     cr = ConcurrentRunner()
 
-    # Test-specific values so that it is likely that ledger files contain
-    # at least two signatures, so that they can be split at the first one
     cr.add(
         "recovery",
         run,

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -423,8 +423,7 @@ def run(args):
     ) as network:
         network.start_and_open(args)
 
-        # This one may be special?
-        # network = test_recover_service_with_wrong_identity(network, args)
+        network = test_recover_service_with_wrong_identity(network, args)
 
         for i in range(recoveries_count):
             # Issue transactions which will required historical ledger queries recovery

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -9,7 +9,6 @@ import suite.test_requirements as reqs
 import ccf.split_ledger
 import ccf.ledger
 import os
-import random
 import json
 from infra.runner import ConcurrentRunner
 from distutils.dir_util import copy_tree
@@ -18,45 +17,9 @@ from infra.consortium import slurp_file
 from loguru import logger as LOG
 
 
-def split_all_ledger_files_in_dir(input_dir, output_dir):
-    # A ledger file can only be split at a seqno that contains a signature
-    # (so that all files end on a signature that verifies their integrity).
-    # We first detect all signature transactions in a ledger file and truncate
-    # at any one (but not the last one, which would have no effect) at random.
-    for ledger_file in os.listdir(input_dir):
-        sig_seqnos = []
-
-        if ledger_file.endswith(ccf.ledger.RECOVERY_FILE_SUFFIX):
-            # Ignore recovery files
-            continue
-
-        ledger_file_path = os.path.join(input_dir, ledger_file)
-        ledger_chunk = ccf.ledger.LedgerChunk(ledger_file_path, ledger_validator=None)
-        for transaction in ledger_chunk:
-            public_domain = transaction.get_public_domain()
-            if ccf.ledger.SIGNATURE_TX_TABLE_NAME in public_domain.get_tables().keys():
-                sig_seqnos.append(public_domain.get_seqno())
-
-        if len(sig_seqnos) <= 1:
-            # A chunk may not contain enough signatures to be worth truncating
-            continue
-
-        # Ignore last signature, which would result in a no-op split
-        split_seqno = random.choice(sig_seqnos[:-1])
-
-        assert ccf.split_ledger.run(
-            [ledger_file_path, str(split_seqno), f"--output-dir={output_dir}"]
-        ), f"Ledger file {ledger_file_path} was not split at {split_seqno}"
-        LOG.info(
-            f"Ledger file {ledger_file_path} was successfully split at {split_seqno}"
-        )
-        LOG.debug(f"Deleting input ledger file {ledger_file_path}")
-        os.remove(ledger_file_path)
-
-
 @reqs.description("Recover a service")
 @reqs.recover(number_txs=2)
-def test_recover_service(network, args, from_snapshot=False, split_ledger=False):
+def test_recover_service(network, args, from_snapshot=False):
     network.save_service_identity(args)
     old_primary, _ = network.find_primary()
 
@@ -67,17 +30,6 @@ def test_recover_service(network, args, from_snapshot=False, split_ledger=False)
     network.stop_all_nodes()
 
     current_ledger_dir, committed_ledger_dirs = old_primary.get_ledger()
-
-    if split_ledger:
-        # Test that ledger files can be arbitrarily split and that recovery
-        # and historical queries work as expected.
-        # Note: For real operations, it would be best practice to use a separate
-        # output directory
-        split_all_ledger_files_in_dir(current_ledger_dir, current_ledger_dir)
-        if committed_ledger_dirs:
-            split_all_ledger_files_in_dir(
-                committed_ledger_dirs[0], committed_ledger_dirs[0]
-            )
 
     recovered_network = infra.network.Network(
         args.nodes,
@@ -458,7 +410,7 @@ def run_corrupted_ledger(args):
 
 
 def run(args):
-    recoveries_count = 10
+    recoveries_count = 5
 
     txs = app.LoggingTxs("user0")
     with infra.network.network(
@@ -490,9 +442,7 @@ def run(args):
                     network, args, from_snapshot=False
                 )
             else:
-                network = test_recover_service(
-                    network, args, from_snapshot=False, split_ledger=True
-                )
+                network = test_recover_service(network, args, from_snapshot=False)
 
             for node in network.get_joined_nodes():
                 node.verify_certificate_validity_period()

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -458,7 +458,7 @@ def run_corrupted_ledger(args):
 
 
 def run(args):
-    recoveries_count = 3
+    recoveries_count = 10
 
     txs = app.LoggingTxs("user0")
     with infra.network.network(
@@ -471,7 +471,8 @@ def run(args):
     ) as network:
         network.start_and_open(args)
 
-        network = test_recover_service_with_wrong_identity(network, args)
+        # This one may be special?
+        # network = test_recover_service_with_wrong_identity(network, args)
 
         for i in range(recoveries_count):
             # Issue transactions which will required historical ledger queries recovery


### PR DESCRIPTION
When running the recovery tests more than 3 times with ledger splitting enabled, it frequently happened that the ledger files on disc went out of sync. We didn't see this in CI runs because we only ever ran 3 or 4 recoveries with splitting enabled for some of them. That test is now moved to e2e_operations, where we check that the split ledger can be read successfully and the recovery tests run without splitting ledgers.