### PR TITLE
Log seeds used in unit tests

### DIFF
--- a/src/consensus/aft/test/committable_suffix.cpp
+++ b/src/consensus/aft/test/committable_suffix.cpp
@@ -478,7 +478,9 @@ DOCTEST_TEST_CASE("Multi-term divergence")
 {
   logger::config::level() = logger::INFO;
 
-  srand(time(NULL));
+  const auto seed = time(NULL);
+  std::cout << fmt::format("Seed is {}", seed) << std::endl;
+  srand(seed);
 
   // Single configuration has all nodes, fully connected
   aft::Configuration::Nodes initial_config;

--- a/src/consensus/aft/test/committable_suffix.cpp
+++ b/src/consensus/aft/test/committable_suffix.cpp
@@ -479,7 +479,7 @@ DOCTEST_TEST_CASE("Multi-term divergence")
   logger::config::level() = logger::INFO;
 
   const auto seed = time(NULL);
-  std::cout << fmt::format("Seed is {}", seed) << std::endl;
+  DOCTEST_INFO("Using seed: ", seed);
   srand(seed);
 
   // Single configuration has all nodes, fully connected

--- a/src/ds/test/oversized.cpp
+++ b/src/ds/test/oversized.cpp
@@ -168,7 +168,9 @@ TEST_CASE("Reconstruction" * doctest::test_suite("oversized"))
     streams.push_back({descending, 2, 0});
     streams.push_back({descending, 3, 0});
 
-    srand(0x42);
+    const auto seed = time(NULL);
+    INFO("Using seed: ", seed);
+    srand(seed);
 
     while (!streams.empty())
     {

--- a/src/ds/test/ring_buffer.cpp
+++ b/src/ds/test/ring_buffer.cpp
@@ -681,7 +681,9 @@ TEST_CASE(
   // SparseReader
   * doctest::skip(ccf::pal::require_alignment_for_untrusted_reads()))
 {
-  srand(time(NULL));
+  const auto seed = time(NULL);
+  INFO("Using seed: ", seed);
+  srand(seed);
 
   // Pass a randomly constructed list of messages of mixed size, some extremely
   // large

--- a/src/indexing/test/indexing.cpp
+++ b/src/indexing/test/indexing.cpp
@@ -709,7 +709,9 @@ public:
 TEST_CASE(
   "multi-threaded indexing - bucketed" * doctest::test_suite("indexing"))
 {
-  srand(time(NULL));
+  const auto seed = time(NULL);
+  INFO("Using seed: ", seed);
+  srand(seed);
 
   auto kv_store_p = std::make_shared<kv::Store>();
   auto& kv_store = *kv_store_p;

--- a/src/indexing/test/lfs.cpp
+++ b/src/indexing/test/lfs.cpp
@@ -691,7 +691,10 @@ TEST_CASE("Sparse index" * doctest::test_suite("lfs"))
   run_sparse_index_test(8, 6);
   run_sparse_index_test(500, 10);
 
-  srand(time(NULL));
+  const auto seed = time(NULL);
+  INFO("Using seed: ", seed);
+  srand(seed);
+
   for (auto i = 0; i < 20; ++i)
   {
     const auto bucket_size = (rand() % 100) + 5;

--- a/src/kv/test/kv_contention.cpp
+++ b/src/kv/test/kv_contention.cpp
@@ -58,7 +58,10 @@ DOCTEST_TEST_CASE("Concurrent kv access" * doctest::test_suite("concurrency"))
   };
   ThreadArgs args[thread_count] = {};
 
-  srand(42);
+  const auto seed = time(NULL);
+  DOCTEST_INFO("Using seed: ", seed);
+  srand(seed);
+
   constexpr size_t map_count = 8;
   for (size_t i = 0u; i < map_count; ++i)
   {

--- a/src/node/test/channels.cpp
+++ b/src/node/test/channels.cpp
@@ -792,7 +792,9 @@ TEST_CASE("Full NodeToNode test")
     n2n2.initialize(ni2, service_cert, channel2_kp, channel2_cert);
     n2n2.set_message_limit(message_limit);
 
-    srand(0); // keep it deterministic
+    const auto seed = time(NULL);
+    INFO("Using seed: ", seed);
+    srand(seed);
 
     INFO("Send/receive a number of messages");
     {

--- a/src/node/test/channels.cpp
+++ b/src/node/test/channels.cpp
@@ -750,12 +750,12 @@ TEST_CASE("Full NodeToNode test")
     crypto::CurveID::SECP384R1,
     crypto::CurveID::SECP384R1,
     crypto::CurveID::SECP384R1};
-  // One node on a different curve
+  // One backup on a different curve
   constexpr auto mixed_0 = CurveChoices{
     crypto::CurveID::SECP256R1,
     crypto::CurveID::SECP256R1,
     crypto::CurveID::SECP384R1};
-  // Both nodes on a different curve
+  // Both backups on a different curve
   constexpr auto mixed_1 = CurveChoices{
     crypto::CurveID::SECP384R1,
     crypto::CurveID::SECP256R1,

--- a/src/node/test/historical_queries.cpp
+++ b/src/node/test/historical_queries.cpp
@@ -1359,7 +1359,9 @@ TEST_CASE("StateCache concurrent access")
     query_random_range_states(20, 23, handle, error_printer);
   }
 
-  srand(time(NULL));
+  const auto seed = time(NULL);
+  INFO("Using seed: ", seed);
+  srand(seed);
 
   const auto num_threads = 30;
   std::vector<std::thread> random_queries;


### PR DESCRIPTION
Related to #4558.

I have a habit of writing smoky unit tests with a random seed. The problem is if those fail extremely rarely, we can't repro the failure. We should always log these seeds. Sometimes these then spin up multiple threads, so we still have non-deterministic and potentially non-reproducible runs, but logging the seed should at least help narrow down the issue.