### PR TITLE
Pin requests-http-signature to 0.2.0

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 loguru >= 0.5, == 0.*
 requests >= 2.24, == 2.*
-requests-http-signature >= 0.2, == 0.*
+requests-http-signature == 0.2.0
 websocket-client >= 0.57, == 0.*
 cryptography >= 3.2, == 3.*


### PR DESCRIPTION
Fix break introduced in later releases, see https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=44775&view=logs&j=5435e0ac-25e5-5426-50be-61b0d0ea8d34&t=3e1ef318-4174-5329-41dd-e9ef66c4c6d0