### PR TITLE
[release/2.x] Cherry pick: Upgrade to OpenEnclave 0.18.2 (#4134)

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -7,7 +7,7 @@ trigger:
 
 jobs:
   - job: build_and_publish_docs
-    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
+    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
     pool:
       vmImage: ubuntu-20.04
 

--- a/.azure-pipelines-quictls.yml
+++ b/.azure-pipelines-quictls.yml
@@ -17,7 +17,7 @@ parameters:
 
 jobs:
   - job: build_quictls
-    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
+    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
     pool: 1es-dv4-focal
 
     strategy:

--- a/.azure-pipelines-v8.yml
+++ b/.azure-pipelines-v8.yml
@@ -20,7 +20,7 @@ parameters:
 
 jobs:
   - job: build_v8
-    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
+    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
     pool: 1es-dv4-focal
 
     strategy:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -27,11 +27,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
 
 variables:

--- a/.daily.yml
+++ b/.daily.yml
@@ -23,11 +23,11 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Sample Development Environment for CCF",
   "context": "..",
-  "image": "ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0",
+  "image": "ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0",
   "runArgs": [],
   "extensions": ["ms-vscode.cpptools", "ms-python.python"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Sample Development Environment for CCF",
   "context": "..",
-  "image": "ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.0",
+  "image": "ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0",
   "runArgs": [],
   "extensions": ["ms-vscode.cpptools", "ms-python.python"]
 }

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
+    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
 
     steps:
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -16,7 +16,7 @@ pr:
 resources:
   containers:
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/.stress.yml
+++ b/.stress.yml
@@ -21,7 +21,7 @@ schedules:
 resources:
   containers:
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.1-0
+      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Dependencies
+
+- Upgraded OpenEnclave to 0.18.2 (#4132).
+
 ### Added
 
 - Added a new method `get_decoded_request_path_params` that returns a map of decoded path parameters (#4126)

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -30,7 +30,7 @@ if((NOT ${IS_VALID_TARGET}))
 endif()
 
 # Find OpenEnclave package
-find_package(OpenEnclave 0.18.0 CONFIG REQUIRED)
+find_package(OpenEnclave 0.18.2 CONFIG REQUIRED)
 # As well as pulling in openenclave:: targets, this sets variables which can be
 # used for our edge cases (eg - for virtual libraries). These do not follow the
 # standard naming patterns, for example use OE_INCLUDEDIR rather than

--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -19,7 +19,7 @@ endif()
 
 # CPack variables for Debian packages
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-    "open-enclave (>=0.18.1), libuv1 (>= 1.34.2), libc++1-10, libc++abi1-10, openssl (>=1.1.1)"
+    "open-enclave (>=0.18.2), libuv1 (>= 1.34.2), libc++1-10, libc++abi1-10, openssl (>=1.1.1)"
 )
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 


### PR DESCRIPTION
Manual backport of #4134.

(Re-creation of #4135, which fails `lts_compatibility` test due to branch name)