### PR TITLE
Fix operator resolve.js to not throw on undefined member data

### DIFF
--- a/samples/constitutions/operator/resolve.js
+++ b/samples/constitutions/operator/resolve.js
@@ -8,7 +8,7 @@ function getMemberInfo(memberId) {
 // Returns true if the member is a recovery member.
 function isRecoveryMember(memberId) {
   const info = getMemberInfo(memberId);
-  if (info.member_data.encryption_pub_key) {
+  if (info.member_data !== null && info.member_data !== undefined && info.member_data.encryption_pub_key) {
     return true;
   }
   return false;
@@ -21,7 +21,7 @@ function isOperator(memberId) {
     return false;
   }
   const info = getMemberInfo(memberId);
-  return info.member_data.is_operator;
+  return info.member_data !== null && info.member_data !== undefined && info.member_data.is_operator;
 }
 
 // Defines actions that can be passed with sole operator input.

--- a/samples/constitutions/operator/resolve.js
+++ b/samples/constitutions/operator/resolve.js
@@ -7,8 +7,10 @@ function getMemberInfo(memberId) {
 
 // Returns true if the member is a recovery member.
 function isRecoveryMember(memberId) {
-  const info = getMemberInfo(memberId);
-  if (info.encryption_pub_key) {
+  const key = ccf.strToBuf(memberId);
+  const value = ccf.kv["public:ccf.gov.members.encryption_public_keys"].get(key);
+
+  if (value) {
     return true;
   }
   return false;

--- a/samples/constitutions/operator/resolve.js
+++ b/samples/constitutions/operator/resolve.js
@@ -8,7 +8,8 @@ function getMemberInfo(memberId) {
 // Returns true if the member is a recovery member.
 function isRecoveryMember(memberId) {
   const key = ccf.strToBuf(memberId);
-  const value = ccf.kv["public:ccf.gov.members.encryption_public_keys"].get(key);
+  const value =
+    ccf.kv["public:ccf.gov.members.encryption_public_keys"].get(key);
 
   if (value) {
     return true;

--- a/samples/constitutions/operator/resolve.js
+++ b/samples/constitutions/operator/resolve.js
@@ -8,7 +8,7 @@ function getMemberInfo(memberId) {
 // Returns true if the member is a recovery member.
 function isRecoveryMember(memberId) {
   const info = getMemberInfo(memberId);
-  if (info.member_data !== null && info.member_data !== undefined && info.member_data.encryption_pub_key) {
+  if (info.encryption_pub_key) {
     return true;
   }
   return false;
@@ -21,7 +21,7 @@ function isOperator(memberId) {
     return false;
   }
   const info = getMemberInfo(memberId);
-  return info.member_data !== null && info.member_data !== undefined && info.member_data.is_operator;
+  return info.member_data && info.member_data.is_operator;
 }
 
 // Defines actions that can be passed with sole operator input.


### PR DESCRIPTION
In the sample `resolve.js` for operators, `isOperator` can throw an exception if a member is defined without member data as member data field access was unconditional (i.e. `info.member_data.is_operator` without checking if `info.member_data` is defined). Further, `isRecoveryMember` checks if the member has a public encryption key, but the public encryption key is not a field in member data.