### PR TITLE
Fix cmake install prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@ message(STATUS "CCF version = ${CCF_VERSION}")
 message(STATUS "CCF release version = ${CCF_RELEASE_VERSION}")
 message(STATUS "CCF version suffix = ${CCF_VERSION_SUFFIX}")
 
-include(${CCF_DIR}/cmake/cpack_settings.cmake)
-
 # Set the default install prefix for CCF. Users may override this value with the
 # cmake command. For example:
 #
@@ -29,6 +27,8 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
       CACHE PATH "Default install prefix" FORCE
   )
 endif()
+
+include(${CCF_DIR}/cmake/cpack_settings.cmake)
 
 message(STATUS "CMAKE_INSTALL_PREFIX is '${CMAKE_INSTALL_PREFIX}'")
 


### PR DESCRIPTION
Because we are setting our cpack values *before* we define the CMAKE_INSTALL_PREFIX, they are generally wrong!

But, we rarely notice, since we run cmake again (just to extract flags) *before* cpack in our release process: https://github.com/microsoft/CCF/blob/main/.azure-pipelines-templates/install_deb.yml#L4

And so we typically end up ok, except sometimes on local builds, where most of the files mysteriously end up installed in /usr/local if cmake has been run once and only once.

Special thanks to @eddyashton for helping me spot this.