### PR TITLE
Fix PyPi pipeline

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -3,6 +3,9 @@ name: "Build and Publish PyPi package"
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - "fix_pypi_pipeline"
 
 jobs:
   build_and_publish:
@@ -14,7 +17,7 @@ jobs:
 
       - name: Get release number from git tag (release) or latest (branch)
         run: |
-          echo "version=${GITHUB_REF#refs/tags/ccf-}" >> $GITHUB_OUTPUT
+          echo "version=4.0.0-dev2" >> $GITHUB_OUTPUT
         id: tref
 
       - name: Fetch PyPi Package from release

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           set -ex
           cd python
-          python3.8 -m venv env
+          python3 -m venv env
           source ./env/bin/activate
           pip install -r requirements.txt
           pip install twine


### PR DESCRIPTION
Raised by https://github.com/microsoft/LSKV/pull/201#issuecomment-1351547412 

The PyPi release pipeline seems to be broken because the executors seems to now run a Ubuntu 22.04 image that no longer has Python 3.8. 