### PR TITLE
Correct RC version detection in Python infra

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Rice nice
+Nice rice

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -86,11 +86,12 @@ def strip_version(full_version):
 
 
 def version_rc(full_version):
-    if full_version is None:
-        return (None, 0)
-    tokens = full_version.split("-")
-    rc_tkn = tokens[2] if len(tokens) > 2 else None
-    return (int(rc_tkn[2:]), len(tokens)) if rc_tkn else (None, 0)
+    if full_version is not None:
+        tokens = full_version.split("-")
+        if len(tokens) > 2 and "rc" in tokens[2]:
+            rc_tkn = tokens[2]
+            return (int(rc_tkn[2:]), len(tokens))
+    return (None, 0)
 
 
 class Node:


### PR DESCRIPTION
The `lts_compatibility` test is currently failing on `release/2.x`, because this `version_rc` function fails to parse versions like `ccf-2.0.0-1-g51f57be9a`. Now it recognized that they're not a release candidate.