### PR TITLE
Narrow down trigger for Stress job

### DIFF
--- a/.stress.yml
+++ b/.stress.yml
@@ -6,7 +6,6 @@ pr:
     include:
       - .stress.yml
       - .stress-matrix.yml
-      - .azure-pipelines-templates/*
 
 trigger: none
 


### PR DESCRIPTION
Bring job in line with multi-threading: only trigger on direct job definition change. Includes get picked up post-merge to main. This is especially useful at the moment, with the churn in .azure-pipelines-templates.