### PR TITLE
Stricter JSON configuration schema for `cchost` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed consensus issue where a node would grant its vote even though it already knew about the current primary (#3810).
 - Fixed issue with JSON configuration for `cchost` where extra fields were silently ignored rather than being rejected at startup (#3816).
 
-### Changes
+### Changed
 
-- Upgraded Open Enclave to 0.17.7
+- Upgraded Open Enclave to 0.17.7 (#3815).
 
 ## [2.0.0-rc8]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fixed an issue where new node started without a snapshot would be able to join from a node that started with a snapshot (#3573).
 - Fixed consensus issue where a node would grant its vote even though it already knew about the current primary (#3810).
+- Fixed issue with JSON configuration for `cchost` where extra fields were silently ignored rather than being rejected at startup (#3816).
 
 ## [2.0.0-rc8]
 

--- a/doc/generate_config_rst.py
+++ b/doc/generate_config_rst.py
@@ -88,9 +88,7 @@ def print_object(output, obj, depth=0, required_entries=None, additional_desc=No
                 )
                 # Strict schema with no extra fields allowed https://github.com/microsoft/CCF/issues/3813
                 assert (
-                    "allOf" in v
-                    or "additionalProperties" in v
-                    and v["additionalProperties"] is False
+                    "allOf" in v or v.get("additionalProperties") == False
                 ), f"AdditionalProperties not set to false in {k}:{v}"
             if "additionalProperties" in v:
                 if isinstance(v["additionalProperties"], dict):
@@ -135,7 +133,7 @@ def generate_configuration_docs(input_file_path, output_file_path):
         output, j["properties"], required_entries=j["required"], depth=START_DEPTH
     )
     assert (
-        "additionalProperties" in j and j["additionalProperties"] is False
+        j.get("additionalProperties") == False
     ), f"AdditionalProperties not set to false in top level schema"
 
     out = output.render()

--- a/doc/generate_config_rst.py
+++ b/doc/generate_config_rst.py
@@ -86,6 +86,10 @@ def print_object(output, obj, depth=0, required_entries=None, additional_desc=No
                 print_object(
                     output, v["properties"], depth=depth + 1, required_entries=reqs
                 )
+                # Strict schema with no extra fields allowed https://github.com/microsoft/CCF/issues/3813
+                assert (
+                    "additionalProperties" in v and v["additionalProperties"] is False
+                ), f"AdditionalProperties not set to false in {k}"
             if "additionalProperties" in v:
                 if isinstance(v["additionalProperties"], dict):
                     print_object(
@@ -128,6 +132,9 @@ def generate_configuration_docs(input_file_path, output_file_path):
     print_object(
         output, j["properties"], required_entries=j["required"], depth=START_DEPTH
     )
+    assert (
+        "additionalProperties" in j and j["additionalProperties"] is False
+    ), f"AdditionalProperties not set to false in top level schema"
 
     out = output.render()
     # Only update output file if the file will be modified

--- a/doc/generate_config_rst.py
+++ b/doc/generate_config_rst.py
@@ -61,6 +61,8 @@ def print_entry(output, entry, name, required=False, depth=0):
 
 
 def has_subobjs(obj):
+    if not isinstance(obj, dict):
+        return False
     return any(
         k in ["properties", "additionalProperties", "items"] for k in obj.keys()
     ) and ("items" not in obj or obj["items"]["type"] == "object")
@@ -85,12 +87,13 @@ def print_object(output, obj, depth=0, required_entries=None, additional_desc=No
                     output, v["properties"], depth=depth + 1, required_entries=reqs
                 )
             if "additionalProperties" in v:
-                print_object(
-                    output,
-                    v["additionalProperties"]["properties"],
-                    depth=depth + 1,
-                    required_entries=v["additionalProperties"].get("required", []),
-                )
+                if isinstance(v["additionalProperties"], dict):
+                    print_object(
+                        output,
+                        v["additionalProperties"]["properties"],
+                        depth=depth + 1,
+                        required_entries=v["additionalProperties"].get("required", []),
+                    )
             if "items" in v and v["items"]["type"] == "object":
                 print_object(
                     output,
@@ -108,6 +111,10 @@ def print_object(output, obj, depth=0, required_entries=None, additional_desc=No
                         required_entries=reqs,
                         additional_desc=f'Only if ``{k_}`` is ``"{cond_["const"]}"``',
                     )
+        elif k == "additionalProperties" and isinstance(v, bool):
+            # Skip display of additionalProperties if bool as it is used
+            # to make the schema stricter
+            pass
         else:
             print_entry(output, v, name=k, required=k in required_entries, depth=depth)
 

--- a/doc/generate_config_rst.py
+++ b/doc/generate_config_rst.py
@@ -88,8 +88,10 @@ def print_object(output, obj, depth=0, required_entries=None, additional_desc=No
                 )
                 # Strict schema with no extra fields allowed https://github.com/microsoft/CCF/issues/3813
                 assert (
-                    "additionalProperties" in v and v["additionalProperties"] is False
-                ), f"AdditionalProperties not set to false in {k}"
+                    "allOf" in v
+                    or "additionalProperties" in v
+                    and v["additionalProperties"] is False
+                ), f"AdditionalProperties not set to false in {k}:{v}"
             if "additionalProperties" in v:
                 if isinstance(v["additionalProperties"], dict):
                     print_object(

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -96,8 +96,7 @@
           "type": "string",
           "default": "service_cert.pem",
           "description": "For ``Start`` and ``Recover`` nodes, path to which service certificate will be written to on startup. For ``Join`` nodes, path to the certificate of the existing network to join"
-        },
-        "additionalProperties": false
+        }
       },
       "allOf": [
         {
@@ -132,15 +131,16 @@
                           "description": "Path to member x509 identity certificate (PEM)"
                         },
                         "encryption_public_key_file": {
-                          "type": "string",
+                          "type": ["string", "null"],
                           "description": "Path to member encryption public key (PEM)"
                         },
                         "data_json_file": {
-                          "type": "string",
+                          "type": ["string", "null"],
                           "description": "Path to member data file (JSON)"
                         }
                       },
-                      "required": ["certificate_file"]
+                      "required": ["certificate_file"],
+                      "additionalProperties": false
                     },
                     "description": "List of initial consortium members files, including identity certificates, public encryption keys and member data files"
                   },
@@ -158,6 +158,12 @@
                         "description": "The maximum number of days allowed for node certificate validity period",
                         "minimum": 1
                       },
+                      "maximum_service_certificate_validity_days": {
+                        "type": "integer",
+                        "default": 365,
+                        "description": "The maximum number of days allowed for service certificate validity period",
+                        "minimum": 1
+                      },
                       "reconfiguration_type": {
                         "type": "string",
                         "default": "OneTransaction",
@@ -172,8 +178,7 @@
                 "additionalProperties": false
               }
             },
-            "required": ["start"],
-            "additionalProperties": false
+            "required": ["start"]
           }
         },
         {
@@ -199,8 +204,7 @@
                 "additionalProperties": false
               }
             },
-            "required": ["join"],
-            "additionalProperties": false
+            "required": ["join"]
           }
         },
         {
@@ -231,8 +235,7 @@
         }
       ],
       "description": "This section includes configuration of how the node should start (either start, join or recover) and associated information",
-      "required": ["type"],
-      "additionalProperties": false
+      "required": ["type"]
     },
     "node_certificate": {
       "type": "object",
@@ -266,7 +269,7 @@
       "additionalProperties": false
     },
     "node_data_json_file": {
-      "type": "string",
+      "type": ["string", "null"],
       "description": "Path to file (JSON) containing initial node data. It is intended to store correlation IDs describing the node's deployment, such as a VM name or Pod identifier."
     },
     "ledger": {
@@ -370,7 +373,6 @@
       },
       "description": "This section includes configuration for the ledger signatures emitted by this node (note: should be the same for all other nodes in the service). Transaction commit latency in a CCF network is primarily a function of signature frequency. A network emitting signatures more frequently will be able to commit transactions faster, but will spend a larger proportion of its execution resources creating and verifying signatures. Setting signature frequency is a trade-off between transaction latency and throughput.",
       "additionalProperties": false
-
     },
     "jwt": {
       "type": "object",

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -31,11 +31,11 @@
             "bind_address": {
               "type": "string",
               "description": "Local address the node binds to and listens on"
-            },
-            "additionalProperties": false
+            }
           },
           "description": "Address (host:port) to listen on for incoming node-to-node connections (e.g. internal consensus messages)",
-          "required": ["bind_address"]
+          "required": ["bind_address"],
+          "additionalProperties": false
         },
         "rpc_interfaces": {
           "type": "object",
@@ -71,7 +71,8 @@
                     "description": "The type of endorsement for the TLS certificate used in client sessions. If the endorsement is not available, client sessions will be terminated, before the TLS handshake is complete. 'Node' means self-signed, 'Service' means service-endorsed."
                   }
                 },
-                "required": ["authority"]
+                "required": ["authority"],
+                "additionalProperties": false
               }
             },
             "required": ["bind_address"]
@@ -80,7 +81,8 @@
         }
       },
       "description": "This section includes configuration for the interfaces a node listens on (for both client and node-to-node communications)",
-      "required": ["node_to_node_interface", "rpc_interfaces"]
+      "required": ["node_to_node_interface", "rpc_interfaces"],
+      "additionalProperties": false
     },
     "command": {
       "type": "object",
@@ -162,7 +164,8 @@
                         "enum": ["OneTransaction", "TwoTransaction"]
                       }
                     },
-                    "required": ["recovery_threshold"]
+                    "required": ["recovery_threshold"],
+                    "additionalProperties": false
                   }
                 },
                 "required": ["constitution_files", "members"],
@@ -228,7 +231,8 @@
         }
       ],
       "description": "This section includes configuration of how the node should start (either start, join or recover) and associated information",
-      "required": ["type"]
+      "required": ["type"],
+      "additionalProperties": false
     },
     "node_certificate": {
       "type": "object",
@@ -364,7 +368,9 @@
           "description": "Maximum duration after which a signature transaction is automatically generated"
         }
       },
-      "description": "This section includes configuration for the ledger signatures emitted by this node (note: should be the same for all other nodes in the service). Transaction commit latency in a CCF network is primarily a function of signature frequency. A network emitting signatures more frequently will be able to commit transactions faster, but will spend a larger proportion of its execution resources creating and verifying signatures. Setting signature frequency is a trade-off between transaction latency and throughput."
+      "description": "This section includes configuration for the ledger signatures emitted by this node (note: should be the same for all other nodes in the service). Transaction commit latency in a CCF network is primarily a function of signature frequency. A network emitting signatures more frequently will be able to commit transactions faster, but will spend a larger proportion of its execution resources creating and verifying signatures. Setting signature frequency is a trade-off between transaction latency and throughput.",
+      "additionalProperties": false
+
     },
     "jwt": {
       "type": "object",

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -19,7 +19,8 @@
         }
       },
       "description": "This section includes configuration for the enclave application launched by this node",
-      "required": ["file"]
+      "required": ["file"],
+      "additionalProperties": false
     },
     "network": {
       "type": "object",
@@ -30,7 +31,8 @@
             "bind_address": {
               "type": "string",
               "description": "Local address the node binds to and listens on"
-            }
+            },
+            "additionalProperties": false
           },
           "description": "Address (host:port) to listen on for incoming node-to-node connections (e.g. internal consensus messages)",
           "required": ["bind_address"]
@@ -92,7 +94,8 @@
           "type": "string",
           "default": "service_cert.pem",
           "description": "For ``Start`` and ``Recover`` nodes, path to which service certificate will be written to on startup. For ``Join`` nodes, path to the certificate of the existing network to join"
-        }
+        },
+        "additionalProperties": false
       },
       "allOf": [
         {
@@ -162,10 +165,12 @@
                     "required": ["recovery_threshold"]
                   }
                 },
-                "required": ["constitution_files", "members"]
+                "required": ["constitution_files", "members"],
+                "additionalProperties": false
               }
             },
-            "required": ["start"]
+            "required": ["start"],
+            "additionalProperties": false
           }
         },
         {
@@ -187,10 +192,12 @@
                     "description": "Interval (time string) at which the node sends join requests to the existing network"
                   }
                 },
-                "required": ["target_rpc_address"]
+                "required": ["target_rpc_address"],
+                "additionalProperties": false
               }
             },
-            "required": ["join"]
+            "required": ["join"],
+            "additionalProperties": false
           }
         },
         {
@@ -213,7 +220,8 @@
                     "description": "Path to the previous service certificate (PEM) file"
                   }
                 },
-                "required": ["previous_service_identity_file"]
+                "required": ["previous_service_identity_file"],
+                "additionalProperties": false
               }
             }
           }
@@ -250,7 +258,8 @@
           "minimum": 1
         }
       },
-      "description": "This section includes configuration for the node x509 identity certificate"
+      "description": "This section includes configuration for the node x509 identity certificate",
+      "additionalProperties": false
     },
     "node_data_json_file": {
       "type": "string",
@@ -277,7 +286,8 @@
           "description": "Minimum size (size string) of the current ledger file after which a new ledger file (chunk) is created"
         }
       },
-      "description": "This section includes configuration for the ledger directories and files"
+      "description": "This section includes configuration for the ledger directories and files",
+      "additionalProperties": false
     },
     "snapshots": {
       "type": "object",
@@ -294,7 +304,8 @@
           "minimum": 1
         }
       },
-      "description": "This section includes configuration for the snapshot directory and files"
+      "description": "This section includes configuration for the snapshot directory and files",
+      "additionalProperties": false
     },
     "logging": {
       "type": "object",
@@ -312,7 +323,8 @@
           "description": "If 'json', node logs will be formatted as JSON"
         }
       },
-      "description": "This section includes configuration for the logging of the node process"
+      "description": "This section includes configuration for the logging of the node process",
+      "additionalProperties": false
     },
     "consensus": {
       "type": "object",
@@ -334,7 +346,8 @@
           "description": "Maximum timeout (time string) after which backup nodes that have not received any message from the primary node (or voted for a candidate) will trigger a new election. This timeout is also used by candidates to restart unsuccessful elections. This should be set to a significantly greater value than 'message_timeout' plus the expected network delay."
         }
       },
-      "description": "This section includes configuration for the consensus protocol (note: should be the same for all other nodes in the service)"
+      "description": "This section includes configuration for the consensus protocol (note: should be the same for all other nodes in the service)",
+      "additionalProperties": false
     },
     "ledger_signatures": {
       "type": "object",
@@ -362,7 +375,8 @@
           "description": "Interval at which JWT keys for issuers registered with auto-refresh are automatically refreshed"
         }
       },
-      "description": "This section includes configuration for JWT issuers automatic refresh"
+      "description": "This section includes configuration for JWT issuers automatic refresh",
+      "additionalProperties": false
     },
     "output_files": {
       "type": "object",
@@ -386,7 +400,8 @@
           "description": "Path to file in which all RPC addresses (hostnames and ports) will be written to on startup. This option is particularly useful when binding to port 0 and getting auto-assigned a port by the OS. No file is created if this entry is not specified"
         }
       },
-      "description": "This section includes configuration for additional files output by the node"
+      "description": "This section includes configuration for additional files output by the node",
+      "additionalProperties": false
     },
     "tick_interval": {
       "type": "string",
@@ -432,8 +447,10 @@
           "description": "Maximum size (size string) of individual ringbuffer message fragments. Messages larger than this will be split into multiple fragments"
         }
       },
-      "description": "This section includes configuration for the host-enclave ring-buffer memory (modify with care!)"
+      "description": "This section includes configuration for the host-enclave ring-buffer memory (modify with care!)",
+      "additionalProperties": false
     }
   },
-  "required": ["enclave", "network", "command"]
+  "required": ["enclave", "network", "command"],
+  "additionalProperties": false
 }

--- a/python/ccf/migrate_1_x_config.py
+++ b/python/ccf/migrate_1_x_config.py
@@ -137,13 +137,13 @@ if __name__ == "__main__":
             elif k == "node_address":
                 output["network"]["node_to_node_interface"]["bind_address"] = v
             elif k == "network_cert_file":
-                output["service_certificate_file"] = v
+                output["command"]["service_certificate_file"] = v
 
             # node certificate
             elif k == "san":
-                output["node_certificate"][k] = json.loads(v)
+                output["node_certificate"]["subject_alt_names"] = json.loads(v)
             elif k == "sn":
-                output["node_certificate"][k] = v
+                output["node_certificate"]["subject_name"] = v
             elif k == "curve_id":
                 output["node_certificate"][k] = v.title()
 
@@ -163,7 +163,7 @@ if __name__ == "__main__":
 
             # logging
             elif k == "log_format_json":
-                output["logging"]["log_format"] = "Json" if bool(v) else "Text"
+                output["logging"]["format"] = "Json" if bool(v) else "Text"
             elif k == "host_log_level":
                 output["logging"]["host_level"] = v.title()
 

--- a/python/ccf/migrate_1_x_config.py
+++ b/python/ccf/migrate_1_x_config.py
@@ -163,7 +163,7 @@ if __name__ == "__main__":
 
             # logging
             elif k == "log_format_json":
-                output["logging"]["format"] = "Json" if bool(v) else "Text"
+                output["logging"]["format"] = "Json" if v else "Text"
             elif k == "host_log_level":
                 output["logging"]["host_level"] = v.title()
 

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -77,19 +77,9 @@ int main(int argc, char** argv)
     return app.exit(e);
   }
 
-  host::CCHostConfig config = {};
   std::string config_str = files::slurp_string(config_file_path);
-  try
-  {
-    config = nlohmann::json::parse(config_str);
-  }
-  catch (const std::exception& e)
-  {
-    throw std::logic_error(fmt::format(
-      "Error parsing configuration file {}: {}", config_file_path, e.what()));
-  }
 
-  auto config_json = nlohmann::json(config);
+  auto config_json = nlohmann::json::parse(config_str);
   auto schema_json = nlohmann::json::parse(host::host_config_schema);
 
   auto schema_error_msg = json::validate_json(config_json, schema_json);
@@ -99,6 +89,17 @@ int main(int argc, char** argv)
       "Error validating JSON schema for configuration file {}: {}",
       config_file_path,
       schema_error_msg.value()));
+  }
+
+  host::CCHostConfig config = {};
+  try
+  {
+    config = nlohmann::json::parse(config_str);
+  }
+  catch (const std::exception& e)
+  {
+    throw std::logic_error(fmt::format(
+      "Error parsing configuration file {}: {}", config_file_path, e.what()));
   }
 
   if (config.logging.format == host::LogFormat::JSON)

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -78,8 +78,16 @@ int main(int argc, char** argv)
   }
 
   std::string config_str = files::slurp_string(config_file_path);
-
-  auto config_json = nlohmann::json::parse(config_str);
+  nlohmann::json config_json;
+  try
+  {
+    config_json = nlohmann::json::parse(config_str);
+  }
+  catch (const std::exception& e)
+  {
+    throw std::logic_error(fmt::format(
+      "Error parsing configuration file {}: {}", config_file_path, e.what()));
+  }
   auto schema_json = nlohmann::json::parse(host::host_config_schema);
 
   auto schema_error_msg = json::validate_json(config_json, schema_json);
@@ -91,16 +99,7 @@ int main(int argc, char** argv)
       schema_error_msg.value()));
   }
 
-  host::CCHostConfig config = {};
-  try
-  {
-    config = nlohmann::json::parse(config_str);
-  }
-  catch (const std::exception& e)
-  {
-    throw std::logic_error(fmt::format(
-      "Error parsing configuration file {}: {}", config_file_path, e.what()));
-  }
+  host::CCHostConfig config = config_json;
 
   if (config.logging.format == host::LogFormat::JSON)
   {

--- a/tests/config.jinja
+++ b/tests/config.jinja
@@ -17,6 +17,7 @@
   "node_data_json_file": {{ node_data_json_file|tojson }},
   "command": {
     "type": "{{ start_type }}",
+    "service_certificate_file": "service_cert.pem", 
     "start":
     {
       "members": {{ members_info|tojson }},
@@ -77,7 +78,6 @@
     "node_to_node_address_file": "{{ node_address_file }}",
     "rpc_addresses_file" : "{{ rpc_addresses_file }}"
   },
-  "service_certificate_file": "service_cert.pem",
   "tick_interval": "1ms",
   "slow_io_logging_threshold": "10ms",
   "client_connection_timeout": "2s",


### PR DESCRIPTION
Resolves #3813 

We did not throw an error when an operator started a node with extra entries in the JSON configuration file. This was because we parsed the configuration file into the `host::CCHostConfig` configuration type first (`nlohmann::json(config_str)`), which removed the extra entries. We now do this with `nlohmann::json::parse(config_str)`, which we feed directly to `valijson`.

I also updated the documentation generator to accommodate this and fixed a couple of inconsistencies in some of the sample configuration files.