### PR TITLE
[release/2.x] Cherry pick: Try to get the correct group ID (#4575)

### DIFF
--- a/.azure-pipelines-templates/cmake.yml
+++ b/.azure-pipelines-templates/cmake.yml
@@ -6,7 +6,7 @@ steps:
       set -ex
       tests/sgxinfo.sh
       cat /proc/cpuinfo | grep flags | uniq
-      sudo groupadd -g 119 sgx_prv
+      sudo groupadd -fg $(/usr/bin/stat -Lc '%g' /dev/sgx/provision) sgx_prv
       sudo usermod -a -G sgx_prv $(whoami)
     displayName: Platform Info
     condition: succeededOrFailed()


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Try to get the correct group ID (#4575)](https://github.com/microsoft/CCF/pull/4575)