### PR TITLE
`release/1.x`: Fix expected output when testing multiple protocols

### DIFF
--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -148,16 +148,14 @@ def test_illegal(network, args, verify=True):
 def test_protocols(network, args):
     primary, _ = network.find_primary()
 
-    primary_root = (
-        f"https://{primary.pubhost}:{primary.pubport}"
-    )
+    primary_root = f"https://{primary.pubhost}:{primary.pubport}"
     url = f"{primary_root}/node/state"
     ca_path = os.path.join(network.common_dir, "networkcert.pem")
 
     common_options = [url, "-sS", "--cacert", ca_path]
 
     with primary.client("user0") as c:
-        r = c.get("/node/state")
+        r = c.get("/node/version")
         assert r.status_code == http.HTTPStatus.OK, r.status_code
         expected_response_body = r.body.text()
 


### PR DESCRIPTION
Fix [intermittent CI failures](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=44441&view=logs&j=8f3dc89c-3708-5926-47e7-27120a268dab&t=efdbc34d-c6b6-5dc6-e05c-1751d4c47c20&l=30159) where the expected output could change because of regular snapshot generation. Instead, we test the output for a well-known stable endpoint. 