### PR TITLE
[release/2.x] Cherry pick: Receipt documentation (#3954)

### DIFF
--- a/doc/audit/receipts.rst
+++ b/doc/audit/receipts.rst
@@ -7,7 +7,45 @@ Check for transaction inclusion
 -------------------------------
 
 A user having executed a transaction, fetched a receipt for it, can check for its inclusion in the ledger.
-All they need to do is scan to the corresponding :term:`Transaction ID`, digest the transaction, and compare it with `write_set_digest` in their receipt.
+All they need to do is scan to the corresponding :term:`Transaction ID`, digest the serialised transaction, and compare it with :term:`Write Set` digest in their receipt.
+
+For example, given the following transaction receipt:
+
+.. code-block:: python
+   :emphasize-lines: 15
+
+    {"cert": "-----BEGIN CERTIFICATE-----\n"
+            "MIIB0DCCAVWgAwIBAgIRAKut43pNWfrRFqoU3CiDwQMwCgYIKoZIzj0EAwMwFjEU\n"
+            "MBIGA1UEAwwLQ0NGIE5ldHdvcmswHhcNMjIwNjIzMTI1NDMwWhcNMjIwNjI0MTI1\n"
+            "NDI5WjATMREwDwYDVQQDDAhDQ0YgTm9kZTB2MBAGByqGSM49AgEGBSuBBAAiA2IA\n"
+            "BEbyEIuw666ZinL2V1hRrP5MCLL2rUoM/BLyz7sECnwJKMPr8NL9zm1QawkuSjoG\n"
+            "OBLBr1E+M74q0RgJFcc/r4M0NKyqgy3MG2JskXsFsZx4IlsEw1h8dAeeGoQ5zbPM\n"
+            "46NqMGgwCQYDVR0TBAIwADAdBgNVHQ4EFgQUPAUVdR+vSnLqMrEMrCHbWI7XTXEw\n"
+            "HwYDVR0jBBgwFoAU5947gxFF/Fe+60BAT/fxl/l2eFkwGwYDVR0RBBQwEocEfwAA\n"
+            "AYcEfw55KocEfwAAAjAKBggqhkjOPQQDAwNpADBmAjEA2404WF4g1GRfcwXzB74b\n"
+            "s+DRtsjalqkGVbjCTcSPWxZMRDnCgAfLp8FvjnoWFURQAjEArKvzYoZ71r+Lejdr\n"
+            "ptMmANqMma9fh8eYSAwRgyM+DTlsvcjHqamnbqdp4xcQBqBb\n"
+            "-----END CERTIFICATE-----\n",
+    "leaf_components": {"claims_digest": "0000000000000000000000000000000000000000000000000000000000000000",
+                        "commit_evidence": "ce:2.662:e423779b5314e92b79852c7b17888752d5e61e4f1ef3e79d9a06ef25cbfe2744",
+                        "write_set_digest": "89145f455cb3e0854052232078989faf083237dae354180ca9942b1821f60c5d"},
+    "node_id": "c5f66bbdca022af31050e104615ff0eaabd633b472bfda6650e8bee09a632ca3",
+    "proof": [{"right": "3cd7b9c512371e411884917617462eacbeaf27988546a0c87fc7da89aec5b77d"},
+            {"left": "6f5a6d0613488ac942af045b64782d4a14bb7466b9ad64619c7c50f335ac0ed3"},
+            {"left": "d6401bf622794ae4d50b2f736cb2b6d590f42faa76cf0796ba05a57e9fb153fe"},
+            {"right": "24032f6c4b57233a9ff30478b6c209ac2a7ac27c136899618fcf1d54cdcd6313"},
+            {"left": "e16c5aa89b950b6ae23ff6eb297d330e7e4a239f2958d1e09d671bd8e72974ec"},
+            {"left": "6058b0e8cfe37550f2feec7ae8e89905df6b7e67c2e4aff227fcb5ea0a9100cd"},
+            {"left": "b582e168cd35dff37794d0f0fbac3de6dcb9271bcebc4a654f1e74be592370f3"}],
+    "signature": "MGQCMBQz7qIuHxc512Prg9NjKWDYwg0i6myQ/LCm6APVYRxlLdi1gng3/CmQ6bEE2Siy7QIwRWGOVobolhrWOavwr8WPm+YqdB6LsxQhOqqU/diZ/mU9gE6NavufIKPHA6zsl46h"}
+
+The corresponding transaction, ``2.662``, can be extracted from ledger files, and the digest compared:
+
+.. code-block:: bash
+   :emphasize-lines: 2
+
+    $ read_ledger.py -d workspace/cpp_e2e_logging_cft_0/0.ledger/ | grep "2\.662"
+        2.662 89145f455cb3e0854052232078989faf083237dae354180ca9942b1821f60c5d
 
 Denounce an invalid recovery
 ----------------------------
@@ -18,4 +56,4 @@ This may occur if the consortium approves a catastrophic recovery from a truncat
 This user can either:
 
 1. Query the new service for receipts at the same :term:`Transaction ID` values.  If those transactions come back as `INVALID`, because they were truncated, the signature over the old receipts is proof of truncation. If they come back as `COMMITTED` with a different root, the existence of two signatures over different roots at the same TxID is proof that a fork happened.
-2. Scan the ledger, for example using the :doc:`/audit/python_library`, and find the transactions for which they have receipts. The `write_set_digest` in the receipt should match the digest of the transactions on disk. If it doesn't, the signature over the receipt is proof of a fork.
+2. Scan the ledger, for example using the :doc:`/audit/python_library`, and find the transactions for which they have receipts. The `write_set_digest` in the receipts should match the digest of the serialised :term:`Write Set` in the ledger on disk. If it does not, the signature over the receipt is proof of a fork. See :ref:`audit/receipts:Check for transaction inclusion` for an example.

--- a/doc/build_apps/logging_cpp.rst
+++ b/doc/build_apps/logging_cpp.rst
@@ -206,7 +206,8 @@ Historical state always contains a receipt. Users wishing to implement a receipt
 User-Defined Claims in Receipts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A user wanting to tie transaction-specific values to a receipt can do so by attaching a claims digest to their transaction:
+A user wanting to tie transaction-specific values to a receipt can do so by attaching a claims digest to their transaction.
+This is conceptually equivalent to getting a signature from the service for claims made by the application logic.
 
 .. literalinclude:: ../../samples/apps/logging/logging.cpp
     :language: cpp
@@ -214,7 +215,7 @@ A user wanting to tie transaction-specific values to a receipt can do so by atta
     :end-before: SNIPPET_END: set_claims_digest
     :dedent:
 
-CCF will then record this transaction as a leaf in the Merkle tree constructed from the combined digest of the write set, this ``claims_digest``, and the commit evidence.
+CCF will record this transaction as a leaf in the Merkle tree constructed from the combined digest of the write set, this ``claims_digest``, and the :term:`Commit Evidence`.
 
 This ``claims_digest`` will be exposed in receipts under ``leaf_components``. It can then be revealed externally,
 or by the endpoint directly if it has been stored in the ledger. The receipt object deliberately makes the ``claims_digest`` optional,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -93,7 +93,8 @@ language = "en"
 exclude_patterns = []
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "zenburn"
+pygments_style = "default"
+pygments_dark_style = "zenburn"
 
 # Ignore main index file that has clickable images, JS/Doxygen output,
 # github anchors https://github.com/sphinx-doc/sphinx/issues/9016), and nghttp2

--- a/doc/operations/certificates.rst
+++ b/doc/operations/certificates.rst
@@ -78,3 +78,62 @@ The procedure that operators and members should follow is summarised in the foll
     section Service <br> Certificate
     Initial Validity Period (24h default): done, 01-01/00:00, 1d
     Post Service Open Validity Period    : 01-01/15:00, 5d
+
+ACME-endorsed TLS certificates
+------------------------------
+
+Unendorsed, self-signed (CA) service certificates are a complication for clients as they need to be given a copy of the certificate before they can establish TLS connections to the service, or the service certificate is permanently installed in their trust store. To alleviate this, CCF provides an `ACME <https://en.wikipedia.org/wiki/Automatic_Certificate_Management_Environment>`_ client, which is used to obtain TLS certificates that are endorsed by external certificate authorities. For instance, the `Let's Encrypt <https://letsencrypt.org/>`_ CA is endorsed by a root certificate that is pre-installed on most current operating systems, which means that clients usually have all required certificates to establish TLS connections without further configuration, if the service certificate is endorsed by Let's Encrypt. CCF handles the creation and renewal of ACME certificates, but it requires some configuration:
+
+1. Get a globally reachable DNS name for your CCF network, e.g. ``my-ccf.example.com``, which resolves to the address of at least one node in the network. Multiple nodes or a load balancer address are fine too.
+
+2. ACME `http-01 <https://letsencrypt.org/docs/challenge-types/>`_ challenges require a challenge server to be reachable on port 80 (non-negotiable).
+To be able to bind to that port, the ``cchost`` binary may need to be given special permission, e.g. by running ``sudo setcap CAP_NET_BIND_SERVICE=+eip cchost``. Alternatively, port 80 can be redirected to a non-privileged port that ``cchost`` may bind to without special permission.
+
+3. Each interface defined in the ``cchost`` configuration file can be given the name of an ACME configuration to use. The settings of each ACME configuration are defined in ``network.acme`` :doc:`configuration entry </operations/configuration>`. Note that this information is required by *all* nodes as they might have to renew the certificate(s) later. Further, an additional interface for the challenge server is required.
+
+    The various options are as follows:
+
+    .. code-block:: python
+
+        "network": {
+            "rpc_interfaces": { 
+                # ... ,
+                "acme_endorsed_interface": {
+                    # ... ,
+                    "endorsement": {
+                        # ... ,
+                        "acme_configuration": "my-acme-cfg"
+                    }
+                },
+                "acme_challenge_server_interface": {
+                    "bind_address": "...:80",
+                    "endorsement": {
+                        "authority": "Unsecured"
+                    },
+                    "accepted_endpoints": [ "/.well-known/acme-challenge/.*" ]
+                    # ...
+                }
+            },
+            "acme": {
+                "my-acme-cfg": {
+                    "ca_certs": [ "-----BEGIN CERTIFICATE-----\nMIIBg ..." ],
+                    "directory_url": "https://...",
+                    "service_dns_name": "my-ccf.example.com",
+                    "contact": ["mailto:john@example.com"],
+                    "terms_of_service_agreed": true,
+                    "challenge_type": "http-01",
+                    "challenge_server_interface": "acme_challenge_server_interface"
+                }
+            }
+        }
+
+
+    - ``ca_certs``: CCF will need to establish https connections with the CA, but does not come with root certificates by default and therefore will fail to establish connections. This setting is populated with one or more such certificates; e.g. for Let's Encrypt this would be their ISRG Root X1 certificate (see `here <https://letsencrypt.org/certificates/>`_) in PEM format.
+    - ``directory_url``: This is the main entry point for the ACME protocol. For Let's Encrypt's `staging environment <https://letsencrypt.org/docs/staging-environment/>`_, this is ``https://acme-staging-v02.api.letsencrypt.org/directory``; minus the ``-staging`` for their production environment).
+    - ``service_dns_name``: The DNS name for the network from step 1.
+    - ``contact``: A list of contact addresses, usually e-mail addresses, which must be prefixed with ``mailto:``. These contacts may receive notifications about service changes, e.g. certificate revocation or expiry.
+    - ``terms_of_service_agreed``: A Boolean confirming that the operator accepts the terms of service for the CA. RFC8555 requires this to be set explicitly by the operator.
+    - ``challenge_type``: Currently only `http-01 <https://letsencrypt.org/docs/challenge-types/>`_ is supported.
+    - ``challenge_server_interface``: Name of the interface that the ACME challenge server listens on. For http-01 challenges in production, this interface must be exposed publicly on port 80.
+
+4. CCF nodes periodically check for certificate expiry and trigger renewal when 66% of the validity period has elapsed. The resulting certificates are stored in the ``ccf.gov.service.acme_certificates`` table and upon an update to this table, nodes will automatically install the corresponding certificate on their interfaces. If necessary, renewal can also be triggered manually by submitting a ``trigger_acme_refresh`` governance proposal.

--- a/doc/overview/glossary.rst
+++ b/doc/overview/glossary.rst
@@ -22,6 +22,9 @@ Glossary
   Constitution
     JavaScript module that defines possible governance actions, and how members' proposals are validated, resolved and applied to the service.
 
+  Commit Evidence
+    A :ref:`unique string <use_apps/verify_tx:Commit Evidence>` produced per transaction, and included in the Merkle Tree along with the :term:`Write Set` digest and the `claims_digest`. The reveal of that string guarantees the transaction is committed.
+
   CFT
     Crash Fault Tolerance is a type of fault tolerance that allows the system to tolerate network and node failures up to
     a given limit. CFT however does not account for any nodes behaving maliciously (in contrast to :term:`BFT`). Read more on CFT :ref:`here <architecture/consensus/index:CFT Consensus Protocol>`.
@@ -85,3 +88,6 @@ Glossary
 
   Users
     Directly interact with the application running in CCF. Their public identity should be voted in by members before they are allowed to issue requests.
+
+  Write Set
+    The keys and values written to during a CCF transaction. The state of the Key Value store at a given :term:`Transaction ID` is logically the successive application of all write sets up to that point.

--- a/python/ccf/read_ledger.py
+++ b/python/ccf/read_ledger.py
@@ -123,6 +123,7 @@ def run(
     uncommitted=False,
     insecure_skip_verification=False,
     tables_format_rules=None,
+    digests_only=None,
 ):
 
     # Extend and compile rules
@@ -159,7 +160,12 @@ def run(
                     f"chunk {chunk.filename()} ({'' if chunk.is_committed() else 'un'}committed)"
                 )
                 for transaction in chunk:
-                    dump_entry(transaction, table_filter, tables_format_rules)
+                    if digests_only:
+                        print(
+                            f"{transaction.gcm_header.view}.{transaction.gcm_header.seqno} {transaction.get_write_set_digest().hex()}"
+                        )
+                    else:
+                        dump_entry(transaction, table_filter, tables_format_rules)
         except Exception as e:
             LOG.exception(f"Error parsing ledger: {e}")
             has_error = True
@@ -201,6 +207,12 @@ if __name__ == "__main__":
         action="store_true",
     )
     parser.add_argument(
+        "-d",
+        "--digests-only",
+        help="Only print transaction digests",
+        action="store_true",
+    )
+    parser.add_argument(
         "-t",
         "--tables",
         help="Regex filter for tables to display",
@@ -224,5 +236,7 @@ if __name__ == "__main__":
         args.tables,
         args.uncommitted,
         args.insecure_skip_verification,
+        None,
+        args.digests_only,
     ):
         sys.exit(1)

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -33,6 +33,7 @@ from hashlib import sha256
 import e2e_common_endpoints
 from types import MappingProxyType
 
+
 from loguru import logger as LOG
 
 


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Receipt documentation (#3954)](https://github.com/microsoft/CCF/pull/3954)