### PR TITLE
Add `protoc` to app dev Docker image

### DIFF
--- a/getting_started/setup_vm/app-dev.yml
+++ b/getting_started/setup_vm/app-dev.yml
@@ -20,3 +20,6 @@
     - import_role:
         name: ccf_install
         tasks_from: deb_install.yml
+    - import_role:
+        name: protoc
+        tasks_from: install.yml


### PR DESCRIPTION
So that developers using the `https://mcr.microsoft.com/ccf/app/dev/` image can use `protoc` out of the box.