### PR TITLE
[release/2.x] Cherry pick: PSW update to 2.16.100 (#3920)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Primary node now automatically steps down as backup (in the same view) if it has not heard back from a majority of backup nodes for an election timeout (#3685).
-- Node and service PEM certificates no longer contain a trailing null byte (#3885).
-- New nodes automatically shutdown if the target service certificate is misconfigured (#3895).
 - Updated PSW in images to 2.16.100.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added a `GET /node/service/previous_identity` endpoint, which can be used during a recovery to look up the identity of the service before the catastrophic failure (#3880).
 
+### Changed
+
+- Primary node now automatically steps down as backup (in the same view) if it has not heard back from a majority of backup nodes for an election timeout (#3685).
+- Node and service PEM certificates no longer contain a trailing null byte (#3885).
+- New nodes automatically shutdown if the target service certificate is misconfigured (#3895).
+- Updated PSW in images to 2.16.100.
+
 ### Removed
 
 - Removed deprecated `set_execute_outside_consensus()` API (#3886, #3673).

--- a/docker/app_dev
+++ b/docker/app_dev
@@ -11,10 +11,8 @@ RUN echo "APT::Acquire::Retries \"5\";" | tee /etc/apt/apt.conf.d/80-retries
 RUN mkdir -p /etc/init
 
 ENV UBUNTU=focal
-ENV PSW_VERSION=2.15.100
+ENV PSW_VERSION=2.16.100
 RUN if [ -z "$PSW_VERSION" ]; then echo "Please set PSW_VERSION (e.g. 2.11)." >&2; exit 1; fi
-ENV DCAP_CLIENT_VERSION=1.10
-RUN if [ -z "$DCAP_CLIENT_VERSION" ]; then echo "Please set DCAP_CLIENT_VERSION (e.g. 1.8)." >&2; exit 1; fi
 
 RUN apt-get update && apt-get install -y wget gnupg
 

--- a/docker/app_run
+++ b/docker/app_run
@@ -11,10 +11,8 @@ RUN echo "APT::Acquire::Retries \"5\";" | tee /etc/apt/apt.conf.d/80-retries
 RUN mkdir -p /etc/init
 
 ENV UBUNTU=focal
-ENV PSW_VERSION=2.15.100
+ENV PSW_VERSION=2.16.100
 RUN if [ -z "$PSW_VERSION" ]; then echo "Please set PSW_VERSION (e.g. 2.11)." >&2; exit 1; fi
-ENV DCAP_CLIENT_VERSION=1.10
-RUN if [ -z "$DCAP_CLIENT_VERSION" ]; then echo "Please set DCAP_CLIENT_VERSION (e.g. 1.8)." >&2; exit 1; fi
 
 RUN apt-get update && apt-get install -y wget gnupg
 

--- a/docker/ccf_ci
+++ b/docker/ccf_ci
@@ -11,10 +11,8 @@ RUN echo "APT::Acquire::Retries \"5\";" | tee /etc/apt/apt.conf.d/80-retries
 RUN mkdir -p /etc/init
 
 ENV UBUNTU=focal
-ENV PSW_VERSION=2.15.100
+ENV PSW_VERSION=2.16.100
 RUN if [ -z "$PSW_VERSION" ]; then echo "Please set PSW_VERSION (e.g. 2.11)." >&2; exit 1; fi
-ENV DCAP_CLIENT_VERSION=1.10
-RUN if [ -z "$DCAP_CLIENT_VERSION" ]; then echo "Please set DCAP_CLIENT_VERSION (e.g. 1.8)." >&2; exit 1; fi
 
 RUN apt-get update && apt-get install -y wget gnupg
 


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [PSW update to 2.16.100 (#3920)](https://github.com/microsoft/CCF/pull/3920)