### PR TITLE
[release/2.x] Cherry pick: Parse new versions of forwarded request (#4185)

### DIFF
--- a/src/enclave/forwarder_types.h
+++ b/src/enclave/forwarder_types.h
@@ -25,6 +25,8 @@ namespace ccf
     virtual bool forward_command(
       std::shared_ptr<ccf::RpcContextImpl> rpc_ctx,
       const ccf::NodeId& to,
-      const std::vector<uint8_t>& caller_cert) = 0;
+      const std::vector<uint8_t>& caller_cert,
+      const std::chrono::milliseconds& timeout =
+        std::chrono::milliseconds(3'000)) = 0;
   };
 }

--- a/src/node/node_types.h
+++ b/src/node/node_types.h
@@ -14,7 +14,7 @@ namespace ccf
   using Node2NodeMsg = uint64_t;
 
   // Type of messages exchanged between nodes
-  enum NodeMsgType : uint64_t
+  enum NodeMsgType : Node2NodeMsg
   {
     channel_msg = 0,
     consensus_msg,
@@ -32,8 +32,10 @@ namespace ccf
   // Types of frontend messages
   enum ForwardedMsg : Node2NodeMsg
   {
-    forwarded_cmd = 0,
-    forwarded_response
+    forwarded_cmd_v1 = 0,
+    forwarded_response_v1,
+    forwarded_cmd_v2,
+    forwarded_response_v2
   };
 
 #pragma pack(push, 1)
@@ -45,10 +47,16 @@ namespace ccf
   };
 
   // Frontend-specific header for forwarding
-  struct ForwardedHeader
+  struct ForwardedHeader_v1
   {
     ForwardedMsg msg;
     ccf::FrameFormat frame_format = ccf::FrameFormat::http;
+  };
+
+  struct ForwardedHeader_v2 : public ForwardedHeader_v1
+  {
+    using ForwardedCommandId = size_t;
+    ForwardedCommandId id;
   };
 
   struct MessageHash

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -32,7 +32,71 @@ namespace ccf
     ConsensusType consensus_type;
     NodeId self;
 
+    using ForwardedCommandId = ForwardedHeader_v2::ForwardedCommandId;
+    ForwardedCommandId next_command_id = 0;
+    std::unordered_map<ForwardedCommandId, threading::Task::TimerEntry>
+      timeout_tasks;
+    ccf::pal::Mutex timeout_tasks_lock;
+
     using IsCallerCertForwarded = bool;
+
+    struct SendTimeoutErrorMsg
+    {
+      SendTimeoutErrorMsg(
+        Forwarder<ChannelProxy>* forwarder_,
+        const ccf::NodeId& to_,
+        size_t client_session_id_,
+        const std::chrono::milliseconds& timeout_) :
+        forwarder(forwarder_),
+        to(to_),
+        client_session_id(client_session_id_),
+        timeout(timeout_)
+      {}
+
+      Forwarder<ChannelProxy>* forwarder;
+      ccf::NodeId to;
+      size_t client_session_id;
+      std::chrono::milliseconds timeout;
+    };
+
+    std::unique_ptr<threading::Tmsg<SendTimeoutErrorMsg>>
+    create_timeout_error_task(
+      const ccf::NodeId& to,
+      size_t client_session_id,
+      const std::chrono::milliseconds& timeout)
+    {
+      return std::make_unique<threading::Tmsg<SendTimeoutErrorMsg>>(
+        [](std::unique_ptr<threading::Tmsg<SendTimeoutErrorMsg>> msg) {
+          msg->data.forwarder->send_timeout_error_response(
+            msg->data.to, msg->data.client_session_id, msg->data.timeout);
+        },
+        this,
+        to,
+        client_session_id,
+        timeout);
+    }
+
+    void send_timeout_error_response(
+      NodeId to,
+      size_t client_session_id,
+      const std::chrono::milliseconds& timeout)
+    {
+      auto rpc_responder_shared = rpcresponder.lock();
+      if (rpc_responder_shared)
+      {
+        auto response = http::Response(HTTP_STATUS_GATEWAY_TIMEOUT);
+        auto body = fmt::format(
+          "Request was forwarded to node {}, but no response was received "
+          "after {}ms",
+          to,
+          timeout.count());
+        response.set_body(body);
+        response.set_header(
+          http::headers::CONTENT_TYPE, http::headervalues::contenttype::TEXT);
+        rpc_responder_shared->reply_async(
+          client_session_id, response.build_response());
+      }
+    }
 
   public:
     Forwarder(
@@ -54,13 +118,16 @@ namespace ccf
     bool forward_command(
       std::shared_ptr<ccf::RpcContextImpl> rpc_ctx,
       const NodeId& to,
-      const std::vector<uint8_t>& caller_cert) override
+      const std::vector<uint8_t>& caller_cert,
+      const std::chrono::milliseconds& timeout) override
     {
       IsCallerCertForwarded include_caller = false;
       const auto method = rpc_ctx->get_method();
       const auto& raw_request = rpc_ctx->get_serialised_request();
-      size_t size = sizeof(rpc_ctx->get_session_context()->client_session_id) +
-        sizeof(IsCallerCertForwarded) + raw_request.size();
+      auto client_session_id =
+        rpc_ctx->get_session_context()->client_session_id;
+      size_t size = sizeof(client_session_id) + sizeof(IsCallerCertForwarded) +
+        raw_request.size();
       if (!caller_cert.empty())
       {
         size += sizeof(size_t) + caller_cert.size();
@@ -70,8 +137,7 @@ namespace ccf
       std::vector<uint8_t> plain(size);
       auto data_ = plain.data();
       auto size_ = plain.size();
-      serialized::write(
-        data_, size_, rpc_ctx->get_session_context()->client_session_id);
+      serialized::write(data_, size_, client_session_id);
       serialized::write(data_, size_, include_caller);
       if (include_caller)
       {
@@ -80,24 +146,24 @@ namespace ccf
       }
       serialized::write(data_, size_, raw_request.data(), raw_request.size());
 
-      ForwardedHeader msg = {
-        ForwardedMsg::forwarded_cmd, rpc_ctx->frame_format()};
+      ForwardedHeader_v1 msg = {
+        ForwardedMsg::forwarded_cmd_v1, rpc_ctx->frame_format()};
 
       return n2n_channels->send_encrypted(
         to, NodeMsgType::forwarded_msg, plain, msg);
     }
 
+    template <typename TFwdHdr>
     std::shared_ptr<http::HttpRpcContext> recv_forwarded_command(
       const NodeId& from, const uint8_t* data, size_t size)
     {
-      std::pair<ForwardedHeader, std::vector<uint8_t>> r;
+      std::pair<TFwdHdr, std::vector<uint8_t>> r;
       try
       {
         LOG_TRACE_FMT("Receiving forwarded command of {} bytes", size);
         LOG_TRACE_FMT(" => {:02x}", fmt::join(data, data + size, ""));
 
-        r = n2n_channels->template recv_encrypted<ForwardedHeader>(
-          from, data, size);
+        r = n2n_channels->template recv_encrypted<TFwdHdr>(from, data, size);
       }
       catch (const std::logic_error& err)
       {
@@ -137,9 +203,11 @@ namespace ccf
       }
     }
 
+    template <typename TFwdHdr>
     bool send_forwarded_response(
       size_t client_session_id,
       const NodeId& from_node,
+      const TFwdHdr& header,
       const std::vector<uint8_t>& data)
     {
       std::vector<uint8_t> plain(sizeof(client_session_id) + data.size());
@@ -148,26 +216,24 @@ namespace ccf
       serialized::write(data_, size_, client_session_id);
       serialized::write(data_, size_, data.data(), data.size());
 
-      // frame_format is deliberately unset, the forwarder ignores it
-      // and expects the same format they forwarded.
-      ForwardedHeader msg = {ForwardedMsg::forwarded_response};
-
       return n2n_channels->send_encrypted(
-        from_node, NodeMsgType::forwarded_msg, plain, msg);
+        from_node, NodeMsgType::forwarded_msg, plain, header);
     }
 
-    std::optional<std::pair<size_t, std::vector<uint8_t>>>
-    recv_forwarded_response(
+    using ForwardedResponseResult =
+      std::optional<std::pair<size_t, std::vector<uint8_t>>>;
+
+    template <typename TFwdHdr>
+    ForwardedResponseResult recv_forwarded_response(
       const NodeId& from, const uint8_t* data, size_t size)
     {
-      std::pair<ForwardedHeader, std::vector<uint8_t>> r;
+      std::pair<TFwdHdr, std::vector<uint8_t>> r;
       try
       {
         LOG_TRACE_FMT("Receiving response of {} bytes", size);
         LOG_TRACE_FMT(" => {:02x}", fmt::join(data, data + size, ""));
 
-        r = n2n_channels->template recv_encrypted<ForwardedHeader>(
-          from, data, size);
+        r = n2n_channels->template recv_encrypted<TFwdHdr>(from, data, size);
       }
       catch (const std::logic_error& err)
       {
@@ -185,11 +251,63 @@ namespace ccf
       return std::make_pair(client_session_id, rpc);
     }
 
+    std::shared_ptr<ForwardedRpcHandler> get_forwarder_handler(
+      const std::shared_ptr<http::HttpRpcContext>& ctx)
+    {
+      if (ctx == nullptr)
+      {
+        LOG_FAIL_FMT("Failed to receive forwarded command");
+        return nullptr;
+      }
+
+      std::shared_ptr<ccf::RPCMap> rpc_map_shared = rpc_map.lock();
+      if (rpc_map_shared == nullptr)
+      {
+        LOG_FAIL_FMT("Failed to obtain RPCMap");
+        return nullptr;
+      }
+
+      const auto actor_opt = http::extract_actor(*ctx);
+      if (!actor_opt.has_value())
+      {
+        LOG_FAIL_FMT("Failed to extract actor from forwarded context.");
+        LOG_DEBUG_FMT(
+          "Failed to extract actor from forwarded context. Method is "
+          "'{}'",
+          ctx->get_method());
+      }
+
+      const auto& actor_s = actor_opt.value();
+      auto actor = rpc_map_shared->resolve(actor_s);
+      auto handler = rpc_map_shared->find(actor);
+      if (actor == ccf::ActorsType::unknown || !handler.has_value())
+      {
+        LOG_FAIL_FMT("Failed to process forwarded command: unknown actor");
+        LOG_DEBUG_FMT(
+          "Failed to process forwarded command: unknown actor {}", actor_s);
+        return nullptr;
+      }
+
+      auto fwd_handler =
+        std::dynamic_pointer_cast<ForwardedRpcHandler>(handler.value());
+      if (!fwd_handler)
+      {
+        LOG_FAIL_FMT(
+          "Failed to process forwarded command: handler is not a "
+          "ForwardedRpcHandler");
+        return nullptr;
+      }
+
+      return fwd_handler;
+    }
+
     void recv_message(const ccf::NodeId& from, const uint8_t* data, size_t size)
     {
       try
       {
-        auto forwarded_msg = serialized::peek<ForwardedMsg>(data, size);
+        const auto forwarded_hdr_v1 =
+          serialized::peek<ForwardedHeader_v1>(data, size);
+        const auto forwarded_msg = forwarded_hdr_v1.msg;
         LOG_TRACE_FMT(
           "recv_message({}, {} bytes) (type={})",
           from,
@@ -198,64 +316,107 @@ namespace ccf
 
         switch (forwarded_msg)
         {
-          case ForwardedMsg::forwarded_cmd:
+          case ForwardedMsg::forwarded_cmd_v1:
           {
-            std::shared_ptr<ccf::RPCMap> rpc_map_shared = rpc_map.lock();
-            if (rpc_map_shared)
+            auto ctx =
+              recv_forwarded_command<ForwardedHeader_v1>(from, data, size);
+
+            auto fwd_handler = get_forwarder_handler(ctx);
+            if (fwd_handler == nullptr)
             {
-              auto ctx = recv_forwarded_command(from, data, size);
-              if (ctx == nullptr)
-              {
-                LOG_FAIL_FMT("Failed to receive forwarded command");
-                return;
-              }
-
-              const auto actor_opt = http::extract_actor(*ctx);
-              if (!actor_opt.has_value())
-              {
-                LOG_FAIL_FMT("Failed to extract actor from forwarded context.");
-                LOG_DEBUG_FMT(
-                  "Failed to extract actor from forwarded context. Method is "
-                  "'{}'",
-                  ctx->get_method());
-              }
-
-              const auto& actor_s = actor_opt.value();
-              auto actor = rpc_map_shared->resolve(actor_s);
-              auto handler = rpc_map_shared->find(actor);
-              if (actor == ccf::ActorsType::unknown || !handler.has_value())
-              {
-                LOG_FAIL_FMT(
-                  "Failed to process forwarded command: unknown actor");
-                LOG_DEBUG_FMT(
-                  "Failed to process forwarded command: unknown actor {}",
-                  actor_s);
-                return;
-              }
-
-              auto fwd_handler =
-                dynamic_cast<ForwardedRpcHandler*>(handler.value().get());
-              if (!fwd_handler)
-              {
-                LOG_FAIL_FMT(
-                  "Failed to process forwarded command: handler is not a "
-                  "ForwardedRpcHandler");
-                return;
-              }
-
-              // Ignore return value - false only means it is pending
-              send_forwarded_response(
-                ctx->get_session_context()->client_session_id,
-                from,
-                fwd_handler->process_forwarded(ctx));
-              LOG_DEBUG_FMT("Sending forwarded response to {}", from);
+              return;
             }
+
+            // frame_format is deliberately unset, the forwarder ignores it
+            // and expects the same format they forwarded.
+            ForwardedHeader_v1 response_header{
+              ForwardedMsg::forwarded_response_v1};
+
+            LOG_DEBUG_FMT("Sending forwarded response to {}", from);
+            fwd_handler->process_forwarded(ctx);
+
+            // Ignore return value - false only means it is pending
+            send_forwarded_response(
+              ctx->get_session_context()->client_session_id,
+              from,
+              response_header,
+              ctx->serialise_response());
             break;
           }
 
-          case ForwardedMsg::forwarded_response:
+          case ForwardedMsg::forwarded_cmd_v2:
           {
-            auto rep = recv_forwarded_response(from, data, size);
+            auto ctx =
+              recv_forwarded_command<ForwardedHeader_v2>(from, data, size);
+
+            auto fwd_handler = get_forwarder_handler(ctx);
+            if (fwd_handler == nullptr)
+            {
+              return;
+            }
+
+            const auto forwarded_hdr_v2 =
+              serialized::peek<ForwardedHeader_v2>(data, size);
+            const auto cmd_id = forwarded_hdr_v2.id;
+
+            // frame_format is deliberately unset, the forwarder ignores it
+            // and expects the same format they forwarded.
+            ForwardedHeader_v2 response_header{
+              {ForwardedMsg::forwarded_response_v2, {}}, cmd_id};
+
+            LOG_DEBUG_FMT("Sending forwarded response to {}", from);
+            fwd_handler->process_forwarded(ctx);
+
+            // Ignore return value - false only means it is pending
+            send_forwarded_response(
+              ctx->get_session_context()->client_session_id,
+              from,
+              response_header,
+              ctx->serialise_response());
+            break;
+          }
+
+          case ForwardedMsg::forwarded_response_v2:
+          {
+            const auto forwarded_hdr_v2 =
+              serialized::peek<ForwardedHeader_v2>(data, size);
+            const auto cmd_id = forwarded_hdr_v2.id;
+
+            // Cancel and delete the corresponding timeout task, so it will no
+            // longer trigger a timeout error
+            std::lock_guard<ccf::pal::Mutex> guard(timeout_tasks_lock);
+            auto it = timeout_tasks.find(cmd_id);
+            if (it != timeout_tasks.end())
+            {
+              threading::ThreadMessaging::thread_messaging.cancel_timer_task(
+                it->second);
+              it = timeout_tasks.erase(it);
+            }
+            else
+            {
+              LOG_FAIL_FMT(
+                "Response for {} received too late - already sent timeout "
+                "error to client",
+                cmd_id);
+              return;
+            }
+            // Deliberate fall-through
+          }
+
+          case ForwardedMsg::forwarded_response_v1:
+          {
+            ForwardedResponseResult rep;
+            if (forwarded_msg == ForwardedMsg::forwarded_response_v2)
+            {
+              rep =
+                recv_forwarded_response<ForwardedHeader_v2>(from, data, size);
+            }
+            else
+            {
+              rep =
+                recv_forwarded_response<ForwardedHeader_v1>(from, data, size);
+            }
+
             if (!rep.has_value())
             {
               return;

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -36,7 +36,7 @@ namespace ccf
     ForwardedCommandId next_command_id = 0;
     std::unordered_map<ForwardedCommandId, threading::Task::TimerEntry>
       timeout_tasks;
-    ccf::pal::Mutex timeout_tasks_lock;
+    ccf::Mutex timeout_tasks_lock;
 
     using IsCallerCertForwarded = bool;
 
@@ -90,7 +90,7 @@ namespace ccf
           "after {}ms",
           to,
           timeout.count());
-        response.set_body(body);
+        response.set_body((const uint8_t*)body.data(), body.size());
         response.set_header(
           http::headers::CONTENT_TYPE, http::headervalues::contenttype::TEXT);
         rpc_responder_shared->reply_async(
@@ -384,7 +384,7 @@ namespace ccf
 
             // Cancel and delete the corresponding timeout task, so it will no
             // longer trigger a timeout error
-            std::lock_guard<ccf::pal::Mutex> guard(timeout_tasks_lock);
+            std::lock_guard<ccf::Mutex> guard(timeout_tasks_lock);
             auto it = timeout_tasks.find(cmd_id);
             if (it != timeout_tasks.end())
             {

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -1220,8 +1220,11 @@ TEST_CASE("Forwarding" * doctest::test_suite("forwarding"))
     REQUIRE(channel_stub->size() == 1);
 
     auto forwarded_msg = channel_stub->get_pop_back();
-    auto fwd_ctx = backup_forwarder->recv_forwarded_command(
-      kv::test::FirstBackupNodeId, forwarded_msg.data(), forwarded_msg.size());
+    auto fwd_ctx =
+      backup_forwarder->recv_forwarded_command<ccf::ForwardedHeader_v1>(
+        kv::test::FirstBackupNodeId,
+        forwarded_msg.data(),
+        forwarded_msg.size());
 
     {
       INFO("Invalid caller");
@@ -1249,8 +1252,11 @@ TEST_CASE("Forwarding" * doctest::test_suite("forwarding"))
     REQUIRE(channel_stub->size() == 1);
 
     auto forwarded_msg = channel_stub->get_pop_back();
-    auto fwd_ctx = backup_forwarder->recv_forwarded_command(
-      kv::test::FirstBackupNodeId, forwarded_msg.data(), forwarded_msg.size());
+    auto fwd_ctx =
+      backup_forwarder->recv_forwarded_command<ccf::ForwardedHeader_v1>(
+        kv::test::FirstBackupNodeId,
+        forwarded_msg.data(),
+        forwarded_msg.size());
 
     // Processing forwarded response by a backup frontend (here, the same
     // frontend that the command was originally issued to)
@@ -1290,8 +1296,11 @@ TEST_CASE("Forwarding" * doctest::test_suite("forwarding"))
     REQUIRE(channel_stub->size() == 1);
 
     auto forwarded_msg = channel_stub->get_pop_back();
-    auto fwd_ctx = backup_forwarder->recv_forwarded_command(
-      kv::test::FirstBackupNodeId, forwarded_msg.data(), forwarded_msg.size());
+    auto fwd_ctx =
+      backup_forwarder->recv_forwarded_command<ccf::ForwardedHeader_v1>(
+        kv::test::FirstBackupNodeId,
+        forwarded_msg.data(),
+        forwarded_msg.size());
 
     auto response =
       parse_response(user_frontend_primary.process_forwarded(fwd_ctx));
@@ -1350,8 +1359,9 @@ TEST_CASE("Nodefrontend forwarding" * doctest::test_suite("forwarding"))
   REQUIRE(channel_stub->size() == 1);
 
   auto forwarded_msg = channel_stub->get_pop_back();
-  auto fwd_ctx = backup_forwarder->recv_forwarded_command(
-    kv::test::FirstBackupNodeId, forwarded_msg.data(), forwarded_msg.size());
+  auto fwd_ctx =
+    backup_forwarder->recv_forwarded_command<ccf::ForwardedHeader_v1>(
+      kv::test::FirstBackupNodeId, forwarded_msg.data(), forwarded_msg.size());
 
   auto response =
     parse_response(node_frontend_primary.process_forwarded(fwd_ctx));
@@ -1394,8 +1404,9 @@ TEST_CASE("Userfrontend forwarding" * doctest::test_suite("forwarding"))
   REQUIRE(channel_stub->size() == 1);
 
   auto forwarded_msg = channel_stub->get_pop_back();
-  auto fwd_ctx = backup_forwarder->recv_forwarded_command(
-    kv::test::FirstBackupNodeId, forwarded_msg.data(), forwarded_msg.size());
+  auto fwd_ctx =
+    backup_forwarder->recv_forwarded_command<ccf::ForwardedHeader_v1>(
+      kv::test::FirstBackupNodeId, forwarded_msg.data(), forwarded_msg.size());
 
   auto response =
     parse_response(user_frontend_primary.process_forwarded(fwd_ctx));
@@ -1442,8 +1453,9 @@ TEST_CASE("Memberfrontend forwarding" * doctest::test_suite("forwarding"))
   REQUIRE(channel_stub->size() == 1);
 
   auto forwarded_msg = channel_stub->get_pop_back();
-  auto fwd_ctx = backup_forwarder->recv_forwarded_command(
-    kv::test::FirstBackupNodeId, forwarded_msg.data(), forwarded_msg.size());
+  auto fwd_ctx =
+    backup_forwarder->recv_forwarded_command<ccf::ForwardedHeader_v1>(
+      kv::test::FirstBackupNodeId, forwarded_msg.data(), forwarded_msg.size());
 
   auto response =
     parse_response(member_frontend_primary.process_forwarded(fwd_ctx));


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Parse new versions of forwarded request (#4185)](https://github.com/microsoft/CCF/pull/4185)