### PR TITLE
Allow sgx and virtual builds to be installed side-by-side using Ansible.

### DIFF
--- a/getting_started/setup_vm/app-dev.yml
+++ b/getting_started/setup_vm/app-dev.yml
@@ -14,14 +14,21 @@
     - import_role:
         name: az_dcap
         tasks_from: install.yml
+
+    # If OE is already installed, we don't want to install hostverify as they are mutually
+    # exclusive. Non-SGX CCF builds can use either of them.
+    - name: Gather the package facts
+      ansible.builtin.package_facts:
+        manager: auto
     - import_role:
         name: openenclave
         tasks_from: binary_install.yml
-      when: platform == "sgx"
+      when: (platform == "sgx") or ("open-enclave" in ansible_facts.packages)
     - import_role:
         name: openenclave
         tasks_from: install_host_verify.yml
-      when: platform != "sgx"
+      when: (platform != "sgx") and ("open-enclave" not in ansible_facts.packages)
+
     - import_role:
         name: ccf_build
         tasks_from: install.yml

--- a/getting_started/setup_vm/roles/openenclave/tasks/binary_install.yml
+++ b/getting_started/setup_vm/roles/openenclave/tasks/binary_install.yml
@@ -1,6 +1,12 @@
 - name: Include vars
   include_vars: common.yml
 
+- name: Uninstall Open Enclave Host Verify
+  apt:
+    name: open-enclave-hostverify
+    state: absent
+  become: yes
+
 - name: Install Open Enclave
   apt:
     deb: "{{ oe_deb }}"


### PR DESCRIPTION
The Ansible playbook for SGX tries to install the open-enclave package, whereas on Virtual builds it installs hostverify. Since these two are mutually exclusive, they cannot be run on the same machine.

This changes the playbook to install hostverify only if OE is not already installed. This allows the virtual build to be installed even after the SGX one has been.

We also uninstall hostverify when trying to install OE, as this allows the SGX build after the virtual one.

Unfortunately, it is still vital to install the SGX build first, then the virtual one. When running the playbooks in the reverse order, removing hostverify also removes ccf_virtual.