### PR TITLE
Reduce number of verified receipts in LTS compatibility test

### DIFF
--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -48,7 +48,7 @@ jobs:
       suffix: "Instrumented"
       artifact_name: "NoSGX_Instrumented"
       ctest_filter: '-LE "benchmark|perf"'
-      ctest_timeout: "600"
+      ctest_timeout: "800"
 
   - template: common.yml
     parameters:

--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Cui cui
+Cui cui.

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -358,7 +358,7 @@ def test_large_messages(network, args):
     # pass but not others, and finding where does it fail).
     log_id = 7
     for p in range(10, 20) if args.consensus == "CFT" else range(10, 13):
-        long_msg = "X" * (2**p)
+        long_msg = "X" * (2 ** p)
         network.txs.issue(network, 1, idx=log_id, send_public=False, msg=long_msg)
         check(network.txs.request(log_id, priv=True), result={"msg": long_msg})
         log_id += 1
@@ -1410,10 +1410,11 @@ def test_random_receipts(
         last_sig_seqno = max_seqno
         interesting_prefix = [genesis_seqno, likely_first_sig_seqno]
         seqnos = range(len(interesting_prefix) + 1, max_seqno)
+        random_sample_count = 20 if lts else 50
         for s in (
             interesting_prefix
             + sorted(
-                random.sample(seqnos, min(50, len(seqnos)))
+                random.sample(seqnos, min(random_sample_count, len(seqnos)))
                 + list(additional_seqnos.keys())
             )
             + [last_sig_seqno]

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -358,7 +358,7 @@ def test_large_messages(network, args):
     # pass but not others, and finding where does it fail).
     log_id = 7
     for p in range(10, 20) if args.consensus == "CFT" else range(10, 13):
-        long_msg = "X" * (2 ** p)
+        long_msg = "X" * (2**p)
         network.txs.issue(network, 1, idx=log_id, send_public=False, msg=long_msg)
         check(network.txs.request(log_id, priv=True), result={"msg": long_msg})
         log_id += 1


### PR DESCRIPTION
#3776 seems to have taken the `lts_compatibility` over its allowed timeout so this PR reduces the number of receipts we sample in this test. 