### PR TITLE
Increase timeout for app to open after recovery

### DIFF
--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -552,7 +552,7 @@ class Network:
                 infra.node.State.PART_OF_NETWORK.value,
                 timeout=args.ledger_recovery_timeout,
             )
-            self._wait_for_app_open(node)
+            self._wait_for_app_open(node, timeout=args.ledger_recovery_timeout)
 
         self.consortium.check_for_service(self.find_random_node(), ServiceStatus.OPEN)
         LOG.success("***** Recovered network is now open *****")


### PR DESCRIPTION
I've seen `recovery.test_recover_service` time out in `_wait_for_app_open` a few times locally but also in the CI (e.g. one of today's daily runs), usually when this test is execute multiple times (like in the test suite). I think the timeout needs to be increased because of the additional time taken for snapshot generation after recovery, which we added recently, but `args.ledger_recovery_timeout` may perhaps be too much. 