### PR TITLE
Add new JS application runtime docker image

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Build App Run SGX container
         run: docker build -f docker/app_run . --build-arg="extra_vars=--extra-vars ccf_ver=${{steps.tref.outputs.tag}}" -t $ACR_REGISTRY/public/ccf/app/run:${{steps.tref.outputs.tag}}-sgx
 
+      - name: Build JS App Run SGX container
+        run: docker build -f docker/app_run . --build-arg="extra_vars=--extra-vars ccf_ver=${{steps.tref.outputs.tag}} --extra-vars run_js=true" -t $ACR_REGISTRY/public/ccf/app/run-js:${{steps.tref.outputs.tag}}-sgx
+
       - name: Log in
         run: docker login -u $ACR_TOKEN_NAME -p ${{ secrets.ACR_APP_PUSH_TOKEN_PASSWORD }} $ACR_REGISTRY
 
@@ -34,5 +37,8 @@ jobs:
       - name: Push App Run SGX container
         run: docker push $ACR_REGISTRY/public/ccf/app/run:${{steps.tref.outputs.tag}}-sgx
 
-      - name: Push App Dev SGX latest container
+      - name: Push JS App Run SGX container
+        run: docker push $ACR_REGISTRY/public/ccf/app/run-js:${{steps.tref.outputs.tag}}-sgx
+
+      - name: Push App Dev SGX devcontainer
         run: docker push $ACR_REGISTRY/public/ccf/app/dev:lts-devcontainer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - The `ccfmsrc.azurecr.io/ccf-sgx-app-run` image is now available at `ccfmsrc.azurecr.io/public/ccf/app/run:<tag>-sgx`.
   - The `ccfmsrc.azurecr.io/ccf-sgx-app-dev` image is now available at `ccfmsrc.azurecr.io/public/ccf/app/dev:<tag>-sgx`.
 
+### Added
+
+- Added new JavaScript application runtime image (including `libjs_generic` application under `/usr/lib/ccf`) ().
+
 ## [2.0.0-rc9]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added new JavaScript application runtime image (including `libjs_generic` application under `/usr/lib/ccf`) ().
+- Added new `ccfmsrc.azurecr.io/public/ccf/app/run-js` JavaScript application runtime image (including `libjs_generic` application under `/usr/lib/ccf`) (#3845).
 
 ## [2.0.0-rc9]
 

--- a/getting_started/setup_vm/roles/ccf_install/tasks/deb_install.yml
+++ b/getting_started/setup_vm/roles/ccf_install/tasks/deb_install.yml
@@ -25,6 +25,22 @@
   become: true
   when: run_only|bool
 
+- name: Create ccf folder in /usr/lib
+  file:
+    path: "/usr/lib/ccf"
+    state: directory
+    recurse: yes
+  become: true
+  when: run_js|bool
+
+- name: Copy JS generic
+  copy:
+    src: "/opt/ccf/lib/{{ ccf_js_app_name }}"
+    dest: "/usr/lib/ccf/{{ ccf_js_app_name }}"
+    remote_src: true
+  become: true
+  when: run_js|bool
+
 - name: Remove release
   apt:
     name: ccf

--- a/getting_started/setup_vm/roles/ccf_install/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_install/vars/common.yml
@@ -1,1 +1,3 @@
 ccf_ver: "latest"
+run_js: false
+ccf_js_app_name: "libjs_generic.enclave.so.signed"


### PR DESCRIPTION
Resolves https://github.com/microsoft/CCF/issues/3825

Note the new `--extra-vars run_js=true` argument when building the new `public/ccf/app/run-js` image. 