### PR TITLE
Fix warnings in Typedoc build

### DIFF
--- a/js/ccf-app/src/converters.ts
+++ b/js/ccf-app/src/converters.ts
@@ -177,9 +177,9 @@ class JSONConverter<T extends JsonCompatible<T>> implements DataConverter<T> {
   }
 }
 
-type TypedArray = ArrayBufferView;
+export type TypedArray = ArrayBufferView;
 
-interface TypedArrayConstructor<T extends TypedArray> {
+export interface TypedArrayConstructor<T extends TypedArray> {
   new (buffer: ArrayBuffer, byteOffset?: number, length?: number): T;
 }
 

--- a/js/ccf-app/src/global.ts
+++ b/js/ccf-app/src/global.ts
@@ -269,7 +269,7 @@ export interface CCFRpc {
    * Set a claims digest to be associated with the transaction if it succeeds. This
    * digest can later be accessed from the receipt, and expanded into a full claim.
    *
-   * The `digest` argument must be a sha-256 ArrayBuffer, eg. produced by {@link global!CCF.digest}
+   * The `digest` argument must be a sha-256 ArrayBuffer, eg. produced by {@link global!CCF.digest}.
    */
   setClaimsDigest(digest: ArrayBuffer): void;
 }

--- a/js/ccf-app/src/global.ts
+++ b/js/ccf-app/src/global.ts
@@ -269,7 +269,7 @@ export interface CCFRpc {
    * Set a claims digest to be associated with the transaction if it succeeds. This
    * digest can later be accessed from the receipt, and expanded into a full claim.
    *
-   * The `digest` argument must be a sha-256 ArrayBuffer, eg. produced by {@link CCF.digest}
+   * The `digest` argument must be a sha-256 ArrayBuffer, eg. produced by {@link global!CCF.digest}
    */
   setClaimsDigest(digest: ArrayBuffer): void;
 }
@@ -331,7 +331,7 @@ export interface CCFHistorical {
    *
    * If the requested range failed to be retrieved then `null` is returned.
    * This may happen if the range is not known to the node (see also
-   * {@linkcode CCFConsensus.getStatusForTxId | getStatusForTxId}) or not available for
+   * {@linkcode global!CCFConsensus.getStatusForTxId | getStatusForTxId}) or not available for
    * other reasons (for example, the node is missing ledger files on disk).
    */
   getStateRange(

--- a/js/ccf-app/src/historical.ts
+++ b/js/ccf-app/src/historical.ts
@@ -32,7 +32,7 @@
 import { ccf } from "./global.js";
 
 /**
- * @inheritDoc CCF.historicalState
+ * @inheritDoc global!CCF.historicalState
  */
 export const historicalState = ccf.historicalState;
 

--- a/js/ccf-app/src/kv.ts
+++ b/js/ccf-app/src/kv.ts
@@ -110,7 +110,7 @@ export function typedKv<K, V>(
 }
 
 /**
- * @inheritDoc CCF.kv
+ * @inheritDoc global!CCF.kv
  */
 export const rawKv = ccf.kv;
 

--- a/js/ccf-app/typedoc.json
+++ b/js/ccf-app/typedoc.json
@@ -8,7 +8,8 @@
     "src/global.ts",
     "src/historical.ts",
     "src/kv.ts",
-    "src/polyfill.ts"
+    "src/polyfill.ts",
+    "src/openenclave.ts"
   ],
   "out": "html",
   "theme": "default",


### PR DESCRIPTION
Some links that Typedoc failed to resolve, I think because of some ambiguous `CCF` name? Fixed by explicit module references.