### PR TITLE
Ensure LF line returns are used in construction of scurl's To-Be-Signed string

### DIFF
--- a/python/utils/scurl.sh
+++ b/python/utils/scurl.sh
@@ -125,9 +125,8 @@ url=/${url#*/} # Remove domain name, restore leading slash
 url=${url%\#*} # Remove fragment
 
 # Construct string to sign
-string_to_sign="(request-target): ${command,,} ${url}
-digest: SHA-256=$req_digest
-content-length: $content_length"
+newline=$'\n'
+string_to_sign="(request-target): ${command,,} ${url}${newline}digest: SHA-256=${req_digest}${newline}content-length: ${content_length}"
 
 # https://tools.ietf.org/html/draft-cavage-http-signatures-12#appendix-E.2
 signature_algorithm="hs2019"


### PR DESCRIPTION
I think CRLF line endings will make `scurl.sh` unexecutable (it certainly does for Ubuntu's bash), but just in case we make sure that we don't produce the wrong TBS string.