### PR TITLE
Point to TLA+ documentation that doesn't confuse learners with PlusCal.

### DIFF
--- a/doc/architecture/raft_tla.rst
+++ b/doc/architecture/raft_tla.rst
@@ -16,7 +16,7 @@ CCF implements various modifications to Raft as it was originally proposed by On
 
 The TLA+ specification models the intended behavior of Raft as it is modified for CCF. Below, we explain several core parts of the specification in more detail.
 
-You can find the full specification in the :ccf_repo:`tla/` directory and more information on TLA+ `here <http://lamport.azurewebsites.net/tla/tla.html>`_. Several good resources exist online, one good example is `this guide <https://www.learntla.com>`_.
+You can find the full specification in the :ccf_repo:`tla/` directory and more information on TLA+ `here <http://lamport.azurewebsites.net/tla/tla.html>`_. Several good resources exist online, one good example is Lamport's `Specifying Systems <https://lamport.azurewebsites.net/tla/book.html>`_.
 
 Running the model checker
 -------------------------


### PR DESCRIPTION
The CCF spec is pure TLA+.  Thus, no need to see or learn PlusCal.