### PR TITLE
Backport GH Action: `auto-backport` label is required

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.pull_request.merged == true
-      && endsWith(github.event.pull_request.labels.*.name, '-todo')
+      && contains(github.event.pull_request.labels.*.name, 'auto-backport')
       && (
-        (github.event.action == 'labeled' && endsWith(github.event.label.name, '-todo'))
+        (github.event.action == 'labeled' && github.event.label.name == 'auto-backport')
         || (github.event.action == 'closed')
       )
     steps:

--- a/doc/contribute/release_ccf.rst
+++ b/doc/contribute/release_ccf.rst
@@ -13,7 +13,7 @@ Patching a release, ie. issuing a ``N.0.x+1`` version when the current version i
     4. Merge PR, subject to approval and automated checks
     5. Tag head of ``release/N.x`` as ``ccf-N.0.x+1``
 
-.. tip:: Alternatively, pull requests merged to ``main`` with the ``N.x-todo`` GitHub label(s) will be automatically backported to the corresponding LTS branch(es).
+.. tip:: Alternatively, pull requests merged to ``main`` with the ``auto-backport`` and ``N.x-todo`` GitHub label(s) will be automatically backported to the corresponding LTS branch(es).
 
 Create an LTS release
 ---------------------


### PR DESCRIPTION
It turns out, there's no way to only trigger a GH Action if a label ends with a specific pattern (here, `-todo`) but only when it contains a specific string (here `auto-backport`). So I'm reverting the changes introduced in https://github.com/microsoft/CCF/pull/3905 and the `auto-backport` label is now necessary. 