### PR TITLE
Remove null byte from PEM files

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Nice rice
+Nice rice, mice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Node and service PEM certificates no longer contain a trailing null byte.
+
 ### Added
 
 - The node-to-node interface configuration now supports a `published_address` to enable networks with nodes running in different (virtual) subnets (#3867).

--- a/include/ccf/crypto/pem.h
+++ b/include/ccf/crypto/pem.h
@@ -74,8 +74,7 @@ namespace crypto
 
     size_t size() const
     {
-      // +1 for null termination
-      return s.size() + 1;
+      return s.size();
     }
 
     bool empty() const


### PR DESCRIPTION
This was required for mbedtls, but not for OpenSSL. Hoping it's this trivial fix, will let the CI confirm.