### PR TITLE
Add support for setting HTTP/2 trailing headers

### DIFF
--- a/include/ccf/ds/nonstd.h
+++ b/include/ccf/ds/nonstd.h
@@ -171,4 +171,49 @@ namespace nonstd
 
     return s;
   }
+
+  // Iterators for map-keys and map-values
+  template <typename TMapIterator>
+  class KeyIterator : public TMapIterator
+  {
+  public:
+    KeyIterator() : TMapIterator() {}
+    KeyIterator(TMapIterator it) : TMapIterator(it) {}
+
+    using Key =
+      typename std::iterator_traits<TMapIterator>::value_type::first_type;
+    using value_type = Key;
+
+    Key* operator->()
+    {
+      return TMapIterator::operator->()->first;
+    }
+
+    Key operator*()
+    {
+      return TMapIterator::operator*().first;
+    }
+  };
+
+  template <typename TMapIterator>
+  class ValueIterator : public TMapIterator
+  {
+  public:
+    ValueIterator() : TMapIterator() {}
+    ValueIterator(TMapIterator it) : TMapIterator(it) {}
+
+    using Value =
+      typename std::iterator_traits<TMapIterator>::value_type::second_type;
+    using value_type = Value;
+
+    Value* operator->()
+    {
+      return TMapIterator::operator->()->second;
+    }
+
+    Value operator*()
+    {
+      return TMapIterator::operator*().second;
+    }
+  };
 }

--- a/include/ccf/http_consts.h
+++ b/include/ccf/http_consts.h
@@ -10,6 +10,7 @@ namespace http
     static constexpr auto ACCEPT = "accept";
     static constexpr auto ALLOW = "allow";
     static constexpr auto AUTHORIZATION = "authorization";
+    static constexpr auto CACHE_CONTROL = "cache-control";
     static constexpr auto CONTENT_LENGTH = "content-length";
     static constexpr auto CONTENT_TYPE = "content-type";
     static constexpr auto DATE = "date";
@@ -17,8 +18,8 @@ namespace http
     static constexpr auto HOST = "host";
     static constexpr auto LOCATION = "location";
     static constexpr auto RETRY_AFTER = "retry-after";
+    static constexpr auto TRAILER = "trailer";
     static constexpr auto WWW_AUTHENTICATE = "www-authenticate";
-    static constexpr auto CACHE_CONTROL = "cache-control";
 
     static constexpr auto CCF_TX_ID = "x-ms-ccf-transaction-id";
   }

--- a/include/ccf/rpc_context.h
+++ b/include/ccf/rpc_context.h
@@ -118,6 +118,13 @@ namespace ccf
       set_response_header(name, std::to_string(n));
     }
 
+    virtual void set_response_trailer(
+      const std::string_view& name, const std::string_view& value) = 0;
+    virtual void set_response_trailer(const std::string_view& name, size_t n)
+    {
+      set_response_trailer(name, std::to_string(n));
+    }
+
     /// Construct OData-formatted response to capture multiple error details
     virtual void set_error(
       http_status status,

--- a/src/apps/external_executor/external_executor.cpp
+++ b/src/apps/external_executor/external_executor.cpp
@@ -31,8 +31,8 @@ namespace externalexecutor
     {
       return [fn](ccf::endpoints::EndpointContext& ctx) {
         fn(ctx);
-        ctx.rpc_ctx->set_response_trailer("gprc-status", 0);
-        //ctx.rpc_ctx->set_response_trailer("gprc-message", "I'm helping!");
+        ctx.rpc_ctx->set_response_trailer("grpc-status", 0);
+        ctx.rpc_ctx->set_response_trailer("grpc-message", "Ok");
       };
     }
 

--- a/src/apps/external_executor/external_executor.cpp
+++ b/src/apps/external_executor/external_executor.cpp
@@ -26,6 +26,16 @@ namespace externalexecutor
       }
     }
 
+    ccf::endpoints::EndpointFunction grpc_response_status_wrapper(
+      const ccf::endpoints::EndpointFunction& fn)
+    {
+      return [fn](ccf::endpoints::EndpointContext& ctx) {
+        fn(ctx);
+        ctx.rpc_ctx->set_response_trailer("gprc-status", 0);
+        //ctx.rpc_ctx->set_response_trailer("gprc-message", "I'm helping!");
+      };
+    }
+
   public:
     EndpointRegistry(ccfapp::AbstractNodeContext& context) :
       ccf::UserEndpointRegistry(context)
@@ -51,7 +61,11 @@ namespace externalexecutor
         CCF_APP_INFO("ECHO HANDLER END");
       };
 
-      make_endpoint("ccf.Echo/Echo", HTTP_POST, do_echo, ccf::no_auth_required)
+      make_endpoint(
+        "ccf.Echo/Echo",
+        HTTP_POST,
+        grpc_response_status_wrapper(do_echo),
+        ccf::no_auth_required)
         .install();
     }
   };

--- a/src/http/http2.h
+++ b/src/http/http2.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ccf/ds/logger.h"
+#include "ccf/ds/nonstd.h"
 #include "enclave/endpoint.h"
 #include "http2_types.h"
 #include "http_proc.h"
@@ -496,16 +497,11 @@ namespace http2
       hdrs.emplace_back(
         make_nv(http::headers::CONTENT_LENGTH, body_size.data()));
 
-      std::string trailer_header_val;
-
-      for (const auto& [k, v] : trailers)
-      {
-        if (!trailer_header_val.empty())
-        {
-          trailer_header_val += ",";
-        }
-        trailer_header_val += k;
-      }
+      using HeaderKeysIt = nonstd::KeyIterator<http::HeaderMap::iterator>;
+      const auto trailer_header_val = fmt::format(
+        "{}",
+        fmt::join(
+          HeaderKeysIt(trailers.begin()), HeaderKeysIt(trailers.end()), ","));
 
       if (!trailer_header_val.empty())
       {

--- a/src/http/http2.h
+++ b/src/http/http2.h
@@ -54,6 +54,7 @@ namespace http2
 
     if (!stream_data->trailers.empty())
     {
+      LOG_TRACE_FMT("Submitting {} trailers", stream_data->trailers.size());
       std::vector<nghttp2_nv> trlrs;
       trlrs.reserve(stream_data->trailers.size());
       for (auto& [k, v] : stream_data->trailers)

--- a/src/http/http2_endpoint.h
+++ b/src/http/http2_endpoint.h
@@ -191,6 +191,7 @@ namespace http
             stream_id,
             rpc_ctx->get_response_http_status(),
             rpc_ctx->get_response_headers(),
+            rpc_ctx->get_response_trailers(),
             std::move(rpc_ctx->get_response_body()));
         }
       }

--- a/src/http/http2_types.h
+++ b/src/http/http2_types.h
@@ -23,6 +23,7 @@ namespace http2
   {
     StreamId id;
     http::HeaderMap headers;
+    http::HeaderMap trailers;
     std::string url;
     ccf::RESTVerb verb;
     std::vector<uint8_t> request_body;

--- a/src/http/http_rpc_context.h
+++ b/src/http/http_rpc_context.h
@@ -51,6 +51,7 @@ namespace http
     std::vector<uint8_t> serialised_request = {};
 
     http::HeaderMap response_headers;
+    http::HeaderMap response_trailers;
     std::vector<uint8_t> response_body = {};
     http_status response_status = HTTP_STATUS_OK;
 
@@ -117,6 +118,11 @@ namespace http
     http::HeaderMap get_response_headers() const
     {
       return response_headers;
+    }
+
+    http::HeaderMap get_response_trailers() const
+    {
+      return response_trailers;
     }
 
     std::vector<uint8_t>& get_response_body()
@@ -226,6 +232,12 @@ namespace http
       const std::string_view& name, const std::string_view& value) override
     {
       response_headers[std::string(name)] = value;
+    }
+
+    virtual void set_response_trailer(
+      const std::string_view& name, const std::string_view& value) override
+    {
+      response_trailers[std::string(name)] = value;
     }
 
     virtual void set_apply_writes(bool apply) override


### PR DESCRIPTION
Pretty barebones at the moment, but sufficient for setting the `grpc-response` trailer required by gRPC clients.

I think technically we should only be inserting response trailers if a `te: trailers` header was received in the request, and not everything requires the `trailer:` response header, but we can revisit those if they cause problems.