### PR TITLE
Cleanup backport GitHub Action

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -13,6 +13,6 @@
   "targetPRLabels": ["2.x-backport"],
   "autoAssign": false,
   "publishStatusCommentOnSuccess": false,
-  "publishStatusCommentOnFailure": false,
-  "publishStatusCommentOnAbort": false
+  "publishStatusCommentOnFailure": true,
+  "publishStatusCommentOnAbort": true
 }

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -12,5 +12,7 @@
   "sourcePRLabels": ["backported"],
   "targetPRLabels": ["backport"],
   "autoAssign": false,
-  "publishStatusCommentOnSuccess": false
+  "publishStatusCommentOnSuccess": false,
+  "publishStatusCommentOnFailure": false,
+  "publishStatusCommentOnAbort": false
 }

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,14 +2,15 @@
   "repoOwner": "microsoft",
   "repoName": "ccf",
   "targetBranchChoices": ["release/2.x"],
-
   "branchLabelMapping": {
     "^(.+)-todo$": "release/$1"
   },
   "autoMerge": true,
   "autoMergeMethod": "squash",
   "prTitle": "[{targetBranch}] Cherry pick: {commitMessages}",
-  "prDescription": "Backports the following commits to {targetBranch}:\n{commitMessages}",
+  "prDescription": "Backports the following commits to `{targetBranch}`:\n{commitMessages}",
   "sourcePRLabels": ["backported"],
-  "targetPRLabels": ["backport"]
+  "targetPRLabels": ["backport"],
+  "autoAssign": false,
+  "publishStatusCommentOnSuccess": false
 }

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -10,7 +10,7 @@
   "prTitle": "[{targetBranch}] Cherry pick: {commitMessages}",
   "prDescription": "Backports the following commits to `{targetBranch}`:\n{commitMessages}",
   "sourcePRLabels": ["backported"],
-  "targetPRLabels": ["backport"],
+  "targetPRLabels": ["2.x-backport"],
   "autoAssign": false,
   "publishStatusCommentOnSuccess": false,
   "publishStatusCommentOnFailure": false,

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -28,10 +28,10 @@ jobs:
           git config --local include.path .gitconfig
           git config --global merge.keeplocal.name "Always keep local file during merge"
           git config --global merge.keeplocal.driver true
-          git config --global user.name CCF [bot]
-          git config --global user.email 62645686+ccf-bot@users.noreply.github.com
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Backport Action
-        uses: sqren/backport-github-action@v8.4.2
+        uses: sqren/backport-github-action@v8.4.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -35,6 +35,3 @@ jobs:
         uses: sqren/backport-github-action@v8.4.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Backport log
-        run: cat ~/.backport/backport.log

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -25,7 +25,7 @@ jobs:
 
       # This is necessary as the repository is checked out to avoid merge conflicts
       # on daily canary file
-      - name: Sets 
+      - name: Sets committed to GitHub Actions bot
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -35,7 +35,7 @@ jobs:
           git config --local include.path .gitconfig
           git config --global merge.keeplocal.name "Always keep local file during merge"
           git config --global merge.keeplocal.driver true
-          
+
       - name: Backport Action
         uses: sqren/backport-github-action@v8.4.3
         with:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.pull_request.merged == true
-      && contains(github.event.pull_request.labels.*.name, 'auto-backport')
+      && endsWith(github.event.pull_request.labels.*.name, '-todo')
       && (
-        (github.event.action == 'labeled' && github.event.label.name == 'auto-backport')
+        (github.event.action == 'labeled' && endsWith(github.event.label.name == '-todo'))
         || (github.event.action == 'closed')
       )
     steps:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,14 +23,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      # This is necessary as the repository is checked out to avoid merge conflicts
+      # on daily canary file
+      - name: Sets 
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Local canary file always wins
         run: |
           git config --local include.path .gitconfig
           git config --global merge.keeplocal.name "Always keep local file during merge"
           git config --global merge.keeplocal.driver true
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
+          
       - name: Backport Action
         uses: sqren/backport-github-action@v8.4.3
         with:

--- a/doc/contribute/release_ccf.rst
+++ b/doc/contribute/release_ccf.rst
@@ -13,6 +13,8 @@ Patching a release, ie. issuing a ``N.0.x+1`` version when the current version i
     4. Merge PR, subject to approval and automated checks
     5. Tag head of ``release/N.x`` as ``ccf-N.0.x+1``
 
+.. tip:: Alternatively, pull requests merged to ``main`` with the `auto-backport GitHub label <https://github.com/microsoft/CCF/pulls?q=is%3Apr+label%3Aauto-backport+>`_ will be automatically backported to the active LTS branches.
+
 Create an LTS release
 ---------------------
 

--- a/doc/contribute/release_ccf.rst
+++ b/doc/contribute/release_ccf.rst
@@ -13,7 +13,7 @@ Patching a release, ie. issuing a ``N.0.x+1`` version when the current version i
     4. Merge PR, subject to approval and automated checks
     5. Tag head of ``release/N.x`` as ``ccf-N.0.x+1``
 
-.. tip:: Alternatively, pull requests merged to ``main`` with the ``N.x-todo`` GitHub label will be automatically backported to the active LTS branches.
+.. tip:: Alternatively, pull requests merged to ``main`` with the ``N.x-todo`` GitHub label(s) will be automatically backported to the corresponding LTS branch(es).
 
 Create an LTS release
 ---------------------

--- a/doc/contribute/release_ccf.rst
+++ b/doc/contribute/release_ccf.rst
@@ -13,7 +13,7 @@ Patching a release, ie. issuing a ``N.0.x+1`` version when the current version i
     4. Merge PR, subject to approval and automated checks
     5. Tag head of ``release/N.x`` as ``ccf-N.0.x+1``
 
-.. tip:: Alternatively, pull requests merged to ``main`` with the `auto-backport GitHub label <https://github.com/microsoft/CCF/pulls?q=is%3Apr+label%3Aauto-backport+>`_ will be automatically backported to the active LTS branches.
+.. tip:: Alternatively, pull requests merged to ``main`` with the ``N.x-todo`` GitHub label will be automatically backported to the active LTS branches.
 
 Create an LTS release
 ---------------------


### PR DESCRIPTION
The backport GitHub Action is now working (see https://github.com/microsoft/CCF/pull/3892 -> https://github.com/microsoft/CCF/pull/3904). 

This PR cleans up a few things (e.g. do not publish verbose comments on original PR) and adds documentation for it.