### PR TITLE
Update minimum view on partition test

### DIFF
--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -340,7 +340,7 @@ def test_expired_certs(network, args):
 
         # Restore connectivity between backups and wait for election
         network.wait_for_primary_unanimity(
-            nodes=[backup_a, backup_b], min_view=r.view + 1, timeout_multiplier=5
+            nodes=[backup_a, backup_b], min_view=r.view, timeout_multiplier=5
         )
 
         # Should now be able to make progress

--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -340,7 +340,7 @@ def test_expired_certs(network, args):
 
         # Restore connectivity between backups and wait for election
         network.wait_for_primary_unanimity(
-            nodes=[backup_a, backup_b], min_view=r.view + 1
+            nodes=[backup_a, backup_b], min_view=r.view + 1, timeout_multiplier=5
         )
 
         # Should now be able to make progress

--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -340,7 +340,7 @@ def test_expired_certs(network, args):
 
         # Restore connectivity between backups and wait for election
         network.wait_for_primary_unanimity(
-            nodes=[backup_a, backup_b], min_view=r.view, timeout_multiplier=5
+            nodes=[backup_a, backup_b], min_view=r.view
         )
 
         # Should now be able to make progress


### PR DESCRIPTION
Failures seem to take place, but post-failure diagnostics show nodes agreeing about the primary post-failure.

Edit: this is not because the timeout choice was unlucky, but because the view boundary was too strong: the comparison is strict.