### PR TITLE
Add timeouts to raw requests calls

### DIFF
--- a/tests/governance.py
+++ b/tests/governance.py
@@ -356,6 +356,7 @@ def test_invalid_client_signature(network, args):
             f"https://{node.get_public_rpc_host()}:{node.get_public_rpc_port()}/gov/proposals",
             headers=headers,
             verify=os.path.join(node.common_dir, "service_cert.pem"),
+            timeout=3,
         ).json()
         assert r["error"]["code"] == "InvalidAuthenticationInfo"
         assert (

--- a/tests/infra/github.py
+++ b/tests/infra/github.py
@@ -151,7 +151,9 @@ class GitEnv:
     def has_release_for_tag_name(self, tag_name):
         return (
             requests.head(
-                get_debian_package_url_from_tag_name(tag_name), allow_redirects=True
+                get_debian_package_url_from_tag_name(tag_name),
+                allow_redirects=True,
+                timeout=3,
             ).status_code
             == 200
         )


### PR DESCRIPTION
Flagged by Pylint since v2.15.0. Seems sensible to add a small timeout to these calls. All our wrapped CCF client calls already include a timeout.