### PR TITLE
Re-enable `CCF Github Stress` pipeline

### DIFF
--- a/.azure-pipelines-templates/stress-matrix.yml
+++ b/.azure-pipelines-templates/stress-matrix.yml
@@ -5,7 +5,6 @@ jobs:
       env:
         container: sgx
         pool: 1es-dcv2-focal
-        timeoutInMinutes: 120 # Trying to run 2 45-minute tests; these must complete in < 2 hours
       cmake_args: "-DCOMPILE_TARGETS=sgx"
       suffix: "StressTest"
       artifact_name: "StressTest"


### PR DESCRIPTION
This pipeline hasn't been running for a few days, because
![image](https://user-images.githubusercontent.com/6000239/197158936-bc10aad3-f935-44f3-921d-546b517ff9e2.png)
