### PR TITLE
Miscellaneous improvements in crypto API

### DIFF
--- a/include/ccf/crypto/eddsa_key_pair.h
+++ b/include/ccf/crypto/eddsa_key_pair.h
@@ -59,6 +59,13 @@ namespace crypto
   using EdDSAKeyPairPtr = std::shared_ptr<EdDSAKeyPair>;
 
   /**
+   * Create a public / private EdDSA key pair from existing private key data
+   *
+   * Currently only Curve25519 is supported.
+   */
+  EdDSAPublicKeyPtr make_eddsa_public_key(const Pem& pem);
+
+  /**
    * Create a new public / private EdDSA key pair on specified curve and
    * implementation
    *
@@ -74,11 +81,4 @@ namespace crypto
    * Currently only Curve25519 is supported.
    */
   EdDSAKeyPairPtr make_eddsa_key_pair(const Pem& pem);
-
-  /**
-   * Create a public / private EdDSA key pair from existing private key data
-   *
-   * Currently only Curve25519 is supported.
-   */
-  EdDSAPublicKeyPtr make_eddsa_public_key(const Pem& pem);
 }

--- a/js/ccf-app/src/crypto.ts
+++ b/js/ccf-app/src/crypto.ts
@@ -18,32 +18,32 @@
 import { ccf } from "./global.js";
 
 /**
- * @inheritDoc global!CCF.generateAesKey
+ * @inheritDoc global!CCFCrypto.generateAesKey
  */
 export const generateAesKey = ccf.crypto.generateAesKey;
 
 /**
- * @inheritDoc global!CCF.generateRsaKeyPair
+ * @inheritDoc global!CCFCrypto.generateRsaKeyPair
  */
 export const generateRsaKeyPair = ccf.crypto.generateRsaKeyPair;
 
 /**
- * @inheritDoc global!CCF.generateEcdsaKeyPair
+ * @inheritDoc global!CCFCrypto.generateEcdsaKeyPair
  */
 export const generateEcdsaKeyPair = ccf.crypto.generateEcdsaKeyPair;
 
 /**
- * @inheritDoc global!CCF.generateEcdsaKeyPair
+ * @inheritDoc global!CCFCrypto.generateEcdsaKeyPair
  */
 export const generateEddsaKeyPair = ccf.crypto.generateEddsaKeyPair;
 
 /**
- * @inheritDoc global!CCF.wrapKey
+ * @inheritDoc global!CCFCrypto.wrapKey
  */
 export const wrapKey = ccf.crypto.wrapKey;
 
 /**
- * @inheritDoc global!CCFCrypto.verifySignature
+ * @inheritDoc global!CCFCrypto.sign
  */
 export const sign = ccf.crypto.sign;
 

--- a/src/crypto/eddsa_key_pair.cpp
+++ b/src/crypto/eddsa_key_pair.cpp
@@ -17,6 +17,11 @@ namespace crypto
   using PublicKeyImpl = EdDSAPublicKey_OpenSSL;
   using KeyPairImpl = EdDSAKeyPair_OpenSSL;
 
+  EdDSAPublicKeyPtr make_eddsa_public_key(const Pem& pem)
+  {
+    return std::make_shared<PublicKeyImpl>(pem);
+  }
+
   EdDSAKeyPairPtr make_eddsa_key_pair(CurveID curve_id)
   {
     return std::make_shared<KeyPairImpl>(curve_id);
@@ -25,10 +30,5 @@ namespace crypto
   EdDSAKeyPairPtr make_eddsa_key_pair(const Pem& pem)
   {
     return std::make_shared<KeyPairImpl>(pem);
-  }
-
-  EdDSAPublicKeyPtr make_eddsa_public_key(const Pem& pem)
-  {
-    return std::make_shared<PublicKeyImpl>(pem);
   }
 }

--- a/tests/js-modules/modules.py
+++ b/tests/js-modules/modules.py
@@ -662,7 +662,7 @@ def test_npm_app(network, args):
         assert r.status_code == http.HTTPStatus.OK, r.status_code
         assert r.body.json() == False, r.body
 
-        curves = [ec.SECP256R1, ec.SECP256K1]
+        curves = [ec.SECP256R1, ec.SECP256K1, ec.SECP384R1]
         for curve in curves:
             key_priv_pem, key_pub_pem = infra.crypto.generate_ec_keypair(curve)
             algorithm = {"name": "ECDSA", "hash": "SHA-256"}


### PR DESCRIPTION
Closes #4426 

### About the ccf-app doc commit (3953a8fd5fd00d3cc05ae6b8134a03b411f6dad1)
Currently some functions don't show the doc correctly.

example:

https://microsoft.github.io/CCF/main/js/ccf-app/functions/crypto.generateEcdsaKeyPair.html

<img width="383" alt="Screenshot 2022-11-14 140153" src="https://user-images.githubusercontent.com/79583855/201686129-426c227d-9f21-4cbe-af83-1a52a5177188.png">

This PR fixes it.

<img width="450" alt="Screenshot 2022-11-14 140841" src="https://user-images.githubusercontent.com/79583855/201685940-676d8bd6-ede3-4707-957e-de5bb5a26e81.png">


#### Test
```bash
cd js/ccf-app && npm run docs # it generates html files
```

