### PR TITLE
Stop building versioned documentation for 1.x

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -216,12 +216,12 @@ breathe_default_project = "CCF"
 # Set up multiversion extension
 
 smv_tag_whitelist = None
-smv_branch_whitelist = r"^(main)|(release\/\d+\.x)$"
+smv_branch_whitelist = r"^(main)|(release\/([2-9]|\d\d\d*)\.x)$"
 smv_remote_whitelist = None
 smv_outputdir_format = "{ref.name}"
 
 assert re.match(smv_branch_whitelist, "main")
-assert re.match(smv_branch_whitelist, "release/1.x")
+assert not re.match(smv_branch_whitelist, "release/1.x")
 assert re.match(smv_branch_whitelist, "release/2.x")
 assert re.match(smv_branch_whitelist, "release/100.x")
 assert not re.match(smv_branch_whitelist, "release/1.x_feature")


### PR DESCRIPTION
Now that `1.x` has been deprecated, we can stop building versioned documentation for it. 