### PR TITLE
Remove hardcoded prefix `/app` for application endpoints

### DIFF
--- a/doc/build_apps/example_cpp.rst
+++ b/doc/build_apps/example_cpp.rst
@@ -72,11 +72,11 @@ Each function is installed as the handler for a specific HTTP resource, defined 
     :end-before: SNIPPET_END: install_record
     :dedent:
 
-This example installs at ``"log/private", HTTP_POST``, so will be invoked for HTTP requests beginning :http:POST:`/app/log/private`.
+This example installs at ``"log/private", HTTP_POST``, so will be invoked for HTTP requests beginning :http:POST:`/log/private`.
 
-The return value from ``make_endpoint`` is an ``Endpoint&`` object which can be used to alter how the handler is executed. For example, the handler for :http:POST:`/app/log/private` shown above sets a `schema` declaring the types of its request and response bodies. These will be used in calls to the :http:GET:`/app/api` endpoint to populate the relevant parts of the OpenAPI document. That OpenAPI document in turn is used to generate the entries in this documentation describing :http:POST:`/app/log/private`.
+The return value from ``make_endpoint`` is an ``Endpoint&`` object which can be used to alter how the handler is executed. For example, the handler for :http:POST:`/log/private` shown above sets a `schema` declaring the types of its request and response bodies. These will be used in calls to the :http:GET:`/api` endpoint to populate the relevant parts of the OpenAPI document. That OpenAPI document in turn is used to generate the entries in this documentation describing :http:POST:`/log/private`.
 
-There are other endpoints installed for the URI path ``/app/log/private`` with different verbs, to handle :http:GET:`GET </app/log/private>` and :http:DELETE:`DELETE </app/log/private>` requests. Requests with those verbs will be executed by the appropriate handler. Any other verbs, without an installed endpoint, will not be accepted - the framework will return a ``405 Method Not Allowed`` response.
+There are other endpoints installed for the URI path ``/log/private`` with different verbs, to handle :http:GET:`GET </log/private>` and :http:DELETE:`DELETE </log/private>` requests. Requests with those verbs will be executed by the appropriate handler. Any other verbs, without an installed endpoint, will not be accepted - the framework will return a ``405 Method Not Allowed`` response.
 
 To process the raw body directly, a handler should use the general lambda signature which takes a single ``EndpointContext&`` parameter. Examples of this are also included in the logging sample app. For instance the ``log_record_text`` handler takes a raw string as the request body:
 
@@ -163,7 +163,7 @@ The final piece is the definition of the endpoint itself, which uses an instance
 Default Endpoints
 ~~~~~~~~~~~~~~~~~
 
-The logging app sample exposes several built-in endpoints which are provided by the framework for convenience, such as :http:GET:`/app/tx`, :http:GET:`/app/commit`, and :http:GET:`/app/receipt`. It is also possible to write an app which does not expose these endpoints, either to build a minimal user-facing API or to re-wrap this common functionality in your own format or authentication. A sample of this is provided in ``samples/apps/nobuiltins``. Whereas the logging app declares a registry inheriting from :cpp:class:`ccf::CommonEndpointRegistry`, this app inherits from :cpp:class:`ccf::BaseEndpointRegistry` which does not install any default endpoints:
+The logging app sample exposes several built-in endpoints which are provided by the framework for convenience, such as :http:GET:`/tx`, :http:GET:`/commit`, and :http:GET:`/receipt`. It is also possible to write an app which does not expose these endpoints, either to build a minimal user-facing API or to re-wrap this common functionality in your own format or authentication. A sample of this is provided in ``samples/apps/nobuiltins``. Whereas the logging app declares a registry inheriting from :cpp:class:`ccf::CommonEndpointRegistry`, this app inherits from :cpp:class:`ccf::BaseEndpointRegistry` which does not install any default endpoints:
 
 .. literalinclude:: ../../samples/apps/nobuiltins/nobuiltins.cpp
     :language: cpp

--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -268,11 +268,11 @@
   "info": {
     "description": "This CCF sample app implements a simple logging application, securely recording messages at client-specified IDs. It demonstrates most of the features available to CCF apps.",
     "title": "CCF Sample Logging App",
-    "version": "1.10.0"
+    "version": "1.10.1"
   },
   "openapi": "3.0.0",
   "paths": {
-    "/app/api": {
+    "/api": {
       "get": {
         "responses": {
           "200": {
@@ -291,7 +291,7 @@
         }
       }
     },
-    "/app/api/metrics": {
+    "/api/metrics": {
       "get": {
         "responses": {
           "200": {
@@ -310,7 +310,7 @@
         }
       }
     },
-    "/app/code": {
+    "/code": {
       "get": {
         "responses": {
           "200": {
@@ -329,7 +329,7 @@
         }
       }
     },
-    "/app/commit": {
+    "/commit": {
       "get": {
         "responses": {
           "200": {
@@ -348,7 +348,7 @@
         }
       }
     },
-    "/app/custom_auth": {
+    "/custom_auth": {
       "get": {
         "responses": {
           "200": {
@@ -367,7 +367,7 @@
         }
       }
     },
-    "/app/local_tx": {
+    "/local_tx": {
       "get": {
         "parameters": [
           {
@@ -396,7 +396,7 @@
         }
       }
     },
-    "/app/log/private": {
+    "/log/private": {
       "delete": {
         "parameters": [
           {
@@ -494,7 +494,7 @@
         }
       }
     },
-    "/app/log/private/admin_only": {
+    "/log/private/admin_only": {
       "post": {
         "requestBody": {
           "content": {
@@ -528,7 +528,7 @@
         }
       }
     },
-    "/app/log/private/all": {
+    "/log/private/all": {
       "delete": {
         "responses": {
           "200": {
@@ -552,7 +552,7 @@
         }
       }
     },
-    "/app/log/private/anonymous": {
+    "/log/private/anonymous": {
       "post": {
         "requestBody": {
           "content": {
@@ -581,7 +581,7 @@
         }
       }
     },
-    "/app/log/private/count": {
+    "/log/private/count": {
       "get": {
         "responses": {
           "200": {
@@ -605,7 +605,7 @@
         }
       }
     },
-    "/app/log/private/historical": {
+    "/log/private/historical": {
       "get": {
         "parameters": [
           {
@@ -639,7 +639,7 @@
         }
       }
     },
-    "/app/log/private/historical/sparse": {
+    "/log/private/historical/sparse": {
       "get": {
         "parameters": [
           {
@@ -681,7 +681,7 @@
         }
       }
     },
-    "/app/log/private/historical_receipt": {
+    "/log/private/historical_receipt": {
       "get": {
         "parameters": [
           {
@@ -715,7 +715,7 @@
         }
       }
     },
-    "/app/log/private/prefix_cert": {
+    "/log/private/prefix_cert": {
       "post": {
         "requestBody": {
           "content": {
@@ -749,7 +749,7 @@
         }
       }
     },
-    "/app/log/private/raw_text/{id}": {
+    "/log/private/raw_text/{id}": {
       "parameters": [
         {
           "in": "path",
@@ -776,7 +776,7 @@
         }
       }
     },
-    "/app/log/public": {
+    "/log/public": {
       "delete": {
         "parameters": [
           {
@@ -874,7 +874,7 @@
         }
       }
     },
-    "/app/log/public/all": {
+    "/log/public/all": {
       "delete": {
         "responses": {
           "200": {
@@ -898,7 +898,7 @@
         }
       }
     },
-    "/app/log/public/count": {
+    "/log/public/count": {
       "get": {
         "responses": {
           "200": {
@@ -922,7 +922,7 @@
         }
       }
     },
-    "/app/log/public/historical/range": {
+    "/log/public/historical/range": {
       "get": {
         "parameters": [
           {
@@ -972,7 +972,7 @@
         }
       }
     },
-    "/app/log/public/historical_receipt": {
+    "/log/public/historical_receipt": {
       "get": {
         "parameters": [
           {
@@ -1006,7 +1006,7 @@
         }
       }
     },
-    "/app/log/request_query": {
+    "/log/request_query": {
       "get": {
         "responses": {
           "200": {
@@ -1025,7 +1025,7 @@
         }
       }
     },
-    "/app/log/signed_request_query": {
+    "/log/signed_request_query": {
       "get": {
         "responses": {
           "200": {
@@ -1049,7 +1049,7 @@
         }
       }
     },
-    "/app/multi_auth": {
+    "/multi_auth": {
       "get": {
         "responses": {
           "200": {
@@ -1080,7 +1080,7 @@
         }
       }
     },
-    "/app/receipt": {
+    "/receipt": {
       "get": {
         "parameters": [
           {
@@ -1109,7 +1109,7 @@
         }
       }
     },
-    "/app/tx": {
+    "/tx": {
       "get": {
         "parameters": [
           {

--- a/include/ccf/actors.h
+++ b/include/ccf/actors.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 namespace ccf
 {
@@ -15,6 +16,17 @@ namespace ccf
     // not to be used
     unknown
   };
+
+  inline bool is_valid_actor(const std::string& actor)
+  {
+    if (
+      actor != "gov" && actor != "app" && actor != "node" &&
+      actor != ".well-known")
+    {
+      return false;
+    }
+    return true;
+  }
 
   constexpr auto get_actor_prefix(ActorsType at)
   {

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -247,7 +247,7 @@ namespace loggingapp
         "This CCF sample app implements a simple logging application, securely "
         "recording messages at client-specified IDs. It demonstrates most of "
         "the features available to CCF apps.";
-      openapi_info.document_version = "1.10.0";
+      openapi_info.document_version = "1.10.1";
 
       index_per_public_key = std::make_shared<RecordsIndexingStrategy>(
         PUBLIC_RECORDS, context, 10000, 20);

--- a/src/endpoints/endpoint_registry.cpp
+++ b/src/endpoints/endpoint_registry.cpp
@@ -140,9 +140,16 @@ namespace ccf::endpoints
     {
       endpoint.dispatch.uri_path = fmt::format("/{}", method);
     }
+    if (method_prefix == "app")
+    {
+      endpoint.full_uri_path = endpoint.dispatch.uri_path;
+    }
+    else
+    {
+      endpoint.full_uri_path =
+        fmt::format("/{}{}", method_prefix, endpoint.dispatch.uri_path);
+    }
     endpoint.dispatch.verb = verb;
-    endpoint.full_uri_path =
-      fmt::format("/{}{}", method_prefix, endpoint.dispatch.uri_path);
     endpoint.func = f;
     endpoint.authn_policies = ap;
     // By default, all write transactions are forwarded

--- a/src/http/http2_endpoint.h
+++ b/src/http/http2_endpoint.h
@@ -160,30 +160,21 @@ namespace http
         }
 
         const auto actor_opt = http::extract_actor(*rpc_ctx);
-        if (!actor_opt.has_value())
+        std::optional<std::shared_ptr<ccf::RpcHandler>> search;
+        ccf::ActorsType actor;
+        if (actor_opt.has_value())
         {
-          rpc_ctx->set_error(
-            HTTP_STATUS_NOT_FOUND,
-            ccf::errors::ResourceNotFound,
-            fmt::format(
-              "Request path must contain '/[actor]/[method]'. Unable to parse "
-              "'{}'.",
-              rpc_ctx->get_method()));
-          // Note: return HTTP_STATUS_NOT_FOUND, e.what()
-          return;
+          const auto& actor_s = actor_opt.value();
+          actor = rpc_map->resolve(actor_s);
+          search = rpc_map->find(actor);
         }
-
-        const auto& actor_s = actor_opt.value();
-        auto actor = rpc_map->resolve(actor_s);
-        auto search = rpc_map->find(actor);
-        if (actor == ccf::ActorsType::unknown || !search.has_value())
+        if (
+          !actor_opt.has_value() || actor == ccf::ActorsType::unknown ||
+          !search.has_value())
         {
-          rpc_ctx->set_error(
-            HTTP_STATUS_NOT_FOUND,
-            ccf::errors::ResourceNotFound,
-            fmt::format("Unknown actor '{}'.", actor_s));
-          // Note: return HTTP_STATUS_NOT_FOUND, e.what()
-          return;
+          // if there is no actor, proceed with the "app" as the ActorType and
+          // process the request
+          search = rpc_map->find(ccf::ActorsType::users);
         }
 
         auto response = search.value()->process(rpc_ctx);

--- a/src/http/http_endpoint.h
+++ b/src/http/http_endpoint.h
@@ -4,6 +4,7 @@
 
 #include "ccf/ds/logger.h"
 #include "enclave/client_endpoint.h"
+#include "enclave/rpc_handler.h"
 #include "enclave/rpc_map.h"
 #include "error_reporter.h"
 #include "http_parser.h"
@@ -209,30 +210,21 @@ namespace http
         }
 
         const auto actor_opt = http::extract_actor(*rpc_ctx);
-        if (!actor_opt.has_value())
+        std::optional<std::shared_ptr<ccf::RpcHandler>> search;
+        ccf::ActorsType actor;
+        if (actor_opt.has_value())
         {
-          rpc_ctx->set_error(
-            HTTP_STATUS_NOT_FOUND,
-            ccf::errors::ResourceNotFound,
-            fmt::format(
-              "Request path must contain '/[actor]/[method]'. Unable to parse "
-              "'{}'.",
-              rpc_ctx->get_method()));
-          send_raw(rpc_ctx->serialise_response());
-          return;
+          const auto& actor_s = actor_opt.value();
+          actor = rpc_map->resolve(actor_s);
+          search = rpc_map->find(actor);
         }
-
-        const auto& actor_s = actor_opt.value();
-        auto actor = rpc_map->resolve(actor_s);
-        auto search = rpc_map->find(actor);
-        if (actor == ccf::ActorsType::unknown || !search.has_value())
+        if (
+          !actor_opt.has_value() || actor == ccf::ActorsType::unknown ||
+          !search.has_value())
         {
-          rpc_ctx->set_error(
-            HTTP_STATUS_NOT_FOUND,
-            ccf::errors::ResourceNotFound,
-            fmt::format("Unknown actor '{}'.", actor_s));
-          send_raw(rpc_ctx->serialise_response());
-          return;
+          // if there is no actor, proceed with the "app" as the ActorType and
+          // process the request
+          search = rpc_map->find(ccf::ActorsType::users);
         }
 
         auto response = search.value()->process(rpc_ctx);

--- a/src/http/http_rpc_context.h
+++ b/src/http/http_rpc_context.h
@@ -268,7 +268,6 @@ namespace http
   inline static std::optional<std::string> extract_actor(HttpRpcContext& ctx)
   {
     const auto path = ctx.get_method();
-
     const auto first_slash = path.find_first_of('/');
     const auto second_slash = path.find_first_of('/', first_slash + 1);
 
@@ -284,8 +283,18 @@ namespace http
     {
       return std::nullopt;
     }
-
-    ctx.set_method(remaining_path);
+    // TODO: Remove ActorType hardcoding
+    // if the extracted actor is a known type, set the remaining path
+    if (
+      actor == "gov" || actor == "node" || actor == ".well-known" ||
+      actor == "app")
+    {
+      ctx.set_method(remaining_path);
+    }
+    else
+    {
+      ctx.set_method(path);
+    }
     return actor;
   }
 }

--- a/src/http/http_rpc_context.h
+++ b/src/http/http_rpc_context.h
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ccf/actors.h"
 #include "ccf/odata_error.h"
 #include "ccf/rpc_context.h"
 #include "http_parser.h"
@@ -283,11 +284,9 @@ namespace http
     {
       return std::nullopt;
     }
-    // TODO: Remove ActorType hardcoding
+
     // if the extracted actor is a known type, set the remaining path
-    if (
-      actor == "gov" || actor == "node" || actor == ".well-known" ||
-      actor == "app")
+    if (ccf::is_valid_actor(actor))
     {
       ctx.set_method(remaining_path);
     }

--- a/tests/connections.py
+++ b/tests/connections.py
@@ -123,7 +123,7 @@ def run(args):
                             )
                         )
                         r = clients[-1].post(
-                            "/app/log/private",
+                            "/log/private",
                             {"id": 42, "msg": "foo"},
                             log_capture=logs,
                         )
@@ -185,7 +185,7 @@ def run(args):
                     logs = []
                     try:
                         client.post(
-                            "/app/log/private",
+                            "/log/private",
                             {"id": 42, "msg": "foo"},
                             timeout=1,
                             log_capture=logs,

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1382,7 +1382,7 @@ def test_random_receipts(
         certs[infra.crypto.compute_public_key_der_hash_hex_from_pem(cert)] = cert
 
     with node.client("user0") as c:
-        r = c.get("/app/commit")
+        r = c.get("/commit")
         max_view, max_seqno = [
             int(e) for e in r.body.json()["transaction_id"].split(".")
         ]

--- a/tests/nobuiltins.py
+++ b/tests/nobuiltins.py
@@ -10,7 +10,7 @@ import time
 def test_nobuiltins_endpoints(network, args):
     primary, backups = network.find_nodes()
     with primary.client() as c:
-        r = c.get("/app/commit")
+        r = c.get("/commit")
         assert r.status_code == HTTPStatus.OK
         body_j = r.body.json()
         tx_id = TxID.from_str(body_j["transaction_id"])

--- a/tests/recovery_benchmark.sh
+++ b/tests/recovery_benchmark.sh
@@ -42,7 +42,7 @@ set -e
 
 function service_http_status()
 {
-    curl -o /dev/null -s https://127.0.0.1:8000/app/commit -w "%{http_code}" --cacert ./workspace/sandbox_common/service_cert.pem
+    curl -o /dev/null -s https://127.0.0.1:8000/commit -w "%{http_code}" --cacert ./workspace/sandbox_common/service_cert.pem
 }
 
 function current_ledger_length()

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -5,7 +5,7 @@ set -e
 
 function service_http_status()
 {
-    curl -o /dev/null -s https://127.0.0.1:8000/app/commit -w "%{http_code}" --cacert ./workspace/sandbox_common/service_cert.pem
+    curl -o /dev/null -s https://127.0.0.1:8000/commit -w "%{http_code}" --cacert ./workspace/sandbox_common/service_cert.pem
 }
 
 function poll_for_service_open()


### PR DESCRIPTION
Resolves #3893 

This change will allow applications to use endpoints as defined when creating them i.e. an endpoint created at `/log/private`
will be available at `/log/private` without the additional prefix of `/app/`. The reference openapi schema now reflects this change.

This change will also allow existing (and new) applications to continue using and calling with `/app/` prefix as well.

TODO:
- [x] Cleanup TODOs in code
- [x] Update rst files