### PR TITLE
[release/2.x] Cherry pick: Fix rename properly (#3930)

### DIFF
--- a/.azure-pipelines-templates/release.yml
+++ b/.azure-pipelines-templates/release.yml
@@ -20,7 +20,7 @@ jobs:
       - script: |
           set -ex
           cd $(Build.ArtifactStagingDirectory)
-          for f in *+*.deb; do mv -- "$f" "${f//+/_}" || true; done
+          rename.ul + _ *+*.deb || true
         displayName: Remove characters that break GitHubRelease
 
       - task: GitHubRelease@0


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Fix rename properly (#3930)](https://github.com/microsoft/CCF/pull/3930)