### PR TITLE
Add a UBSan suppression for QCBOR.

### DIFF
--- a/src/ubsan.suppressions
+++ b/src/ubsan.suppressions
@@ -10,4 +10,7 @@ src:*/3rdparty/exported/quickjs/quickjs.h
 src:*/3rdparty/exported/quickjs/cutils.c
 src:*/3rdparty/exported/quickjs/cutils.h
 
+# https://github.com/laurencelundblade/QCBOR/issues/164
+fun:UsefulOutBuf_InsertUsefulBuf
+
 #############################################################################


### PR DESCRIPTION
QCBOR has a bug which can cause memmove to be called with a NULL source argument (and zero size), which is technically undefined behaviour and triggers a UBSan violation.

This bug cannot be reached by CCF's use of QCBOR (it mostly occurs when encoding messages, which CCF doesn't do), but it affects downstream application which use QCBOR themselves and are forced to use the copy of the library provided by CCF.

https://github.com/laurencelundblade/QCBOR/issues/164