### PR TITLE
Remove verification of legacy receipt format from Python infra

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Rice
+Rice nice


### PR DESCRIPTION
Fixes #3835.