### PR TITLE
More script pkg fixes

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -19,10 +19,12 @@ jobs:
 
       - name: Fetch NPM Package from release
         run: |
+          cd js/ccf-app
           wget https://github.com/microsoft/CCF/releases/download/ccf-${{steps.tref.outputs.version}}/microsoft-ccf-app-${{steps.tref.outputs.version}}.tgz
 
       - name: Publish NPM Package to https://www.npmjs.com/package/@microsoft/ccf-app
         run: |
           set -ex
+          cd js/ccf-app
           echo "//registry.npmjs.org/:_authToken=\${{ secrets.NPM_TOKEN }}" > .npmrc
           npm publish microsoft-ccf-app*.tgz --access public

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Fetch PyPi Package from release
         run: |
           VERSION=${{steps.tref.outputs.version}}
-          VERSION=${VERSION//-}
-          wget https://github.com/microsoft/CCF/releases/download/ccf-${VERSION}/ccf-${VERSION}-py3-none-any.whl
+          PYPY_VERSION=${VERSION//-}
+          wget https://github.com/microsoft/CCF/releases/download/ccf-${VERSION}/ccf-${PYPY_VERSION}-py3-none-any.whl
 
       - name: Publish PyPi Package to https://pypi.org/project/ccf/
         run: |

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,7 +19,9 @@ jobs:
 
       - name: Fetch PyPi Package from release
         run: |
-          wget https://github.com/microsoft/CCF/releases/download/ccf-${{steps.tref.outputs.version}}/ccf-${{steps.tref.outputs.version}}-py3-none-any.whl
+          VERSION=${{steps.tref.outputs.version}}
+          VERSION=${VERSION//-}
+          wget https://github.com/microsoft/CCF/releases/download/ccf-${VERSION}/ccf-${VERSION}-py3-none-any.whl
 
       - name: Publish PyPi Package to https://pypi.org/project/ccf/
         run: |


### PR DESCRIPTION
pip shortens "3.0.0-rc1' to '3.0.0rc1' it seems, and for npm the only difference I can see is the directory, which perhaps makes finding package.json fail?