### PR TITLE
[release/2.x] Cherry pick: Track number of service recoveries  (#3982)

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Splicer!!!!!!
+Splicer!!!!!!!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- Added new `recovery_count` field to `GET /node/network` endpoint to track the number of disaster recovery procedures undergone by the service (#3982).
+
 ### Changed
 
 - Node and service PEM certificates no longer contain a trailing null byte.

--- a/doc/operations/recovery.rst
+++ b/doc/operations/recovery.rst
@@ -113,6 +113,11 @@ Summary Diagram
 
 Once operators have established a recovered crash-fault tolerant public network, the existing members of the consortium :ref:`must vote to accept the recovery of the network and submit their recovery shares <governance/accept_recovery:Accepting Recovery and Submitting Shares>`.
 
+Notes
+-----
+
+- Operators can track the number of times a given service has undergone the disaster recovery procedure via the :http:GET:`/node/network` endpoint (``recovery_count`` field).
+
 .. rubric:: Footnotes
 
 .. [#crash] When using CFT as consensus algorithm, CCF tolerates up to `N/2 - 1` crashed nodes (where `N` is the number of trusted nodes constituting the network) before having to perform a recovery procedure. For example, in a 5-node network, no more than 2 nodes are allowed to fail for the service to be able to commit new transactions.

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -250,6 +250,9 @@
           "primary_id": {
             "$ref": "#/components/schemas/NodeId"
           },
+          "recovery_count": {
+            "$ref": "#/components/schemas/uint64"
+          },
           "service_certificate": {
             "$ref": "#/components/schemas/Pem"
           },
@@ -261,7 +264,8 @@
           "service_status",
           "service_certificate",
           "current_view",
-          "primary_id"
+          "primary_id",
+          "recovery_count"
         ],
         "type": "object"
       },
@@ -801,7 +805,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "2.20.0"
+    "version": "2.22.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/include/ccf/service/tables/service.h
+++ b/include/ccf/service/tables/service.h
@@ -31,10 +31,13 @@ namespace ccf
     ServiceStatus status = ServiceStatus::OPENING;
     /// Version of previous service identity (before the last recovery)
     std::optional<kv::Version> previous_service_identity_version = std::nullopt;
+    /// Number of disaster recoveries performed on this service
+    std::optional<size_t> recovery_count = std::nullopt;
   };
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(ServiceInfo);
   DECLARE_JSON_REQUIRED_FIELDS(ServiceInfo, cert, status);
-  DECLARE_JSON_OPTIONAL_FIELDS(ServiceInfo, previous_service_identity_version);
+  DECLARE_JSON_OPTIONAL_FIELDS(
+    ServiceInfo, previous_service_identity_version, recovery_count);
 
   // As there is only one service active at a given time, it is stored in single
   // Value in the KV

--- a/src/node/rpc/call_types.h
+++ b/src/node/rpc/call_types.h
@@ -58,6 +58,7 @@ namespace ccf
       crypto::Pem service_certificate;
       std::optional<ccf::View> current_view;
       std::optional<NodeId> primary_id;
+      size_t recovery_count;
     };
   };
 

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -370,7 +370,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
-      openapi_info.document_version = "2.20.0";
+      openapi_info.document_version = "2.22.0";
     }
 
     void init_handlers() override
@@ -808,6 +808,7 @@ namespace ccf
           const auto& service_value = service_state.value();
           out.service_status = service_value.status;
           out.service_certificate = service_value.cert;
+          out.recovery_count = service_value.recovery_count.value_or(0);
           if (consensus != nullptr)
           {
             out.current_view = consensus->get_view();

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -88,7 +88,8 @@ namespace ccf
     service_status,
     service_certificate,
     current_view,
-    primary_id)
+    primary_id,
+    recovery_count)
 
   DECLARE_JSON_TYPE(GetNode::NodeInfo)
   DECLARE_JSON_REQUIRED_FIELDS(

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -701,15 +701,20 @@ class Consortium:
         proposal = self.get_any_active_member().propose(remote_node, proposal_body)
         return self.vote_using_majority(remote_node, proposal, careful_vote)
 
-    def check_for_service(self, remote_node, status):
+    def check_for_service(self, remote_node, status, recovery_count=None):
         """
         Check the certificate associated with current CCF service signing key has been recorded in
         the KV store with the appropriate status.
         """
         with remote_node.client() as c:
-            r = c.get("/node/network")
-            current_status = r.body.json()["service_status"]
-            current_cert = r.body.json()["service_certificate"]
+            r = c.get("/node/network").body.json()
+            current_status = r["service_status"]
+            current_cert = r["service_certificate"]
+            # Note: to change once this is backported to 2.x
+            if remote_node.version_after("ccf-2.0.3"):
+                current_recovery_count = r["recovery_count"]
+            else:
+                assert "recovery_count" not in r
 
             expected_cert = slurp_file(
                 os.path.join(self.common_dir, "service_cert.pem")
@@ -725,6 +730,10 @@ class Consortium:
             assert (
                 current_status == status.value
             ), f"Service status {current_status} (expected {status.value})"
+            if remote_node.version_after("ccf-2.0.3"):
+                assert (
+                    recovery_count is None or current_recovery_count == recovery_count
+                ), f"Current recovery count {current_recovery_count} is not expected {recovery_count}"
 
     def submit_2tx_migration_proposal(self, remote_node, timeout=10):
         proposal_body = {

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -710,8 +710,7 @@ class Consortium:
             r = c.get("/node/network").body.json()
             current_status = r["service_status"]
             current_cert = r["service_certificate"]
-            # Note: to change once this is backported to 2.x
-            if remote_node.version_after("ccf-2.0.3"):
+            if remote_node.version_after("ccf-2.0.4"):
                 current_recovery_count = r["recovery_count"]
             else:
                 assert "recovery_count" not in r
@@ -730,7 +729,7 @@ class Consortium:
             assert (
                 current_status == status.value
             ), f"Service status {current_status} (expected {status.value})"
-            if remote_node.version_after("ccf-2.0.3"):
+            if remote_node.version_after("ccf-2.0.4"):
                 assert (
                     recovery_count is None or current_recovery_count == recovery_count
                 ), f"Current recovery count {current_recovery_count} is not expected {recovery_count}"

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -94,6 +94,21 @@ def version_rc(full_version):
     return (None, 0)
 
 
+def version_after(version, cmp_version):
+    if version is None and cmp_version is not None:
+        # It is assumed that version is None for latest development
+        # branch (i.e. main)
+        return True
+    rc, _ = version_rc(cmp_version)
+    self_rc, self_num_rc_tkns = version_rc(version)
+    ver = Version(strip_version(cmp_version))
+    self_ver = Version(strip_version(version))
+    return self_ver > ver or (
+        self_ver == ver
+        and (not self_rc or self_rc > rc or (self_rc == rc and self_num_rc_tkns > 3))
+    )
+
+
 class Node:
     # Default to using httpx
     curl = False
@@ -678,18 +693,7 @@ class Node:
         return False
 
     def version_after(self, version):
-        rc, _ = version_rc(version)
-        if rc is None or self.version is None:
-            return True
-        self_rc, self_num_rc_tkns = version_rc(self.version)
-        ver = Version(strip_version(version))
-        self_ver = Version(strip_version(self.version))
-        return self_ver > ver or (
-            self_ver == ver
-            and (
-                not self_rc or self_rc > rc or (self_rc == rc and self_num_rc_tkns > 3)
-            )
-        )
+        return version_after(self.version, version)
 
     def get_receipt(self, view, seqno, timeout=3):
         found = False

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -8,6 +8,7 @@ import infra.utils
 import infra.github
 import infra.jwt_issuer
 import infra.crypto
+import infra.node
 import suite.test_requirements as reqs
 import ccf.ledger
 import os
@@ -433,6 +434,7 @@ def run_ledger_compatibility_since_first(args, local_branch, use_snapshot):
     jwt_issuer = infra.jwt_issuer.JwtIssuer(
         "https://localhost", refresh_interval=args.jwt_key_refresh_interval_s
     )
+    previous_version = None
     with jwt_issuer.start_openid_server():
         txs = app.LoggingTxs(jwt_issuer=jwt_issuer)
         for idx, (_, lts_release) in enumerate(lts_releases.items()):
@@ -473,7 +475,15 @@ def run_ledger_compatibility_since_first(args, local_branch, use_snapshot):
                         committed_ledger_dirs,
                         snapshots_dir=snapshots_dir,
                     )
-                    network.recover(args)
+                    # Recovery count is not stored in pre-2.0.3 ledgers
+                    network.recover(
+                        args,
+                        expected_recovery_count=1
+                        if not infra.node.version_after(previous_version, "ccf-2.0.3")
+                        else None,
+                    )
+
+                previous_version = version
 
                 nodes = network.get_joined_nodes()
                 primary, _ = network.find_primary()

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -475,11 +475,11 @@ def run_ledger_compatibility_since_first(args, local_branch, use_snapshot):
                         committed_ledger_dirs,
                         snapshots_dir=snapshots_dir,
                     )
-                    # Recovery count is not stored in pre-2.0.3 ledgers
+                    # Recovery count is not stored in pre-2.0.4 ledgers
                     network.recover(
                         args,
                         expected_recovery_count=1
-                        if not infra.node.version_after(previous_version, "ccf-2.0.3")
+                        if not infra.node.version_after(previous_version, "ccf-2.0.4")
                         else None,
                     )
 

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -368,10 +368,13 @@ def test_share_resilience(network, args, from_snapshot=False):
             timeout=args.ledger_recovery_timeout,
         )
 
+    recovered_network.recovery_count += 1
     recovered_network.consortium.check_for_service(
         new_primary,
         infra.network.ServiceStatus.OPEN,
+        recovery_count=recovered_network.recovery_count,
     )
+
     if recovered_network.service_load:
         recovered_network.service_load.set_network(recovered_network)
     return recovered_network


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Track number of service recoveries  (#3982)](https://github.com/microsoft/CCF/pull/3982)