### PR TITLE
Test AMD pool

### DIFF
--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -12,6 +12,9 @@ parameters:
     SGX:
       container: sgx
       pool: 1es-dcv2-focal
+    AMD:
+      container: nosgx
+      pool: 1es-dcasv5-focal
 
   build:
     common:
@@ -74,7 +77,7 @@ jobs:
       - template: common.yml
         parameters:
           target: NoSGX
-          env: ${{ parameters.env.NoSGX }}
+          env: ${{ parameters.env.AMD }}
           fetch_v8: release
           cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.perf.cmake_args }} ${{ parameters.build.v8.cmake_args }} ${{ parameters.build.NoSGX.cmake_args }}"
           suffix: "Perf"


### PR DESCRIPTION
This is running the virtual perf tests on Standard D8ads v5 (AMD), rather than Standard D8ds v5 (Intel).