### PR TITLE
Remove unused types

### DIFF
--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -149,35 +149,6 @@ namespace aft
     AppendEntriesResponseType success;
   };
 
-  struct SignaturesReceivedAck : RaftHeader
-  {
-    Term term;
-    Index idx;
-  };
-
-  struct NonceRevealMsg : RaftHeader
-  {
-    Term term;
-    Index idx;
-    Nonce nonce;
-  };
-
-  struct RequestViewChangeMsg : RaftHeader
-  {
-    ccf::View view = 0;
-    ccf::SeqNo seqno = 0;
-  };
-
-  struct ViewChangeEvidenceMsg : RaftHeader
-  {
-    ccf::View view = 0;
-  };
-
-  struct SkipViewMsg : RaftHeader
-  {
-    ccf::View view = 0;
-  };
-
   struct RequestVote : RaftHeader
   {
     Term term;


### PR DESCRIPTION
As pointed out in #3402, we still have a few unused types kicking around. `SignedAppendEntriesResponse` was already removed. This removes the other.

Resolves #3402.