### PR TITLE
[release/2.x] Cherry pick: Download Doxygen from SourceForge to keep v1.9.4 (#4432)

### DIFF
--- a/.azure-pipelines-templates/install_deb.yml
+++ b/.azure-pipelines-templates/install_deb.yml
@@ -30,8 +30,11 @@ steps:
       fi
     displayName: Test building a sample against installed CCF
 
-  - task: PublishPipelineArtifact@1
-    inputs:
-      path: $(Build.ArtifactStagingDirectory)/$(pkgname)
-      artifact: $(pkgname)
-      displayName: "Publish CCF Debian Package"
+  # Note: Do not publish pipeline artefact for SGXIceLake to avoid
+  # publishing the same artefact twice (SGX and SGXIceLake)
+  - ${{ if ne(parameters.target, 'SGXIceLake') }}:
+      - task: PublishPipelineArtifact@1
+        inputs:
+          path: $(Build.ArtifactStagingDirectory)/$(pkgname)
+          artifact: $(pkgname)
+          displayName: "Publish CCF Debian Package"

--- a/getting_started/setup_vm/roles/ccf_build/vars/common.yml
+++ b/getting_started/setup_vm/roles/ccf_build/vars/common.yml
@@ -34,4 +34,4 @@ docker_debs:
 
 doxygen_ver: "1.9.4"
 doxygen_bin: "doxygen-{{ doxygen_ver }}.linux.bin.tar.gz"
-doxygen_url: "https://doxygen.nl/files/{{ doxygen_bin }}"
+doxygen_url: "https://sourceforge.net/projects/doxygen/files/rel-{{ doxygen_ver }}/{{ doxygen_bin }}/download"


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Download Doxygen from SourceForge to keep v1.9.4 (#4432)](https://github.com/microsoft/CCF/pull/4432)