### PR TITLE
[release/2.x] Cherry pick: Add a method that decodes path parameters (#4126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.0.5]
 
-### Added
-
-- New `GET /node/network/removable_nodes` and `DELETE /node/network/nodes/{node_id}` exposed to allow operator to decide which nodes can be safely shut down after retirement, and clear their state from the Key-Value Store.
-
 ### Fixed
 
 - Fixed issue where two primary nodes could be elected if an election occurred while a reconfiguration transaction was still pending (#4018).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added a new method `get_decoded_request_path_params` that returns a map of decoded path parameters (#4126)
+
 ## [2.0.5]
+
+### Added
+
+- New `GET /node/network/removable_nodes` and `DELETE /node/network/nodes/{node_id}` exposed to allow operator to decide which nodes can be safely shut down after retirement, and clear their state from the Key-Value Store.
 
 ### Fixed
 

--- a/include/ccf/rpc_context.h
+++ b/include/ccf/rpc_context.h
@@ -72,6 +72,12 @@ namespace ccf
     /// {"name": "bob", "age": "42"}
     virtual const PathParams& get_request_path_params() = 0;
 
+    /// Decodes the path before returning a map of all PathParams.
+    /// For example, if the endpoint was installed at `/foo/{name}/{age}`, and
+    /// for the request path `/foo/bob%3A/42`, this would return the map:
+    /// {"name": "bob:", "age": "42"}
+    virtual const PathParams& get_decoded_request_path_params() = 0;
+
     /// Returns map of all headers found in the request.
     virtual const http::HeaderMap& get_request_headers() const = 0;
 

--- a/src/endpoints/endpoint_registry.cpp
+++ b/src/endpoints/endpoint_registry.cpp
@@ -4,6 +4,7 @@
 #include "ccf/endpoint_registry.h"
 
 #include "ccf/common_auth_policies.h"
+#include "http/http_parser.h"
 #include "node/rpc/rpc_context_impl.h"
 
 namespace ccf::endpoints
@@ -240,7 +241,6 @@ namespace ccf::endpoints
     kv::Tx&, ccf::RpcContext& rpc_ctx)
   {
     auto method = rpc_ctx.get_method();
-
     auto endpoints_for_exact_method = fully_qualified_endpoints.find(method);
     if (endpoints_for_exact_method != fully_qualified_endpoints.end())
     {
@@ -279,6 +279,7 @@ namespace ccf::endpoints
                 throw std::logic_error("Unexpected type of RpcContext");
               }
               auto& path_params = ctx_impl->path_params;
+              auto& decoded_path_params = ctx_impl->decoded_path_params;
               for (size_t i = 0;
                    i < endpoint->spec.template_component_names.size();
                    ++i)
@@ -286,7 +287,9 @@ namespace ccf::endpoints
                 const auto& template_name =
                   endpoint->spec.template_component_names[i];
                 const auto& template_value = match[i + 1].str();
+                auto decoded_value = http::url_decode(template_value);
                 path_params[template_name] = template_value;
+                decoded_path_params[template_name] = decoded_value;
               }
             }
 

--- a/src/node/rpc/rpc_context_impl.h
+++ b/src/node/rpc/rpc_context_impl.h
@@ -36,6 +36,12 @@ namespace ccf
       return path_params;
     }
 
+    ccf::PathParams decoded_path_params = {};
+    virtual const ccf::PathParams& get_decoded_request_path_params() override
+    {
+      return decoded_path_params;
+    }
+
     bool is_create_request = false;
     bool execute_on_node = false;
 


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Add a method that decodes path parameters (#4126)](https://github.com/microsoft/CCF/pull/4126)