### PR TITLE
[release/2.x] Cherry pick: Update to build image to PSW 2.16.100 (#3921)

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -7,7 +7,7 @@ trigger:
 
 jobs:
   - job: build_and_publish_docs
-    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-1
+    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-2
     pool:
       vmImage: ubuntu-20.04
 

--- a/.azure-pipelines-v8.yml
+++ b/.azure-pipelines-v8.yml
@@ -20,7 +20,7 @@ parameters:
 
 jobs:
   - job: build_v8
-    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-1
+    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-2
     pool: 1es-dv4-focal
 
     strategy:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -27,11 +27,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-1
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-2
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-1
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-2
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
 variables:

--- a/.daily.yml
+++ b/.daily.yml
@@ -23,11 +23,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-1
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-2
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-1
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-2
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-1
+    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-2
 
     steps:
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -16,7 +16,7 @@ pr:
 resources:
   containers:
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-1
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-2
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.stress.yml
+++ b/.stress.yml
@@ -21,7 +21,7 @@ schedules:
 resources:
   containers:
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-1
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.17.7-2
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Update to build image to PSW 2.16.100 (#3921)](https://github.com/microsoft/CCF/pull/3921)