### PR TITLE
Try to get the correct group ID

### DIFF
--- a/.azure-pipelines-templates/platform.yml
+++ b/.azure-pipelines-templates/platform.yml
@@ -7,8 +7,7 @@ steps:
   - ${{ if eq(parameters.target, 'SGX') }}:
       - script: |
           set -ex
-          SGX_GROUP_ID=$(grep sgx_prv /tmp/host_group | cut -d ':' -f 3)
-          sudo groupadd -g $SGX_GROUP_ID sgx_prv
+          sudo groupadd -fg $(/usr/bin/stat -Lc '%g' /dev/sgx/provision) sgx_prv
           sudo usermod -a -G sgx_prv $(whoami)
         displayName: SGX Group
         condition: succeededOrFailed()

--- a/.azure-pipelines-templates/platform.yml
+++ b/.azure-pipelines-templates/platform.yml
@@ -7,7 +7,8 @@ steps:
   - ${{ if eq(parameters.target, 'SGX') }}:
       - script: |
           set -ex
-          sudo groupadd -g 119 sgx_prv
+          SGX_GROUP_ID=$(grep sgx_prv /tmp/host_group | cut -d ':' -f 3)
+          sudo groupadd -g $SGX_GROUP_ID sgx_prv
           sudo usermod -a -G sgx_prv $(whoami)
         displayName: SGX Group
         condition: succeededOrFailed()

--- a/.azure-pipelines-templates/platform.yml
+++ b/.azure-pipelines-templates/platform.yml
@@ -2,8 +2,6 @@ parameters:
   target: ""
 
 steps:
-  # 119 is GID of special "sgx_prv" group on underlying VM that is
-  # required to run SGX on kernel > 5.11
   - ${{ if eq(parameters.target, 'SGX') }}:
       - script: |
           set -ex

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -34,7 +34,7 @@ resources:
 
     - container: sgx
       image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /lib/modules:/lib/modules:ro
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /lib/modules:/lib/modules:ro -v /etc/group:/tmp/host_group
 
 variables:
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/ccf-') }}:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -34,7 +34,7 @@ resources:
 
     - container: sgx
       image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /lib/modules:/lib/modules:ro -v /etc/group:/tmp/host_group
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /lib/modules:/lib/modules:ro
 
 variables:
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/ccf-') }}:


### PR DESCRIPTION
Remove the hardcoded group creation of sgx_prv with 119, fetch the owner of /dev/sgx_provision instead.

Same as https://github.com/microsoft/scitt-ccf-ledger/pull/16