### PR TITLE
[release/2.x] Cherry pick: Reflect unsafe status in /node/version (#3942)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - New per-interface configuration entries (`network.rpc_interfaces.http_configuration`) are added to let operators cap the maximum size of body, header value size and number of headers in client HTTP requests. The client session is automatically closed if the HTTP request exceeds one of these limits (#3941).
+- `/node/version` now contains an `unsafe` flag reflecting the status of the build.
 
 ### Changed
 
@@ -1609,3 +1610,4 @@ Initial pre-release
 [0.4]: https://github.com/microsoft/CCF/releases/tag/v0.4
 [0.3]: https://github.com/microsoft/CCF/releases/tag/v0.3
 [2.0.0-rc8]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.0-rc8
+[unreleased]: https://github.com/microsoft/CCF/releases/tag/ccf-Unreleased

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -10,6 +10,9 @@ option(UNSAFE_VERSION "Produce build with unsafe logging levels" OFF)
 set(CCF_PROJECT "ccf")
 if(UNSAFE_VERSION)
   set(CCF_PROJECT "${CCF_PROJECT}_unsafe")
+  add_compile_definitions(UNSAFE_VERSION)
+  file(WRITE ${CMAKE_BINARY_DIR}/UNSAFE "UNSAFE")
+  install(FILES ${CMAKE_BINARY_DIR}/UNSAFE DESTINATION share)
 endif()
 
 # If possible, deduce project version from git environment

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -386,11 +386,15 @@
           },
           "quickjs_version": {
             "$ref": "#/components/schemas/string"
+          },
+          "unsafe": {
+            "$ref": "#/components/schemas/boolean"
           }
         },
         "required": [
           "ccf_version",
-          "quickjs_version"
+          "quickjs_version",
+          "unsafe"
         ],
         "type": "object"
       },
@@ -797,7 +801,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "2.18.1"
+    "version": "2.20.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -44,6 +44,7 @@ namespace ccf
     {
       std::string ccf_version;
       std::string quickjs_version;
+      bool unsafe;
     };
   };
 

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -370,7 +370,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
-      openapi_info.document_version = "2.18.1";
+      openapi_info.document_version = "2.20.0";
     }
 
     void init_handlers() override
@@ -1302,6 +1302,12 @@ namespace ccf
         GetVersion::Out result;
         result.ccf_version = ccf::ccf_version;
         result.quickjs_version = ccf::quickjs_version;
+#ifdef UNSAFE_VERSION
+        result.unsafe = true;
+#else
+        result.unsafe = false;
+#endif
+
         return make_success(result);
       };
 

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -17,7 +17,8 @@ namespace ccf
     GetState::Out, recovery_target_seqno, last_recovered_seqno)
 
   DECLARE_JSON_TYPE(GetVersion::Out)
-  DECLARE_JSON_REQUIRED_FIELDS(GetVersion::Out, ccf_version, quickjs_version)
+  DECLARE_JSON_REQUIRED_FIELDS(
+    GetVersion::Out, ccf_version, quickjs_version, unsafe)
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(JoinNetworkNodeToNode::In)
   DECLARE_JSON_REQUIRED_FIELDS(

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -386,6 +386,9 @@ def test_version(network, args):
         with node.client() as c:
             r = c.get("/node/version")
             assert r.body.json()["ccf_version"] == args.ccf_version
+            assert r.body.json()["unsafe"] == os.path.exists(
+                os.path.join(args.binary_dir, "UNSAFE")
+            )
 
 
 @reqs.description("Replace a node on the same addresses")


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Reflect unsafe status in /node/version (#3942)](https://github.com/microsoft/CCF/pull/3942)