### PR TITLE
[release/3.x] Cherry pick: Fix containers and PyPi release workflows (#4607)

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -37,4 +37,4 @@ jobs:
         run: docker login -u $ACR_TOKEN_NAME -p ${{ secrets.ACR_APP_PUSH_TOKEN_PASSWORD }} $ACR_REGISTRY
 
       - name: Push App container
-        run: docker push $ACR_REGISTRY/public/ccf/app/${{ matrix.type }}:${{steps.tref.outputs.tag}}-${{ matrix.platform }}
+        run: docker push $ACR_REGISTRY/public/ccf/app/${{ matrix.type }}${{ matrix.run_js && '-js' || '' }}:${{ steps.tref.outputs.tag }}-${{ matrix.platform }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -20,9 +20,8 @@ jobs:
       - name: Fetch PyPi Package from release
         run: |
           cd python
-          VERSION=${{steps.tref.outputs.version}}
-          PYPY_VERSION=${VERSION//-}
-          wget https://github.com/microsoft/CCF/releases/download/ccf-${VERSION}/ccf-${PYPY_VERSION}-py3-none-any.whl
+          RELEASE_WHEEL_URL=$(curl -s  https://api.github.com/repos/microsoft/ccf/releases/tags/ccf-${{steps.tref.outputs.version}} | jq -r '.assets[] | select(.name|test("ccf-.*.whl")) | .browser_download_url')
+          wget ${RELEASE_WHEEL_URL}
 
       - name: Publish PyPi Package to https://pypi.org/project/ccf/
         run: |

--- a/getting_started/setup_vm/roles/ccf_install/tasks/deb_install.yml
+++ b/getting_started/setup_vm/roles/ccf_install/tasks/deb_install.yml
@@ -51,8 +51,8 @@
 
 - name: Copy JS generic (SNP)
   copy:
-    src: "/opt/ccf_{{ platform }}/lib/{{ ccf_js_app_name }}.virtual.so"
-    dest: "/usr/lib/ccf/{{ ccf_js_app_name }}.virtual.so"
+    src: "/opt/ccf_{{ platform }}/lib/{{ ccf_js_app_name }}.snp.so"
+    dest: "/usr/lib/ccf/{{ ccf_js_app_name }}.snp.so"
     remote_src: true
   become: true
   when: (run_js|bool) and (platform == "snp")


### PR DESCRIPTION
Backports the following commits to `release/3.x`:
 - [Fix containers and PyPi release workflows (#4607)](https://github.com/microsoft/CCF/pull/4607)