### PR TITLE
Fix election test

### DIFF
--- a/tests/election.py
+++ b/tests/election.py
@@ -3,6 +3,7 @@
 import copy
 import http
 import math
+import time
 
 import infra.checker
 import infra.e2e_args
@@ -85,7 +86,27 @@ def test_kill_primary(network, args):
 @reqs.description("Test the commit endpoints view_history feature")
 def test_commit_view_history(network, args):
     remote_node, _ = network.find_primary()
+
     with remote_node.client() as c:
+        # Wait for new primary to have committed a first transaction in their new term,
+        # to account for the fact that later assertions assume the view history
+        # does not change
+        timeout = 2
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            commit_view = int(
+                c.get("/app/commit").body.json()["transaction_id"].split(".")[0]
+            )
+            current_view = c.get("/node/consensus").body.json()["details"][
+                "current_view"
+            ]
+            if commit_view == current_view:
+                break
+            time.sleep(0.1)
+        assert (
+            commit_view == current_view
+        ), f"Primary has not committed latest transaction after {timeout} seconds"
+
         # Endpoint works with no query parameter
         res = c.get("/app/commit")
         assert res.status_code == http.HTTPStatus.OK


### PR DESCRIPTION
The election test will occasionally break because the newly elected primary hasn't had time to commit a new transaction, for example here: https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=58749&view=logs&j=f3457e4b-102d-5a4f-f801-dc119e4853a8&t=ae98f324-492e-5969-593b-258ede9c5463

The test then proceeds to sample a view history, and assumes further view histories will be subsets of it as it queries, which turns out to be incorrect as a new transaction gets appended in the new term.

Adding a barrier to wait until at least one transaction is committed in a new term (necessarily a signature here) avoids this problem. A --repeat-until-fail 30 is generally enough to trigger the issue, and this one with the fix doesn't:

```
The following tests passed:
        election_test

100% tests passed, 0 tests failed out of 1

Label Time Summary:
cft    =  19.07 sec*proc (1 test)
e2e    =  19.07 sec*proc (1 test)

Total Test time (real) = 557.10 sec
```

At least one view mismatch took place:

```
$ grep  VIEW out
61: VIEW MISMATCH: 3 != 2
```

That printout is removed in the commit, but was at line 105.