### PR TITLE
Fix for `release/2.x` docs build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -230,11 +230,21 @@ assert not re.match(smv_branch_whitelist, "release/1.x_feature")
 # Intercept command line arguments passed by sphinx-multiversion to retrieve doc version.
 # This is a little hacky with sphinx-multiversion 0.2.4 and the `SPHINX_MULTIVERSION_NAME`
 # envvar should be used for further versions (release pending).
-docs_version = "main"
+docs_version = None
 for arg in sys.argv:
     if "smv_current_version=" in arg:
         docs_version = arg.split("=")[1]
+        break
 
+# If that didn't work, try extracting it from env vars inserted by Azure pipelines. This
+# is used by single-build jobs and Link checks targeting release branches.
+if docs_version is None:
+    if os.environ.get("BUILD_REASON") == "PullRequest":
+        docs_version = os.environ["SYSTEM_PULLREQUEST_TARGETBRANCH"]
+
+# If we still have no docs_version, assume we're on main
+if docs_version is None:
+    docs_version = "main"
 
 # :ccf_repo: directive can be used to create a versioned link to GitHub repo
 extlinks = {


### PR DESCRIPTION
We haven't run the CCF GitHub Pages job on the `release/2.x` branch in a while, since it only runs on PRs targeting that branch. It's now failing in the `Link checks` step because its reading `.rst` files describing files on the `release/2.x` branch, but looking for those (via links generated by the `:ccf_repo:` directive) under `/tree/main`.

For instance, this one:
https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=51879&view=logs&j=f1fd332c-cd58-5ba4-fc7d-3c1d3a3f0cd3&t=31418c00-d4df-5619-e99a-3cbbc8fcc481&l=654

The existing logic to set `docs_version` only works for sphinx-multiversion runs, and doesn't help us for single-builds (including this link check build). The new approach is to use [DevOps' System Variables](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services), which are auto-inserted as environment variables:

> In YAML pipelines, you can reference predefined variables as environment variables. For example, the variable Build.ArtifactStagingDirectory becomes the variable BUILD_ARTIFACTSTAGINGDIRECTORY.

See [here](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=51879&view=logs&j=f1fd332c-cd58-5ba4-fc7d-3c1d3a3f0cd3&t=31418c00-d4df-5619-e99a-3cbbc8fcc481&l=186 )for the output of a debugging run where I dumped these env vars to confirm. The code that does that, for posterity (in case we want to add it for real), is [here](https://github.com/microsoft/CCF/commit/7311c132dc0a5ca63575505cf91bdb6e82558183).