### PR TITLE
Fix table access snippet in the doc

### DIFF
--- a/doc/build_apps/example_cpp.rst
+++ b/doc/build_apps/example_cpp.rst
@@ -34,13 +34,13 @@ The Logging example application simply has:
     .. literalinclude:: ../../samples/apps/logging/logging.cpp
         :language: cpp
         :start-after: SNIPPET: public_table_access
-        :lines: 1
+        :end-before: SNIPPET_END: public_table_access
         :dedent:
 
     .. literalinclude:: ../../samples/apps/logging/logging.cpp
         :language: cpp
         :start-after: SNIPPET: private_table_access
-        :lines: 1
+        :end-before: SNIPPET_END: private_table_access
         :dedent:
 
 Application Endpoints

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -273,6 +273,7 @@ namespace loggingapp
         // SNIPPET: private_table_access
         auto records_handle =
           ctx.tx.template rw<RecordsMap>(private_records(ctx));
+        // SNIPPET_END: private_table_access
         records_handle->put(in.id, in.msg);
         update_first_write(ctx.tx, in.id, true, get_scope(ctx));
         return ccf::make_success(true);
@@ -401,6 +402,7 @@ namespace loggingapp
         // SNIPPET: public_table_access
         auto records_handle =
           ctx.tx.template rw<RecordsMap>(public_records(ctx));
+        // SNIPPET_END: public_table_access
         const auto id = params["id"].get<size_t>();
         records_handle->put(id, in.msg);
         update_first_write(ctx.tx, in.id, false, get_scope(ctx));


### PR DESCRIPTION
It fixes the page https://microsoft.github.io/CCF/main/build_apps/example_cpp.html .

Current:

![image](https://user-images.githubusercontent.com/79583855/192256535-89e54913-e903-48bc-b757-a7520b63c083.png)

The right-hand side of the assignment to `records_handle` is missing. 

After the fix

![image](https://user-images.githubusercontent.com/79583855/192256459-77ca7277-3940-476c-bd30-34a254e371f6.png)

## Test
Run `livehtml.sh` locally and see if the doc looks correct.
