### PR TITLE
Raft scenario: support for reconfiguration

### DIFF
--- a/src/consensus/aft/test/driver.cpp
+++ b/src/consensus/aft/test/driver.cpp
@@ -149,6 +149,20 @@ int main(int argc, char** argv)
         assert(items.size() == 2);
         driver->assert_is_primary(items[1]);
         break;
+      case shash("assert_commit_idx"):
+        assert(items.size() == 3);
+        driver->assert_commit_idx(items[1], items[2]);
+        break;
+      case shash("replicate_new_configuration"):
+        assert(items.size() >= 3);
+        items.erase(items.begin());
+        driver->replicate_new_configuration(
+          items[0], {std::next(items.begin()), items.end()});
+        break;
+      case shash("create_new_node"):
+        assert(items.size() == 2);
+        driver->create_new_node(items[1]);
+        break;
       case shash(""):
         // Ignore empty lines
         break;

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -20,7 +20,7 @@ std::string stringify(const std::vector<uint8_t>& v, size_t max_size = 15ul)
 {
   auto size = std::min(v.size(), max_size);
   return fmt::format(
-    "[{} bytes] {}", v.size(), std::string(v.begin(), v.end()));
+    "[{} bytes] {}", v.size(), std::string(v.begin(), v.begin() + size));
 }
 
 std::string stringify(const std::optional<std::vector<uint8_t>>& o)
@@ -63,16 +63,16 @@ struct LedgerStubProxy_Mermaid : public aft::LedgerStubProxy
   }
 };
 
-struct LoggingStubStoreSig_Mermaid : public aft::LoggingStubStoreSig
+struct LoggingStubStoreSig_Mermaid : public aft::LoggingStubStoreSigConfig
 {
-  using LoggingStubStoreSig::LoggingStubStoreSig;
+  using LoggingStubStoreSigConfig::LoggingStubStoreSigConfig;
 
   void compact(aft::Index idx) override
   {
     RAFT_DRIVER_OUT << fmt::format(
                          "  {}->>{}: [KV] compacting to {}", _id, _id, idx)
                     << std::endl;
-    aft::LoggingStubStoreSig::compact(idx);
+    aft::LoggingStubStoreSigConfig::compact(idx);
   }
 
   void rollback(const kv::TxID& tx_id, aft::Term t) override
@@ -85,7 +85,7 @@ struct LoggingStubStoreSig_Mermaid : public aft::LoggingStubStoreSig
                          tx_id.version,
                          t)
                     << std::endl;
-    aft::LoggingStubStoreSig::rollback(tx_id, t);
+    aft::LoggingStubStoreSigConfig::rollback(tx_id, t);
   }
 
   void initialise_term(aft::Term t) override
@@ -93,15 +93,8 @@ struct LoggingStubStoreSig_Mermaid : public aft::LoggingStubStoreSig
     RAFT_DRIVER_OUT << fmt::format(
                          "  {}->>{}: [KV] initialising in term {}", _id, _id, t)
                     << std::endl;
-    aft::LoggingStubStoreSig::initialise_term(t);
+    aft::LoggingStubStoreSigConfig::initialise_term(t);
   }
-
-  bool flag_enabled(kv::AbstractStore::Flag)
-  {
-    return false;
-  }
-
-  void unset_flag(kv::AbstractStore::Flag) {}
 };
 
 using ms = std::chrono::milliseconds;
@@ -126,6 +119,78 @@ private:
   std::map<ccf::NodeId, NodeDriver> _nodes;
   std::set<std::pair<ccf::NodeId, ccf::NodeId>> _connections;
 
+  void _replicate(
+    const std::string& term_s,
+    std::vector<uint8_t> data,
+    const std::optional<kv::Configuration::Nodes>& configuration = std::nullopt)
+  {
+    const auto opt = find_primary_in_term(term_s);
+    if (!opt.has_value())
+    {
+      RAFT_DRIVER_OUT << fmt::format(
+                           "  Note left of {}: No primary to replicate {}",
+                           _nodes.begin()->first,
+                           stringify(data))
+                      << std::endl;
+      return;
+    }
+    const auto& [term, node_id] = *opt;
+    auto& raft = _nodes.at(node_id).raft;
+    const auto idx = raft->get_last_idx() + 1;
+    RAFT_DRIVER_OUT << fmt::format(
+                         "  {}->>{}: replicate {}.{} = {} [{}]",
+                         node_id,
+                         node_id,
+                         term_s,
+                         idx,
+                         stringify(data),
+                         configuration.has_value() ? "reconfiguration" : "raw")
+                    << std::endl;
+
+    aft::ReplicatedDataType type = aft::ReplicatedDataType::raw;
+    auto hooks = std::make_shared<kv::ConsensusHookPtrs>();
+    if (configuration.has_value())
+    {
+      auto hook = std::make_unique<aft::ConfigurationChangeHook>(
+        configuration.value(), idx);
+      hooks->push_back(std::move(hook));
+      type = aft::ReplicatedDataType::reconfiguration;
+      auto c = nlohmann::json(configuration).dump();
+
+      // If the entry is a reconfiguration, the replicated data is overwritten
+      // with the serialised configuration
+      data = std::vector<uint8_t>(c.begin(), c.end());
+    }
+
+    auto s = nlohmann::json(aft::ReplicatedData{type, data}).dump();
+    auto d = std::make_shared<std::vector<uint8_t>>(s.begin(), s.end());
+    // True means all these entries are committable
+    raft->replicate(kv::BatchVector{{idx, d, true, hooks}}, term);
+  }
+
+  std::shared_ptr<TRaft> add_node(ccf::NodeId node_id)
+  {
+    auto kv = std::make_shared<Store>(node_id);
+    const consensus::Configuration settings{
+      ConsensusType::CFT, {"10ms"}, {"100ms"}};
+    auto raft = std::make_shared<TRaft>(
+      settings,
+      std::make_unique<Adaptor>(kv),
+      std::make_unique<LedgerStubProxy_Mermaid>(node_id),
+      std::make_shared<aft::ChannelStubProxy>(),
+      std::make_shared<aft::State>(node_id),
+      nullptr,
+      nullptr);
+
+    if (_nodes.find(node_id) != _nodes.end())
+    {
+      throw std::logic_error(fmt::format("Node {} already exists", node_id));
+    }
+
+    _nodes.emplace(node_id, NodeDriver{kv, raft});
+    return raft;
+  }
+
 public:
   RaftDriver(std::vector<std::string> node_ids)
   {
@@ -133,29 +198,45 @@ public:
 
     for (const auto& node_id_s : node_ids)
     {
-      ccf::NodeId node_id(node_id_s);
-
-      auto kv = std::make_shared<Store>(node_id);
-      const consensus::Configuration settings{
-        ConsensusType::CFT, {"10ms"}, {"100ms"}};
-      auto raft = std::make_shared<TRaft>(
-        settings,
-        std::make_unique<Adaptor>(kv),
-        std::make_unique<LedgerStubProxy_Mermaid>(node_id),
-        std::make_shared<aft::ChannelStubProxy>(),
-        std::make_shared<aft::State>(node_id),
-        nullptr,
-        nullptr);
+      auto raft = add_node(node_id_s);
       raft->start_ticking();
-
-      _nodes.emplace(node_id, NodeDriver{kv, raft});
-      configuration.try_emplace(node_id);
+      configuration.try_emplace(node_id_s);
     }
 
     for (auto& node : _nodes)
     {
       node.second.raft->add_configuration(0, configuration);
     }
+  }
+
+  void create_new_node(std::string node_id_s)
+  {
+    ccf::NodeId node_id(node_id_s);
+    add_node(node_id);
+    RAFT_DRIVER_OUT << fmt::format(
+                         "  Note over {}: Node {} created", node_id, node_id)
+                    << std::endl;
+  }
+
+  void replicate_new_configuration(
+    const std::string& term_s, std::vector<std::string> node_ids)
+  {
+    kv::Configuration::Nodes configuration;
+    for (const auto& node_id_s : node_ids)
+    {
+      ccf::NodeId node_id(node_id_s);
+
+      if (_nodes.find(node_id) == _nodes.end())
+      {
+        throw std::runtime_error(fmt::format(
+          "Node {} does not exist yet. Use \"create_new_node, <node_id>\"",
+          node_id));
+      }
+
+      configuration.try_emplace(node_id);
+    }
+
+    _replicate(term_s, {}, configuration);
   }
 
   void log(
@@ -525,30 +606,7 @@ public:
   void replicate(
     const std::string& term_s, std::shared_ptr<std::vector<uint8_t>> data)
   {
-    const auto opt = find_primary_in_term(term_s);
-    if (!opt.has_value())
-    {
-      RAFT_DRIVER_OUT << fmt::format(
-                           "  Note left of {}: No primary to replicate {}",
-                           _nodes.begin()->first,
-                           stringify(*data))
-                      << std::endl;
-      return;
-    }
-    const auto& [term, node_id] = *opt;
-    auto& raft = _nodes.at(node_id).raft;
-    const auto idx = raft->get_last_idx() + 1;
-    RAFT_DRIVER_OUT << fmt::format(
-                         "  {}->>{}: replicate {}.{} = {}",
-                         node_id,
-                         node_id,
-                         term_s,
-                         idx,
-                         stringify(*data))
-                    << std::endl;
-    auto hooks = std::make_shared<kv::ConsensusHookPtrs>();
-    // True means all these entries are committable
-    raft->replicate(kv::BatchVector{{idx, data, true, hooks}}, term);
+    _replicate(term_s, *data);
   }
 
   void disconnect(ccf::NodeId left, ccf::NodeId right)
@@ -735,6 +793,21 @@ public:
     if (!all_match)
     {
       throw std::runtime_error("States not in sync");
+    }
+  }
+
+  void assert_commit_idx(ccf::NodeId node_id, const std::string& idx_s)
+  {
+    auto idx = std::stol(idx_s);
+    if (_nodes.at(node_id).raft->get_committed_seqno() != idx)
+    {
+      RAFT_DRIVER_OUT
+        << fmt::format(
+             "  Note over {}: Node is not at expected commit idx {}",
+             node_id,
+             idx)
+        << std::endl;
+      throw std::runtime_error("Node not at expected commit idx");
     }
   }
 };

--- a/src/ds/serialized.h
+++ b/src/ds/serialized.h
@@ -60,20 +60,6 @@ namespace serialized
     return v;
   }
 
-  // Read a length-prefixed (uint16_t) buffer into a string view
-  inline std::string_view read_lpsv(const uint8_t*& data, size_t& size)
-  {
-    auto len = read<uint16_t>(data, size);
-    if (size < len)
-      throw std::logic_error(
-        "Insufficient space (read block: " + std::to_string(size) + " < " +
-        std::to_string(len) + ")");
-    std::string_view v((char*)data, len);
-    data += len;
-    size -= len;
-    return v;
-  };
-
   template <class T>
   void write(uint8_t*& data, size_t& size, const T& v)
   {

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -459,7 +459,7 @@ class Node:
                 rep = nc.get("/node/commit")
                 assert (
                     rep.status_code == 200
-                ), f"An error occured after node {self.local_node_id} joined the network: {rep.body}"
+                ), f"An error occurred after node {self.local_node_id} joined the network: {rep.body}"
                 self.network_state = infra.node.NodeNetworkState.joined
         except infra.clients.CCFConnectionException as e:
             raise TimeoutError(

--- a/tests/raft_scenarios/reconfiguration
+++ b/tests/raft_scenarios/reconfiguration
@@ -1,0 +1,46 @@
+nodes,0,1
+connect,0,1
+
+periodic_one,0,110
+dispatch_all
+
+assert_is_primary,0
+assert_is_backup,1
+
+periodic_all,10
+dispatch_all
+
+state_all
+
+# Reconfiguration: add two nodes at once that are necessary to 
+# commit reconfiguration entry itself
+create_new_node,2
+connect,0,2
+connect,1,2
+
+create_new_node,3
+connect,0,3
+connect,1,3
+connect,2,3
+
+replicate_new_configuration,1,0,1,2,3 # New configuration: [0, 1, 2, 3] in term 1
+periodic_all,10
+dispatch_one,0
+
+state_all
+
+dispatch_one,1
+
+state_all # 1 isn't committed until one of the new nodes (either 2 or 3) acks
+assert_commit_idx,0,0
+
+dispatch_one,2
+
+state_all # 1 is now committed as new node 2 has acked
+assert_commit_idx,0,1
+
+periodic_all,10
+dispatch_all
+
+state_all
+assert_state_sync


### PR DESCRIPTION
Part of https://github.com/microsoft/CCF/issues/3948

The raft test scenarios now support live reconfiguration. This is done via two new calls `create_new_node,node_id` (to create a new node) and `replicate_new_configuration,term,node_id1,node_id2,...` (to replicate this new configuration). To do this, we now serialise the reconfiguration entry, containing all nodes ids, and execute the reconfiguration hooks on both primary and backup nodes.

<details>
  <summary>Click to expand generated sequence diagram for new reconfiguration scenario </summary>

```mermaid
sequenceDiagram
  participant n[0]
  participant n[1] 
  participant n[2]
  participant n[3]
  Note over n[2]: Node n[2] created
  n[0]-->n[2]: connect
  n[1]-->n[2]: connect
  Note over n[3]: Node n[3] created
  n[0]-->n[3]: connect
  n[1]-->n[3]: connect
  n[2]-->n[3]: connect
  n[0]->>n[0]: replicate 1.1 = [0 bytes]  [reconfiguration]
  n[0]->>n[0]: [ledger] appending: 1.1=[144 bytes] {"data":"eyIwIj
  n[0]->>n[0]: periodic for 10 ms
  n[1]->>n[1]: periodic for 10 ms
  n[2]->>n[2]: periodic for 10 ms
  n[3]->>n[3]: periodic for 10 ms
  n[0]->>n[2]: append_entries (0.0, 0.0] (term 1, commit 0)
  n[2]->>n[2]: [KV] rolling back to 0.0, in term 1
  n[2]->>n[2]: [ledger] truncating to 0
  n[0]->>n[3]: append_entries (0.0, 0.0] (term 1, commit 0)
  n[3]->>n[3]: [KV] rolling back to 0.0, in term 1
  n[3]->>n[3]: [ledger] truncating to 0
  n[0]->>n[3]: append_entries (0.0, 1.1] (term 1, commit 0)
  n[3]->>n[3]: [ledger] appending: 1.1=[144 bytes] {"data":"eyIwIj
  n[0]->>n[2]: append_entries (0.0, 1.1] (term 1, commit 0)
  n[2]->>n[2]: [ledger] appending: 1.1=[144 bytes] {"data":"eyIwIj
  n[0]->>n[1]: append_entries (0.0, 1.1] (term 1, commit 0)
  n[1]->>n[1]: [ledger] appending: 1.1=[144 bytes] {"data":"eyIwIj
  Note right of n[0]: P @1.1 (committed 0)
  Note right of n[1]: F @1.1 (committed 0)
  Note right of n[2]: F @1.1 (committed 0)
  Note right of n[3]: F @1.1 (committed 0)
  n[1]-->>n[0]: append_entries_response ACK for 1.1
  Note right of n[0]: P @1.1 (committed 0)
  Note right of n[1]: F @1.1 (committed 0)
  Note right of n[2]: F @1.1 (committed 0)
  Note right of n[3]: F @1.1 (committed 0)
  n[2]-->>n[0]: append_entries_response ACK for 1.0
  n[2]-->>n[0]: append_entries_response ACK for 1.1
  n[0]->>n[0]: [KV] compacting to 1
  Note right of n[0]: P @1.1 (committed 1)
  Note right of n[1]: F @1.1 (committed 0)
  Note right of n[2]: F @1.1 (committed 0)
  Note right of n[3]: F @1.1 (committed 0)
  n[0]->>n[0]: periodic for 10 ms
  n[1]->>n[1]: periodic for 10 ms
  n[2]->>n[2]: periodic for 10 ms
  n[3]->>n[3]: periodic for 10 ms
  n[0]->>n[3]: append_entries (1.1, 1.1] (term 1, commit 1)
  n[3]->>n[3]: [KV] compacting to 1
  n[0]->>n[2]: append_entries (1.1, 1.1] (term 1, commit 1)
  n[2]->>n[2]: [KV] compacting to 1
  n[0]->>n[1]: append_entries (1.1, 1.1] (term 1, commit 1)
  n[1]->>n[1]: [KV] compacting to 1
  n[3]-->>n[0]: append_entries_response ACK for 1.0
  n[3]-->>n[0]: append_entries_response ACK for 1.1
  n[1]-->>n[0]: append_entries_response ACK for 1.1
  n[2]-->>n[0]: append_entries_response ACK for 1.1
  n[3]-->>n[0]: append_entries_response ACK for 1.1
  Note right of n[0]: P @1.1 (committed 1)
  Note right of n[1]: F @1.1 (committed 1)
  Note right of n[2]: F @1.1 (committed 1)
  Note right of n[3]: F @1.1 (committed 1)
```
</details>