### PR TITLE
Improved compatibility for clang-12 and clang-13

### DIFF
--- a/include/ccf/service/code_digest.h
+++ b/include/ccf/service/code_digest.h
@@ -14,6 +14,8 @@ namespace ccf
 
     CodeDigest() = default;
     CodeDigest(const CodeDigest&) = default;
+
+    CodeDigest& operator=(const CodeDigest&) = default;
   };
 
   inline void to_json(nlohmann::json& j, const CodeDigest& code_digest)

--- a/src/ds/files.h
+++ b/src/ds/files.h
@@ -14,6 +14,7 @@
 
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 namespace files
 {

--- a/src/node/historical_queries_adapter.cpp
+++ b/src/node/historical_queries_adapter.cpp
@@ -102,7 +102,8 @@ namespace ccf
           ccf::ProofReceipt::ProofStep::Left :
           ccf::ProofReceipt::ProofStep::Right;
         const auto hash = crypto::Sha256Hash::from_span(
-          {node.hash.bytes, sizeof(node.hash.bytes)});
+          std::span<const uint8_t, ccf::ClaimsDigest::Digest::SIZE>(
+            node.hash.bytes, sizeof(node.hash.bytes)));
         proof_receipt->proof.push_back({direction, hash});
       }
 
@@ -129,8 +130,9 @@ namespace ccf
     {
       // Signature transaction
       auto sig_receipt = std::make_shared<SignatureReceipt>();
-      sig_receipt->signed_root =
-        crypto::Sha256Hash::from_span({in.root.bytes, sizeof(in.root.bytes)});
+      sig_receipt->signed_root = crypto::Sha256Hash::from_span(
+        std::span<const uint8_t, ccf::ClaimsDigest::Digest::SIZE>(
+          in.root.bytes, sizeof(in.root.bytes)));
 
       receipt = sig_receipt;
     }

--- a/src/service/tables/node_signature.h
+++ b/src/service/tables/node_signature.h
@@ -36,6 +36,8 @@ namespace ccf
     NodeSignature(const NodeId& node_) : node(node_) {}
     NodeSignature() = default;
 
+    NodeSignature& operator=(const NodeSignature& ns) = default;
+
     bool operator==(const NodeSignature& o) const
     {
       return sig == o.sig && hashed_nonce == o.hashed_nonce;


### PR DESCRIPTION
- If the default copy constructor is defined manually and the copy assignment operator is used, then the latter also needs to be defined.
- The constructor for std::span with statically defined extent (via the template argument) has been made `explicit` so .
- Changes to the type of `std::filesystem::path` make it so that it is not default formattable by fmtlib, it needs the `fmt/ostream.h` header.