### PR TITLE
[LTS 1.x] Update `lts_compatibility` test infra to handle 2.x branch

### DIFF
--- a/tests/infra/github.py
+++ b/tests/infra/github.py
@@ -165,9 +165,9 @@ class Repository:
         """
         releases = {}
         for release_branch in self.get_release_branches_names():
-            releases[release_branch] = self.get_tags_for_release_branch(release_branch)[
-                0
-            ]
+            tags = self.get_tags_for_release_branch(release_branch)
+            if tags:
+                releases[release_branch] = tags[0]
         return releases
 
     def install_release(self, tag):


### PR DESCRIPTION
Alternative approach to #3827. Rather than trying to back-port multiple changes to this test, which has diverged heavily over time, instead just handle the specific error caused by the existence of the new branch. Passes locally.