### PR TITLE
Fix 1.x snapshot verification on 2.x node join

### DIFF
--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -314,6 +314,7 @@ class Node:
                 if self.remote.check_done():
                     raise RuntimeError("Node crashed at startup")
                 self.remote.get_startup_files(self.common_dir)
+                break
             except Exception as e:
                 if self.remote.check_done():
                     self.remote.get_logs(tail_lines_len=None)
@@ -332,7 +333,10 @@ class Node:
 
         self._read_ports()
         self.certificate_validity_days = kwargs.get("initial_node_cert_validity_days")
-        LOG.info(f"Node {self.local_node_id} started: {self.node_id}")
+        start_msg = f"Node {self.local_node_id} started: {self.node_id}"
+        if self.version is not None:
+            start_msg += f" [version: {self.version}]"
+        LOG.info(start_msg)
 
     def _resolve_address(self, address_file_path, interfaces):
         with open(address_file_path, "r", encoding="utf-8") as f:


### PR DESCRIPTION
This currently blocks releases on new `2.x` release candidates.

https://github.com/microsoft/CCF/pull/3746 modified the logic around recovering ledger entries, which is also used to verify 1.x snapshots. This is only tested when cutting a new 2.0 release candidate tag. 

This is now fixed:
```bash
# with CCF 1.0.19 installed at /opt/ccf

$ "python3" "lts_compatibility.py" "-b" "." "--label" "lts_compatibility" "--host-log-level" "info" "--worker-threads" "0" ... "--ccf-version" "ccf-2.0.0-rc7" "--check-ledger-compatibility" "--check-2tx-reconfig-migration" -e virtual --release-install-path /opt/ccf/
09:42:46.919 | SUCCESS  | __main__:<module>:623 - Compatibility report:
 {
  "version": "ccf-2.0.0-rc7",
  "live compatibility": {
    "with release (/opt/ccf/)": "ccf-1.0.19"
  }
}
```

I will fix the LTS compatibility tag detection logic separately.