### PR TITLE
Remove `app` prefix from API docs

### DIFF
--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -317,7 +317,7 @@
   },
   "openapi": "3.0.0",
   "paths": {
-    "/app/api": {
+    "/api": {
       "get": {
         "responses": {
           "200": {
@@ -339,7 +339,7 @@
         }
       }
     },
-    "/app/api/metrics": {
+    "/api/metrics": {
       "get": {
         "responses": {
           "200": {
@@ -361,7 +361,7 @@
         }
       }
     },
-    "/app/code": {
+    "/code": {
       "get": {
         "responses": {
           "200": {
@@ -383,7 +383,7 @@
         }
       }
     },
-    "/app/commit": {
+    "/commit": {
       "get": {
         "responses": {
           "200": {
@@ -405,7 +405,7 @@
         }
       }
     },
-    "/app/custom_auth": {
+    "/custom_auth": {
       "get": {
         "responses": {
           "200": {
@@ -427,7 +427,7 @@
         }
       }
     },
-    "/app/local_tx": {
+    "/local_tx": {
       "get": {
         "parameters": [
           {
@@ -459,7 +459,7 @@
         }
       }
     },
-    "/app/log/private": {
+    "/log/private": {
       "delete": {
         "parameters": [
           {
@@ -566,7 +566,7 @@
         }
       }
     },
-    "/app/log/private/admin_only": {
+    "/log/private/admin_only": {
       "post": {
         "requestBody": {
           "content": {
@@ -603,7 +603,7 @@
         }
       }
     },
-    "/app/log/private/all": {
+    "/log/private/all": {
       "delete": {
         "responses": {
           "200": {
@@ -630,7 +630,7 @@
         }
       }
     },
-    "/app/log/private/anonymous": {
+    "/log/private/anonymous": {
       "post": {
         "requestBody": {
           "content": {
@@ -721,7 +721,7 @@
         }
       }
     },
-    "/app/log/private/historical": {
+    "/log/private/historical": {
       "get": {
         "parameters": [
           {
@@ -758,7 +758,7 @@
         }
       }
     },
-    "/app/log/private/historical/sparse": {
+    "/log/private/historical/sparse": {
       "get": {
         "parameters": [
           {
@@ -803,7 +803,7 @@
         }
       }
     },
-    "/app/log/private/historical_receipt": {
+    "/log/private/historical_receipt": {
       "get": {
         "parameters": [
           {
@@ -840,7 +840,7 @@
         }
       }
     },
-    "/app/log/private/prefix_cert": {
+    "/log/private/prefix_cert": {
       "post": {
         "requestBody": {
           "content": {
@@ -877,7 +877,7 @@
         }
       }
     },
-    "/app/log/private/raw_text/{id}": {
+    "/log/private/raw_text/{id}": {
       "parameters": [
         {
           "in": "path",
@@ -907,7 +907,7 @@
         }
       }
     },
-    "/app/log/public": {
+    "/log/public": {
       "delete": {
         "parameters": [
           {
@@ -1014,7 +1014,7 @@
         }
       }
     },
-    "/app/log/public/all": {
+    "/log/public/all": {
       "delete": {
         "responses": {
           "200": {
@@ -1041,7 +1041,7 @@
         }
       }
     },
-    "/app/log/public/count": {
+    "/log/public/count": {
       "get": {
         "responses": {
           "200": {
@@ -1068,7 +1068,7 @@
         }
       }
     },
-    "/app/log/public/historical/range": {
+    "/log/public/historical/range": {
       "get": {
         "parameters": [
           {
@@ -1121,7 +1121,7 @@
         }
       }
     },
-    "/app/log/public/historical_receipt": {
+    "/log/public/historical_receipt": {
       "get": {
         "parameters": [
           {
@@ -1158,7 +1158,7 @@
         }
       }
     },
-    "/app/log/request_query": {
+    "/log/request_query": {
       "get": {
         "responses": {
           "200": {
@@ -1180,7 +1180,7 @@
         }
       }
     },
-    "/app/log/signed_request_query": {
+    "/log/signed_request_query": {
       "get": {
         "responses": {
           "200": {
@@ -1207,7 +1207,7 @@
         }
       }
     },
-    "/app/multi_auth": {
+    "/multi_auth": {
       "get": {
         "responses": {
           "200": {
@@ -1241,7 +1241,7 @@
         }
       }
     },
-    "/app/receipt": {
+    "/receipt": {
       "get": {
         "parameters": [
           {
@@ -1273,7 +1273,7 @@
         }
       }
     },
-    "/app/tx": {
+    "/tx": {
       "get": {
         "parameters": [
           {

--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -313,7 +313,7 @@
   "info": {
     "description": "This CCF sample app implements a simple logging application, securely recording messages at client-specified IDs. It demonstrates most of the features available to CCF apps.",
     "title": "CCF Sample Logging App",
-    "version": "1.12.0"
+    "version": "1.12.1"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -662,7 +662,7 @@
         }
       }
     },
-    "/app/log/private/anonymous/v2": {
+    "/log/private/anonymous/v2": {
       "post": {
         "requestBody": {
           "content": {
@@ -694,7 +694,7 @@
         }
       }
     },
-    "/app/log/private/count": {
+    "/log/private/count": {
       "get": {
         "responses": {
           "200": {

--- a/include/ccf/endpoint.h
+++ b/include/ccf/endpoint.h
@@ -111,7 +111,7 @@ namespace ccf::endpoints
     /// Full URI path to endpoint, including method prefix
     URI full_uri_path;
 
-    /// URI path for the API documentation, that reflects the latest changes
+    /// URI path for the API documentation
     URI api_uri_path;
 
     EndpointProperties properties;

--- a/include/ccf/endpoint.h
+++ b/include/ccf/endpoint.h
@@ -111,6 +111,9 @@ namespace ccf::endpoints
     /// Full URI path to endpoint, including method prefix
     URI full_uri_path;
 
+    /// URI path for the API documentation, that reflects the latest changes
+    URI api_uri_path;
+
     EndpointProperties properties;
 
     /** List of authentication policies which will be checked before executing
@@ -234,7 +237,7 @@ namespace ccf::endpoints
             }
 
             ds::openapi::add_request_body_schema<In>(
-              document, endpoint.full_uri_path, http_verb.value());
+              document, endpoint.api_uri_path, http_verb.value());
           });
       }
       else
@@ -258,7 +261,7 @@ namespace ccf::endpoints
 
             ds::openapi::add_response_schema<Out>(
               document,
-              endpoint.full_uri_path,
+              endpoint.api_uri_path,
               http_verb.value(),
               endpoint.success_status);
           });
@@ -328,7 +331,7 @@ namespace ccf::endpoints
           parameter["schema"] = ds::openapi::add_schema_to_components(
             document, schema_name, query_schema);
           ds::openapi::add_request_parameter_schema(
-            document, endpoint.full_uri_path, http_verb.value(), parameter);
+            document, endpoint.api_uri_path, http_verb.value(), parameter);
         });
 
       return *this;

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -274,7 +274,7 @@ namespace loggingapp
         "This CCF sample app implements a simple logging application, securely "
         "recording messages at client-specified IDs. It demonstrates most of "
         "the features available to CCF apps.";
-      openapi_info.document_version = "1.12.0";
+      openapi_info.document_version = "1.12.1";
 
       index_per_public_key = std::make_shared<RecordsIndexingStrategy>(
         PUBLIC_RECORDS, context, 10000, 20);

--- a/src/endpoints/endpoint.cpp
+++ b/src/endpoints/endpoint.cpp
@@ -26,7 +26,7 @@ namespace ccf::endpoints
         using namespace ds::openapi;
 
         auto& rb = request_body(path_operation(
-          ds::openapi::path(document, endpoint.full_uri_path),
+          ds::openapi::path(document, endpoint.api_uri_path),
           http_verb.value()));
         schema(media_type(rb, http::headervalues::contenttype::JSON)) =
           endpoint.params_schema;
@@ -52,7 +52,7 @@ namespace ccf::endpoints
         using namespace ds::openapi;
         auto& r = response(
           path_operation(
-            ds::openapi::path(document, endpoint.full_uri_path),
+            ds::openapi::path(document, endpoint.api_uri_path),
             http_verb.value()),
           endpoint.success_status);
 
@@ -76,7 +76,7 @@ namespace ccf::endpoints
       LOG_FATAL_FMT(
         "Can't install this endpoint ({}) - it is not associated with an "
         "installer",
-        full_uri_path);
+        api_uri_path);
     }
     else
     {

--- a/src/endpoints/endpoint_registry.cpp
+++ b/src/endpoints/endpoint_registry.cpp
@@ -31,8 +31,7 @@ namespace ccf::endpoints
       // informed schema builders
 
       auto& path_op = ds::openapi::path_operation(
-        ds::openapi::path(document, endpoint->full_uri_path),
-        http_verb.value());
+        ds::openapi::path(document, endpoint->api_uri_path), http_verb.value());
 
       // Path Operation must contain at least one response - if none has been
       // defined, assume this can return 200
@@ -155,6 +154,13 @@ namespace ccf::endpoints
     }
     endpoint.full_uri_path =
       fmt::format("/{}{}", method_prefix, endpoint.dispatch.uri_path);
+    endpoint.api_uri_path = endpoint.full_uri_path;
+
+    if (method_prefix == "app")
+    {
+      endpoint.api_uri_path = endpoint.dispatch.uri_path;
+    }
+
     endpoint.dispatch.verb = verb;
     endpoint.func = f;
     endpoint.locally_committed_func = &default_locally_committed_func;
@@ -334,7 +340,7 @@ namespace ccf::endpoints
           parameter["required"] = true;
           parameter["schema"] = {{"type", "string"}};
           ds::openapi::add_path_parameter_schema(
-            document, endpoint->full_uri_path, parameter);
+            document, endpoint->api_uri_path, parameter);
         }
       }
     }

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -182,7 +182,7 @@ namespace ccf
             LOG_FAIL_FMT(
               "Request for {} rejected because the interface is unsecured and "
               "no accepted_endpoints have been configured.",
-              endpoint->full_uri_path);
+              endpoint->api_uri_path);
             ctx->set_response_status(HTTP_STATUS_SERVICE_UNAVAILABLE);
             return false;
           }


### PR DESCRIPTION
This is an attempt to work around the `lts_compatibility` test (see https://github.com/microsoft/CCF/pull/4168) and may end up resolving https://github.com/microsoft/CCF/issues/4292