### PR TITLE
Track number of service recoveries 

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Splicer!!!
+Splicer!!!!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `/node/version` now contains an `unsafe` flag reflecting the status of the build.
 - New per-interface configuration entries (`network.rpc_interfaces.http_configuration`) are added to let operators cap the maximum size of body, header value size and number of headers in client HTTP requests. The client session is automatically closed if the HTTP request exceeds one of these limits (#3941).
+- Added new `recovery_count` field to `GET /node/network` endpoint to track the number of disaster recovery procedures undergone by the service.
 
 ### Changed
 

--- a/doc/operations/recovery.rst
+++ b/doc/operations/recovery.rst
@@ -113,6 +113,11 @@ Summary Diagram
 
 Once operators have established a recovered crash-fault tolerant public network, the existing members of the consortium :ref:`must vote to accept the recovery of the network and submit their recovery shares <governance/accept_recovery:Accepting Recovery and Submitting Shares>`.
 
+Notes
+-----
+
+- Operators can track the number of times a given service has undergone the disaster recovery procedure via the :http:GET:`/node/network` endpoint (``recovery_count`` field).
+
 .. rubric:: Footnotes
 
 .. [#crash] When using CFT as consensus algorithm, CCF tolerates up to `N/2 - 1` crashed nodes (where `N` is the number of trusted nodes constituting the network) before having to perform a recovery procedure. For example, in a 5-node network, no more than 2 nodes are allowed to fail for the service to be able to commit new transactions.

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -255,6 +255,9 @@
           "primary_id": {
             "$ref": "#/components/schemas/NodeId"
           },
+          "recovery_count": {
+            "$ref": "#/components/schemas/uint64"
+          },
           "service_certificate": {
             "$ref": "#/components/schemas/Pem"
           },
@@ -266,7 +269,8 @@
           "service_status",
           "service_certificate",
           "current_view",
-          "primary_id"
+          "primary_id",
+          "recovery_count"
         ],
         "type": "object"
       },
@@ -809,7 +813,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "2.21.0"
+    "version": "2.22.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/include/ccf/service/tables/service.h
+++ b/include/ccf/service/tables/service.h
@@ -31,10 +31,13 @@ namespace ccf
     ServiceStatus status = ServiceStatus::OPENING;
     /// Version of previous service identity (before the last recovery)
     std::optional<kv::Version> previous_service_identity_version = std::nullopt;
+    /// Number of disaster recoveries performed on this service
+    std::optional<size_t> recovery_count = std::nullopt;
   };
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(ServiceInfo);
   DECLARE_JSON_REQUIRED_FIELDS(ServiceInfo, cert, status);
-  DECLARE_JSON_OPTIONAL_FIELDS(ServiceInfo, previous_service_identity_version);
+  DECLARE_JSON_OPTIONAL_FIELDS(
+    ServiceInfo, previous_service_identity_version, recovery_count);
 
   // As there is only one service active at a given time, it is stored in single
   // Value in the KV

--- a/src/node/rpc/call_types.h
+++ b/src/node/rpc/call_types.h
@@ -58,6 +58,7 @@ namespace ccf
       crypto::Pem service_certificate;
       std::optional<ccf::View> current_view;
       std::optional<NodeId> primary_id;
+      size_t recovery_count;
     };
   };
 

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -370,7 +370,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
-      openapi_info.document_version = "2.21.0";
+      openapi_info.document_version = "2.22.0";
     }
 
     void init_handlers() override
@@ -808,6 +808,7 @@ namespace ccf
           const auto& service_value = service_state.value();
           out.service_status = service_value.status;
           out.service_certificate = service_value.cert;
+          out.recovery_count = service_value.recovery_count.value_or(0);
           if (consensus != nullptr)
           {
             out.current_view = consensus->get_view();

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -88,7 +88,8 @@ namespace ccf
     service_status,
     service_certificate,
     current_view,
-    primary_id)
+    primary_id,
+    recovery_count)
 
   DECLARE_JSON_TYPE(GetNode::NodeInfo)
   DECLARE_JSON_REQUIRED_FIELDS(

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -169,8 +169,6 @@ class Network:
                 self.service_load.set_network(self)
             self.recovery_count = existing_network.recovery_count
 
-        LOG.success(f"Recovery count: {self.recovery_count}")
-
         self.ignoring_shutdown_errors = False
         self.ignore_error_patterns = []
         self.nodes = []

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -542,7 +542,7 @@ class Network:
         self.wait_for_all_nodes_to_commit(primary=primary, timeout=20)
         LOG.success("All nodes joined public network")
 
-    def recover(self, args):
+    def recover(self, args, expected_recovery_count=None):
         """
         Recovers a CCF network previously started in recovery mode.
         :param args: command line arguments to configure the CCF nodes.
@@ -581,8 +581,7 @@ class Network:
             )
             self._wait_for_app_open(node)
 
-        self.recovery_count += 1
-        LOG.error(f"Bumping recovery count: {self.recovery_count}")
+        self.recovery_count = expected_recovery_count or self.recovery_count + 1
         self.consortium.check_for_service(
             self.find_random_node(),
             ServiceStatus.OPEN,

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -94,6 +94,21 @@ def version_rc(full_version):
     return (None, 0)
 
 
+def version_after(version, cmp_version):
+    if version is None and cmp_version is not None:
+        # It is assumed that version is None for latest development
+        # branch (i.e. main)
+        return True
+    rc, _ = version_rc(cmp_version)
+    self_rc, self_num_rc_tkns = version_rc(version)
+    ver = Version(strip_version(cmp_version))
+    self_ver = Version(strip_version(version))
+    return self_ver > ver or (
+        self_ver == ver
+        and (not self_rc or self_rc > rc or (self_rc == rc and self_num_rc_tkns > 3))
+    )
+
+
 class Node:
     # Default to using httpx
     curl = False
@@ -681,18 +696,7 @@ class Node:
         return False
 
     def version_after(self, version):
-        rc, _ = version_rc(version)
-        if rc is None or self.version is None:
-            return True
-        self_rc, self_num_rc_tkns = version_rc(self.version)
-        ver = Version(strip_version(version))
-        self_ver = Version(strip_version(self.version))
-        return self_ver > ver or (
-            self_ver == ver
-            and (
-                not self_rc or self_rc > rc or (self_rc == rc and self_num_rc_tkns > 3)
-            )
-        )
+        return version_after(self.version, version)
 
     def get_receipt(self, view, seqno, timeout=3):
         found = False

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -512,15 +512,15 @@ def run_ledger_compatibility_since_first(args, local_branch, use_snapshot):
                 else:
                     time.sleep(3)
 
-                # if idx > 0:
-                #     test_new_service(
-                #         network,
-                #         args,
-                #         install_path,
-                #         binary_dir,
-                #         library_dir,
-                #         version,
-                #     )
+                if idx > 0:
+                    test_new_service(
+                        network,
+                        args,
+                        install_path,
+                        binary_dir,
+                        library_dir,
+                        version,
+                    )
 
                 # We accept ledger chunk file differences during upgrades
                 # from 1.x to 2.x post rc7 ledger. This is necessary because
@@ -618,21 +618,21 @@ if __name__ == "__main__":
 
         # Compatibility with previous LTS
         # (e.g. when releasing 2.0.1, check compatibility with existing 1.0.17)
-        # latest_lts_version = run_live_compatibility_with_latest(
-        #     args, repo, local_branch, this_release_branch_only=False
-        # )
-        # compatibility_report["live compatibility"].update(
-        #     {"with previous LTS": latest_lts_version}
-        # )
+        latest_lts_version = run_live_compatibility_with_latest(
+            args, repo, local_branch, this_release_branch_only=False
+        )
+        compatibility_report["live compatibility"].update(
+            {"with previous LTS": latest_lts_version}
+        )
 
-        # # Compatibility with latest LTS on the same release branch
-        # # (e.g. when releasing 2.0.1, check compatibility with existing 2.0.0)
-        # latest_lts_version = run_live_compatibility_with_latest(
-        #     args, repo, local_branch, this_release_branch_only=True
-        # )
-        # compatibility_report["live compatibility"].update(
-        #     {"with same LTS": latest_lts_version}
-        # )
+        # Compatibility with latest LTS on the same release branch
+        # (e.g. when releasing 2.0.1, check compatibility with existing 2.0.0)
+        latest_lts_version = run_live_compatibility_with_latest(
+            args, repo, local_branch, this_release_branch_only=True
+        )
+        compatibility_report["live compatibility"].update(
+            {"with same LTS": latest_lts_version}
+        )
 
         if args.check_ledger_compatibility:
             compatibility_report["data compatibility"] = {}

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -368,10 +368,13 @@ def test_share_resilience(network, args, from_snapshot=False):
             timeout=args.ledger_recovery_timeout,
         )
 
+    recovered_network.recovery_count += 1
     recovered_network.consortium.check_for_service(
         new_primary,
         infra.network.ServiceStatus.OPEN,
+        recovery_count=recovered_network.recovery_count,
     )
+
     if recovered_network.service_load:
         recovered_network.service_load.set_network(recovered_network)
     return recovered_network


### PR DESCRIPTION
Resolves #3974 

This adds a new field to the service info table to keep track of the number of disaster recoveries that have happened on this service. This number is also reported by the `GET /node/network` endpoint.