### PR TITLE
[release/3.x] Cherry pick: Increase NumHeapPages for js_generic (#4759)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.3]
+
+[3.0.3]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.3
+
+- Increased default NumHeapPages (heap size) for js_generic from 131072 (500MB) to 524288 (2GB).
+
 ## [3.0.2]
 
 [3.0.2]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.2

--- a/src/apps/js_generic/oe_sign.conf
+++ b/src/apps/js_generic/oe_sign.conf
@@ -1,5 +1,5 @@
 # Enclave settings:
-NumHeapPages=131072
+NumHeapPages=524288
 NumStackPages=1024
 NumTCS=8
 ProductID=1


### PR DESCRIPTION
Backports the following commits to `release/3.x`:
 - [Increase NumHeapPages for js_generic (#4759)](https://github.com/microsoft/CCF/pull/4759)