### PR TITLE
Add error schema to openapi definition

### DIFF
--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -9,21 +9,27 @@
             }
           }
         },
-        "description": "An error occurred. The possible HTTP status, code, and message strings are listed below"
+        "description": "An error occurred"
       }
     },
     "schemas": {
       "CCFError": {
-        "error": {
-          "code": {
-            "description": "Response error code",
-            "type": "string"
-          },
-          "message": {
-            "description": "Response error message",
-            "type": "string"
+        "properties": {
+          "error": {
+            "properties": {
+              "code": {
+                "description": "Response error code. CCF error codes: https://microsoft.github.io/CCF/main/operations/troubleshooting.html#error-codes",
+                "type": "string"
+              },
+              "message": {
+                "description": "Response error message",
+                "type": "string"
+              }
+            },
+            "type": "object"
           }
-        }
+        },
+        "type": "object"
       },
       "CodeStatus": {
         "enum": [
@@ -292,7 +298,7 @@
   "info": {
     "description": "This CCF sample app implements a simple logging application, securely recording messages at client-specified IDs. It demonstrates most of the features available to CCF apps.",
     "title": "CCF Sample Logging App",
-    "version": "1.11.1"
+    "version": "1.11.5"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -310,7 +316,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -332,7 +338,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -354,7 +360,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -376,7 +382,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -398,7 +404,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -430,7 +436,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -462,7 +468,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -497,7 +503,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -532,7 +538,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -569,7 +575,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -596,7 +602,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -633,7 +639,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -655,7 +661,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -692,7 +698,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -737,7 +743,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -774,7 +780,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -811,7 +817,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -841,7 +847,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -878,7 +884,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -913,7 +919,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -948,7 +954,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -975,7 +981,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -1002,7 +1008,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -1055,7 +1061,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -1092,7 +1098,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -1119,7 +1125,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1141,7 +1147,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -1168,7 +1174,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -1212,7 +1218,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1244,7 +1250,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {

--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -1,11 +1,15 @@
 {
   "components": {
     "responses": {
-      "ErrorResponse": {
-        "description": "An error occurred. The possible HTTP status, code, and message strings are listed below",
-        "schema": {
-          "$ref": "#/components/schemas/CCFError"
-        }
+      "default": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CCFError"
+            }
+          }
+        },
+        "description": "An error occurred. The possible HTTP status, code, and message strings are listed below"
       }
     },
     "schemas": {
@@ -288,7 +292,7 @@
   "info": {
     "description": "This CCF sample app implements a simple logging application, securely recording messages at client-specified IDs. It demonstrates most of the features available to CCF apps.",
     "title": "CCF Sample Logging App",
-    "version": "1.10.5"
+    "version": "1.11.1"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -304,6 +308,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -323,6 +330,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -342,6 +352,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -361,6 +374,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -380,6 +396,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -409,6 +428,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -438,6 +460,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -470,6 +495,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -502,6 +530,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -536,6 +567,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -560,6 +594,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -594,6 +631,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -613,6 +653,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -647,6 +690,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -689,6 +735,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -723,6 +772,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -757,6 +809,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -784,6 +839,9 @@
         "responses": {
           "200": {
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -818,6 +876,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -850,6 +911,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -882,6 +946,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -906,6 +973,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -930,6 +1000,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -980,6 +1053,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -1014,6 +1090,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -1038,6 +1117,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1057,6 +1139,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -1081,6 +1166,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -1122,6 +1210,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1151,6 +1242,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {

--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -1,6 +1,26 @@
 {
   "components": {
+    "responses": {
+      "ErrorResponse": {
+        "description": "An error occurred. The possible HTTP status, code, and message strings are listed below",
+        "schema": {
+          "$ref": "#/components/schemas/CCFError"
+        }
+      }
+    },
     "schemas": {
+      "CCFError": {
+        "error": {
+          "code": {
+            "description": "Response error code",
+            "type": "string"
+          },
+          "message": {
+            "description": "Response error message",
+            "type": "string"
+          }
+        }
+      },
       "CodeStatus": {
         "enum": [
           "AllowedToJoin"
@@ -268,7 +288,7 @@
   "info": {
     "description": "This CCF sample app implements a simple logging application, securely recording messages at client-specified IDs. It demonstrates most of the features available to CCF apps.",
     "title": "CCF Sample Logging App",
-    "version": "1.10.2"
+    "version": "1.10.5"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -1,5 +1,13 @@
 {
   "components": {
+    "responses": {
+      "ErrorResponse": {
+        "description": "An error occurred. The possible HTTP status, code, and message strings are listed below",
+        "schema": {
+          "$ref": "#/components/schemas/CCFError"
+        }
+      }
+    },
     "schemas": {
       "Action": {
         "properties": {
@@ -32,6 +40,18 @@
           "ballot"
         ],
         "type": "object"
+      },
+      "CCFError": {
+        "error": {
+          "code": {
+            "description": "Response error code",
+            "type": "string"
+          },
+          "message": {
+            "description": "Response error message",
+            "type": "string"
+          }
+        }
       },
       "CodeStatus": {
         "enum": [
@@ -430,7 +450,7 @@
   "info": {
     "description": "This API is used to submit and query proposals which affect CCF's public governance tables.",
     "title": "CCF Governance API",
-    "version": "2.8.1"
+    "version": "2.8.4"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -9,7 +9,7 @@
             }
           }
         },
-        "description": "An error occurred. The possible HTTP status, code, and message strings are listed below"
+        "description": "An error occurred"
       }
     },
     "schemas": {
@@ -46,16 +46,22 @@
         "type": "object"
       },
       "CCFError": {
-        "error": {
-          "code": {
-            "description": "Response error code",
-            "type": "string"
-          },
-          "message": {
-            "description": "Response error message",
-            "type": "string"
+        "properties": {
+          "error": {
+            "properties": {
+              "code": {
+                "description": "Response error code. CCF error codes: https://microsoft.github.io/CCF/main/operations/troubleshooting.html#error-codes",
+                "type": "string"
+              },
+              "message": {
+                "description": "Response error message",
+                "type": "string"
+              }
+            },
+            "type": "object"
           }
-        }
+        },
+        "type": "object"
       },
       "CodeStatus": {
         "enum": [
@@ -454,7 +460,7 @@
   "info": {
     "description": "This API is used to submit and query proposals which affect CCF's public governance tables.",
     "title": "CCF Governance API",
-    "version": "2.9.1"
+    "version": "2.9.5"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -475,7 +481,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -502,7 +508,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -529,7 +535,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -551,7 +557,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -573,7 +579,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -595,7 +601,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -617,7 +623,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -649,7 +655,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -671,7 +677,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -703,7 +709,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -730,7 +736,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -767,7 +773,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -824,7 +830,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -851,7 +857,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -906,7 +912,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -943,7 +949,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -965,7 +971,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -1000,7 +1006,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "security": [
@@ -1037,7 +1043,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -1,11 +1,15 @@
 {
   "components": {
     "responses": {
-      "ErrorResponse": {
-        "description": "An error occurred. The possible HTTP status, code, and message strings are listed below",
-        "schema": {
-          "$ref": "#/components/schemas/CCFError"
-        }
+      "default": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CCFError"
+            }
+          }
+        },
+        "description": "An error occurred. The possible HTTP status, code, and message strings are listed below"
       }
     },
     "schemas": {
@@ -450,7 +454,7 @@
   "info": {
     "description": "This API is used to submit and query proposals which affect CCF's public governance tables.",
     "title": "CCF Governance API",
-    "version": "2.8.4"
+    "version": "2.9.1"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -469,6 +473,9 @@
         "responses": {
           "204": {
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -493,6 +500,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -517,6 +527,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -536,6 +549,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -555,6 +571,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -574,6 +593,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -593,6 +615,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -622,6 +647,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -641,6 +669,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -670,6 +701,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -694,6 +728,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -728,6 +765,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -782,6 +822,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -806,6 +849,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -858,6 +904,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -892,6 +941,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -911,6 +963,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -943,6 +998,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "security": [
@@ -977,6 +1035,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -1,5 +1,13 @@
 {
   "components": {
+    "responses": {
+      "ErrorResponse": {
+        "description": "An error occurred. The possible HTTP status, code, and message strings are listed below",
+        "schema": {
+          "$ref": "#/components/schemas/CCFError"
+        }
+      }
+    },
     "schemas": {
       "ApplicationProtocol": {
         "enum": [
@@ -16,6 +24,18 @@
           "Unsecured"
         ],
         "type": "string"
+      },
+      "CCFError": {
+        "error": {
+          "code": {
+            "description": "Response error code",
+            "type": "string"
+          },
+          "message": {
+            "description": "Response error message",
+            "type": "string"
+          }
+        }
       },
       "CodeStatus": {
         "enum": [
@@ -845,7 +865,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "2.30.1"
+    "version": "2.30.4"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -1,11 +1,15 @@
 {
   "components": {
     "responses": {
-      "ErrorResponse": {
-        "description": "An error occurred. The possible HTTP status, code, and message strings are listed below",
-        "schema": {
-          "$ref": "#/components/schemas/CCFError"
-        }
+      "default": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CCFError"
+            }
+          }
+        },
+        "description": "An error occurred. The possible HTTP status, code, and message strings are listed below"
       }
     },
     "schemas": {
@@ -865,7 +869,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "2.30.4"
+    "version": "2.31.1"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -881,6 +885,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -900,6 +907,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -919,6 +929,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -938,6 +951,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -957,6 +973,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -976,6 +995,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -995,6 +1017,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1014,6 +1039,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1043,6 +1071,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1062,6 +1093,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1081,6 +1115,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1100,6 +1137,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1145,6 +1185,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1157,6 +1200,9 @@
         "responses": {
           "200": {
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1169,6 +1215,9 @@
         "responses": {
           "200": {
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1188,6 +1237,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1205,6 +1257,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1234,6 +1289,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1246,6 +1304,9 @@
         "responses": {
           "200": {
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1265,6 +1326,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1284,6 +1348,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1313,6 +1380,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1332,6 +1402,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1351,6 +1424,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1370,6 +1446,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1389,6 +1468,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1418,6 +1500,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {
@@ -1437,6 +1522,9 @@
               }
             },
             "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "x-ccf-forwarding": {

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -9,7 +9,7 @@
             }
           }
         },
-        "description": "An error occurred. The possible HTTP status, code, and message strings are listed below"
+        "description": "An error occurred"
       }
     },
     "schemas": {
@@ -30,16 +30,22 @@
         "type": "string"
       },
       "CCFError": {
-        "error": {
-          "code": {
-            "description": "Response error code",
-            "type": "string"
-          },
-          "message": {
-            "description": "Response error message",
-            "type": "string"
+        "properties": {
+          "error": {
+            "properties": {
+              "code": {
+                "description": "Response error code. CCF error codes: https://microsoft.github.io/CCF/main/operations/troubleshooting.html#error-codes",
+                "type": "string"
+              },
+              "message": {
+                "description": "Response error message",
+                "type": "string"
+              }
+            },
+            "type": "object"
           }
-        }
+        },
+        "type": "object"
       },
       "CodeStatus": {
         "enum": [
@@ -869,7 +875,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "2.31.1"
+    "version": "2.31.5"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -887,7 +893,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -909,7 +915,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -931,7 +937,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -953,7 +959,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -975,7 +981,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -997,7 +1003,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1019,7 +1025,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1041,7 +1047,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1073,7 +1079,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1095,7 +1101,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1117,7 +1123,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1139,7 +1145,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1187,7 +1193,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1202,7 +1208,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1217,7 +1223,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1239,7 +1245,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1259,7 +1265,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1291,7 +1297,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1306,7 +1312,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1328,7 +1334,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1350,7 +1356,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1382,7 +1388,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1404,7 +1410,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1426,7 +1432,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1448,7 +1454,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1470,7 +1476,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1502,7 +1508,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {
@@ -1524,7 +1530,7 @@
             "description": "Default response description"
           },
           "default": {
-            "$ref": "#/components/responses/ErrorResponse"
+            "$ref": "#/components/responses/default"
           }
         },
         "x-ccf-forwarding": {

--- a/include/ccf/ds/openapi.h
+++ b/include/ccf/ds/openapi.h
@@ -136,7 +136,7 @@ namespace ds
     {
       auto& all_responses = responses(path_operation);
       auto& response = access::get_object(all_responses, "default");
-      response["$ref"] = "#/components/responses/ErrorResponse";
+      response["$ref"] = "#/components/responses/default";
       return response;
     }
 

--- a/include/ccf/ds/openapi.h
+++ b/include/ccf/ds/openapi.h
@@ -131,6 +131,15 @@ namespace ds
       return response;
     }
 
+    static inline nlohmann::json& error_response_default(
+      nlohmann::json& path_operation)
+    {
+      auto& all_responses = responses(path_operation);
+      auto& response = access::get_object(all_responses, "default");
+      response["$ref"] = "#/components/responses/ErrorResponse";
+      return response;
+    }
+
     static inline nlohmann::json& request_body(nlohmann::json& path_operation)
     {
       auto& request_body = access::get_object(path_operation, "requestBody");

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -247,7 +247,7 @@ namespace loggingapp
         "This CCF sample app implements a simple logging application, securely "
         "recording messages at client-specified IDs. It demonstrates most of "
         "the features available to CCF apps.";
-      openapi_info.document_version = "1.11.1";
+      openapi_info.document_version = "1.11.5";
 
       index_per_public_key = std::make_shared<RecordsIndexingStrategy>(
         PUBLIC_RECORDS, context, 10000, 20);

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -247,7 +247,7 @@ namespace loggingapp
         "This CCF sample app implements a simple logging application, securely "
         "recording messages at client-specified IDs. It demonstrates most of "
         "the features available to CCF apps.";
-      openapi_info.document_version = "1.10.2";
+      openapi_info.document_version = "1.10.5";
 
       index_per_public_key = std::make_shared<RecordsIndexingStrategy>(
         PUBLIC_RECORDS, context, 10000, 20);

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -247,7 +247,7 @@ namespace loggingapp
         "This CCF sample app implements a simple logging application, securely "
         "recording messages at client-specified IDs. It demonstrates most of "
         "the features available to CCF apps.";
-      openapi_info.document_version = "1.10.5";
+      openapi_info.document_version = "1.11.1";
 
       index_per_public_key = std::make_shared<RecordsIndexingStrategy>(
         PUBLIC_RECORDS, context, 10000, 20);

--- a/src/endpoints/endpoint_registry.cpp
+++ b/src/endpoints/endpoint_registry.cpp
@@ -41,6 +41,9 @@ namespace ccf::endpoints
         ds::openapi::response(path_op, endpoint->success_status);
       }
 
+      // Add a default error response
+      ds::openapi::error_response_default(path_op);
+
       if (!endpoint->authn_policies.empty())
       {
         for (const auto& auth_policy : endpoint->authn_policies)
@@ -260,12 +263,13 @@ namespace ccf::endpoints
 
     // Add a default error response definition
     auto& responses = document["components"]["responses"];
-    auto& default_error = responses["ErrorResponse"];
+    auto& default_error = responses["default"];
+    ds::openapi::schema(
+      ds::openapi::media_type(default_error, "application/json"))["$ref"] =
+      "#/components/schemas/CCFError";
     default_error["description"] =
       "An error occurred. The possible HTTP status, code, and message strings "
       "are listed below";
-    auto& schema = default_error["schema"];
-    schema["$ref"] = "#/components/schemas/CCFError";
 
     for (const auto& [path, verb_endpoints] : fully_qualified_endpoints)
     {

--- a/src/endpoints/endpoint_registry.cpp
+++ b/src/endpoints/endpoint_registry.cpp
@@ -252,14 +252,21 @@ namespace ccf::endpoints
 
     // Add ccf OData error response schema
     auto& schemas = document["components"]["schemas"];
-    auto& ccf_error = schemas["CCFError"];
-    auto& error = ccf_error["error"];
-    auto& code = error["code"];
-    code["description"] = "Response error code";
-    code["type"] = "string";
-    auto& message = error["message"];
-    message["description"] = "Response error message";
-    message["type"] = "string";
+    schemas["CCFError"]["type"] = "object";
+    schemas["CCFError"]["properties"] = nlohmann::json::object();
+    schemas["CCFError"]["properties"]["error"] = nlohmann::json::object();
+    schemas["CCFError"]["properties"]["error"]["type"] = "object";
+    schemas["CCFError"]["properties"]["error"]["properties"] =
+      nlohmann::json::object();
+    auto& error_properties =
+      schemas["CCFError"]["properties"]["error"]["properties"];
+    error_properties["code"]["description"] =
+      "Response error code. CCF error codes: "
+      "https://microsoft.github.io/CCF/main/operations/"
+      "troubleshooting.html#error-codes";
+    error_properties["code"]["type"] = "string";
+    error_properties["message"]["description"] = "Response error message";
+    error_properties["message"]["type"] = "string";
 
     // Add a default error response definition
     auto& responses = document["components"]["responses"];
@@ -267,9 +274,7 @@ namespace ccf::endpoints
     ds::openapi::schema(
       ds::openapi::media_type(default_error, "application/json"))["$ref"] =
       "#/components/schemas/CCFError";
-    default_error["description"] =
-      "An error occurred. The possible HTTP status, code, and message strings "
-      "are listed below";
+    default_error["description"] = "An error occurred";
 
     for (const auto& [path, verb_endpoints] : fully_qualified_endpoints)
     {

--- a/src/endpoints/endpoint_registry.cpp
+++ b/src/endpoints/endpoint_registry.cpp
@@ -247,6 +247,26 @@ namespace ccf::endpoints
       "receiving node, potentially breaking session consistency. If this "
       "attempts to write on a backup, this will fail.";
 
+    // Add ccf OData error response schema
+    auto& schemas = document["components"]["schemas"];
+    auto& ccf_error = schemas["CCFError"];
+    auto& error = ccf_error["error"];
+    auto& code = error["code"];
+    code["description"] = "Response error code";
+    code["type"] = "string";
+    auto& message = error["message"];
+    message["description"] = "Response error message";
+    message["type"] = "string";
+
+    // Add a default error response definition
+    auto& responses = document["components"]["responses"];
+    auto& default_error = responses["ErrorResponse"];
+    default_error["description"] =
+      "An error occurred. The possible HTTP status, code, and message strings "
+      "are listed below";
+    auto& schema = default_error["schema"];
+    schema["$ref"] = "#/components/schemas/CCFError";
+
     for (const auto& [path, verb_endpoints] : fully_qualified_endpoints)
     {
       for (const auto& [verb, endpoint] : verb_endpoints)

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -489,7 +489,7 @@ namespace ccf
       openapi_info.description =
         "This API is used to submit and query proposals which affect CCF's "
         "public governance tables.";
-      openapi_info.document_version = "2.8.4";
+      openapi_info.document_version = "2.9.1";
     }
 
     static std::optional<MemberId> get_caller_member_id(

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -489,7 +489,7 @@ namespace ccf
       openapi_info.description =
         "This API is used to submit and query proposals which affect CCF's "
         "public governance tables.";
-      openapi_info.document_version = "2.8.1";
+      openapi_info.document_version = "2.8.4";
     }
 
     static std::optional<MemberId> get_caller_member_id(

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -489,7 +489,7 @@ namespace ccf
       openapi_info.description =
         "This API is used to submit and query proposals which affect CCF's "
         "public governance tables.";
-      openapi_info.document_version = "2.9.1";
+      openapi_info.document_version = "2.9.5";
     }
 
     static std::optional<MemberId> get_caller_member_id(

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -367,7 +367,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
-      openapi_info.document_version = "2.31.1";
+      openapi_info.document_version = "2.31.5";
     }
 
     void init_handlers() override

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -367,7 +367,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
-      openapi_info.document_version = "2.30.4";
+      openapi_info.document_version = "2.31.1";
     }
 
     void init_handlers() override

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -367,7 +367,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
-      openapi_info.document_version = "2.30.1";
+      openapi_info.document_version = "2.30.4";
     }
 
     void init_handlers() override


### PR DESCRIPTION
Resolves #2004

Tasks
- [x] Add JSON error schema
- [x] Add error response definition along with common error codes
- [x] Add the default error response to appropriate endpoints
~- [ ] Define API to enable per endpoint error schema definition~

This PR is a WIP, just pushing this whilst I work on something else (and also the last task above is pending discussion) 
Edit: Last task will be in a different PR