### PR TITLE
Restore ability to launch infra nodes with debugger attached

### DIFF
--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -543,7 +543,7 @@ class LocalRemote(CmdMixin):
         return f"cd {self.root} && {DBG} --args {cmd}"
 
     def check_done(self):
-        return self.proc.poll() is not None
+        return self.proc is not None and self.proc.poll() is not None
 
     def get_result(self, line_count):
         with open(self.out, "rb") as out:


### PR DESCRIPTION
The recent changes to add early-crash detection broke the `-d` argument to sandbox/start_network/etc. Specifically, `check_done` attempts to access `self.proc`, which only exists in the `self.remote.start()` path, but not if the node was started manually with a debugger.

I considered moving the `Detect whether node started up successfully` block, so it wouldn't run at all on the debugger-attached nodes. I think this approach, even though it's an ugly change, gives nice behaviour - if debug-attached nodes crash on start-up, the infra recognises this quickly from missing startup files, rather than ignoring it entirely.