### PR TITLE
Update backport action to make use of dynamic target labels

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -10,7 +10,7 @@
   "prTitle": "[{targetBranch}] Cherry pick: {commitMessages}",
   "prDescription": "Backports the following commits to `{targetBranch}`:\n{commitMessages}",
   "sourcePRLabels": ["backported"],
-  "targetPRLabels": ["2.x-backport"],
+  "targetPRLabels": ["$1-backport"],
   "autoAssign": false,
   "publishStatusCommentOnSuccess": false,
   "publishStatusCommentOnFailure": true,

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -39,6 +39,6 @@ jobs:
           git config --global merge.keeplocal.driver true
 
       - name: Backport Action
-        uses: sqren/backport-github-action@v8.4.3
+        uses: sqren/backport-github-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -38,6 +38,7 @@ jobs:
           git config --global merge.keeplocal.name "Always keep local file during merge"
           git config --global merge.keeplocal.driver true
 
+      # Update backport action (https://github.com/sqren/backport/issues/391#issuecomment-1156355381)
       - name: Backport Action
         uses: sqren/backport-github-action@main
         with:


### PR DESCRIPTION
Now that backport supports [dynamic target labels](https://github.com/sqren/backport/pull/400), we make use of them to deduce the backport label from the target branch. 