### PR TITLE
Truncate OpenSSL::error_string

### DIFF
--- a/src/crypto/openssl/openssl_wrappers.h
+++ b/src/crypto/openssl/openssl_wrappers.h
@@ -35,6 +35,8 @@ namespace crypto
       {
         std::string err(256, '\0');
         ERR_error_string_n((unsigned long)ec, err.data(), err.size());
+        // Remove any trailing NULs before returning
+        err.resize(std::strlen(err.c_str()));
         return err;
       }
       else


### PR DESCRIPTION
Lib fmt will print these `NUL` bytes if we retain them. We don't actually want them here, they're just reserved memory, so truncate before returning.