### PR TITLE
Do not buffer incoming TLS frames if session is closed

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Splicer!!!
+Splicer!!!!

--- a/src/enclave/tls_endpoint.h
+++ b/src/enclave/tls_endpoint.h
@@ -65,6 +65,11 @@ namespace ccf
       return status == ready || status == closing;
     }
 
+    bool can_recv()
+    {
+      return status == ready || status == handshake;
+    }
+
   public:
     TLSEndpoint(
       int64_t session_id_,
@@ -219,7 +224,11 @@ namespace ccf
       {
         throw std::runtime_error("Called recv_buffered from incorrect thread");
       }
-      pending_read.insert(pending_read.end(), data, data + size);
+
+      if (can_recv())
+      {
+        pending_read.insert(pending_read.end(), data, data + size);
+      }
 
       do_handshake();
     }

--- a/tests/e2e_common_endpoints.py
+++ b/tests/e2e_common_endpoints.py
@@ -160,7 +160,6 @@ def test_memory(network, args):
 
 
 @reqs.description("Write/Read large messages on primary")
-@reqs.supports_methods("/app/log/private")
 def test_large_messages(network, args):
     primary, _ = network.find_primary()
 
@@ -182,6 +181,7 @@ def test_large_messages(network, args):
             args.max_http_body_size,
             args.max_http_body_size + 1,
             args.max_http_body_size * 2,
+            args.max_http_body_size * 200,
         ]
     )
 
@@ -203,9 +203,9 @@ def test_large_messages(network, args):
                 *args,
                 **kwargs,
             )
-        except BrokenPipeError:
+        except infra.clients.CCFConnectionException:
             # In some cases, the client ends up writing to the now-closed socket first
-            # before reading the server error, resulting in a BrokenPipeError error
+            # before reading the server error, resulting in a connection error
             assert length > threshold
             assert get_main_interface_errors()[metrics_name] == before_errors_count + 1
         else:
@@ -233,6 +233,8 @@ def test_large_messages(network, args):
                 long_msg,
                 headers={"content-type": "application/json"},
             )
+
+        return
 
         header_sizes = [
             args.max_http_header_size - 1,
@@ -294,8 +296,8 @@ def run(args):
     ) as network:
         network.start_and_open(args)
 
-        test_primary(network, args)
-        test_network_node_info(network, args)
-        test_node_ids(network, args)
-        test_memory(network, args)
+        # test_primary(network, args)
+        # test_network_node_info(network, args)
+        # test_node_ids(network, args)
+        # test_memory(network, args)
         test_large_messages(network, args)

--- a/tests/e2e_common_endpoints.py
+++ b/tests/e2e_common_endpoints.py
@@ -234,8 +234,6 @@ def test_large_messages(network, args):
                 headers={"content-type": "application/json"},
             )
 
-        return
-
         header_sizes = [
             args.max_http_header_size - 1,
             args.max_http_header_size,
@@ -296,8 +294,8 @@ def run(args):
     ) as network:
         network.start_and_open(args)
 
-        # test_primary(network, args)
-        # test_network_node_info(network, args)
-        # test_node_ids(network, args)
-        # test_memory(network, args)
+        test_primary(network, args)
+        test_network_node_info(network, args)
+        test_node_ids(network, args)
+        test_memory(network, args)
         test_large_messages(network, args)


### PR DESCRIPTION
We no longer append to `pending_read` in enclave when a session is closing. This could have caused large memory growth in enclave when the client was sending very large messages.

As hinted by @letmaik in https://github.com/microsoft/CCF/issues/3912, when a client sends a large message, it is possible that it still writes to the now-closed socket before receiving the error response from the server. The infra wasn't resilient to such failures (see [here](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=47039&view=logs&j=abb827b0-1387-5f0d-393d-8da14bd7f99d&t=328e9e87-12fb-5696-903c-0f14a0ce494d&l=39382)) and this PR addresses this.