### PR TITLE
Pin `httpx` to 0.22

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -13,6 +13,6 @@ docker
 better_exceptions
 pyasn1
 Jinja2
-httpx == 0.21.*
+httpx
 locust
 pyOpenSSL


### PR DESCRIPTION
This currently causes the following security alert: https://github.com/microsoft/CCF/security/dependabot/3

![image](https://user-images.githubusercontent.com/42961061/166455972-0ff24016-8ceb-40eb-ad4d-5d54d73cacca.png)
