### PR TITLE
Silence messages from protobuf cmake

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -8,9 +8,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 find_package(Threads REQUIRED)
 
 function(message)
-    if (NOT MESSAGE_QUIET)
-        _message(${ARGN})
-    endif()
+  if(NOT MESSAGE_QUIET)
+    _message(${ARGN})
+  endif()
 endfunction()
 
 option(PROFILE_TESTS "Profile tests" OFF)

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -7,6 +7,12 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_package(Threads REQUIRED)
 
+function(message)
+    if (NOT MESSAGE_QUIET)
+        _message(${ARGN})
+    endif()
+endfunction()
+
 option(PROFILE_TESTS "Profile tests" OFF)
 set(PYTHON unbuffer python3)
 
@@ -188,7 +194,9 @@ include(${CCF_DIR}/cmake/crypto.cmake)
 include(${CCF_DIR}/cmake/quickjs.cmake)
 include(${CCF_DIR}/cmake/sss.cmake)
 include(${CCF_DIR}/cmake/nghttp2.cmake)
+set(MESSAGE_QUIET ON)
 include(${CCF_DIR}/cmake/protobuf.cmake)
+unset(MESSAGE_QUIET)
 
 # Unit test wrapper
 function(add_unit_test name)


### PR DESCRIPTION
The protobuf cmake that is included since #4181 adds some unhelpful `message()`s to our CMake output - an empty line for some missing version, and a version with no prefix. It'd be fine if they indicated they were about protobufs, or were only enabled by a flag (all the cmake file's _other_ logging is gated by `protobuf_VERBOSE`, I don't know why this isn't).

If we were on CMake 3.17, we could at least add some [context](https://cmake.org/cmake/help/latest/variable/CMAKE_MESSAGE_CONTEXT.html#variable:CMAKE_MESSAGE_CONTEXT) ourselves to prefix these lines, but we're not.

This approach is taken from [here](https://stackoverflow.com/a/38983571/747433), and mutes _all_ logging by the included cmake. This isn't ideal - I'd still like logs if there are errors! But assuming we continue with no errors, the version lines are more annoying.

Before:
```
-- QuickJS prefix: /data/src/3.CCF/3rdparty/exported/quickjs version: 2021-03-27
-- Using sss at /data/src/3.CCF/3rdparty/internal/sss
-- 
-- 3.21.5.0
-- Configuring done
```

After:
```
-- QuickJS prefix: /data/src/3.CCF/3rdparty/exported/quickjs version: 2021-03-27
-- Using sss at /data/src/3.CCF/3rdparty/internal/sss
-- Configuring done
```