### PR TITLE
[release/2.x] Cherry pick: Fix set user metadata nesting (#4231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.8]
+
+### Fixed
+
+- `set_user` action in sample constitutions correctly handles `user_data` (#4229).
+
 ## [2.0.7]
 
 ### Added
@@ -1576,6 +1582,7 @@ Some discrepancies with the TR remain, and are being tracked under https://githu
 
 Initial pre-release
 
+[2.0.8]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.8
 [2.0.7]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.7
 [2.0.6]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.6
 [2.0.5]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.5
@@ -1668,3 +1675,4 @@ Initial pre-release
 [0.3]: https://github.com/microsoft/CCF/releases/tag/v0.3
 [2.0.0-rc8]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.0-rc8
 [unreleased]: https://github.com/microsoft/CCF/releases/tag/ccf-Unreleased
+[3.0.0-dev4]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.0-dev4

--- a/samples/constitutions/default/actions.js
+++ b/samples/constitutions/default/actions.js
@@ -489,9 +489,11 @@ const actions = new Map([
         );
 
         if (args.user_data !== null && args.user_data !== undefined) {
+          let userInfo = {};
+          userInfo.user_data = args.user_data;
           ccf.kv["public:ccf.gov.users.info"].set(
             rawUserId,
-            ccf.jsonCompatibleToBuf(args.user_data)
+            ccf.jsonCompatibleToBuf(userInfo)
           );
         } else {
           ccf.kv["public:ccf.gov.users.info"].delete(rawUserId);


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Fix set user metadata nesting (#4231)](https://github.com/microsoft/CCF/pull/4231)