### PR TITLE
Sandbox ssh fixups

### DIFF
--- a/tests/governance.py
+++ b/tests/governance.py
@@ -307,8 +307,9 @@ def test_all_members(network, args):
             )
             assert response_details["member_data"] == member.member_data
             if member.is_recovery_member:
+                enc_pub_key_file = os.path.join(primary.common_dir, member.member_info["encryption_public_key_file"])
                 recovery_enc_key = open(
-                    member.member_info["encryption_public_key_file"], encoding="utf-8"
+                    enc_pub_key_file, encoding="utf-8"
                 ).read()
                 assert response_details["public_encryption_key"] == recovery_enc_key
             else:

--- a/tests/governance.py
+++ b/tests/governance.py
@@ -307,10 +307,10 @@ def test_all_members(network, args):
             )
             assert response_details["member_data"] == member.member_data
             if member.is_recovery_member:
-                enc_pub_key_file = os.path.join(primary.common_dir, member.member_info["encryption_public_key_file"])
-                recovery_enc_key = open(
-                    enc_pub_key_file, encoding="utf-8"
-                ).read()
+                enc_pub_key_file = os.path.join(
+                    primary.common_dir, member.member_info["encryption_public_key_file"]
+                )
+                recovery_enc_key = open(enc_pub_key_file, encoding="utf-8").read()
                 assert response_details["public_encryption_key"] == recovery_enc_key
             else:
                 assert response_details["public_encryption_key"] is None

--- a/tests/governance_js.py
+++ b/tests/governance_js.py
@@ -462,10 +462,11 @@ def test_operator_provisioner_proposals_and_votes(network, args):
         authenticate_session=network.consortium.authenticate_session,
     )
 
+    cert_file = os.path.join(node.common_dir, operator.member_info["certificate_file"])
     set_operator, _ = network.consortium.make_proposal(
         "set_member",
         cert=open(
-            operator.member_info["certificate_file"],
+            cert_file,
             encoding="utf-8",
         ).read(),
         member_data={"is_operator": True},

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -53,14 +53,10 @@ class Member:
         self.member_info = {}
         self.member_info["certificate_file"] = f"{self.local_id}_cert.pem"
         self.member_info["encryption_public_key_file"] = (
-            f"{self.local_id}_enc_pubk.pem"
-            if is_recovery_member
-            else None
+            f"{self.local_id}_enc_pubk.pem" if is_recovery_member else None
         )
         self.member_info["data_json_file"] = (
-            f"{self.local_id}_data.json"
-            if member_data
-            else None
+            f"{self.local_id}_data.json" if member_data else None
         )
 
         if key_generator is not None:

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -51,16 +51,14 @@ class Member:
         self.authenticate_session = authenticate_session
 
         self.member_info = {}
-        self.member_info["certificate_file"] = os.path.join(
-            common_dir, f"{self.local_id}_cert.pem"
-        )
+        self.member_info["certificate_file"] = f"{self.local_id}_cert.pem"
         self.member_info["encryption_public_key_file"] = (
-            os.path.join(common_dir, f"{self.local_id}_enc_pubk.pem")
+            f"{self.local_id}_enc_pubk.pem"
             if is_recovery_member
             else None
         )
         self.member_info["data_json_file"] = (
-            os.path.join(common_dir, f"{self.local_id}_data.json")
+            f"{self.local_id}_data.json"
             if member_data
             else None
         )

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -760,7 +760,8 @@ class CCFRemote(object):
         bin_path = os.path.join(".", os.path.basename(self.BIN))
 
         if major_version is None or major_version > 1:
-            cmd = [bin_path, "--config", config_file]
+            # use the relative path to the config file so that it works on remotes too
+            cmd = [bin_path, "--config", os.path.basename(config_file)]
             if start_type == StartType.join:
                 data_files += [os.path.join(self.common_dir, "service_cert.pem")]
 

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -662,9 +662,7 @@ class CCFRemote(object):
         )
 
         # Constitution
-        constitution = [
-            os.path.basename(f) for f in constitution
-        ]
+        constitution = [os.path.basename(f) for f in constitution]
 
         # ACME
         if "acme" in kwargs and host.acme_challenge_server_interface:
@@ -772,15 +770,22 @@ class CCFRemote(object):
                 if not members_info:
                     raise ValueError("no members info for start node")
                 for mi in members_info:
-                    data_files += [os.path.join(self.common_dir,mi["certificate_file"])]
+                    data_files += [
+                        os.path.join(self.common_dir, mi["certificate_file"])
+                    ]
                     if mi["encryption_public_key_file"]:
-                       data_files += [os.path.join(self.common_dir,mi["encryption_public_key_file"])]
+                        data_files += [
+                            os.path.join(
+                                self.common_dir, mi["encryption_public_key_file"]
+                            )
+                        ]
                     if mi["data_json_file"]:
-                       data_files += [os.path.join(self.common_dir,mi["data_json_file"])]
+                        data_files += [
+                            os.path.join(self.common_dir, mi["data_json_file"])
+                        ]
 
                 for c in constitution:
                     data_files += [os.path.join(self.common_dir, c)]
-
 
             if start_type == StartType.join:
                 data_files += [os.path.join(self.common_dir, "service_cert.pem")]

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -660,7 +660,7 @@ class CCFRemote(object):
 
         # Constitution
         constitution = [
-            os.path.join(self.common_dir, os.path.basename(f)) for f in constitution
+            os.path.basename(f) for f in constitution
         ]
 
         # ACME
@@ -762,6 +762,22 @@ class CCFRemote(object):
         if major_version is None or major_version > 1:
             # use the relative path to the config file so that it works on remotes too
             cmd = [bin_path, "--config", os.path.basename(config_file)]
+
+            if start_type == StartType.start:
+                members_info = kwargs.get("members_info")
+                if not members_info:
+                    raise ValueError("no members info for start node")
+                for mi in members_info:
+                    data_files += [os.path.join(self.common_dir,mi["certificate_file"])]
+                    if mi["encryption_public_key_file"]:
+                       data_files += [os.path.join(self.common_dir,mi["encryption_public_key_file"])]
+                    if mi["data_json_file"]:
+                       data_files += [os.path.join(self.common_dir,mi["data_json_file"])]
+
+                for c in constitution:
+                    data_files += [os.path.join(self.common_dir, c)]
+
+
             if start_type == StartType.join:
                 data_files += [os.path.join(self.common_dir, "service_cert.pem")]
 

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -145,6 +145,7 @@ class SSHRemote(CmdMixin):
         workspace,
         common_dir,
         env=None,
+        pid_file=None,
     ):
         """
         Runs a command on a remote host, through an SSH connection. A temporary
@@ -175,7 +176,7 @@ class SSHRemote(CmdMixin):
         self.out = os.path.join(self.root, "out")
         self.err = os.path.join(self.root, "err")
         self.suspension_proc = None
-        self.pid_file = f"{os.path.basename(self.cmd[0])}.pid"
+        self.pid_file = pid_file
         self._pid = None
 
     def _rc(self, cmd):
@@ -412,6 +413,7 @@ class LocalRemote(CmdMixin):
         workspace,
         common_dir,
         env=None,
+        pid_file=None,
     ):
         """
         Local Equivalent to the SSHRemote
@@ -599,6 +601,7 @@ class CCFRemote(object):
         service_cert_file="service_cert.pem",
         service_data_json_file=None,
         snp_endorsements_servers=None,
+        node_pid_file="node.pid",
         **kwargs,
     ):
         """
@@ -733,6 +736,7 @@ class CCFRemote(object):
                 service_data_json_file=service_data_json_file,
                 service_cert_file=service_cert_file,
                 snp_endorsements_servers=snp_endorsements_servers_list,
+                node_pid_file=node_pid_file,
                 **kwargs,
             )
 
@@ -950,6 +954,7 @@ class CCFRemote(object):
             workspace,
             common_dir,
             env,
+            pid_file=node_pid_file,
         )
 
     def setup(self):


### PR DESCRIPTION
These changes managed to get the `liblogging.virtual.so` working through ssh for me.

For running (from the `build` dir): `../tests/sandbox/sandbox.sh -p samples/apps/logging/liblogging.virtual.so --node ssh://0.0.0.0:8000,<hostname>:8000 -v`