### PR TITLE
Add pebble to CI images

### DIFF
--- a/getting_started/setup_vm/ccf-dev.yml
+++ b/getting_started/setup_vm/ccf-dev.yml
@@ -19,6 +19,9 @@
         name: vegeta
         tasks_from: install.yml
     - import_role:
+        name: pebble
+        tasks_from: install.yml
+    - import_role:
         name: ccf_run
         tasks_from: install.yml
     - import_role:

--- a/getting_started/setup_vm/roles/pebble/tasks/install.yml
+++ b/getting_started/setup_vm/roles/pebble/tasks/install.yml
@@ -1,0 +1,20 @@
+- name: Include vars
+  include_vars: common.yml
+
+- name: Create directory for pebble
+  file:
+    path: "{{ pebble_install_prefix }}"
+    state: directory
+  become: true
+
+- name: Download pebble
+  get_url:
+    url: https://github.com/letsencrypt/pebble/releases/{{ pebble_version }}/download/pebble_linux-amd64
+    dest: "{{ pebble_install_prefix }}/pebble_linux-amd64"
+  become: true
+
+- name: Download pebble challenge server
+  get_url:
+    url: https://github.com/letsencrypt/pebble/releases/latest/download/pebble-challtestsrv_linux-amd64
+    dest: "{{ pebble_install_prefix }}/pebble-challtestsrv_linux-amd64"
+  become: true

--- a/getting_started/setup_vm/roles/pebble/tasks/install.yml
+++ b/getting_started/setup_vm/roles/pebble/tasks/install.yml
@@ -9,12 +9,12 @@
 
 - name: Download pebble
   get_url:
-    url: https://github.com/letsencrypt/pebble/releases/{{ pebble_version }}/download/pebble_linux-amd64
+    url: https://github.com/letsencrypt/pebble/releases/download/{{ pebble_version }}/pebble_linux-amd64
     dest: "{{ pebble_install_prefix }}/pebble_linux-amd64"
   become: true
 
 - name: Download pebble challenge server
   get_url:
-    url: https://github.com/letsencrypt/pebble/releases/latest/download/pebble-challtestsrv_linux-amd64
+    url: https://github.com/letsencrypt/pebble/releases/download/{{ pebble_version }}/pebble-challtestsrv_linux-amd64
     dest: "{{ pebble_install_prefix }}/pebble-challtestsrv_linux-amd64"
   become: true

--- a/getting_started/setup_vm/roles/pebble/vars/common.yml
+++ b/getting_started/setup_vm/roles/pebble/vars/common.yml
@@ -1,0 +1,3 @@
+workspace: "/tmp/"
+pebble_version: latest
+pebble_install_prefix: "/opt/pebble"

--- a/getting_started/setup_vm/roles/pebble/vars/common.yml
+++ b/getting_started/setup_vm/roles/pebble/vars/common.yml
@@ -1,2 +1,2 @@
-pebble_version: latest
+pebble_version: "v2.3.1"
 pebble_install_prefix: "/opt/pebble"

--- a/getting_started/setup_vm/roles/pebble/vars/common.yml
+++ b/getting_started/setup_vm/roles/pebble/vars/common.yml
@@ -1,3 +1,2 @@
-workspace: "/tmp/"
 pebble_version: latest
 pebble_install_prefix: "/opt/pebble"


### PR DESCRIPTION
This adds [pebble](https://github.com/letsencrypt/pebble) to our CI images. This is used for local ACME client tests.