### PR TITLE
Fix implementation of `Math.random()` in JS interpreter

### DIFF
--- a/3rdparty/exported/quickjs/quickjs-time.h
+++ b/3rdparty/exported/quickjs/quickjs-time.h
@@ -2,11 +2,19 @@
 
 int qjs_gettimeofday(struct timeval* tv, void* tz)
 {
+  if (tv != NULL)
+  {
+    memset(tv, 0, sizeof(struct timeval));
+  }
   return 0;
 }
 
 struct tm* qjs_localtime_r(const time_t* timep, struct tm* result)
 {
+  if (result != NULL)
+  {
+    memset(result, 0, sizeof(struct tm));
+  }
   return 0;
 }
 

--- a/tests/js-api/app.json
+++ b/tests/js-api/app.json
@@ -51,6 +51,16 @@
         "mode": "readonly",
         "openapi": {}
       }
+    },
+    "/make_randoms": {
+      "get": {
+        "js_module": "endpoints.js",
+        "js_function": "make_randoms",
+        "forwarding_required": "never",
+        "authn_policies": ["no_auth"],
+        "mode": "readonly",
+        "openapi": {}
+      }
     }
   }
 }

--- a/tests/js-api/src/endpoints.js
+++ b/tests/js-api/src/endpoints.js
@@ -1,3 +1,12 @@
 export function echo(request) {
   return { body: JSON.stringify(request) };
 }
+
+export function make_randoms(request) {
+  return {
+    body: {
+      a: Math.random(),
+      b: Math.random()
+    }
+  };
+}

--- a/tests/js-api/src/endpoints.js
+++ b/tests/js-api/src/endpoints.js
@@ -6,7 +6,7 @@ export function make_randoms(request) {
   return {
     body: {
       a: Math.random(),
-      b: Math.random()
-    }
+      b: Math.random(),
+    },
   };
 }

--- a/tests/js-custom-authorization/custom_authorization.py
+++ b/tests/js-custom-authorization/custom_authorization.py
@@ -379,6 +379,34 @@ def run_content_types(args):
 
 
 @reqs.description("Test request object API")
+def test_random_api(args):
+    # Test that Math.random() does not repeat values:
+    # - on multiple invocations within a single request
+    # - on multiple requests
+    # - on network restarts
+
+    seen_values = set()
+
+    def assert_fresh(n):
+        assert n not in seen_values, f"{n} has already been returned"
+        seen_values.add(n)
+
+    n_repeats = 3
+    for _ in range(n_repeats):
+        with infra.network.network(
+            args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
+        ) as network:
+            network.start_and_open(args)
+            primary, _ = network.find_nodes()
+            for _ in range(n_repeats):
+                with primary.client() as c:
+                    r = c.get("/app/make_randoms")
+                    assert r.status_code == 200, r
+                    for _, n in r.body.json().items():
+                        assert_fresh(n)
+
+
+@reqs.description("Test request object API")
 def test_request_object_api(network, args):
     primary, _ = network.find_nodes()
 
@@ -455,7 +483,9 @@ def test_request_object_api(network, args):
     return network
 
 
-def run_request_object(args):
+def run_api(args):
+    test_random_api(args)
+
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
@@ -497,8 +527,8 @@ if __name__ == "__main__":
     )
 
     cr.add(
-        "request_object",
-        run_request_object,
+        "api",
+        run_api,
         nodes=infra.e2e_args.nodes(cr.args, 1),
         js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-api"),
     )


### PR DESCRIPTION
Our stubs for QuickJS's `gettimeofday` functions weren't clearing the passed value, so were relying on uninitialized data.

Beyond that, we don't actually want to rely on `gettimeofday` to seed the random state, which is the implementation of `Math.random()` that QuickJS uses. Instead we overwrite this function entirely with our own implementation, which uses our existing in-enclave `Entropy`.

Includes an end-to-end test that tries to ensure we don't see the same sequence of numbers from this, across calls or network restarts.