### PR TITLE
Add sample of value-based indexing strategy

### DIFF
--- a/samples/apps/logging/index_by_value.h
+++ b/samples/apps/logging/index_by_value.h
@@ -30,7 +30,7 @@ namespace loggingapp
       const ccf::TxID tx_id;
       const ccf::ByteVector key;
       const ccf::ByteVector value;
-    }
+    };
 
     IndexByValue(const std::string& map_name, const Categoriser& cat) :
       ccf::indexing::strategies::VisitEachEntryInMap(map_name, "IndexByValue"),
@@ -45,18 +45,25 @@ namespace loggingapp
       const auto category = categoriser(tx_id, k, v);
       if (category.has_value())
       {
+        LOG_TRACE_FMT("Storing category {}", category.value());
         auto& cd = current[category.value()];
-        cd.entries.emplace_back({tx_id, k, v});
+        cd.entries.emplace_back(KVEntry{tx_id, k, v});
       }
     }
 
-    std::vector<KVEntry> get_entry_for_category(const Category& cat)
+    std::vector<KVEntry> get_entries_for_category(const Category& cat)
     {
       const auto it = current.find(cat);
       if (it != current.end())
       {
+        LOG_TRACE_FMT(
+          "Returning {} entries for category {}",
+          it->second.entries.size(),
+          cat);
         return it->second.entries;
       }
+      LOG_TRACE_FMT(
+        "Returning no entries for category {}", cat);
       return {};
     }
 

--- a/samples/apps/logging/index_by_value.h
+++ b/samples/apps/logging/index_by_value.h
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ccf/indexing/strategies/visit_each_entry_in_map.h"
+
+namespace loggingapp
+{
+  // Sample indexing policy which can construct an index by value. Takes a
+  // functor which considers each write to a given table, and returns an
+  // optional Category. Stores a map from each Category to each KvEntry where it
+  // was present. Exposes a `get_entries_for_category` method for retrieval.
+  // For instance, an app many/ parse the value as a JSON object, find a
+  // specific field in it, and use that as the category.
+  // Alternatively, it could create a category like "contains_foo" for every
+  // value which contains the byte string "foo".
+  // Note that this builds an in-memory index, so should be bucketed/chunked to
+  // disk in the same way as SeqnosByKey_Bucketed.
+  class IndexByValue : public ccf::indexing::strategies::VisitEachEntryInMap
+  {
+  public:
+    using Category = std::string;
+    using Categoriser = std::function<std::optional<Category>(
+      const ccf::TxID& tx_id,
+      const ccf::ByteVector& k,
+      const ccf::ByteVector& v)>;
+
+    struct KVEntry
+    {
+      const ccf::TxID tx_id;
+      const ccf::ByteVector key;
+      const ccf::ByteVector value;
+    }
+
+    IndexByValue(const std::string& map_name, const Categoriser& cat) :
+      ccf::indexing::strategies::VisitEachEntryInMap(map_name, "IndexByValue"),
+      categoriser(cat)
+    {}
+
+    void visit_entry(
+      const ccf::TxID& tx_id,
+      const ccf::ByteVector& k,
+      const ccf::ByteVector& v) override
+    {
+      const auto category = categoriser(tx_id, k, v);
+      if (category.has_value())
+      {
+        auto& cd = current[category.value()];
+        cd.entries.emplace_back({tx_id, k, v});
+      }
+    }
+
+    std::vector<KVEntry> get_entry_for_category(const Category& cat)
+    {
+      const auto it = current.find(cat);
+      if (it != current.end())
+      {
+        return it->second.entries;
+      }
+      return {};
+    }
+
+  protected:
+    Categoriser categoriser;
+
+    struct CategoryData
+    {
+      std::vector<KVEntry> entries = {};
+    };
+    std::unordered_map<Category, CategoryData> current;
+  };
+}

--- a/samples/apps/logging/index_by_value.h
+++ b/samples/apps/logging/index_by_value.h
@@ -62,8 +62,7 @@ namespace loggingapp
           cat);
         return it->second.entries;
       }
-      LOG_TRACE_FMT(
-        "Returning no entries for category {}", cat);
+      LOG_TRACE_FMT("Returning no entries for category {}", cat);
       return {};
     }
 


### PR DESCRIPTION
Expanding samples of how historical queries/indexes can be used, with a strategy defined entirely in app-space. There's a few more things to do here, though they might not all make this PR:

- [ ] Add tests for this new endpoint
- [ ] Add docs referencing this app-space strategy.
- [ ] Factor out the common bits of historical endpoints. Now that we have several different range/sparse historical queries, we have a lot of duplicated code. We should factor this out, and see if it makes sense to create another `adapter` for historical queries.
- [ ] See if we can build an intermediate data structure for dumping data from an index like this to LFS. I don't think they should all access it directly, but I don't yet see the API for doing so generically.