### PR TITLE
Remove empty line in generator, breaking the command line run

### DIFF
--- a/perf-system/generator/generate_packages.py
+++ b/perf-system/generator/generate_packages.py
@@ -58,9 +58,7 @@ def main():
         "-ct",
         "--content_type",
         help="The Content-Type representation header is used\
-
-            to indicate the original media type of the resource.\
-            Default `application-json`",
+            to indicate the original media type of the resource.",
         default="application-json",
         type=str,
     )


### PR DESCRIPTION
While making the suggested changes on the generator-pr, I missed an empty line on the arg parsing options, which very cunningly escaped my tests. As a result, when one wants to generate requests using command line options, the script would break.  This PR resolves this issue.