### PR TITLE
CI: Do not publish debian package for SGXIceLake

### DIFF
--- a/.azure-pipelines-templates/install_deb.yml
+++ b/.azure-pipelines-templates/install_deb.yml
@@ -68,8 +68,11 @@ steps:
           fi
         displayName: Test building a sample against installed CCF (SNP)
 
-  - task: PublishPipelineArtifact@1
-    inputs:
-      path: $(Build.ArtifactStagingDirectory)/$(pkgname)
-      artifact: $(pkgname)
-      displayName: "Publish CCF Debian Package"
+  # Note: Do not publish pipeline artefact for SGXIceLake to avoid 
+  # publishing the same artefact twice (SGX and SGXIceLake)
+  - ${{ if ne(parameters.target, 'SGXIceLake') }}:
+    - task: PublishPipelineArtifact@1
+      inputs:
+        path: $(Build.ArtifactStagingDirectory)/$(pkgname)
+        artifact: $(pkgname)
+        displayName: "Publish CCF Debian Package"


### PR DESCRIPTION
This fixes the current failure in the Daily pipeline where two identical artefacts are published in the same pipeline.