### PR TITLE
Fix set user metadata nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.0-dev4]
+
+### Fixed
+
+- `set_user` action in sample constitutions correctly handles `user_data` (#4229).
+
 ## [3.0.0-dev3]
 
 ### Added
@@ -15,9 +21,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Application-defined endpoints are now accessible with both `/app` prefix and un-prefixed, e.g. `GET /app/log/private` and `GET /log/private` (#4147).
-
-### Changed
-
 - The method `EndpointRegistry::get_metrics_for_endpoint(const EndpointDefinitionPtr&)` has been replaced with `EndpointRegistry::get_metrics_for_endpoint(const std::string& method, const std::string& verb)`.
 
 ## [3.0.0-dev2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1584,6 +1584,7 @@ Some discrepancies with the TR remain, and are being tracked under https://githu
 
 Initial pre-release
 
+[3.0.0-dev4]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.0-dev4
 [3.0.0-dev3]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.0-dev3
 [3.0.0-dev2]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.0-dev2
 [3.0.0-dev1]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.0-dev1
@@ -1673,3 +1674,4 @@ Initial pre-release
 [0.3]: https://github.com/microsoft/CCF/releases/tag/v0.3
 [2.0.0-rc8]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.0-rc8
 [unreleased]: https://github.com/microsoft/CCF/releases/tag/ccf-Unreleased
+[3.0.0-dev4]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.0-dev4

--- a/samples/constitutions/default/actions.js
+++ b/samples/constitutions/default/actions.js
@@ -489,9 +489,11 @@ const actions = new Map([
         );
 
         if (args.user_data !== null && args.user_data !== undefined) {
+          let userInfo = {};
+          userInfo.user_data = args.user_data;
           ccf.kv["public:ccf.gov.users.info"].set(
             rawUserId,
-            ccf.jsonCompatibleToBuf(args.user_data)
+            ccf.jsonCompatibleToBuf(userInfo)
           );
         } else {
           ccf.kv["public:ccf.gov.users.info"].delete(rawUserId);

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1149,27 +1149,34 @@ def test_user_data_ACL(network, args):
 
     user = network.users[0]
 
-    # Give isAdmin permissions to a single user
-    network.consortium.set_user_data(
-        primary, user.service_id, user_data={"isAdmin": True}
-    )
+    def by_set_user_data(user_data):
+        network.consortium.set_user_data(primary, user.service_id, user_data=user_data)
 
-    log_id = network.txs.find_max_log_id() + 1
+    def by_set_user(user_data):
+        network.consortium.add_user(primary, user.local_id, user_data=user_data)
 
-    # Confirm that user can now use this endpoint
-    with primary.client(user.local_id) as c:
-        r = c.post("/app/log/private/admin_only", {"id": log_id, "msg": "hello world"})
-        assert r.status_code == http.HTTPStatus.OK.value, r.status_code
+    for set_user_data in (by_set_user_data, by_set_user):
+        # Give isAdmin permissions to a single user
+        set_user_data(user_data={"isAdmin": True})
 
-    # Remove permission
-    network.consortium.set_user_data(
-        primary, user.service_id, user_data={"isAdmin": False}
-    )
+        log_id = network.txs.find_max_log_id() + 1
 
-    # Confirm that user is now forbidden on this endpoint
-    with primary.client(user.local_id) as c:
-        r = c.post("/app/log/private/admin_only", {"id": log_id, "msg": "hello world"})
-        assert r.status_code == http.HTTPStatus.FORBIDDEN.value, r.status_code
+        # Confirm that user can now use this endpoint
+        with primary.client(user.local_id) as c:
+            r = c.post(
+                "/app/log/private/admin_only", {"id": log_id, "msg": "hello world"}
+            )
+            assert r.status_code == http.HTTPStatus.OK.value, r.status_code
+
+        # Remove permission
+        set_user_data(user_data={"isAdmin": False})
+
+        # Confirm that user is now forbidden on this endpoint
+        with primary.client(user.local_id) as c:
+            r = c.post(
+                "/app/log/private/admin_only", {"id": log_id, "msg": "hello world"}
+            )
+            assert r.status_code == http.HTTPStatus.FORBIDDEN.value, r.status_code
 
     return network
 

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -427,24 +427,16 @@ def test_recover_service_truncated_ledger(
             old_primary, wait_for_commit=True
         )
         # A signature will have been emitted by now (wait_for_commit)
-        # Wait a little longer so it should have been persisted to disk, but
-        # retry if that has produced a committed chunk
-        time.sleep(0.2)
+        network.consortium.create_and_withdraw_large_proposal(old_primary)
         if not all(
             f.endswith(ccf.ledger.COMMITTED_FILE_SUFFIX)
             for f in os.listdir(current_ledger_path)
         ):
-            LOG.warning(
-                f"Decided to stop network after looking at ledger dir {current_ledger_path}: {os.listdir(current_ledger_path)}"
-            )
             break
 
     network.stop_all_nodes()
 
     current_ledger_dir, committed_ledger_dirs = old_primary.get_ledger()
-    LOG.warning(
-        f"Ledger dir after stopping node is {current_ledger_dir}: {os.listdir(current_ledger_dir)}"
-    )
 
     # Corrupt _uncommitted_ ledger before starting new service
     ledger = ccf.ledger.Ledger([current_ledger_dir], committed_only=False)


### PR DESCRIPTION
Fixes #4229.

Our sample constitution had an incorrect implementation of `set_user`, which didn't nest `user_data` in the same object type that other actions (`set_user_data`) did, and the C++ parsers expect.

So this proposal:
```
{
  "actions": [
    {
      "args": {
        "user_id": "12689d4e3997db1e8d7635c83d1c5955e35edaf3a1398ec163d10c145b03bb42",
        "user_data": {
          "hello": "world"
        }
      },
      "name": "set_user_data"
    }
  ]
}
```

Would (when it passes) result in this write to the ledger:
```
    table "public:ccf.gov.users.info" (1 write):
      12689d4e3997db1e8d7635c83d1c5955e35edaf3a1398ec163d10c145b03bb42:
        {
          "user_data": {
            "hello": "world"
          }
        }
```

But this proposal:
```
{
  "actions": [
    {
      "args": {
        "cert": "-----BEGIN CERTIFICATE-----\nMIIBsTCCATigAwIBAgIURSeMI2U1egZEjwwwms/OxH24hGMwCgYIKoZIzj0EAwMw\nEDEOMAwGA1UEAwwFdXNlcjAwHhcNMjIwOTE0MDkxODI1WhcNMjMwOTE0MDkxODI1\nWjAQMQ4wDAYDVQQDDAV1c2VyMDB2MBAGByqGSM49AgEGBSuBBAAiA2IABOfL+V9g\nwYLyRa8EL7jV+mprtAUlkDQ5zwsw6r59iT/n1DXY6nygnOYtLsSV5Ry/ooepc5tS\nsZFxTMu7ayjT/NuLbluXYgyd0JGRtAUEO6y/KtHX0lg59PmPkhPThAsLC6NTMFEw\nHQYDVR0OBBYEFM3RYrMmyMmW7Mo8Egxd4zieZUnhMB8GA1UdIwQYMBaAFM3RYrMm\nyMmW7Mo8Egxd4zieZUnhMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwMDZwAw\nZAIwIgKIcvefFfDIxGt5i7Pb3I8RCGaggO9epIKV8/4O9b0WlYBYxrK5SdadGBd8\n2AmcAjBaUGx2w0tU6vEUGaxwfqaaPgcoGyXmJxuNPe7qbFFvEE5kXYxtjFpyxW07\nvV79ZkU=\n-----END CERTIFICATE-----\n",
        "user_data": {
          "hello": "world"
        }
      },
      "name": "set_user"
    }
  ]
}
```

Would produce this write:
```
    table "public:ccf.gov.users.info" (1 write):
      12689d4e3997db1e8d7635c83d1c5955e35edaf3a1398ec163d10c145b03bb42:
        {
          "hello": "world"
        }
```

When the C++ parser looks at the latter object expecting a `UserInfo` object, with a top-level `user_data` field, it throws. In JS we try to pre-populate the user data by calling `get_user_data_v1`, resulting in an early but obscure failure for this user from this point on.

The fix is a simple re-nesting, and we extend testing to cover `set_user` with user_data where we previously only tested `set_user_data`.