### PR TITLE
Add pull_request_target to GH project

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -5,6 +5,9 @@ on:
   issues:
     types:
       - opened
+  pull_request_target:
+    types:
+      - opened
 
 jobs:
   add-to-project:


### PR DESCRIPTION
Add pull_request_target to GH project to allow fork PR access to secrets and automatically get added to the board.