### PR TITLE
add missing headers required when including files for certain options

### DIFF
--- a/include/ccf/ds/json_schema.h
+++ b/include/ccf/ds/json_schema.h
@@ -4,6 +4,7 @@
 
 #include "ccf/ds/nonstd.h"
 
+#include <optional>
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>

--- a/include/ccf/pal/hardware_info.h
+++ b/include/ccf/pal/hardware_info.h
@@ -2,6 +2,8 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include <cstdint>
+#include <cstring>
 #include <set>
 
 namespace ccf::pal


### PR DESCRIPTION
Importing these files throw an error during compilation because of the following missing headers.