### PR TITLE
Define clock_gettime rather than gettimeofday

### DIFF
--- a/src/enclave/stub_time.c
+++ b/src/enclave/stub_time.c
@@ -3,7 +3,7 @@
 #include <sys/time.h>
 #include <time.h>
 
-int gettimeofday(struct timeval* tv, void* tz)
+int clock_gettime(clockid_t clk_id, struct timespec* tp)
 {
   return 0;
 }


### PR DESCRIPTION
Tested against https://github.com/letmaik/ccf-repro-1