### PR TITLE
Add `protoc` to `ccf-ci` image

### DIFF
--- a/getting_started/setup_vm/ccf-dev.yml
+++ b/getting_started/setup_vm/ccf-dev.yml
@@ -27,3 +27,6 @@
     - import_role:
         name: ccf_build
         tasks_from: install.yml
+    - import_role:
+        name: protoc
+        tasks_from: install.yml

--- a/getting_started/setup_vm/roles/ccf_build/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_build/vars/common.yml
@@ -27,6 +27,7 @@ debs:
   - libclang-cpp9 # required to build doxygen
   - pkg-config # required by v8
   - graphviz # required to run doxygen
+  - unzip # required to unzip protoc install
 
 # Not installed on GitHub Actions environment because of conflicting package
 docker_debs:

--- a/getting_started/setup_vm/roles/protoc/tasks/install.yml
+++ b/getting_started/setup_vm/roles/protoc/tasks/install.yml
@@ -1,0 +1,20 @@
+- name: Include vars
+  include_vars: common.yml
+
+- name: Download protoc
+  get_url:
+    url: https://github.com/protocolbuffers/protobuf/releases/download/v{{ protoc_version }}/protoc-{{ protoc_version }}-linux-x86_64.zip
+    dest: "{{ workspace }}/protoc.zip"
+  become: true
+
+- name: Create directory for protoc
+  file:
+    path: "{{ protoc_install_prefix }}"
+    state: directory
+  become: true
+
+- name: Unpack protoc
+  unarchive:
+    src: "{{ workspace }}/protoc.zip"
+    dest: "{{ protoc_install_prefix }}"
+  become: true

--- a/getting_started/setup_vm/roles/protoc/vars/common.yml
+++ b/getting_started/setup_vm/roles/protoc/vars/common.yml
@@ -1,0 +1,3 @@
+workspace: "/tmp/"
+protoc_version: 21.5 # Should be in sync with 3rdparty/internal/protobuf
+protoc_install_prefix: "/opt/protoc"


### PR DESCRIPTION
This is required by the [external executor app](https://github.com/microsoft/CCF/tree/main/src/apps/external_executor), as well as any built-in apps that want to support gRPC.