### PR TITLE
Remove ExecuteOutsideConsensus type

### DIFF
--- a/doc/audit/builtin_maps.rst
+++ b/doc/audit/builtin_maps.rst
@@ -249,9 +249,6 @@ JavaScript endpoint definitions.
 .. doxygenenum:: ccf::endpoints::ForwardingRequired
    :project: CCF
 
-.. doxygenenum:: ccf::endpoints::ExecuteOutsideConsensus
-   :project: CCF
-
 ``tls.ca_cert_bundles``
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/include/ccf/endpoint.h
+++ b/include/ccf/endpoint.h
@@ -34,13 +34,6 @@ namespace ccf::endpoints
     Never
   };
 
-  enum class ExecuteOutsideConsensus
-  {
-    Never,
-    Locally,
-    Primary
-  };
-
   enum class Mode
   {
     ReadWrite,
@@ -61,12 +54,6 @@ namespace ccf::endpoints
      {ForwardingRequired::Never, "never"}});
 
   DECLARE_JSON_ENUM(
-    ExecuteOutsideConsensus,
-    {{ExecuteOutsideConsensus::Never, "never"},
-     {ExecuteOutsideConsensus::Locally, "locally"},
-     {ExecuteOutsideConsensus::Primary, "primary"}});
-
-  DECLARE_JSON_ENUM(
     Mode,
     {{Mode::ReadWrite, "readwrite"},
      {Mode::ReadOnly, "readonly"},
@@ -78,9 +65,6 @@ namespace ccf::endpoints
     Mode mode = Mode::ReadWrite;
     /// Endpoint forwarding policy
     ForwardingRequired forwarding_required = ForwardingRequired::Always;
-    /// Execution policy
-    ExecuteOutsideConsensus execute_outside_consensus =
-      ExecuteOutsideConsensus::Never;
     /// Authentication policies
     std::vector<std::string> authn_policies = {};
     /// OpenAPI schema for endpoint

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -232,11 +232,7 @@ namespace ccf
                 (ctx->get_session_context()->is_forwarding &&
                  consensus->type() == ConsensusType::CFT) ||
                 (consensus->type() != ConsensusType::CFT &&
-                 !ctx->execute_on_node &&
-                 (endpoint == nullptr ||
-                  (endpoint != nullptr &&
-                   endpoint->properties.execute_outside_consensus !=
-                     endpoints::ExecuteOutsideConsensus::Locally))))
+                 !ctx->execute_on_node))
               {
                 ctx->get_session_context()->is_forwarding = true;
                 return forward(ctx, tx, endpoint);


### PR DESCRIPTION
Followup to #3886. That remove the function for setting this field. This removes the field (and associated enum type) entirely.