### PR TITLE
Drop tasks in `ThreadMessaging` destructor

### DIFF
--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -209,11 +209,6 @@ public:
     }
   }
 
-  ~RaftDriver()
-  {
-    threading::ThreadMessaging::thread_messaging.drop_tasks();
-  }
-
   void create_new_node(std::string node_id_s)
   {
     ccf::NodeId node_id(node_id_s);

--- a/src/ds/test/thread_messaging.cpp
+++ b/src/ds/test/thread_messaging.cpp
@@ -51,8 +51,6 @@ TEST_CASE("Unpopped messages are freed")
     tm.add_task<Foo>(0, std::move(m2));
     // Task is owned by the queue, hasn't run
     CHECK(Foo::count == 1);
-
-    tm.drop_tasks();
   }
   // Task payload (and TMsg) is also freed if it hasn't run
   // but the queue was destructed

--- a/src/ds/thread_messaging.h
+++ b/src/ds/thread_messaging.h
@@ -225,6 +225,11 @@ namespace threading
       tasks(num_threads)
     {}
 
+    ~ThreadMessaging()
+    {
+      drop_tasks();
+    }
+
     // Drop all pending tasks, this is only ever to be used
     // on shutdown, to avoid leaks, and after all thread but
     // the main one have been shut down.

--- a/src/ds/thread_messaging.h
+++ b/src/ds/thread_messaging.h
@@ -213,6 +213,17 @@ namespace threading
     std::atomic<bool> finished;
     std::vector<Task> tasks;
 
+    // Drop all pending tasks, this is only ever to be used
+    // on shutdown, to avoid leaks, and after all thread but
+    // the main one have been shut down.
+    void drop_tasks()
+    {
+      for (auto& t : tasks)
+      {
+        t.drop();
+      }
+    }
+
   public:
     static ThreadMessaging thread_messaging;
     static std::atomic<uint16_t> thread_count;
@@ -228,17 +239,6 @@ namespace threading
     ~ThreadMessaging()
     {
       drop_tasks();
-    }
-
-    // Drop all pending tasks, this is only ever to be used
-    // on shutdown, to avoid leaks, and after all thread but
-    // the main one have been shut down.
-    void drop_tasks()
-    {
-      for (auto& t : tasks)
-      {
-        t.drop();
-      }
     }
 
     void set_finished(bool v = true)

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -342,9 +342,6 @@ extern "C"
                threading::ThreadMessaging::thread_count - 1)
         {
         }
-        // All threads are done, we can drop any remaining tasks safely and
-        // completely
-        threading::ThreadMessaging::thread_messaging.drop_tasks();
         return s;
       }
       else


### PR DESCRIPTION
I don't think we should be calling this externally, as it implies an owning/responsible system. Instead we can cleanup when the static instance is destroyed to avoid leaks.