### PR TITLE
[Draft, DO-NOT-MERGE] Add debug logging around external_executor failures

### DIFF
--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -1,5 +1,5 @@
 parameters:
-  target: ["Virtual", "SGX"]
+  target: ["Virtual", "SGX", "SNPCC"]
 
   env:
     Hosted:
@@ -55,96 +55,96 @@ jobs:
           cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.debug.cmake_args }} ${{ parameters.build[target].cmake_args }}"
           suffix: "Debug"
           artifact_name: "${{ target }}_Debug"
-          ctest_filter: "${{ parameters.test[target].ctest_args }}"
+          ctest_filter: "${{ parameters.test[target].ctest_args }} -R external_executor_test"
           depends_on: configure
 
-  # Performance
-  - ${{ if eq(parameters.perf_tests, 'run') }}:
-      - template: common.yml
-        parameters:
-          target: SGX
-          env: ${{ parameters.env.SGX }}
-          cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.perf.cmake_args }} ${{ parameters.build.SGX.cmake_args }}"
-          suffix: "Perf"
-          artifact_name: "SGX_Perf"
-          ctest_filter: "${{ parameters.test.perf.ctest_args }}"
-          depends_on: configure
+  # # Performance
+  # - ${{ if eq(parameters.perf_tests, 'run') }}:
+  #     - template: common.yml
+  #       parameters:
+  #         target: SGX
+  #         env: ${{ parameters.env.SGX }}
+  #         cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.perf.cmake_args }} ${{ parameters.build.SGX.cmake_args }}"
+  #         suffix: "Perf"
+  #         artifact_name: "SGX_Perf"
+  #         ctest_filter: "${{ parameters.test.perf.ctest_args }}"
+  #         depends_on: configure
 
-  - ${{ if eq(parameters.perf_tests, 'run') }}:
-      - template: common.yml
-        parameters:
-          target: Virtual
-          env: ${{ parameters.env.Virtual }}
-          cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.perf.cmake_args }} ${{ parameters.build.Virtual.cmake_args }}"
-          suffix: "Perf"
-          artifact_name: "Virtual_Perf"
-          ctest_filter: "${{ parameters.test.virtual_perf.ctest_args }}"
-          depends_on: configure
+  # - ${{ if eq(parameters.perf_tests, 'run') }}:
+  #     - template: common.yml
+  #       parameters:
+  #         target: Virtual
+  #         env: ${{ parameters.env.Virtual }}
+  #         cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.perf.cmake_args }} ${{ parameters.build.Virtual.cmake_args }}"
+  #         suffix: "Perf"
+  #         artifact_name: "Virtual_Perf"
+  #         ctest_filter: "${{ parameters.test.virtual_perf.ctest_args }}"
+  #         depends_on: configure
 
-  - ${{ if eq(parameters.perf_tests, 'run') }}:
-      - template: cimetrics.yml
-        parameters:
-          target: Virtual
-          env: ${{ parameters.env.Virtual }}
-          suffix: "Perf"
-          depends_on:
-            - configure
-            - SGX_Perf
-            - Virtual_Perf
+  # - ${{ if eq(parameters.perf_tests, 'run') }}:
+  #     - template: cimetrics.yml
+  #       parameters:
+  #         target: Virtual
+  #         env: ${{ parameters.env.Virtual }}
+  #         suffix: "Perf"
+  #         depends_on:
+  #           - configure
+  #           - SGX_Perf
+  #           - Virtual_Perf
 
-  # Release
-  - ${{ if eq(parameters.perf_or_release, 'release') }}:
-      - template: checks.yml
-        parameters:
-          env: ${{ parameters.env.Hosted }}
+  # # Release
+  # - ${{ if eq(parameters.perf_or_release, 'release') }}:
+  #     - template: checks.yml
+  #       parameters:
+  #         env: ${{ parameters.env.Hosted }}
 
-      - template: common.yml
-        parameters:
-          target: SGX
-          env: ${{ parameters.env.SGX }}
-          cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.release.cmake_args }} ${{ parameters.build.SGX.cmake_args }}"
-          suffix: "Release"
-          artifact_name: "SGX_Release"
-          ctest_filter: "${{ parameters.test.release.ctest_args }}"
-          depends_on: configure
+  #     - template: common.yml
+  #       parameters:
+  #         target: SGX
+  #         env: ${{ parameters.env.SGX }}
+  #         cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.release.cmake_args }} ${{ parameters.build.SGX.cmake_args }}"
+  #         suffix: "Release"
+  #         artifact_name: "SGX_Release"
+  #         ctest_filter: "${{ parameters.test.release.ctest_args }}"
+  #         depends_on: configure
 
-      - template: common.yml
-        parameters:
-          target: SNPCC
-          env: ${{ parameters.env.Virtual }}
-          cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.release.cmake_args }} ${{ parameters.build.SNPCC.cmake_args }}"
-          suffix: "Release"
-          artifact_name: "SNPCC_Release"
-          ctest_filter: "${{ parameters.test.release.ctest_args }}"
-          depends_on: configure
+  #     - template: common.yml
+  #       parameters:
+  #         target: SNPCC
+  #         env: ${{ parameters.env.Virtual }}
+  #         cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.release.cmake_args }} ${{ parameters.build.SNPCC.cmake_args }}"
+  #         suffix: "Release"
+  #         artifact_name: "SNPCC_Release"
+  #         ctest_filter: "${{ parameters.test.release.ctest_args }}"
+  #         depends_on: configure
 
-      - template: common.yml
-        parameters:
-          target: Virtual
-          env: ${{ parameters.env.Virtual }}
-          cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.release.cmake_args }} ${{ parameters.build.Virtual.cmake_args }}"
-          suffix: "Release"
-          artifact_name: "Virtual_Release"
-          ctest_filter: "${{ parameters.test.release.ctest_args }}"
-          depends_on: configure
+  #     - template: common.yml
+  #       parameters:
+  #         target: Virtual
+  #         env: ${{ parameters.env.Virtual }}
+  #         cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.release.cmake_args }} ${{ parameters.build.Virtual.cmake_args }}"
+  #         suffix: "Release"
+  #         artifact_name: "Virtual_Release"
+  #         ctest_filter: "${{ parameters.test.release.ctest_args }}"
+  #         depends_on: configure
 
-      # Build that produces unsafe binaries for troubleshooting purposes
-      - template: common.yml
-        parameters:
-          target: SGX
-          env: ${{ parameters.env.SGX }}
-          cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.unsafe.cmake_args }} ${{ parameters.build.SGX.cmake_args }}"
-          suffix: "Unsafe"
-          artifact_name: "SGX_Unsafe"
-          ctest_filter: "${{ parameters.test.release.ctest_args }}"
-          depends_on: configure
+  #     # Build that produces unsafe binaries for troubleshooting purposes
+  #     - template: common.yml
+  #       parameters:
+  #         target: SGX
+  #         env: ${{ parameters.env.SGX }}
+  #         cmake_args: "${{ parameters.build.common.cmake_args }} ${{ parameters.build.unsafe.cmake_args }} ${{ parameters.build.SGX.cmake_args }}"
+  #         suffix: "Unsafe"
+  #         artifact_name: "SGX_Unsafe"
+  #         ctest_filter: "${{ parameters.test.release.ctest_args }}"
+  #         depends_on: configure
 
-      - template: release.yml
-        parameters:
-          env: ${{ parameters.env.Hosted }}
-          depends_on:
-            - Checks
-            - SGX_Release
-            - Virtual_Release
-            - SNPCC_Release
-            - SGX_Unsafe
+  #     - template: release.yml
+  #       parameters:
+  #         env: ${{ parameters.env.Hosted }}
+  #         depends_on:
+  #           - Checks
+  #           - SGX_Release
+  #           - Virtual_Release
+  #           - SNPCC_Release
+  #           - SGX_Unsafe

--- a/.azure-pipelines-templates/test.yml
+++ b/.azure-pipelines-templates/test.yml
@@ -16,26 +16,26 @@ steps:
     displayName: CTest
     workingDirectory: build
 
-  # Only run privileged tests in container environment
-  - ${{ if ne(parameters.suffix, 'Perf') }}:
-      - script: |
-          set -ex
-          sudo bash -c "source env/bin/activate && ctest -VV --timeout ${{ parameters.ctest_timeout }} --no-compress-output -L partitions -C partitions"
-        env:
-          CTEST_TIMEOUT: "${{ parameters.ctest_timeout }}"
-        condition: succeededOrFailed()
-        displayName: "CTest Partitions"
-        workingDirectory: build
+  # # Only run privileged tests in container environment
+  # - ${{ if ne(parameters.suffix, 'Perf') }}:
+  #     - script: |
+  #         set -ex
+  #         sudo bash -c "source env/bin/activate && ctest -VV --timeout ${{ parameters.ctest_timeout }} --no-compress-output -L partitions -C partitions"
+  #       env:
+  #         CTEST_TIMEOUT: "${{ parameters.ctest_timeout }}"
+  #       condition: succeededOrFailed()
+  #       displayName: "CTest Partitions"
+  #       workingDirectory: build
 
-      # This unconditional step is necessary as workspace files survive the container
-      # in which they are created
-      - script: |
-          set -ex
-          ci_user=$(whoami)
-          sudo chown -R $ci_user: workspace
-        condition: always()
-        displayName: "Change root files ownership to ci user"
-        workingDirectory: build
+  #     # This unconditional step is necessary as workspace files survive the container
+  #     # in which they are created
+  #     - script: |
+  #         set -ex
+  #         ci_user=$(whoami)
+  #         sudo chown -R $ci_user: workspace
+  #       condition: always()
+  #       displayName: "Change root files ownership to ci user"
+  #       workingDirectory: build
 
   # If a test fails, crudely upload nodes' logs for all tests
   - task: CopyFiles@2

--- a/src/apps/external_executor/executor_auth_policy.h
+++ b/src/apps/external_executor/executor_auth_policy.h
@@ -37,6 +37,7 @@ public:
       return executor_identity;
     }
     error_reason = "Could not find matching Executor certificate";
+    LOG_FAIL_FMT("Caller failed ExecutorAuthPolicy!");
     return nullptr;
   }
 

--- a/src/enclave/tls_session.h
+++ b/src/enclave/tls_session.h
@@ -254,6 +254,10 @@ namespace ccf
       status = closing;
       if (threading::get_current_thread_id() != execution_thread)
       {
+        LOG_INFO_FMT(
+          "Sending close message to other thread ({} != {})",
+          threading::get_current_thread_id(),
+          execution_thread);
         auto msg = std::make_unique<threading::Tmsg<EmptyMsg>>(&close_cb);
         msg->data.self = this->shared_from_this();
 
@@ -263,6 +267,9 @@ namespace ccf
       else
       {
         // Close inline immediately
+        LOG_INFO_FMT(
+          "Closing inline on thread {}",
+          execution_thread);
         close_thread();
       }
     }

--- a/tests/external_executor/external_executor.py
+++ b/tests/external_executor/external_executor.py
@@ -115,11 +115,11 @@ def test_executor_registration(network, args):
     # access to the KV service on the target node, but no other nodes
     for node in (
         primary,
-        backup,
+        # backup,
     ):
         for credentials in (
             anonymous_credentials,
-            executor_credentials,
+            # executor_credentials,
         ):
             with grpc.secure_channel(
                 target=node.get_public_rpc_address(),
@@ -138,6 +138,7 @@ def test_executor_registration(network, args):
                     # pylint: disable=no-member
                     assert e.code() == grpc.StatusCode.UNAUTHENTICATED, e
 
+    raise ValueError("Fail regardless")
     return network
 
 
@@ -405,10 +406,10 @@ def run(args):
             ), "Target node does not support HTTP/2"
 
         network = test_executor_registration(network, args)
-        network = test_put_get(network, args)
-        network = test_simple_executor(network, args)
-        network = test_parallel_executors(network, args)
-        network = test_streaming(network, args)
+        # network = test_put_get(network, args)
+        # network = test_simple_executor(network, args)
+        # network = test_parallel_executors(network, args)
+        # network = test_streaming(network, args)
 
 
 if __name__ == "__main__":

--- a/tests/external_executor/external_executor.py
+++ b/tests/external_executor/external_executor.py
@@ -115,22 +115,25 @@ def test_executor_registration(network, args):
     # access to the KV service on the target node, but no other nodes
     for node in (
         primary,
-        # backup,
+        backup,
     ):
         for credentials in (
             anonymous_credentials,
-            # executor_credentials,
+            executor_credentials,
         ):
             with grpc.secure_channel(
                 target=node.get_public_rpc_address(),
                 credentials=credentials,
             ) as channel:
                 should_pass = node == primary and credentials == executor_credentials
+                LOG.warning(f"node={node}, credentials={credentials}, should_pass={should_pass}")
                 try:
                     rd = Service.KVStub(channel).StartTx(Empty())
+                    LOG.warning("StartTx call succeeded")
                     assert should_pass, "Expected StartTx to fail"
                     assert not rd.HasField("optional")
                 except grpc.RpcError as e:
+                    LOG.warning(f"StartTx call produced error: {e}")
                     # NB: This failure will have printed errors like:
                     #   Error parsing metadata: error=invalid value key=content-type value=application/json
                     # These are harmless and expected, and I haven't found a way to swallow them


### PR DESCRIPTION
Hacky PR to get a repro of the `external_executor_test` failure on SNPCC, with some additional logging.