### PR TITLE
Docs: ignore link check for RFC2616

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -105,6 +105,7 @@ linkcheck_ignore = [
     r"../js/ccf-app.*",
     r"../doxygen/index.html",
     r"https://nghttp2.org/.*",
+    r"https://www.w3.org/Protocols/rfc2616/.*",
 ]
 
 


### PR DESCRIPTION
These links (automatically generated by the OpenAPI Sphinx extension) have become flaky lately, e.g.: https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=48244&view=logs&j=f1fd332c-cd58-5ba4-fc7d-3c1d3a3f0cd3&t=31418c00-d4df-5619-e99a-3cbbc8fcc481&l=537 so we now ignore them.