### PR TITLE
Format documents on save

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,17 @@
 {
-  "name": "Sample Development Environment for CCF",
-  "context": "..",
+  "name": "CCF Development Environment",
   "image": "ccfmsrc.azurecr.io/ccf/ci:oe-0.18.2-virtual",
   "runArgs": [],
-  "extensions": ["ms-vscode.cpptools", "ms-python.python"]
+  "extensions": [
+    "ms-vscode.cpptools",
+    "vsls-contrib.codetour",
+    "esbenp.prettier-vscode"
+  ],
+  "settings": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll": true
+    }
+  }
 }


### PR DESCRIPTION
Related to #4512 

Really small change and more than happy for you to just ignore this! :-)

In my devcontainer I cannot get the ci_checks to fix my files. So I used a plugin. Changes are

1. Changing the name of DevContainer as it's not a sample
2. You should not define context as you have an inline image tag and context is only used if you are using a Dockerfile
3. Added the Prettier extension into the devcontainer as that is what you are using for your linting checks.
4. Tell vscode that the default document formatter is prettier
5. Then tell vscode to format the documents when you save them.

To show this working, rebuild your dev container with these settings and then add some bad document formatting (e.g. extra line breaks). You should be able to Ctrl+S (save) the file and it will format it for you.

This will also work for js/json/etc files
