### PR TITLE
[release/2.x] Cherry pick: Fix recording of node_data in KV for Start nodes (#4762)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.14]
+
+[2.0.14]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.14
+
+### Fixed
+
+- `node_data_json_file` configuration option is now correctly applied in `Start` and `Recover` modes (#4761).
+
+### Changed
+
+- Increased default NumHeapPages (heap size) for js_generic from 131072 (500MB) to 524288 (2GB).
+
 ## [2.0.13]
 
 [2.0.13]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.13

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -368,6 +368,7 @@ int main(int argc, char** argv)
     {
       startup_config.node_data =
         files::slurp_json(config.node_data_json_file.value());
+      LOG_TRACE_FMT("Read node_data: {}", startup_config.node_data.dump());
     }
 
     if (config.service_data_json_file.has_value())

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -1518,7 +1518,8 @@ namespace ccf
           std::nullopt,
           ds::to_hex(in.code_digest.data),
           in.certificate_signing_request,
-          in.public_key};
+          in.public_key,
+          in.node_data};
         g.add_node(in.node_id, node_info);
 
 #ifdef GET_QUOTE

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -143,6 +143,7 @@ class Network:
         init_partitioner=False,
         version=None,
         service_load=None,
+        node_data_json_file=None,
     ):
         if existing_network is None:
             self.consortium = None
@@ -199,7 +200,9 @@ class Network:
             pass
 
         for host in self.hosts:
-            self.create_node(host, version=self.version)
+            self.create_node(
+                host, version=self.version, node_data_json_file=node_data_json_file
+            )
 
     def _get_next_local_node_id(self):
         next_node_id = self.next_node_id
@@ -1404,6 +1407,7 @@ def network(
     init_partitioner=False,
     version=None,
     service_load=None,
+    node_data_json_file=None,
 ):
     """
     Context manager for Network class.
@@ -1433,6 +1437,7 @@ def network(
         init_partitioner=init_partitioner,
         version=version,
         service_load=service_load,
+        node_data_json_file=node_data_json_file,
     )
     try:
         yield net

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -70,29 +70,44 @@ def test_recover_service(network, args, from_snapshot=True):
 
     current_ledger_dir, committed_ledger_dirs = old_primary.get_ledger()
 
-    recovered_network = infra.network.Network(
-        args.nodes,
-        args.binary_dir,
-        args.debug_nodes,
-        args.perf_nodes,
-        existing_network=network,
-    )
-    with tempfile.NamedTemporaryFile(mode="w+") as ntf:
-        service_data = {"this is a": "recovery service"}
-        json.dump(service_data, ntf)
-        ntf.flush()
-        recovered_network.start_in_recovery(
-            args,
-            ledger_dir=current_ledger_dir,
-            committed_ledger_dirs=committed_ledger_dirs,
-            snapshots_dir=snapshots_dir,
-            service_data_json_file=ntf.name,
+    with tempfile.NamedTemporaryFile(mode="w+") as node_data_tf:
+        start_node_data = {"this is a": "recovery node"}
+        json.dump(start_node_data, node_data_tf)
+        node_data_tf.flush()
+        recovered_network = infra.network.Network(
+            args.nodes,
+            args.binary_dir,
+            args.debug_nodes,
+            args.perf_nodes,
+            existing_network=network,
+            node_data_json_file=node_data_tf.name,
         )
-        LOG.info("Check that service data has been set")
-        primary, _ = recovered_network.find_primary()
-        with primary.client() as c:
-            r = c.get("/node/network").body.json()
-            assert r["service_data"] == service_data
+
+        with tempfile.NamedTemporaryFile(mode="w+") as ntf:
+            service_data = {"this is a": "recovery service"}
+            json.dump(service_data, ntf)
+            ntf.flush()
+            recovered_network.start_in_recovery(
+                args,
+                ledger_dir=current_ledger_dir,
+                committed_ledger_dirs=committed_ledger_dirs,
+                snapshots_dir=snapshots_dir,
+                service_data_json_file=ntf.name,
+            )
+            LOG.info("Check that service data has been set")
+            primary, _ = recovered_network.find_primary()
+            with primary.client() as c:
+                r = c.get("/node/network").body.json()
+                assert r["service_data"] == service_data
+                LOG.info("Check that the node data has been set")
+                r = c.get("/node/network/nodes").body.json()
+                assert r["nodes"]
+                did_check = False
+                for node in r["nodes"]:
+                    if node["status"] == "Trusted":
+                        assert node["node_data"] == start_node_data
+                        did_check = True
+                assert did_check
 
     recovered_network.verify_service_certificate_validity_period(
         args.initial_service_cert_validity_days


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Fix recording of node_data in KV for Start nodes (#4762)](https://github.com/microsoft/CCF/pull/4762)