### PR TITLE
Removing a line break from map_handle.h

### DIFF
--- a/include/ccf/kv/map_handle.h
+++ b/include/ccf/kv/map_handle.h
@@ -108,7 +108,8 @@ namespace kv
 
     /** Iterate over all entries in the map.
      *
-     * The passed functor should have the signature `bool(const K& k, const V& v)`.
+     * The passed functor should have the signature
+     * `bool(const K& k, const V& v)`.
      * The iteration order is undefined.
      * Return true to continue iteration, or return false from any invocation to
      * terminate the iteration at that point - the functor will not be invoked

--- a/include/ccf/kv/map_handle.h
+++ b/include/ccf/kv/map_handle.h
@@ -108,8 +108,7 @@ namespace kv
 
     /** Iterate over all entries in the map.
      *
-     * The passed functor should have the signature `bool(const K& k, const V&
-     * v)`.
+     * The passed functor should have the signature `bool(const K& k, const V& v)`.
      * The iteration order is undefined.
      * Return true to continue iteration, or return false from any invocation to
      * terminate the iteration at that point - the functor will not be invoked


### PR DESCRIPTION
Fixing line break midway through a code sample in docs. See image below
![image](https://user-images.githubusercontent.com/1835251/188149543-d935808f-031d-415c-8701-0f46db2e73b0.png)
