### PR TITLE
Ignore nghttp2 URLs in linkcheck

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -95,13 +95,15 @@ exclude_patterns = []
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "zenburn"
 
-# Ignore main index file that has clickable images, JS/Doxygen output and
-# github anchors https://github.com/sphinx-doc/sphinx/issues/9016)
+# Ignore main index file that has clickable images, JS/Doxygen output,
+# github anchors https://github.com/sphinx-doc/sphinx/issues/9016), and nghttp2
+# (which is now HTTP2-only)
 linkcheck_exclude_documents = [r"^index$"]
 linkcheck_ignore = [
     r"https://github.com/.*#",
     r"../js/ccf-app.*",
     r"../doxygen/index.html",
+    r"https://nghttp2.org/.*",
 ]
 
 


### PR DESCRIPTION
`nghttp2.org` no longer responds to HTTP1.1, which means it looks dead to Sphinx's link-check (and various other services).

```
$ curl https://nghttp2.org/nghttp3/programmers-guide.html -I --http1.1
curl: (52) Empty reply from server

$ curl https://nghttp2.org/nghttp3/programmers-guide.html -I --http2
HTTP/2 200
...
```

This PR adds those URLs to the ignore list.