### PR TITLE
Increase `wait_for_commit` timeouts to workaround `lts_compatibility` failures

### DIFF
--- a/tests/infra/commit.py
+++ b/tests/infra/commit.py
@@ -49,5 +49,5 @@ def wait_for_commit(
             time.sleep(0.1)
     flush_info(logs, log_capture, 1)
     raise TimeoutError(
-        f'Timed out waiting for commit: {pprint.pformat(client.get("/node/consensus").body.json())}'
+        f'Timed out waiting {timeout}s for commit: {pprint.pformat(client.get("/node/commit").body.json())}\n{pprint.pformat(client.get("/node/consensus").body.json())}'
     )

--- a/tests/infra/commit.py
+++ b/tests/infra/commit.py
@@ -12,7 +12,7 @@ from infra.log_capture import flush_info
 
 
 def wait_for_commit(
-    client, seqno: int, view: int, timeout: int = 3, log_capture: Optional[list] = None
+    client, seqno: int, view: int, timeout: int = 5, log_capture: Optional[list] = None
 ) -> None:
     """
     Waits for a specific seqno/view pair to be committed by the network,

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -271,7 +271,7 @@ class Consortium:
         )
 
     def vote_using_majority(
-        self, remote_node, proposal, ballot, wait_for_commit=True, timeout=3
+        self, remote_node, proposal, ballot, wait_for_commit=True, timeout=5
     ):
         response = None
 


### PR DESCRIPTION
This is basically #4283, but also modifying the timeout in `consortium.vote_using_majority()`. Evidence this works is the [green run](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=50379&view=results) of #4285 (which includes the core timeout change, and also a bunch of hacks to the CI to run the failing test in a loop).

Still don't have a complete story on why this test, and this test only, is newly slower, so consider this a mitigation rather than a total fix.