### PR TITLE
Enforce type of arg in TS DataConverter.convert

### DIFF
--- a/js/ccf-app/src/converters.ts
+++ b/js/ccf-app/src/converters.ts
@@ -32,29 +32,25 @@ export interface DataConverter<T> {
   decode(arr: ArrayBuffer): T;
 }
 
-function checkBoolean(val: any)
-{
+function checkBoolean(val: any) {
   if (typeof val !== "boolean") {
     throw new TypeError(`Value ${val} is not a boolean`)
   }
 }
 
-function checkNumber(val: any)
-{
+function checkNumber(val: any) {
   if (typeof val !== "number") {
     throw new TypeError(`Value ${val} is not a number`)
   }
 }
 
-function checkBigInt(val: any)
-{
+function checkBigInt(val: any) {
   if (typeof val !== "bigint") {
     throw new TypeError(`Value ${val} is not a bigint`)
   }
 }
 
-function checkString(val: any)
-{
+function checkString(val: any) {
   if (typeof val !== "string") {
     throw new TypeError(`Value ${val} is not a string`)
   }
@@ -221,11 +217,11 @@ class JSONConverter<T extends JsonCompatible<T>> implements DataConverter<T> {
 export type TypedArray = ArrayBufferView;
 
 export interface TypedArrayConstructor<T extends TypedArray> {
-  new (buffer: ArrayBuffer, byteOffset?: number, length?: number): T;
+  new(buffer: ArrayBuffer, byteOffset?: number, length?: number): T;
 }
 
 class TypedArrayConverter<T extends TypedArray> implements DataConverter<T> {
-  constructor(private clazz: TypedArrayConstructor<T>) {}
+  constructor(private clazz: TypedArrayConstructor<T>) { }
   encode(val: T): ArrayBuffer {
     return val.buffer.slice(val.byteOffset, val.byteOffset + val.byteLength);
   }

--- a/js/ccf-app/src/converters.ts
+++ b/js/ccf-app/src/converters.ts
@@ -32,8 +32,38 @@ export interface DataConverter<T> {
   decode(arr: ArrayBuffer): T;
 }
 
+function checkBoolean(val: any)
+{
+  if (typeof val !== "boolean") {
+    throw new TypeError(`Value ${val} is not a boolean`)
+  }
+}
+
+function checkNumber(val: any)
+{
+  if (typeof val !== "number") {
+    throw new TypeError(`Value ${val} is not a number`)
+  }
+}
+
+function checkBigInt(val: any)
+{
+  if (typeof val !== "bigint") {
+    throw new TypeError(`Value ${val} is not a bigint`)
+  }
+}
+
+function checkString(val: any)
+{
+  if (typeof val !== "string") {
+    throw new TypeError(`Value ${val} is not a string`)
+  }
+}
+
+
 class BoolConverter implements DataConverter<boolean> {
   encode(val: boolean): ArrayBuffer {
+    checkBoolean(val);
     const buf = new ArrayBuffer(1);
     new DataView(buf).setUint8(0, val ? 1 : 0);
     return buf;
@@ -44,6 +74,7 @@ class BoolConverter implements DataConverter<boolean> {
 }
 class Int8Converter implements DataConverter<number> {
   encode(val: number): ArrayBuffer {
+    checkNumber(val);
     if (val < -128 || val > 127) {
       throw new RangeError("value is not within int8 range");
     }
@@ -57,6 +88,7 @@ class Int8Converter implements DataConverter<number> {
 }
 class Uint8Converter implements DataConverter<number> {
   encode(val: number): ArrayBuffer {
+    checkNumber(val);
     if (val < 0 || val > 255) {
       throw new RangeError("value is not within uint8 range");
     }
@@ -70,6 +102,7 @@ class Uint8Converter implements DataConverter<number> {
 }
 class Int16Converter implements DataConverter<number> {
   encode(val: number): ArrayBuffer {
+    checkNumber(val);
     if (val < -32768 || val > 32767) {
       throw new RangeError("value is not within int16 range");
     }
@@ -83,6 +116,7 @@ class Int16Converter implements DataConverter<number> {
 }
 class Uint16Converter implements DataConverter<number> {
   encode(val: number): ArrayBuffer {
+    checkNumber(val);
     if (val < 0 || val > 65535) {
       throw new RangeError("value is not within uint16 range");
     }
@@ -96,6 +130,7 @@ class Uint16Converter implements DataConverter<number> {
 }
 class Int32Converter implements DataConverter<number> {
   encode(val: number): ArrayBuffer {
+    checkNumber(val);
     if (val < -2147483648 || val > 2147483647) {
       throw new RangeError("value is not within int32 range");
     }
@@ -109,6 +144,7 @@ class Int32Converter implements DataConverter<number> {
 }
 class Uint32Converter implements DataConverter<number> {
   encode(val: number): ArrayBuffer {
+    checkNumber(val);
     if (val < 0 || val > 4294967295) {
       throw new RangeError("value is not within uint32 range");
     }
@@ -122,6 +158,7 @@ class Uint32Converter implements DataConverter<number> {
 }
 class Int64Converter implements DataConverter<bigint> {
   encode(val: bigint): ArrayBuffer {
+    checkBigInt(val);
     const buf = new ArrayBuffer(8);
     new DataView(buf).setBigInt64(0, val, true);
     return buf;
@@ -132,6 +169,7 @@ class Int64Converter implements DataConverter<bigint> {
 }
 class Uint64Converter implements DataConverter<bigint> {
   encode(val: bigint): ArrayBuffer {
+    checkBigInt(val);
     const buf = new ArrayBuffer(8);
     new DataView(buf).setBigUint64(0, val, true);
     return buf;
@@ -142,6 +180,7 @@ class Uint64Converter implements DataConverter<bigint> {
 }
 class Float32Converter implements DataConverter<number> {
   encode(val: number): ArrayBuffer {
+    checkNumber(val);
     const buf = new ArrayBuffer(4);
     new DataView(buf).setFloat32(0, val, true);
     return buf;
@@ -152,6 +191,7 @@ class Float32Converter implements DataConverter<number> {
 }
 class Float64Converter implements DataConverter<number> {
   encode(val: number): ArrayBuffer {
+    checkNumber(val);
     const buf = new ArrayBuffer(8);
     new DataView(buf).setFloat64(0, val, true);
     return buf;
@@ -162,6 +202,7 @@ class Float64Converter implements DataConverter<number> {
 }
 class StringConverter implements DataConverter<string> {
   encode(val: string): ArrayBuffer {
+    checkString(val);
     return ccf.strToBuf(val);
   }
   decode(buf: ArrayBuffer): string {

--- a/js/ccf-app/src/converters.ts
+++ b/js/ccf-app/src/converters.ts
@@ -34,28 +34,27 @@ export interface DataConverter<T> {
 
 function checkBoolean(val: any) {
   if (typeof val !== "boolean") {
-    throw new TypeError(`Value ${val} is not a boolean`)
+    throw new TypeError(`Value ${val} is not a boolean`);
   }
 }
 
 function checkNumber(val: any) {
   if (typeof val !== "number") {
-    throw new TypeError(`Value ${val} is not a number`)
+    throw new TypeError(`Value ${val} is not a number`);
   }
 }
 
 function checkBigInt(val: any) {
   if (typeof val !== "bigint") {
-    throw new TypeError(`Value ${val} is not a bigint`)
+    throw new TypeError(`Value ${val} is not a bigint`);
   }
 }
 
 function checkString(val: any) {
   if (typeof val !== "string") {
-    throw new TypeError(`Value ${val} is not a string`)
+    throw new TypeError(`Value ${val} is not a string`);
   }
 }
-
 
 class BoolConverter implements DataConverter<boolean> {
   encode(val: boolean): ArrayBuffer {
@@ -217,11 +216,11 @@ class JSONConverter<T extends JsonCompatible<T>> implements DataConverter<T> {
 export type TypedArray = ArrayBufferView;
 
 export interface TypedArrayConstructor<T extends TypedArray> {
-  new(buffer: ArrayBuffer, byteOffset?: number, length?: number): T;
+  new (buffer: ArrayBuffer, byteOffset?: number, length?: number): T;
 }
 
 class TypedArrayConverter<T extends TypedArray> implements DataConverter<T> {
-  constructor(private clazz: TypedArrayConstructor<T>) { }
+  constructor(private clazz: TypedArrayConstructor<T>) {}
   encode(val: T): ArrayBuffer {
     return val.buffer.slice(val.byteOffset, val.byteOffset + val.byteLength);
   }

--- a/js/ccf-app/test/kv.test.ts
+++ b/js/ccf-app/test/kv.test.ts
@@ -77,17 +77,12 @@ class TypeErasedKvMap<K, V> {
 
 describe("erased types", function () {
   const bar = new TypeErasedKvMap(kv.typedKv("bar", conv.int32, conv.uint16));
-  const key = "bar";
-  const key2 = "baz";
+  const key = "baz";
   const val = 65535;
 
   it("basic", function () {
-    assert.isFalse(bar.has(key));
-    assert.isFalse(bar.has(key2));
-    assert.equal(bar.get(key), undefined);
-    bar.set(key, val);
-    assert.equal(bar.get(key), val);
-    assert.isTrue(bar.has(key));
-    assert.isFalse(bar.has(key2));
+    assert.throws(() => bar.has(key), `${key} is not a number`);
+    assert.throws(() => bar.get(key), `${key} is not a number`);
+    assert.throws(() => bar.set(key, val), `${key} is not a number`);
   });
 });

--- a/js/ccf-app/test/kv.test.ts
+++ b/js/ccf-app/test/kv.test.ts
@@ -64,15 +64,18 @@ describe("typedKv", function () {
   });
 });
 
-
 class TypeErasedKvMap<K, V> {
-  constructor(
-    private map: kv.TypedKvMap<K, V>
-  ) { }
+  constructor(private map: kv.TypedKvMap<K, V>) {}
 
-  has(key: any): boolean { return this.map.has(key); }
-  get(key: any): V | undefined { return this.map.get(key); }
-  set(key: any, value: V) { this.map.set(key, value); }
+  has(key: any): boolean {
+    return this.map.has(key);
+  }
+  get(key: any): V | undefined {
+    return this.map.get(key);
+  }
+  set(key: any, value: V) {
+    this.map.set(key, value);
+  }
 }
 
 describe("erased types", function () {

--- a/js/ccf-app/test/kv.test.ts
+++ b/js/ccf-app/test/kv.test.ts
@@ -17,10 +17,13 @@ describe("typedKv", function () {
   const val = 65535;
 
   it("basic", function () {
+    assert.isFalse(foo.has(key));
+    assert.isFalse(foo.has(key2));
     assert.equal(foo.get(key), undefined);
     foo.set(key, val);
     assert.equal(foo.get(key), val);
     assert.isTrue(foo.has(key));
+    assert.isFalse(foo.has(key2));
     let found = false;
     foo.forEach((v, k) => {
       if (k == key && v == val) {
@@ -29,7 +32,8 @@ describe("typedKv", function () {
     });
     assert.isTrue(found);
     foo.delete(key);
-    assert.isNotTrue(foo.has(key));
+    assert.isFalse(foo.has(key));
+    assert.isFalse(foo.has(key2));
     assert.equal(foo.get(key), undefined);
   });
 
@@ -57,5 +61,33 @@ describe("typedKv", function () {
     assert.equal(foo.size, 2);
     foo.clear();
     assert.equal(foo.size, 0);
+  });
+});
+
+
+class TypeErasedKvMap<K, V> {
+  constructor(
+    private map: kv.TypedKvMap<K, V>
+  ) { }
+
+  has(key: any): boolean { return this.map.has(key); }
+  get(key: any): V | undefined { return this.map.get(key); }
+  set(key: any, value: V) { this.map.set(key, value); }
+}
+
+describe("erased types", function () {
+  const bar = new TypeErasedKvMap(kv.typedKv("bar", conv.int32, conv.uint16));
+  const key = "bar";
+  const key2 = "baz";
+  const val = 65535;
+
+  it("basic", function () {
+    assert.isFalse(bar.has(key));
+    assert.isFalse(bar.has(key2));
+    assert.equal(bar.get(key), undefined);
+    bar.set(key, val);
+    assert.equal(bar.get(key), val);
+    assert.isTrue(bar.has(key));
+    assert.isFalse(bar.has(key2));
   });
 });


### PR DESCRIPTION
Resolves #4326.

If the calling TypeScript has used `any` or other kinds of type erasure, they may actually pass us a key or value of completely the wrong type. Rather than encoding junk, we now throw a `TypeError`.