### PR TITLE
Use CCF CI container in VSCode `.devcontainer.json`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 {
   "name": "Sample Development Environment for CCF",
   "context": "..",
-  "image": "mcr.microsoft.com/ccf/app/dev:lts-devcontainer",
+  "image": "ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-1",
   "runArgs": [],
-  "extensions": ["ms-vscode.cpptools", "ms-python.python"]
+  "extensions": [
+    "ms-vscode.cpptools",
+    "ms-python.python"
+  ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,5 @@
   "context": "..",
   "image": "ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-1",
   "runArgs": [],
-  "extensions": [
-    "ms-vscode.cpptools",
-    "ms-python.python"
-  ]
+  "extensions": ["ms-vscode.cpptools", "ms-python.python"]
 }


### PR DESCRIPTION
I think this got slowly muddled up. The purpose of the `.devcontainer.json` file is to help build CCF locally. To do so, we should use the CI container rather than `ccf/app/dev` which is to build applications.