### PR TITLE
Explicitly add `libsgx-dcap-ql-dev` to PSW

### DIFF
--- a/getting_started/setup_vm/roles/intel/vars/common.yml
+++ b/getting_started/setup_vm/roles/intel/vars/common.yml
@@ -17,3 +17,7 @@ intel_dcap_packages:
   - "libsgx-dcap-ql"
   - "libsgx-urts"
   - "libsgx-quote-ex"
+  # Note: libsgx-dcap-ql-dev used to be automatically pulled by the
+  # open-enclave deb package until 0.18.4. This is only necessary
+  # to run <= 2.x CCF nodes that are built against OE <= 0.18.2.
+  - "libsgx-dcap-ql-dev"


### PR DESCRIPTION
This is a fix for the `lts_compatibility` issue created by the update to Open Enclave 0.18.4. 

Open Enclave no longer pulls `libsgx-dcap-ql-dev` (see https://github.com/openenclave/openenclave/commit/70ceead69f55a99755e02b90e53648446f8006bf). This is fine for new nodes built against OE 0.18.4 but not OK for older nodes (e.g. 2.0.8) built against OE 0.18.2 that still expect to dynamically find `libsgx-dcap-ql-dev` at enclave creation. 