### PR TITLE
Add published_address to node-to-node interface configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+### Added
+
+- The node-to-node interface configuration now supports a `published_address` to enable networks with nodes running in different (virtual) subnets (#3867).
+
 ## [2.0.0]
 
 See [documentation for code upgrade 1.x to 2.0](https://microsoft.github.io/CCF/main/operations/code_upgrade_1x.html) to upgrade an existing 1.x CCF service to 2.0

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -35,7 +35,7 @@
             "published_address": {
               "type": "string",
               "default": "Value of 'bind_address'",
-              "description": "The published RPC address advertised to other nodes"
+              "description": "The published node address advertised to other nodes"
             }
           },
           "description": "Address (host:port) to listen on for incoming node-to-node connections (e.g. internal consensus messages)",

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -31,6 +31,11 @@
             "bind_address": {
               "type": "string",
               "description": "Local address the node binds to and listens on"
+            },
+            "published_address": {
+              "type": "string",
+              "default": "Value of 'bind_address'",
+              "description": "The published RPC address advertised to other nodes"
             }
           },
           "description": "Address (host:port) to listen on for incoming node-to-node connections (e.g. internal consensus messages)",

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -288,6 +288,11 @@ int main(int argc, char** argv)
       config.client_connection_timeout);
     config.network.node_to_node_interface.bind_address =
       ccf::make_net_address(node_host, node_port);
+    if (config.network.node_to_node_interface.published_address.empty())
+    {
+      config.network.node_to_node_interface.published_address =
+        config.network.node_to_node_interface.bind_address;
+    }
     if (!config.output_files.node_to_node_address_file.empty())
     {
       ResolvedAddresses resolved_node_address;

--- a/src/node/hooks.h
+++ b/src/node/hooks.h
@@ -37,7 +37,7 @@ namespace ccf
 
         const auto& ni = opt_ni.value();
         const auto [host, port] =
-          split_net_address(ni.node_to_node_interface.bind_address);
+          split_net_address(ni.node_to_node_interface.published_address);
         switch (ni.status)
         {
           case NodeStatus::PENDING:


### PR DESCRIPTION
This adds a `published_address` to the configuration of the node-interface. The reason to add this is that my nodes run in different virtual networks, where they may have the same `bind_address`, or when the `bind_address` is not an internet-reachable address, e.g. `0.0.0.0:0`.

In my specific use-case, I have two nodes on Azure VMs in different vnets. One of them on `10.1.0.4` and the other on `172.18.0.4` and they do not themselves know what their actual IPs are. I can make them bind to `0.0.0.0`, but then that address is put into the nodes table and consequently nodes can't connect to each other when they use the address from the nodes table. Thus, I now put `published_address` into the nodes table, which defaults to the `bind_address` if not specified.

Many thanks to @jumaffre for figuring out how to solve this problem!