### PR TITLE
Fix yet another DNS resolver memory leak

### DIFF
--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -599,7 +599,7 @@ namespace asynchost
       return true;
     }
 
-    static void on_resolved(uv_getaddrinfo_t* req, int rc, struct addrinfo*)
+    static void on_resolved(uv_getaddrinfo_t* req, int rc, struct addrinfo* res)
     {
       std::unique_lock<std::mutex> guard(pending_resolve_requests_mtx);
       pending_resolve_requests.erase(req);
@@ -612,6 +612,7 @@ namespace asynchost
       {
         // The TCPImpl that submitted the request has been destroyed, but we
         // need to clean up the request object.
+        uv_freeaddrinfo(res);
         delete req;
       }
     }


### PR DESCRIPTION
Fixes #3693 

According to the libuv docs, the `res` must be freed manually. Something around that must have changed though, as I never saw this the last time I tested for leaks and the exactly same test I used at that time, now produced lots of these errors, where it used to produce none. Perhaps I was just unbelievably lucky then.