### PR TITLE
Describe text objects as `text/plain` in generated OpenAPI

### DIFF
--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -322,7 +322,7 @@
   "info": {
     "description": "This CCF sample app implements a simple logging application, securely recording messages at client-specified IDs. It demonstrates most of the features available to CCF apps.",
     "title": "CCF Sample Logging App",
-    "version": "1.9.1"
+    "version": "1.9.2"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -990,7 +990,7 @@
         "responses": {
           "200": {
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
                   "$ref": "#/components/schemas/string"
                 }
@@ -1006,7 +1006,7 @@
         "responses": {
           "200": {
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
                   "$ref": "#/components/schemas/string"
                 }
@@ -1027,7 +1027,7 @@
         "responses": {
           "200": {
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
                   "$ref": "#/components/schemas/string"
                 }

--- a/include/ccf/endpoint.h
+++ b/include/ccf/endpoint.h
@@ -229,10 +229,7 @@ namespace ccf::endpoints
             }
 
             ds::openapi::add_request_body_schema<In>(
-              document,
-              endpoint.full_uri_path,
-              http_verb.value(),
-              http::headervalues::contenttype::JSON);
+              document, endpoint.full_uri_path, http_verb.value());
           });
       }
       else
@@ -258,8 +255,7 @@ namespace ccf::endpoints
               document,
               endpoint.full_uri_path,
               http_verb.value(),
-              endpoint.success_status,
-              http::headervalues::contenttype::JSON);
+              endpoint.success_status);
           });
       }
       else

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -222,7 +222,7 @@ namespace loggingapp
         "This CCF sample app implements a simple logging application, securely "
         "recording messages at client-specified IDs. It demonstrates most of "
         "the features available to CCF apps.";
-      openapi_info.document_version = "1.9.1";
+      openapi_info.document_version = "1.9.2";
 
       index_per_public_key = std::make_shared<RecordsIndexingStrategy>(
         PUBLIC_RECORDS, context, 10000, 20);

--- a/src/ds/test/openapi.cpp
+++ b/src/ds/test/openapi.cpp
@@ -85,20 +85,10 @@ TEST_CASE("Simple custom types")
 
   openapi::server(doc, server_url);
 
-  openapi::add_request_body_schema<Foo>(
-    doc, "/app/foo", HTTP_POST, http::headervalues::contenttype::JSON);
+  openapi::add_request_body_schema<Foo>(doc, "/app/foo", HTTP_POST);
   openapi::add_response_schema<size_t>(
-    doc,
-    "/app/foo",
-    HTTP_POST,
-    HTTP_STATUS_OK,
-    http::headervalues::contenttype::JSON);
-  openapi::add_response_schema<Foo>(
-    doc,
-    "/app/foo",
-    HTTP_POST,
-    HTTP_STATUS_OK,
-    http::headervalues::contenttype::JSON);
+    doc, "/app/foo", HTTP_POST, HTTP_STATUS_OK);
+  openapi::add_response_schema<Foo>(doc, "/app/foo", HTTP_POST, HTTP_STATUS_OK);
 
   required_doc_elements(doc);
 }
@@ -157,44 +147,18 @@ TEST_CASE("Complex custom types")
   openapi::server(doc, server_url);
 
   openapi::add_response_schema<std::vector<Foo>>(
-    doc,
-    "/app/foos",
-    HTTP_GET,
-    HTTP_STATUS_OK,
-    http::headervalues::contenttype::JSON);
+    doc, "/app/foos", HTTP_GET, HTTP_STATUS_OK);
   openapi::add_response_schema<std::vector<std::vector<Foo>>>(
-    doc,
-    "/app/fooss",
-    HTTP_GET,
-    HTTP_STATUS_OK,
-    http::headervalues::contenttype::JSON);
-  openapi::add_response_schema<Bar>(
-    doc,
-    "/app/bar",
-    HTTP_GET,
-    HTTP_STATUS_OK,
-    http::headervalues::contenttype::JSON);
-  openapi::add_response_schema<Baz>(
-    doc,
-    "/app/baz",
-    HTTP_GET,
-    HTTP_STATUS_OK,
-    http::headervalues::contenttype::JSON);
+    doc, "/app/fooss", HTTP_GET, HTTP_STATUS_OK);
+  openapi::add_response_schema<Bar>(doc, "/app/bar", HTTP_GET, HTTP_STATUS_OK);
+  openapi::add_response_schema<Baz>(doc, "/app/baz", HTTP_GET, HTTP_STATUS_OK);
   openapi::add_response_schema<std::map<std::string, Buzz>>(
-    doc,
-    "/app/buzz",
-    HTTP_GET,
-    HTTP_STATUS_OK,
-    http::headervalues::contenttype::JSON);
+    doc, "/app/buzz", HTTP_GET, HTTP_STATUS_OK);
 
   openapi::add_request_body_schema<std::optional<Bar>>(
-    doc, "/app/complex", HTTP_POST, http::headervalues::contenttype::JSON);
+    doc, "/app/complex", HTTP_POST);
   openapi::add_response_schema<std::map<Baz, std::vector<Buzz>>>(
-    doc,
-    "/app/complex",
-    HTTP_POST,
-    HTTP_STATUS_OK,
-    http::headervalues::contenttype::JSON);
+    doc, "/app/complex", HTTP_POST, HTTP_STATUS_OK);
 
   required_doc_elements(doc);
 }
@@ -282,8 +246,7 @@ TEST_CASE("Manual function definitions")
       "Some longer description enhanced with **Markdown**",
       "0.1.42");
 
-    openapi::add_request_body_schema<bbb::Person>(
-      doc, "/person", HTTP_POST, http::headervalues::contenttype::JSON);
+    openapi::add_request_body_schema<bbb::Person>(doc, "/person", HTTP_POST);
 
     const auto components_schemas = doc["components"]["schemas"];
     REQUIRE(components_schemas.find("Person") != components_schemas.end());


### PR DESCRIPTION
We previously marked all auto-generated OpenAPI request/response bodies as `application/json`, on the assumption they were using JSON serializers. This is obviously not true for plain-text responses, leading to inaccurate OpenAPI elements (and a follow-on warning during docs build).

We would ideally only insert the `application/json` content type if we knew it was using a JSON serializer, but that would need a type trait from the macro that doesn't currently exist, and it's not clear what we do in the fallback cases (we need a sensible default value, since the content type of each response is required).