### PR TITLE
Extend e2e testing of `setApplyWrites` JS API

### DIFF
--- a/tests/npm-app/app.json
+++ b/tests/npm-app/app.json
@@ -581,7 +581,37 @@
     "/rpc/apply_writes": {
       "post": {
         "js_module": "endpoints/rpc.js",
-        "js_function": "applyWrites",
+        "js_function": "postApplyWrites",
+        "forwarding_required": "always",
+        "authn_policies": ["user_cert"],
+        "mode": "readwrite",
+        "openapi": {
+          "responses": {
+            "400": {
+              "description": "Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "js_module": "endpoints/rpc.js",
+        "js_function": "getApplyWrites",
+        "forwarding_required": "always",
+        "authn_policies": ["user_cert"],
+        "mode": "readwrite",
+        "openapi": {
+          "responses": {
+            "400": {
+              "description": "Error"
+            }
+          }
+        }
+      }
+    },
+    "/rpc/nextTxnId": {
+      "get": {
+        "js_module": "endpoints/rpc.js",
+        "js_function": "transfer",
         "forwarding_required": "always",
         "authn_policies": ["user_cert"],
         "mode": "readwrite",

--- a/tests/npm-app/app.json
+++ b/tests/npm-app/app.json
@@ -607,22 +607,6 @@
           }
         }
       }
-    },
-    "/rpc/nextTxnId": {
-      "get": {
-        "js_module": "endpoints/rpc.js",
-        "js_function": "transfer",
-        "forwarding_required": "always",
-        "authn_policies": ["user_cert"],
-        "mode": "readwrite",
-        "openapi": {
-          "responses": {
-            "400": {
-              "description": "Error"
-            }
-          }
-        }
-      }
     }
   }
 }

--- a/tests/npm-app/src/endpoints/rpc.ts
+++ b/tests/npm-app/src/endpoints/rpc.ts
@@ -1,14 +1,58 @@
 import * as ccfapp from "@microsoft/ccf-app";
 
-export function applyWrites(request: ccfapp.Request): ccfapp.Response {
+export function postApplyWrites(request: ccfapp.Request): ccfapp.Response {
   const kv = ccfapp.typedKv(
     "public:apply_writes",
     ccfapp.string,
     ccfapp.string
   );
-  kv.set("foo", "bar");
-  ccfapp.setApplyWrites(true);
+  const params = request.body.json();
+  kv.set("foo", params.val);
+  if ('setApplyWrites' in params) {
+    ccfapp.setApplyWrites(params.setApplyWrites);
+  }
   return {
-    statusCode: 400,
+    statusCode: params.statusCode,
+  };
+}
+
+export function getApplyWrites(request: ccfapp.Request): ccfapp.Response {
+  const kv = ccfapp.typedKv(
+    "public:apply_writes",
+    ccfapp.string,
+    ccfapp.string
+  );
+  const v = kv.get("foo");
+  return {
+    body: v
+  };
+}
+
+export function sequenceNumber(): ccfapp.TypedKvMap<number, number> {
+  return ccfapp.typedKv(`private-sequence`, ccfapp.int32, ccfapp.int32);
+}
+
+export function getNextSequence(domain: number): number {
+  let sequenceNum = sequenceNumber().get(domain);
+  if (sequenceNum) {
+    sequenceNum = sequenceNum + 1;
+  } else {
+    sequenceNum = 1;
+  }
+  sequenceNumber().set(domain, sequenceNum);
+  return sequenceNum;
+}
+
+export function transfer(request: ccfapp.Request): ccfapp.Response {
+  const newTransaction = {
+    txnId: getNextSequence(1)
+  };
+  console.log(`Trying to return ${newTransaction.txnId}`);
+  return {
+    statusCode: 401,
+    headers: {},
+    body: {
+      txnId: newTransaction.txnId
+    }
   };
 }

--- a/tests/npm-app/src/endpoints/rpc.ts
+++ b/tests/npm-app/src/endpoints/rpc.ts
@@ -27,32 +27,3 @@ export function getApplyWrites(request: ccfapp.Request): ccfapp.Response {
     body: v
   };
 }
-
-export function sequenceNumber(): ccfapp.TypedKvMap<number, number> {
-  return ccfapp.typedKv(`private-sequence`, ccfapp.int32, ccfapp.int32);
-}
-
-export function getNextSequence(domain: number): number {
-  let sequenceNum = sequenceNumber().get(domain);
-  if (sequenceNum) {
-    sequenceNum = sequenceNum + 1;
-  } else {
-    sequenceNum = 1;
-  }
-  sequenceNumber().set(domain, sequenceNum);
-  return sequenceNum;
-}
-
-export function transfer(request: ccfapp.Request): ccfapp.Response {
-  const newTransaction = {
-    txnId: getNextSequence(1)
-  };
-  console.log(`Trying to return ${newTransaction.txnId}`);
-  return {
-    statusCode: 401,
-    headers: {},
-    body: {
-      txnId: newTransaction.txnId
-    }
-  };
-}


### PR DESCRIPTION
We had a single e2e test that `setApplyWrites(true)` could be used to apply writes despite a non-2xx status code. This extends that sample endpoint to test the full spectrum of when writes are applied by a JS endpoint.