### PR TITLE
Merge changelog entries for 4.0.0 dev1 and 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- The [ccf Python package](https://pypi.org/project/ccf/) now includes `ccf_cose_sign1_prepare` and `ccf_cose_sign1_finish` CLI tools, to faciliate the creation of [COSE Sign1](https://www.rfc-editor.org/rfc/rfc8152#page-18) requests for governance purposes, signed with external key management systems such as AKV. See [documentation](https://microsoft.github.io/CCF/main/governance/hsm_keys.html#cose-signing) for details.
-
-## [4.0.0-dev1]
-
-[4.0.0-dev1]: https://github.com/microsoft/CCF/releases/tag/ccf-4.0.0-dev1
-
-### Added
-
-- The [ccf Python package](https://pypi.org/project/ccf/) now includes a `ccf_cose_sign1` CLI tool, to facilitate the creation of [COSE Sign1](https://www.rfc-editor.org/rfc/rfc8152#page-18) requests for governance purposes.
+- The [ccf Python package](https://pypi.org/project/ccf/) now includes a `ccf_cose_sign1` CLI tool, to facilitate the creation of [COSE Sign1](https://www.rfc-editor.org/rfc/rfc8152#page-18) requests for governance purposes. It also includes `ccf_cose_sign1_prepare` and `ccf_cose_sign1_finish` CLI tools, to facilitate the creation of [COSE Sign1](https://www.rfc-editor.org/rfc/rfc8152#page-18) requests for governance purposes, signed with external key management systems such as AKV. See [documentation](https://microsoft.github.io/CCF/main/governance/hsm_keys.html#cose-signing) for details.
 - Builtin governance tables now have endpoints for accessing their content directly from the KV, under `/gov/kv`. For instance, `/gov/kv/constitution` will read the current constitution.
 
 ### Fixed


### PR DESCRIPTION
I made a mistake and assumed dev1 had already been released, when it hadn't. As a result, dev0 was followed directly by dev2, this adjusts the changelog to reflect that.