### PR TITLE
Ensure `crypto::Pem`s contain PEM encoded contents

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Splice
+Splicer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,12 +432,12 @@ if(BUILD_TESTS)
     )
 
     add_unit_test(
-      node_frontend_test
+      node_frontend_test ${CMAKE_CURRENT_SOURCE_DIR}/src/js/wrap.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/src/node/rpc/test/node_frontend_test.cpp
     )
     target_link_libraries(
       node_frontend_test PRIVATE ${CMAKE_THREAD_LIBS_INIT} http_parser.host
-                                 sss.host ccf_endpoints.host ccf_kv.host
+                                 sss.host ccf_endpoints.host ccf_kv.host quickjs.host
     )
 
     add_unit_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,8 +436,9 @@ if(BUILD_TESTS)
       ${CMAKE_CURRENT_SOURCE_DIR}/src/node/rpc/test/node_frontend_test.cpp
     )
     target_link_libraries(
-      node_frontend_test PRIVATE ${CMAKE_THREAD_LIBS_INIT} http_parser.host
-                                 sss.host ccf_endpoints.host ccf_kv.host quickjs.host
+      node_frontend_test
+      PRIVATE ${CMAKE_THREAD_LIBS_INIT} http_parser.host sss.host
+              ccf_endpoints.host ccf_kv.host quickjs.host
     )
 
     add_unit_test(

--- a/include/ccf/crypto/key_pair.h
+++ b/include/ccf/crypto/key_pair.h
@@ -73,13 +73,27 @@ namespace crypto
       ISSUER = 1
     };
 
+  private:
+    virtual Pem sign_csr_impl(
+      const std::optional<Pem>& issuer_cert,
+      const Pem& signing_request,
+      const std::string& valid_from,
+      const std::string& valid_to,
+      bool ca = false,
+      Signer signer = Signer::SUBJECT) const = 0;
+
+  public:
     virtual Pem sign_csr(
       const Pem& issuer_cert,
       const Pem& signing_request,
       const std::string& valid_from,
       const std::string& valid_to,
       bool ca = false,
-      Signer signer = Signer::SUBJECT) const = 0;
+      Signer signer = Signer::SUBJECT) const
+    {
+      return sign_csr_impl(
+        issuer_cert, signing_request, valid_from, valid_to, ca, signer);
+    }
 
     Pem self_sign(
       const std::string& name,
@@ -94,7 +108,7 @@ namespace crypto
         sans.push_back(subject_alt_name.value());
       }
       auto csr = create_csr(name, sans);
-      return sign_csr(Pem(0), csr, valid_from, valid_to, ca);
+      return sign_csr_impl(std::nullopt, csr, valid_from, valid_to, ca);
     }
 
     Pem self_sign(
@@ -105,7 +119,7 @@ namespace crypto
       bool ca = true) const
     {
       auto csr = create_csr(subject_name, subject_alt_names);
-      return sign_csr(Pem(0), csr, valid_from, valid_to, ca);
+      return sign_csr_impl(std::nullopt, csr, valid_from, valid_to, ca);
     }
 
     virtual std::vector<uint8_t> derive_shared_secret(

--- a/include/ccf/crypto/pem.h
+++ b/include/ccf/crypto/pem.h
@@ -21,7 +21,7 @@ namespace crypto
 
     void check_pem_format()
     {
-      if (!s.starts_with("-----"))
+      if (s.find("-----BEGIN") == std::string::npos)
       {
         throw std::runtime_error(
           fmt::format("PEM constructed with non-PEM data: {}", s));

--- a/include/ccf/crypto/pem.h
+++ b/include/ccf/crypto/pem.h
@@ -16,14 +16,25 @@ namespace crypto
   // Convenience class ensuring null termination of PEM-encoded certificates
   class Pem
   {
+  private:
     std::string s;
+
+    void check_pem_format()
+    {
+      if (!s.starts_with("-----"))
+      {
+        throw std::runtime_error(
+          fmt::format("PEM constructed with non-PEM data: {}", s));
+      }
+    }
 
   public:
     Pem() = default;
 
-    Pem(const std::string& s_) : s(s_) {}
-
-    Pem(size_t size) : s(size, '0') {}
+    Pem(const std::string& s_) : s(s_)
+    {
+      check_pem_format();
+    }
 
     Pem(const uint8_t* data, size_t size)
     {
@@ -36,6 +47,8 @@ namespace crypto
         size -= 1;
 
       s.assign(reinterpret_cast<const char*>(data), size);
+
+      check_pem_format();
     }
 
     explicit Pem(std::span<const uint8_t> s) : Pem(s.data(), s.size()) {}

--- a/include/ccf/crypto/pem.h
+++ b/include/ccf/crypto/pem.h
@@ -38,9 +38,9 @@ namespace crypto
       s.assign(reinterpret_cast<const char*>(data), size);
     }
 
-    Pem(std::span<const uint8_t> s) : Pem(s.data(), s.size()) {}
+    explicit Pem(std::span<const uint8_t> s) : Pem(s.data(), s.size()) {}
 
-    Pem(const std::vector<uint8_t>& v) : Pem(v.data(), v.size()) {}
+    explicit Pem(const std::vector<uint8_t>& v) : Pem(v.data(), v.size()) {}
 
     bool operator==(const Pem& rhs) const
     {

--- a/src/clients/perf/perf_client.h
+++ b/src/clients/perf/perf_client.h
@@ -302,11 +302,12 @@ namespace client
 
         key = crypto::Pem(raw_key);
 
-        auto cert_der = crypto::cert_pem_to_der(raw_cert);
+        const crypto::Pem cert_pem(raw_cert);
+        auto cert_der = crypto::cert_pem_to_der(cert_pem);
         key_id = crypto::Sha256Hash(cert_der).hex_str();
 
         tls_cert = std::make_shared<tls::Cert>(
-          std::make_shared<tls::CA>(ca), raw_cert, key);
+          std::make_shared<tls::CA>(ca), cert_pem, key);
       }
 
       const auto [host, port] = ccf::split_net_address(options.server_address);

--- a/src/crypto/openssl/key_pair.cpp
+++ b/src/crypto/openssl/key_pair.cpp
@@ -225,8 +225,8 @@ namespace crypto
     return result;
   }
 
-  Pem KeyPair_OpenSSL::sign_csr(
-    const Pem& issuer_cert,
+  Pem KeyPair_OpenSSL::sign_csr_impl(
+    const std::optional<Pem>& issuer_cert,
     const Pem& signing_request,
     const std::string& valid_from,
     const std::string& valid_to,
@@ -262,9 +262,9 @@ namespace crypto
     BN_free(bn);
 
     // Add issuer name
-    if (!issuer_cert.empty())
+    if (issuer_cert.has_value())
     {
-      Unique_BIO imem(issuer_cert);
+      Unique_BIO imem(*issuer_cert);
       OpenSSL::CHECKNULL(icrt = PEM_read_bio_X509(imem, NULL, NULL, NULL));
       OpenSSL::CHECK1(X509_set_issuer_name(crt, X509_get_subject_name(icrt)));
 

--- a/src/crypto/openssl/key_pair.h
+++ b/src/crypto/openssl/key_pair.h
@@ -61,8 +61,8 @@ namespace crypto
       const std::vector<SubjectAltName>& subject_alt_names,
       const std::optional<Pem>& public_key = std::nullopt) const override;
 
-    virtual Pem sign_csr(
-      const Pem& issuer_cert,
+    virtual Pem sign_csr_impl(
+      const std::optional<Pem>& issuer_cert,
       const Pem& signing_request,
       const std::string& valid_from,
       const std::string& valid_to,

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -408,14 +408,13 @@ int main(int argc, char** argv)
     {
       for (auto const& m : config.command.start.members)
       {
-        std::optional<std::vector<uint8_t>> public_encryption_key =
-          std::nullopt;
+        std::optional<crypto::Pem> public_encryption_key = std::nullopt;
         if (
           m.encryption_public_key_file.has_value() &&
           !m.encryption_public_key_file.value().empty())
         {
           public_encryption_key =
-            files::slurp(m.encryption_public_key_file.value());
+            crypto::Pem(files::slurp(m.encryption_public_key_file.value()));
         }
 
         nlohmann::json md = nullptr;
@@ -425,7 +424,9 @@ int main(int argc, char** argv)
         }
 
         startup_config.start.members.emplace_back(
-          files::slurp(m.certificate_file), public_encryption_key, md);
+          crypto::Pem(files::slurp(m.certificate_file)),
+          public_encryption_key,
+          md);
       }
       startup_config.start.constitution = "";
       for (const auto& constitution_path :

--- a/src/js/crypto.cpp
+++ b/src/js/crypto.cpp
@@ -216,6 +216,11 @@ namespace ccf::js
       LOG_DEBUG_FMT("isValidX509Chain: {}", e.what());
       return JS_FALSE;
     }
+    catch (const std::runtime_error& e)
+    {
+      LOG_DEBUG_FMT("isValidX509Chain: {}", e.what());
+      return JS_FALSE;
+    }
 
     return JS_TRUE;
   }

--- a/src/js/wrap.cpp
+++ b/src/js/wrap.cpp
@@ -629,7 +629,7 @@ namespace ccf::js
         }
         identities.previous = crypto::Pem(prev_bytes, prev_bytes_sz);
         LOG_DEBUG_FMT(
-          "previous service identity: {}", ds::to_hex(*identities.previous));
+          "previous service identity: {}", identities.previous->str());
       }
 
       if (JS_IsUndefined(argv[1]))
@@ -648,7 +648,7 @@ namespace ccf::js
       }
 
       identities.next = crypto::Pem(next_bytes, next_bytes_sz);
-      LOG_DEBUG_FMT("next service identity: {}", ds::to_hex(identities.next));
+      LOG_DEBUG_FMT("next service identity: {}", identities.next.str());
 
       gov_effects->transition_service_to_open(*tx_ctx_ptr->tx, identities);
     }

--- a/src/js/wrap.cpp
+++ b/src/js/wrap.cpp
@@ -627,8 +627,7 @@ namespace ccf::js
           return JS_ThrowTypeError(
             ctx, "Previous service identity argument is not an array buffer");
         }
-        identities.previous =
-          std::vector<uint8_t>{prev_bytes, prev_bytes + prev_bytes_sz};
+        identities.previous = crypto::Pem(prev_bytes, prev_bytes_sz);
         LOG_DEBUG_FMT(
           "previous service identity: {}", ds::to_hex(*identities.previous));
       }
@@ -648,8 +647,7 @@ namespace ccf::js
           ctx, "Next service identity argument is not an array buffer");
       }
 
-      identities.next =
-        std::vector<uint8_t>{next_bytes, next_bytes + next_bytes_sz};
+      identities.next = crypto::Pem(next_bytes, next_bytes_sz);
       LOG_DEBUG_FMT("next service identity: {}", ds::to_hex(identities.next));
 
       gov_effects->transition_service_to_open(*tx_ctx_ptr->tx, identities);

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -687,8 +687,7 @@ namespace ccf
       JoinNetworkNodeToNode::In join_params;
 
       join_params.node_info_network = config.network;
-      join_params.public_encryption_key =
-        node_encrypt_kp->public_key_pem().raw();
+      join_params.public_encryption_key = node_encrypt_kp->public_key_pem();
       join_params.quote_info = quote_info;
       join_params.consensus_type = network.consensus_type;
       join_params.startup_seqno = startup_seqno;

--- a/src/node/rpc/gov_effects_interface.h
+++ b/src/node/rpc/gov_effects_interface.h
@@ -19,8 +19,8 @@ namespace ccf
 
     struct ServiceIdentities
     {
-      std::optional<std::vector<uint8_t>> previous;
-      std::vector<uint8_t> next;
+      std::optional<crypto::Pem> previous;
+      crypto::Pem next;
     };
 
     virtual void transition_service_to_open(

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -495,28 +495,15 @@ void prepare_callers(NetworkState& network)
 
   auto tx = network.tables->create_tx();
   network.tables->set_encryptor(encryptor);
+  
+  init_network(network);
 
   GenesisGenerator g(network, tx);
-  g.create_service();
+  g.create_service(network.identity->cert);
   user_id = g.add_user({user_caller});
   member_id = g.add_member(member_cert);
   invalid_member_id = g.add_member(invalid_caller);
   CHECK(tx.commit() == kv::CommitResult::SUCCESS);
-}
-
-void add_callers_bft_store()
-{
-  auto gen_tx = bft_network.tables->create_tx();
-  bft_network.tables->set_encryptor(encryptor);
-  bft_network.tables->set_history(history);
-  auto backup_consensus =
-    std::make_shared<kv::test::PrimaryStubConsensus>(ConsensusType::BFT);
-  bft_network.tables->set_consensus(backup_consensus);
-
-  GenesisGenerator g(bft_network, gen_tx);
-  g.create_service();
-  user_id = g.add_user({user_caller});
-  CHECK(gen_tx.commit() == kv::CommitResult::SUCCESS);
 }
 
 TEST_CASE("SignedReq to and from json")

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -497,7 +497,7 @@ void prepare_callers(NetworkState& network)
   network.tables->set_encryptor(encryptor);
 
   GenesisGenerator g(network, tx);
-  g.create_service({});
+  g.create_service();
   user_id = g.add_user({user_caller});
   member_id = g.add_member(member_cert);
   invalid_member_id = g.add_member(invalid_caller);
@@ -514,7 +514,7 @@ void add_callers_bft_store()
   bft_network.tables->set_consensus(backup_consensus);
 
   GenesisGenerator g(bft_network, gen_tx);
-  g.create_service({});
+  g.create_service();
   user_id = g.add_user({user_caller});
   CHECK(gen_tx.commit() == kv::CommitResult::SUCCESS);
 }

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -495,7 +495,7 @@ void prepare_callers(NetworkState& network)
 
   auto tx = network.tables->create_tx();
   network.tables->set_encryptor(encryptor);
-  
+
   init_network(network);
 
   GenesisGenerator g(network, tx);

--- a/src/node/rpc/test/frontend_test_infra.h
+++ b/src/node/rpc/test/frontend_test_infra.h
@@ -73,6 +73,12 @@ void check_error(const TResponse& r, http_status expected)
   DOCTEST_CHECK(r.status == expected);
 }
 
+void check_error_message(const TResponse& r, const std::string& msg)
+{
+  const std::string body_s(r.body.begin(), r.body.end());
+  CHECK(body_s.find(msg) != std::string::npos);
+}
+
 std::vector<uint8_t> create_request(
   const json& params, const string& method_name, llhttp_method verb = HTTP_POST)
 {
@@ -167,6 +173,15 @@ auto init_frontend(
   return MemberRpcFrontend(network, context, share_manager);
 }
 
+std::unique_ptr<ccf::NetworkIdentity> make_test_network_ident()
+{
+  using namespace std::literals;
+  const auto valid_from =
+    ds::to_x509_time_string(std::chrono::system_clock::now() - 24h);
+  return std::make_unique<ReplicatedNetworkIdentity>(
+    crypto::service_identity_curve_choice, valid_from, 2);
+}
+
 void init_network(NetworkState& network)
 {
   network.tables->set_encryptor(encryptor);
@@ -175,4 +190,5 @@ void init_network(NetworkState& network)
   network.tables->set_history(history);
   auto consensus = std::make_shared<kv::test::PrimaryStubConsensus>();
   network.tables->set_consensus(consensus);
+  network.identity = make_test_network_ident();
 }

--- a/src/node/rpc/test/node_frontend_test.cpp
+++ b/src/node/rpc/test/node_frontend_test.cpp
@@ -211,13 +211,14 @@ TEST_CASE("Add a node to an opening service")
     crypto::KeyPairPtr kp = crypto::make_key_pair();
     auto v = crypto::make_verifier(
       kp->self_sign("CN=Other Joiner", valid_from, valid_to));
-    const auto caller = v->cert_der();
+    const auto new_caller = v->cert_pem();
 
     // Network node info is empty (same as before)
     JoinNetworkNodeToNode::In join_input;
     join_input.public_encryption_key = node_public_encryption_key;
 
-    auto http_response = frontend_process(frontend, join_input, "join", caller);
+    auto http_response =
+      frontend_process(frontend, join_input, "join", new_caller);
 
     check_error(http_response, HTTP_STATUS_BAD_REQUEST);
     check_error_message(http_response, "A node with the same node address");
@@ -290,12 +291,13 @@ TEST_CASE("Add a node to an open service")
     crypto::KeyPairPtr kp = crypto::make_key_pair();
     auto v =
       crypto::make_verifier(kp->self_sign("CN=Joiner", valid_from, valid_to));
-    const auto caller = v->cert_der();
+    const auto new_caller = v->cert_pem();
 
     // Network node info is empty (same as before)
     JoinNetworkNodeToNode::In join_input;
 
-    auto http_response = frontend_process(frontend, join_input, "join", caller);
+    auto http_response =
+      frontend_process(frontend, join_input, "join", new_caller);
 
     check_error(http_response, HTTP_STATUS_BAD_REQUEST);
     check_error_message(http_response, "A node with the same node address");

--- a/src/node/rpc/test/proposal_id_test.cpp
+++ b/src/node/rpc/test/proposal_id_test.cpp
@@ -24,7 +24,7 @@ DOCTEST_TEST_CASE("Unique proposal ids")
   init_network(network);
   auto gen_tx = network.tables->create_tx();
   GenesisGenerator gen(network, gen_tx);
-  gen.create_service();
+  gen.create_service(network.identity->cert);
 
   const auto proposer_cert = get_cert(0, kp);
   const auto proposer_id = gen.add_member(proposer_cert);
@@ -135,6 +135,7 @@ public:
 DOCTEST_TEST_CASE("Compaction conflict")
 {
   NetworkState network;
+  init_network(network);
   network.tables->set_encryptor(encryptor);
   auto history = std::make_shared<NullTxHistoryWithOverride>(
     *network.tables, kv::test::PrimaryNodeId, *kp);
@@ -143,7 +144,7 @@ DOCTEST_TEST_CASE("Compaction conflict")
   network.tables->set_consensus(consensus);
   auto gen_tx = network.tables->create_tx();
   GenesisGenerator gen(network, gen_tx);
-  gen.create_service();
+  gen.create_service(network.identity->cert);
 
   const auto proposer_cert = get_cert(0, kp);
   const auto proposer_id = gen.add_member(proposer_cert);

--- a/src/node/rpc/test/proposal_id_test.cpp
+++ b/src/node/rpc/test/proposal_id_test.cpp
@@ -24,7 +24,7 @@ DOCTEST_TEST_CASE("Unique proposal ids")
   init_network(network);
   auto gen_tx = network.tables->create_tx();
   GenesisGenerator gen(network, gen_tx);
-  gen.create_service({});
+  gen.create_service();
 
   const auto proposer_cert = get_cert(0, kp);
   const auto proposer_id = gen.add_member(proposer_cert);
@@ -143,7 +143,7 @@ DOCTEST_TEST_CASE("Compaction conflict")
   network.tables->set_consensus(consensus);
   auto gen_tx = network.tables->create_tx();
   GenesisGenerator gen(network, gen_tx);
-  gen.create_service({});
+  gen.create_service();
 
   const auto proposer_cert = get_cert(0, kp);
   const auto proposer_id = gen.add_member(proposer_cert);

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -80,6 +80,8 @@ TEST_CASE("Check signature verification")
 
   auto kp = crypto::make_key_pair();
 
+  const auto self_signed = kp->self_sign("CN=Node", valid_from, valid_to);
+
   std::shared_ptr<kv::Consensus> consensus =
     std::make_shared<DummyConsensus>(&backup_store);
   primary_store.set_consensus(consensus);
@@ -90,13 +92,13 @@ TEST_CASE("Check signature verification")
   std::shared_ptr<kv::TxHistory> primary_history =
     std::make_shared<ccf::MerkleTxHistory>(
       primary_store, kv::test::PrimaryNodeId, *kp);
-  primary_history->set_endorsed_certificate({});
+  primary_history->set_endorsed_certificate(self_signed);
   primary_store.set_history(primary_history);
 
   std::shared_ptr<kv::TxHistory> backup_history =
     std::make_shared<ccf::MerkleTxHistory>(
       backup_store, kv::test::FirstBackupNodeId, *kp);
-  backup_history->set_endorsed_certificate({});
+  backup_history->set_endorsed_certificate(self_signed);
   backup_store.set_history(backup_history);
 
   INFO("Write certificate");
@@ -104,7 +106,8 @@ TEST_CASE("Check signature verification")
     auto txs = primary_store.create_tx();
     auto tx = txs.rw(nodes);
     ccf::NodeInfo ni;
-    ni.cert = kp->self_sign("CN=name", valid_from, valid_to);
+    ni.encryption_pub_key = kp->public_key_pem();
+    ni.cert = self_signed;
     tx->put(kv::test::PrimaryNodeId, ni);
     REQUIRE(txs.commit() == kv::CommitResult::SUCCESS);
   }
@@ -142,6 +145,8 @@ TEST_CASE("Check signing works across rollback")
 
   auto kp = crypto::make_key_pair();
 
+  const auto self_signed = kp->self_sign("CN=Node", valid_from, valid_to);
+
   std::shared_ptr<kv::Consensus> consensus =
     std::make_shared<DummyConsensus>(&backup_store);
   primary_store.set_consensus(consensus);
@@ -152,13 +157,13 @@ TEST_CASE("Check signing works across rollback")
   std::shared_ptr<kv::TxHistory> primary_history =
     std::make_shared<ccf::MerkleTxHistory>(
       primary_store, kv::test::PrimaryNodeId, *kp);
-  primary_history->set_endorsed_certificate({});
+  primary_history->set_endorsed_certificate(self_signed);
   primary_store.set_history(primary_history);
 
   std::shared_ptr<kv::TxHistory> backup_history =
     std::make_shared<ccf::MerkleTxHistory>(
       backup_store, kv::test::FirstBackupNodeId, *kp);
-  backup_history->set_endorsed_certificate({});
+  backup_history->set_endorsed_certificate(self_signed);
   backup_store.set_history(backup_history);
 
   INFO("Write certificate");
@@ -166,7 +171,8 @@ TEST_CASE("Check signing works across rollback")
     auto txs = primary_store.create_tx();
     auto tx = txs.rw(nodes);
     ccf::NodeInfo ni;
-    ni.cert = kp->self_sign("CN=name", valid_from, valid_to);
+    ni.encryption_pub_key = kp->public_key_pem();
+    ni.cert = self_signed;
     tx->put(kv::test::PrimaryNodeId, ni);
     REQUIRE(txs.commit() == kv::CommitResult::SUCCESS);
   }

--- a/src/service/genesis_gen.h
+++ b/src/service/genesis_gen.h
@@ -288,8 +288,7 @@ namespace ccf
 
     // Service status should use a state machine, very much like NodeState.
     void create_service(
-      const crypto::Pem& service_cert,
-      bool recovering = false)
+      const crypto::Pem& service_cert, bool recovering = false)
     {
       auto service = tx.rw(tables.service);
 

--- a/src/service/genesis_gen.h
+++ b/src/service/genesis_gen.h
@@ -288,7 +288,8 @@ namespace ccf
 
     // Service status should use a state machine, very much like NodeState.
     void create_service(
-      const crypto::Pem& service_cert, bool recovering = false)
+      const crypto::Pem& service_cert,
+      bool recovering = false)
     {
       auto service = tx.rw(tables.service);
 


### PR DESCRIPTION
Follow up to #3916, hoping to avoid similar issues in other places.

The real fix here is that when a `crypto::Pem` is constructed with contents, it confirms they look a bit like a PEM. Maybe that check should be more precise, but I think it's sufficient for now. This broke a bunch of unit tests, which used various kinds of empty PEMs, but now generate plausible test identities.

I'd like to remove the default constructor for PEMs as well, so we disallowed empty PEMs as well, at compile time. Unfortunately this is tricky to do alongside JSON serialization - we _can_ convert to `crypto::Pem` even when it is not default-constructible, but we'd need to do the same thing for all of our PoD JSON-serialized structs which hold `crypto::Pem`s (or make those `std::optional` or similar). That's tricky and messy for no gain, so I've abandoned it.