### PR TITLE
[release/2.x] Cherry pick: Unsafe different project (#3894)

### DIFF
--- a/.azure-pipelines-templates/install_deb.yml
+++ b/.azure-pipelines-templates/install_deb.yml
@@ -22,12 +22,6 @@ steps:
 
   - script: |
       set -ex
-      cat /tmp/install_prefix | xargs -i bash -c "PYTHON_PACKAGE_PATH=../python ./recovery_benchmark.sh {}"
-    workingDirectory: build
-    displayName: Recovery benchmark for installed CCF
-
-  - script: |
-      set -ex
       unsafe_build=$(grep unsafe /tmp/install_prefix) || true
       if [[ -n "$unsafe_build" ]]; then
         ./tests/test_install_build.sh -DUSE_UNSAFE_VERSION=ON

--- a/.azure-pipelines-templates/install_deb.yml
+++ b/.azure-pipelines-templates/install_deb.yml
@@ -22,7 +22,18 @@ steps:
 
   - script: |
       set -ex
-      ./tests/test_install_build.sh
+      cat /tmp/install_prefix | xargs -i bash -c "PYTHON_PACKAGE_PATH=../python ./recovery_benchmark.sh {}"
+    workingDirectory: build
+    displayName: Recovery benchmark for installed CCF
+
+  - script: |
+      set -ex
+      unsafe_build=$(grep unsafe /tmp/install_prefix) || true
+      if [[ -n "$unsafe_build" ]]; then
+        ./tests/test_install_build.sh -DUSE_UNSAFE_VERSION=ON
+      else
+        ./tests/test_install_build.sh
+      fi
     displayName: Test building a sample against installed CCF
 
   - task: PublishPipelineArtifact@1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(${CCF_DIR}/cmake/preproject.cmake)
 include(${CCF_DIR}/cmake/version.cmake)
 
 project(
-  ccf
+  ${CCF_PROJECT}
   VERSION ${CCF_RELEASE_VERSION}
   LANGUAGES C CXX
 )
@@ -25,7 +25,7 @@ include(${CCF_DIR}/cmake/cpack_settings.cmake)
 #
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX
-      "/opt/ccf"
+      "/opt/${CCF_PROJECT}"
       CACHE PATH "Default install prefix" FORCE
   )
 endif()
@@ -960,16 +960,16 @@ endif()
 # Generate and install CMake export file for consumers using CMake
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ccf-config.cmake.in
-  ${CMAKE_BINARY_DIR}/cmake/ccf-config.cmake
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${CCF_PROJECT}-config.cmake.in
+  ${CMAKE_BINARY_DIR}/cmake/${CCF_PROJECT}-config.cmake
   INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/cmake
   PATH_VARS CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_BINDIR CMAKE_INSTALL_INCLUDEDIR
 )
 write_basic_package_version_file(
-  ${CMAKE_BINARY_DIR}/cmake/ccf-config-version.cmake
+  ${CMAKE_BINARY_DIR}/cmake/${CCF_PROJECT}-config-version.cmake
   COMPATIBILITY SameMajorVersion
 )
-install(FILES ${CMAKE_BINARY_DIR}/cmake/ccf-config.cmake
-              ${CMAKE_BINARY_DIR}/cmake/ccf-config-version.cmake
+install(FILES ${CMAKE_BINARY_DIR}/cmake/${CCF_PROJECT}-config.cmake
+              ${CMAKE_BINARY_DIR}/cmake/${CCF_PROJECT}-config-version.cmake
         DESTINATION ${CMAKE_INSTALL_PREFIX}/cmake
 )

--- a/cmake/ccf_unsafe-config.cmake.in
+++ b/cmake/ccf_unsafe-config.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+set(CCF_DIR "@CMAKE_INSTALL_PREFIX@")
+
+include("${CCF_DIR}/cmake/ccf-targets.cmake")
+include("${CCF_DIR}/cmake/preproject.cmake")
+include("${CCF_DIR}/cmake/ccf_app.cmake")
+include("${CCF_DIR}/cmake/tools.cmake")

--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-set(CPACK_PACKAGE_NAME "ccf")
+set(CPACK_PACKAGE_NAME ${CCF_PROJECT})
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Confidential Consortium Framework")
 set(CPACK_PACKAGE_CONTACT "https://github.com/Microsoft/CCF")
 set(CPACK_RESOURCE_FILE_LICENSE "${CCF_DIR}/LICENSE")
@@ -19,7 +19,7 @@ endif()
 
 # CPack variables for Debian packages
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-    "open-enclave (>=0.17.6), libuv1 (>= 1.34.2), libc++1-10, libc++abi1-10, openssl (>=1.1.1)"
+    "open-enclave (>=0.17.7), libuv1 (>= 1.34.2), libc++1-10, libc++abi1-10, openssl (>=1.1.1)"
 )
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -7,6 +7,11 @@ unset(CCF_VERSION_SUFFIX)
 
 option(UNSAFE_VERSION "Produce build with unsafe logging levels" OFF)
 
+set(CCF_PROJECT "ccf")
+if(UNSAFE_VERSION)
+  set(CCF_PROJECT "${CCF_PROJECT}_unsafe")
+endif()
+
 # If possible, deduce project version from git environment
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
   find_package(Git)
@@ -20,10 +25,6 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
   )
   if(NOT RETURN_CODE STREQUAL "0")
     message(FATAL_ERROR "Error calling git describe")
-  endif()
-
-  if(UNSAFE_VERSION)
-    set(CCF_VERSION "${CCF_VERSION}+unsafe")
   endif()
 
   # Convert git description into cmake list, separated at '-'
@@ -45,10 +46,6 @@ else()
     OUTPUT_VARIABLE "CCF_VERSION"
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
-
-  if(UNSAFE_VERSION)
-    set(CCF_VERSION "${CCF_VERSION}+unsafe")
-  endif()
 
   # Convert directory name into cmake list, separated at '-'
   string(REPLACE "-" ";" CCF_VERSION_COMPONENTS ${CCF_VERSION})

--- a/samples/apps/logging/CMakeLists.txt
+++ b/samples/apps/logging/CMakeLists.txt
@@ -5,8 +5,15 @@ cmake_minimum_required(VERSION 3.16)
 
 project(logging LANGUAGES C CXX)
 
-if(NOT TARGET ccf)
-  find_package(ccf REQUIRED)
+option(USE_UNSAFE_VERSION "Use build with unsafe logging levels" OFF)
+
+set(CCF_PROJECT "ccf")
+if(USE_UNSAFE_VERSION)
+  set(CCF_PROJECT "${CCF_PROJECT}_unsafe")
+endif()
+
+if(NOT TARGET ${CCF_PROJECT})
+  find_package(${CCF_PROJECT} REQUIRED)
 endif()
 
 add_ccf_app(logging SRCS logging.cpp)

--- a/tests/test_install_build.sh
+++ b/tests/test_install_build.sh
@@ -5,5 +5,5 @@ set -ex
 
 mkdir -p build_against_install
 cd build_against_install
-CC=$(command -v clang-10) CXX=$(command -v clang++-10) cmake -GNinja ../samples/apps/logging/
+CC=$(command -v clang-10) CXX=$(command -v clang++-10) cmake -GNinja "$1" ../samples/apps/logging/
 ninja


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Unsafe different project (#3894)](https://github.com/microsoft/CCF/pull/3894)