### PR TITLE
add a playbook to install perf tool dependencies

### DIFF
--- a/getting_started/setup_vm/ccf-dev.yml
+++ b/getting_started/setup_vm/ccf-dev.yml
@@ -30,3 +30,6 @@
     - import_role:
         name: protoc
         tasks_from: install.yml
+    - import_role:
+        name: perf-tool
+        tasks_from: install.yml

--- a/getting_started/setup_vm/roles/perf-tool/tasks/install.yml
+++ b/getting_started/setup_vm/roles/perf-tool/tasks/install.yml
@@ -1,0 +1,43 @@
+- name: Include arrow vars
+  include_vars:
+    file: common.yml
+
+- name: Download arrow
+  get_url:
+    url: " https://apache.jfrog.io/artifactory/arrow/ubuntu/apache-arrow-apt-source-latest-focal.deb"
+    dest: "{{ workspace }}/arrow.deb"
+  become: true
+
+- name: Install arrow
+  apt: deb="{{ workspace }}/arrow.deb"
+  become: true
+
+- name: Update after installing arrow
+  apt:
+    update_cache: yes
+  become: true
+
+- name: Instal libarrow-dev
+  apt:
+    name: libarrow-dev
+    state: present
+  become: true
+
+- name: Instal libparquet-dev
+  apt:
+    name: libparquet-dev
+    state: present
+  become: true
+
+- name: Add stdcxx APT repository
+  apt_repository:
+    repo: "ppa:ubuntu-toolchain-r/test"
+    state: present
+    update_cache: yes
+  become: true
+
+- name: Instal libstdcxx
+  apt:
+    name: libstdc++-11-dev
+    state: present
+  become: true

--- a/getting_started/setup_vm/roles/perf-tool/vars/common.yml
+++ b/getting_started/setup_vm/roles/perf-tool/vars/common.yml
@@ -1,0 +1,4 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+workspace: "/tmp"


### PR DESCRIPTION
The new performance tool is partly written in C++ and in Python. The component that will submit requests (and is not yet PRed) is written in C++. There are a few libraries that are required for the submitter component and they are installed through ansible. For this reason a new playbook under the directory `getting_started/setup_vm/roles/perf-tool` is created to be installed in addition to a yaml file containing the variable of the temporary folder to download the debian.
The installation of this playbook will be triggered by the `ccf-dev.yml` as this will be a part of the development.
The libraries that will be installed are arrow which is required for the libarrow and libparquet -dev containing the cpp headers, as well as the libstdc++-11-dev .