### PR TITLE
Experiment with election fix

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1804,6 +1804,9 @@ namespace aft
       if (state->commit_idx > 0)
       {
         rollback(election_index);
+        // Nothing past is committable at this point, only freshly emitted
+        // transactions are
+        committable_indices.clear();
       }
       else
       {

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -253,6 +253,10 @@ namespace aft
     bool can_replicate() override
     {
       std::unique_lock<std::mutex> guard(state->lock);
+      LOG_DEBUG_FMT(
+        "XXXXXXXXXXXXXXXXXXXXXXXX CAN REPLICATE {}",
+        leadership_state == kv::LeadershipState::Leader &&
+          !retirement_committable_idx.has_value());
       return leadership_state == kv::LeadershipState::Leader &&
         !retirement_committable_idx.has_value();
     }
@@ -261,6 +265,7 @@ namespace aft
     {
       std::unique_lock<std::mutex> guard(state->lock);
       bool should = _should_sign;
+      LOG_DEBUG_FMT("XXXXXXXXXXXXXXXXXX SHOULD SIGN {}", should);
       _should_sign = false;
       return should;
     }

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1315,7 +1315,6 @@ namespace aft
           case kv::ApplyResult::PASS_SIGNATURE:
           {
             LOG_DEBUG_FMT("Deserialising signature at {}", i);
-            auto prev_lci = last_committable_index();
             if (
               membership_state == kv::MembershipState::Retired &&
               retirement_phase == kv::RetirementPhase::Ordered)

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -150,8 +150,6 @@ namespace aft
     std::uniform_int_distribution<int> distrib;
     std::default_random_engine rand;
 
-    bool _should_sign = false;
-
   public:
     static constexpr size_t append_entries_size_limit = 20000;
     std::unique_ptr<LedgerProxy> ledger;
@@ -253,21 +251,8 @@ namespace aft
     bool can_replicate() override
     {
       std::unique_lock<std::mutex> guard(state->lock);
-      LOG_DEBUG_FMT(
-        "XXXXXXXXXXXXXXXXXXXXXXXX CAN REPLICATE {}",
-        leadership_state == kv::LeadershipState::Leader &&
-          !retirement_committable_idx.has_value());
       return leadership_state == kv::LeadershipState::Leader &&
         !retirement_committable_idx.has_value();
-    }
-
-    bool should_sign() override
-    {
-      std::unique_lock<std::mutex> guard(state->lock);
-      bool should = _should_sign;
-      LOG_DEBUG_FMT("XXXXXXXXXXXXXXXXXX SHOULD SIGN {}", should);
-      _should_sign = false;
-      return should;
     }
 
     bool is_backup() override
@@ -1796,8 +1781,6 @@ namespace aft
       {
         return;
       }
-
-      _should_sign = true;
 
       // When we force to become the primary we are going around the
       // consensus protocol. This only happens when a node starts a new network

--- a/src/consensus/aft/test/committable_suffix.cpp
+++ b/src/consensus/aft/test/committable_suffix.cpp
@@ -462,6 +462,10 @@ DOCTEST_TEST_CASE("Retention of dead leader's commit")
 
     // B's term history must match the current primary's
     DOCTEST_REQUIRE(rB.get_last_idx() <= rC.get_last_idx());
+    std::cerr << "rB.get_view_history(rB.get_last_idx()) "
+              << rB.get_view_history(rB.get_last_idx())[2] << std::endl;
+    std::cerr << "rC.get_view_history(rB.get_last_idx()) "
+              << rC.get_view_history(rB.get_last_idx())[2] << std::endl;
     DOCTEST_REQUIRE(
       rB.get_view_history(rB.get_last_idx()) ==
       rC.get_view_history(rB.get_last_idx()));

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -466,6 +466,7 @@ namespace kv
     virtual bool is_primary() = 0;
     virtual bool is_backup() = 0;
     virtual bool can_replicate() = 0;
+    virtual bool should_sign() = 0;
 
     virtual void force_become_primary() = 0;
     virtual void force_become_primary(

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -483,7 +483,7 @@ namespace kv
       ccf::SeqNo version, previous_version;
     };
 
-    virtual std::optional<SignableTxIndices> get_signable_txid() = 0;
+    virtual SignableTxIndices get_signable_txid() = 0;
 
     virtual ccf::View get_view(ccf::SeqNo seqno) = 0;
     virtual ccf::View get_view() = 0;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -466,7 +466,6 @@ namespace kv
     virtual bool is_primary() = 0;
     virtual bool is_backup() = 0;
     virtual bool can_replicate() = 0;
-    virtual bool should_sign() = 0;
 
     virtual void force_become_primary() = 0;
     virtual void force_become_primary(

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -157,7 +157,7 @@ namespace kv::test
       return {committed_txid.view, committed_txid.seqno};
     }
 
-    std::optional<SignableTxIndices> get_signable_txid() override
+    SignableTxIndices get_signable_txid() override
     {
       auto txid = get_committed_txid();
       SignableTxIndices r;

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -62,6 +62,11 @@ namespace kv::test
       return state == Primary;
     }
 
+    bool should_sign() override
+    {
+      return false;
+    }
+
     virtual bool is_backup() override
     {
       return state == Backup;
@@ -270,6 +275,11 @@ namespace kv::test
     {
       return false;
     }
+
+    bool should_sign() override
+    {
+      return false;
+    }
   };
 
   class PrimaryStubConsensus : public StubConsensus
@@ -287,6 +297,11 @@ namespace kv::test
     bool can_replicate() override
     {
       return true;
+    }
+
+    bool should_sign() override
+    {
+      return false;
     }
   };
 }

--- a/src/kv/test/stub_consensus.h
+++ b/src/kv/test/stub_consensus.h
@@ -62,11 +62,6 @@ namespace kv::test
       return state == Primary;
     }
 
-    bool should_sign() override
-    {
-      return false;
-    }
-
     virtual bool is_backup() override
     {
       return state == Backup;
@@ -275,11 +270,6 @@ namespace kv::test
     {
       return false;
     }
-
-    bool should_sign() override
-    {
-      return false;
-    }
   };
 
   class PrimaryStubConsensus : public StubConsensus
@@ -297,11 +287,6 @@ namespace kv::test
     bool can_replicate() override
     {
       return true;
-    }
-
-    bool should_sign() override
-    {
-      return false;
     }
   };
 }

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -755,11 +755,7 @@ namespace ccf
       // // Signatures are only emitted when the consensus is establishing
       // commit
       // // over the node's own transactions
-      auto signable_txid = consensus->get_signable_txid();
-      // if (!signable_txid.has_value())
-      // {
-      //   return;
-      // }
+      auto commit_txid = consensus->get_signable_txid();
 
       if (!endorsed_cert.has_value())
       {
@@ -768,10 +764,6 @@ namespace ccf
       }
 
       auto txid = store.next_txid();
-      auto commit_txid =
-        signable_txid.value_or(kv::Consensus::SignableTxIndices{
-          txid.term, txid.version, txid.version - 1});
-
       last_signed_tx = commit_txid.version;
       time_of_last_signature =
         threading::ThreadMessaging::thread_messaging.get_current_time_offset();

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -540,15 +540,10 @@ namespace ccf
             auto consensus = self->store.get_consensus();
             if (
               (consensus != nullptr) && consensus->can_replicate() &&
-              // Emit signatures when there's either a committable gap
-              // or the consensus believes it should sign, for example because
-              // the node just became leader.
-              (consensus->should_sign() ||
-               (self->store.committable_gap() > 0 &&
-                time > time_of_last_signature &&
-                (time - time_of_last_signature) > sig_ms_interval)))
+              (self->store.committable_gap() > 0 &&
+               time > time_of_last_signature &&
+               (time - time_of_last_signature) > sig_ms_interval))
             {
-              LOG_DEBUG_FMT("XXXXX EMIT");
               should_emit_signature = true;
             }
 

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -540,10 +540,10 @@ namespace ccf
             auto consensus = self->store.get_consensus();
             if (
               (consensus != nullptr) && consensus->can_replicate() &&
-              // Emit signatures even if there is no committable gap
-              // This is obviously excessive, it should only happen the one
-              // time at the beginning of the term
-              /* self->store.committable_gap() > 0 && */
+              // Emit signatures when there's either a committable gap
+              // or the consensus believes it should sign, for example because
+              // the node just became leader.
+              (consensus->should_sign() || self->store.committable_gap() > 0) &&
               time > time_of_last_signature &&
               (time - time_of_last_signature) > sig_ms_interval)
             {

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -540,7 +540,10 @@ namespace ccf
             auto consensus = self->store.get_consensus();
             if (
               (consensus != nullptr) && consensus->can_replicate() &&
-              self->store.committable_gap() > 0 &&
+              // Emit signatures even if there is no committable gap
+              // This is obviously excessive, it should only happen the one
+              // time at the beginning of the term
+              /* self->store.committable_gap() > 0 && */
               time > time_of_last_signature &&
               (time - time_of_last_signature) > sig_ms_interval)
             {

--- a/tests/raft_scenarios/fancy_election
+++ b/tests/raft_scenarios/fancy_election
@@ -61,7 +61,11 @@ dispatch_one,1
 # Node 2 responds in support
 dispatch_one,2
 
+# Node 1 appends a new committable entry to persist its primaryship across potential further elections
+replicate,2,Primary
+
 # Node 1 sends an initial AppendEntries probe
+periodic_one,1,10
 dispatch_one,1
 
 # Node 2 indicates it is behind
@@ -83,6 +87,9 @@ state_all
 # Node 0 rejoins the network
 connect,0,1
 connect,0,2
+
+periodic_all,10
+dispatch_all
 
 periodic_all,10
 dispatch_all

--- a/tests/raft_scenarios_gen.py
+++ b/tests/raft_scenarios_gen.py
@@ -44,6 +44,9 @@ def fully_connected_scenario(nodes, steps):
     for node in range(nodes):
         lines.append(f"periodic_one,{node},100")
         lines.append("dispatch_all")
+        lines.append("replicate,latest,CommitConfirmer")
+        lines.append("periodic_all,10")
+        lines.append("dispatch_all")
         lines.append("periodic_all,10")
         lines.append("dispatch_all")
         lines.append("state_all")

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -331,7 +331,7 @@ def test_retire_primary(network, args):
         new_primary,
         primary.node_id,
         node_status=None,
-        timeout=3,
+        timeout=10,
     )
     check_can_progress(backup)
     post_count = count_nodes(node_configs(network), network)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -40,7 +40,7 @@ def count_nodes(configs, network):
     return len(nodes)
 
 
-def wait_for_reconfiguration_to_complete(network, timeout=3):
+def wait_for_reconfiguration_to_complete(network, timeout=10):
     max_num_configs = 0
     max_rid = 0
     all_same_rid = False
@@ -331,7 +331,7 @@ def test_retire_primary(network, args):
         new_primary,
         primary.node_id,
         node_status=None,
-        timeout=10,
+        timeout=3,
     )
     check_can_progress(backup)
     post_count = count_nodes(node_configs(network), network)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -40,7 +40,7 @@ def count_nodes(configs, network):
     return len(nodes)
 
 
-def wait_for_reconfiguration_to_complete(network, timeout=10):
+def wait_for_reconfiguration_to_complete(network, timeout=3):
     max_num_configs = 0
     max_rid = 0
     all_same_rid = False


### PR DESCRIPTION
First look at #3950.

This is changing the signature and post-election logic to:

1. never commit anything prior to the election index, included.
2. emit a signature as soon as the node becomes leader.

The end to end tests seem to pass, but there are failures in the raft scenario and unit tests that need investigation.