### PR TITLE
Upgrade cryptography pin

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,3 @@
 loguru >= 0.5, == 0.*
-cryptography == 37.*
+cryptography == 38.*
 string-color >= 1.2.1


### PR DESCRIPTION
The current pin blocks the tests from passing on release/2.x.