### PR TITLE
Allow regex to specify endpoints to serve on an interface

### DIFF
--- a/doc/audit/builtin_maps.rst
+++ b/doc/audit/builtin_maps.rst
@@ -101,6 +101,10 @@ Identity, status and attestations (endorsed quotes) of the nodes hosting the net
    :project: CCF
    :members:
 
+.. doxygenstruct:: ccf::NodeInfoNetwork_v2
+   :project: CCF
+   :members:
+
 .. doxygenstruct:: ccf::QuoteInfo
    :project: CCF
    :members:
@@ -182,6 +186,13 @@ PEM identity of previous service, which this service recovered from.
 **Key** Sentinel value 0, represented as a little-endian 64-bit unsigned integer.
 
 **Value** Previous service identity, represented as a PEM-encoded JSON string.
+
+``service.acme_certificates``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Key** Name of a network interface (string).
+
+**Value** Endorsed TLS certificate for the interface, represented as a PEM-encoded string.
 
 ``proposals``
 ~~~~~~~~~~~~~

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -106,6 +106,18 @@
                     "description": "Name of the ACME configuration defined in the network.acme.configurations section"
                   }
                 },
+                "oneOf": [
+                  {
+                    "required": ["acme_configuration"]
+                  },
+                  {
+                    "not": {
+                      "properties": {
+                        "authority": { "const": "ACME" }
+                      }
+                    }
+                  }
+                ],
                 "required": ["authority"],
                 "additionalProperties": false
               },

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -103,7 +103,6 @@
                   },
                   "acme_configuration": {
                     "type": "string",
-                    "default": "",
                     "description": "Name of the ACME configuration defined in the network.acme.configurations section"
                   }
                 },
@@ -115,7 +114,7 @@
                 "items": {
                   "type": "string"
                 },
-                "description": "Acceptable endpoints to serve on the interface"
+                "description": "An array of regular expressions that specify which URL paths are served on the interface. Optional; if not present, all paths are served"
               }
             },
             "required": ["bind_address"]
@@ -140,12 +139,10 @@
                   },
                   "directory_url": {
                     "type": "string",
-                    "default": "",
                     "description": "URL of the ACME server's directory"
                   },
                   "service_dns_name": {
                     "type": "string",
-                    "default": "",
                     "description": "DNS name of the service we represent"
                   },
                   "contact": {
@@ -168,7 +165,7 @@
                   },
                   "challenge_server_interface": {
                     "type": "string",
-                    "description": "Name of the (http) challenge server interface"
+                    "description": "Name of the interface for the (http-01) challenge server to listen on"
                   }
                 },
                 "description": "ACME Configurations",

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -109,6 +109,13 @@
                 },
                 "required": ["authority"],
                 "additionalProperties": false
+              },
+              "accepted_endpoints": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Acceptable endpoints to serve on the interface"
               }
             },
             "required": ["bind_address"]

--- a/doc/operations/certificates.rst
+++ b/doc/operations/certificates.rst
@@ -127,6 +127,6 @@ To be able to bind to that port, the ``cchost`` binary may need to be given spec
     - ``contact``: A list of contact addresses, usually e-mail addresses, which must be prefixed with ``mailto:``. These contacts may receive notifications about service changes, e.g. certificate revocation or expiry.
     - ``terms_of_service_agreed``: A Boolean confirming that the operator accepts the terms of service for the CA. RFC8555 requires this to be set explicitly by the operator.
     - ``challenge_type``: Currently only `http-01 <https://letsencrypt.org/docs/challenge-types/>`_ is supported.
-    - ``challenge_server_interface``: Name of the interface that the ACME challenge server listens on. For http-01 challenges in production, this must listen on port 80.
+    - ``challenge_server_interface``: Name of the interface that the ACME challenge server listens on. For http-01 challenges in production, this interface must be exposed publicly on port 80.
 
 4. CCF nodes periodically check for certificate expiry and trigger renewal when 66% of the validity period has elapsed. The resulting certificates are stored in the ``ccf.gov.service.acme_certificates`` table and upon an update to this table, nodes will automatically install the corresponding certificate on their interfaces. If necessary, renewal can also be triggered manually by submitting a ``trigger_acme_refresh`` governance proposal.

--- a/doc/operations/certificates.rst
+++ b/doc/operations/certificates.rst
@@ -87,29 +87,35 @@ Unendorsed, self-signed (CA) service certificates are a complication for clients
 
 1. Get a globally reachable DNS name for your CCF network, e.g. ``my-ccf.example.com``, which resolves to the address of at least one node in the network. Multiple nodes or a load balancer address are fine too.
 
-2. ACME `http-01 <https://letsencrypt.org/docs/challenge-types/>`_ challenges require a challenge server to be reachable on port 80 (non-negotiable). 
+2. ACME `http-01 <https://letsencrypt.org/docs/challenge-types/>`_ challenges require a challenge server to be reachable on port 80 (non-negotiable).
 To be able to bind to that port, the ``cchost`` binary may need to be given special permission, e.g. by running ``sudo setcap CAP_NET_BIND_SERVICE=+eip cchost``. Alternatively, port 80 can be redirected to a non-privileged port that ``cchost`` may bind to without special permission.
 
-3. Each interface defined in the ``cchost`` configuration file can be given the name of an ACME configuration to use. The settings of each ACME configuration are defined in ``network.acme`` :doc:`configuration entry </operations/configuration>`. Note that this information is required by *all* nodes as they might have to renew the certificate(s) later.
+3. Each interface defined in the ``cchost`` configuration file can be given the name of an ACME configuration to use. The settings of each ACME configuration are defined in ``network.acme`` :doc:`configuration entry </operations/configuration>`. Note that this information is required by *all* nodes as they might have to renew the certificate(s) later. Further, an additional interface for the challenge server is required.
 
     The various options are as follows:
 
     .. code-block:: json
 
         "network": {
-            "rpc_interfaces": { 
+            "rpc_interfaces": {
                 ... ,
-                "acme_endorsed_interface": { ... , "endorsement": { ... , "acme_configuration": "my-acme-cfg" } }
+                "acme_endorsed_interface": { ... , "endorsement": { ... , "acme_configuration": "my-acme-cfg" } },
+                "acme_challenge_server_interface": {
+                    "bind_address": "... :80",
+                    "endorsement": { "authority": "Unsecured" },
+                    "accepted_endpoints": [ "/.well-known/acme-challenge/.*" ],
+                    ...
+                },
             },
             "acme": {
-                "my-acme-cfg": { 
+                "my-acme-cfg": {
                     "ca_certs": [ "-----BEGIN CERTIFICATE-----\nMIIBg ..." ],
                     "directory_url": "https://...",
-                    "service_dns_name": "my-ccf.example.com",        
+                    "service_dns_name": "my-ccf.example.com",
                     "contact": ["mailto:john@example.com"],
                     "terms_of_service_agreed": true,
                     "challenge_type": "http-01",
-                    "challenge_server_interface": "0.0.0.0:80"
+                    "challenge_server_interface": "acme_challenge_server_interface"
                 }
             }
         }
@@ -121,6 +127,6 @@ To be able to bind to that port, the ``cchost`` binary may need to be given spec
     - ``contact``: A list of contact addresses, usually e-mail addresses, which must be prefixed with ``mailto:``. These contacts may receive notifications about service changes, e.g. certificate revocation or expiry.
     - ``terms_of_service_agreed``: A Boolean confirming that the operator accepts the terms of service for the CA. RFC8555 requires this to be set explicitly by the operator.
     - ``challenge_type``: Currently only `http-01 <https://letsencrypt.org/docs/challenge-types/>`_ is supported.
-    - ``challenge_server_interface``: Interface for the ACME challenge server to listen on. For http-01 challenges, this must run on port 80.
+    - ``challenge_server_interface``: Name of the interface that the ACME challenge server listens on. For http-01 challenges in production, this must listen on port 80.
 
 4. CCF nodes periodically check for certificate expiry and trigger renewal when 66% of the validity period has elapsed. The resulting certificates are stored in the ``ccf.gov.service.acme_certificates`` table and upon an update to this table, nodes will automatically install the corresponding certificate on their interfaces. If necessary, renewal can also be triggered manually by submitting a ``trigger_acme_refresh`` governance proposal.

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -494,6 +494,9 @@
       },
       "NodeInfoNetwork_v2__NetInterface": {
         "properties": {
+          "accepted_endpoints": {
+            "$ref": "#/components/schemas/string_array"
+          },
           "bind_address": {
             "$ref": "#/components/schemas/string"
           },
@@ -761,6 +764,12 @@
       "json": {},
       "string": {
         "type": "string"
+      },
+      "string_array": {
+        "items": {
+          "$ref": "#/components/schemas/string"
+        },
+        "type": "array"
       },
       "string_to_ConsensusNodeConfig": {
         "additionalProperties": {

--- a/include/ccf/endpoint.h
+++ b/include/ccf/endpoint.h
@@ -94,22 +94,13 @@ namespace ccf::endpoints
     std::string js_module;
     /// JavaScript function name
     std::string js_function;
-    /// Flag to indicate that an endpoint does not require encrypted
-    /// communication
-    bool unencrypted_ok = false;
   };
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(EndpointProperties);
   DECLARE_JSON_REQUIRED_FIELDS(
     EndpointProperties, forwarding_required, authn_policies);
   DECLARE_JSON_OPTIONAL_FIELDS(
-    EndpointProperties,
-    openapi,
-    openapi_hidden,
-    mode,
-    js_module,
-    js_function,
-    unencrypted_ok);
+    EndpointProperties, openapi, openapi_hidden, mode, js_module, js_function);
 
   struct EndpointDefinition
   {
@@ -363,12 +354,6 @@ namespace ccf::endpoints
         installer->install(*this);
       }
     }
-
-    /** Overrides whether an Endpoint allows unencrypted communication
-     * @param v Boolean indicating whether unencrypted communication is ok
-     * @return This Endpoint for further modification
-     */
-    Endpoint& set_unencrypted_ok(bool v);
   };
 
   using EndpointPtr = std::shared_ptr<const Endpoint>;

--- a/include/ccf/service/node_info_network.h
+++ b/include/ccf/service/node_info_network.h
@@ -57,28 +57,35 @@ namespace ccf
 
   static constexpr auto PRIMARY_RPC_INTERFACE = "ccf.default_rpc_interface";
 
+  /// Node network information
   struct NodeInfoNetwork_v2
   {
     using NetAddress = std::string;
     using RpcInterfaceID = std::string;
     using NetProtocol = std::string;
 
+    /// Network interface description
     struct NetInterface
     {
       NetAddress bind_address;
       NetAddress published_address;
       NetProtocol protocol;
 
+      /// Maximum open sessions soft limit
       std::optional<size_t> max_open_sessions_soft = std::nullopt;
+
+      /// Maximum open sessions hard limit
       std::optional<size_t> max_open_sessions_hard = std::nullopt;
 
+      /// HTTP configuration
       std::optional<http::ParserConfiguration> http_configuration =
         std::nullopt;
 
+      /// Interface endorsement
       std::optional<Endorsement> endorsement = std::nullopt;
 
-      // Regular expressions of endpoints that are accessible over
-      // this interface. std::nullopt means everything is accepted.
+      /// Regular expressions of endpoints that are accessible over
+      /// this interface. std::nullopt means everything is accepted.
       std::optional<std::vector<std::string>> accepted_endpoints = std::nullopt;
 
       bool operator==(const NetInterface& other) const
@@ -89,23 +96,30 @@ namespace ccf
           max_open_sessions_soft == other.max_open_sessions_soft &&
           max_open_sessions_hard == other.max_open_sessions_hard &&
           endorsement == other.endorsement &&
-          http_configuration == other.http_configuration;
-        accepted_endpoints == other.accepted_endpoints;
+          http_configuration == other.http_configuration &&
+          accepted_endpoints == other.accepted_endpoints;
       }
     };
 
+    /// RPC interface mapping
     using RpcInterfaces = std::map<RpcInterfaceID, NetInterface>;
 
+    /// Node-to-node network interface
     NetInterface node_to_node_interface;
+
+    /// RPC interfaces
     RpcInterfaces rpc_interfaces;
 
+    /// ACME configuration description
     struct ACME
     {
+      /// Mapping of ACME client configuration names to configurations
       std::map<std::string, ccf::ACMEClientConfig> configurations;
 
       bool operator==(const ACME&) const = default;
     };
 
+    /// ACME configuration
     std::optional<ACME> acme = std::nullopt;
   };
 

--- a/include/ccf/service/node_info_network.h
+++ b/include/ccf/service/node_info_network.h
@@ -77,6 +77,10 @@ namespace ccf
 
       std::optional<Endorsement> endorsement = std::nullopt;
 
+      // Regular expressions of endpoints that are accessible over
+      // this interface. std::nullopt means everything is accepted.
+      std::optional<std::vector<std::string>> accepted_endpoints = std::nullopt;
+
       bool operator==(const NetInterface& other) const
       {
         return bind_address == other.bind_address &&
@@ -86,6 +90,7 @@ namespace ccf
           max_open_sessions_hard == other.max_open_sessions_hard &&
           endorsement == other.endorsement &&
           http_configuration == other.http_configuration;
+        accepted_endpoints == other.accepted_endpoints;
       }
     };
 
@@ -113,8 +118,8 @@ namespace ccf
     max_open_sessions_hard,
     published_address,
     protocol,
-    http_configuration);
-
+    http_configuration,
+    accepted_endpoints);
   DECLARE_JSON_TYPE(NodeInfoNetwork_v2::ACME);
   DECLARE_JSON_REQUIRED_FIELDS(NodeInfoNetwork_v2::ACME, configurations);
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(NodeInfoNetwork_v2);

--- a/src/endpoints/endpoint.cpp
+++ b/src/endpoints/endpoint.cpp
@@ -68,10 +68,4 @@ namespace ccf::endpoints
     properties.forwarding_required = fr;
     return *this;
   }
-
-  Endpoint& Endpoint::set_unencrypted_ok(bool v)
-  {
-    properties.unencrypted_ok = v;
-    return *this;
-  }
 }

--- a/src/node/acme_challenge_frontend.h
+++ b/src/node/acme_challenge_frontend.h
@@ -64,7 +64,6 @@ namespace ccf
         "/acme-challenge/{token}", HTTP_GET, handler, no_auth_required)
         .set_forwarding_required(endpoints::ForwardingRequired::Never)
         .set_auto_schema<void, std::string>()
-        .set_unencrypted_ok(true)
         .install();
     }
 

--- a/src/node/node_configuration_subsystem.h
+++ b/src/node/node_configuration_subsystem.h
@@ -5,16 +5,28 @@
 #include "ccf/node_subsystem_interface.h"
 #include "node/rpc/node_interface.h"
 
+#include <regex>
+
 namespace ccf
 {
+  struct NodeConfigurationState
+  {
+    const StartupConfig& node_config;
+    std::map<NodeInfoNetwork::RpcInterfaceID, std::vector<std::regex>>
+      rpc_interface_regexes;
+    bool initialized = false;
+  };
+
   class NodeConfigurationSubsystem : public AbstractNodeSubSystem
   {
   protected:
     AbstractNodeState& node_state;
+    NodeConfigurationState node_config_state;
 
   public:
     NodeConfigurationSubsystem(AbstractNodeState& node_state_) :
-      node_state(node_state_)
+      node_state(node_state_),
+      node_config_state({node_state_.get_node_config(), {}, false})
     {}
 
     virtual ~NodeConfigurationSubsystem() = default;
@@ -24,9 +36,38 @@ namespace ccf
       return "NodeConfiguration";
     }
 
-    virtual const StartupConfig& get()
+    virtual const NodeConfigurationState& get()
     {
-      return node_state.get_node_config();
+      if (!node_config_state.initialized)
+      {
+        initialize_interface_regexes();
+        node_config_state.initialized = true;
+      }
+      return node_config_state;
+    }
+
+    void initialize_interface_regexes()
+    {
+      for (const auto& [id, interface] :
+           node_config_state.node_config.network.rpc_interfaces)
+      {
+        LOG_TRACE_FMT("Check regex: {}", id);
+        if (interface.accepted_endpoints)
+        {
+          auto [it, ok] = node_config_state.rpc_interface_regexes.emplace(
+            id, std::vector<std::regex>{});
+          if (!ok)
+          {
+            throw std::runtime_error("Could not emplace interface regexes");
+          }
+          for (const auto& re : *interface.accepted_endpoints)
+          {
+            LOG_TRACE_FMT(
+              "Add accepted endpoint regex to interface config: {}", re);
+            it->second.emplace_back(re);
+          }
+        }
+      }
     }
   };
 }

--- a/tests/acme_endorsement.py
+++ b/tests/acme_endorsement.py
@@ -291,6 +291,7 @@ def run_pebble(args):
             endorsement=infra.interfaces.Endorsement(
                 authority=infra.interfaces.EndorsementAuthority.Unsecured
             ),
+            accepted_endpoints=["/.well-known/acme-challenge/.*"],
         )
         endorsed_interface.public_host = network_name
         node.rpc_interfaces["acme_endorsed_interface"] = endorsed_interface
@@ -396,6 +397,7 @@ def run_lets_encrypt(args):
                 endorsement=infra.interfaces.Endorsement(
                     authority=infra.interfaces.EndorsementAuthority.Unsecured
                 ),
+                accepted_endpoints=["/.well-known/acme-challenge/.*"],
             )
             node.rpc_interfaces["acme_challenge_server_if"] = challenge_server_interface
 
@@ -422,6 +424,7 @@ def run_unsecured(args):
             endorsement=infra.interfaces.Endorsement(
                 authority=infra.interfaces.EndorsementAuthority.Unsecured
             ),
+            accepted_endpoints=["/.well-known/acme-challenge/.*"],
         )
         node.rpc_interfaces["secured_interface"] = endorsed_interface
         node.rpc_interfaces["unsecured_interface"] = challenge_server_interface

--- a/tests/infra/interfaces.py
+++ b/tests/infra/interfaces.py
@@ -80,6 +80,7 @@ class RPCInterface(Interface):
     max_http_headers_count: Optional[int] = DEFAULT_MAX_HTTP_HEADERS_COUNT
     endorsement: Optional[Endorsement] = Endorsement()
     acme_configuration: Optional[str] = None
+    accepted_endpoints: Optional[str] = None
 
     @staticmethod
     def to_json(interface):
@@ -96,8 +97,8 @@ class RPCInterface(Interface):
             },
             "endorsement": Endorsement.to_json(interface.endorsement),
         }
-        if interface.acme_configuration:
-            r["acme_configuration"] = interface.acme_configuration
+        if interface.accepted_endpoints:
+            r["accepted_endpoints"] = interface.accepted_endpoints
         return r
 
     @staticmethod
@@ -118,8 +119,7 @@ class RPCInterface(Interface):
         )
         if "endorsement" in json:
             interface.endorsement = Endorsement.from_json(json["endorsement"])
-        if "acme_configuration" in json:
-            interface.acme_configuration = json.get("acme_configuration")
+        interface.accepted_endpoints = json.get("accepted_endpoints")
         return interface
 
 


### PR DESCRIPTION
This adds a new configuration field to restrict endpoints to a particular set of endpoints (as paths in a regexes). 