### PR TITLE
Add node configuration subsystem

### DIFF
--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -141,6 +141,9 @@ namespace ccf
         std::make_shared<ccf::NetworkIdentitySubsystem>(
           *node, network.identity));
 
+      context->install_subsystem(
+        std::make_shared<ccf::NodeConfigurationSubsystem>(*node));
+
       LOG_TRACE_FMT("Creating RPC actors / ffi");
       rpc_map->register_frontend<ccf::ActorsType::members>(
         std::make_unique<ccf::MemberRpcFrontend>(
@@ -148,7 +151,7 @@ namespace ccf
 
       rpc_map->register_frontend<ccf::ActorsType::users>(
         std::make_unique<ccf::UserRpcFrontend>(
-          network, ccfapp::make_user_endpoints(*context)));
+          network, ccfapp::make_user_endpoints(*context), *context));
 
       rpc_map->register_frontend<ccf::ActorsType::nodes>(
         std::make_unique<ccf::NodeRpcFrontend>(network, *context));

--- a/src/node/node_configuration_subsystem.h
+++ b/src/node/node_configuration_subsystem.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ccf/node_subsystem_interface.h"
+#include "node/rpc/node_interface.h"
+
+namespace ccf
+{
+  class NodeConfigurationSubsystem : public AbstractNodeSubSystem
+  {
+  protected:
+    AbstractNodeState& node_state;
+
+  public:
+    NodeConfigurationSubsystem(AbstractNodeState& node_state_) :
+      node_state(node_state_)
+    {}
+
+    virtual ~NodeConfigurationSubsystem() = default;
+
+    static char const* get_subsystem_name()
+    {
+      return "NodeConfiguration";
+    }
+
+    virtual const StartupConfig& get()
+    {
+      return node_state.get_node_config();
+    }
+  };
+}

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -2581,5 +2581,10 @@ namespace ccf
         client->start_challenge(token);
       }
     }
+
+    virtual const StartupConfig& get_node_config() const override
+    {
+      return config;
+    }
   };
 }

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -1476,7 +1476,7 @@ namespace ccf
       NetworkState& network,
       ccfapp::AbstractNodeContext& context,
       ShareManager& share_manager) :
-      RpcFrontend(*network.tables, member_endpoints),
+      RpcFrontend(*network.tables, member_endpoints, context),
       member_endpoints(network, context, share_manager)
     {}
   };

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -1650,7 +1650,7 @@ namespace ccf
   public:
     NodeRpcFrontend(
       NetworkState& network, ccfapp::AbstractNodeContext& context) :
-      RpcFrontend(*network.tables, node_endpoints),
+      RpcFrontend(*network.tables, node_endpoints, context),
       node_endpoints(network, context)
     {}
   };

--- a/src/node/rpc/node_interface.h
+++ b/src/node/rpc/node_interface.h
@@ -6,6 +6,7 @@
 #include "ccf/node_startup_state.h"
 #include "ccf/quote_info.h"
 #include "ccf/service/tables/code_id.h"
+#include "common/configuration.h"
 #include "node/rpc/gov_effects_interface.h"
 #include "node/rpc/node_operation_interface.h"
 #include "node/session_metrics.h"
@@ -49,5 +50,6 @@ namespace ccf
     virtual SessionMetrics get_session_metrics() = 0;
     virtual size_t get_jwt_attempts() = 0;
     virtual crypto::Pem get_self_signed_certificate() = 0;
+    virtual const StartupConfig& get_node_config() const = 0;
   };
 }

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -40,7 +40,7 @@ protected:
 public:
   SimpleUserRpcFrontend(
     kv::Store& tables, ccfapp::AbstractNodeContext& context) :
-    RpcFrontend(tables, common_handlers),
+    RpcFrontend(tables, common_handlers, context),
     common_handlers(context)
   {}
 };
@@ -279,11 +279,12 @@ public:
 
 class TestNoCertsFrontend : public RpcFrontend
 {
+  ccf::StubNodeContext context;
   ccf::endpoints::EndpointRegistry endpoints;
 
 public:
   TestNoCertsFrontend(kv::Store& tables) :
-    RpcFrontend(tables, endpoints),
+    RpcFrontend(tables, endpoints, context),
     endpoints("test")
   {
     open();

--- a/src/node/rpc/user_frontend.h
+++ b/src/node/rpc/user_frontend.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ccf/app_interface.h"
+#include "ccf/node_context.h"
 #include "node/network_state.h"
 #include "node/rpc/frontend.h"
 
@@ -16,8 +17,9 @@ namespace ccf
   public:
     UserRpcFrontend(
       NetworkState& network,
-      std::unique_ptr<ccf::endpoints::EndpointRegistry>&& endpoints_) :
-      RpcFrontend(*network.tables, *endpoints_),
+      std::unique_ptr<ccf::endpoints::EndpointRegistry>&& endpoints_,
+      ccfapp::AbstractNodeContext& context_) :
+      RpcFrontend(*network.tables, *endpoints_, context_),
       endpoints(std::move(endpoints_))
     {}
   };


### PR DESCRIPTION
This adds a node configuration subsystem. This will be used in the `RpcFrontend` to get better performance by exposing the node configuration directly instead of via a read-only transaction, which will be important in #3945 + follow-ups.  