### PR TITLE
Fix client endorsements fetching logic

### DIFF
--- a/src/node/quote_endorsements_client.h
+++ b/src/node/quote_endorsements_client.h
@@ -144,8 +144,7 @@ namespace ccf
 
       threading::ThreadMessaging::thread_messaging.add_task_after(
         std::move(msg),
-        std::chrono::milliseconds(
-          server_connection_timeout_s * 1)); // TODO: Change back
+        std::chrono::milliseconds(server_connection_timeout_s * 1000));
     }
 
     void handle_success_response(std::vector<uint8_t>&& data, bool is_der)


### PR DESCRIPTION
Follow-up from #4277 

The resilience added to the attestation endorsements client meant that some races could occur between the watchdog task and the handler for the response. These two races (a) timing out too many times, b) receiving a response after having timed out too many times) are now fixed.