### PR TITLE
Update `ledger.py` to handle multiple recoveries

### DIFF
--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -491,7 +491,10 @@ class LedgerValidator:
             elif self.service_status == updated_status:
                 pass
             elif self.service_status == "Opening":
-                assert updated_status in ["Open", "WaitingForRecoveryShares"], updated_status
+                assert updated_status in [
+                    "Open",
+                    "WaitingForRecoveryShares",
+                ], updated_status
             elif self.service_status == "Recovering":
                 assert updated_status in ["WaitingForRecoveryShares"], updated_status
             elif self.service_status == "WaitingForRecoveryShares":

--- a/python/ccf/ledger.py
+++ b/python/ccf/ledger.py
@@ -485,18 +485,21 @@ class LedgerValidator:
             updated_service = service_table.get(WELL_KNOWN_SINGLETON_TABLE_KEY)
             updated_service_json = json.loads(updated_service)
             updated_status = updated_service_json["status"]
-            if self.service_status == updated_status:
+            if updated_status == "Opening":
+                # DR can happen at any point, so a transition to "Opening" is always valid
+                pass
+            elif self.service_status == updated_status:
                 pass
             elif self.service_status == "Opening":
-                assert updated_status in ["Open"]
+                assert updated_status in ["Open", "WaitingForRecoveryShares"], updated_status
             elif self.service_status == "Recovering":
-                assert updated_status in ["WaitingForRecoveryShares"]
+                assert updated_status in ["WaitingForRecoveryShares"], updated_status
             elif self.service_status == "WaitingForRecoveryShares":
-                assert updated_status in ["Open"]
+                assert updated_status in ["Open"], updated_status
             elif self.service_status == "Open":
-                assert updated_status in ["Recovering"]
+                assert updated_status in ["Recovering"], updated_status
             else:
-                assert self.service_status == None
+                assert self.service_status == None, self.service_status
             self.service_status = updated_status
 
         # Checks complete, add this transaction to tree


### PR DESCRIPTION
Assertions of state transitions in `ledger.py` didn't handle recoveries started during an existing recovery.