### PR TITLE
Allow `null` for `node_client_interface` field in `cchost` configuration

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Piou Piou
+Piou Piou Piou

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -422,7 +422,7 @@
       "description": "Maximum duration of I/O operations (ledger and snapshots) after which slow operations will be logged to node log"
     },
     "node_client_interface": {
-      "type": "string",
+      "type": ["string", "null"],
       "description": "Address to bind to for node-to-node client connections. If unspecified, this is automatically assigned by the OS. This option is particularly useful for testing purposes (e.g. establishing network partitions between nodes)"
     },
     "client_connection_timeout": {


### PR DESCRIPTION
I broke the daily build in #3816. 