### PR TITLE
[release/2.x] Cherry pick: Use new IceLake SGX pool for Azure DevOps (#4440)

### DIFF
--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -5,10 +5,7 @@ parameters:
       pool: 1es-dv4-focal
     SGX:
       container: sgx
-      pool: 1es-dcv2-focal
-    SGXIceLake:
-      container: sgx
-      pool: 1es-dcdv3-focal
+      pool: 1es-DC16s_v3-focal
 
   build:
     common:

--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -11,7 +11,7 @@ parameters:
       pool: 1es-dv4-focal
     SGX:
       container: sgx
-      pool: 1es-dcv2-focal
+      pool: 1es-DC16s_v3-focal
 
   build:
     common:

--- a/.azure-pipelines-templates/stress-matrix.yml
+++ b/.azure-pipelines-templates/stress-matrix.yml
@@ -4,7 +4,7 @@ jobs:
       target: SGX
       env:
         container: sgx
-        pool: 1es-dcv2-focal
+        pool: 1es-DC16s_v3-focal
         timeoutInMinutes: 120 # Trying to run 2 45-minute tests; these must complete in < 2 hours
       cmake_args: "-DCOMPILE_TARGETS=sgx"
       suffix: "StressTest"

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -25,7 +25,7 @@ jobs:
       target: SGX
       env:
         container: sgx
-        pool: 1es-dcv2-focal
+        pool: 1es-DC16s_v3-focal
       cmake_args: "-DCOMPILE_TARGETS=sgx -DWORKER_THREADS=2 -DENABLE_2TX_RECONFIG=ON"
       suffix: "MultiThread"
       artifact_name: "MultiThread"


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Use new IceLake SGX pool for Azure DevOps (#4440)](https://github.com/microsoft/CCF/pull/4440)