### PR TITLE
Update playbooks to use OE 0.18.2

### DIFF
--- a/getting_started/setup_vm/roles/openenclave/vars/common.yml
+++ b/getting_started/setup_vm/roles/openenclave/vars/common.yml
@@ -1,6 +1,6 @@
-oe_ver: "0.18.1"
+oe_ver: "0.18.2"
 # Usually the same, except for rc, where ver is -rc and ver_ is _rc
-oe_ver_: "0.18.1"
+oe_ver_: "0.18.2"
 
 # Source install
 workspace: "/tmp/"


### PR DESCRIPTION
To be tagged as `ccf_ci_image/oe-0.18.2-0`.