### PR TITLE
[release/2.x] Cherry pick: Upgrade to Open Enclave 0.18.1 (#4023)

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -7,7 +7,7 @@ trigger:
 
 jobs:
   - job: build_and_publish_docs
-    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.0-0
+    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
     pool:
       vmImage: ubuntu-20.04
 

--- a/.azure-pipelines-quictls.yml
+++ b/.azure-pipelines-quictls.yml
@@ -1,0 +1,61 @@
+trigger:
+  batch: false
+
+parameters:
+  - name: VERSION
+    displayName: QUICTLS version
+    type: string
+    default: "1.1.1"
+  - name: REV
+    displayName: QUICTLS version revision
+    type: string
+    default: "o"
+  - name: PUSH_ARTIFACT
+    displayName: Publish to package feed
+    type: boolean
+    default: true
+
+jobs:
+  - job: build_quictls
+    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
+    pool: 1es-dv4-focal
+
+    strategy:
+      matrix:
+        debug:
+          MODE: "debug"
+        release:
+          MODE: "release"
+
+    steps:
+      - checkout: self
+        clean: true
+
+      - script: scripts/quictls/build.sh ${{ parameters.VERSION }} ${{ parameters.REV }} $(MODE) ${{ parameters.PUSH_ARTIFACT }}
+        displayName: "Build QUICTLS"
+
+      - ${{ if eq(parameters.PUSH_ARTIFACT, true) }}:
+          - script: |
+              # Version to MAJOR
+              VERSION=${{ parameters.VERSION }}
+              MAJOR=${VERSION//./}
+              # Rev to MINOR (assuming it doesn't go beyond 'z')
+              CHAR=$(printf '%d' "'${{ parameters.REV }}'")
+              BASE=$(printf '%d' "'a'")
+              MINOR=$(($CHAR-$BASE+1))
+              # MAJOR.MINOR (BUILD automatic and incrementing)
+              echo "##vso[task.setvariable variable=pkg-ver]$MAJOR.$MINOR.$(Build.BuildId)"
+
+              mv scripts/quictls/quictls-${{ parameters.VERSION }}${{ parameters.REV }}-$(MODE).tar.xz $(Build.ArtifactStagingDirectory)
+            displayName: "Prepare Artifact Staging Directory"
+
+          - task: UniversalPackages@0
+            displayName: "Publish QUICTLS Artifact"
+            inputs:
+              command: publish
+              publishDirectory: "$(Build.ArtifactStagingDirectory)"
+              vstsFeedPublish: "CCF/QUICTLS"
+              vstsFeedPackagePublish: "quictls-$(MODE)"
+              versionOption: custom
+              versionPublish: "$(pkg-ver)"
+              packagePublishDescription: "CCF build of QUICTLS-enabled OpenSSL"

--- a/.azure-pipelines-v8.yml
+++ b/.azure-pipelines-v8.yml
@@ -20,7 +20,7 @@ parameters:
 
 jobs:
   - job: build_v8
-    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.0-0
+    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
     pool: 1es-dv4-focal
 
     strategy:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -27,11 +27,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.0-0
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.0-0
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
 variables:

--- a/.daily.yml
+++ b/.daily.yml
@@ -23,11 +23,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.0-0
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.0-0
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.0-0
+    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
 
     steps:
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -16,7 +16,7 @@ pr:
 resources:
   containers:
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.0-0
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.stress.yml
+++ b/.stress.yml
@@ -21,7 +21,7 @@ schedules:
 resources:
   containers:
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.0-0
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Dependencies
+
+- Upgraded Open Enclave to 0.18.1 (#4023).
+
 ## [2.0.4]
 
 ### Added

--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -19,7 +19,7 @@ endif()
 
 # CPack variables for Debian packages
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-    "open-enclave (>=0.18.0), libuv1 (>= 1.34.2), libc++1-10, libc++abi1-10, openssl (>=1.1.1)"
+    "open-enclave (>=0.18.1), libuv1 (>= 1.34.2), libc++1-10, libc++abi1-10, openssl (>=1.1.1)"
 )
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Upgrade to Open Enclave 0.18.1 (#4023)](https://github.com/microsoft/CCF/pull/4023)