### PR TITLE
[release/3.x] Cherry pick: Remove unintended time checks from node-to-node validation (#4733)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.3]
+
+[3.0.3]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.3
+
+### Fixed
+
+- Node-to-node channels no longer check certificate expiry times. This previously caused "Peer certificate verification failed" error messages when node or service certs expired. (#4733)
+
 ## [3.0.2]
 
 [3.0.2]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.2

--- a/include/ccf/crypto/verifier.h
+++ b/include/ccf/crypto/verifier.h
@@ -189,7 +189,7 @@ namespace crypto
      * @param chain Vector of ordered untrusted certificates used to
      *  build a chain to trusted certificates
      * @param ignore_time Flag to disable certificate expiry checks
-     * @return true if the verification is successfull
+     * @return true if the verification is successful
      */
     virtual bool verify_certificate(
       const std::vector<const Pem*>& trusted_certs,

--- a/src/kv/test/kv_snapshot.cpp
+++ b/src/kv/test/kv_snapshot.cpp
@@ -181,7 +181,7 @@ TEST_CASE("Old snapshots" * doctest::test_suite("snapshot"))
       "YXoiAAAACAAAAAAAAAD+/////////"
       "wUAAAAAAAAAImZvbyIAAAANAAAAAAAAAAEAAAAAAAAAImJhciIAAAA=";
   }
-  else SUBCASE("True deletions")
+  SUBCASE("True deletions")
   {
     raw_snapshot_b64 =
       "AQC4AAAAAACwAAAAAAAAAAECAAAAAAAAAAAAAAAAAAAADgAAAAAAAABwdWJsaWM6bnVtX21h"

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -734,7 +734,11 @@ namespace ccf
         cert = crypto::Pem(pc);
         verifier = crypto::make_verifier(cert);
 
-        if (!verifier->verify_certificate({&service_cert}))
+        // 'true' is `ignore_time` => These node-to-node channels do not care
+        // about certificate times, and should still pass even when given
+        // expired certs
+        if (!verifier->verify_certificate(
+              {&service_cert}, {}, true /* no validity expiration check */))
         {
           return false;
         }

--- a/src/node/test/channels.cpp
+++ b/src/node/test/channels.cpp
@@ -57,35 +57,47 @@ static NodeId nid2 = std::string("nid2");
 
 static constexpr auto default_curve = crypto::CurveID::SECP384R1;
 
-static crypto::Pem generate_self_signed_cert(
-  const crypto::KeyPairPtr& kp, const std::string& name)
+static std::pair<std::string, size_t> make_validity_pair(bool expired)
 {
-  constexpr size_t certificate_validity_period_days = 365;
   using namespace std::literals;
-  auto valid_from =
-    ds::to_x509_time_string(std::chrono::system_clock::now() - 24h);
+  const auto now = std::chrono::system_clock::now();
+  constexpr size_t validity_days = 365;
+  if (expired)
+  {
+    return std::make_pair(
+      ds::to_x509_time_string(now - std::chrono::days(2 * validity_days)),
+      validity_days);
+  }
+  else
+  {
+    return std::make_pair(ds::to_x509_time_string(now - 24h), validity_days);
+  }
+}
+
+static crypto::Pem generate_self_signed_cert(
+  const crypto::KeyPairPtr& kp, const std::string& name, bool expired = false)
+{
+  const auto [valid_from, validity_days] = make_validity_pair(expired);
 
   return crypto::create_self_signed_cert(
-    kp, name, {}, valid_from, certificate_validity_period_days);
+    kp, name, {}, valid_from, validity_days);
 }
 
 static crypto::Pem generate_endorsed_cert(
   const crypto::KeyPairPtr& kp,
   const std::string& name,
   const crypto::KeyPairPtr& issuer_kp,
-  const crypto::Pem& issuer_cert)
+  const crypto::Pem& issuer_cert,
+  bool expired = false)
 {
-  constexpr size_t certificate_validity_period_days = 365;
-  using namespace std::literals;
-  auto valid_from =
-    ds::to_x509_time_string(std::chrono::system_clock::now() - 24h);
+  const auto [valid_from, validity_days] = make_validity_pair(expired);
 
   return crypto::create_endorsed_cert(
     kp,
     name,
     {},
     valid_from,
-    certificate_validity_period_days,
+    validity_days,
     issuer_kp->private_key_pem(),
     issuer_cert);
 }
@@ -1006,6 +1018,65 @@ TEST_CASE("Interrupted key exchange")
   }
 }
 
+TEST_CASE("Expired certs")
+{
+  auto network_kp = crypto::make_key_pair(default_curve);
+  auto channel1_kp = crypto::make_key_pair(default_curve);
+  auto channel2_kp = crypto::make_key_pair(default_curve);
+
+  auto service_cert = generate_self_signed_cert(network_kp, "CN=MyNetwork");
+  auto channel1_cert =
+    generate_endorsed_cert(channel1_kp, "CN=Node1", network_kp, service_cert);
+  auto channel2_cert =
+    generate_endorsed_cert(channel2_kp, "CN=Node2", network_kp, service_cert);
+
+  SUBCASE("Expired service cert")
+  {
+    service_cert = generate_self_signed_cert(network_kp, "CN=MyNetwork", true);
+  }
+  SUBCASE("Expired sender cert")
+  {
+    channel1_cert = generate_endorsed_cert(
+      channel1_kp,
+      "CN=Node1",
+      network_kp,
+      service_cert,
+      // Generate expired cert
+      true);
+  }
+  SUBCASE("Expired receiver cert")
+  {
+    channel2_cert = generate_endorsed_cert(
+      channel2_kp,
+      "CN=Node2",
+      network_kp,
+      service_cert,
+      // Generate expired cert
+      true);
+  }
+
+  auto channels1 = NodeToNodeChannelManager(wf1);
+  channels1.initialize(nid1, service_cert, channel1_kp, channel1_cert);
+
+  auto channels2 = NodeToNodeChannelManager(wf2);
+  channels2.initialize(nid2, service_cert, channel2_kp, channel2_cert);
+
+  std::vector<uint8_t> payload;
+  payload.push_back(0x1);
+  payload.push_back(0x0);
+  payload.push_back(0x10);
+  payload.push_back(0x42);
+
+  channels1.send_authenticated(
+    nid2, NodeMsgType::consensus_msg, payload.data(), payload.size());
+
+  auto msgs = read_outbound_msgs<MsgType>(eio1);
+  for (const auto& msg : msgs)
+  {
+    REQUIRE(channels2.recv_channel_message(nid1, msg.data()));
+  }
+}
+
 TEST_CASE("Robust key exchange")
 {
   auto network_kp = crypto::make_key_pair(default_curve);
@@ -1234,46 +1305,4 @@ TEST_CASE("Robust key exchange")
     REQUIRE(channels2.send_encrypted(
       nid1, NodeMsgType::consensus_msg, {aad.data(), aad.size()}, payload));
   }
-}
-
-TEST_CASE("Mismatched certs")
-{
-  logger::config::level() = logger::Level::TRACE;
-  logger::config::default_init();
-  auto network1_kp = crypto::make_key_pair(default_curve);
-  auto service1_cert = generate_self_signed_cert(network1_kp, "CN=MyNetwork");
-
-  auto channel1_kp = crypto::make_key_pair(default_curve);
-  auto channel1_cert =
-    generate_endorsed_cert(channel1_kp, "CN=Node1", network1_kp, service1_cert);
-
-  auto channels1 = NodeToNodeChannelManager(wf1);
-  channels1.initialize(nid1, service1_cert, channel1_kp, channel1_cert);
-
-  auto network2_kp = crypto::make_key_pair(default_curve);
-  auto service2_cert = generate_self_signed_cert(network2_kp, "CN=MyNetwork");
-
-  auto channel2_kp = crypto::make_key_pair(default_curve);
-  auto channel2_cert =
-    generate_endorsed_cert(channel2_kp, "CN=Node2", network2_kp, service2_cert);
-
-  auto channels2 = NodeToNodeChannelManager(wf2);
-  channels2.initialize(nid2, service2_cert, channel2_kp, channel2_cert);
-
-  std::vector<uint8_t> payload;
-  payload.push_back(0x1);
-  payload.push_back(0x0);
-  payload.push_back(0x10);
-  payload.push_back(0x42);
-
-  channels1.send_authenticated(
-    nid2, NodeMsgType::consensus_msg, payload.data(), payload.size());
-
-  auto msgs = read_outbound_msgs<MsgType>(eio1);
-  for (const auto& msg : msgs)
-  {
-    REQUIRE_FALSE(channels2.recv_channel_message(nid1, msg.data()));
-  }
-
-  logger::config::loggers().clear();
 }

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -1076,7 +1076,7 @@ class CCFClient:
         A ``TimeoutError`` exception is raised if the transaction is not committed within ``timeout`` seconds.
         """
         if response.seqno is None or response.view is None:
-            raise ValueError("Response seqno and view should not be None")
+            raise ValueError(f"Response seqno and view should not be None: {response}")
 
         infra.commit.wait_for_commit(self, response.seqno, response.view, timeout)
 

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -146,6 +146,7 @@ class Node:
         self.certificate_validity_days = None
         self.initial_node_data_json_file = node_data_json_file
         self.label = None
+        self.verify_ca_by_default = True
 
         if os.getenv("CONTAINER_NODES"):
             self.remote_shim = infra.remote_shim.DockerShim
@@ -586,7 +587,10 @@ class Node:
                 self_signed_cert_file.write(new_self_signed_cert)
             return new_self_signed_cert
 
-    def session_ca(self, self_signed=False, verify_ca=True):
+    def session_ca(self, self_signed=False, verify_ca=None):
+        if verify_ca is None:
+            verify_ca = self.verify_ca_by_default
+
         if not verify_ca:
             return {"ca": None}
 
@@ -601,7 +605,7 @@ class Node:
         signing_identity=None,
         cose_signing_identity=None,
         interface_name=infra.interfaces.PRIMARY_RPC_INTERFACE,
-        verify_ca=True,
+        verify_ca=None,
         description_suffix=None,
         **kwargs,
     ):

--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -8,6 +8,7 @@ import infra.e2e_args
 import infra.partitions
 import infra.logging_app as app
 import suite.test_requirements as reqs
+from datetime import datetime, timedelta
 from infra.checker import check_can_progress, check_does_not_progress
 import pprint
 from infra.tx_status import TxStatus
@@ -19,7 +20,6 @@ import ccf.ledger
 from loguru import logger as LOG
 
 from math import ceil
-from datetime import datetime
 
 
 @reqs.description("Invalid partitions are not allowed")
@@ -274,6 +274,89 @@ def test_new_joiner_helps_liveness(network, args):
         network.wait_for_primary_unanimity()
         primary, _ = network.find_nodes()
         network.wait_for_all_nodes_to_commit(primary=primary)
+
+
+@reqs.description("Test node-to-node channel behaviour once certs have expired")
+@reqs.exactly_n_nodes(3)
+def test_expired_certs(network, args):
+    primary, (backup_a, backup_b) = network.find_nodes()
+
+    def set_certs(from_days_diff, validity_period_days, nodes):
+        valid_from = str(
+            infra.crypto.datetime_to_X509time(
+                datetime.utcnow() + timedelta(days=from_days_diff)
+            )
+        )
+        for node in nodes:
+            network.consortium.set_node_certificate_validity(
+                primary,
+                node,
+                valid_from=valid_from,
+                validity_period_days=validity_period_days,
+            )
+            node.set_certificate_validity_period(
+                valid_from,
+                validity_period_days,
+            )
+            # Wait for this node to receive this updated cert, and start advertising it
+            timeout = 2
+            end_time = time.time() + timeout
+            while True:
+                try:
+                    node.verify_certificate_validity_period()
+                    LOG.info("Successfully updated cert")
+                    break
+                except ValueError as ve:
+                    LOG.warning(f"Cert is still old value: {ve}")
+                    assert (
+                        time.time() < end_time
+                    ), f"Cert has not been updated after {timeout}s"
+                    time.sleep(0.2)
+
+    # Expired cert is only an issue on channel creation.
+    # Force channel creation by partitioning to cause controlled election.
+    with contextlib.ExitStack() as stack:
+        # Partition backup_b from others
+        with network.partitioner.partition([backup_b]):
+            # Advance state, committed by presence on primary and backup_a
+            with primary.client("user0") as c:
+                r = c.post("/app/log/private", {"id": 42, "msg": "hello world"})
+                assert r.status_code == http.HTTPStatus.OK, r
+                c.wait_for_commit(r)
+
+            # Expire the certs of primary and backup_a - these are the only viable
+            # candidates due to the newly committed suffix
+            # NB: Once we start doing this, speaking to these nodes is tricky, because
+            # client auth will also fail => disable ca verification
+            primary.verify_ca_by_default = False
+            backup_a.verify_ca_by_default = False
+            set_certs(
+                from_days_diff=-30, validity_period_days=7, nodes=(primary, backup_a)
+            )
+
+            # Partition primary, so that backup_a is only viable candidate, and must try
+            # to create channels to backup_b
+            stack.enter_context(network.partitioner.partition([primary]))
+
+        # Restore connectivity between backups and wait for election
+        network.wait_for_primary_unanimity(
+            nodes=[backup_a, backup_b], min_view=r.view + 1
+        )
+
+        # Should now be able to make progress
+        check_can_progress(backup_a)
+
+    # Restore connectivity with primary
+    network.wait_for_primary_unanimity(min_view=r.view + 1)
+
+    # Set valid node certs so that future clients can speak to these nodes
+    set_certs(from_days_diff=-1, validity_period_days=7, nodes=(primary, backup_a))
+
+    # Can now speak to these again
+    primary.verify_ca_by_default = True
+    backup_a.verify_ca_by_default = True
+
+    return network
 
 
 @reqs.description("Test election while reconfiguration is in flight")
@@ -750,6 +833,7 @@ def run(args):
         test_partition_majority(network, args)
         test_isolate_primary_from_one_backup(network, args)
         test_new_joiner_helps_liveness(network, args)
+        test_expired_certs(network, args)
         for n in range(5):
             test_isolate_and_reconnect_primary(network, args, iteration=n)
         test_election_reconfiguration(network, args)


### PR DESCRIPTION
Backports the following commits to `release/3.x`:
 - [Remove unintended time checks from node-to-node validation (#4733)](https://github.com/microsoft/CCF/pull/4733)