### PR TITLE
Allow applications to be built with sanitizers enabled.

### DIFF
--- a/cmake/ccf-config.cmake.in
+++ b/cmake/ccf-config.cmake.in
@@ -1,6 +1,7 @@
 @PACKAGE_INIT@
 
 set(CCF_DIR "@CMAKE_INSTALL_PREFIX@")
+set(SAN "@SAN@")
 
 include("${CCF_DIR}/cmake/ccf-targets.cmake")
 include("${CCF_DIR}/cmake/preproject.cmake")

--- a/cmake/ccf_unsafe-config.cmake.in
+++ b/cmake/ccf_unsafe-config.cmake.in
@@ -1,6 +1,7 @@
 @PACKAGE_INIT@
 
 set(CCF_DIR "@CMAKE_INSTALL_PREFIX@")
+set(SAN "@SAN@")
 
 include("${CCF_DIR}/cmake/ccf-targets.cmake")
 include("${CCF_DIR}/cmake/preproject.cmake")

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -140,9 +140,9 @@ install(PROGRAMS ${CCF_DIR}/samples/scripts/sgxinfo.sh DESTINATION bin)
 install(PROGRAMS ${CCF_DIR}/samples/scripts/snpinfo.sh DESTINATION bin)
 install(FILES ${CCF_DIR}/tests/config.jinja DESTINATION bin)
 
-if (SAN)
+if(SAN)
   install(FILES ${CCF_DIR}/src/ubsan.suppressions DESTINATION bin)
-endif ()
+endif()
 
 # Install getting_started scripts for VM creation and setup
 install(

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -140,6 +140,10 @@ install(PROGRAMS ${CCF_DIR}/samples/scripts/sgxinfo.sh DESTINATION bin)
 install(PROGRAMS ${CCF_DIR}/samples/scripts/snpinfo.sh DESTINATION bin)
 install(FILES ${CCF_DIR}/tests/config.jinja DESTINATION bin)
 
+if (SAN)
+  install(FILES ${CCF_DIR}/src/ubsan.suppressions DESTINATION bin)
+endif ()
+
 # Install getting_started scripts for VM creation and setup
 install(
   DIRECTORY ${CCF_DIR}/getting_started/

--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -5,8 +5,10 @@ function(add_san name)
   if(SAN)
     # CCF_PROJECT is defined when building CCF itself, but not when this
     # function is used by downstream applications.
-    if (CCF_PROJECT)
-      set(suppressions_file $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/ubsan.suppressions>$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/bin/ubsan.suppressions>)
+    if(CCF_PROJECT)
+      set(suppressions_file
+          $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/ubsan.suppressions>$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/bin/ubsan.suppressions>
+      )
     else()
       set(suppressions_file ${CCF_DIR}/bin/ubsan.suppressions)
     endif()

--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -3,17 +3,25 @@
 
 function(add_san name)
   if(SAN)
+    # CCF_PROJECT is defined when building CCF itself, but not when this
+    # function is used by downstream applications.
+    if (CCF_PROJECT)
+      set(suppressions_file $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/ubsan.suppressions>$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/bin/ubsan.suppressions>)
+    else()
+      set(suppressions_file ${CCF_DIR}/bin/ubsan.suppressions)
+    endif()
+
     target_compile_options(
       ${name}
       PRIVATE -fsanitize=undefined,address -fno-omit-frame-pointer
               -fno-sanitize-recover=all -fno-sanitize=function
-              -fsanitize-blacklist=${CCF_DIR}/src/ubsan.suppressions
+              -fsanitize-blacklist=${suppressions_file}
     )
     target_link_libraries(
       ${name}
       PRIVATE -fsanitize=undefined,address -fno-omit-frame-pointer
               -fno-sanitize-recover=all -fno-sanitize=function
-              -fsanitize-blacklist=${CCF_DIR}/src/ubsan.suppressions
+              -fsanitize-blacklist=${suppressions_file}
     )
   endif()
 endfunction()


### PR DESCRIPTION
In order for this to work, we need a few things:
- Install the ubsan.suppressions file
- Change the add_san function to point to the correct location, based on whether it is called on a CCF library or downstream app.
- Persist the value of the SAN option in ccf-config.cmake, so it gets picked up when importing CCF in downstream projects.