### PR TITLE
Perf tool: support binary data

### DIFF
--- a/tests/perf-system/generator/generator.py
+++ b/tests/perf-system/generator/generator.py
@@ -30,30 +30,36 @@ class Messages:
         append it to self.df and return the new df
         """
         batch_df = pd.DataFrame(columns=["messageID", "request"])
-        data_headers = "\r\n"
+        data_headers = b"\r\n"
         if len(additional_headers) > 0:
             additional_headers += "\r\n"
         if len(data) > 0:
-            data_headers = "content-length: " + str(len(data)) + "\r\n\r\n" + data
+            if isinstance(data, str):
+                data = data.encode("ascii")
+            data_headers = (
+                "content-length: " + str(len(data)) + "\r\n\r\n"
+            ).encode("ascii") + data
 
         df_size = len(self.df.index)
 
         for ind in range(iterations):
             batch_df.loc[ind] = [
                 str(ind + df_size),
-                verb.upper()
-                + " "
-                + path
-                + " "
-                + request_type
-                + "\r\n"
-                + "host: "
-                + host
-                + "\r\n"
-                + additional_headers
-                + "content-type: "
-                + content_type.lower()
-                + "\r\n"
+                (
+                    verb.upper()
+                    + " "
+                    + path
+                    + " "
+                    + request_type
+                    + "\r\n"
+                    + "host: "
+                    + host
+                    + "\r\n"
+                    + additional_headers
+                    + "content-type: "
+                    + content_type.lower()
+                    + "\r\n"
+                ).encode("ascii")
                 + data_headers,
             ]
 

--- a/tests/perf-system/submitter/handle_arguments.h
+++ b/tests/perf-system/submitter/handle_arguments.h
@@ -32,21 +32,21 @@ public:
         cert,
         "Use the provided certificate file when working with a SSL-based "
         "protocol.")
-      ->required(false)
+      ->required(true)
       ->check(CLI::ExistingFile);
     app
       .add_option(
         "-k,--key",
         key,
         "Specify the path to the file containing the private key.")
-      ->required(false)
+      ->required(true)
       ->check(CLI::ExistingFile);
     app
       .add_option(
         "--cacert",
         rootCa,
         "Use the specified file for certificate verification.")
-      ->required(false)
+      ->required(true)
       ->check(CLI::ExistingFile);
     app
       .add_option(

--- a/tests/perf-system/submitter/parquet_data.h
+++ b/tests/perf-system/submitter/parquet_data.h
@@ -3,14 +3,17 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
+
 class ParquetData
 {
 public:
   ParquetData() {}
 
   std::vector<std::string> ids;
-  std::vector<std::string> request;
-  std::vector<std::string> raw_response;
+  std::vector<std::vector<uint8_t>> request;
+  std::vector<std::vector<uint8_t>> raw_response;
   std::vector<double> send_time;
   std::vector<double> response_time;
 };


### PR DESCRIPTION
This changes the Parquet data type for the requests and responses to binary (previously UTF-8 string) to support a wider range of APIs.

I had to switch away from `parquet::StreamWriter` as that doesn't support binary data yet. See also https://github.com/apache/arrow/issues/14998.