### PR TITLE
[release/2.x] Cherry pick: Add arbitrary service data (#3997)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added new `recovery_count` field to `GET /node/network` endpoint to track the number of disaster recovery procedures undergone by the service (#3982).
 - Added new `read_only_directory` snapshots directory node configuration so that committed snapshots can be shared between nodes (#3973).
 - Added new `current_service_create_txid` field to `GET /node/network` endpoint to indicate `TxID` at which current service was created (#3996).
+- Added new `service_data_json_file` configuration entry to `cchost` to point to free-form JSON file to set arbitrary data to service (#3997).
 
 ### Changed
 

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -293,6 +293,10 @@
       "type": ["string", "null"],
       "description": "Path to file (JSON) containing initial node data. It is intended to store correlation IDs describing the node's deployment, such as a VM name or Pod identifier"
     },
+    "service_data_json_file": {
+      "type": ["string", "null"],
+      "description": "Path to file (JSON) containing initial service data. It is used when the node starts in 'Start' or 'Recover' mode and is intended to store arbitrary information about the service"
+    },
     "ledger": {
       "type": "object",
       "properties": {

--- a/doc/operations/start_network.rst
+++ b/doc/operations/start_network.rst
@@ -133,6 +133,14 @@ To start a CCF node in ``virtual`` mode, the JSON configuration file should spec
 
 .. warning:: Nodes started in virtual mode provide no security guarantees. They should never be used for production purposes.
 
+Node and Service Data
+---------------------
+
+To be able to better identify a specific service and its nodes, operators can specify arbitrary JSON data to attach to each service/node:
+
+- The optional :ref:`operations/configuration:``node_data_json_file``` configuration entry specifies the path to a JSON file containing node-specific information, e.g. the pod identifier in a Kubernetes deployment. This data is recorded in the :ref:`audit/builtin_maps:``nodes.info``` table and accessible via the :http:GET:`/node/network/nodes` endpoint.
+- The optional :ref:`operations/configuration:``service_data_json_file``` configuration entry specifies the path to a JSON file containing service-specific information, e.g. the timestamp at which the service started or the cluster identifier in a Kubernetes deployment. This data is recorded in the :ref:`audit/builtin_maps:``service.info``` table and accessible via the :http:GET:`/node/network` endpoint.
+
 .. rubric:: Footnotes
 
 .. [#remote_attestation] When a new node joins an existing network, the network performs the remote attestation protocol by verifying the joining node's quote. It also checks that the version of the code running by the joining node is trusted by the consortium.

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -259,6 +259,9 @@
           "service_certificate": {
             "$ref": "#/components/schemas/Pem"
           },
+          "service_data": {
+            "$ref": "#/components/schemas/json"
+          },
           "service_status": {
             "$ref": "#/components/schemas/ServiceStatus"
           }
@@ -269,6 +272,7 @@
           "current_view",
           "primary_id",
           "recovery_count",
+          "service_data",
           "current_service_create_txid"
         ],
         "type": "object"
@@ -809,7 +813,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "2.23.0"
+    "version": "2.24.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/include/ccf/service/tables/service.h
+++ b/include/ccf/service/tables/service.h
@@ -34,6 +34,9 @@ namespace ccf
     std::optional<kv::Version> previous_service_identity_version = std::nullopt;
     /// Number of disaster recoveries performed on this service
     std::optional<size_t> recovery_count = std::nullopt;
+    /// Free-form user data, can be used by members to store additional
+    /// information about service
+    nlohmann::json service_data = nullptr;
     /// TxID at which current service was created
     std::optional<ccf::TxID> current_service_create_txid = std::nullopt;
   };
@@ -43,6 +46,7 @@ namespace ccf
     ServiceInfo,
     previous_service_identity_version,
     recovery_count,
+    service_data,
     current_service_create_txid);
 
   // As there is only one service active at a given time, it is stored in single

--- a/src/common/configuration.h
+++ b/src/common/configuration.h
@@ -126,6 +126,7 @@ struct StartupConfig : CCFConfig
 
   // Only if starting or recovering
   size_t initial_service_certificate_validity_days = 1;
+  nlohmann::json service_data = nullptr;
 
   nlohmann::json node_data = nullptr;
 
@@ -173,6 +174,7 @@ DECLARE_JSON_REQUIRED_FIELDS(
   startup_host_time,
   snapshot_tx_interval,
   initial_service_certificate_validity_days,
+  service_data,
   node_data,
   start,
   join,

--- a/src/host/configuration.h
+++ b/src/host/configuration.h
@@ -60,6 +60,7 @@ namespace host
     std::optional<std::string> node_client_interface = std::nullopt;
     ds::TimeString client_connection_timeout = {"2000ms"};
     std::optional<std::string> node_data_json_file = std::nullopt;
+    std::optional<std::string> service_data_json_file = std::nullopt;
 
     struct OutputFiles
     {
@@ -213,6 +214,7 @@ namespace host
     node_client_interface,
     client_connection_timeout,
     node_data_json_file,
+    service_data_json_file,
     output_files,
     ledger,
     snapshots,

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -370,6 +370,22 @@ int main(int argc, char** argv)
         files::slurp_json(config.node_data_json_file.value());
     }
 
+    if (config.service_data_json_file.has_value())
+    {
+      if (
+        config.command.type == StartType::Start ||
+        config.command.type == StartType::Recover)
+      {
+        startup_config.service_data =
+          files::slurp_json(config.service_data_json_file.value());
+      }
+      else
+      {
+        LOG_FAIL_FMT(
+          "Service data is ignored for start type {}", config.command.type);
+      }
+    }
+
     auto startup_host_time = std::chrono::system_clock::now();
     LOG_INFO_FMT("Startup host time: {}", startup_host_time);
 

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1859,6 +1859,7 @@ namespace ccf
       create_params.code_digest = node_code_id;
       create_params.node_info_network = config.network;
       create_params.node_data = config.node_data;
+      create_params.service_data = config.service_data;
       create_params.create_txid = {create_view, last_recovered_signed_idx + 1};
 
       const auto body = serdes::pack(create_params, serdes::Pack::Text);

--- a/src/node/rpc/call_types.h
+++ b/src/node/rpc/call_types.h
@@ -59,6 +59,7 @@ namespace ccf
       std::optional<ccf::View> current_view;
       std::optional<NodeId> primary_id;
       size_t recovery_count;
+      nlohmann::json service_data;
       std::optional<ccf::TxID> current_service_create_txid;
     };
   };

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -62,6 +62,7 @@ namespace ccf
       CodeDigest code_digest;
       NodeInfoNetwork node_info_network;
       nlohmann::json node_data;
+      nlohmann::json service_data;
       ccf::TxID create_txid;
 
       // Only set on genesis transaction, but not on recovery

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -370,7 +370,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
-      openapi_info.document_version = "2.23.0";
+      openapi_info.document_version = "2.24.0";
     }
 
     void init_handlers() override
@@ -809,6 +809,7 @@ namespace ccf
           out.service_status = service_value.status;
           out.service_certificate = service_value.cert;
           out.recovery_count = service_value.recovery_count.value_or(0);
+          out.service_data = service_value.service_data;
           out.current_service_create_txid =
             service_value.current_service_create_txid;
           if (consensus != nullptr)
@@ -1348,7 +1349,8 @@ namespace ccf
             "Service is already created.");
         }
 
-        g.create_service(in.service_cert, in.create_txid, recovering);
+        g.create_service(
+          in.service_cert, in.create_txid, in.service_data, recovering);
 
         // Retire all nodes, in case there are any (i.e. post recovery)
         g.retire_active_nodes();

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -75,7 +75,7 @@ namespace ccf
     node_info_network,
     create_txid)
   DECLARE_JSON_OPTIONAL_FIELDS(
-    CreateNetworkNodeToNode::In, genesis_info, node_data)
+    CreateNetworkNodeToNode::In, genesis_info, node_data, service_data)
 
   DECLARE_JSON_TYPE(GetCommit::Out)
   DECLARE_JSON_REQUIRED_FIELDS(GetCommit::Out, transaction_id)
@@ -91,6 +91,7 @@ namespace ccf
     current_view,
     primary_id,
     recovery_count,
+    service_data,
     current_service_create_txid)
 
   DECLARE_JSON_TYPE(GetNode::NodeInfo)

--- a/src/service/genesis_gen.h
+++ b/src/service/genesis_gen.h
@@ -290,6 +290,7 @@ namespace ccf
     void create_service(
       const crypto::Pem& service_cert,
       ccf::TxID create_txid,
+      nlohmann::json service_data = nullptr,
       bool recovering = false)
     {
       auto service = tx.rw(tables.service);
@@ -314,6 +315,7 @@ namespace ccf
          recovering ? ServiceStatus::RECOVERING : ServiceStatus::OPENING,
          recovering ? service->get_version_of_previous_write() : std::nullopt,
          recovery_count,
+         service_data,
          create_txid});
     }
 

--- a/tests/config.jinja
+++ b/tests/config.jinja
@@ -15,6 +15,7 @@
     "initial_validity_days": {{ initial_node_cert_validity_days }}
   },
   "node_data_json_file": {{ node_data_json_file|tojson }},
+  "service_data_json_file": {{ service_data_json_file|tojson }},
   "command": {
     "type": "{{ start_type }}",
     "service_certificate_file": "{{ service_cert_file }}", 

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -596,6 +596,7 @@ class CCFRemote(object):
         election_timeout_ms=None,
         node_data_json_file=None,
         service_cert_file="service_cert.pem",
+        service_data_json_file=None,
         **kwargs,
     ):
         """
@@ -695,6 +696,7 @@ class CCFRemote(object):
                 jwt_key_refresh_interval=f"{jwt_key_refresh_interval_s}s",
                 election_timeout=f"{election_timeout_ms}ms",
                 node_data_json_file=node_data_json_file,
+                service_data_json_file=service_data_json_file,
                 service_cert_file=service_cert_file,
                 **kwargs,
             )


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Add arbitrary service data (#3997)](https://github.com/microsoft/CCF/pull/3997)