### PR TITLE
Fix off-by-one in indexer

### DIFF
--- a/src/indexing/indexer.h
+++ b/src/indexing/indexer.h
@@ -90,7 +90,7 @@ namespace ccf::indexing
 
       if (min_requested.has_value())
       {
-        if (*min_requested < committed.seqno)
+        if (*min_requested <= committed.seqno)
         {
           // Request a prefix of the missing entries. Cap the requested range,
           // so we don't overload the node with a huge historical request

--- a/src/indexing/test/lfs.cpp
+++ b/src/indexing/test/lfs.cpp
@@ -692,7 +692,7 @@ TEST_CASE("Sparse index" * doctest::test_suite("lfs"))
   run_sparse_index_test(500, 10);
 
   srand(time(NULL));
-  for (auto i = 0; i < 5; ++i)
+  for (auto i = 0; i < 20; ++i)
   {
     const auto bucket_size = (rand() % 100) + 5;
     const auto num_buckets = (rand() % 20) + 3;


### PR DESCRIPTION
Noticed occasional failure in the `indexing_test`. We have some randomisation in this unit test deliberately to catch these unexpected boundary conditions. In this case, they found an off-by-one error during the calculation of whether the indexing strategies are all up-to-date.