### PR TITLE
Add EdDSA support for verifySignature() in polyfill

### DIFF
--- a/js/ccf-app/src/polyfill.ts
+++ b/js/ccf-app/src/polyfill.ts
@@ -179,8 +179,20 @@ class CCFPolyfill implements CCF {
         if (algorithm.name !== "ECDSA") {
           throw new Error("incompatible signing algorithm for given key type");
         }
+      } else if (pubKey.asymmetricKeyType == "ed25519") {
+        if (algorithm.name !== "EdDSA") {
+          throw new Error("incompatible signing algorithm for given key type");
+        }
       } else {
         throw new Error("unrecognized signing algorithm");
+      }
+      if (algorithm.name === "EdDSA") {
+        return jscrypto.verify(
+          null,
+          new Uint8Array(data),
+          pubKey,
+          new Uint8Array(signature)
+        );
       }
       const hashAlg = (algorithm.hash as string).replace("-", "").toLowerCase();
       const verifier = jscrypto.createVerify(hashAlg);

--- a/js/ccf-app/test/polyfill.test.ts
+++ b/js/ccf-app/test/polyfill.test.ts
@@ -384,6 +384,55 @@ describe("polyfill", function () {
         )
       );
     });
+    it("performs EdDSA validation correctly", function () {
+      const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519", {
+        publicKeyEncoding: {
+          type: "spki",
+          format: "pem",
+        },
+        privateKeyEncoding: {
+          type: "pkcs8",
+          format: "pem",
+        },
+      });
+      const data = ccf.strToBuf("foo");
+      const signature = crypto.sign(
+        null,
+        new Uint8Array(data),
+        crypto.createPrivateKey(privateKey)
+      );
+      assert.isTrue(
+        ccf.crypto.verifySignature(
+          {
+            name: "EdDSA",
+          },
+          publicKey,
+          signature,
+          data
+        )
+      );
+      assert.isNotTrue(
+        ccf.crypto.verifySignature(
+          {
+            name: "EdDSA",
+          },
+          publicKey,
+          signature,
+          ccf.strToBuf("bar")
+        )
+      );
+      assert.throws(() =>
+        ccf.crypto.verifySignature(
+          {
+            name: "RSASSA-PKCS1-v1_5",
+            hash: "SHA-256",
+          },
+          publicKey,
+          signature,
+          data
+        )
+      );
+    });
   });
   describe("digest", function () {
     it("generates a valid SHA-256 hash", function () {


### PR DESCRIPTION
It resolves #4426 partially.
The actual implementation already exists.

