### PR TITLE
Better LTS compatibility checks when committing to `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.0.0-rc7]
 
 ### Fixed
 
@@ -1285,6 +1285,7 @@ Some discrepancies with the TR remain, and are being tracked under https://githu
 
 Initial pre-release
 
+[2.0.0-rc7]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.0-rc7
 [2.0.0-rc6]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.0-rc6
 [2.0.0-rc5]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.0-rc5
 [2.0.0-rc4]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.0-rc4


### PR DESCRIPTION
This is expected to fail until https://github.com/microsoft/CCF/pull/3775 is merged.

When committing to `main`, the `lts_compatibility` test only checked for live compatibility with the latest release candidate (i.e. `ccf-2.0.0-rc6`), but not with the latest previous final release (i.e. `ccf-1.0.19`). The compatibility with `ccf-1.0.19` was only checked when the next release tag (i.e. `ccf-2.0.0-rc7`) was cut:

```bash
# when committing to main, lts_compatibility test outputs:
{
  "version": "ccf-2.0.0-rc6-27-gea38c18f",
  "live compatibility": {
    "with previous LTS": "ccf-2.0.0-rc6",
    "with same LTS": null
  }
}
```

This now checks for compatibility with both `ccf-2.0.0-rc6` and `ccf-1.0.19`, helping us catch compatibility issues early:

```bash
# when committing to main, lts_compatibility test now outputs:
 {
  "version": null,
  "live compatibility": {
    "with previous LTS": "ccf-1.0.19",
    "with same LTS": "ccf-2.0.0-rc6"
  }
}
```