### PR TITLE
[release/2.x] Cherry pick: Increase `wait_for_commit` timeouts to workaround `lts_compatibility` failures (#4286)

### DIFF
--- a/tests/infra/commit.py
+++ b/tests/infra/commit.py
@@ -12,7 +12,7 @@ from infra.log_capture import flush_info
 
 
 def wait_for_commit(
-    client, seqno: int, view: int, timeout: int = 3, log_capture: Optional[list] = None
+    client, seqno: int, view: int, timeout: int = 5, log_capture: Optional[list] = None
 ) -> None:
     """
     Waits for a specific seqno/view pair to be committed by the network,
@@ -49,5 +49,5 @@ def wait_for_commit(
             time.sleep(0.1)
     flush_info(logs, log_capture, 1)
     raise TimeoutError(
-        f'Timed out waiting for commit: {pprint.pformat(client.get("/node/consensus").body.json())}'
+        f'Timed out waiting {timeout}s for commit: {pprint.pformat(client.get("/node/commit").body.json())}\n{pprint.pformat(client.get("/node/consensus").body.json())}'
     )

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -271,7 +271,7 @@ class Consortium:
         )
 
     def vote_using_majority(
-        self, remote_node, proposal, ballot, wait_for_global_commit=True, timeout=3
+        self, remote_node, proposal, ballot, wait_for_global_commit=True, timeout=5
     ):
         response = None
 


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Increase `wait_for_commit` timeouts to workaround `lts_compatibility` failures (#4286)](https://github.com/microsoft/CCF/pull/4286)