### PR TITLE
Fix LTS ledger compatibility chunks

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Quack
+Quack Quack


### PR DESCRIPTION
Since releasing [2.0.0-rc8](https://github.com/microsoft/CCF/releases/tag/ccf-2.0.0-rc8), the `lts_compatibility` test is failing because of the ledger chunks inconsistency introduced in https://github.com/microsoft/CCF/pull/3768 when upgrading from 1.x to 2.x-rc8+. I've simplified the logic so that we accept any ledger incompatibility when upgrading from 1.x to 2.x-rc8+. 