### PR TITLE
Add secp256k1 to the JS crypto API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+### Added
+
+- Add secp256k1 support to `ccf.crypto.generateEcdsaKeyPair()` and `ccf.crypto.verifySignature()` (#4347).
+
 ### Deprecated
 
 - `ccf::EnclaveAttestationProvider` is deprecated and will be removed in a future release. It should be replaced by `ccf::AttestationProvider`

--- a/include/ccf/crypto/curve.h
+++ b/include/ccf/crypto/curve.h
@@ -21,14 +21,17 @@ namespace crypto
     /// The SECP384R1 curve
     SECP384R1,
     /// The SECP256R1 curve
-    SECP256R1
+    SECP256R1,
+    /// The SECP256K1 curve
+    SECP256K1
   };
 
   DECLARE_JSON_ENUM(
     CurveID,
     {{CurveID::NONE, "None"},
      {CurveID::SECP384R1, "Secp384R1"},
-     {CurveID::SECP256R1, "Secp256R1"}});
+     {CurveID::SECP256R1, "Secp256R1"},
+     {CurveID::SECP256K1, "Secp256K1"}});
 
   static constexpr CurveID service_identity_curve_choice = CurveID::SECP384R1;
   // SNIPPET_END: supported_curves
@@ -41,6 +44,8 @@ namespace crypto
       case CurveID::SECP384R1:
         return MDType::SHA384;
       case CurveID::SECP256R1:
+        return MDType::SHA256;
+      case CurveID::SECP256K1:
         return MDType::SHA256;
       default:
       {

--- a/js/ccf-app/src/global.ts
+++ b/js/ccf-app/src/global.ts
@@ -394,7 +394,7 @@ export interface CCF {
   /**
    * Generate an ECDSA key pair.
    *
-   * @param curve The name of the curve, one of "secp256r1", "secp384r1".
+   * @param curve The name of the curve, one of "secp256r1", "secp256k1", "secp384r1".
    */
   generateEcdsaKeyPair(curve: string): CryptoKeyPair;
 

--- a/js/ccf-app/test/polyfill.test.ts
+++ b/js/ccf-app/test/polyfill.test.ts
@@ -55,6 +55,13 @@ describe("polyfill", function () {
       assert.isTrue(pair.privateKey.startsWith("-----BEGIN PRIVATE KEY-----"));
     });
   });
+  describe("generateEcdsaKeyPair/secp256k1", function () {
+    it("generates a random ECDSA P256K1 key pair", function () {
+      const pair = ccf.generateEcdsaKeyPair("secp256k1");
+      assert.isTrue(pair.publicKey.startsWith("-----BEGIN PUBLIC KEY-----"));
+      assert.isTrue(pair.privateKey.startsWith("-----BEGIN PRIVATE KEY-----"));
+    });
+  });
   describe("generateEcdsaKeyPair/secp384r1", function () {
     it("generates a random ECDSA P384R1 key pair", function () {
       const pair = ccf.generateEcdsaKeyPair("secp384r1");

--- a/src/crypto/openssl/public_key.cpp
+++ b/src/crypto/openssl/public_key.cpp
@@ -64,6 +64,8 @@ namespace crypto
         return CurveID::SECP384R1;
       case NID_X9_62_prime256v1:
         return CurveID::SECP256R1;
+      case NID_secp256k1:
+        return CurveID::SECP256K1;
       default:
         throw std::runtime_error(fmt::format("Unknown OpenSSL curve {}", nid));
     }
@@ -86,6 +88,8 @@ namespace crypto
         return NID_secp384r1;
       case CurveID::SECP256R1:
         return NID_X9_62_prime256v1;
+      case CurveID::SECP256K1:
+        return NID_secp256k1;
       default:
         throw std::logic_error(
           fmt::format("unsupported OpenSSL CurveID {}", gid));

--- a/src/crypto/test/bench.cpp
+++ b/src/crypto/test/bench.cpp
@@ -165,6 +165,22 @@ namespace SIGN_SECP256R1
   PICOBENCH(sign_256r1_ossl_100k).PICO_SUFFIX(CurveID::SECP256R1);
 }
 
+PICOBENCH_SUITE("sign secp256k1");
+namespace SIGN_SECP256K1
+{
+  auto sign_256k1_ossl_1byte =
+    benchmark_sign<KeyPair_OpenSSL, CurveID::SECP256K1, 1>;
+  PICOBENCH(sign_256k1_ossl_1byte).PICO_SUFFIX(CurveID::SECP256K1);
+
+  auto sign_256k1_ossl_1k =
+    benchmark_sign<KeyPair_OpenSSL, CurveID::SECP256K1, 1024>;
+  PICOBENCH(sign_256k1_ossl_1k).PICO_SUFFIX(CurveID::SECP256K1);
+
+  auto sign_256k1_ossl_100k =
+    benchmark_sign<KeyPair_OpenSSL, CurveID::SECP256K1, 102400>;
+  PICOBENCH(sign_256k1_ossl_100k).PICO_SUFFIX(CurveID::SECP256K1);
+}
+
 PICOBENCH_SUITE("verify secp384r1");
 namespace SECP384R1
 {
@@ -207,6 +223,28 @@ namespace SECP256R1
     CurveID::SECP256R1,
     102400>;
   PICOBENCH(verify_256r1_ossl_100k).PICO_SUFFIX(CurveID::SECP256R1);
+}
+
+PICOBENCH_SUITE("verify secp256k1");
+namespace SECP256K1
+{
+  auto verify_256k1_ossl_1byte =
+    benchmark_verify<KeyPair_OpenSSL, PublicKey_OpenSSL, CurveID::SECP256K1, 1>;
+  PICOBENCH(verify_256k1_ossl_1byte).PICO_SUFFIX(CurveID::SECP256K1);
+
+  auto verify_256k1_ossl_1k = benchmark_verify<
+    KeyPair_OpenSSL,
+    PublicKey_OpenSSL,
+    CurveID::SECP256K1,
+    1024>;
+  PICOBENCH(verify_256k1_ossl_1k).PICO_SUFFIX(CurveID::SECP256K1);
+
+  auto verify_256k1_ossl_100k = benchmark_verify<
+    KeyPair_OpenSSL,
+    PublicKey_OpenSSL,
+    CurveID::SECP256K1,
+    102400>;
+  PICOBENCH(verify_256k1_ossl_100k).PICO_SUFFIX(CurveID::SECP256K1);
 }
 
 PICOBENCH_SUITE("sign RSA-2048");

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -156,7 +156,8 @@ TEST_CASE("Sign, fail to verify with wrong key on correct curve")
 
 TEST_CASE("Sign, fail to verify with wrong key on wrong curve")
 {
-  constexpr size_t num_supported_curves = static_cast<size_t>(sizeof(supported_curves)/sizeof(CurveID));
+  constexpr size_t num_supported_curves =
+    static_cast<size_t>(sizeof(supported_curves) / sizeof(CurveID));
   for (auto i = 0; i < num_supported_curves; ++i)
   {
     const auto curve = supported_curves[i];

--- a/src/js/crypto.cpp
+++ b/src/js/crypto.cpp
@@ -98,6 +98,10 @@ namespace ccf::js
     {
       cid = crypto::CurveID::SECP256R1;
     }
+    else if (curve == "secp256k1")
+    {
+      cid = crypto::CurveID::SECP256K1;
+    }
     else if (curve == "secp384r1")
     {
       cid = crypto::CurveID::SECP384R1;
@@ -105,7 +109,7 @@ namespace ccf::js
     else
     {
       return JS_ThrowRangeError(
-        ctx, "Unsupported curve id, supported: secp256r1, secp384r1");
+        ctx, "Unsupported curve id, supported: secp256r1, secp256k1, secp384r1");
     }
     auto k = crypto::make_key_pair(cid);
 

--- a/src/js/crypto.cpp
+++ b/src/js/crypto.cpp
@@ -109,7 +109,8 @@ namespace ccf::js
     else
     {
       return JS_ThrowRangeError(
-        ctx, "Unsupported curve id, supported: secp256r1, secp256k1, secp384r1");
+        ctx,
+        "Unsupported curve id, supported: secp256r1, secp256k1, secp384r1");
     }
     auto k = crypto::make_key_pair(cid);
 

--- a/tests/infra/crypto.py
+++ b/tests/infra/crypto.py
@@ -85,6 +85,8 @@ def generate_rsa_keypair(key_size: int) -> Tuple[str, str]:
 def generate_ec_keypair(curve_name: str) -> Tuple[str, str]:
     if curve_name == "secp256r1":
         curve = ec.SECP256R1()
+    elif curve_name == "secp256k1":
+        curve = ec.SECP256K1
     elif curve_name == "secp384r1":
         curve = ec.SECP384R1()
     else:

--- a/tests/infra/crypto.py
+++ b/tests/infra/crypto.py
@@ -86,7 +86,7 @@ def generate_ec_keypair(curve_name: str) -> Tuple[str, str]:
     if curve_name == "secp256r1":
         curve = ec.SECP256R1()
     elif curve_name == "secp256k1":
-        curve = ec.SECP256K1
+        curve = ec.SECP256K1()
     elif curve_name == "secp384r1":
         curve = ec.SECP384R1()
     else:


### PR DESCRIPTION
Issue: #4319

## Change
- Allow to pass 'secp256k1' to [`generateEcdsaKeyPair()`](https://microsoft.github.io/CCF/main/js/ccf-app/functions/crypto.generateEcdsaKeyPair.html). [`verifySignature()`](https://microsoft.github.io/CCF/main/js/ccf-app/functions/crypto.verifySignature.html) should be able to verify signatures made with secp256k1.

Note: I only changed codes related to JS crypto API. So files like `src/node/acme_client.h` is not edited.
