### PR TITLE
Shutdown new joining node early if target service certificate is invalid

### DIFF
--- a/src/enclave/client_endpoint.h
+++ b/src/enclave/client_endpoint.h
@@ -7,6 +7,9 @@
 
 namespace ccf
 {
+  // TODO: Remove duplication
+  using ErrorCallback = std::function<void(const std::string& error_msg)>;
+
   class ClientEndpoint
   {
   protected:
@@ -27,7 +30,8 @@ namespace ccf
       to_host(writer_factory.create_writer_to_outside())
     {}
 
-    virtual void send_request(std::vector<uint8_t>&& data) = 0;
+    virtual void send_request(
+      std::vector<uint8_t>&& data, const ErrorCallback error_cb = nullptr) = 0;
 
     void connect(
       const std::string& hostname,

--- a/src/enclave/client_endpoint.h
+++ b/src/enclave/client_endpoint.h
@@ -10,13 +10,18 @@ namespace ccf
   class ClientEndpoint
   {
   protected:
-    using HandleDataCallback = std::function<bool(
+    using HandleDataCallback = std::function<void(
       http_status status,
       http::HeaderMap&& headers,
       std::vector<uint8_t>&& body)>;
 
-    HandleDataCallback handle_data_cb;
+    using HandleErrorCallback =
+      std::function<void(const std::string& error_msg)>;
 
+    HandleDataCallback handle_data_cb;
+    HandleErrorCallback handle_error_cb;
+
+  private:
     int64_t session_id;
     ringbuffer::WriterPtr to_host;
 
@@ -32,11 +37,13 @@ namespace ccf
     void connect(
       const std::string& hostname,
       const std::string& service,
-      const HandleDataCallback f)
+      const HandleDataCallback f,
+      const HandleErrorCallback e = nullptr)
     {
       RINGBUFFER_WRITE_MESSAGE(
         tls::tls_connect, to_host, session_id, hostname, service);
       handle_data_cb = f;
+      handle_error_cb = e;
     }
   };
 }

--- a/src/enclave/client_endpoint.h
+++ b/src/enclave/client_endpoint.h
@@ -7,9 +7,6 @@
 
 namespace ccf
 {
-  // TODO: Remove duplication
-  using ErrorCallback = std::function<void(const std::string& error_msg)>;
-
   class ClientEndpoint
   {
   protected:
@@ -30,8 +27,7 @@ namespace ccf
       to_host(writer_factory.create_writer_to_outside())
     {}
 
-    virtual void send_request(
-      std::vector<uint8_t>&& data, const ErrorCallback error_cb = nullptr) = 0;
+    virtual void send_request(std::vector<uint8_t>&& data) = 0;
 
     void connect(
       const std::string& hostname,

--- a/src/enclave/tls_endpoint.h
+++ b/src/enclave/tls_endpoint.h
@@ -77,6 +77,11 @@ namespace ccf
       RINGBUFFER_WRITE_MESSAGE(tls::tls_closed, to_host, session_id);
     }
 
+    virtual void on_handshake_error(const std::string& error_msg)
+    {
+      LOG_TRACE_FMT("error_msg");
+    }
+
     std::string hostname()
     {
       if (status != ready)
@@ -398,10 +403,10 @@ namespace ccf
 
         case TLS_ERR_NEED_CERT:
         {
-          LOG_TRACE_FMT(
+          on_handshake_error(fmt::format(
             "TLS {} verify error on handshake: {}",
             session_id,
-            tls::error_string(rc));
+            tls::error_string(rc)));
           stop(authfail);
           break;
         }
@@ -419,20 +424,21 @@ namespace ccf
         case TLS_ERR_X509_VERIFY:
         {
           auto err = ctx->get_verify_error();
-
-          LOG_TRACE_FMT(
+          on_handshake_error(fmt::format(
             "TLS {} invalid cert on handshake: {} [{}]",
             session_id,
             err,
-            tls::error_string(rc));
+            tls::error_string(rc)));
           stop(authfail);
           return;
         }
 
         default:
         {
-          LOG_TRACE_FMT(
-            "TLS {} error on handshake: {}", session_id, tls::error_string(rc));
+          on_handshake_error(fmt::format(
+            "TLS {} error on handshake: {}",
+            session_id,
+            tls::error_string(rc)));
           stop(error);
           break;
         }

--- a/src/enclave/tls_endpoint.h
+++ b/src/enclave/tls_endpoint.h
@@ -207,7 +207,6 @@ namespace ccf
       }
       pending_read.insert(pending_read.end(), data, data + size);
 
-      LOG_FAIL_FMT("recv_buffered");
       do_handshake();
     }
 
@@ -275,8 +274,6 @@ namespace ccf
       {
         throw std::runtime_error("Called flush from incorrect thread");
       }
-
-      LOG_FAIL_FMT("flush");
 
       do_handshake();
 
@@ -422,12 +419,12 @@ namespace ccf
         case TLS_ERR_X509_VERIFY:
         {
           auto err = ctx->get_verify_error();
+
           LOG_TRACE_FMT(
             "TLS {} invalid cert on handshake: {} [{}]",
             session_id,
             err,
             tls::error_string(rc));
-
           stop(authfail);
           return;
         }
@@ -437,8 +434,7 @@ namespace ccf
           LOG_TRACE_FMT(
             "TLS {} error on handshake: {}", session_id, tls::error_string(rc));
           stop(error);
-          return;
-          ;
+          break;
         }
       }
     }

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -269,10 +269,13 @@ namespace http
 
     void on_handshake_error(const std::string& error_msg) override
     {
-      LOG_FAIL_FMT("{}", error_msg);
       if (handle_error_cb)
       {
         handle_error_cb(error_msg);
+      }
+      else
+      {
+        LOG_FAIL_FMT("{}", error_msg);
       }
     }
 

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -256,9 +256,11 @@ namespace http
       response_parser(*this)
     {}
 
-    void send_request(std::vector<uint8_t>&& data) override
+    void send_request(
+      std::vector<uint8_t>&& data,
+      const ccf::ErrorCallback error_cb = nullptr) override
     {
-      send_raw(std::move(data));
+      send_raw(std::move(data), error_cb);
     }
 
     void send(std::vector<uint8_t>&&, sockaddr) override

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -267,6 +267,15 @@ namespace http
         "send() should not be called directly on HTTPClient");
     }
 
+    void on_handshake_error(const std::string& error_msg) override
+    {
+      LOG_FAIL_FMT("{}", error_msg);
+      if (handle_error_cb)
+      {
+        handle_error_cb(error_msg);
+      }
+    }
+
     void handle_response(
       http_status status,
       http::HeaderMap&& headers,

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -256,11 +256,9 @@ namespace http
       response_parser(*this)
     {}
 
-    void send_request(
-      std::vector<uint8_t>&& data,
-      const ccf::ErrorCallback error_cb = nullptr) override
+    void send_request(std::vector<uint8_t>&& data) override
     {
-      send_raw(std::move(data), error_cb);
+      send_raw(std::move(data));
     }
 
     void send(std::vector<uint8_t>&&, sockaddr) override

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -492,7 +492,7 @@ namespace ccf
           std::lock_guard<std::mutex> guard(lock);
           if (!sm.check(NodeStartupState::pending))
           {
-            return false;
+            return;
           }
 
           if (status != HTTP_STATUS_OK)
@@ -517,7 +517,7 @@ namespace ccf
                   "" :
                   fmt::format("  '{}'", std::string(data.begin(), data.end())));
             }
-            return false;
+            return;
           }
 
           auto j = serdes::unpack(data, serdes::Pack::Text);
@@ -534,7 +534,7 @@ namespace ccf
             LOG_DEBUG_FMT(
               "An error occurred while parsing the join network response: {}",
               j.dump());
-            return false;
+            return;
           }
 
           // Set network secrets, node id and become part of network.
@@ -670,8 +670,10 @@ namespace ccf
             LOG_INFO_FMT(
               "Node {} is waiting for votes of members to be trusted", self);
           }
-
-          return true;
+        },
+        [this](const std::string& error_msg) {
+          std::lock_guard<std::mutex> guard(lock);
+          LOG_FAIL_FMT("Shutdown node gracefully!");
         });
 
       // Send RPC request to remote node to join the network.

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -698,7 +698,11 @@ namespace ccf
         http::headers::CONTENT_TYPE, http::headervalues::contenttype::JSON);
       r.set_body(&body);
 
-      join_client->send_request(r.build_request());
+      join_client->send_request(
+        r.build_request(), [this](const std::string& error_msg) {
+          LOG_FAIL_FMT("Error during join protocol: {}", error_msg);
+          // TODO: Stop node gracefully
+        });
     }
 
     // Note: _unsafe() pattern can be simplified once 2.x has been released

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -698,11 +698,7 @@ namespace ccf
         http::headers::CONTENT_TYPE, http::headervalues::contenttype::JSON);
       r.set_body(&body);
 
-      join_client->send_request(
-        r.build_request(), [this](const std::string& error_msg) {
-          LOG_FAIL_FMT("Error during join protocol: {}", error_msg);
-          // TODO: Stop node gracefully
-        });
+      join_client->send_request(r.build_request());
     }
 
     // Note: _unsafe() pattern can be simplified once 2.x has been released

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -673,7 +673,14 @@ namespace ccf
         },
         [this](const std::string& error_msg) {
           std::lock_guard<std::mutex> guard(lock);
-          LOG_FAIL_FMT("Shutdown node gracefully!");
+          auto long_error_msg = fmt::format(
+            "Early error when joining existing network at {}: {}. Shutting "
+            "down node gracefully...",
+            config.join.target_rpc_address,
+            error_msg);
+          LOG_FAIL_FMT("{}", long_error_msg);
+          RINGBUFFER_WRITE_MESSAGE(
+            AdminMessage::fatal_error_msg, to_host, long_error_msg);
         });
 
       // Send RPC request to remote node to join the network.

--- a/tests/config.jinja
+++ b/tests/config.jinja
@@ -17,7 +17,7 @@
   "node_data_json_file": {{ node_data_json_file|tojson }},
   "command": {
     "type": "{{ start_type }}",
-    "service_certificate_file": "service_cert.pem", 
+    "service_certificate_file": "{{ service_cert_file }}", 
     "start":
     {
       "members": {{ members_info|tojson }},

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -360,6 +360,7 @@ class Network:
                         from_snapshot=snapshots_dir is not None,
                         read_only_ledger_dirs=read_only_ledger_dirs,
                         snapshots_dir=snapshots_dir,
+                        service_cert_file="/home/jumaffre/git/CCF/build/service_cert.pem",
                         **forwarded_args,
                         **kwargs,
                     )

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -594,6 +594,7 @@ class CCFRemote(object):
         jwt_key_refresh_interval_s=None,
         election_timeout_ms=None,
         node_data_json_file=None,
+        service_cert_file="service_cert.pem",
         **kwargs,
     ):
         """
@@ -684,6 +685,7 @@ class CCFRemote(object):
                 jwt_key_refresh_interval=f"{jwt_key_refresh_interval_s}s",
                 election_timeout=f"{election_timeout_ms}ms",
                 node_data_json_file=node_data_json_file,
+                service_cert_file=service_cert_file,
                 **kwargs,
             )
 


### PR DESCRIPTION
Resolves https://github.com/microsoft/CCF/issues/733

When the target service certificate supplied to a new node is wrong (e.g. misconfigured by the operator), the node automatically shuts down with the following error message: `Early error when joining existing network at 127.147.212.20:34215: TLS -1 invalid cert on handshake: unable to get local issuer certificate [error:FFFFFFFF80000000:lib(128):func(0):reason(0)]. Shutting down node gracefully...`