### PR TITLE
[release/2.x] Cherry pick: Shutdown new joining node early if target service certificate is invalid (#3895)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-### Added
-
-- The node-to-node interface configuration now supports a `published_address` to enable networks with nodes running in different (virtual) subnets (#3867).
+- New nodes automatically shutdown if the target service certificate is misconfigured (#3895).
 
 ## [2.0.0]
 

--- a/src/enclave/client_endpoint.h
+++ b/src/enclave/client_endpoint.h
@@ -10,13 +10,18 @@ namespace ccf
   class ClientEndpoint
   {
   protected:
-    using HandleDataCallback = std::function<bool(
+    using HandleDataCallback = std::function<void(
       http_status status,
       http::HeaderMap&& headers,
       std::vector<uint8_t>&& body)>;
 
-    HandleDataCallback handle_data_cb;
+    using HandleErrorCallback =
+      std::function<void(const std::string& error_msg)>;
 
+    HandleDataCallback handle_data_cb;
+    HandleErrorCallback handle_error_cb;
+
+  private:
     int64_t session_id;
     ringbuffer::WriterPtr to_host;
 
@@ -32,11 +37,13 @@ namespace ccf
     void connect(
       const std::string& hostname,
       const std::string& service,
-      const HandleDataCallback f)
+      const HandleDataCallback f,
+      const HandleErrorCallback e = nullptr)
     {
       RINGBUFFER_WRITE_MESSAGE(
         tls::tls_connect, to_host, session_id, hostname, service);
       handle_data_cb = f;
+      handle_error_cb = e;
     }
   };
 }

--- a/src/enclave/tls_endpoint.h
+++ b/src/enclave/tls_endpoint.h
@@ -77,6 +77,11 @@ namespace ccf
       RINGBUFFER_WRITE_MESSAGE(tls::tls_closed, to_host, session_id);
     }
 
+    virtual void on_handshake_error(const std::string& error_msg)
+    {
+      LOG_TRACE_FMT("{}", error_msg);
+    }
+
     std::string hostname()
     {
       if (status != ready)
@@ -206,6 +211,7 @@ namespace ccf
         throw std::runtime_error("Called recv_buffered from incorrect thread");
       }
       pending_read.insert(pending_read.end(), data, data + size);
+
       do_handshake();
     }
 
@@ -377,7 +383,9 @@ namespace ccf
       // This should be called when additional data is written to the
       // input buffer, until the handshake is complete.
       if (status != handshake)
+      {
         return;
+      }
 
       auto rc = ctx->handshake();
 
@@ -395,10 +403,10 @@ namespace ccf
 
         case TLS_ERR_NEED_CERT:
         {
-          LOG_TRACE_FMT(
+          on_handshake_error(fmt::format(
             "TLS {} verify error on handshake: {}",
             session_id,
-            tls::error_string(rc));
+            tls::error_string(rc)));
           stop(authfail);
           break;
         }
@@ -416,20 +424,21 @@ namespace ccf
         case TLS_ERR_X509_VERIFY:
         {
           auto err = ctx->get_verify_error();
-
-          LOG_TRACE_FMT(
+          on_handshake_error(fmt::format(
             "TLS {} invalid cert on handshake: {} [{}]",
             session_id,
             err,
-            tls::error_string(rc));
+            tls::error_string(rc)));
           stop(authfail);
           return;
         }
 
         default:
         {
-          LOG_TRACE_FMT(
-            "TLS {} error on handshake: {}", session_id, tls::error_string(rc));
+          on_handshake_error(fmt::format(
+            "TLS {} error on handshake: {}",
+            session_id,
+            tls::error_string(rc)));
           stop(error);
           break;
         }

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -267,6 +267,18 @@ namespace http
         "send() should not be called directly on HTTPClient");
     }
 
+    void on_handshake_error(const std::string& error_msg) override
+    {
+      if (handle_error_cb)
+      {
+        handle_error_cb(error_msg);
+      }
+      else
+      {
+        LOG_FAIL_FMT("{}", error_msg);
+      }
+    }
+
     void handle_response(
       http_status status,
       http::HeaderMap&& headers,

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -492,7 +492,7 @@ namespace ccf
           std::lock_guard<std::mutex> guard(lock);
           if (!sm.check(NodeStartupState::pending))
           {
-            return false;
+            return;
           }
 
           if (status != HTTP_STATUS_OK)
@@ -517,7 +517,7 @@ namespace ccf
                   "" :
                   fmt::format("  '{}'", std::string(data.begin(), data.end())));
             }
-            return false;
+            return;
           }
 
           auto j = serdes::unpack(data, serdes::Pack::Text);
@@ -534,7 +534,7 @@ namespace ccf
             LOG_DEBUG_FMT(
               "An error occurred while parsing the join network response: {}",
               j.dump());
-            return false;
+            return;
           }
 
           // Set network secrets, node id and become part of network.
@@ -670,8 +670,17 @@ namespace ccf
             LOG_INFO_FMT(
               "Node {} is waiting for votes of members to be trusted", self);
           }
-
-          return true;
+        },
+        [this](const std::string& error_msg) {
+          std::lock_guard<std::mutex> guard(lock);
+          auto long_error_msg = fmt::format(
+            "Early error when joining existing network at {}: {}. Shutting "
+            "down node gracefully...",
+            config.join.target_rpc_address,
+            error_msg);
+          LOG_FAIL_FMT("{}", long_error_msg);
+          RINGBUFFER_WRITE_MESSAGE(
+            AdminMessage::fatal_error_msg, to_host, long_error_msg);
         });
 
       // Send RPC request to remote node to join the network.

--- a/tests/config.jinja
+++ b/tests/config.jinja
@@ -17,7 +17,7 @@
   "node_data_json_file": {{ node_data_json_file|tojson }},
   "command": {
     "type": "{{ start_type }}",
-    "service_certificate_file": "service_cert.pem", 
+    "service_certificate_file": "{{ service_cert_file }}", 
     "start":
     {
       "members": {{ members_info|tojson }},

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -75,6 +75,10 @@ class StartupSeqnoIsOld(Exception):
     pass
 
 
+class ServiceCertificateInvalid(Exception):
+    pass
+
+
 class NetworkShutdownError(Exception):
     def __init__(self, msg, errors=None):
         super().__init__(msg)
@@ -692,7 +696,14 @@ class Network:
                 )
 
     def join_node(
-        self, node, lib_name, args, target_node=None, timeout=JOIN_TIMEOUT, **kwargs
+        self,
+        node,
+        lib_name,
+        args,
+        target_node=None,
+        timeout=JOIN_TIMEOUT,
+        stop_on_error=False,
+        **kwargs,
     ):
         forwarded_args = {
             arg: getattr(args, arg, None)
@@ -714,6 +725,8 @@ class Network:
             )
         except TimeoutError as e:
             LOG.error(f"New pending node {node.node_id} failed to join the network")
+            if stop_on_error:
+                assert node.remote.check_done()
             errors, _ = node.stop()
             self.nodes.remove(node)
             if errors:
@@ -723,6 +736,8 @@ class Network:
                         raise CodeIdNotFound from e
                     if "StartupSeqnoIsOld" in error:
                         raise StartupSeqnoIsOld from e
+                    if "invalid cert on handshake" in error:
+                        raise ServiceCertificateInvalid from e
             raise
 
     def trust_node(

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -594,6 +594,7 @@ class CCFRemote(object):
         jwt_key_refresh_interval_s=None,
         election_timeout_ms=None,
         node_data_json_file=None,
+        service_cert_file="service_cert.pem",
         **kwargs,
     ):
         """
@@ -684,6 +685,7 @@ class CCFRemote(object):
                 jwt_key_refresh_interval=f"{jwt_key_refresh_interval_s}s",
                 election_timeout=f"{election_timeout_ms}ms",
                 node_data_json_file=node_data_json_file,
+                service_cert_file=service_cert_file,
                 **kwargs,
             )
 

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -68,6 +68,35 @@ def wait_for_reconfiguration_to_complete(network, timeout=10):
             raise Exception("Reconfiguration did not complete in time")
 
 
+@reqs.description("Adding a node with invalid target service certificate")
+def test_add_node_invalid_service_cert(network, args):
+    primary, _ = network.find_primary()
+
+    # Incorrect target service certificate file, in this case the primary's node
+    # identity
+    service_cert_file = os.path.join(primary.common_dir, f"{primary.local_node_id}.pem")
+    new_node = network.create_node("local://localhost")
+    try:
+        network.join_node(
+            new_node,
+            args.package,
+            args,
+            service_cert_file=service_cert_file,
+            timeout=3,
+            stop_on_error=True,
+        )
+    except infra.network.ServiceCertificateInvalid:
+        LOG.info(
+            f"Node {new_node.local_node_id} with invalid service certificate failed to start, as expected"
+        )
+    else:
+        assert (
+            False
+        ), f"Node {new_node.local_node_id} with invalid service certificate unexpectedly started"
+
+    return network
+
+
 @reqs.description("Adding a valid node")
 def test_add_node(network, args, from_snapshot=True):
     # Note: host is supplied explicitly to avoid having differently
@@ -576,6 +605,7 @@ def run(args):
         test_version(network, args)
 
         if args.consensus != "BFT":
+            test_add_node_invalid_service_cert(network, args)
             test_add_node(network, args, from_snapshot=False)
             test_add_node_with_read_only_ledger(network, args)
             test_join_straddling_primary_replacement(network, args)


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Shutdown new joining node early if target service certificate is invalid (#3895)](https://github.com/microsoft/CCF/pull/3895)