### PR TITLE
Fix counting of authentication exceptions in endpoint metrics

### DIFF
--- a/src/endpoints/authentication/cert_auth.cpp
+++ b/src/endpoints/authentication/cert_auth.cpp
@@ -16,6 +16,12 @@ namespace ccf
     std::string& error_reason)
   {
     const auto& caller_cert = ctx->get_session_context()->caller_cert;
+    if (caller_cert.empty())
+    {
+      error_reason = "No caller user certificate";
+      return nullptr;
+    }
+
     auto caller_id = crypto::Sha256Hash(caller_cert).hex_str();
 
     auto user_certs = tx.ro<UserCerts>(Tables::USER_CERTS);
@@ -36,6 +42,12 @@ namespace ccf
     std::string& error_reason)
   {
     const auto& caller_cert = ctx->get_session_context()->caller_cert;
+    if (caller_cert.empty())
+    {
+      error_reason = "No caller member certificate";
+      return nullptr;
+    }
+
     auto caller_id = crypto::Sha256Hash(caller_cert).hex_str();
 
     auto member_certs = tx.ro<MemberCerts>(Tables::MEMBER_CERTS);
@@ -55,8 +67,14 @@ namespace ccf
     const std::shared_ptr<ccf::RpcContext>& ctx,
     std::string& error_reason)
   {
-    auto node_caller_id =
-      compute_node_id_from_cert_der(ctx->get_session_context()->caller_cert);
+    const auto& caller_cert = ctx->get_session_context()->caller_cert;
+    if (caller_cert.empty())
+    {
+      error_reason = "No caller node certificate";
+      return nullptr;
+    }
+
+    auto node_caller_id = compute_node_id_from_cert_der(caller_cert);
 
     auto nodes = tx.ro<ccf::Nodes>(Tables::NODES);
     auto node = nodes->get(node_caller_id);

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -363,7 +363,7 @@ namespace ccf
             update_metrics(ctx, endpoint);
             return ctx->serialise_response();
           }
-          catch (JsonParseError& e)
+          catch (const JsonParseError& e)
           {
             ctx->set_error(
               HTTP_STATUS_BAD_REQUEST,

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -691,9 +691,7 @@ TEST_CASE("process with caller")
       auto response = parse_response(serialized_response);
       REQUIRE(response.status == HTTP_STATUS_UNAUTHORIZED);
       const std::string error_msg(response.body.begin(), response.body.end());
-      CHECK(
-        error_msg.find("Could not find matching user certificate") !=
-        std::string::npos);
+      CHECK(error_msg.find("No caller user certificate") != std::string::npos);
     }
   }
 }


### PR DESCRIPTION
Discovered while following up on something from #3770:

> - Don't increment successes in /jwt_metrics when a manual /jwt_keys/refresh returns 500.

The reason that was happening is 2-fold.
1. First, exceptions thrown by an authentication policy result are caught in `http_endpoint.h`  rather than the main loop in `frontend.h`, and don't get counted in endpoint metrics. I've fixed that by extending the scope of the generic `try-catch`, to cover all of the code once the `endpoint` is known.
2. Second, the node cert authentication policy was throwing an OpenSSL error when called anonymously (eg, by `curl https://127.0.0.1:8000/node/jwt_keys/refresh -k -X POST`). I've converted this to a nicer error working within the authn policy chain system. A missing cert means you can't use `[User|Member|Node]CertAuthn`, where previously we'd calculate the empty digest and that _could_ have been accepted by governance, presumably resulting in weirdness later.