### PR TITLE
Fix LTS compatibility test on `release/1.x`

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-chirp chirp chirp
+chirp chirp chirp chirp

--- a/tests/infra/github.py
+++ b/tests/infra/github.py
@@ -105,7 +105,7 @@ class Repository:
 
     def get_release_branches_names(self):
         # Hardcoded here. This is because we only ever want to test
-        # compatibility with past release branches, and this is case
+        # compatibility with past release branches, and in this case
         # (local branch is "release/1.x") the only past branch is this one.
         return ["release/1.x"]
 

--- a/tests/infra/github.py
+++ b/tests/infra/github.py
@@ -104,11 +104,10 @@ class Repository:
         ]
 
     def get_release_branches_names(self):
-        # Branches are ordered based on major version, with oldest first
-        return sorted(
-            self.release_branches,
-            key=get_major_version_from_release_branch_name,
-        )
+        # Hardcoded here. This is because we only ever want to test
+        # compatibility with past release branches, and this is case
+        # (local branch is "release/1.x") the only past branch is this one.
+        return ["release/1.x"]
 
     def get_release_branch_name_before(self, release_branch_name):
         release_branches = self.get_release_branches_names()


### PR DESCRIPTION
Now that we have released `2.0.0`, the `release/1.x` branch tries to (incorrectly) test for compatibility with this future release. Instead, we now hardcode which release branches this branch should test for compatibility with.