### PR TITLE
[release/3.x] Cherry pick: Session consistency: Parse forwarded messages with consistency info (#4595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [3.0.0-rc3]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.0-rc3
 
-## Added
+### Added
 
 - The [ccf Python package](https://pypi.org/project/ccf/) now includes a `ccf_cose_sign1` CLI tool, to faciliate the creation of [COSE Sign1](https://www.rfc-editor.org/rfc/rfc8152#page-18) requests for governance purposes.
 

--- a/include/ccf/odata_error.h
+++ b/include/ccf/odata_error.h
@@ -91,6 +91,7 @@ namespace ccf
     ERROR(PrimaryNotFound)
     ERROR(RequestAlreadyForwarded)
     ERROR(NodeNotRetiredCommitted)
+    ERROR(SessionConsistencyLost)
 
     // node-to-node (/join and /create):
     ERROR(ConsensusTypeMismatch)

--- a/include/ccf/rpc_context.h
+++ b/include/ccf/rpc_context.h
@@ -22,7 +22,7 @@ namespace ccf
   {
     size_t client_session_id = InvalidSessionId;
 
-    // Usually a DER certificate, may be a PEM on forwardee
+    // Contains DER encoding of original caller
     std::vector<uint8_t> caller_cert = {};
     bool is_forwarding = false;
 
@@ -31,6 +31,11 @@ namespace ccf
 
     // Only set in the case of a forwarded RPC
     bool is_forwarded = false;
+
+    // All requests on this session must occur within the same view. If the view
+    // changes, the next request will receive an error response and the session
+    // will be closed.
+    std::optional<ccf::View> active_view = std::nullopt;
 
     SessionContext(
       size_t client_session_id_,

--- a/src/enclave/forwarder_types.h
+++ b/src/enclave/forwarder_types.h
@@ -14,7 +14,8 @@ namespace ccf
   {
   public:
     virtual ~AbstractRPCResponder() {}
-    virtual bool reply_async(int64_t id, std::vector<uint8_t>&& data) = 0;
+    virtual bool reply_async(
+      int64_t id, bool terminate_after_reply, std::vector<uint8_t>&& data) = 0;
   };
 
   class AbstractForwarder

--- a/src/enclave/rpc_sessions.h
+++ b/src/enclave/rpc_sessions.h
@@ -78,7 +78,7 @@ namespace ccf
       NoMoreSessionsImpl(Ts&&... ts) : Base(std::forward<Ts>(ts)...)
       {}
 
-      void handle_incoming_data_thread(std::span<const uint8_t> data) override
+      void handle_incoming_data_thread(std::vector<uint8_t>&& data) override
       {
         Base::tls_io->recv_buffered(data.data(), data.size());
 
@@ -474,7 +474,10 @@ namespace ccf
       return search->second.second;
     }
 
-    bool reply_async(tls::ConnID id, std::vector<uint8_t>&& data) override
+    bool reply_async(
+      tls::ConnID id,
+      bool terminate_after_send,
+      std::vector<uint8_t>&& data) override
     {
       auto session = find_session(id);
       if (session == nullptr)
@@ -486,6 +489,12 @@ namespace ccf
       LOG_DEBUG_FMT("Replying to session {}", id);
 
       session->send_data(data);
+
+      if (terminate_after_send)
+      {
+        session->close_session();
+      }
+
       return true;
     }
 

--- a/src/enclave/session.h
+++ b/src/enclave/session.h
@@ -16,6 +16,7 @@ namespace ccf
 
     virtual void handle_incoming_data(std::span<const uint8_t> data) = 0;
     virtual void send_data(std::span<const uint8_t> data) = 0;
+    virtual void close_session() = 0;
   };
 
   class ThreadedSession : public Session,
@@ -55,9 +56,9 @@ namespace ccf
     static void handle_incoming_data_cb(
       std::unique_ptr<threading::Tmsg<SendRecvMsg>> msg)
     {
-      msg->data.self->handle_incoming_data_thread(msg->data.data);
+      msg->data.self->handle_incoming_data_thread(std::move(msg->data.data));
     }
 
-    virtual void handle_incoming_data_thread(std::span<const uint8_t> data) = 0;
+    virtual void handle_incoming_data_thread(std::vector<uint8_t>&& data) = 0;
   };
 }

--- a/src/enclave/tls_session.h
+++ b/src/enclave/tls_session.h
@@ -249,7 +249,7 @@ namespace ccf
       do_handshake();
     }
 
-    virtual void close()
+    void close()
     {
       status = closing;
       if (threading::get_current_thread_id() != execution_thread)

--- a/src/http/http2_session.h
+++ b/src/http/http2_session.h
@@ -36,15 +36,28 @@ namespace http
       tls_io->send_raw(data.data(), data.size());
     }
 
-    void handle_incoming_data_thread(std::span<const uint8_t> data) override
+    void close_session() override
+    {
+      tls_io->close();
+    }
+
+    void handle_incoming_data_thread(std::vector<uint8_t>&& data) override
     {
       tls_io->recv_buffered(data.data(), data.size());
 
       LOG_TRACE_FMT("recv called with {} bytes", data.size());
 
-      constexpr auto read_block_size = 4096;
-      std::vector<uint8_t> buf(read_block_size);
-      auto n_read = tls_io->read(buf.data(), buf.size(), false);
+      // Try to parse all incoming data, reusing the vector we were just passed
+      // for storage. Increase the size if the received vector was too small
+      // (for the case where this chunk is very small, but we had some previous
+      // data to continue reading).
+      constexpr auto min_read_block_size = 4096;
+      if (data.size() < min_read_block_size)
+      {
+        data.resize(min_read_block_size);
+      }
+
+      auto n_read = tls_io->read(data.data(), data.size(), false);
 
       while (true)
       {
@@ -55,14 +68,14 @@ namespace http
 
         LOG_TRACE_FMT("Going to parse {} bytes", n_read);
 
-        bool cont = parse({buf.data(), n_read});
+        bool cont = parse({data.data(), n_read});
         if (!cont)
         {
           return;
         }
 
         // Used all provided bytes - check if more are available
-        n_read = tls_io->read(buf.data(), buf.size(), false);
+        n_read = tls_io->read(data.data(), data.size(), false);
       }
     }
   };

--- a/src/http/http_session.h
+++ b/src/http/http_session.h
@@ -40,15 +40,28 @@ namespace http
       tls_io->send_raw(data.data(), data.size());
     }
 
-    void handle_incoming_data_thread(std::span<const uint8_t> data) override
+    void close_session() override
+    {
+      tls_io->close();
+    }
+
+    void handle_incoming_data_thread(std::vector<uint8_t>&& data) override
     {
       tls_io->recv_buffered(data.data(), data.size());
 
       LOG_TRACE_FMT("recv called with {} bytes", data.size());
 
-      constexpr auto read_block_size = 4096;
-      std::vector<uint8_t> buf(read_block_size);
-      auto n_read = tls_io->read(buf.data(), buf.size(), false);
+      // Try to parse all incoming data, reusing the vector we were just passed
+      // for storage. Increase the size if the received vector was too small
+      // (for the case where this chunk is very small, but we had some previous
+      // data to continue reading).
+      constexpr auto min_read_block_size = 4096;
+      if (data.size() < min_read_block_size)
+      {
+        data.resize(min_read_block_size);
+      }
+
+      auto n_read = tls_io->read(data.data(), data.size(), false);
 
       while (true)
       {
@@ -59,14 +72,14 @@ namespace http
 
         LOG_TRACE_FMT("Going to parse {} bytes", n_read);
 
-        bool cont = parse({buf.data(), n_read});
+        bool cont = parse({data.data(), n_read});
         if (!cont)
         {
           return;
         }
 
         // Used all provided bytes - check if more are available
-        n_read = tls_io->read(buf.data(), buf.size(), false);
+        n_read = tls_io->read(data.data(), data.size(), false);
       }
     }
   };
@@ -203,6 +216,7 @@ namespace http
             HTTP_STATUS_INTERNAL_SERVER_ERROR,
             ccf::errors::InternalError,
             fmt::format("Error constructing RpcContext: {}", e.what())});
+          tls_io->close();
         }
 
         const auto actor_opt = http::extract_actor(*rpc_ctx);
@@ -238,6 +252,11 @@ namespace http
             rpc_ctx->get_response_headers(),
             rpc_ctx->get_response_trailers(),
             std::move(rpc_ctx->get_response_body()));
+
+          if (rpc_ctx->terminate_session)
+          {
+            tls_io->close();
+          }
         }
       }
       catch (const std::exception& e)

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -94,7 +94,7 @@ namespace ccf
         response.set_header(
           http::headers::CONTENT_TYPE, http::headervalues::contenttype::TEXT);
         rpc_responder_shared->reply_async(
-          client_session_id, response.build_response());
+          client_session_id, false, response.build_response());
       }
     }
 
@@ -121,11 +121,12 @@ namespace ccf
       const std::vector<uint8_t>& caller_cert,
       const std::chrono::milliseconds& timeout) override
     {
+      auto session_ctx = rpc_ctx->get_session_context();
+
       IsCallerCertForwarded include_caller = false;
       const auto method = rpc_ctx->get_method();
       const auto& raw_request = rpc_ctx->get_serialised_request();
-      auto client_session_id =
-        rpc_ctx->get_session_context()->client_session_id;
+      auto client_session_id = session_ctx->client_session_id;
       size_t size = sizeof(client_session_id) + sizeof(IsCallerCertForwarded) +
         raw_request.size();
       if (!caller_cert.empty())
@@ -155,11 +156,13 @@ namespace ccf
             create_timeout_error_task(to, client_session_id, timeout), timeout);
       }
 
-      ForwardedHeader_v2 msg = {
+      // NB: This version of the code understands the *_v3 messages, but still
+      // _emits_ only *_v2 messages
+      ForwardedHeader_v2 header = {
         {ForwardedMsg::forwarded_cmd_v2, rpc_ctx->frame_format()}, command_id};
 
       return n2n_channels->send_encrypted(
-        to, NodeMsgType::forwarded_msg, plain, msg);
+        to, NodeMsgType::forwarded_msg, plain, header);
     }
 
     template <typename TFwdHdr>
@@ -199,6 +202,12 @@ namespace ccf
         std::make_shared<ccf::SessionContext>(client_session_id, caller_cert);
       session->is_forwarded = true;
 
+      if constexpr (std::is_same_v<TFwdHdr, ForwardedCommandHeader_v3>)
+      {
+        ccf::View view = r.first.active_view;
+        session->active_view = view;
+      }
+
       try
       {
         return ccf::make_fwd_rpc_context(
@@ -229,11 +238,15 @@ namespace ccf
         from_node, NodeMsgType::forwarded_msg, plain, header);
     }
 
-    using ForwardedResponseResult =
-      std::optional<std::pair<size_t, std::vector<uint8_t>>>;
+    struct ForwardedResponseResult
+    {
+      size_t client_session_id;
+      std::vector<uint8_t> response_body;
+      bool should_terminate_session = false;
+    };
 
     template <typename TFwdHdr>
-    ForwardedResponseResult recv_forwarded_response(
+    std::optional<ForwardedResponseResult> recv_forwarded_response(
       const NodeId& from, const uint8_t* data, size_t size)
     {
       std::pair<TFwdHdr, std::vector<uint8_t>> r;
@@ -251,13 +264,19 @@ namespace ccf
         return std::nullopt;
       }
 
+      ForwardedResponseResult ret = {};
+      if constexpr (std::is_same_v<TFwdHdr, ForwardedResponseHeader_v3>)
+      {
+        ret.should_terminate_session = r.first.terminate_session;
+      }
+
       const auto& plain_ = r.second;
       auto data_ = plain_.data();
       auto size_ = plain_.size();
-      auto client_session_id = serialized::read<size_t>(data_, size_);
-      std::vector<uint8_t> rpc = serialized::read(data_, size_, size_);
+      ret.client_session_id = serialized::read<size_t>(data_, size_);
+      ret.response_body = serialized::read(data_, size_, size_);
 
-      return std::make_pair(client_session_id, rpc);
+      return ret;
     }
 
     std::shared_ptr<ForwardedRpcHandler> get_forwarder_handler(
@@ -312,9 +331,7 @@ namespace ccf
     {
       try
       {
-        const auto forwarded_hdr_v1 =
-          serialized::peek<ForwardedHeader_v1>(data, size);
-        const auto forwarded_msg = forwarded_hdr_v1.msg;
+        const auto forwarded_msg = serialized::peek<ForwardedMsg>(data, size);
         LOG_TRACE_FMT(
           "recv_message({}, {} bytes) (type={})",
           from,
@@ -366,13 +383,14 @@ namespace ccf
               serialized::peek<ForwardedHeader_v2>(data, size);
             const auto cmd_id = forwarded_hdr_v2.id;
 
+            fwd_handler->process_forwarded(ctx);
+
             // frame_format is deliberately unset, the forwarder ignores it
             // and expects the same format they forwarded.
             ForwardedHeader_v2 response_header{
               {ForwardedMsg::forwarded_response_v2, {}}, cmd_id};
 
             LOG_DEBUG_FMT("Sending forwarded response to {}", from);
-            fwd_handler->process_forwarded(ctx);
 
             // Ignore return value - false only means it is pending
             send_forwarded_response(
@@ -383,6 +401,40 @@ namespace ccf
             break;
           }
 
+          case ForwardedMsg::forwarded_cmd_v3:
+          {
+            auto ctx = recv_forwarded_command<ForwardedCommandHeader_v3>(
+              from, data, size);
+
+            auto fwd_handler = get_forwarder_handler(ctx);
+            if (fwd_handler == nullptr)
+            {
+              return;
+            }
+
+            const auto forwarded_hdr_v3 =
+              serialized::peek<ForwardedCommandHeader_v3>(data, size);
+            const auto cmd_id = forwarded_hdr_v3.id;
+
+            fwd_handler->process_forwarded(ctx);
+
+            // frame_format is deliberately unset, the forwarder ignores it
+            // and expects the same format they forwarded.
+            ForwardedResponseHeader_v3 response_header(
+              cmd_id, ctx->terminate_session);
+
+            LOG_DEBUG_FMT("Sending forwarded response to {}", from);
+
+            // Ignore return value - false only means it is pending
+            send_forwarded_response(
+              ctx->get_session_context()->client_session_id,
+              from,
+              response_header,
+              ctx->serialise_response());
+            break;
+          }
+
+          case ForwardedMsg::forwarded_response_v3:
           case ForwardedMsg::forwarded_response_v2:
           {
             const auto forwarded_hdr_v2 =
@@ -412,8 +464,13 @@ namespace ccf
 
           case ForwardedMsg::forwarded_response_v1:
           {
-            ForwardedResponseResult rep;
-            if (forwarded_msg == ForwardedMsg::forwarded_response_v2)
+            std::optional<ForwardedResponseResult> rep;
+            if (forwarded_msg == ForwardedMsg::forwarded_response_v3)
+            {
+              rep = recv_forwarded_response<ForwardedResponseHeader_v3>(
+                from, data, size);
+            }
+            else if (forwarded_msg == ForwardedMsg::forwarded_response_v2)
             {
               rep =
                 recv_forwarded_response<ForwardedHeader_v2>(from, data, size);
@@ -430,13 +487,16 @@ namespace ccf
             }
 
             LOG_DEBUG_FMT(
-              "Sending forwarded response to RPC endpoint {}", rep->first);
+              "Sending forwarded response to RPC endpoint {}",
+              rep->client_session_id);
 
             auto rpc_responder_shared = rpcresponder.lock();
             if (
               rpc_responder_shared &&
               !rpc_responder_shared->reply_async(
-                rep->first, std::move(rep->second)))
+                rep->client_session_id,
+                rep->should_terminate_session,
+                std::move(rep->response_body)))
             {
               return;
             }

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -197,6 +197,39 @@ namespace ccf
       return true;
     }
 
+    bool check_session_consistency(std::shared_ptr<ccf::RpcContextImpl> ctx)
+    {
+      if (consensus != nullptr)
+      {
+        auto current_view = consensus->get_view();
+        auto session_ctx = ctx->get_session_context();
+        if (!session_ctx->active_view.has_value())
+        {
+          // First request on this session - assign the active term
+          session_ctx->active_view = current_view;
+        }
+        else if (current_view != session_ctx->active_view.value())
+        {
+          auto msg = fmt::format(
+            "Potential loss of session consistency on session {}. Started "
+            "in view {}, now in view {}. Closing session.",
+            session_ctx->client_session_id,
+            session_ctx->active_view.value(),
+            current_view);
+          LOG_INFO_FMT("{}", msg);
+
+          ctx->set_error(
+            HTTP_STATUS_INTERNAL_SERVER_ERROR,
+            ccf::errors::SessionConsistencyLost,
+            std::move(msg));
+          ctx->terminate_session = true;
+          return false;
+        }
+      }
+
+      return true;
+    }
+
     std::unique_ptr<AuthnIdentity> get_authenticated_identity(
       std::shared_ptr<ccf::RpcContextImpl> ctx,
       kv::CommittableTx& tx,
@@ -270,6 +303,13 @@ namespace ccf
           ccf::errors::RequestAlreadyForwarded,
           "RPC was already forwarded.");
         update_metrics(ctx);
+        return;
+      }
+
+      // Before attempting to forward, make sure we're in the same View as we
+      // previously thought we were.
+      if (!check_session_consistency(ctx))
+      {
         return;
       }
 
@@ -408,6 +448,13 @@ namespace ccf
           }
 
           endpoints.execute_endpoint(endpoint, args);
+
+          // If we've seen a View change, abandon this transaction as
+          // inconsistent
+          if (!check_session_consistency(ctx))
+          {
+            return;
+          }
 
           if (!ctx->should_apply_writes())
           {

--- a/src/node/rpc/rpc_context_impl.h
+++ b/src/node/rpc/rpc_context_impl.h
@@ -57,6 +57,7 @@ namespace ccf
     bool is_create_request = false;
     bool execute_on_node = false;
     bool response_is_pending = false;
+    bool terminate_session = false;
 
     virtual void set_tx_id(const ccf::TxID& tx_id) = 0;
     virtual bool should_apply_writes() const = 0;

--- a/src/quic/quic_session.h
+++ b/src/quic/quic_session.h
@@ -260,7 +260,7 @@ namespace quic
       msg->data.self->close_thread();
     }
 
-    void close()
+    void close_session() override
     {
       auto msg = std::make_unique<threading::Tmsg<EmptyMsg>>(&close_cb);
       msg->data.self = this->shared_from_this();

--- a/tests/e2e_tutorial.py
+++ b/tests/e2e_tutorial.py
@@ -3,6 +3,7 @@
 import infra.e2e_args
 import infra.network
 import infra.proc
+import infra.clients
 
 
 def run(args):
@@ -10,7 +11,7 @@ def run(args):
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
         for node in network.nodes:
-            node.curl = True
+            node.client_impl = infra.clients.CurlClient
         network.start_and_open(args)
         primary, _ = network.find_primary()
 

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -22,6 +22,9 @@ import base64
 import re
 from typing import Union, Optional, List, Any
 from ccf.tx_id import TxID
+import ssl
+import socket
+import urllib.parse
 
 import httpx
 from loguru import logger as LOG  # type: ignore
@@ -40,28 +43,37 @@ class HttpSig(httpx.Auth):
             pem_private_key, password=None, backend=default_backend()
         )
 
-    def auth_flow(self, request):
-        body_digest = base64.b64encode(hashlib.sha256(request.content).digest()).decode(
-            "ascii"
-        )
-        request.headers["digest"] = f"SHA-256={body_digest}"
+    @staticmethod
+    def add_signature_headers(headers, content, method, path, key_id, private_key):
+        body_digest = base64.b64encode(hashlib.sha256(content).digest()).decode("ascii")
+        headers["digest"] = f"SHA-256={body_digest}"
         string_to_sign = "\n".join(
             [
-                f"(request-target): {request.method.lower()} {request.url.raw_path.decode('utf-8')}",
+                f"(request-target): {method.lower()} {path}",
                 f"digest: SHA-256={body_digest}",
-                f"content-length: {len(request.content)}",
+                f"content-length: {len(content)}",
             ]
         ).encode("utf-8")
         digest_algo = {256: hashes.SHA256(), 384: hashes.SHA384()}[
-            self.private_key.curve.key_size
+            private_key.curve.key_size
         ]
-        signature = self.private_key.sign(
+        signature = private_key.sign(
             signature_algorithm=ec.ECDSA(algorithm=digest_algo), data=string_to_sign
         )
         b64signature = base64.b64encode(signature).decode("ascii")
-        request.headers[
+        headers[
             "authorization"
-        ] = f'Signature keyId="{self.key_id}",algorithm="hs2019",headers="(request-target) digest content-length",signature="{b64signature}"'
+        ] = f'Signature keyId="{key_id}",algorithm="hs2019",headers="(request-target) digest content-length",signature="{b64signature}"'
+
+    def auth_flow(self, request):
+        HttpSig.add_signature_headers(
+            request.headers,
+            request.content,
+            request.method,
+            request.url.raw_path.decode("utf-8"),
+            self.key_id,
+            self.private_key,
+        )
         yield request
 
 
@@ -262,6 +274,20 @@ class Response:
             headers=response.headers,
         )
 
+    @staticmethod
+    def from_socket(socket):
+        response = HTTPResponse(socket)
+        response.begin()
+        raw_body = response.read()
+        tx_id = TxID.from_str(response.getheader(CCF_TX_ID_HEADER))
+        return Response(
+            response.status,
+            body=RawResponseBody(raw_body),
+            seqno=tx_id.seqno,
+            view=tx_id.view,
+            headers=response.headers,
+        )
+
 
 def human_readable_size(n):
     suffixes = ("B", "KB", "MB", "GB")
@@ -350,7 +376,26 @@ class CurlClient:
         timeout: int = DEFAULT_REQUEST_TIMEOUT_SEC,
     ):
         with tempfile.NamedTemporaryFile() as nf:
+            if self.signing_auth:
+                cmd = ["scurl.sh"]
+            else:
+                cmd = ["curl"]
+
+            url = f"{self.protocol}://{self.hostname}{request.path}"
+
+            cmd += [url, "-X", request.http_verb, "-i", f"-m {timeout}"]
+
+            if request.allow_redirects:
+                cmd.append("-L")
+
+            headers = {}
+            if self.common_headers is not None:
+                headers.update(self.common_headers)
+
+            headers.update(request.headers)
+
             content_path = None
+
             if request.body is not None:
                 if isinstance(request.body, str) and request.body.startswith("@"):
                     # Request is already a file path - pass it directly
@@ -374,13 +419,14 @@ class CurlClient:
                     nf.write(msg_bytes)
                     nf.flush()
                     content_path = f"@{nf.name}"
-                if not "content-type" in request.headers and len(request.body) > 0:
-                    request.headers["content-type"] = content_type
+                if not "content-type" in headers and len(request.body) > 0:
+                    headers["content-type"] = content_type
 
             if self.signing_auth:
                 cmd = ["scurl.sh"]
             else:
                 cmd = ["curl"]
+
             if self.cose_signing_auth:
                 pre_cmd = ["ccf_cose_sign1"]
                 phdr = cose_protected_headers(request.path)
@@ -392,7 +438,7 @@ class CurlClient:
                 pre_cmd.extend(["--signing-key", self.cose_signing_auth.key])
                 pre_cmd.extend(["--signing-cert", self.cose_signing_auth.cert])
                 pre_cmd.extend(["--content", content_path.strip("@")])
-                request.headers["content-type"] = CONTENT_TYPE_COSE
+                headers["content-type"] = CONTENT_TYPE_COSE
 
             url = f"{self.protocol}://{self.hostname}{request.path}"
 
@@ -408,10 +454,7 @@ class CurlClient:
                     cmd.extend(["--data-binary", content_path])
 
             # Set requested headers first - so they take precedence over defaults
-            for k, v in request.headers.items():
-                cmd.extend(["-H", f"{k}: {v}"])
-
-            for k, v in self.common_headers.items():
+            for k, v in headers.items():
                 cmd.extend(["-H", f"{k}: {v}"])
 
             if self.ca:
@@ -585,7 +628,7 @@ class HttpxClient:
             raise CCFConnectionException from exc
         except Exception as exc:
             raise RuntimeError(
-                f"Request client failed with unexpected error: {exc}"
+                f"HttpxClient failed with unexpected error: {exc}"
             ) from exc
 
         return Response.from_requests_response(response)
@@ -602,6 +645,193 @@ class HttpxClient:
         #  connection: keep-alive
         #  user-agent: python-httpx/<version>
         return 5
+
+
+class RawSocketClient:
+    """
+    This client wraps a single SSL socket, and reports errors if the TCP or SSL layers fail.
+    """
+
+    def __init__(
+        self,
+        netloc: str,
+        ca: str,
+        session_auth: Optional[Identity] = None,
+        signing_auth: Optional[Identity] = None,
+        cose_signing_auth: Optional[Identity] = None,
+        common_headers: Optional[dict] = None,
+        **kwargs,
+    ):
+        self.ca = ca
+        self.session_auth = session_auth
+        self.common_headers = common_headers
+
+        if signing_auth:
+            with open(signing_auth.cert, encoding="utf-8") as cert_file:
+                key_id = (
+                    x509.load_pem_x509_certificate(
+                        cert_file.read().encode(), default_backend()
+                    )
+                    .fingerprint(hashes.SHA256())
+                    .hex()
+                )
+                private_key = load_pem_private_key(
+                    open(signing_auth.key, "rb").read(),
+                    password=None,
+                    backend=default_backend(),
+                )
+                self.signing_details = (key_id, private_key)
+        else:
+            self.signing_details = None
+
+        hostname, port = infra.interfaces.split_netloc(netloc)
+
+        self.socket = RawSocketClient._create_socket(
+            hostname,
+            port,
+            self.ca,
+            self.session_auth,
+        )
+
+    @staticmethod
+    def _create_socket(hostname, port, ca, session_auth):
+        end_time = time.time() + DEFAULT_CONNECTION_TIMEOUT_SEC
+        while True:
+            try:
+                context = ssl.create_default_context(cafile=ca)
+                if session_auth is not None:
+                    context.load_cert_chain(
+                        certfile=session_auth.cert,
+                        keyfile=session_auth.key,
+                    )
+
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                ssl_socket = context.wrap_socket(
+                    sock, server_side=False, server_hostname=hostname
+                )
+                ssl_socket.connect((hostname, port))
+                return ssl_socket
+            except (ssl.SSLEOFError, ConnectionResetError) as exc:
+                if time.time() > end_time:
+                    raise CCFConnectionException(
+                        "Timed out connecting to node"
+                    ) from exc
+                else:
+                    # If the initial connection fails (e.g. due to node certificate
+                    # not yet being endorsed by the network) sleep briefly and try again
+                    time.sleep(0.1)
+
+    @staticmethod
+    def _send_request(
+        ssl_socket,
+        verb,
+        path,
+        headers,
+        content,
+    ):
+        data = f"{verb} {path} HTTP/1.1\r\n".encode("ascii")
+        for k, v in headers.items():
+            data += f"{k}: {v}\r\n".encode("ascii")
+
+        data += b"\r\n"
+        if content is not None:
+            data += content
+
+        ssl_socket.sendall(data)
+
+    def request(
+        self,
+        request: Request,
+        timeout: int = DEFAULT_REQUEST_TIMEOUT_SEC,
+    ):
+        extra_headers = {}
+        if self.common_headers is not None:
+            extra_headers.update(self.common_headers)
+
+        extra_headers.update(request.headers)
+
+        request_body = None
+        content_length = 0
+        if request.body is not None:
+            if isinstance(request.body, str) and request.body.startswith("@"):
+                # Request is a file path - read contents
+                with open(request.body[1:], "rb") as f:
+                    request_body = f.read()
+                if request.body.lower().endswith(".json"):
+                    content_type = CONTENT_TYPE_JSON
+                else:
+                    content_type = CONTENT_TYPE_BINARY
+            elif isinstance(request.body, str):
+                request_body = request.body.encode()
+                content_type = CONTENT_TYPE_TEXT
+            elif isinstance(request.body, bytes):
+                request_body = request.body
+                content_type = CONTENT_TYPE_BINARY
+            else:
+                request_body = json.dumps(request.body).encode()
+                content_type = CONTENT_TYPE_JSON
+            content_length = len(request_body)
+
+            if not "content-type" in request.headers and len(request.body) > 0:
+                extra_headers["content-type"] = content_type
+
+        if not "content-length" in extra_headers:
+            extra_headers["content-length"] = content_length
+
+        if self.signing_details is not None:
+            HttpSig.add_signature_headers(
+                extra_headers,
+                request_body or b"",
+                request.http_verb,
+                request.path,
+                key_id=self.signing_details[0],
+                private_key=self.signing_details[1],
+            )
+
+        self.socket.settimeout(timeout)
+        RawSocketClient._send_request(
+            ssl_socket=self.socket,
+            verb=request.http_verb,
+            path=request.path,
+            headers=extra_headers,
+            content=request_body,
+        )
+
+        response = Response.from_socket(self.socket)
+        while response.status_code == 308 and request.allow_redirects:
+            assert (
+                self.signing_details is None
+            ), f"Received redirect response from {request.path}, but submitted signed request. Combination of signed requests and forwarding is currently unsupported"
+
+            # Create a temporary socket to follow this redirect
+            redirect_url = response.headers["location"]
+            LOG.trace(f"Following redirect to: {redirect_url}")
+            parsed = urllib.parse.urlparse(redirect_url)
+            with RawSocketClient._create_socket(
+                parsed.hostname,
+                parsed.port,
+                self.ca,
+                self.session_auth,
+            ) as redirect_socket:
+                redirect_socket.settimeout(timeout)
+                RawSocketClient._send_request(
+                    ssl_socket=redirect_socket,
+                    verb=request.http_verb,
+                    path=parsed.path,
+                    headers=extra_headers,
+                    content=request_body,
+                )
+                response = Response.from_socket(redirect_socket)
+
+        return response
+
+    def close(self):
+        self.socket.close()
+
+    @staticmethod
+    def extra_headers_count():
+        # This client always inserts a content-length header
+        return 1
 
 
 class CCFClient:
@@ -626,8 +856,12 @@ class CCFClient:
     A :py:exc:`CCFConnectionException` exception is raised if the connection is not established successfully within ``connection_timeout`` seconds.
     """
 
-    default_impl_type: Union[CurlClient, HttpxClient] = (
-        CurlClient if os.getenv("CURL_CLIENT") else HttpxClient
+    default_impl_type = (
+        CurlClient
+        if os.getenv("CURL_CLIENT")
+        else RawSocketClient
+        if os.getenv("SOCKET_CLIENT")
+        else HttpxClient
     )
 
     def __init__(
@@ -640,7 +874,7 @@ class CCFClient:
         cose_signing_auth: Optional[Identity] = None,
         connection_timeout: int = DEFAULT_CONNECTION_TIMEOUT_SEC,
         description: Optional[str] = None,
-        curl: bool = False,
+        impl_type: Union[CurlClient, HttpxClient, RawSocketClient] = default_impl_type,
         common_headers: Optional[dict] = None,
         **kwargs,
     ):
@@ -652,11 +886,6 @@ class CCFClient:
         self.auth = bool(session_auth)
         self.sign = bool(signing_auth)
         self.cose = bool(cose_signing_auth)
-
-        impl_type = CCFClient.default_impl_type
-
-        if curl:
-            impl_type = CurlClient
 
         self.client_impl = impl_type(
             self.hostname,

--- a/tests/infra/logging_app.py
+++ b/tests/infra/logging_app.py
@@ -107,9 +107,10 @@ class LoggingTxs:
         private_url=None,
     ):
         self.network = network
-        remote_node, _ = network.find_primary(log_capture=log_capture)
         if on_backup:
-            remote_node = network.find_any_backup()
+            remote_node = network.find_any_backup(log_capture=log_capture)
+        else:
+            remote_node, _ = network.find_primary(log_capture=log_capture)
 
         LOG.info(
             f"Applying {number_txs} logging txs to node {remote_node.local_node_id}"

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -996,6 +996,26 @@ class Network:
         backup = random.choice(backups)
         return primary, backup
 
+    def resize(self, target_count, args):
+        node_count = len(self.get_joined_nodes())
+        initial_node_count = node_count
+        LOG.info(f"Resizing network from {initial_node_count} to {target_count} nodes")
+        while node_count < target_count:
+            new_node = self.create_node("local://localhost")
+            self.join_node(new_node, args.package, args)
+            self.trust_node(new_node, args)
+            node_count += 1
+        while node_count > target_count:
+            primary, backup = self.find_primary_and_any_backup()
+            self.retire_node(primary, backup)
+            node_count -= 1
+        primary, _ = self.find_primary()
+        self.wait_for_all_nodes_to_commit(primary)
+        LOG.success(
+            f"Resized network from {initial_node_count} to {target_count} nodes"
+        )
+        return initial_node_count
+
     def wait_for_all_nodes_to_commit(self, primary=None, tx_id=None, timeout=10):
         """
         Wait for all nodes to have joined the network and committed all transactions

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -109,9 +109,6 @@ def version_after(version, cmp_version):
 
 
 class Node:
-    # Default to using httpx
-    curl = False
-
     def __init__(
         self,
         local_node_id,
@@ -605,6 +602,7 @@ class Node:
         cose_signing_identity=None,
         interface_name=infra.interfaces.PRIMARY_RPC_INTERFACE,
         verify_ca=True,
+        description_suffix=None,
         **kwargs,
     ):
         if self.network_state == NodeNetworkState.stopped:
@@ -631,16 +629,25 @@ class Node:
         if rpc_interface.app_protocol == infra.interfaces.AppProtocol.HTTP2:
             akwargs["http1"] = False
             akwargs["http2"] = True
+
         akwargs.update(self.session_auth(identity))
         akwargs.update(self.signing_auth(signing_identity))
         akwargs.update(self.cose_signing_auth(cose_signing_identity))
-        akwargs[
-            "description"
-        ] = f"[{self.local_node_id}|{identity or ''}|{signing_identity or ''}|{cose_signing_identity or ''}]"
+
+        description = f"{self.local_node_id}"
+        if identity is not None:
+            description += f"|tls={identity}"
+        if signing_identity is not None:
+            description += f"|sig={signing_identity}"
+        if cose_signing_identity is not None:
+            description += f"|cose={cose_signing_identity}"
+        if description_suffix is not None:
+            description += f"|{description_suffix}"
+        akwargs["description"] = f"[{description}]"
         akwargs.update(kwargs)
 
-        if self.curl:
-            akwargs["curl"] = True
+        if hasattr(self, "client_impl"):
+            akwargs["impl_type"] = self.client_impl
 
         return infra.clients.client(
             rpc_interface.public_host, rpc_interface.public_port, **akwargs
@@ -767,19 +774,19 @@ class Node:
                 f"Unable to retrieve entry at TxID {view}.{seqno} on node {node.local_node_id} after {timeout}s"
             )
 
-    def wait_for_leadership_state(self, min_view, leadership_state, timeout=3):
+    def wait_for_leadership_state(self, min_view, leadership_states, timeout=3):
         end_time = time.time() + timeout
         while time.time() < end_time:
             with self.client() as c:
                 r = c.get("/node/consensus").body.json()["details"]
                 if (
                     r["current_view"] > min_view
-                    and r["leadership_state"] == leadership_state
+                    and r["leadership_state"] in leadership_states
                 ):
                     return
             time.sleep(0.1)
         raise TimeoutError(
-            f"Node {self.local_node_id} was not in leadership state {leadership_state} in view > {min_view} after {timeout}s: {r}"
+            f"Node {self.local_node_id} was not in leadership states {leadership_states} in view > {min_view} after {timeout}s: {r}"
         )
 
 

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -45,8 +45,12 @@ def issue_activity_on_live_service(network, args):
     network.txs.issue(
         network, number_txs=args.snapshot_tx_interval * 2, log_capture=log_capture
     )
+
     # At least one transaction that will require historical fetching
     network.txs.issue(network, number_txs=1, repeat=True)
+
+    # At least one transaction that will require forwarding
+    network.txs.issue(network, number_txs=1, on_backup=True)
 
 
 def get_new_constitution_for_install(args, install_path):

--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -195,7 +195,7 @@ def test_isolate_and_reconnect_primary(network, args, **kwargs):
         # The isolated primary will stay in follower state once Pre-Vote
         # is implemented. https://github.com/microsoft/CCF/issues/2577
         primary.wait_for_leadership_state(
-            primary_view, "Candidate", timeout=2 * args.election_timeout_ms / 1000
+            primary_view, ["Candidate"], timeout=2 * args.election_timeout_ms / 1000
         )
 
     # Check reconnected former primary has caught up
@@ -472,7 +472,7 @@ def test_forwarding_timeout(network, args):
 
             network.wait_for_new_primary(primary, nodes=backups)
 
-            # This may need a new client after https://github.com/microsoft/CCF/issues/3952
+        with backup.client("user0") as c:
             r = c.get(f"/app/log/private?id={key}")
             assert r.status_code == http.HTTPStatus.OK, r
             assert r.body.json()["msg"] == val_a, r
@@ -565,6 +565,9 @@ if __name__ == "__main__":
     args = infra.e2e_args.cli_args(add)
     args.nodes = infra.e2e_args.min_nodes(args, f=1)
     args.package = "samples/apps/logging/liblogging"
+    args.snapshot_tx_interval = (
+        20  # Increase snapshot frequency for faster reconfigurations
+    )
 
     run(args)
     run_2tx_reconfig_tests(args)


### PR DESCRIPTION
Manual cherry-pick backport of #4595.

NB: This is still just the parsing component, and needs a follow-up PR (on `main` and `release/3.x`) which actually enables the behaviour.