### PR TITLE
Restore SIG_IGN handler

### DIFF
--- a/doc/operations/troubleshooting.rst
+++ b/doc/operations/troubleshooting.rst
@@ -123,3 +123,15 @@ This may occur on SGX deployments where the ``SGX_AESM_ADDR`` environment variab
 While CCF supports out-of-process attestation, the AESM service is not installed as part of the CCF dependencies. For local deployments, it is expected that operators use in-process quote generation.
 
 **Resolution:** Unset the ``SGX_AESM_ADDR`` environment variable: ``$ unset SGX_AESM_ADDR``.
+
+Info Messages
+-------------
+
+``Ignoring signal: 13``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Signal 13 (`SIGPIPE`) is emitted on writes to closed fds. It is superfluous in programs that handle write errors, such as CCF, and is therefore ignored. This message does not indicate a malfunction.
+
+Most CCF releases set the `SIG_IGN` handler, but a bug introduced in Open Enclave `0.18.0 <https://github.com/openenclave/openenclave/releases/tag/v0.18.0>` caused the process to crash rather than ignore the signal. CCF installed an alternative handler as a workaround in `2.0.2 <https://github.com/microsoft/CCF/releases/tag/ccf-2.0.2>`_ , which produces this log line.
+
+The issue was fixed upstream in Open Enclave `0.18.1 <https://github.com/openenclave/openenclave/releases/tag/v0.18.1>`_ (see `#4542 <https://github.com/openenclave/openenclave/issues/4542>`_). This log line is now redundant and will be removed from later releases.

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -51,7 +51,6 @@ void print_version(size_t)
   exit(0);
 }
 
-
 int main(int argc, char** argv)
 {
   // ignore SIGPIPE

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -51,20 +51,11 @@ void print_version(size_t)
   exit(0);
 }
 
-static void _signal_handler(int sig_num)
-{
-  LOG_INFO_FMT("Ignoring signal: {}", sig_num);
-}
 
 int main(int argc, char** argv)
 {
   // ignore SIGPIPE
-  {
-    // Avoiding use of SIG_IGN due to OE issue:
-    // https://github.com/openenclave/openenclave/issues/4542
-    signal(SIGPIPE, _signal_handler);
-  }
-
+  signal(SIGPIPE, SIG_IGN);
   CLI::App app{"ccf"};
 
   std::string config_file_path = "config.json";


### PR DESCRIPTION
Explain info message we've logged from 2.0.2 until now, and restore SIG_IGN.