### PR TITLE
Add recovery benchmark script

### DIFF
--- a/.azure-pipelines-templates/install_deb.yml
+++ b/.azure-pipelines-templates/install_deb.yml
@@ -27,7 +27,7 @@ steps:
 
   - script: |
       set -ex
-      cat /tmp/install_prefix | xargs -i bash -c "./recovery_benchmark.sh {}"
+      cat /tmp/install_prefix | xargs -i bash -c "PYTHON_PACKAGE_PATH=../python ./recovery_benchmark.sh {}"
     workingDirectory: build
     displayName: Recovery benchmark for installed CCF
 

--- a/.azure-pipelines-templates/install_deb.yml
+++ b/.azure-pipelines-templates/install_deb.yml
@@ -16,9 +16,20 @@ steps:
   - script: |
       set -ex
       sudo apt -y install ./$(pkgname)
+    workingDirectory: build
+    displayName: Install CCF Debian package
+
+  - script: |
+      set -ex
       cat /tmp/install_prefix | xargs -i bash -c "PYTHON_PACKAGE_PATH=../python ./test_install.sh {}"
     workingDirectory: build
     displayName: Test installed CCF
+
+  - script: |
+      set -ex
+      cat /tmp/install_prefix | xargs -i bash -c "./recovery_benchmark.sh {}"
+    workingDirectory: build
+    displayName: Recovery benchmark for installed CCF
 
   - script: |
       set -ex

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -118,8 +118,14 @@ foreach(UTILITY ${CCF_UTILITIES})
 endforeach()
 
 # Copy utilities from tests directory
-set(CCF_TEST_UTILITIES tests.sh cimetrics_env.sh upload_pico_metrics.py
-                       test_install.sh docker_wrap.sh config.jinja
+set(CCF_TEST_UTILITIES
+    tests.sh
+    cimetrics_env.sh
+    upload_pico_metrics.py
+    test_install.sh
+    docker_wrap.sh
+    config.jinja
+    recovery_benchmark.sh
 )
 foreach(UTILITY ${CCF_TEST_UTILITIES})
   configure_file(

--- a/tests/recovery_benchmark.sh
+++ b/tests/recovery_benchmark.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+# This script 
+# Note that this benchmark is crude.
+
+if [ -z "$1" ]; then
+    echo "Error: First argument should be CCF install path"
+    exit 1
+fi
+ccf_install_path=$1
+shift
+
+with_snapshot=false
+signature_tx_interval=10000 # CCF default
+load_run_time_s=20
+
+while [ "$1" != "" ]; do
+    case $1 in
+        --with-snapshot)
+            with_snapshot=true
+            ;;
+        --sig-tx-interval)
+            signature_tx_interval="$2"
+            shift
+            ;;
+        --load-run-time-s)
+            load_run_time_s="$2"
+            shift
+            ;;
+        *)
+            break
+    esac
+    shift
+done
+
+set -e
+
+function service_http_status()
+{
+    curl -o /dev/null -s https://127.0.0.1:8000/app/commit -w "%{http_code}" --cacert ./workspace/sandbox_common/service_cert.pem
+}
+
+function current_ledger_length()
+{
+    curl -s https://127.0.0.1:8000/node/commit --cacert ./workspace/sandbox_common/service_cert.pem | jq '.transaction_id | split(".")[1] | tonumber'
+}
+
+function poll_for_service_open()
+{
+    network_live_time=$1
+    polls=0
+    while [ ! "$(service_http_status)" == "200" ] && [ "${polls}" -lt "${network_live_time}" ]; do
+        echo "Waiting for service to open..."
+        polls=$((polls+1))
+        sleep 1
+    done
+
+    if [ "$(service_http_status)" == "200" ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+function cleanup() {
+  kill "$(jobs -p)"
+}
+trap cleanup EXIT
+
+echo "** Start original service"
+"${ccf_install_path}"/bin/sandbox.sh -e release --sig-tx-interval "${signature_tx_interval}" & 
+sandbox_pid=$!
+
+network_live_time=60
+if poll_for_service_open ${network_live_time}; then
+    echo "Error: Timeout waiting for service to open"
+    kill "$(jobs -p)"
+    exit 1
+fi
+
+echo "** Load service"
+python3.8 -m venv .recovery_bench_env
+source .recovery_bench_env/bin/activate
+python -m pip -q install locust
+
+locust --headless --locustfile ../tests/infra/locust_file.py --ca ./workspace/sandbox_common/service_cert.pem --key ./workspace/sandbox_common/user0_privk.pem --cert ./workspace/sandbox_common/user0_cert.pem --spawn-rate 100 --users 100 --rate 1000000 --node-host https://127.0.0.1:8000 --host https://0.0.0.0 --run-time "${load_run_time_s}s"
+
+entries_to_recover=$(current_ledger_length)
+
+echo "** Stop service"
+kill $sandbox_pid
+
+echo "** Copy data from defunct service"
+LEDGER_DIR="0.ledger/"
+SNAPSHOTS_DIR="0.snapshots/"
+rm -rf $LEDGER_DIR $SNAPSHOTS_DIR
+cp -R ./workspace/sandbox_0/$LEDGER_DIR .
+cp -R ./workspace/sandbox_0/$SNAPSHOTS_DIR .
+recovery_snapshot_dir_args=""
+if [ "$with_snapshot" = true ]; then 
+    recovery_snapshot_dir_args="--snapshots-dir $SNAPSHOTS_DIR"
+fi
+
+echo "** Recover service"
+seconds_before_recovery=$SECONDS
+# shellcheck disable=SC2086
+"${ccf_install_path}"/bin/sandbox.sh -e release --recover --ledger-dir $LEDGER_DIR --common-dir ./workspace/sandbox_common --ledger-recovery-timeout 1000 ${recovery_snapshot_dir_args} &
+network_live_time=600
+if poll_for_service_open ${network_live_time}; then
+    echo "Error: Timeout waiting for service to open"
+    kill "$(jobs -p)"
+    exit 1
+fi
+
+total_recovery_time=$((SECONDS-seconds_before_recovery))
+echo "** Successfully recovered $(current_ledger_length) entries"
+
+echo "Total recovery time: $total_recovery_time secs [# entries: ${entries_to_recover}, with snapshot: ${with_snapshot}, sig interval: ${signature_tx_interval}]"

--- a/tests/recovery_benchmark.sh
+++ b/tests/recovery_benchmark.sh
@@ -2,8 +2,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-# This script 
-# Note that this benchmark is crude.
+# This script measures how long the recovery procedure takes.
+# Note that the script makes uses of the sandbox and as such, 
+# the timing results are rough (+/- a few seconds).
+
+# Usage: $ recovery_benchmark.sh /opt/ccf [--with-snapshot] [--sig-tx-interval 100] [--load-run-time-s 30]
 
 if [ -z "$1" ]; then
     echo "Error: First argument should be CCF install path"

--- a/tests/recovery_benchmark.sh
+++ b/tests/recovery_benchmark.sh
@@ -72,6 +72,10 @@ function cleanup() {
 }
 trap cleanup EXIT
 
+if [ -n "$PYTHON_PACKAGE_PATH" ]; then
+    PYTHON_PACKAGE_PATH=$(realpath -s "${PYTHON_PACKAGE_PATH}")
+fi
+
 echo "** Start original service"
 "${ccf_install_path}"/bin/sandbox.sh -e release --sig-tx-interval "${signature_tx_interval}" & 
 sandbox_pid=$!

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -5,7 +5,7 @@ set -e
 
 function service_http_status()
 {
-    curl -o /dev/null -s https://127.0.0.1:8000/app/commit -w "%{http_code}" --key ./workspace/sandbox_common/user0_privk.pem --cert ./workspace/sandbox_common/user0_cert.pem --cacert ./workspace/sandbox_common/service_cert.pem
+    curl -o /dev/null -s https://127.0.0.1:8000/app/commit -w "%{http_code}" --cacert ./workspace/sandbox_common/service_cert.pem
 }
 
 function poll_for_service_open()


### PR DESCRIPTION
This PR adds a new `recovery_benchmark.sh` script to conveniently measure how long a recovery procedure takes. The script accepts parameters to change the signature interval, to recover from a snapshot and how long to load the service for (i.e. how many entries to recover). 

The script is also run in the Daily pipeline. 