### PR TITLE
[release/3.x] Cherry pick: Fix recording of node_data in KV for Start nodes (#4762)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [3.0.3]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.3
 
+### Fixed
+
+- Node-to-node channels no longer check certificate expiry times. This previously caused "Peer certificate verification failed" error messages when node or service certs expired. (#4733)
+- `node_data_json_file` configuration option is now correctly applied in `Start` and `Recover` modes (#4761).
+
+### Changed
+
 - Increased default NumHeapPages (heap size) for js_generic from 131072 (500MB) to 524288 (2GB).
 
 ## [3.0.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Node-to-node channels no longer check certificate expiry times. This previously caused "Peer certificate verification failed" error messages when node or service certs expired. (#4733)
 - `node_data_json_file` configuration option is now correctly applied in `Start` and `Recover` modes (#4761).
 
 ### Changed

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -412,6 +412,7 @@ int main(int argc, char** argv)
     {
       startup_config.node_data =
         files::slurp_json(config.node_data_json_file.value());
+      LOG_TRACE_FMT("Read node_data: {}", startup_config.node_data.dump());
     }
 
     if (config.service_data_json_file.has_value())

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -1542,7 +1542,8 @@ namespace ccf
           std::nullopt,
           ds::to_hex(in.code_digest.data),
           in.certificate_signing_request,
-          in.public_key};
+          in.public_key,
+          in.node_data};
         g.add_node(in.node_id, node_info);
         g.trust_node_code_id(in.code_digest, in.quote_info.format);
         if (in.quote_info.format == QuoteFormat::amd_sev_snp_v1)

--- a/tests/governance.py
+++ b/tests/governance.py
@@ -633,6 +633,30 @@ def gov(args):
         test_service_cert_renewal_extended(network, args)
 
 
+def node_data_on_start_node(args):
+    with tempfile.NamedTemporaryFile(mode="w+") as ntf:
+        start_node_data = {"on_start": "some_node_data"}
+        json.dump(start_node_data, ntf)
+        ntf.flush()
+
+        with infra.network.network(
+            args.nodes,
+            args.binary_dir,
+            args.debug_nodes,
+            args.perf_nodes,
+            pdb=args.pdb,
+            node_data_json_file=ntf.name,
+        ) as network:
+            network.start_and_open(args)
+            primary, _ = network.find_primary()
+            with primary.client() as c:
+                r = c.get("/node/network/nodes")
+                assert r.status_code == 200, (r.status_code, r.body.text())
+                assert (
+                    r.body.json()["nodes"][0]["node_data"] == start_node_data
+                ), r.body.json()["nodes"][0]["node_data"]
+
+
 def js_gov(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
@@ -664,6 +688,15 @@ if __name__ == "__main__":
         )
 
     cr = ConcurrentRunner(add)
+
+    cr.add(
+        "node_data_on_start_node",
+        node_data_on_start_node,
+        package="samples/apps/logging/liblogging",
+        nodes=infra.e2e_args.min_nodes(cr.args, f=0),
+        initial_user_count=3,
+        authenticate_session="COSE",
+    )
 
     cr.add(
         "session_coseauth",

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -147,6 +147,7 @@ class Network:
         init_partitioner=False,
         version=None,
         service_load=None,
+        node_data_json_file=None,
     ):
         if existing_network is None:
             self.consortium = None
@@ -205,7 +206,9 @@ class Network:
             pass
 
         for host in self.hosts:
-            self.create_node(host, version=self.version)
+            self.create_node(
+                host, version=self.version, node_data_json_file=node_data_json_file
+            )
 
     def _get_next_local_node_id(self):
         next_node_id = self.next_node_id
@@ -1431,6 +1434,7 @@ def network(
     init_partitioner=False,
     version=None,
     service_load=None,
+    node_data_json_file=None,
 ):
     """
     Context manager for Network class.
@@ -1460,6 +1464,7 @@ def network(
         init_partitioner=init_partitioner,
         version=version,
         service_load=service_load,
+        node_data_json_file=node_data_json_file,
     )
     try:
         yield net

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -70,29 +70,44 @@ def test_recover_service(network, args, from_snapshot=True):
 
     current_ledger_dir, committed_ledger_dirs = old_primary.get_ledger()
 
-    recovered_network = infra.network.Network(
-        args.nodes,
-        args.binary_dir,
-        args.debug_nodes,
-        args.perf_nodes,
-        existing_network=network,
-    )
-    with tempfile.NamedTemporaryFile(mode="w+") as ntf:
-        service_data = {"this is a": "recovery service"}
-        json.dump(service_data, ntf)
-        ntf.flush()
-        recovered_network.start_in_recovery(
-            args,
-            ledger_dir=current_ledger_dir,
-            committed_ledger_dirs=committed_ledger_dirs,
-            snapshots_dir=snapshots_dir,
-            service_data_json_file=ntf.name,
+    with tempfile.NamedTemporaryFile(mode="w+") as node_data_tf:
+        start_node_data = {"this is a": "recovery node"}
+        json.dump(start_node_data, node_data_tf)
+        node_data_tf.flush()
+        recovered_network = infra.network.Network(
+            args.nodes,
+            args.binary_dir,
+            args.debug_nodes,
+            args.perf_nodes,
+            existing_network=network,
+            node_data_json_file=node_data_tf.name,
         )
-        LOG.info("Check that service data has been set")
-        primary, _ = recovered_network.find_primary()
-        with primary.client() as c:
-            r = c.get("/node/network").body.json()
-            assert r["service_data"] == service_data
+
+        with tempfile.NamedTemporaryFile(mode="w+") as ntf:
+            service_data = {"this is a": "recovery service"}
+            json.dump(service_data, ntf)
+            ntf.flush()
+            recovered_network.start_in_recovery(
+                args,
+                ledger_dir=current_ledger_dir,
+                committed_ledger_dirs=committed_ledger_dirs,
+                snapshots_dir=snapshots_dir,
+                service_data_json_file=ntf.name,
+            )
+            LOG.info("Check that service data has been set")
+            primary, _ = recovered_network.find_primary()
+            with primary.client() as c:
+                r = c.get("/node/network").body.json()
+                assert r["service_data"] == service_data
+                LOG.info("Check that the node data has been set")
+                r = c.get("/node/network/nodes").body.json()
+                assert r["nodes"]
+                did_check = False
+                for node in r["nodes"]:
+                    if node["status"] == "Trusted":
+                        assert node["node_data"] == start_node_data
+                        did_check = True
+                assert did_check
 
     recovered_network.verify_service_certificate_validity_period(
         args.initial_service_cert_validity_days


### PR DESCRIPTION
Backports the following commits to `release/3.x`:
 - [Fix recording of node_data in KV for Start nodes (#4762)](https://github.com/microsoft/CCF/pull/4762)