### PR TITLE
Docs: Update CCF app Docker images from ACR to MCR

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Sample Development Environment for CCF",
   "context": "..",
-  "image": "ccfmsrc.azurecr.io/ccf/app/dev:lts-devcontainer",
+  "image": "mcr.microsoft.com/ccf/app/dev:lts-devcontainer",
   "runArgs": [],
   "extensions": ["ms-vscode.cpptools", "ms-python.python"]
 }

--- a/doc/contribute/build_images.rst
+++ b/doc/contribute/build_images.rst
@@ -10,29 +10,3 @@ CCF build images are produced by running the :ccf_repo:`docker/ccf_ci` Docker fi
 Pushing a git tag of the form ``ccf_ci_image/$TAG`` will trigger the :ccf_repo:`.github/workflows/ci-containers.yml` workflow that builds and pushes a new ``ccfmsrc.azurecr.io/ccf/ci/sgx:$TAG`` image.
 
 That image can then be used in CI and CD pipelines.
-
-Azure Container Registry Notes
-------------------------------
-
-The ``ccfmsrc.azurecr.io`` Azure Container Registry (ACR) has been setup so that all images can be pulled by unauthenticated users (see `documentation <https://docs.microsoft.com/en-us/azure/container-registry/anonymous-pull-access>`_):
-
-.. code-block:: bash
-    
-    $ az login
-    $ az account set --subscription CCF
-    $ az acr update --name ccfmsrc --anonymous-pull-enabled
-
-The ``ci-push-token`` has been setup so that only authorised users (in this case the :ccf_repo:`.github/workflows/ci-containers.yml` workflow) can push new ``ccf/ci/sgx`` images:
-
-.. code-block:: bash
-
-    $ az login
-    $ az account set --subscription CCF
-    # Create d map
-    $ az acr scope-map create --name ci-push --registry ccfmsrc --description "Push CCF CI images"
-    # Add repository, even before repository is created
-    $ az acr scope-map update --name ci-push --registry ccfmsrc --add-repository ccf/ci/sgx content/write content/read
-    # Create token, outputs password to add as GitHub ACR_CI_PUSH_TOKEN_PASSWORD secret
-    $ az acr token create --name ci-push-token --registry ccfmsrc --scope-map ci-push
-
-.. note:: The ``ccfmsrc`` ACR instance was upgraded to Premium to enable preview features such as `scope maps <https://docs.microsoft.com/en-us/azure/container-registry/container-registry-repository-scoped-permissions#concepts>`_.

--- a/doc/contribute/build_setup.rst
+++ b/doc/contribute/build_setup.rst
@@ -22,7 +22,7 @@ The quickest way to get started building CCF applications is to use the CCF buil
 
 .. code-block:: bash
 
-    $ docker pull ccfmsrc.azurecr.io/ccf/app/dev:X.YZ-sgx
+    $ docker pull mcr.microsoft.com/ccf/app/dev:X.Y.Z-sgx
 
 The container contains the latest release of CCF along with a complete build toolchain, and startup scripts.
 

--- a/doc/operations/run_setup.rst
+++ b/doc/operations/run_setup.rst
@@ -16,13 +16,13 @@ Then, to quickly set up the dependencies necessary to start CCF applications, si
 Runtime Container
 -----------------
 
-The ``ccfmsrc.azurecr.io/ccf/app/run`` container can be run to setup an environment containing the ``cchost`` binary (as per the `latest release of CCF <https://github.com/microsoft/CCF/releases/latest>`_) and the associated dependencies.
+The ``mcr.microsoft.com/ccf/app/run`` container can be run to setup an environment containing the ``cchost`` binary and the associated dependencies.
 
-The pre-built container can be obtained from the ``ccfmsrc.azurecr.io/ccf/app/run`` image on Azure Container Registry:
+The pre-built container can be obtained from the ``mcr.microsoft.com/ccf/app/run`` image on Azure Container Registry:
 
 .. code-block:: bash
 
-   $ docker pull ccfmsrc.azurecr.io/ccf/app/run:X.YZ
+   $ docker pull mcr.microsoft.com/ccf/app/run:X.Y.Z
 
 The container does not contain any particular CCF enclave application, and may be helpful when deploying CCF nodes via docker, k8s, etc. It is up to the operator(s) to mount the appropriate CCF enclave application and start and manage the CCF node.
 

--- a/doc/operations/run_setup.rst
+++ b/doc/operations/run_setup.rst
@@ -22,7 +22,7 @@ The pre-built container can be obtained from the ``mcr.microsoft.com/ccf/app/run
 
 .. code-block:: bash
 
-   $ docker pull mcr.microsoft.com/ccf/app/run:X.Y.Z
+   $ docker pull mcr.microsoft.com/ccf/app/run:X.Y.Z-sgx
 
 The container does not contain any particular CCF enclave application, and may be helpful when deploying CCF nodes via docker, k8s, etc. It is up to the operator(s) to mount the appropriate CCF enclave application and start and manage the CCF node.
 


### PR DESCRIPTION
Now that we push Docker images to MCR, update documentation to point to it.