### PR TITLE
Add a py.typed file to the python package.

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,4 +1,5 @@
 include requirements.txt
+include ccf/py.typed
 
 include utils/scurl.sh
 include utils/submit_recovery_share.sh


### PR DESCRIPTION
This makes the type information that exists in the python package available to downstream packages. See PEP 561 for some rationale.