### PR TITLE
Remove the line to add PRs

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -5,9 +5,6 @@ on:
   issues:
     types:
       - opened
-  pull_request:
-    types:
-      - opened
 
 jobs:
   add-to-project:


### PR DESCRIPTION
Removing the line to automatically add PRs to the project board. Eddy found out that this seems to be a known issue (https://github.com/actions/add-to-project/issues/93) and because the PRs are from forks, dependabot can't read `secrets`. Not a high priority to add PRs automatically so removing this line.