### PR TITLE
<docs>[kvStoreAPI]: correct the comments in WriteOnlyHandle

### DIFF
--- a/include/ccf/tx.h
+++ b/include/ccf/tx.h
@@ -213,7 +213,7 @@ namespace kv
       return get_handle_by_name<typename M::Handle>(m.get_name());
     }
 
-    /** Get a read-write handle by map name. Map type must be specified
+    /** Get a write-only handle by map name. Map type must be specified
      * as explicit template parameter.
      *
      * @param map_name Name of map


### PR DESCRIPTION
This patch changes to comments about Key-Value Store API.
This PR is related to issue #4055.

## Detailed Changes
>/** Get a **read-write** handle by map name. Map type must be specified

to

>/** Get a **write-only** handle by map name. Map type must be specified

Thanks.