### PR TITLE
Add `h2spec` to CI Docker image

### DIFF
--- a/getting_started/setup_vm/ccf-dev.yml
+++ b/getting_started/setup_vm/ccf-dev.yml
@@ -31,6 +31,9 @@
         name: pebble
         tasks_from: install.yml
     - import_role:
+        name: h2spec
+        tasks_from: install.yml
+    - import_role:
         name: ccf_run
         tasks_from: install.yml
     - import_role:

--- a/getting_started/setup_vm/roles/h2spec/tasks/install.yml
+++ b/getting_started/setup_vm/roles/h2spec/tasks/install.yml
@@ -1,0 +1,20 @@
+- name: Include vars
+  include_vars: common.yml
+
+- name: Download h2spec
+  get_url:
+    url: https://github.com/summerwind/h2spec/releases/download/v{{ h2spec_version }}/h2spec_linux_amd64.tar.gz
+    dest: "{{ workspace }}/h2spec.tar.gz"
+  become: true
+
+- name: Create directory for h2spec
+  file:
+    path: "{{ h2spec_install_prefix }}"
+    state: directory
+  become: true
+
+- name: Unpack h2spec
+  unarchive:
+    src: "{{ workspace }}/h2spec.tar.gz"
+    dest: "{{ h2spec_install_prefix }}"
+  become: true

--- a/getting_started/setup_vm/roles/h2spec/vars/common.yml
+++ b/getting_started/setup_vm/roles/h2spec/vars/common.yml
@@ -1,0 +1,3 @@
+workspace: "/tmp/"
+h2spec_version: 2.6.0
+h2spec_install_prefix: "/opt/h2spec"


### PR DESCRIPTION
Part of #3342 

This PR adds [`h2spec`](https://github.com/summerwind/h2spec) to the CI image so that we can test CCF's HTTP/2 compliance.