### PR TITLE
Move all SGX CI executors to IceLake

### DIFF
--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -5,9 +5,6 @@ parameters:
       pool: 1es-dv4-focal
     SGX:
       container: sgx
-      pool: 1es-dcv2-focal
-    SGXIceLake:
-      container: sgx
       pool: 1es-dcdv3-focal
     SNPCC:
       pool: sev-snp-pool
@@ -73,16 +70,6 @@ jobs:
       cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.unsafe.cmake_args }}"
       suffix: "Unsafe"
       artifact_name: "SGX_Unsafe"
-      ctest_filter: '-LE "benchmark|perf|rotation"'
-      depends_on: configure
-
-  - template: common.yml
-    parameters:
-      target: SGXIceLake
-      env: "${{ parameters.env.SGXIceLake }}"
-      cmake_args: "${{ parameters.build.common.cmake_args }} -DTLS_TEST=ON -DSHUFFLE_SUITE=ON"
-      suffix: "Release"
-      artifact_name: "SGX_IceLake_Release"
       ctest_filter: '-LE "benchmark|perf|rotation"'
       depends_on: configure
 

--- a/.azure-pipelines-templates/install_deb.yml
+++ b/.azure-pipelines-templates/install_deb.yml
@@ -35,7 +35,7 @@ steps:
         workingDirectory: build
         displayName: Recovery benchmark for installed CCF
 
-  - ${{ if or(eq(parameters.target, 'SGX'), eq(parameters.target, 'SGXIceLake')) }}:
+  - ${{ if eq(parameters.target, 'SGX') }}:
       - script: |
           set -ex
           unsafe_build=$(grep unsafe /tmp/install_prefix) || true
@@ -68,11 +68,8 @@ steps:
           fi
         displayName: Test building a sample against installed CCF (SNP)
 
-  # Note: Do not publish pipeline artefact for SGXIceLake to avoid
-  # publishing the same artefact twice (SGX and SGXIceLake)
-  - ${{ if ne(parameters.target, 'SGXIceLake') }}:
-      - task: PublishPipelineArtifact@1
-        inputs:
-          path: $(Build.ArtifactStagingDirectory)/$(pkgname)
-          artifact: $(pkgname)
-          displayName: "Publish CCF Debian Package"
+  - task: PublishPipelineArtifact@1
+    inputs:
+      path: $(Build.ArtifactStagingDirectory)/$(pkgname)
+      artifact: $(pkgname)
+      displayName: "Publish CCF Debian Package"

--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -11,7 +11,7 @@ parameters:
       pool: 1es-dv4-focal
     SGX:
       container: sgx
-      pool: 1es-dcv2-focal
+      pool: 1es-dcdv3-focal
     SNPCC:
       pool: sev-snp-pool
 

--- a/.azure-pipelines-templates/platform.yml
+++ b/.azure-pipelines-templates/platform.yml
@@ -4,7 +4,7 @@ parameters:
 steps:
   # 119 is GID of special "sgx_prv" group on underlying VM that is
   # required to run SGX on kernel > 5.11
-  - ${{ if or(eq(parameters.target, 'SGX'), eq(parameters.target, 'SGXIceLake')) }}:
+  - ${{ if eq(parameters.target, 'SGX') }}:
       - script: |
           set -ex
           sudo groupadd -g 119 sgx_prv

--- a/.azure-pipelines-templates/stress-matrix.yml
+++ b/.azure-pipelines-templates/stress-matrix.yml
@@ -4,7 +4,7 @@ jobs:
       target: SGX
       env:
         container: sgx
-        pool: 1es-dcv2-focal
+        pool: 1es-dcdv3-focal
       cmake_args: "-DCOMPILE_TARGET=sgx"
       suffix: "StressTest"
       artifact_name: "StressTest"

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -27,7 +27,7 @@ jobs:
       target: SGX
       env:
         container: sgx
-        pool: 1es-dcv2-focal
+        pool: 1es-dcdv3-focal
       cmake_args: "-DCOMPILE_TARGET=sgx -DWORKER_THREADS=2 -DENABLE_2TX_RECONFIG=ON"
       suffix: "MultiThread"
       artifact_name: "MultiThread"


### PR DESCRIPTION
As discussed, now is time to move all CI executors to IceLake so that we have a single SGX variant.