### PR TITLE
Download Doxygen from SourceForge to keep v1.9.4

### DIFF
--- a/.azure-pipelines-templates/install_deb.yml
+++ b/.azure-pipelines-templates/install_deb.yml
@@ -68,11 +68,11 @@ steps:
           fi
         displayName: Test building a sample against installed CCF (SNP)
 
-  # Note: Do not publish pipeline artefact for SGXIceLake to avoid 
+  # Note: Do not publish pipeline artefact for SGXIceLake to avoid
   # publishing the same artefact twice (SGX and SGXIceLake)
   - ${{ if ne(parameters.target, 'SGXIceLake') }}:
-    - task: PublishPipelineArtifact@1
-      inputs:
-        path: $(Build.ArtifactStagingDirectory)/$(pkgname)
-        artifact: $(pkgname)
-        displayName: "Publish CCF Debian Package"
+      - task: PublishPipelineArtifact@1
+        inputs:
+          path: $(Build.ArtifactStagingDirectory)/$(pkgname)
+          artifact: $(pkgname)
+          displayName: "Publish CCF Debian Package"

--- a/getting_started/setup_vm/roles/ccf_build/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_build/vars/common.yml
@@ -35,4 +35,4 @@ docker_debs:
 
 doxygen_ver: "1.9.4"
 doxygen_bin: "doxygen-{{ doxygen_ver }}.linux.bin.tar.gz"
-doxygen_url: "https://doxygen.nl/files/{{ doxygen_bin }}"
+doxygen_url: "https://sourceforge.net/projects/doxygen/files/rel-{{ doxygen_ver }}/{{ doxygen_bin }}/download"


### PR DESCRIPTION
CodeQL is failing because Doxygen v1.9.5 is out, and the previous v1.9.4 we were using is no longer present.

We already had to fix this in #3823. Rather than bumping the version, I think we should just download from SourceForge, which should host old versions for longer.