### PR TITLE
Fix docs warning

### DIFF
--- a/doc/audit/builtin_maps.rst
+++ b/doc/audit/builtin_maps.rst
@@ -175,7 +175,7 @@ Service configuration.
    :members:
 
 ``service.previous_service_identity``
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 PEM identity of previous service, which this service recovered from.
 


### PR DESCRIPTION
Fixing a warning in the docs build, which appears to have recently escalated to a build failure.