### PR TITLE
Decorate and identify SNP libraries

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -11,6 +11,7 @@ with section("parse"):
                 "INCLUDE_DIRS": "*",
                 "LINK_LIBS_ENCLAVE": "*",
                 "LINK_LIBS_VIRTUAL": "*",
+                "LINK_LIBS_SNP": "*",
             },
         },
         "add_client_exe": {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,10 +123,8 @@ if(COMPILE_TARGET STREQUAL "sgx")
 
   target_link_libraries(
     ccf.enclave PUBLIC quickjs.enclave http_parser.enclave sss.enclave
-                       ccf_endpoints.enclave ccfcrypto.enclave ccf_kv.enclave
+                       ccf_endpoints.enclave ccfcrypto.enclave ccf_kv.enclave nghttp2.enclave
   )
-
-  target_link_libraries(ccf.enclave PUBLIC nghttp2.enclave)
 
   add_lvi_mitigations(ccf.enclave)
 
@@ -141,19 +139,19 @@ if(COMPILE_TARGET STREQUAL "sgx")
   # Same as virtual for the time being but will diverge soon
 elseif(COMPILE_TARGET STREQUAL "snp")
 
-  # virtual version
-  add_library(ccf.virtual STATIC ${CCF_IMPL_SOURCE})
+  # SNO version
+  add_library(ccf.snp STATIC ${CCF_IMPL_SOURCE})
 
   target_compile_definitions(
-    ccf.virtual PUBLIC INSIDE_ENCLAVE VIRTUAL_ENCLAVE
+    ccf.snp PUBLIC INSIDE_ENCLAVE VIRTUAL_ENCLAVE
                        _LIBCPP_HAS_THREAD_API_PTHREAD PLATFORM_SNP
   )
 
-  target_compile_options(ccf.virtual PUBLIC ${COMPILE_LIBCXX})
-  add_warning_checks(ccf.virtual)
+  target_compile_options(ccf.snp PUBLIC ${COMPILE_LIBCXX})
+  add_warning_checks(ccf.snp)
 
   target_include_directories(
-    ccf.virtual SYSTEM
+    ccf.snp SYSTEM
     PUBLIC
       $<BUILD_INTERFACE:${CCF_GENERATED_DIR}>
       $<INSTALL_INTERFACE:include/ccf/> #< This contains the private headers
@@ -164,32 +162,31 @@ elseif(COMPILE_TARGET STREQUAL "snp")
   )
 
   target_link_libraries(
-    ccf.virtual
+    ccf.snp
     PUBLIC ${LINK_LIBCXX}
            -lgcc
-           http_parser.host
-           quickjs.host
-           sss.host
-           ccf_endpoints.host
-           ccfcrypto.host
-           ccf_kv.host
+           http_parser.snp
+           quickjs.snp
+           sss.snp
+           ccf_endpoints.snp
+           ccfcrypto.snp
+           ccf_kv.snp
+           nghttp2.snp
            ${OE_HOST_LIBRARY}
            ${CMAKE_THREAD_LIBS_INIT}
   )
 
-  target_link_libraries(ccf.virtual PUBLIC nghttp2.host)
+  set_property(TARGET ccf.snp PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-  set_property(TARGET ccf.virtual PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-  add_san(ccf.virtual)
+  add_san(ccf.snp)
 
   install(
-    TARGETS ccf.virtual
+    TARGETS ccf.snp
     EXPORT ccf
     DESTINATION lib
   )
 
-  add_dependencies(ccf ccf.virtual)
+  add_dependencies(ccf ccf.snp)
 
 elseif(COMPILE_TARGET STREQUAL "virtual")
 
@@ -225,11 +222,10 @@ elseif(COMPILE_TARGET STREQUAL "virtual")
            ccf_endpoints.host
            ccfcrypto.host
            ccf_kv.host
+           nghttp2.host
            ${OE_HOST_LIBRARY}
            ${CMAKE_THREAD_LIBS_INIT}
   )
-
-  target_link_libraries(ccf.virtual PUBLIC nghttp2.host)
 
   set_property(TARGET ccf.virtual PROPERTY POSITION_INDEPENDENT_CODE ON)
 

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -96,7 +96,7 @@ function(add_ccf_app name)
 
   cmake_parse_arguments(
     PARSE_ARGV 1 PARSED_ARGS "" ""
-    "SRCS;INCLUDE_DIRS;LINK_LIBS_ENCLAVE;LINK_LIBS_VIRTUAL;DEPS;INSTALL_LIBS"
+    "SRCS;INCLUDE_DIRS;LINK_LIBS_ENCLAVE;LINK_LIBS_VIRTUAL;LINK_LIBS_SNP;DEPS;INSTALL_LIBS"
   )
   add_custom_target(${name} ALL)
 
@@ -126,42 +126,42 @@ function(add_ccf_app name)
     endif()
 
   elseif(COMPILE_TARGET STREQUAL "snp")
-    # Build a virtual enclave, loaded as a shared library without OE
-    set(virt_name ${name}.virtual)
+    # Build an SNP enclave, loaded as a shared library without OE
+    set(snp_name ${name}.snp)
 
-    add_library(${virt_name} SHARED ${PARSED_ARGS_SRCS})
+    add_library(${snp_name} SHARED ${PARSED_ARGS_SRCS})
 
-    target_compile_definitions(${virt_name} PUBLIC PLATFORM_SNP)
+    target_compile_definitions(${snp_name} PUBLIC PLATFORM_SNP)
 
     target_include_directories(
-      ${virt_name} SYSTEM PRIVATE ${PARSED_ARGS_INCLUDE_DIRS}
+      ${snp_name} SYSTEM PRIVATE ${PARSED_ARGS_INCLUDE_DIRS}
     )
-    add_warning_checks(${virt_name})
+    add_warning_checks(${snp_name})
 
     target_link_libraries(
-      ${virt_name} PRIVATE ${PARSED_ARGS_LINK_LIBS_VIRTUAL} ccf.virtual
+      ${snp_name} PRIVATE ${PARSED_ARGS_LINK_LIBS_SNP} ccf.snp
     )
 
     if(NOT SAN)
-      target_link_options(${virt_name} PRIVATE LINKER:--no-undefined)
+      target_link_options(${snp_name} PRIVATE LINKER:--no-undefined)
     endif()
 
     target_link_options(
-      ${virt_name} PRIVATE
+      ${snp_name} PRIVATE
       LINKER:--undefined=enclave_create_node,--undefined=enclave_run
     )
 
-    set_property(TARGET ${virt_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
+    set_property(TARGET ${snp_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-    add_san(${virt_name})
+    add_san(${snp_name})
 
-    add_dependencies(${name} ${virt_name})
+    add_dependencies(${name} ${snp_name})
     if(PARSED_ARGS_DEPS)
-      add_dependencies(${virt_name} ${PARSED_ARGS_DEPS})
+      add_dependencies(${snp_name} ${PARSED_ARGS_DEPS})
     endif()
 
     if(${PARSED_ARGS_INSTALL_LIBS})
-      install(TARGETS ${virt_name} DESTINATION lib)
+      install(TARGETS ${snp_name} DESTINATION lib)
     endif()
 
   elseif(COMPILE_TARGET STREQUAL "virtual")

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -158,12 +158,16 @@ if(COMPILE_TARGET STREQUAL "sgx")
   # not get installed to minimise installation size
   set(INSTALL_VIRTUAL_LIBRARIES OFF)
 
+  set(DEFAULT_ENCLAVE_PLATFORM "SGX")
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(DEFAULT_ENCLAVE_TYPE debug)
   endif()
+elseif(COMPILE_TARGET STREQUAL "snp")
+  set(INSTALL_VIRTUAL_LIBRARIES OFF)
+  set(DEFAULT_ENCLAVE_PLATFORM "SNP")
 else()
   set(INSTALL_VIRTUAL_LIBRARIES ON)
-  set(DEFAULT_ENCLAVE_TYPE virtual)
+  set(DEFAULT_ENCLAVE_PLATFORM "Virtual")
 endif()
 
 set(HTTP_PARSER_SOURCES
@@ -310,7 +314,16 @@ if(COMPILE_TARGET STREQUAL "sgx")
     EXPORT ccf
     DESTINATION lib
   )
+elseif(COMPILE_TARGET STREQUAL "snp")
+  add_library(http_parser.snp "${HTTP_PARSER_SOURCES}")
+  set_property(TARGET http_parser.snp PROPERTY POSITION_INDEPENDENT_CODE ON)
+  install(
+    TARGETS http_parser.snp
+    EXPORT ccf
+    DESTINATION lib
+  )
 endif()
+
 
 add_library(http_parser.host "${HTTP_PARSER_SOURCES}")
 set_property(TARGET http_parser.host PROPERTY POSITION_INDEPENDENT_CODE ON)
@@ -336,7 +349,17 @@ if(COMPILE_TARGET STREQUAL "sgx")
     EXPORT ccf
     DESTINATION lib
   )
+elseif(COMPILE_TARGET STREQUAL "snp")
+  add_host_library(ccf_kv.snp "${CCF_KV_SOURCES}")
+  add_san(ccf_kv.snp)
+  add_warning_checks(ccf_kv.snp)
+  install(
+    TARGETS ccf_kv.snp
+    EXPORT ccf
+    DESTINATION lib
+  )
 endif()
+
 add_host_library(ccf_kv.host "${CCF_KV_SOURCES}")
 add_san(ccf_kv.host)
 add_warning_checks(ccf_kv.host)
@@ -356,6 +379,17 @@ if(COMPILE_TARGET STREQUAL "sgx")
   add_warning_checks(ccf_endpoints.enclave)
   install(
     TARGETS ccf_endpoints.enclave
+    EXPORT ccf
+    DESTINATION lib
+  )
+elseif(COMPILE_TARGET STREQUAL "snp")
+  add_host_library(ccf_endpoints.snp "${CCF_ENDPOINTS_SOURCES}")
+  target_link_libraries(ccf_endpoints.snp PUBLIC qcbor.snp)
+  target_link_libraries(ccf_endpoints.snp PUBLIC t_cose.snp)
+  add_san(ccf_endpoints.snp)
+  add_warning_checks(ccf_endpoints.snp)
+  install(
+    TARGETS ccf_endpoints.snp
     EXPORT ccf
     DESTINATION lib
   )
@@ -405,19 +439,19 @@ if(COMPILE_TARGET STREQUAL "sgx")
     DESTINATION lib
   )
 elseif(COMPILE_TARGET STREQUAL "snp")
-  add_library(js_openenclave.virtual STATIC ${CCF_DIR}/src/js/openenclave.cpp)
-  add_san(js_openenclave.virtual)
-  target_link_libraries(js_openenclave.virtual PUBLIC ccf.virtual)
-  target_compile_options(js_openenclave.virtual PRIVATE ${COMPILE_LIBCXX})
+  add_library(js_openenclave.snp STATIC ${CCF_DIR}/src/js/openenclave.cpp)
+  add_san(js_openenclave.snp)
+  target_link_libraries(js_openenclave.snp PUBLIC ccf.snp)
+  target_compile_options(js_openenclave.snp PRIVATE ${COMPILE_LIBCXX})
   target_compile_definitions(
-    js_openenclave.virtual PUBLIC INSIDE_ENCLAVE VIRTUAL_ENCLAVE
+    js_openenclave.snp PUBLIC INSIDE_ENCLAVE VIRTUAL_ENCLAVE
                                   _LIBCPP_HAS_THREAD_API_PTHREAD PLATFORM_SNP
   )
   set_property(
-    TARGET js_openenclave.virtual PROPERTY POSITION_INDEPENDENT_CODE ON
+    TARGET js_openenclave.snp PROPERTY POSITION_INDEPENDENT_CODE ON
   )
   install(
-    TARGETS js_openenclave.virtual
+    TARGETS js_openenclave.snp
     EXPORT ccf
     DESTINATION lib
   )
@@ -454,22 +488,22 @@ if(COMPILE_TARGET STREQUAL "sgx")
   )
 elseif(COMPILE_TARGET STREQUAL "snp")
   add_library(
-    js_generic_base.virtual STATIC
+    js_generic_base.snp STATIC
     ${CCF_DIR}/src/apps/js_generic/js_generic_base.cpp
   )
-  add_san(js_generic_base.virtual)
-  add_warning_checks(js_generic_base.virtual)
-  target_link_libraries(js_generic_base.virtual PUBLIC ccf.virtual)
-  target_compile_options(js_generic_base.virtual PRIVATE ${COMPILE_LIBCXX})
+  add_san(js_generic_base.snp)
+  add_warning_checks(js_generic_base.snp)
+  target_link_libraries(js_generic_base.snp PUBLIC ccf.snp)
+  target_compile_options(js_generic_base.snp PRIVATE ${COMPILE_LIBCXX})
   target_compile_definitions(
-    js_generic_base.virtual PUBLIC INSIDE_ENCLAVE VIRTUAL_ENCLAVE
+    js_generic_base.snp PUBLIC INSIDE_ENCLAVE VIRTUAL_ENCLAVE
                                    _LIBCPP_HAS_THREAD_API_PTHREAD PLATFORM_SNP
   )
   set_property(
-    TARGET js_generic_base.virtual PROPERTY POSITION_INDEPENDENT_CODE ON
+    TARGET js_generic_base.snp PROPERTY POSITION_INDEPENDENT_CODE ON
   )
   install(
-    TARGETS js_generic_base.virtual
+    TARGETS js_generic_base.snp
     EXPORT ccf
     DESTINATION lib
   )
@@ -501,8 +535,9 @@ add_ccf_app(
   js_generic
   SRCS ${CCF_DIR}/src/apps/js_generic/js_generic.cpp
   LINK_LIBS_ENCLAVE js_generic_base.enclave js_openenclave.enclave
-  LINK_LIBS_VIRTUAL js_generic_base.virtual js_openenclave.virtual INSTALL_LIBS
-                    ON
+  LINK_LIBS_VIRTUAL js_generic_base.virtual js_openenclave.virtual 
+  LINK_LIBS_SNP js_generic_base.snp js_openenclave.snp 
+  INSTALL_LIBS ON
 )
 sign_app_library(
   js_generic.enclave ${CCF_DIR}/src/apps/js_generic/oe_sign.conf
@@ -636,6 +671,14 @@ function(add_e2e_test)
         PROPERTY ENVIRONMENT "DEFAULT_ENCLAVE_TYPE=${DEFAULT_ENCLAVE_TYPE}"
       )
     endif()
+
+    if(DEFINED DEFAULT_ENCLAVE_PLATFORM)
+      set_property(
+        TEST ${PARSED_ARGS_NAME}
+        APPEND
+        PROPERTY ENVIRONMENT "DEFAULT_ENCLAVE_PLATFORM=${DEFAULT_ENCLAVE_PLATFORM}"
+      )
+    endif()
   endif()
 endfunction()
 
@@ -703,6 +746,13 @@ function(add_perf_test)
       TEST ${TEST_NAME}
       APPEND
       PROPERTY ENVIRONMENT "DEFAULT_ENCLAVE_TYPE=${DEFAULT_ENCLAVE_TYPE}"
+    )
+  endif()
+  if(DEFINED DEFAULT_ENCLAVE_PLATFORM)
+    set_property(
+      TEST ${TEST_NAME}
+      APPEND
+      PROPERTY ENVIRONMENT "DEFAULT_ENCLAVE_PLATFORM=${DEFAULT_ENCLAVE_PLATFORM}"
     )
   endif()
   set_property(

--- a/cmake/crypto.cmake
+++ b/cmake/crypto.cmake
@@ -35,6 +35,22 @@ if(COMPILE_TARGET STREQUAL "sgx")
     EXPORT ccf
     DESTINATION lib
   )
+elseif(COMPILE_TARGET STREQUAL "snp")
+  add_library(ccfcrypto.snp ${CCFCRYPTO_SRC})
+  add_san(ccfcrypto.snp)
+  target_compile_options(ccfcrypto.snp PUBLIC ${COMPILE_LIBCXX})
+  target_link_options(ccfcrypto.snp PUBLIC ${LINK_LIBCXX})
+  target_link_libraries(ccfcrypto.snp PUBLIC qcbor.snp)
+  target_link_libraries(ccfcrypto.snp PUBLIC t_cose.snp)
+  target_link_libraries(ccfcrypto.snp PUBLIC crypto)
+  target_link_libraries(ccfcrypto.snp PUBLIC ssl)
+  set_property(TARGET ccfcrypto.snp PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+  install(
+    TARGETS ccfcrypto.snp
+    EXPORT ccf
+    DESTINATION lib
+  )
 endif()
 
 add_library(ccfcrypto.host STATIC ${CCFCRYPTO_SRC})

--- a/cmake/nghttp2.cmake
+++ b/cmake/nghttp2.cmake
@@ -47,6 +47,23 @@ if(COMPILE_TARGET STREQUAL "sgx")
     EXPORT ccf
     DESTINATION lib
   )
+elseif(COMPILE_TARGET STREQUAL "snp")
+  add_library(nghttp2.snp STATIC ${NGHTTP2_SRCS})
+  target_include_directories(
+    nghttp2.snp PUBLIC $<BUILD_INTERFACE:${NGHTTP2_PREFIX}/includes>
+                        $<INSTALL_INTERFACE:include/3rdparty/nghttp2>
+  )
+  target_compile_definitions(
+    nghttp2.snp PUBLIC -DNGHTTP2_STATICLIB -DHAVE_ARPA_INET_H=1
+  )
+  add_san(nghttp2.snp)
+  set_property(TARGET nghttp2.snp PROPERTY POSITION_INDEPENDENT_CODE ON)
+  
+  install(
+    TARGETS nghttp2.snp
+    EXPORT ccf
+    DESTINATION lib
+  )
 endif()
 
 add_library(nghttp2.host STATIC ${NGHTTP2_SRCS})

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -27,6 +27,14 @@ if(COMPILE_TARGET STREQUAL "sgx")
     EXPORT ccf
     DESTINATION lib
   )
+elseif(COMPILE_TARGET STREQUAL "snp")
+  add_host_library(protobuf.snp ${LIBPROTOBUF_SOURCES})
+  list(APPEND PROTOBUF_TARGETS "protobuf.snp")
+  install(
+    TARGETS protobuf.snp
+    EXPORT ccf
+    DESTINATION lib
+  )
 else()
   install(
     TARGETS protobuf.virtual

--- a/cmake/qcbor.cmake
+++ b/cmake/qcbor.cmake
@@ -21,6 +21,21 @@ if(COMPILE_TARGET STREQUAL "sgx")
     EXPORT ccf
     DESTINATION lib
   )
+elseif(COMPILE_TARGET STREQUAL "snp")
+  add_library(qcbor.snp STATIC ${QCBOR_SRCS})
+
+  target_include_directories(
+    qcbor.snp PUBLIC $<BUILD_INTERFACE:${CCF_3RD_PARTY_EXPORTED_DIR}/QCBOR>
+                      $<INSTALL_INTERFACE:include/3rdparty/QCBOR>
+  )
+  set_property(TARGET qcbor.snp PROPERTY POSITION_INDEPENDENT_CODE ON)
+  add_san(qcbor.snp)
+  
+  install(
+    TARGETS qcbor.snp
+    EXPORT ccf
+    DESTINATION lib
+  )
 endif()
 
 add_library(qcbor.host STATIC ${QCBOR_SRCS})

--- a/cmake/quickjs.cmake
+++ b/cmake/quickjs.cmake
@@ -46,6 +46,25 @@ if(COMPILE_TARGET STREQUAL "sgx")
     EXPORT ccf
     DESTINATION lib
   )
+elseif(COMPILE_TARGET STREQUAL "snp")
+  add_library(quickjs.snp STATIC ${QUICKJS_SRC})
+  target_compile_options(
+    quickjs.snp
+    PUBLIC -DCONFIG_VERSION="${QUICKJS_VERSION}" -DCONFIG_BIGNUM
+    PRIVATE $<$<CONFIG:Debug>:-DDUMP_LEAKS>
+  )
+  add_san(quickjs.snp)
+  set_property(TARGET quickjs.snp PROPERTY POSITION_INDEPENDENT_CODE ON)
+  target_include_directories(
+    quickjs.snp PUBLIC $<BUILD_INTERFACE:${CCF_3RD_PARTY_EXPORTED_DIR}/quickjs>
+                        $<INSTALL_INTERFACE:include/3rdparty/quickjs>
+  )
+
+  install(
+    TARGETS quickjs.snp
+    EXPORT ccf
+    DESTINATION lib
+  )
 endif()
 
 add_library(quickjs.host STATIC ${QUICKJS_SRC})

--- a/cmake/sss.cmake
+++ b/cmake/sss.cmake
@@ -18,6 +18,15 @@ if(COMPILE_TARGET STREQUAL "sgx")
     EXPORT ccf
     DESTINATION lib
   )
+elseif(COMPILE_TARGET STREQUAL "snp")
+  add_library(sss.snp STATIC ${SSS_SRC})
+  add_san(sss.snp)
+  set_property(TARGET sss.snp PROPERTY POSITION_INDEPENDENT_CODE ON)
+  install(
+    TARGETS sss.snp
+    EXPORT ccf
+    DESTINATION lib
+  )
 endif()
 
 add_library(sss.host STATIC ${SSS_SRC})

--- a/cmake/t_cose.cmake
+++ b/cmake/t_cose.cmake
@@ -34,6 +34,28 @@ if(COMPILE_TARGET STREQUAL "sgx")
     EXPORT ccf
     DESTINATION lib
   )
+elseif(COMPILE_TARGET STREQUAL "snp")
+  find_package(OpenSSL REQUIRED)
+  add_library(t_cose.snp STATIC ${T_COSE_SRCS})
+  target_compile_definitions(t_cose.snp PRIVATE ${T_COSE_DEFS})
+  target_compile_options(t_cose.snp INTERFACE ${T_COSE_OPTS_INTERFACE})
+  
+  target_include_directories(t_cose.snp PRIVATE "${T_COSE_SRC}")
+  
+  target_include_directories(
+    t_cose.snp PUBLIC $<BUILD_INTERFACE:${CCF_3RD_PARTY_EXPORTED_DIR}/t_cose>
+                       $<INSTALL_INTERFACE:include/3rdparty/t_cose>
+  )
+  
+  target_link_libraries(t_cose.snp PUBLIC qcbor.snp crypto)
+  set_property(TARGET t_cose.snp PROPERTY POSITION_INDEPENDENT_CODE ON)
+  add_san(t_cose.snp)
+  
+  install(
+    TARGETS t_cose.snp
+    EXPORT ccf
+    DESTINATION lib
+  )
 endif()
 
 find_package(OpenSSL REQUIRED)

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -11,12 +11,18 @@
           "type": "string",
           "description": "Path to enclave application"
         },
+        "platform": {
+          "type": "string",
+          "enum": ["SGX", "SNP", "Virtual"],
+          "default": "SGX",
+          "description": "Trusted Execution Environment platform"
+        },
         "type": {
           "type": "string",
-          "enum": ["Release", "Debug", "Virtual"],
+          "enum": ["Release", "Debug"],
           "default": "Release",
-          "description": "Type of enclave application"
-        }
+          "description": "Type of enclave application (only if platform is SGX)"
+        }        
       },
       "description": "This section includes configuration for the enclave application launched by this node",
       "required": ["file"],

--- a/src/apps/external_executor/CMakeLists.txt
+++ b/src/apps/external_executor/CMakeLists.txt
@@ -23,6 +23,9 @@ add_ccf_app(
   LINK_LIBS_VIRTUAL
     executor_registration.proto.virtual kv.proto.virtual status.proto.virtual
     stringops.proto.virtual protobuf.virtual
+  LINK_LIBS_SNP
+    executor_registration.proto.virtual kv.proto.virtual status.proto.virtual
+    stringops.proto.virtual protobuf.snp
 )
 
 # Generate an ephemeral signing key

--- a/src/host/configuration.h
+++ b/src/host/configuration.h
@@ -13,15 +13,24 @@ namespace host
 {
   enum class EnclaveType
   {
-    SGX_RELEASE,
-    SGX_DEBUG,
-    VIRTUAL,
+    RELEASE,
+    DEBUG
   };
   DECLARE_JSON_ENUM(
     EnclaveType,
-    {{EnclaveType::SGX_RELEASE, "Release"},
-     {EnclaveType::SGX_DEBUG, "Debug"},
-     {EnclaveType::VIRTUAL, "Virtual"}});
+    {{EnclaveType::RELEASE, "Release"}, {EnclaveType::DEBUG, "Debug"}});
+
+  enum class EnclavePlatform
+  {
+    SGX,
+    SNP,
+    VIRTUAL,
+  };
+  DECLARE_JSON_ENUM(
+    EnclavePlatform,
+    {{EnclavePlatform::SGX, "SGX"},
+     {EnclavePlatform::SNP, "SNP"},
+     {EnclavePlatform::VIRTUAL, "Virtual"}});
 
   enum class LogFormat
   {
@@ -51,6 +60,7 @@ namespace host
     {
       std::string file;
       EnclaveType type;
+      EnclavePlatform platform;
     };
     Enclave enclave = {};
 
@@ -151,7 +161,7 @@ namespace host
   };
 
   DECLARE_JSON_TYPE(CCHostConfig::Enclave);
-  DECLARE_JSON_REQUIRED_FIELDS(CCHostConfig::Enclave, type, file);
+  DECLARE_JSON_REQUIRED_FIELDS(CCHostConfig::Enclave, type, file, platform);
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(CCHostConfig::OutputFiles);
   DECLARE_JSON_REQUIRED_FIELDS(CCHostConfig::OutputFiles);

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -194,7 +194,8 @@ int main(int argc, char** argv)
     config.slow_io_logging_threshold;
 
   // create the enclave
-  host::Enclave enclave(config.enclave.file, config.enclave.type);
+  host::Enclave enclave(
+    config.enclave.file, config.enclave.type, config.enclave.platform);
 
   // messaging ring buffers
   const auto buffer_size = config.memory.circuit_size;

--- a/tests/code_update.py
+++ b/tests/code_update.py
@@ -28,7 +28,7 @@ SNP_ACI_MEASUREMENT = "ede826880a4e1a41898a96810efb09f2070513abb355e89652564cd18
 
 @reqs.description("Verify node evidence")
 def test_verify_quotes(network, args):
-    if args.enclave_type == "virtual":
+    if args.enclave_platform == "virtual":
         LOG.warning("Skipping quote test with virtual enclave")
         return network
     elif IS_SNP:
@@ -230,7 +230,7 @@ def test_add_node_with_bad_code(network, args):
     )
 
     new_code_id = infra.utils.get_code_id(
-        args.enclave_type, args.oe_binary, replacement_package
+        args.enclave_platform, args.oe_binary, replacement_package
     )
 
     LOG.info(f"Adding a node with unsupported code id {new_code_id}")
@@ -264,13 +264,13 @@ def test_update_all_nodes(network, args):
     primary, _ = network.find_nodes()
 
     first_code_id = infra.utils.get_code_id(
-        args.enclave_type, args.oe_binary, args.package
+        args.enclave_platform, args.oe_binary, args.package
     )
     new_code_id = infra.utils.get_code_id(
-        args.enclave_type, args.oe_binary, replacement_package
+        args.enclave_platform, args.oe_binary, replacement_package
     )
 
-    if args.enclave_type == "virtual":
+    if args.enclave_platform == "virtual":
         # Pretend this was already present
         network.consortium.add_new_code(primary, first_code_id)
 
@@ -283,7 +283,7 @@ def test_update_all_nodes(network, args):
             {"digest": first_code_id, "status": "AllowedToJoin"},
             {"digest": new_code_id, "status": "AllowedToJoin"},
         ]
-        if args.enclave_type == "virtual":
+        if args.enclave_platform == "virtual":
             expected.insert(0, {"digest": VIRTUAL_CODE_ID, "status": "AllowedToJoin"})
 
         versions = sorted(r.body.json()["versions"], key=lambda x: x["digest"])
@@ -298,7 +298,7 @@ def test_update_all_nodes(network, args):
             {"digest": first_code_id, "status": "AllowedToJoin"},
             {"digest": new_code_id, "status": "AllowedToJoin"},
         ]
-        if args.enclave_type == "virtual":
+        if args.enclave_platform == "virtual":
             expected.insert(0, {"digest": VIRTUAL_CODE_ID, "status": "AllowedToJoin"})
 
         expected.sort(key=lambda x: x["digest"])

--- a/tests/config.jinja
+++ b/tests/config.jinja
@@ -1,7 +1,8 @@
 {
   "enclave": {
     "file": "{{ enclave_file }}",
-    "type": "{{ enclave_type }}"
+    "type": "{{ enclave_type }}",
+    "platform": "{{ enclave_platform }}"
   },
   "network": {
     "node_to_node_interface": { "bind_address": "{{ node_address }}" },

--- a/tests/governance.py
+++ b/tests/governance.py
@@ -60,7 +60,9 @@ def test_quote(network, args):
                 os.path.join(args.oe_binary, "oesign"),
                 "dump",
                 "-e",
-                infra.path.build_lib_path(args.package, args.enclave_type),
+                infra.path.build_lib_path(
+                    args.package, args.enclave_type, args.enclave_platform
+                ),
             ],
             capture_output=True,
             check=True,

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -111,7 +111,14 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         "--enclave-type",
         help="Enclave type",
         default=os.getenv("TEST_ENCLAVE", os.getenv("DEFAULT_ENCLAVE_TYPE", "release")),
-        choices=("release", "debug", "virtual"),
+        choices=("release", "debug"),
+    )
+    parser.add_argument(
+        "-t",
+        "--enclave-platform",
+        help="Enclave platform (Trusted Execution Environment)",
+        default=os.getenv("TEST_ENCLAVE", os.getenv("DEFAULT_ENCLAVE_PLATFORM", "SGX")),
+        choices=("SGX", "SNP", "Virtual"),
     )
     parser.add_argument(
         "--host-log-level",

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -100,6 +100,7 @@ class Network:
     SHARE_SCRIPT = "submit_recovery_share.sh"
     node_args_to_forward = [
         "enclave_type",
+        "enclave_platform",
         "host_log_level",
         "sig_tx_interval",
         "sig_ms_interval",
@@ -331,6 +332,8 @@ class Network:
             arg: getattr(args, arg, None)
             for arg in infra.network.Network.node_args_to_forward
         }
+
+        LOG.error(forwarded_args)
 
         for i, node in enumerate(self.nodes):
             try:

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -261,6 +261,7 @@ class Node:
         label,
         common_dir,
         members_info=None,
+        enclave_platform="SGX",
         **kwargs,
     ):
         """
@@ -271,7 +272,7 @@ class Node:
         prompt the user to do so manually.
         """
         lib_path = infra.path.build_lib_path(
-            lib_name, enclave_type, library_dir=self.library_dir
+            lib_name, enclave_type, enclave_platform, library_dir=self.library_dir
         )
         self.common_dir = common_dir
         members_info = members_info or []
@@ -297,6 +298,7 @@ class Node:
             version=self.version,
             major_version=self.major_version,
             node_data_json_file=self.initial_node_data_json_file,
+            enclave_platform=enclave_platform,
             **kwargs,
         )
         self.remote.setup()

--- a/tests/infra/path.py
+++ b/tests/infra/path.py
@@ -20,16 +20,24 @@ def mk_new(name, contents):
         mk(name, contents)
 
 
-def build_lib_path(lib_name, enclave_type=None, library_dir="."):
-    if enclave_type == "virtual":
+def build_lib_path(
+    lib_name, enclave_type=None, enclave_platform="SGX", library_dir="."
+):
+    if enclave_platform == "Virtual":
         ext = ".virtual.so"
         mode = "Virtual mode"
-    elif enclave_type == "debug":
-        ext = ".enclave.so.debuggable"
-        mode = "Debuggable enclave"
-    elif enclave_type == "release":
-        ext = ".enclave.so.signed"
-        mode = "Real enclave"
+    elif enclave_platform == "SGX":
+        if enclave_type == "debug":
+            ext = ".enclave.so.debuggable"
+            mode = "Debuggable SGX enclave"
+        elif enclave_type == "release":
+            ext = ".enclave.so.signed"
+            mode = "Release SGX enclave"
+        else:
+            raise ValueError(f"Invalid enclave_type {enclave_type} for SGX enclave")
+    elif enclave_platform == "SNP":
+        ext = ".snp.so"
+        mode = "SNP enclave"
     else:
         raise ValueError(f"Invalid enclave_type passed {enclave_type}")
     if os.path.isfile(lib_name):

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -602,6 +602,7 @@ class CCFRemote(object):
         service_data_json_file=None,
         snp_endorsements_servers=None,
         node_pid_file="node.pid",
+        enclave_platform="SGX",
         **kwargs,
     ):
         """
@@ -714,6 +715,7 @@ class CCFRemote(object):
                 start_type=start_type.name.title(),
                 enclave_file=self.enclave_file,
                 enclave_type=enclave_type.title(),
+                enclave_platform=enclave_platform,
                 rpc_interfaces=infra.interfaces.HostSpec.to_json(host),
                 node_certificate_file=self.pem,
                 node_address_file=self.node_address_file,


### PR DESCRIPTION
Resolves #4069 (last remaining item)

1. Libraries/enclave apps built for SNP are now suffixed with `.snp` (rather than `.virtual`). 
2. Because of 1., the Python infra now needs to differentiate between these libraries based on CMake's `COMPILE_TARGET`.
3. The [`enclave`](https://microsoft.github.io/CCF/main/operations/configuration.html#enclave) configuration entry now accepts a new `"platform"` field to differentiate between SGX, SNP and Virtual, while the existing `"type"` can now either be debug or release (only applies to SGX for now). Note that this isn't a breaking change for production deployment as the new `"platform"` field defaults to SGX.