### PR TITLE
Updating URL of tla2tools in TLA+ install script

### DIFF
--- a/tla/download_or_update_tla.sh
+++ b/tla/download_or_update_tla.sh
@@ -24,7 +24,7 @@ download_curl() {
 		if_modified=(-z tla2tools.jar)
 	fi
 
-	curl -f -Ss -R -O "${if_modified[@]}" "$1"
+	curl -f -Ss -L -R -O "${if_modified[@]}" "$1"
 
 	if [ $? -ne 0 ]; then
 		echo "Couldn't download tla2tools.jar"
@@ -39,7 +39,7 @@ print_version() {
 main() {
 	echo "Downloading tla2tools.jar..."
 	before=$(date -r tla2tools.jar 2>/dev/null)
-	download https://tla.msr-inria.inria.fr/tlatoolbox/dist/tla2tools.jar
+	download https://github.com/tlaplus/tlaplus/releases/latest/download/tla2tools.jar
 	after=$(date -r tla2tools.jar 2>/dev/null)
 
 	if [ ! -e tla2tools.jar ]; then


### PR DESCRIPTION
The current tla+ install script (https://github.com/microsoft/CCF/blob/main/tla/download_or_update_tla.sh) fetches tla+ from  https://tla.msr-inria.inria.fr/tlatoolbox/dist/tla2tools.jar, however, this file has not been updated since December 2020. This PR updates the URL in the install script to point at the latest GitHub release for tla+.

**Aside:**
As acknowledged in the file itself, this script was originally adapted from https://github.com/pmer/tla-bin. I have also reported this issue to tla-bin (https://github.com/pmer/tla-bin/issues/14) and its now been fixed (https://github.com/pmer/tla-bin/pull/15).