### PR TITLE
Increase timeout while waiting for committed snapshot

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Cui cui.
+Cui cui cui.

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -1203,7 +1203,7 @@ class Network:
             r = c.get("/node/commit").body.json()
             target_seqno = TxID.from_str(r["transaction_id"]).seqno
 
-        def wait_for_snapshots_to_be_committed(src_dir, list_src_dir_func, timeout=6):
+        def wait_for_snapshots_to_be_committed(src_dir, list_src_dir_func, timeout=20):
             LOG.info(
                 f"Waiting for a snapshot to be committed including seqno {target_seqno}"
             )
@@ -1225,6 +1225,9 @@ class Network:
                         ), f"Error ack/update_state_digest: {r}"
                     c.wait_for_commit(r)
                 time.sleep(0.1)
+            LOG.error(
+                f"Could not find committed snapshot for seqno {target_seqno} after {timeout}s in {src_dir}: {list_src_dir_func(src_dir)}"
+            )
             return False
 
         return node.get_committed_snapshots(wait_for_snapshots_to_be_committed)

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -1214,6 +1214,9 @@ class Network:
                     if snapshot_seqno >= target_seqno and infra.node.is_file_committed(
                         f
                     ):
+                        LOG.info(
+                            f"Found committed snapshot {f} for seqno {target_seqno} after {timeout - (end_time - time.time())}s"
+                        )
                         return True
 
                 with node.client(self.consortium.get_any_active_member().local_id) as c:


### PR DESCRIPTION
This issue has recently [appeared in the Daily CI](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=44605&view=results), only with release SGX builds (?). I couldn't reproduce the error locally, but it seems that the timeout current value is dangerously low, and this may throw if the disk is slow.