### PR TITLE
Use pull_request_target trigger to allow access to secret on fork PR's

### DIFF
--- a/.github/workflows/build-ci-container.yml
+++ b/.github/workflows/build-ci-container.yml
@@ -1,7 +1,7 @@
 name: "Build SNP CI Testing CCF Container"
 
 on:
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
My understanding is we require permission for workflows to run from fork PR's from outside contributors, so it should be safe to allow those PRs to access secrets (in this case, the ACR tokens password) 