### PR TITLE
Docs: Remove mention of `ccf` Python client from docs

### DIFF
--- a/doc/architecture/merkle_tree.rst
+++ b/doc/architecture/merkle_tree.rst
@@ -1,7 +1,7 @@
 Merkle Tree
 ===========
 
-.. note:: The :doc:`CCF Python package </use_apps/python_tutorial>` provides the ``ledger`` module to easily parse the ledger. More details :doc:`here </audit/python_library>`.
+.. note:: The ``ccf`` Python package provides the ``ledger`` module to easily parse the ledger. More details :doc:`here </audit/python_library>`.
 
 The high-integrity guarantees of CCF are enforced by a single :term:`Merkle Tree` which records the cryptographic hash (leaves) of all transactions that mutate the key-value store. The root of the Merkle Tree is regularly signed by the primary node and the signature is recorded in the ``public:ccf.internal.signatures`` key-value map. Like any other transaction, the signature transaction is also recorded in the ledger, which allows for offline auditability of the service (for both governance and application history).
 

--- a/doc/architecture/raft_tla.rst
+++ b/doc/architecture/raft_tla.rst
@@ -32,7 +32,7 @@ During the model check, the model checker will exhaustively search through all p
 
 Variables and their initial state
 ---------------------------------
-The model uses multiple variables that are initialized as seen below. Most variables are used as a TLA function which behaves similiar to a Map as known from Python or other programming languages. These variables then map each node to a given value, for example the state variable which maps each node to either ``Follower``, ``Leader``, ``Retired``, or ``Pending``. In the initial state shown below, all nodes states are set to the ``InitialConfig`` that is set in ``MCraft.tla``.
+The model uses multiple variables that are initialized as seen below. Most variables are used as a TLA function which behaves similar to a Map as known from Python or other programming languages. These variables then map each node to a given value, for example the state variable which maps each node to either ``Follower``, ``Leader``, ``Retired``, or ``Pending``. In the initial state shown below, all nodes states are set to the ``InitialConfig`` that is set in ``MCraft.tla``.
 
 .. literalinclude:: ../../tla/raft_spec/ccfraft.tla
     :language: text

--- a/doc/use_apps/index.rst
+++ b/doc/use_apps/index.rst
@@ -38,5 +38,4 @@ This section describes how :term:`Users` can issue transactions to CCF applicati
     issue_commands
     verify_tx
     verify_quote
-    python_tutorial
     rpc_api

--- a/doc/use_apps/index.rst
+++ b/doc/use_apps/index.rst
@@ -26,18 +26,6 @@ This section describes how :term:`Users` can issue transactions to CCF applicati
 
     ---
 
-    .. image:: ../img/python.svg
-      :alt: Python
-      :align: left
-      :class: ccf-tile-icon
-
-    :doc:`python_tutorial`
-    ^^^^^^^^^^^^^^^^^^^^^^
-
-    **[Removed]** Common user operations from a Python client.
-
-    ---
-
     :fa:`terminal` :doc:`rpc_api`
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/use_apps/issue_commands.rst
+++ b/doc/use_apps/issue_commands.rst
@@ -41,4 +41,4 @@ CCF identifies the signing identity for a request via the SHA-256 digest of its 
 That value must be set in the ``keyId`` field of the ``Authorization`` HTTP header for a signed request.
 
 These commands can also be signed and transmitted by external libraries.
-For example, the CCF test infrastructure uses `an auth plugin <https://pypi.org/project/requests-http-signature/>`_ for `Python Requests <https://requests.readthedocs.io/en/master/>`_.
+For example, the CCF test infrastructure uses a custom authentication provider for `Python HTTPX <https://www.python-httpx.org/>`_.

--- a/doc/use_apps/python_tutorial.rst
+++ b/doc/use_apps/python_tutorial.rst
@@ -1,4 +1,0 @@
-Python Client
-=============
-
-.. warning:: As of CCF 2.0, the ``ccf`` Python package no longer provides utilities to issue requests to a running CCF service. This is because CCF supports widely-used client-server protocols (TLS, HTTP) that should already be provided by libraries for all programming languages. The ``ccf`` Python package can still be used to audit the ledger and snapshot files (see :doc:`/audit/python_library`).

--- a/doc/use_apps/verify_quote.rst
+++ b/doc/use_apps/verify_quote.rst
@@ -1,7 +1,7 @@
 Verifying Quote
 ===============
 
-A client can verify the validity of the SGX quote of the CCF node that it connects to. This can be done using the ``verify_quote.sh`` script installed as part of the CCF install or ccf Python package (see :doc:`/use_apps/python_tutorial`).
+A client can verify the validity of the SGX quote of the CCF node that it connects to. This can be done using the ``verify_quote.sh`` script installed as part of the CCF install or ``ccf`` Python package.
 
 .. code-block:: bash
 

--- a/doc/use_apps/verify_tx.rst
+++ b/doc/use_apps/verify_tx.rst
@@ -4,8 +4,6 @@ Verifying Transactions
 Checking for Commit
 -------------------
 
-.. note:: As part of the :doc:`CCF Python package <python_tutorial>`, the ``wait_for_commit()`` method can be used to verify that a transaction has successfully been committed.
-
 Because of the decentralised nature of CCF, a request is committed to the ledger only once a number of nodes have agreed on that request.
 
 To guarantee that their request is successfully committed to the ledger, a user should issue a :http:GET:`/app/tx` request, specifying the version received in the response. This version is constructed from a view and a sequence number.
@@ -120,14 +118,14 @@ Application Claims
 CCF allows application code to attach arbitrary claims to a transaction, via the :cpp:func:`enclave::RpcContext::set_claims_digest` API, as illustrated in :ref:`build_apps/logging_cpp:User-Defined Claims in Receipts`.
 
 This is useful to allow the reveal and verification of application-related claims offline, ie. without access to the CCF network.
-For example, a logging application may choose to set the digest of the payload being logged as `claims_digest`.
+For example, a logging application may choose to set the digest of the payload being logged as ``claims_digest``.
 A user who logs a payload can then present the receipt and the payload to a third party, who can confirm that they match, having verified the receipt. They can perform this verification without access to the service.
 
-Multiple claims can be registered by storing them in a collection or object whose digest is set as `claims_digest`. It is possible to reveal them selectively, by capturing their digest in turn, rather than their raw value directly, eg:
+Multiple claims can be registered by storing them in a collection or object whose digest is set as ``claims_digest``. It is possible to reveal them selectively, by capturing their digest in turn, rather than their raw value directly, eg:
 
-`claims_digest = hash( hash(claim_a) + hash(claim_b) )`
+``claims_digest = hash( hash(claim_a) + hash(claim_b) )``
 
-Revealing `hash(claim_a)` and `claim_b` allows verification without revealing `claim_a` in this case.
+Revealing ``hash(claim_a)`` and ``claim_b`` allows verification without revealing ``claim_a`` in this case.
 
 Although CCF takes the approach of concatenating leaf components to keep its implementation simple and format-agnostic, an application may choose to encode its claims in a structured way for convenience, for example as JSON, CBOR etc.
 
@@ -137,10 +135,10 @@ If some claims must stay confidential, applications should encrypt them rather t
 Commit Evidence
 ---------------
 
-The `commit_evidence` field in receipts fulfills two purposes:
+The ``commit_evidence`` field in receipts fulfills two purposes:
 
 1. It exposes the full :term:`Transaction ID` in a format that is easy for a user to extract, and does not require parsing the ledger entry.
 2. Because it cannot be extracted from the ledger without access to the ledger secrets, it guarantees the transaction is committed.
 
 Entries are written out to the ledger as early as possible, to relieve memory pressure inside the enclave. If receipts could be produced from these entries regardless of their replication status, a malicious actor could emit them for transactions that have been tentatively run by a primary, appended to its local ledger, but since rolled back.
-By including a committment to the digest of `commit_evidence` as a leaf component in the Merkle Tree, which is effectively a nonce derived from ledger secrets and TxID, we ensure that only receipts produced by nodes that can reveal this nonce are verifiable.
+By including a committment to the digest of ``commit_evidence`` as a leaf component in the Merkle Tree, which is effectively a nonce derived from ledger secrets and TxID, we ensure that only receipts produced by nodes that can reveal this nonce are verifiable.


### PR DESCRIPTION
Resolves #3876 