### PR TITLE
[release/2.x] Cherry pick: Use custom mutex implementation on SGX (#3978)

### DIFF
--- a/.threading_canary
+++ b/.threading_canary
@@ -1,1 +1,1 @@
-Apparently, there are resuscitation cages for canaries, to get multiple "uses" out of them!
+This looks like a 'job' for Threading Canary!

--- a/include/ccf/ds/mutex.h
+++ b/include/ccf/ds/mutex.h
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#if defined(INSIDE_ENCLAVE) && !defined(VIRTUAL_ENCLAVE)
+#  include <pthread.h>
+
+namespace ccf
+{
+  class Mutex
+  {
+  private:
+    pthread_spinlock_t sl;
+
+  public:
+    Mutex()
+    {
+      pthread_spin_init(&sl, PTHREAD_PROCESS_PRIVATE);
+    }
+
+    ~Mutex()
+    {
+      pthread_spin_destroy(&sl);
+    }
+
+    void lock()
+    {
+      pthread_spin_lock(&sl);
+    }
+
+    bool try_lock()
+    {
+      return pthread_spin_trylock(&sl) == 0;
+    }
+
+    void unlock()
+    {
+      pthread_spin_unlock(&sl);
+    }
+  };
+}
+
+#else
+#  include <mutex>
+
+namespace ccf
+{
+  using Mutex = std::mutex;
+}
+#endif

--- a/include/ccf/endpoint_registry.h
+++ b/include/ccf/endpoint_registry.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ccf/ds/json_schema.h"
+#include "ccf/ds/mutex.h"
 #include "ccf/endpoint.h"
 #include "ccf/endpoint_context.h"
 #include "ccf/rpc_context.h"
@@ -162,7 +163,7 @@ namespace ccf::endpoints
       std::map<RESTVerb, std::shared_ptr<PathTemplatedEndpoint>>>
       templated_endpoints;
 
-    std::mutex metrics_lock;
+    ccf::Mutex metrics_lock;
     std::map<std::string, std::map<std::string, Metrics>> metrics;
 
     EndpointRegistry::Metrics& get_metrics_for_endpoint(

--- a/src/consensus/aft/impl/state.h
+++ b/src/consensus/aft/impl/state.h
@@ -5,6 +5,7 @@
 #include "ccf/crypto/key_pair.h"
 #include "ccf/crypto/verifier.h"
 #include "ccf/ds/logger.h"
+#include "ccf/ds/mutex.h"
 #include "ccf/tx_status.h"
 #include "consensus/aft/raft_types.h"
 #include "kv/kv_types.h"
@@ -140,7 +141,7 @@ namespace aft
   {
     State(const ccf::NodeId& my_node_id_) : my_node_id(my_node_id_) {}
 
-    std::mutex lock;
+    ccf::Mutex lock;
 
     ccf::NodeId my_node_id;
     ccf::View current_view = 0;

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ccf/ds/logger.h"
+#include "ccf/ds/mutex.h"
 #include "ccf/tx_id.h"
 #include "ccf/tx_status.h"
 #include "ds/serialized.h"
@@ -21,7 +22,6 @@
 #include <algorithm>
 #include <deque>
 #include <list>
-#include <mutex>
 #include <random>
 #include <unordered_map>
 #include <vector>
@@ -226,7 +226,7 @@ namespace aft
 
     bool view_change_in_progress() override
     {
-      std::unique_lock<std::mutex> guard(state->lock);
+      std::unique_lock<ccf::Mutex> guard(state->lock);
       if (consensus_type == ConsensusType::BFT)
       {
         LOG_FAIL_FMT("Unsupported");
@@ -250,7 +250,7 @@ namespace aft
 
     bool can_replicate() override
     {
-      std::unique_lock<std::mutex> guard(state->lock);
+      std::unique_lock<ccf::Mutex> guard(state->lock);
       return leadership_state == kv::LeadershipState::Leader &&
         !retirement_committable_idx.has_value();
     }
@@ -296,7 +296,7 @@ namespace aft
     {
       // When receiving append entries as a follower, all security domains will
       // be deserialised
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
       public_only = false;
     }
 
@@ -315,7 +315,7 @@ namespace aft
           "Can't force leadership if there is already a leader");
       }
 
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
       state->current_view += starting_view_change;
       become_leader(true);
     }
@@ -334,7 +334,7 @@ namespace aft
           "Can't force leadership if there is already a leader");
       }
 
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
       state->current_view = term;
       state->last_idx = index;
       state->commit_idx = commit_idx_;
@@ -352,7 +352,7 @@ namespace aft
     {
       // This should only be called when the node resumes from a snapshot and
       // before it has received any append entries.
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
 
       state->last_idx = index;
       state->commit_idx = index;
@@ -371,26 +371,26 @@ namespace aft
 
     Index get_committed_seqno() override
     {
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
       return get_commit_idx_unsafe();
     }
 
     Term get_view() override
     {
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
       return state->current_view;
     }
 
     std::pair<Term, Index> get_committed_txid() override
     {
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
       ccf::SeqNo commit_idx = get_commit_idx_unsafe();
       return {get_term_internal(commit_idx), commit_idx};
     }
 
     std::optional<kv::Consensus::SignableTxIndices> get_signable_txid() override
     {
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
       if (
         consensus_type == ConsensusType::BFT ||
         state->commit_idx >= election_index)
@@ -409,7 +409,7 @@ namespace aft
 
     Term get_view(Index idx) override
     {
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
       return get_term_internal(idx);
     }
 
@@ -605,7 +605,7 @@ namespace aft
     std::optional<kv::Configuration::Nodes> orc(
       kv::ReconfigurationId rid, const ccf::NodeId& node_id) override
     {
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
 
       LOG_DEBUG_FMT(
         "Configurations: ORC for configuration #{} from {}", rid, node_id);
@@ -669,14 +669,14 @@ namespace aft
 
     Configuration::Nodes get_latest_configuration() override
     {
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
       return get_latest_configuration_unsafe();
     }
 
     kv::ConsensusDetails get_details() override
     {
       kv::ConsensusDetails details;
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
       details.primary_id = leader_id;
       details.current_view = state->current_view;
       details.ticking = ticking;
@@ -705,7 +705,7 @@ namespace aft
 
     bool replicate(const kv::BatchVector& entries, Term term) override
     {
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
 
       if (leadership_state != kv::LeadershipState::Leader)
       {
@@ -865,7 +865,7 @@ namespace aft
 
     void periodic(std::chrono::milliseconds elapsed) override
     {
-      std::unique_lock<std::mutex> guard(state->lock);
+      std::unique_lock<ccf::Mutex> guard(state->lock);
       timeout_elapsed += elapsed;
 
       if (leadership_state == kv::LeadershipState::Leader)
@@ -1079,7 +1079,7 @@ namespace aft
       const uint8_t* data,
       size_t size)
     {
-      std::unique_lock<std::mutex> guard(state->lock);
+      std::unique_lock<ccf::Mutex> guard(state->lock);
 
       LOG_DEBUG_FMT(
         "Received append entries: {}.{} to {}.{} (from {} in term {})",
@@ -1452,7 +1452,7 @@ namespace aft
     void recv_append_entries_response(
       const ccf::NodeId& from, AppendEntriesResponse r)
     {
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
       // Ignore if we're not the leader.
 
       if (leadership_state != kv::LeadershipState::Leader)
@@ -1582,7 +1582,7 @@ namespace aft
 
     void recv_request_vote(const ccf::NodeId& from, RequestVote r)
     {
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
 
       // Do not check that from is a known node. It is possible to receive
       // RequestVotes from nodes that this node doesn't yet know, just as it
@@ -1690,7 +1690,7 @@ namespace aft
     void recv_request_vote_response(
       const ccf::NodeId& from, RequestVoteResponse r)
     {
-      std::lock_guard<std::mutex> guard(state->lock);
+      std::lock_guard<ccf::Mutex> guard(state->lock);
 
       if (leadership_state != kv::LeadershipState::Candidate)
       {

--- a/src/ds/histogram.h
+++ b/src/ds/histogram.h
@@ -6,11 +6,12 @@
 #  include <intrin.h>
 #endif
 
+#include "ccf/ds/mutex.h"
+
 #include <cassert>
 #include <chrono>
 #include <limits>
 #include <map>
-#include <mutex>
 #include <utility>
 
 namespace histogram
@@ -252,7 +253,7 @@ namespace histogram
   class Global
   {
   private:
-    std::mutex m;
+    ccf::Mutex m;
     std::string name;
     std::string file;
     size_t line;
@@ -270,7 +271,7 @@ namespace histogram
 
     void add(H& histogram)
     {
-      std::lock_guard<std::mutex> lock(m);
+      std::lock_guard<ccf::Mutex> lock(m);
       histogram.next = head;
       head = &histogram;
     }

--- a/src/ds/test/stub_writer.h
+++ b/src/ds/test/stub_writer.h
@@ -2,10 +2,10 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ccf/ds/mutex.h"
 #include "ds/ring_buffer_types.h"
 
 #include <limits>
-#include <mutex>
 #include <vector>
 
 struct StubWriter : public ringbuffer::AbstractWriter
@@ -17,7 +17,7 @@ public:
     bool finished;
     std::vector<uint8_t> contents;
   };
-  std::mutex writes_mutex;
+  ccf::Mutex writes_mutex;
   std::vector<Write> writes;
 
   Write& get_write(const WriteMarker& marker)
@@ -35,7 +35,7 @@ public:
     bool wait = true,
     size_t* identifier = nullptr) override
   {
-    std::lock_guard<std::mutex> guard(writes_mutex);
+    std::lock_guard<ccf::Mutex> guard(writes_mutex);
     const auto seqno = writes.size();
     writes.push_back(Write{m, false, {}});
     return seqno;
@@ -43,14 +43,14 @@ public:
 
   void finish(const WriteMarker& marker) override
   {
-    std::lock_guard<std::mutex> guard(writes_mutex);
+    std::lock_guard<ccf::Mutex> guard(writes_mutex);
     get_write(marker).finished = true;
   }
 
   WriteMarker write_bytes(
     const WriteMarker& marker, const uint8_t* bytes, size_t size) override
   {
-    std::lock_guard<std::mutex> guard(writes_mutex);
+    std::lock_guard<ccf::Mutex> guard(writes_mutex);
     auto& write = get_write(marker);
     write.contents.insert(write.contents.end(), bytes, bytes + size);
     return marker;

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -14,7 +14,7 @@
 #include <thread>
 
 // the central enclave object
-static std::mutex create_lock;
+static ccf::Mutex create_lock;
 static std::atomic<ccf::Enclave*> e;
 
 std::atomic<uint16_t> num_pending_threads = 0;
@@ -58,6 +58,24 @@ extern "C"
     }
   }
 
+  // Confirming in-enclave behaviour in separate unit tests is tricky, so we do
+  // final sanity checks on some basic behaviour here, on every enclave launch.
+  void enclave_sanity_checks()
+  {
+    {
+      ccf::Mutex m;
+      m.lock();
+      if (m.try_lock())
+      {
+        LOG_FATAL_FMT("Able to lock mutex multiple times");
+        abort();
+      }
+      m.unlock();
+    }
+
+    LOG_DEBUG_FMT("All sanity check tests passed");
+  }
+
   CreateNodeStatus enclave_create_node(
     void* enclave_config,
     char* ccf_config,
@@ -75,7 +93,7 @@ extern "C"
     size_t num_worker_threads,
     void* time_location)
   {
-    std::lock_guard<std::mutex> guard(create_lock);
+    std::lock_guard<ccf::Mutex> guard(create_lock);
 
     if (e != nullptr)
     {
@@ -112,6 +130,8 @@ extern "C"
     logger::config::loggers().push_back(std::move(new_logger));
 
     oe_enclave_log_set_callback(nullptr, &open_enclave_logging_callback);
+
+    enclave_sanity_checks();
 
     {
       // Report enclave version to host
@@ -299,7 +319,7 @@ extern "C"
     {
       uint16_t tid;
       {
-        std::lock_guard<std::mutex> guard(create_lock);
+        std::lock_guard<ccf::Mutex> guard(create_lock);
 
         tid = threading::ThreadMessaging::thread_count.fetch_add(1);
         threading::thread_ids.emplace(std::pair<std::thread::id, uint16_t>(

--- a/src/enclave/rpc_sessions.h
+++ b/src/enclave/rpc_sessions.h
@@ -50,7 +50,7 @@ namespace ccf
     std::shared_ptr<RPCMap> rpc_map;
     std::unordered_map<ListenInterfaceID, std::shared_ptr<tls::Cert>> certs;
 
-    std::mutex lock;
+    ccf::Mutex lock;
     std::unordered_map<
       tls::ConnID,
       std::pair<ListenInterfaceID, std::shared_ptr<Endpoint>>>
@@ -172,26 +172,26 @@ namespace ccf
 
     void report_parsing_error(tls::ConnID id) override
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       get_interface_from_session_id(id).errors.parsing++;
     }
 
     void report_request_payload_too_large_error(tls::ConnID id) override
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       get_interface_from_session_id(id).errors.request_payload_too_large++;
     }
 
     void report_request_header_too_large_error(tls::ConnID id) override
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       get_interface_from_session_id(id).errors.request_header_too_large++;
     }
 
     void update_listening_interface_options(
       const ccf::NodeInfoNetwork& node_info)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       for (const auto& [name, interface] : node_info.rpc_interfaces)
       {
@@ -222,7 +222,7 @@ namespace ccf
     ccf::SessionMetrics get_session_metrics()
     {
       ccf::SessionMetrics sm;
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       sm.active = sessions.size();
       sm.peak = sessions_peak;
@@ -260,7 +260,7 @@ namespace ccf
       auto cert = std::make_shared<tls::Cert>(
         nullptr, cert_, pk, std::nullopt, /*auth_required ==*/false);
 
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       for (auto& [listen_interface_id, interface] : listening_interfaces)
       {
@@ -273,7 +273,7 @@ namespace ccf
 
     void accept(tls::ConnID id, const ListenInterfaceID& listen_interface_id)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       if (sessions.find(id) != sessions.end())
       {
@@ -370,7 +370,7 @@ namespace ccf
 
     bool reply_async(tls::ConnID id, std::vector<uint8_t>&& data) override
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       auto search = sessions.find(id);
       if (search == sessions.end())
@@ -387,7 +387,7 @@ namespace ccf
 
     void remove_session(tls::ConnID id)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       LOG_DEBUG_FMT("Closing a session inside the enclave: {}", id);
       const auto search = sessions.find(id);
       if (search != sessions.end())
@@ -404,7 +404,7 @@ namespace ccf
     std::shared_ptr<ClientEndpoint> create_client(
       std::shared_ptr<tls::Cert> cert)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       auto ctx = std::make_unique<tls::Client>(cert);
       auto id = get_next_client_id();
 

--- a/src/endpoints/authentication/sig_auth.cpp
+++ b/src/endpoints/authentication/sig_auth.cpp
@@ -4,6 +4,7 @@
 #include "ccf/endpoints/authentication/sig_auth.h"
 
 #include "ccf/crypto/verifier.h"
+#include "ccf/ds/mutex.h"
 #include "ccf/rpc_context.h"
 #include "ccf/service/tables/members.h"
 #include "ccf/service/tables/users.h"
@@ -26,7 +27,7 @@ namespace ccf
   {
     static constexpr size_t DEFAULT_MAX_VERIFIERS = 50;
 
-    std::mutex verifiers_lock;
+    ccf::Mutex verifiers_lock;
     LRU<crypto::Pem, crypto::VerifierPtr> verifiers;
 
     VerifierCache(size_t max_verifiers = DEFAULT_MAX_VERIFIERS) :
@@ -35,7 +36,7 @@ namespace ccf
 
     crypto::VerifierPtr get_verifier(const crypto::Pem& pem)
     {
-      std::lock_guard<std::mutex> guard(verifiers_lock);
+      std::lock_guard<ccf::Mutex> guard(verifiers_lock);
 
       crypto::VerifierPtr verifier = nullptr;
 

--- a/src/endpoints/base_endpoint_registry.cpp
+++ b/src/endpoints/base_endpoint_registry.cpp
@@ -287,7 +287,7 @@ namespace ccf
     EndpointMetrics& endpoint_metrics)
   {
     endpoint_metrics.metrics.clear();
-    std::lock_guard<std::mutex> guard(metrics_lock);
+    std::lock_guard<ccf::Mutex> guard(metrics_lock);
     for (const auto& [path, verb_metrics] : metrics)
     {
       for (const auto& [verb, metric] : verb_metrics)

--- a/src/endpoints/endpoint_registry.cpp
+++ b/src/endpoints/endpoint_registry.cpp
@@ -393,28 +393,28 @@ namespace ccf::endpoints
 
   void EndpointRegistry::increment_metrics_calls(const EndpointDefinitionPtr& e)
   {
-    std::lock_guard<std::mutex> guard(metrics_lock);
+    std::lock_guard<ccf::Mutex> guard(metrics_lock);
     get_metrics_for_endpoint(e).calls++;
   }
 
   void EndpointRegistry::increment_metrics_errors(
     const EndpointDefinitionPtr& e)
   {
-    std::lock_guard<std::mutex> guard(metrics_lock);
+    std::lock_guard<ccf::Mutex> guard(metrics_lock);
     get_metrics_for_endpoint(e).errors++;
   }
 
   void EndpointRegistry::increment_metrics_failures(
     const EndpointDefinitionPtr& e)
   {
-    std::lock_guard<std::mutex> guard(metrics_lock);
+    std::lock_guard<ccf::Mutex> guard(metrics_lock);
     get_metrics_for_endpoint(e).failures++;
   }
 
   void EndpointRegistry::increment_metrics_retries(
     const EndpointDefinitionPtr& e)
   {
-    std::lock_guard<std::mutex> guard(metrics_lock);
+    std::lock_guard<ccf::Mutex> guard(metrics_lock);
     get_metrics_for_endpoint(e).retries++;
   }
 }

--- a/src/host/dns.h
+++ b/src/host/dns.h
@@ -10,7 +10,7 @@
 namespace asynchost
 {
   static std::unordered_set<uv_getaddrinfo_t*> pending_resolve_requests;
-  static std::mutex pending_resolve_requests_mtx;
+  static ccf::Mutex pending_resolve_requests_mtx;
 
   class DNS
   {
@@ -36,7 +36,7 @@ namespace asynchost
       if (async)
       {
         {
-          std::unique_lock<std::mutex> guard(pending_resolve_requests_mtx);
+          std::unique_lock<ccf::Mutex> guard(pending_resolve_requests_mtx);
           pending_resolve_requests.insert(resolver);
         }
 
@@ -56,7 +56,7 @@ namespace asynchost
             service,
             uv_strerror(rc));
           {
-            std::unique_lock<std::mutex> guard(pending_resolve_requests_mtx);
+            std::unique_lock<ccf::Mutex> guard(pending_resolve_requests_mtx);
             pending_resolve_requests.erase(resolver);
           }
           delete resolver;

--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ccf/ds/logger.h"
+#include "ccf/ds/mutex.h"
 #include "ccf/ds/nonstd.h"
 #include "consensus/ledger_enclave_types.h"
 #include "ds/files.h"
@@ -132,7 +133,7 @@ namespace asynchost
     // This uses C stdio instead of fstream because an fstream
     // cannot be truncated.
     FILE* file = nullptr;
-    std::mutex file_lock;
+    ccf::Mutex file_lock;
 
     size_t start_idx = 1;
     size_t total_len = 0; // Points to end of last written entry
@@ -374,7 +375,7 @@ namespace asynchost
         return std::nullopt;
       }
 
-      std::unique_lock<std::mutex> guard(file_lock);
+      std::unique_lock<ccf::Mutex> guard(file_lock);
       auto size = entries_size(from, to);
       std::vector<uint8_t> entries(size);
       fseeko(file, positions.at(from - start_idx), SEEK_SET);
@@ -573,7 +574,7 @@ namespace asynchost
     // Cache of ledger files for reading
     size_t max_read_cache_files;
     std::list<std::shared_ptr<LedgerFile>> files_read_cache;
-    std::mutex read_cache_lock;
+    ccf::Mutex read_cache_lock;
 
     const size_t chunk_threshold;
     size_t last_idx = 0;
@@ -614,7 +615,7 @@ namespace asynchost
       }
 
       {
-        std::unique_lock<std::mutex> guard(read_cache_lock);
+        std::unique_lock<ccf::Mutex> guard(read_cache_lock);
 
         // First, try to find file from read cache
         for (auto const& f : files_read_cache)
@@ -669,7 +670,7 @@ namespace asynchost
       }
 
       {
-        std::unique_lock<std::mutex> guard(read_cache_lock);
+        std::unique_lock<ccf::Mutex> guard(read_cache_lock);
 
         files_read_cache.emplace_back(match_file);
         if (files_read_cache.size() > max_read_cache_files)

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -149,7 +149,7 @@ namespace asynchost
     ~TCPImpl()
     {
       {
-        std::unique_lock<std::mutex> guard(pending_resolve_requests_mtx);
+        std::unique_lock<ccf::Mutex> guard(pending_resolve_requests_mtx);
         for (auto& req : pending_resolve_requests)
         {
           // The UV request objects can stay, but if there are any references
@@ -601,7 +601,7 @@ namespace asynchost
 
     static void on_resolved(uv_getaddrinfo_t* req, int rc, struct addrinfo* res)
     {
-      std::unique_lock<std::mutex> guard(pending_resolve_requests_mtx);
+      std::unique_lock<ccf::Mutex> guard(pending_resolve_requests_mtx);
       pending_resolve_requests.erase(req);
 
       if (req->data)

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -26,16 +26,16 @@ namespace kv
     // indicates the version at which the Map was created.
     using Maps = std::
       map<std::string, std::pair<kv::Version, std::shared_ptr<untyped::Map>>>;
-    std::mutex maps_lock;
+    ccf::Mutex maps_lock;
     Maps maps;
 
-    std::mutex version_lock;
+    ccf::Mutex version_lock;
     Version version = 0;
     Version last_new_map = kv::NoVersion;
     Version compacted = 0;
 
     // Calls to Store::commit are made atomic by taking this lock.
-    std::mutex commit_lock;
+    ccf::Mutex commit_lock;
 
     // Term at which write future transactions should be committed.
     Term term_of_next_version = 0;
@@ -59,8 +59,8 @@ namespace kv
   public:
     void clear()
     {
-      std::lock_guard<std::mutex> mguard(maps_lock);
-      std::lock_guard<std::mutex> vguard(version_lock);
+      std::lock_guard<ccf::Mutex> mguard(maps_lock);
+      std::lock_guard<ccf::Mutex> vguard(version_lock);
 
       maps.clear();
       pending_txs.clear();
@@ -127,7 +127,7 @@ namespace kv
         return false;
       }
       {
-        std::lock_guard<std::mutex> vguard(version_lock);
+        std::lock_guard<ccf::Mutex> vguard(version_lock);
         version = v;
         last_replicated = version;
         term_of_last_version = term;
@@ -356,7 +356,7 @@ namespace kv
       auto snapshot = std::make_unique<StoreSnapshot>(v);
 
       {
-        std::lock_guard<std::mutex> mguard(maps_lock);
+        std::lock_guard<ccf::Mutex> mguard(maps_lock);
 
         for (auto& it : maps)
         {
@@ -421,7 +421,7 @@ namespace kv
       }
       auto v = v_.value();
 
-      std::lock_guard<std::mutex> mguard(maps_lock);
+      std::lock_guard<ccf::Mutex> mguard(maps_lock);
 
       for (auto& it : maps)
       {
@@ -518,7 +518,7 @@ namespace kv
       }
 
       {
-        std::lock_guard<std::mutex> vguard(version_lock);
+        std::lock_guard<ccf::Mutex> vguard(version_lock);
         version = v;
         last_replicated = v;
       }
@@ -552,7 +552,7 @@ namespace kv
         snapshotter->commit(v, generate_snapshot);
       }
 
-      std::lock_guard<std::mutex> mguard(maps_lock);
+      std::lock_guard<ccf::Mutex> mguard(maps_lock);
 
       if (v > current_version())
       {
@@ -578,7 +578,7 @@ namespace kv
       }
 
       {
-        std::lock_guard<std::mutex> vguard(version_lock);
+        std::lock_guard<ccf::Mutex> vguard(version_lock);
         compacted = v;
 
         auto h = get_history();
@@ -606,10 +606,10 @@ namespace kv
         snapshotter->rollback(tx_id.version);
       }
 
-      std::lock_guard<std::mutex> mguard(maps_lock);
+      std::lock_guard<ccf::Mutex> mguard(maps_lock);
 
       {
-        std::lock_guard<std::mutex> vguard(version_lock);
+        std::lock_guard<ccf::Mutex> vguard(version_lock);
         if (tx_id.version < compacted)
         {
           throw std::logic_error(fmt::format(
@@ -687,7 +687,7 @@ namespace kv
     {
       // Note: This should only be called once, when the store is first
       // initialised. term_of_next_version is later updated via rollback.
-      std::lock_guard<std::mutex> vguard(version_lock);
+      std::lock_guard<ccf::Mutex> vguard(version_lock);
       if (term_of_next_version != 0)
       {
         throw std::logic_error("term_of_next_version is already initialised");
@@ -764,7 +764,7 @@ namespace kv
       // rather than with the actual value read. As a result, they don't
       // need snapshot isolation on the map state, and so do not need to
       // lock each of the maps before creating the transaction.
-      std::lock_guard<std::mutex> mguard(maps_lock);
+      std::lock_guard<ccf::Mutex> mguard(maps_lock);
 
       for (auto r = d.start_map(); r.has_value(); r = d.start_map())
       {
@@ -866,14 +866,14 @@ namespace kv
     Version current_version() override
     {
       // Must lock in case the version is being incremented.
-      std::lock_guard<std::mutex> vguard(version_lock);
+      std::lock_guard<ccf::Mutex> vguard(version_lock);
       return version;
     }
 
     kv::TxID current_txid() override
     {
       // Must lock in case the version or read term is being incremented.
-      std::lock_guard<std::mutex> vguard(version_lock);
+      std::lock_guard<ccf::Mutex> vguard(version_lock);
       return current_txid_unsafe();
     }
 
@@ -886,21 +886,21 @@ namespace kv
     std::pair<TxID, Term> current_txid_and_commit_term() override
     {
       // Must lock in case the version or commit term is being incremented.
-      std::lock_guard<std::mutex> vguard(version_lock);
+      std::lock_guard<ccf::Mutex> vguard(version_lock);
       return {current_txid_unsafe(), term_of_next_version};
     }
 
     Version compacted_version() override
     {
       // Must lock in case the store is being compacted.
-      std::lock_guard<std::mutex> vguard(version_lock);
+      std::lock_guard<ccf::Mutex> vguard(version_lock);
       return compacted;
     }
 
     Term commit_view() override
     {
       // Must lock in case the commit_view is being incremented.
-      std::lock_guard<std::mutex> vguard(version_lock);
+      std::lock_guard<ccf::Mutex> vguard(version_lock);
       return term_of_next_version;
     }
 
@@ -915,7 +915,7 @@ namespace kv
         return CommitResult::SUCCESS;
       }
 
-      std::lock_guard<std::mutex> cguard(commit_lock);
+      std::lock_guard<ccf::Mutex> cguard(commit_lock);
 
       LOG_DEBUG_FMT(
         "Store::commit {}{}",
@@ -929,7 +929,7 @@ namespace kv
       ccf::View replication_view = 0;
 
       {
-        std::lock_guard<std::mutex> vguard(version_lock);
+        std::lock_guard<ccf::Mutex> vguard(version_lock);
         if (txid.term != term_of_next_version && consensus->is_primary())
         {
           // This can happen when a transaction started before a view change,
@@ -1027,7 +1027,7 @@ namespace kv
 
       if (c->replicate(batch, replication_view))
       {
-        std::lock_guard<std::mutex> vguard(version_lock);
+        std::lock_guard<ccf::Mutex> vguard(version_lock);
         if (
           last_replicated == previous_last_replicated &&
           previous_rollback_count == rollback_count &&
@@ -1046,7 +1046,7 @@ namespace kv
 
     bool must_force_ledger_chunk(Version version) override
     {
-      std::lock_guard<std::mutex> vguard(version_lock);
+      std::lock_guard<ccf::Mutex> vguard(version_lock);
       return must_force_ledger_chunk_unsafe(version);
     }
 
@@ -1079,7 +1079,7 @@ namespace kv
 
     std::tuple<Version, Version> next_version(bool commit_new_map) override
     {
-      std::lock_guard<std::mutex> vguard(version_lock);
+      std::lock_guard<ccf::Mutex> vguard(version_lock);
       Version v = next_version_unsafe();
 
       auto previous_last_new_map = last_new_map;
@@ -1093,13 +1093,13 @@ namespace kv
 
     Version next_version() override
     {
-      std::lock_guard<std::mutex> vguard(version_lock);
+      std::lock_guard<ccf::Mutex> vguard(version_lock);
       return next_version_unsafe();
     }
 
     TxID next_txid() override
     {
-      std::lock_guard<std::mutex> vguard(version_lock);
+      std::lock_guard<ccf::Mutex> vguard(version_lock);
       next_version_unsafe();
 
       return {term_of_next_version, version};
@@ -1107,7 +1107,7 @@ namespace kv
 
     size_t committable_gap() override
     {
-      std::lock_guard<std::mutex> vguard(version_lock);
+      std::lock_guard<ccf::Mutex> vguard(version_lock);
       return version - last_committable;
     }
 
@@ -1138,8 +1138,8 @@ namespace kv
         }
       }
 
-      std::lock_guard<std::mutex> this_maps_guard(maps_lock);
-      std::lock_guard<std::mutex> other_maps_guard(store.maps_lock);
+      std::lock_guard<ccf::Mutex> this_maps_guard(maps_lock);
+      std::lock_guard<ccf::Mutex> other_maps_guard(store.maps_lock);
 
       // Each entry is (Name, MyMap, TheirMap)
       using MapEntry = std::tuple<std::string, AbstractMap*, AbstractMap*>;
@@ -1273,19 +1273,19 @@ namespace kv
 
     virtual void set_flag(Flag f) override
     {
-      std::lock_guard<std::mutex> vguard(version_lock);
+      std::lock_guard<ccf::Mutex> vguard(version_lock);
       set_flag_unsafe(f);
     }
 
     virtual void unset_flag(Flag f) override
     {
-      std::lock_guard<std::mutex> vguard(version_lock);
+      std::lock_guard<ccf::Mutex> vguard(version_lock);
       unset_flag_unsafe(f);
     }
 
     virtual bool flag_enabled(Flag f) override
     {
-      std::lock_guard<std::mutex> vguard(version_lock);
+      std::lock_guard<ccf::Mutex> vguard(version_lock);
       return flag_enabled_unsafe(f);
     }
 

--- a/src/kv/untyped_map.h
+++ b/src/kv/untyped_map.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ccf/ds/logger.h"
+#include "ccf/ds/mutex.h"
 #include "ccf/kv/untyped_map_handle.h"
 #include "ds/dl_list.h"
 #include "kv/kv_serialiser.h"
@@ -81,7 +82,7 @@ namespace kv::untyped
     CommitHook global_hook = nullptr;
     MapHook hook = nullptr;
     std::list<std::pair<Version, Write>> commit_deltas;
-    std::mutex sl;
+    ccf::Mutex sl;
     const SecurityDomain security_domain;
     const bool replicated;
     const bool include_conflict_read_version;

--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -502,7 +502,7 @@ namespace ccf::historical
     };
 
     // Guard all access to internal state with this lock
-    std::mutex requests_lock;
+    ccf::Mutex requests_lock;
 
     // Track all things currently requested by external callers
     std::map<CompoundHandle, Request> requests;
@@ -747,7 +747,7 @@ namespace ccf::historical
           "Invalid range for historical query: Cannot request empty range");
       }
 
-      std::lock_guard<std::mutex> guard(requests_lock);
+      std::lock_guard<ccf::Mutex> guard(requests_lock);
 
       const auto ms_until_expiry =
         std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -994,7 +994,7 @@ namespace ccf::historical
 
     bool drop_cached_states(const CompoundHandle& handle)
     {
-      std::lock_guard<std::mutex> guard(requests_lock);
+      std::lock_guard<ccf::Mutex> guard(requests_lock);
       const auto erased_count = requests.erase(handle);
       return erased_count > 0;
     }
@@ -1006,7 +1006,7 @@ namespace ccf::historical
 
     bool handle_ledger_entry(ccf::SeqNo seqno, const uint8_t* data, size_t size)
     {
-      std::lock_guard<std::mutex> guard(requests_lock);
+      std::lock_guard<ccf::Mutex> guard(requests_lock);
       const auto it = pending_fetches.find(seqno);
       if (it == pending_fetches.end())
       {
@@ -1126,7 +1126,7 @@ namespace ccf::historical
 
     void handle_no_entry_range(ccf::SeqNo from_seqno, ccf::SeqNo to_seqno)
     {
-      std::lock_guard<std::mutex> guard(requests_lock);
+      std::lock_guard<ccf::Mutex> guard(requests_lock);
 
       for (auto seqno = from_seqno; seqno <= to_seqno; ++seqno)
       {
@@ -1215,7 +1215,7 @@ namespace ccf::historical
 
     void tick(const std::chrono::milliseconds& elapsed_ms)
     {
-      std::lock_guard<std::mutex> guard(requests_lock);
+      std::lock_guard<ccf::Mutex> guard(requests_lock);
       auto it = requests.begin();
       while (it != requests.end())
       {

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -482,7 +482,7 @@ namespace ccf
     size_t sig_tx_interval;
     size_t sig_ms_interval;
 
-    std::mutex state_lock;
+    ccf::Mutex state_lock;
     kv::Term term_of_last_version = 0;
     kv::Term term_of_next_version;
 
@@ -520,7 +520,7 @@ namespace ccf
         [](std::unique_ptr<threading::Tmsg<EmitSigMsg>> msg) {
           auto self = msg->data.self;
 
-          std::unique_lock<std::mutex> mguard(
+          std::unique_lock<ccf::Mutex> mguard(
             self->signature_lock, std::defer_lock);
 
           const int64_t sig_ms_interval = self->sig_ms_interval;
@@ -589,7 +589,7 @@ namespace ccf
     bool init_from_snapshot(
       const std::vector<uint8_t>& hash_at_snapshot) override
     {
-      std::lock_guard<std::mutex> guard(state_lock);
+      std::lock_guard<ccf::Mutex> guard(state_lock);
       // The history can be initialised after a snapshot has been applied by
       // deserialising the tree in the signatures table and then applying the
       // hash of the transaction at which the snapshot was taken
@@ -618,14 +618,14 @@ namespace ccf
 
     crypto::Sha256Hash get_replicated_state_root() override
     {
-      std::lock_guard<std::mutex> guard(state_lock);
+      std::lock_guard<ccf::Mutex> guard(state_lock);
       return replicated_state_tree.get_root();
     }
 
     std::tuple<kv::TxID, crypto::Sha256Hash, kv::Term>
     get_replicated_state_txid_and_root() override
     {
-      std::lock_guard<std::mutex> guard(state_lock);
+      std::lock_guard<ccf::Mutex> guard(state_lock);
       return {
         {term_of_last_version,
          static_cast<kv::Version>(replicated_state_tree.end_index())},
@@ -681,7 +681,7 @@ namespace ccf
 
     std::vector<uint8_t> serialise_tree(size_t from, size_t to) override
     {
-      std::lock_guard<std::mutex> guard(state_lock);
+      std::lock_guard<ccf::Mutex> guard(state_lock);
       return replicated_state_tree.serialise(from, to);
     }
 
@@ -689,7 +689,7 @@ namespace ccf
     {
       // This should only be called once, when the store first knows about its
       // term
-      std::lock_guard<std::mutex> guard(state_lock);
+      std::lock_guard<ccf::Mutex> guard(state_lock);
       term_of_last_version = t;
       term_of_next_version = t;
     }
@@ -697,7 +697,7 @@ namespace ccf
     void rollback(
       const kv::TxID& tx_id, kv::Term term_of_next_version_) override
     {
-      std::lock_guard<std::mutex> guard(state_lock);
+      std::lock_guard<ccf::Mutex> guard(state_lock);
       LOG_TRACE_FMT("Rollback to {}.{}", tx_id.term, tx_id.version);
       term_of_last_version = tx_id.term;
       term_of_next_version = term_of_next_version_;
@@ -707,7 +707,7 @@ namespace ccf
 
     void compact(kv::Version v) override
     {
-      std::lock_guard<std::mutex> guard(state_lock);
+      std::lock_guard<ccf::Mutex> guard(state_lock);
       // Receipts can only be retrieved to the flushed index. Keep a range of
       // history so that a range of receipts are available.
       if (v > MAX_HISTORY_LEN)
@@ -721,11 +721,11 @@ namespace ccf
     std::chrono::milliseconds time_of_last_signature =
       std::chrono::milliseconds(0);
 
-    std::mutex signature_lock;
+    ccf::Mutex signature_lock;
 
     void try_emit_signature() override
     {
-      std::unique_lock<std::mutex> mguard(signature_lock, std::defer_lock);
+      std::unique_lock<ccf::Mutex> mguard(signature_lock, std::defer_lock);
       if (store.committable_gap() < sig_tx_interval || !mguard.try_lock())
       {
         return;
@@ -785,20 +785,20 @@ namespace ccf
 
     std::vector<uint8_t> get_proof(kv::Version index) override
     {
-      std::lock_guard<std::mutex> guard(state_lock);
+      std::lock_guard<ccf::Mutex> guard(state_lock);
       return replicated_state_tree.get_proof(index).to_v();
     }
 
     bool verify_proof(const std::vector<uint8_t>& v) override
     {
       Proof proof(v);
-      std::lock_guard<std::mutex> guard(state_lock);
+      std::lock_guard<ccf::Mutex> guard(state_lock);
       return replicated_state_tree.verify(proof);
     }
 
     std::vector<uint8_t> get_raw_leaf(uint64_t index) override
     {
-      std::lock_guard<std::mutex> guard(state_lock);
+      std::lock_guard<ccf::Mutex> guard(state_lock);
       auto leaf = replicated_state_tree.get_leaf(index);
       return {leaf.h.begin(), leaf.h.end()};
     }
@@ -807,14 +807,14 @@ namespace ccf
     {
       crypto::Sha256Hash rh(data);
       log_hash(rh, APPEND);
-      std::lock_guard<std::mutex> guard(state_lock);
+      std::lock_guard<ccf::Mutex> guard(state_lock);
       replicated_state_tree.append(rh);
     }
 
     void append_entry(const crypto::Sha256Hash& digest) override
     {
       log_hash(digest, APPEND);
-      std::lock_guard<std::mutex> guard(state_lock);
+      std::lock_guard<ccf::Mutex> guard(state_lock);
       replicated_state_tree.append(digest);
     }
 

--- a/src/node/jwt_key_auto_refresh.h
+++ b/src/node/jwt_key_auto_refresh.h
@@ -9,8 +9,9 @@
 #include "node/rpc/node_frontend.h"
 
 #define FMT_HEADER_ONLY
+#include "ccf/ds/mutex.h"
+
 #include <fmt/format.h>
-#include <mutex>
 
 namespace ccf
 {

--- a/src/node/ledger_secrets.h
+++ b/src/node/ledger_secrets.h
@@ -21,7 +21,7 @@ namespace ccf
   class LedgerSecrets
   {
   private:
-    std::mutex lock;
+    ccf::Mutex lock;
     LedgerSecretsMap ledger_secrets;
 
     // Set once when the LedgerSecrets are initialised. This prevents a backup
@@ -108,7 +108,7 @@ namespace ccf
 
     void init(kv::Version initial_version = 1)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       ledger_secrets.emplace(initial_version, make_ledger_secret());
       initial_latest_ledger_secret_version = initial_version;
@@ -116,7 +116,7 @@ namespace ccf
 
     void init_from_map(LedgerSecretsMap&& ledger_secrets_)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       CCF_ASSERT_FMT(
         ledger_secrets.empty(), "Should only init an empty LedgerSecrets");
@@ -132,7 +132,7 @@ namespace ccf
       // complete should point to the version at which the past ledger secret
       // has just been written to the store. This can only be done once the
       // private recovery is complete.
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       if (ledger_secrets.empty())
       {
@@ -145,7 +145,7 @@ namespace ccf
 
     bool is_empty()
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       return ledger_secrets.empty();
     }
@@ -154,7 +154,7 @@ namespace ccf
     {
       // This does not need a transaction as the first ledger secret is
       // considered stable with regards to concurrent rekey transactions
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       if (ledger_secrets.empty())
       {
@@ -167,7 +167,7 @@ namespace ccf
 
     VersionedLedgerSecret get_latest(kv::ReadOnlyTx& tx)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       take_dependency_on_secrets(tx);
 
@@ -183,7 +183,7 @@ namespace ccf
     std::pair<VersionedLedgerSecret, std::optional<VersionedLedgerSecret>>
     get_latest_and_penultimate(kv::ReadOnlyTx& tx)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       take_dependency_on_secrets(tx);
 
@@ -205,7 +205,7 @@ namespace ccf
     LedgerSecretsMap get(
       kv::ReadOnlyTx& tx, std::optional<kv::Version> up_to = std::nullopt)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       take_dependency_on_secrets(tx);
 
@@ -226,7 +226,7 @@ namespace ccf
 
     void restore_historical(LedgerSecretsMap&& restored_ledger_secrets)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       if (
         !ledger_secrets.empty() && !restored_ledger_secrets.empty() &&
@@ -246,7 +246,7 @@ namespace ccf
     std::shared_ptr<crypto::KeyAesGcm> get_encryption_key_for(
       kv::Version version, bool historical_hint = false)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       auto ls = get_secret_for_version(version, historical_hint);
       if (ls == nullptr)
       {
@@ -258,13 +258,13 @@ namespace ccf
     LedgerSecretPtr get_secret_for(
       kv::Version version, bool historical_hint = false)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       return get_secret_for_version(version, historical_hint);
     }
 
     void set_secret(kv::Version version, LedgerSecretPtr&& secret)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       CCF_ASSERT_FMT(
         ledger_secrets.find(version) == ledger_secrets.end(),
@@ -278,7 +278,7 @@ namespace ccf
 
     void rollback(kv::Version version)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       if (ledger_secrets.empty())
       {
         return;

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -128,7 +128,7 @@ namespace ccf
     // this node's core state
     //
     ds::StateMachine<NodeStartupState> sm;
-    std::mutex lock;
+    ccf::Mutex lock;
 
     crypto::CurveID curve_id;
     std::vector<crypto::SubjectAltName> subject_alt_names = {};
@@ -296,7 +296,7 @@ namespace ccf
       size_t sig_tx_interval_,
       size_t sig_ms_interval_)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       sm.expect(NodeStartupState::uninitialized);
 
       consensus_config = consensus_config_;
@@ -324,7 +324,7 @@ namespace ccf
     //
     NodeCreateInfo create(StartType start_type, StartupConfig&& config_)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       sm.expect(NodeStartupState::initialized);
 
       config = std::move(config_);
@@ -489,7 +489,7 @@ namespace ccf
           http_status status,
           http::HeaderMap&& headers,
           std::vector<uint8_t>&& data) {
-          std::lock_guard<std::mutex> guard(lock);
+          std::lock_guard<ccf::Mutex> guard(lock);
           if (!sm.check(NodeStartupState::pending))
           {
             return;
@@ -672,7 +672,7 @@ namespace ccf
           }
         },
         [this](const std::string& error_msg) {
-          std::lock_guard<std::mutex> guard(lock);
+          std::lock_guard<ccf::Mutex> guard(lock);
           auto long_error_msg = fmt::format(
             "Early error when joining existing network at {}: {}. Shutting "
             "down node gracefully...",
@@ -715,7 +715,7 @@ namespace ccf
     // (https://github.com/microsoft/CCF/issues/2981)
     void initiate_join()
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       initiate_join_unsafe();
     }
 
@@ -743,7 +743,7 @@ namespace ccf
 
     void join()
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       start_join_timer();
     }
 
@@ -784,7 +784,7 @@ namespace ccf
     //
     void start_ledger_recovery()
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       if (
         !sm.check(NodeStartupState::readingPublicLedger) &&
         !sm.check(NodeStartupState::verifyingSnapshot))
@@ -803,7 +803,7 @@ namespace ccf
 
     void recover_public_ledger_entries(const std::vector<uint8_t>& entries)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       std::shared_ptr<kv::Store> store;
       if (sm.check(NodeStartupState::readingPublicLedger))
@@ -991,13 +991,13 @@ namespace ccf
 
     void verify_snapshot_end()
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       verify_snapshot_end_unsafe();
     }
 
     void advance_part_of_public_network()
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       sm.expect(NodeStartupState::readingPublicLedger);
       history->start_signature_emit_timer();
       sm.advance(NodeStartupState::partOfPublicNetwork);
@@ -1115,7 +1115,7 @@ namespace ccf
     //
     void recover_private_ledger_entries(const std::vector<uint8_t>& entries)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       if (!sm.check(NodeStartupState::readingPrivateLedger))
       {
         LOG_FAIL_FMT(
@@ -1287,7 +1287,7 @@ namespace ccf
     //
     void recover_ledger_end()
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       if (is_reading_public_ledger())
       {
@@ -1392,7 +1392,7 @@ namespace ccf
       kv::Tx& tx,
       AbstractGovernanceEffects::ServiceIdentities identities) override
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       auto service = tx.rw<Service>(Tables::SERVICE);
       auto service_info = service->get();
@@ -1489,7 +1489,7 @@ namespace ccf
 
     void initiate_private_recovery(kv::Tx& tx) override
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       sm.expect(NodeStartupState::partOfPublicNetwork);
 
       recovered_ledger_secrets = share_manager.restore_recovery_shares_info(
@@ -1639,7 +1639,7 @@ namespace ccf
 
     ExtendedState state() override
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       auto s = sm.value();
       if (s == NodeStartupState::readingPrivateLedger)
       {
@@ -1653,7 +1653,7 @@ namespace ccf
 
     bool rekey_ledger(kv::Tx& tx) override
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       sm.expect(NodeStartupState::partOfNetwork);
 
       // The ledger should not be re-keyed when the service is not open
@@ -1688,7 +1688,7 @@ namespace ccf
 
     kv::Version get_startup_snapshot_seqno() override
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       return startup_seqno;
     }
 
@@ -1699,7 +1699,7 @@ namespace ccf
 
     crypto::Pem get_self_signed_certificate() override
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       return self_signed_node_cert;
     }
 
@@ -2125,7 +2125,7 @@ namespace ccf
                   "Could not find endorsed node certificate for {}", self));
               }
 
-              std::lock_guard<std::mutex> guard(lock);
+              std::lock_guard<ccf::Mutex> guard(lock);
 
               endorsed_node_cert = endorsed_certificate.value();
               history->set_endorsed_certificate(endorsed_node_cert.value());
@@ -2198,7 +2198,7 @@ namespace ccf
       // from. If the primary changes while the network is public-only, the
       // new primary should also know at which version the new ledger secret
       // is applicable from.
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       return last_recovered_signed_idx;
     }
 

--- a/src/node/node_to_node_channel_manager.h
+++ b/src/node/node_to_node_channel_manager.h
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ccf/ds/mutex.h"
 #include "channels.h"
 #include "node/node_to_node.h"
 
@@ -14,7 +15,7 @@ namespace ccf
     ringbuffer::WriterPtr to_host;
 
     std::unordered_map<NodeId, std::shared_ptr<Channel>> channels;
-    std::mutex lock; //< Protects access to channels map
+    ccf::Mutex lock; //< Protects access to channels map
 
     struct ThisNode
     {
@@ -35,7 +36,7 @@ namespace ccf
         "Requested channel with self {}",
         peer_id);
 
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       CCF_ASSERT_FMT(
         this_node != nullptr && this_node->endorsed_node_cert.has_value(),
         "Endorsed node certificate has not yet been set");
@@ -95,7 +96,7 @@ namespace ccf
 
     void set_endorsed_node_cert(const crypto::Pem& endorsed_node_cert) override
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       this_node->endorsed_node_cert = endorsed_node_cert;
     }
 

--- a/src/node/request_tracker.h
+++ b/src/node/request_tracker.h
@@ -57,7 +57,7 @@ namespace aft
   public:
     void insert(const crypto::Sha256Hash& hash, std::chrono::milliseconds time)
     {
-      std::unique_lock<std::mutex> guard(lock);
+      std::unique_lock<ccf::Mutex> guard(lock);
       if (!tracking_requests)
       {
         return;
@@ -73,7 +73,7 @@ namespace aft
     void insert_deleted(
       const crypto::Sha256Hash& hash, std::chrono::milliseconds time)
     {
-      std::unique_lock<std::mutex> guard(lock);
+      std::unique_lock<ccf::Mutex> guard(lock);
       if (!tracking_requests)
       {
         return;
@@ -90,7 +90,7 @@ namespace aft
 
     bool remove(const crypto::Sha256Hash& hash)
     {
-      std::unique_lock<std::mutex> guard(lock);
+      std::unique_lock<ccf::Mutex> guard(lock);
       if (!tracking_requests)
       {
         return false;
@@ -100,7 +100,7 @@ namespace aft
 
     void tick(std::chrono::milliseconds current_time)
     {
-      std::unique_lock<std::mutex> guard(lock);
+      std::unique_lock<ccf::Mutex> guard(lock);
       if (current_time < retail_unmatched_deleted_hashes)
       {
         return;
@@ -118,7 +118,7 @@ namespace aft
 
     std::optional<std::chrono::milliseconds> oldest_entry()
     {
-      std::unique_lock<std::mutex> guard(lock);
+      std::unique_lock<ccf::Mutex> guard(lock);
       if (requests_list.is_empty())
       {
         return std::nullopt;
@@ -128,7 +128,7 @@ namespace aft
 
     bool is_empty()
     {
-      std::unique_lock<std::mutex> guard(lock);
+      std::unique_lock<ccf::Mutex> guard(lock);
       return requests.empty() && requests_list.is_empty() &&
         hashes_without_requests.empty() &&
         hashes_without_requests_list.is_empty();
@@ -136,7 +136,7 @@ namespace aft
 
     void insert_signed_request(ccf::SeqNo seqno, std::chrono::milliseconds time)
     {
-      std::unique_lock<std::mutex> guard(lock);
+      std::unique_lock<ccf::Mutex> guard(lock);
       if (seqno > seqno_last_signature)
       {
         seqno_last_signature = seqno;
@@ -147,13 +147,13 @@ namespace aft
     std::tuple<ccf::SeqNo, std::chrono::milliseconds>
     get_seqno_time_last_request() const
     {
-      std::unique_lock<std::mutex> guard(lock);
+      std::unique_lock<ccf::Mutex> guard(lock);
       return {seqno_last_signature, time_last_signature};
     }
 
     void clear()
     {
-      std::unique_lock<std::mutex> guard(lock);
+      std::unique_lock<ccf::Mutex> guard(lock);
       requests.clear();
       requests_list.clear();
 
@@ -163,7 +163,7 @@ namespace aft
 
     void start_tracking_requests()
     {
-      std::unique_lock<std::mutex> guard(lock);
+      std::unique_lock<ccf::Mutex> guard(lock);
       tracking_requests = true;
     }
 
@@ -179,7 +179,7 @@ namespace aft
     std::chrono::milliseconds time_last_signature =
       std::chrono::milliseconds(0);
     bool tracking_requests = false;
-    mutable std::mutex lock;
+    mutable ccf::Mutex lock;
 
     static void insert(
       const crypto::Sha256Hash& hash,

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -16,8 +16,9 @@
 #include "rpc_exception.h"
 
 #define FMT_HEADER_ONLY
+#include "ccf/ds/mutex.h"
+
 #include <fmt/format.h>
-#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -30,7 +31,7 @@ namespace ccf
     endpoints::EndpointRegistry& endpoints;
 
   private:
-    std::mutex open_lock;
+    ccf::Mutex open_lock;
     bool is_open_ = false;
 
     kv::Consensus* consensus;
@@ -438,7 +439,7 @@ namespace ccf
 
     void open(std::optional<crypto::Pem*> identity = std::nullopt) override
     {
-      std::lock_guard<std::mutex> mguard(open_lock);
+      std::lock_guard<ccf::Mutex> mguard(open_lock);
       // open() without an identity unconditionally opens the frontend.
       // If an identity is passed, the frontend must instead wait for
       // the KV to read that this is identity is present and open,
@@ -459,7 +460,7 @@ namespace ccf
 
     bool is_open(kv::Tx& tx) override
     {
-      std::lock_guard<std::mutex> mguard(open_lock);
+      std::lock_guard<ccf::Mutex> mguard(open_lock);
       if (!is_open_)
       {
         auto service = tx.ro<Service>(Tables::SERVICE);
@@ -479,7 +480,7 @@ namespace ccf
 
     bool is_open() override
     {
-      std::lock_guard<std::mutex> mguard(open_lock);
+      std::lock_guard<ccf::Mutex> mguard(open_lock);
       return is_open_;
     }
 

--- a/src/node/snapshotter.h
+++ b/src/node/snapshotter.h
@@ -25,7 +25,7 @@ namespace ccf
 
   private:
     ringbuffer::WriterPtr to_host;
-    std::mutex lock;
+    ccf::Mutex lock;
 
     std::shared_ptr<kv::Store> store;
 
@@ -233,21 +233,21 @@ namespace ccf
       // After public recovery, the first node should have restored all
       // snapshot indices in next_snapshot_indices so that snapshot
       // generation can continue at the correct interval
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       last_snapshot_idx = next_snapshot_indices.back().idx;
     }
 
     void set_snapshot_generation(bool enabled)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
       snapshot_generation_enabled = enabled;
     }
 
     void set_last_snapshot_idx(consensus::Index idx)
     {
       // Should only be called once, after a snapshot has been applied
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       if (last_snapshot_idx != 0)
       {
@@ -266,7 +266,7 @@ namespace ccf
     {
       // Returns true if the committable idx will require the generation of a
       // snapshot, and thus a new ledger chunk
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       CCF_ASSERT_FMT(
         idx >= next_snapshot_indices.back().idx,
@@ -309,7 +309,7 @@ namespace ccf
       const NodeId& node_id,
       const crypto::Pem& node_cert)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       for (auto& pending_snapshot : pending_snapshots)
       {
@@ -327,7 +327,7 @@ namespace ccf
     void record_serialised_tree(
       consensus::Index idx, const std::vector<uint8_t>& tree)
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       for (auto& pending_snapshot : pending_snapshots)
       {
@@ -357,7 +357,7 @@ namespace ccf
       // at the last snapshottable index before idx, and schedule snapshot
       // serialisation on another thread (round-robin). Otherwise, only record
       // that a snapshot was generated.
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       update_indices(idx);
 
@@ -401,7 +401,7 @@ namespace ccf
 
     void rollback(consensus::Index idx) override
     {
-      std::lock_guard<std::mutex> guard(lock);
+      std::lock_guard<ccf::Mutex> guard(lock);
 
       while (!next_snapshot_indices.empty() &&
              (next_snapshot_indices.back().idx > idx))

--- a/src/node/test/historical_queries.cpp
+++ b/src/node/test/historical_queries.cpp
@@ -948,7 +948,7 @@ TEST_CASE("StateCache concurrent access")
     {
       std::vector<StubWriter::Write> writes;
       {
-        std::lock_guard<std::mutex> guard(writer->writes_mutex);
+        std::lock_guard<ccf::Mutex> guard(writer->writes_mutex);
         auto finished_write_it = std::partition_point(
           writer->writes.begin() + last_handled_write,
           writer->writes.end(),


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Use custom mutex implementation on SGX (#3978)](https://github.com/microsoft/CCF/pull/3978)