### PR TITLE
[release/3.x] Cherry pick: Enable `TCP_NODELAY` for all TCP connections (#4717)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Access to restricted KV tables (eg - private or non-governance reads during governance, or governance writes during application execution) produce more descriptive errors. The documentation has been extended to describe these restrictions. (#4686)
+- `TCP_NODELAY` is now set for all incoming and outgoing TCP connections (#4717).
 
 ## [3.0.1]
 

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -381,6 +381,12 @@ namespace asynchost
         return false;
       }
 
+      if ((rc = uv_tcp_nodelay(&uv_handle, true)) < 0)
+      {
+        LOG_FAIL_FMT("uv_tcp_nodelay failed: {}", uv_strerror(rc));
+        return false;
+      }
+
       if (is_client)
       {
         uv_os_sock_t sock;


### PR DESCRIPTION
Backports the following commits to `release/3.x`:
 - [Enable `TCP_NODELAY` for all TCP connections (#4717)](https://github.com/microsoft/CCF/pull/4717)