### PR TITLE
Fix SAN failure in Daily build

### DIFF
--- a/.daily_canary
+++ b/.daily_canary
@@ -1,1 +1,1 @@
-Canary.
+Canary!


### PR DESCRIPTION
The Instrumented build has detected a container overflow since #4183, which added the external executor test.

We can't work out what's different about this build/app/run, or what's unusual about this bit of code that causes the error. I'm leaning towards it being a false positive, but can't be sure.

The fix here is to refactor the code to avoid the alert entirely.