### PR TITLE
Add .vscode files to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,7 @@ build*/
 Debug*/
 Release*/
 CMakeFiles/
-.vscode/settings.json
-.vscode/launch.json
+.vscode/
 .vs/
 libuv/
 raft_tests.md


### PR DESCRIPTION
Context for this: I had to make some changes to the VSCode auto-generated `c_cpp_properties.json` file and this change was being picked up by git. We already ignore couple of other files under .vscode currently, just applying this broadly now to all files under .vscode