### PR TITLE
Fix some documentation warnings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -216,9 +216,9 @@ breathe_default_project = "CCF"
 
 # Set up multiversion extension
 
-smv_tag_whitelist = None
+smv_tag_whitelist = ""
 smv_branch_whitelist = r"^(main)|(release\/([2-9]|\d\d\d*)\.x)$"
-smv_remote_whitelist = None
+smv_remote_whitelist = ""
 smv_outputdir_format = "{ref.name}"
 
 assert re.match(smv_branch_whitelist, "main")

--- a/doc/operations/data_persistence.rst
+++ b/doc/operations/data_persistence.rst
@@ -1,7 +1,7 @@
 Data Persistence
 =====================
 
-When a new node has joined the network or when a failed node needs to be recovered, latest committed snapshot file can be copied to the node before it is started. It will then automatically resume from the latest snapshot file (see :ref:`operations/ledger_snapshot:Join/Recover From Snapshot`).
+When a new node has joined the network or when a failed node needs to be recovered, latest committed snapshot file can be copied to the node before it is started. It will then automatically resume from the latest snapshot file (see :ref:`operations/ledger_snapshot:Join or Recover From Snapshot`).
 
 The new/recovered node may also need to have access to all ``.committed`` ledger files in some cases, for example, if the node needs to serve historical queries. It is therefore safe to back up all the ``.committed`` ledger and snapshot files. It is recommended to have two separate directories on each node - one being a read-write directory where *all* the ledger and snapshot files reside and another shared read-only directory where *only* the ``.committed`` ledger and snapshot files reside.
 

--- a/doc/operations/platforms/snp.rst
+++ b/doc/operations/platforms/snp.rst
@@ -15,7 +15,7 @@ SNP attestation provide several fields needed to establish trust. This is specif
 
 - Measurement
 
-Measurement is a digest of the initial memory pages for the SEV-SNP VM, which CCF stores in the :ref:`audit/builtin_maps:``nodes.snp.measurement``` table. New nodes joining a network will provide their code id and the primary will perform an identity check against the table entries.
+Measurement is a digest of the initial memory pages for the SEV-SNP VM, which CCF stores in the :ref:`audit/builtin_maps:``nodes.snp.measurements``` table. New nodes joining a network will provide their code id and the primary will perform an identity check against the table entries.
 
 The first node in a new network will add its code id to the table. Members can then manage which code ids are present in the table with the ``add_snp_measurement`` and ``remove_node_code`` actions.
 

--- a/doc/operations/start_network.rst
+++ b/doc/operations/start_network.rst
@@ -62,7 +62,7 @@ The ``Pending`` joining node automatically polls the service (interval configura
 
 .. tip:: After the node has been trusted by members, operators should poll the :http:GET:`/node/state` endpoint on the newly added node, using the node's self-signed certificate as TLS CA, until the ``{"state": "PartOfNetwork"}`` is reported. This status confirms that the replication of the ledger has started on this node.
 
-.. note:: To accelerate the joining procedure, it is possible for new nodes to join from a snapshot. More information on snapshots :ref:`here <operations/ledger_snapshot:Join/Recover From Snapshot>`.
+.. note:: To accelerate the joining procedure, it is possible for new nodes to join from a snapshot. More information on snapshots :ref:`here <operations/ledger_snapshot:Join or Recover From Snapshot>`.
 
 The following diagram summarises the steps that operators and members should follow to add a new node to an open CCF service, and wait for it to be trusted by the consortium and in state ``PartOfNetwork``:
 


### PR DESCRIPTION
Fix some of #4360. Couldn't work out how to fix the typedoc warnings, which are concerning.