### PR TITLE
Use pointers for JSON schema ADL

### DIFF
--- a/include/ccf/crypto/pem.h
+++ b/include/ccf/crypto/pem.h
@@ -117,12 +117,12 @@ namespace crypto
     }
   }
 
-  inline std::string schema_name(const Pem&)
+  inline std::string schema_name(const Pem*)
   {
     return "Pem";
   }
 
-  inline void fill_json_schema(nlohmann::json& schema, const Pem&)
+  inline void fill_json_schema(nlohmann::json& schema, const Pem*)
   {
     schema["type"] = "string";
   }

--- a/include/ccf/ds/json_schema.h
+++ b/include/ccf/ds/json_schema.h
@@ -45,7 +45,7 @@ namespace ds
     void fill_schema(nlohmann::json& schema);
 
     template <typename T>
-    void fill_json_schema(nlohmann::json& j, const T& t);
+    void fill_json_schema(nlohmann::json& j, const T* t);
 
     template <typename T>
     nlohmann::json schema_element()
@@ -72,14 +72,14 @@ namespace ds
       template <typename T>
       std::string schema_name()
       {
-        T t;
+        T* t = nullptr;
         return schema_name(t);
       }
 
       template <typename T>
       void fill_schema(nlohmann::json& schema)
       {
-        T t;
+        T* t = nullptr;
         if constexpr (std::is_enum<T>::value)
         {
           fill_enum_schema(schema, t);

--- a/include/ccf/ds/openapi.h
+++ b/include/ccf/ds/openapi.h
@@ -238,7 +238,7 @@ namespace ds
     // recursive implementation for struct-to-object types is created by the
     // json.h macros, and this could be implemented manually for other types.
     template <typename Doc, typename T>
-    void add_schema_components(Doc&, nlohmann::json& j, const T& t)
+    void add_schema_components(Doc&, nlohmann::json& j, const T* t)
     {
       fill_json_schema(j, t);
     }
@@ -340,7 +340,7 @@ namespace ds
 #  pragma clang diagnostic ignored "-Wuninitialized-const-reference"
 #endif
             // Use argument-dependent-lookup to call correct functions
-            T t;
+            T* t = nullptr;
             if constexpr (std::is_enum<T>::value)
             {
               fill_enum_schema(j, t);

--- a/include/ccf/entity_id.h
+++ b/include/ccf/entity_id.h
@@ -102,14 +102,14 @@ namespace ccf
   }
 
   template <typename FmtExtender>
-  inline std::string schema_name(const EntityId<FmtExtender>&)
+  inline std::string schema_name(const EntityId<FmtExtender>*)
   {
     return FmtExtender::ID_LABEL;
   }
 
   template <typename FmtExtender>
   inline void fill_json_schema(
-    nlohmann::json& schema, const EntityId<FmtExtender>&)
+    nlohmann::json& schema, const EntityId<FmtExtender>*)
   {
     schema["type"] = "string";
 

--- a/include/ccf/tx_id.h
+++ b/include/ccf/tx_id.h
@@ -113,12 +113,12 @@ namespace ccf
     tx_id = opt.value();
   }
 
-  inline std::string schema_name(const TxID&)
+  inline std::string schema_name(const TxID*)
   {
     return "TransactionId";
   }
 
-  inline void fill_json_schema(nlohmann::json& schema, const TxID&)
+  inline void fill_json_schema(nlohmann::json& schema, const TxID*)
   {
     schema["type"] = "string";
     schema["pattern"] = "^[0-9]+\\.[0-9]+$";

--- a/src/ds/test/json_schema.cpp
+++ b/src/ds/test/json_schema.cpp
@@ -213,7 +213,7 @@ namespace custom
         std::string email;
       };
 
-      void fill_json_schema(nlohmann::json& schema, const X&)
+      void fill_json_schema(nlohmann::json& schema, const X*)
       {
         schema["type"] = "string";
         schema["format"] = "email";

--- a/src/ds/test/openapi.cpp
+++ b/src/ds/test/openapi.cpp
@@ -190,13 +190,13 @@ namespace aaa
     fn.surname = s.substr(nickname_end + 2);
   }
 
-  std::string schema_name(const FriendlyName&)
+  std::string schema_name(const FriendlyName*)
   {
     return "FriendlyName";
   }
 
   template <typename T>
-  void add_schema_components(T& doc, nlohmann::json& j, const FriendlyName&)
+  void add_schema_components(T& doc, nlohmann::json& j, const FriendlyName*)
   {
     j["type"] = "string";
     j["pattern"] = "^.* \".*\" .*$";
@@ -250,8 +250,9 @@ TEST_CASE("Manual function definitions")
 
     const auto components_schemas = doc["components"]["schemas"];
     REQUIRE(components_schemas.find("Person") != components_schemas.end());
+    aaa::FriendlyName* fn = nullptr;
     REQUIRE(
-      components_schemas.find(aaa::schema_name(aaa::FriendlyName())) !=
+      components_schemas.find(aaa::schema_name(fn)) !=
       components_schemas.end());
   }
 }

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -128,13 +128,13 @@ namespace kv
     ni.port = p;
   }
 
-  inline std::string schema_name(const Configuration::NodeInfo&)
+  inline std::string schema_name(const Configuration::NodeInfo*)
   {
     return "Configuration__NodeInfo";
   }
 
   inline void fill_json_schema(
-    nlohmann::json& schema, const Configuration::NodeInfo&)
+    nlohmann::json& schema, const Configuration::NodeInfo*)
   {
     schema["type"] = "object";
     schema["required"] = nlohmann::json::array();


### PR DESCRIPTION
C++ nitty-gritty:

We do argument-dependent lookup (ADL) to find various type-specific functions for JSON serialisation and schema generation. I used `const T&` as the lookup type, which means `T` must be constructible, so doesn't support abstract types (and introduces a dumb runtime construction cost!). We can get the same dispatch using `const T*`, but without introducing extra requirements on the type.