### PR TITLE
[release/2.x] Fix virtual CI `sgx_prv` group

### DIFF
--- a/.azure-pipelines-templates/cmake.yml
+++ b/.azure-pipelines-templates/cmake.yml
@@ -1,15 +1,22 @@
 parameters:
   cmake_args: ""
+  target: ""
 
 steps:
   - script: |
       set -ex
       tests/sgxinfo.sh
       cat /proc/cpuinfo | grep flags | uniq
-      sudo groupadd -fg $(/usr/bin/stat -Lc '%g' /dev/sgx/provision) sgx_prv
-      sudo usermod -a -G sgx_prv $(whoami)
     displayName: Platform Info
     condition: succeededOrFailed()
+
+  - ${{ if eq(parameters.target, 'SGX') }}:
+      - script: |
+          set -ex
+          sudo groupadd -fg $(/usr/bin/stat -Lc '%g' /dev/sgx/provision) sgx_prv
+          sudo usermod -a -G sgx_prv $(whoami)
+        displayName: SGX Group
+        condition: succeededOrFailed()
 
   - script: |
       set -ex

--- a/.azure-pipelines-templates/common.yml
+++ b/.azure-pipelines-templates/common.yml
@@ -23,6 +23,7 @@ jobs:
       - template: cmake.yml
         parameters:
           cmake_args: "${{ parameters.cmake_args }}"
+          target: "${{ parameters.target }}"
 
       - template: ninja.yml
         parameters:


### PR DESCRIPTION
I was too keen to merge https://github.com/microsoft/CCF/pull/4577 and did not realise that the previous fix was not guarded by the target platform on the `release/2.x` branch, which breaks the CI pipeline.