### PR TITLE
Docs emphasis fixes

### DIFF
--- a/doc/audit/receipts.rst
+++ b/doc/audit/receipts.rst
@@ -55,5 +55,5 @@ This may occur if the consortium approves a catastrophic recovery from a truncat
 
 This user can either:
 
-1. Query the new service for receipts at the same :term:`Transaction ID` values.  If those transactions come back as `INVALID`, because they were truncated, the signature over the old receipts is proof of truncation. If they come back as `COMMITTED` with a different root, the existence of two signatures over different roots at the same TxID is proof that a fork happened.
+1. Query the new service for receipts at the same :term:`Transaction ID` values.  If those transactions come back as ``INVALID``, because they were truncated, the signature over the old receipts is proof of truncation. If they come back as ``COMMITTED`` with a different root, the existence of two signatures over different roots at the same TxID is proof that a fork happened.
 2. Scan the ledger, for example using the :doc:`/audit/python_library`, and find the transactions for which they have receipts. The `write_set_digest` in the receipts should match the digest of the serialised :term:`Write Set` in the ledger on disk. If it does not, the signature over the receipt is proof of a fork. See :ref:`audit/receipts:Check for transaction inclusion` for an example.

--- a/doc/build_apps/build_app.rst
+++ b/doc/build_apps/build_app.rst
@@ -5,7 +5,7 @@ Build and Sign CCF Applications
 
 Once an application is complete, it needs to be built into a shared object, and signed.
 
-Using `cmake`, an application can be built and then signed using the functions provided by CCF's ``cmake/ccf_app.cmake``. For example, for the ``js_generic`` JavaScript application:
+Using ``cmake``, an application can be built and then signed using the functions provided by CCF's ``cmake/ccf_app.cmake``. For example, for the ``js_generic`` JavaScript application:
 
 .. literalinclude:: ../../cmake/common.cmake
     :language: cmake

--- a/doc/build_apps/example_cpp.rst
+++ b/doc/build_apps/example_cpp.rst
@@ -106,7 +106,7 @@ If a handler makes no writes to the KV, it may be installed as read-only:
     :end-before: SNIPPET_END: install_get
     :dedent:
 
-This offers some additional type safety (accidental `put`\s or `remove`\s will be caught at compile-time) and also enables performance scaling since read-only operations can be executed on any receiving node, whereas writes must always be executed on the primary node.
+This offers some additional type safety (accidental ``put``\s or ``remove``\s will be caught at compile-time) and also enables performance scaling since read-only operations can be executed on any receiving node, whereas writes must always be executed on the primary node.
 
 API Schema
 ~~~~~~~~~~

--- a/doc/build_apps/example_cpp.rst
+++ b/doc/build_apps/example_cpp.rst
@@ -183,7 +183,7 @@ Historical Queries
 ~~~~~~~~~~~~~~~~~~
 
 This sample demonstrates how to define a historical query endpoint with the help of :cpp:func:`ccf::historical::adapter_v3`.
-Most endpoints operate over the _current_ state of the KV, but these historical queries operate over _old_ state, specifically over the writes made by a previous transaction.
+Most endpoints operate over the `current` state of the KV, but these historical queries operate over `old` state, specifically over the writes made by a previous transaction.
 The adapter handles extracting the target :term:`Transaction ID` from the user's request, and interacting with the :ref:`Historical Queries API <build_apps/api:Historical Queries>` to asynchronously fetch this entry from the ledger.
 The deserialised and verified transaction is then presented to the handler code below, which performs reads and constructs a response like any other handler.
 
@@ -214,8 +214,7 @@ Since the indexing system and all the strategies it manages exist entirely withi
 
 An example :cpp:type:`ccf::indexing::Strategy` is included in the logging app, to accelerate historical range queries.
 This :cpp:type:`strategy <ccf::indexing::strategies::SeqnosByKey_Bucketed_Untyped>` stores the list of seqnos where every key is written to, offloading completed ranges to disk to cap the total memory useage.
-This sample strategy is 
-In the endpoint handler, rather than requesting every transaction in the requested range, the node relies on its index to fetch only the _interesting_ transactions; those which write to the target key:
+In the endpoint handler, rather than requesting every transaction in the requested range, the node relies on its index to fetch only the `interesting` transactions; those which write to the target key:
 
 .. literalinclude:: ../../samples/apps/logging/logging.cpp
     :language: cpp

--- a/doc/use_apps/verify_tx.rst
+++ b/doc/use_apps/verify_tx.rst
@@ -94,7 +94,7 @@ Note that receipts over signature transactions are a special case, for example:
      'cert': '<PEM string>'}
 
 The proof is empty, and the ``leaf`` field is set to the value being signed, which is the root of the Merkle Tree covering all transactions until the signature.
-This allows writing verification code that handles both regular and signature receipts similarly, but it is worth noting that the 'leaf' value for signatures is _not_
+This allows writing verification code that handles both regular and signature receipts similarly, but it is worth noting that the 'leaf' value for signatures is `not`
 the digest of the signature transaction itself.
 
 From version 2.0, CCF also includes endorsement certificates for previous service identities, by the current service identity, in `service_endorsements`. Thus, after at least one recovery, the endorsement check now takes the form of a certificate chain verification instead of a single endorsement check.


### PR DESCRIPTION
Noticed a few cases in the docs where we were using the wrong kind of backticks. In `ReStructuredText`, we need to use single backticks (\`) for _italics_ (an underscore \_ in Markdown), and double backticks (``) for `monospace` (a single backtick \` in Markdown).