### PR TITLE
Backport GH Action: canary file is always overwritten 

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,6 +18,13 @@ jobs:
         || (github.event.action == 'closed')
       )
     steps:
+      - name: Local canary file always wins
+        uses: actions/checkout@v3
+        run: |
+          git config --local include.path .gitconfig
+          git config --global merge.keeplocal.name "Always keep local file during merge"
+          git config --global merge.keeplocal.driver true
+
       - name: Backport Action
         uses: sqren/backport-github-action@v8.4.2
         with:


### PR DESCRIPTION
Follow-up from https://github.com/microsoft/CCF/pull/3897

It turns out that we want to always overwrite the canary file to avoid merge conflicts. I followed the steps described in https://github.com/microsoft/CCF/pull/3675. 