### PR TITLE
Initialize enclave logging offset

### DIFF
--- a/src/enclave/ringbuffer_logger.h
+++ b/src/enclave/ringbuffer_logger.h
@@ -13,7 +13,7 @@ namespace ccf
 
     // Current time, as us duration since epoch (from system_clock). Used to
     // produce offsets to host time when logging from inside the enclave
-    std::atomic<std::chrono::microseconds> us;
+    std::atomic<std::chrono::microseconds> us = {};
 
   public:
     RingbufferLogger(const ringbuffer::WriterPtr& writer_) : writer(writer_) {}


### PR DESCRIPTION
Uninitialized variable leads to terrible, horrible, no good very bad logging like this (in debug virtual builds):

```
2022-06-23T10:45:51.198881Z        100 [info ] ../src/host/main.cpp:412             | Startup host time: 2022-06-23 10:45:51
2022-06-23T10:45:51.200313Z        100 [info ] ../src/host/main.cpp:464             | Creating new node: new network (with 3 initial member(s) and 3 member(s) required for recovery)
2022-06-23T10:45:51.200338Z        100 [info ] ../src/host/main.cpp:544             | Initialising enclave: enclave_create_node
2022-06-23T10:45:51.300529Z -1655951080.618 0   [trace] ../src/enclave/enclave.h:110         | Creating ledger secrets
2022-06-23T10:45:51.300577Z -1655951080.618 0   [trace] ../src/enclave/enclave.h:113         | Creating node
2022-06-23T10:45:51.300601Z -1655951080.618 0   [trace] ../src/enclave/enclave.h:117         | Creating context
```

As long as this is 0-initialized (as it is already in most build configs), the logging code correctly recognises that it doesn't yet have a sensible offset to calculate from:
```
2022-06-23T10:51:31.563126Z        100 [info ] ../src/host/main.cpp:412             | Startup host time: 2022-06-23 10:51:31
2022-06-23T10:51:31.564590Z        100 [info ] ../src/host/main.cpp:464             | Creating new node: new network (with 3 initial member(s) and 3 member(s) required for recovery)
2022-06-23T10:51:31.564616Z        100 [info ] ../src/host/main.cpp:544             | Initialising enclave: enclave_create_node
2022-06-23T10:51:31.664804Z        0   [trace] ../src/enclave/enclave.h:110         | Creating ledger secrets
2022-06-23T10:51:31.664859Z        0   [trace] ../src/enclave/enclave.h:113         | Creating node
2022-06-23T10:51:31.664881Z        0   [trace] ../src/enclave/enclave.h:117         | Creating context
```