### PR TITLE
Only render bytevectors as text if all characters are printable.

### DIFF
--- a/include/ccf/byte_vector.h
+++ b/include/ccf/byte_vector.h
@@ -40,7 +40,8 @@ struct formatter<ccf::ByteVector>
   template <typename FormatContext>
   auto format(const ccf::ByteVector& e, FormatContext& ctx) const
   {
-    if (std::find(e.begin(), e.end(), '\0') != e.end())
+    auto non_printable = [](uint8_t b) { return b < 0x20 || b > 0x7e; };
+    if (std::find_if(e.begin(), e.end(), non_printable) != e.end())
     {
       return format_to(
         ctx.out(), "<uint8[{}]: hex={:02x}>", e.size(), fmt::join(e, " "));

--- a/include/ccf/byte_vector.h
+++ b/include/ccf/byte_vector.h
@@ -40,19 +40,20 @@ struct formatter<ccf::ByteVector>
   template <typename FormatContext>
   auto format(const ccf::ByteVector& e, FormatContext& ctx) const
   {
-    auto non_printable = [](uint8_t b) { return b < 0x20 || b > 0x7e; };
-    if (std::find_if(e.begin(), e.end(), non_printable) != e.end())
-    {
-      return format_to(
-        ctx.out(), "<uint8[{}]: hex={:02x}>", e.size(), fmt::join(e, " "));
-    }
-    else
+    // This is the same as std::isprint, but independent of the current locale.
+    auto printable = [](uint8_t b) { return b >= 0x20 && b <= 0x7e; };
+    if (std::all_of(e.begin(), e.end(), printable))
     {
       return format_to(
         ctx.out(),
         "<uint8[{}]: ascii={}>",
         e.size(),
         std::string(e.begin(), e.end()));
+    }
+    else
+    {
+      return format_to(
+        ctx.out(), "<uint8[{}]: hex={:02x}>", e.size(), fmt::join(e, " "));
     }
   }
 };


### PR DESCRIPTION
Previously bytevectors were logged as text as long as they didn't contain null bytes. This could cause crashes if verbose logging in the enclave was enabled, the host used the JSON logger and the application wrote binary data to the KV. The log messages would contain invalid Unicode sequences, which made the JSON logger crash when trying to embed the message as a string field.