### PR TITLE
[release/2.x] Cherry pick: Remove null byte from PEM files (#3885)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Node and service PEM certificates no longer contain a trailing null byte.
+
 ## [2.0.3]
 
 ### Added

--- a/include/ccf/crypto/pem.h
+++ b/include/ccf/crypto/pem.h
@@ -74,8 +74,7 @@ namespace crypto
 
     size_t size() const
     {
-      // +1 for null termination
-      return s.size() + 1;
+      return s.size();
     }
 
     bool empty() const

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -715,8 +715,12 @@ class Consortium:
                 os.path.join(self.common_dir, "service_cert.pem")
             )
 
+            # Certs previously contained a terminating null byte. Strip it for comparison.
+            current_cert = current_cert.strip("\x00")
+            expected_cert = expected_cert.strip("\x00")
+
             assert (
-                current_cert == expected_cert[:-1]
+                current_cert == expected_cert
             ), "Current service certificate did not match with service_cert.pem"
             assert (
                 current_status == status.value


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Remove null byte from PEM files (#3885)](https://github.com/microsoft/CCF/pull/3885)