### PR TITLE
[release/2.x] Cherry pick: Upgrade Open Enclave from 0.18.2 to 0.18.4 (#4510)

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -7,7 +7,7 @@ trigger:
 
 jobs:
   - job: build_and_publish_docs
-    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
+    container: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual
     pool:
       vmImage: ubuntu-20.04
 

--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -7,7 +7,7 @@ trigger:
 
 jobs:
   - job: build_and_publish_docs
-    container: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual
+    container: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
     pool:
       vmImage: ubuntu-20.04
 

--- a/.azure-pipelines-quictls.yml
+++ b/.azure-pipelines-quictls.yml
@@ -17,7 +17,7 @@ parameters:
 
 jobs:
   - job: build_quictls
-    container: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual
+    container: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
     pool: 1es-dv4-focal
 
     strategy:

--- a/.azure-pipelines-quictls.yml
+++ b/.azure-pipelines-quictls.yml
@@ -17,7 +17,7 @@ parameters:
 
 jobs:
   - job: build_quictls
-    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
+    container: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual
     pool: 1es-dv4-focal
 
     strategy:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -27,7 +27,7 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual
+      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: sgx

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -26,13 +26,13 @@ schedules:
 
 resources:
   containers:
-    - container: nosgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
+    - container: virtual
+      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache -v /lib/modules:/lib/modules:ro
+      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /lib/modules:/lib/modules:ro
 
 variables:
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/ccf-') }}:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -26,7 +26,7 @@ schedules:
 
 resources:
   containers:
-    - container: virtual
+    - container: nosgx
       image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 

--- a/.daily.yml
+++ b/.daily.yml
@@ -22,13 +22,13 @@ schedules:
 
 resources:
   containers:
-    - container: nosgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /dev/shm:/tmp/ccache
+    - container: virtual
+      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
+      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx
 
 jobs:
   - template: .azure-pipelines-templates/daily-matrix.yml

--- a/.daily.yml
+++ b/.daily.yml
@@ -23,7 +23,7 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual
+      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE
 
     - container: sgx

--- a/.daily.yml
+++ b/.daily.yml
@@ -22,7 +22,7 @@ schedules:
 
 resources:
   containers:
-    - container: virtual
+    - container: nosgx
       image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
-  "name": "Sample Development Environment for CCF",
-  "context": "..",
-  "image": "ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0",
+  "name": "CCF Development Environment",
+  "image": "ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual",
   "runArgs": [],
   "extensions": ["ms-vscode.cpptools", "ms-python.python"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "CCF Development Environment",
-  "image": "ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual",
+  "image": "ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx",
   "runArgs": [],
   "extensions": ["ms-vscode.cpptools", "ms-python.python"]
 }

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
+    container: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual
 
     steps:
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual
+    container: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
 
     steps:
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -15,9 +15,9 @@ pr:
 
 resources:
   containers:
-    - container: nosgx
-      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
+    - container: sgx
+      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
 
 jobs:
   - template: .azure-pipelines-templates/common.yml

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -15,14 +15,14 @@ pr:
 
 resources:
   containers:
-    - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
+    - container: virtual
+      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
 jobs:
   - template: .azure-pipelines-templates/common.yml
     parameters:
-      target: SGX
+      target: Virtual
       env:
         container: sgx
         pool: 1es-DC16s_v3-focal

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -22,7 +22,7 @@ resources:
 jobs:
   - template: .azure-pipelines-templates/common.yml
     parameters:
-      target: NoSGX
+      target: SGX
       env:
         container: sgx
         pool: 1es-DC16s_v3-focal

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -15,7 +15,7 @@ pr:
 
 resources:
   containers:
-    - container: virtual
+    - container: nosgx
       image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-virtual
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -22,7 +22,7 @@ resources:
 jobs:
   - template: .azure-pipelines-templates/common.yml
     parameters:
-      target: Virtual
+      target: NoSGX
       env:
         container: sgx
         pool: 1es-DC16s_v3-focal

--- a/.stress.yml
+++ b/.stress.yml
@@ -21,8 +21,8 @@ schedules:
 resources:
   containers:
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci/sgx:oe-0.18.2-0
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
+      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx
 
 jobs:
   - template: .azure-pipelines-templates/stress-matrix.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.9]
+
+### Dependencies
+
+- Upgraded OpenEnclave to 0.18.4.
+
 ## [2.0.8]
 
 ### Fixed
@@ -1583,6 +1589,7 @@ Some discrepancies with the TR remain, and are being tracked under https://githu
 
 Initial pre-release
 
+[2.0.9]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.9
 [2.0.8]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.8
 [2.0.7]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.7
 [2.0.6]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.6
@@ -1674,6 +1681,3 @@ Initial pre-release
 [0.5]: https://github.com/microsoft/CCF/releases/tag/v0.5
 [0.4]: https://github.com/microsoft/CCF/releases/tag/v0.4
 [0.3]: https://github.com/microsoft/CCF/releases/tag/v0.3
-[2.0.0-rc8]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.0-rc8
-[unreleased]: https://github.com/microsoft/CCF/releases/tag/ccf-Unreleased
-[3.0.0-dev4]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.0-dev4

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -30,7 +30,7 @@ if((NOT ${IS_VALID_TARGET}))
 endif()
 
 # Find OpenEnclave package
-find_package(OpenEnclave 0.18.2 CONFIG REQUIRED)
+find_package(OpenEnclave 0.18.4 CONFIG REQUIRED)
 # As well as pulling in openenclave:: targets, this sets variables which can be
 # used for our edge cases (eg - for virtual libraries). These do not follow the
 # standard naming patterns, for example use OE_INCLUDEDIR rather than

--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -19,7 +19,7 @@ endif()
 
 # CPack variables for Debian packages
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-    "open-enclave (>=0.18.2), libuv1 (>= 1.34.2), libc++1-10, libc++abi1-10, openssl (>=1.1.1)"
+    "open-enclave (>=0.18.4), libuv1 (>= 1.34.2), libc++1-10, libc++abi1-10, openssl (>=1.1.1)"
 )
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Upgrade Open Enclave from 0.18.2 to 0.18.4 (#4510)](https://github.com/microsoft/CCF/pull/4510)