### PR TITLE
Infra: make ledger file copy more resilient

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Splice
+Splice mice

--- a/.pylintrc
+++ b/.pylintrc
@@ -315,13 +315,6 @@ max-line-length=100
 # Maximum number of lines in a module.
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
-
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
 single-line-class-stmt=no

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -917,8 +917,14 @@ class CCFRemote(object):
     def set_perf(self):
         self.remote.set_perf()
 
-    def _resilient_copy(self, directory, pre_condition_func=lambda src_dir, _: True, target_name=None, max_retry_count=5):
-        # It is possible that files (ledger, snapshots) are committed 
+    def _resilient_copy(
+        self,
+        directory,
+        pre_condition_func=lambda src_dir, _: True,
+        target_name=None,
+        max_retry_count=5,
+    ):
+        # It is possible that files (ledger, snapshots) are committed
         # while the copy is happening so retry a reasonable number of times.
         retry_count = 0
         while retry_count < max_retry_count:
@@ -931,14 +937,13 @@ class CCFRemote(object):
                 )
                 return
             except Exception as e:
-                LOG.warning(
-                    f"Error copying file from {directory}: {e}. Retrying..."
-                )
+                LOG.warning(f"Error copying file from {directory}: {e}. Retrying...")
                 retry_count += 1
                 time.sleep(0.1)
 
-        raise Exception(f"Error copying files from {directory} after {retry_count} retries")
-
+        raise Exception(
+            f"Error copying files from {directory} after {retry_count} retries"
+        )
 
     def get_ledger(self, ledger_dir_name):
         self._resilient_copy(self.ledger_dir_name, target_name=ledger_dir_name)
@@ -958,7 +963,9 @@ class CCFRemote(object):
         return os.path.join(self.common_dir, self.snapshot_dir_name)
 
     def get_committed_snapshots(self, pre_condition_func=lambda src_dir, _: True):
-        self._resilient_copy(self.snapshot_dir_name, pre_condition_func=pre_condition_func)
+        self._resilient_copy(
+            self.snapshot_dir_name, pre_condition_func=pre_condition_func
+        )
         return os.path.join(self.common_dir, self.snapshot_dir_name)
 
     def log_path(self):

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -917,10 +917,31 @@ class CCFRemote(object):
     def set_perf(self):
         self.remote.set_perf()
 
+    def _resilient_copy(self, directory, pre_condition_func=lambda src_dir, _: True, target_name=None, max_retry_count=5):
+        # It is possible that files (ledger, snapshots) are committed 
+        # while the copy is happening so retry a reasonable number of times.
+        retry_count = 0
+        while retry_count < max_retry_count:
+            try:
+                self.remote.get(
+                    directory,
+                    self.common_dir,
+                    pre_condition_func=pre_condition_func,
+                    target_name=target_name,
+                )
+                return
+            except Exception as e:
+                LOG.warning(
+                    f"Error copying file from {directory}: {e}. Retrying..."
+                )
+                retry_count += 1
+                time.sleep(0.1)
+
+        raise Exception(f"Error copying files from {directory} after {retry_count} retries")
+
+
     def get_ledger(self, ledger_dir_name):
-        self.remote.get(
-            self.ledger_dir_name, self.common_dir, target_name=ledger_dir_name
-        )
+        self._resilient_copy(self.ledger_dir_name, target_name=ledger_dir_name)
         read_only_ledger_dirs = []
         for read_only_ledger_dir in self.read_only_ledger_dirs:
             name = f"{read_only_ledger_dir}.ro"
@@ -933,29 +954,11 @@ class CCFRemote(object):
         return (os.path.join(self.common_dir, ledger_dir_name), read_only_ledger_dirs)
 
     def get_snapshots(self):
-        self.remote.get(self.snapshot_dir_name, self.common_dir)
+        self._resilient_copy(self.snapshot_dir_name)
         return os.path.join(self.common_dir, self.snapshot_dir_name)
 
     def get_committed_snapshots(self, pre_condition_func=lambda src_dir, _: True):
-        # It is possible that snapshots are committed while the copy is happening
-        # so retry a reasonable number of times.
-        max_retry_count = 5
-        retry_count = 0
-        while retry_count < max_retry_count:
-            try:
-                self.remote.get(
-                    self.snapshot_dir_name,
-                    self.common_dir,
-                    pre_condition_func=pre_condition_func,
-                )
-                break
-            except Exception as e:
-                LOG.warning(
-                    f"Error copying committed snapshots from {self.snapshot_dir_name}: {e}. Retrying..."
-                )
-                retry_count += 1
-                time.sleep(0.1)
-
+        self._resilient_copy(self.snapshot_dir_name, pre_condition_func=pre_condition_func)
         return os.path.join(self.common_dir, self.snapshot_dir_name)
 
     def log_path(self):


### PR DESCRIPTION
When the Python infra copies ledger files (e.g. when starting a new node), it is possible that a ledger file gets committed while the infra is copying the file, resulting in rare errors in the CI (e.g. [here](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=46315&view=logs&j=e982d093-d12a-5a2d-1a1d-0c6d38b8823f&t=8be5454d-0d8f-51e4-7372-58df022e9ebc&l=18006)). 

We now retry copying files if the initial copy fails (and up to 5 times), like we already do with snapshot files. 