### PR TITLE
HTTP/2: support for configuration and error reporting

### DIFF
--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -596,7 +596,7 @@
                     "type": "string"
                   },
                   "max_headers_count": {
-                    "maximum": 18446744073709551615,
+                    "maximum": 4294967295,
                     "minimum": 0,
                     "type": "integer"
                   }
@@ -684,7 +684,7 @@
                       "type": "string"
                     },
                     "max_headers_count": {
-                      "maximum": 18446744073709551615,
+                      "maximum": 4294967295,
                       "minimum": 0,
                       "type": "integer"
                     }
@@ -1124,7 +1124,7 @@
   "info": {
     "description": "This API is used to submit and query proposals which affect CCF's public governance tables.",
     "title": "CCF Governance API",
-    "version": "2.14.0"
+    "version": "2.15.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -653,7 +653,7 @@
             "$ref": "#/components/schemas/TimeString"
           },
           "max_headers_count": {
-            "$ref": "#/components/schemas/uint64"
+            "$ref": "#/components/schemas/uint32"
           }
         },
         "type": "object"
@@ -924,7 +924,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "2.33.0"
+    "version": "2.34.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/include/ccf/http_configuration.h
+++ b/include/ccf/http_configuration.h
@@ -4,6 +4,7 @@
 
 #include "ccf/ds/json.h"
 #include "ccf/ds/unit_strings.h"
+// #include "http/http2_types.h" // TODO: Move http2_types.h to public headers
 
 #include <optional>
 
@@ -30,4 +31,27 @@ namespace http
   DECLARE_JSON_REQUIRED_FIELDS(ParserConfiguration);
   DECLARE_JSON_OPTIONAL_FIELDS(
     ParserConfiguration, max_body_size, max_header_size, max_headers_count);
+
+  class RequestPayloadTooLarge : public std::runtime_error
+  {
+  private:
+    // using runtime_error::runtime_error;
+    int32_t stream_id;
+
+  public:
+    RequestPayloadTooLarge(const std::string& msg, int32_t stream_id_ = 0) :
+      std::runtime_error(msg),
+      stream_id(stream_id_)
+    {}
+
+    int32_t get_stream_id() const
+    {
+      return stream_id;
+    }
+  };
+
+  class RequestHeaderTooLarge : public std::runtime_error
+  {
+    using runtime_error::runtime_error;
+  };
 }

--- a/include/ccf/http_configuration.h
+++ b/include/ccf/http_configuration.h
@@ -12,13 +12,13 @@ namespace http
 {
   static const ds::SizeString default_max_body_size = {"1MB"};
   static const ds::SizeString default_max_header_size = {"16KB"};
-  static const size_t default_max_headers_count = 256;
+  static const uint32_t default_max_headers_count = 256;
 
   struct ParserConfiguration
   {
     std::optional<ds::SizeString> max_body_size = std::nullopt;
     std::optional<ds::SizeString> max_header_size = std::nullopt;
-    std::optional<size_t> max_headers_count = std::nullopt;
+    std::optional<uint32_t> max_headers_count = std::nullopt;
 
     bool operator==(const ParserConfiguration& other) const
     {
@@ -32,16 +32,15 @@ namespace http
   DECLARE_JSON_OPTIONAL_FIELDS(
     ParserConfiguration, max_body_size, max_header_size, max_headers_count);
 
-  class RequestPayloadTooLarge : public std::runtime_error
+  class RequestTooLargeException : public std::runtime_error
   {
   private:
-    // using runtime_error::runtime_error;
-    int32_t stream_id;
+    int32_t stream_id; // TODO: Use http2::StreamId type
 
   public:
-    RequestPayloadTooLarge(const std::string& msg, int32_t stream_id_ = 0) :
+    RequestTooLargeException(const std::string& msg, int32_t stream_id = 0) :
       std::runtime_error(msg),
-      stream_id(stream_id_)
+      stream_id(stream_id)
     {}
 
     int32_t get_stream_id() const
@@ -50,8 +49,21 @@ namespace http
     }
   };
 
-  class RequestHeaderTooLarge : public std::runtime_error
+  class RequestPayloadTooLargeException : public RequestTooLargeException
   {
-    using runtime_error::runtime_error;
+  public:
+    RequestPayloadTooLargeException(
+      const std::string& msg, int32_t stream_id = 0) :
+      RequestTooLargeException(msg, stream_id)
+    {}
+  };
+
+  class RequestHeaderTooLargeException : public RequestTooLargeException
+  {
+  public:
+    RequestHeaderTooLargeException(
+      const std::string& msg, int32_t stream_id = 0) :
+      RequestTooLargeException(msg, stream_id)
+    {}
   };
 }

--- a/include/ccf/http_configuration.h
+++ b/include/ccf/http_configuration.h
@@ -4,7 +4,6 @@
 
 #include "ccf/ds/json.h"
 #include "ccf/ds/unit_strings.h"
-// #include "http/http2_types.h" // TODO: Move http2_types.h to public headers
 
 #include <optional>
 
@@ -31,39 +30,4 @@ namespace http
   DECLARE_JSON_REQUIRED_FIELDS(ParserConfiguration);
   DECLARE_JSON_OPTIONAL_FIELDS(
     ParserConfiguration, max_body_size, max_header_size, max_headers_count);
-
-  class RequestTooLargeException : public std::runtime_error
-  {
-  private:
-    int32_t stream_id; // TODO: Use http2::StreamId type
-
-  public:
-    RequestTooLargeException(const std::string& msg, int32_t stream_id = 0) :
-      std::runtime_error(msg),
-      stream_id(stream_id)
-    {}
-
-    int32_t get_stream_id() const
-    {
-      return stream_id;
-    }
-  };
-
-  class RequestPayloadTooLargeException : public RequestTooLargeException
-  {
-  public:
-    RequestPayloadTooLargeException(
-      const std::string& msg, int32_t stream_id = 0) :
-      RequestTooLargeException(msg, stream_id)
-    {}
-  };
-
-  class RequestHeaderTooLargeException : public RequestTooLargeException
-  {
-  public:
-    RequestHeaderTooLargeException(
-      const std::string& msg, int32_t stream_id = 0) :
-      RequestTooLargeException(msg, stream_id)
-    {}
-  };
 }

--- a/src/apps/external_executor/external_executor.cpp
+++ b/src/apps/external_executor/external_executor.cpp
@@ -15,7 +15,6 @@
 #include "executor_auth_policy.h"
 #include "executor_code_id.h"
 #include "executor_registration.pb.h"
-#include "http/http2_session.h"
 #include "http/http_builder.h"
 #include "kv.pb.h"
 #include "misc.pb.h"

--- a/src/enclave/rpc_sessions.h
+++ b/src/enclave/rpc_sessions.h
@@ -197,6 +197,9 @@ namespace ccf
     {
       std::lock_guard<ccf::pal::Mutex> guard(lock);
       get_interface_from_session_id(id).errors.request_header_too_large++;
+      LOG_FAIL_FMT(
+        "Header too large now: {}",
+        get_interface_from_session_id(id).errors.request_header_too_large);
     }
 
     void update_listening_interface_options(
@@ -243,6 +246,8 @@ namespace ccf
 
       for (const auto& [name, interface] : listening_interfaces)
       {
+        LOG_FAIL_FMT(
+          "Interface {}: {}", name, interface.errors.request_header_too_large);
         sm.interfaces[name] = {
           interface.open_sessions,
           interface.peak_sessions,

--- a/src/enclave/rpc_sessions.h
+++ b/src/enclave/rpc_sessions.h
@@ -197,9 +197,6 @@ namespace ccf
     {
       std::lock_guard<ccf::pal::Mutex> guard(lock);
       get_interface_from_session_id(id).errors.request_header_too_large++;
-      LOG_FAIL_FMT(
-        "Header too large now: {}",
-        get_interface_from_session_id(id).errors.request_header_too_large);
     }
 
     void update_listening_interface_options(
@@ -246,8 +243,6 @@ namespace ccf
 
       for (const auto& [name, interface] : listening_interfaces)
       {
-        LOG_FAIL_FMT(
-          "Interface {}: {}", name, interface.errors.request_header_too_large);
         sm.interfaces[name] = {
           interface.open_sessions,
           interface.peak_sessions,

--- a/src/http/http2_callbacks.h
+++ b/src/http/http2_callbacks.h
@@ -88,8 +88,7 @@ namespace http2
       {
         LOG_TRACE_FMT(
           "http2::on_begin_frame_recv_callback: cannot process stream id {} "
-          "< "
-          "last stream id {}",
+          "< last stream id {}",
           stream_id,
           p->get_last_stream_id());
         return NGHTTP2_ERR_PROTO;

--- a/src/http/http2_callbacks.h
+++ b/src/http/http2_callbacks.h
@@ -4,6 +4,7 @@
 
 #include "ccf/ds/logger.h"
 #include "ccf/http_configuration.h"
+#include "http/http_exceptions.h"
 #include "http2_types.h"
 #include "http2_utils.h"
 

--- a/src/http/http2_callbacks.h
+++ b/src/http/http2_callbacks.h
@@ -80,22 +80,22 @@ namespace http2
     // So can catch this case early in this callback by making sure that _new_
     // stream ids are not less than the most recent stream id on this session.
     auto* p = get_parser(user_data);
-    if (stream_id != DEFAULT_STREAM_ID && p->get_stream(stream_id) == nullptr)
+    if (
+      stream_id != DEFAULT_STREAM_ID && p->get_stream(stream_id) == nullptr &&
+      hd->type == NGHTTP2_HEADERS)
     {
       if (stream_id < p->get_last_stream_id())
       {
         LOG_TRACE_FMT(
-          "http2::on_begin_frame_recv_callback: cannot process stream id {} < "
+          "http2::on_begin_frame_recv_callback: cannot process stream id {} "
+          "< "
           "last stream id {}",
           stream_id,
           p->get_last_stream_id());
         return NGHTTP2_ERR_PROTO;
       }
 
-      if (hd->type == NGHTTP2_HEADERS)
-      {
-        p->create_stream(stream_id);
-      }
+      p->create_stream(stream_id);
     }
 
     return 0;

--- a/src/http/http2_parser.h
+++ b/src/http/http2_parser.h
@@ -72,6 +72,8 @@ namespace http2
       // Submit initial settings
       std::vector<nghttp2_settings_entry> settings;
       settings.push_back({NGHTTP2_SETTINGS_MAX_FRAME_SIZE, max_frame_size});
+      // NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE is only a hint to client
+      // (https://www.rfc-editor.org/rfc/rfc7540#section-10.5.1)
       settings.push_back(
         {NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE,
          configuration.max_headers_count.value_or(

--- a/src/http/http2_parser.h
+++ b/src/http/http2_parser.h
@@ -21,10 +21,10 @@ namespace http2
     // reject new streams ids less than this value.
     StreamId last_stream_id = 0;
     DataHandlerCB handle_outgoing_data;
-    std::map<StreamId, std::shared_ptr<StreamData>> streams;
     http::ParserConfiguration configuration;
 
   protected:
+    std::map<StreamId, std::shared_ptr<StreamData>> streams;
     nghttp2_session* session;
 
   public:

--- a/src/http/http2_types.h
+++ b/src/http/http2_types.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ccf/ds/nonstd.h"
+#include "ccf/http_configuration.h"
 #include "ccf/http_header_map.h"
 #include "ccf/http_responder.h"
 #include "ccf/http_status.h"
@@ -92,5 +93,6 @@ namespace http2
     virtual std::shared_ptr<StreamData> get_stream(StreamId stream_id) = 0;
     virtual void destroy_stream(StreamId stream_id) = 0;
     virtual StreamId get_last_stream_id() const = 0;
+    virtual http::ParserConfiguration get_configuration() const = 0;
   };
 }

--- a/src/http/http_exceptions.h
+++ b/src/http/http_exceptions.h
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "http2_types.h"
+
+#include <stdexcept>
+
+namespace http
+{
+  class RequestTooLargeException : public std::runtime_error
+  {
+  private:
+    http2::StreamId stream_id;
+
+  public:
+    RequestTooLargeException(
+      const std::string& msg,
+      http2::StreamId stream_id = http2::DEFAULT_STREAM_ID) :
+      std::runtime_error(msg),
+      stream_id(stream_id)
+    {}
+
+    http2::StreamId get_stream_id() const
+    {
+      return stream_id;
+    }
+  };
+
+  class RequestPayloadTooLargeException : public RequestTooLargeException
+  {
+  public:
+    RequestPayloadTooLargeException(
+      const std::string& msg, http2::StreamId stream_id = 0) :
+      RequestTooLargeException(msg, stream_id)
+    {}
+  };
+
+  class RequestHeaderTooLargeException : public RequestTooLargeException
+  {
+  public:
+    RequestHeaderTooLargeException(
+      const std::string& msg,
+      http2::StreamId stream_id = http2::DEFAULT_STREAM_ID) :
+      RequestTooLargeException(msg, stream_id)
+    {}
+  };
+}

--- a/src/http/http_parser.h
+++ b/src/http/http_parser.h
@@ -248,7 +248,7 @@ namespace http
           configuration.max_body_size.value_or(default_max_body_size);
         if (body_buf.size() > max_body_size)
         {
-          throw RequestPayloadTooLarge(fmt::format(
+          throw RequestPayloadTooLargeException(fmt::format(
             "HTTP request body is too large (max size allowed: {})",
             max_body_size));
         }
@@ -302,7 +302,7 @@ namespace http
         configuration.max_headers_count.value_or(default_max_headers_count);
       if (headers.size() >= max_headers_count)
       {
-        throw RequestHeaderTooLarge(fmt::format(
+        throw RequestHeaderTooLargeException(fmt::format(
           "Too many headers (max number allowed: {})", max_headers_count));
       }
 
@@ -317,7 +317,7 @@ namespace http
         configuration.max_header_size.value_or(default_max_header_size);
       if (partial_header_key.size() > max_header_size)
       {
-        throw RequestHeaderTooLarge(fmt::format(
+        throw RequestHeaderTooLargeException(fmt::format(
           "Header key for '{}' is too large (max size allowed: {})",
           partial_parsed_header.first,
           max_header_size));
@@ -332,7 +332,7 @@ namespace http
         configuration.max_header_size.value_or(default_max_header_size);
       if (partial_header_value.size() > max_header_size)
       {
-        throw RequestHeaderTooLarge(fmt::format(
+        throw RequestHeaderTooLargeException(fmt::format(
           "Header value for '{}' is too large (max size allowed: {})",
           partial_parsed_header.first,
           max_header_size));

--- a/src/http/http_parser.h
+++ b/src/http/http_parser.h
@@ -5,6 +5,7 @@
 #include "ccf/ds/hex.h"
 #include "ccf/http_configuration.h"
 #include "enclave/tls_session.h"
+#include "http/http_exceptions.h"
 #include "http_builder.h"
 #include "http_proc.h"
 

--- a/src/http/http_parser.h
+++ b/src/http/http_parser.h
@@ -19,16 +19,6 @@
 
 namespace http
 {
-  class RequestPayloadTooLarge : public std::runtime_error
-  {
-    using runtime_error::runtime_error;
-  };
-
-  class RequestHeaderTooLarge : public std::runtime_error
-  {
-    using runtime_error::runtime_error;
-  };
-
   inline auto split_url_path(const std::string_view& url)
   {
     LOG_TRACE_FMT("Received url to parse: {}", std::string_view(url));

--- a/src/http/http_session.h
+++ b/src/http/http_session.h
@@ -120,7 +120,7 @@ namespace http
 
         return true;
       }
-      catch (RequestPayloadTooLarge& e)
+      catch (RequestPayloadTooLargeException& e)
       {
         if (error_reporter)
         {
@@ -136,7 +136,7 @@ namespace http
 
         tls_io->close();
       }
-      catch (RequestHeaderTooLarge& e)
+      catch (RequestHeaderTooLargeException& e)
       {
         if (error_reporter)
         {

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -510,7 +510,7 @@ namespace ccf
       openapi_info.description =
         "This API is used to submit and query proposals which affect CCF's "
         "public governance tables.";
-      openapi_info.document_version = "2.14.0";
+      openapi_info.document_version = "2.15.0";
     }
 
     static std::optional<MemberId> get_caller_member_id(

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -384,7 +384,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
-      openapi_info.document_version = "2.33.0";
+      openapi_info.document_version = "2.34.0";
     }
 
     void init_handlers() override

--- a/tests/e2e_common_endpoints.py
+++ b/tests/e2e_common_endpoints.py
@@ -161,7 +161,6 @@ def test_memory(network, args):
 
 
 @reqs.description("Write/Read large messages on primary")
-@reqs.no_http2()
 def test_large_messages(network, args):
     primary, _ = network.find_primary()
 
@@ -228,43 +227,43 @@ def test_large_messages(network, args):
             headers={"content-type": "application/json"},
         )
 
-    for s in get_sizes(args.max_http_header_size):
-        long_header = "X" * s
-        LOG.info(f"Verifying cap on max header value, sending a {s} byte header value")
-        run_large_message_test(
-            args.max_http_header_size,
-            http.HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
-            "RequestHeaderTooLarge",
-            "request_header_too_large",
-            len(long_header),
-            headers={"some-header": long_header},
-        )
+    # for s in get_sizes(args.max_http_header_size):
+    #     long_header = "X" * s
+    #     LOG.info(f"Verifying cap on max header value, sending a {s} byte header value")
+    #     run_large_message_test(
+    #         args.max_http_header_size,
+    #         http.HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
+    #         "RequestHeaderTooLarge",
+    #         "request_header_too_large",
+    #         len(long_header),
+    #         headers={"some-header": long_header},
+    #     )
 
-        LOG.info(f"Verifying on cap on max header key, sending a {s} byte header key")
-        run_large_message_test(
-            args.max_http_header_size,
-            http.HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
-            "RequestHeaderTooLarge",
-            "request_header_too_large",
-            len(long_header),
-            headers={long_header: "some header value"},
-        )
+    #     LOG.info(f"Verifying on cap on max header key, sending a {s} byte header key")
+    #     run_large_message_test(
+    #         args.max_http_header_size,
+    #         http.HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
+    #         "RequestHeaderTooLarge",
+    #         "request_header_too_large",
+    #         len(long_header),
+    #         headers={long_header: "some header value"},
+    #     )
 
-    # Note: infra generally inserts extra headers (eg, content type and length, user-agent, accept)
-    extra_headers_count = (
-        infra.clients.CCFClient.default_impl_type.extra_headers_count()
-    )
-    for s in get_sizes(args.max_http_headers_count):
-        LOG.info(f"Verifying on cap on max headers count, sending {s} headers")
-        headers = {f"header-{h}": str(h) for h in range(s - extra_headers_count)}
-        run_large_message_test(
-            args.max_http_headers_count,
-            http.HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
-            "RequestHeaderTooLarge",
-            "request_header_too_large",
-            len(headers) + extra_headers_count,
-            headers=headers,
-        )
+    # # Note: infra generally inserts extra headers (eg, content type and length, user-agent, accept)
+    # extra_headers_count = (
+    #     infra.clients.CCFClient.default_impl_type.extra_headers_count()
+    # )
+    # for s in get_sizes(args.max_http_headers_count):
+    #     LOG.info(f"Verifying on cap on max headers count, sending {s} headers")
+    #     headers = {f"header-{h}": str(h) for h in range(s - extra_headers_count)}
+    #     run_large_message_test(
+    #         args.max_http_headers_count,
+    #         http.HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
+    #         "RequestHeaderTooLarge",
+    #         "request_header_too_large",
+    #         len(headers) + extra_headers_count,
+    #         headers=headers,
+    #     )
 
     return network
 

--- a/tests/e2e_common_endpoints.py
+++ b/tests/e2e_common_endpoints.py
@@ -183,7 +183,6 @@ def test_large_messages(network, args):
             before_errors_count = get_main_interface_errors()[metrics_name]
             # Note: endpoint does not matter as request parsing is done before dispatch
             try:
-                LOG.debug("Call")
                 r = client.get(
                     "/node/commit",
                     *args,
@@ -192,7 +191,6 @@ def test_large_messages(network, args):
             except infra.clients.CCFIOException:
                 # In some cases, the client ends up writing to the now-closed socket first
                 # before reading the server error, resulting in a connection error
-                LOG.debug("Error")
                 assert length > threshold
                 assert (
                     get_main_interface_errors()[metrics_name] == before_errors_count + 1

--- a/tests/e2e_common_endpoints.py
+++ b/tests/e2e_common_endpoints.py
@@ -183,6 +183,7 @@ def test_large_messages(network, args):
             before_errors_count = get_main_interface_errors()[metrics_name]
             # Note: endpoint does not matter as request parsing is done before dispatch
             try:
+                LOG.debug("Call")
                 r = client.get(
                     "/node/commit",
                     *args,
@@ -191,6 +192,7 @@ def test_large_messages(network, args):
             except infra.clients.CCFIOException:
                 # In some cases, the client ends up writing to the now-closed socket first
                 # before reading the server error, resulting in a connection error
+                LOG.debug("Error")
                 assert length > threshold
                 assert (
                     get_main_interface_errors()[metrics_name] == before_errors_count + 1
@@ -209,12 +211,16 @@ def test_large_messages(network, args):
                         get_main_interface_errors()[metrics_name] == before_errors_count
                     )
 
-    def get_sizes(n):
-        ns = [n // 2, n - 10, n - 1, n, n + 1, n + 10, n * 2, n * 20]
-        random.shuffle(ns)
+    def get_sizes(n, http2):
+        ns = [n // 2, n - 10, n - 1, n, n + 1, n + 10, n * 2]
+        if not http2:
+            # nghttp2 does not currently allow header larger than 64KB
+            # https://github.com/nghttp2/nghttp2/issues/1841
+            ns.append(n * 20)
+        # random.shuffle(ns)
         return ns
 
-    for s in get_sizes(args.max_http_body_size):
+    for s in get_sizes(args.max_http_body_size, args.http2):
         long_msg = "X" * s
         LOG.info(f"Verifying cap on max body size, sending a {s} byte body")
         run_large_message_test(
@@ -227,43 +233,44 @@ def test_large_messages(network, args):
             headers={"content-type": "application/json"},
         )
 
-    # for s in get_sizes(args.max_http_header_size):
-    #     long_header = "X" * s
-    #     LOG.info(f"Verifying cap on max header value, sending a {s} byte header value")
-    #     run_large_message_test(
-    #         args.max_http_header_size,
-    #         http.HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
-    #         "RequestHeaderTooLarge",
-    #         "request_header_too_large",
-    #         len(long_header),
-    #         headers={"some-header": long_header},
-    #     )
+    for s in get_sizes(args.max_http_header_size, args.http2):
+        long_header = "X" * s
+        LOG.info(f"Verifying cap on max header value, sending a {s} byte header value")
+        run_large_message_test(
+            args.max_http_header_size,
+            http.HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
+            "RequestHeaderTooLarge",
+            "request_header_too_large",
+            len(long_header),
+            headers={"some-header": long_header},
+        )
 
-    #     LOG.info(f"Verifying on cap on max header key, sending a {s} byte header key")
-    #     run_large_message_test(
-    #         args.max_http_header_size,
-    #         http.HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
-    #         "RequestHeaderTooLarge",
-    #         "request_header_too_large",
-    #         len(long_header),
-    #         headers={long_header: "some header value"},
-    #     )
+        LOG.info(f"Verifying on cap on max header key, sending a {s} byte header key")
+        run_large_message_test(
+            args.max_http_header_size,
+            http.HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
+            "RequestHeaderTooLarge",
+            "request_header_too_large",
+            len(long_header),
+            headers={long_header: "some header value"},
+        )
 
-    # # Note: infra generally inserts extra headers (eg, content type and length, user-agent, accept)
-    # extra_headers_count = (
-    #     infra.clients.CCFClient.default_impl_type.extra_headers_count()
-    # )
-    # for s in get_sizes(args.max_http_headers_count):
-    #     LOG.info(f"Verifying on cap on max headers count, sending {s} headers")
-    #     headers = {f"header-{h}": str(h) for h in range(s - extra_headers_count)}
-    #     run_large_message_test(
-    #         args.max_http_headers_count,
-    #         http.HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
-    #         "RequestHeaderTooLarge",
-    #         "request_header_too_large",
-    #         len(headers) + extra_headers_count,
-    #         headers=headers,
-    #     )
+    # TODO: Fix with httpx HTTP/2 headers
+    # Note: infra generally inserts extra headers (eg, content type and length, user-agent, accept)
+    extra_headers_count = (
+        infra.clients.CCFClient.default_impl_type.extra_headers_count()
+    )
+    for s in get_sizes(args.max_http_headers_count, args.http2):
+        LOG.info(f"Verifying on cap on max headers count, sending {s} headers")
+        headers = {f"header-{h}": str(h) for h in range(s - extra_headers_count)}
+        run_large_message_test(
+            args.max_http_headers_count,
+            http.HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
+            "RequestHeaderTooLarge",
+            "request_header_too_large",
+            len(headers) + extra_headers_count,
+            headers=headers,
+        )
 
     return network
 

--- a/tests/e2e_common_endpoints.py
+++ b/tests/e2e_common_endpoints.py
@@ -217,7 +217,7 @@ def test_large_messages(network, args):
             # nghttp2 does not currently allow header larger than 64KB
             # https://github.com/nghttp2/nghttp2/issues/1841
             ns.append(n * 20)
-        # random.shuffle(ns)
+        random.shuffle(ns)
         return ns
 
     for s in get_sizes(args.max_http_body_size, args.http2):
@@ -255,10 +255,9 @@ def test_large_messages(network, args):
             headers={long_header: "some header value"},
         )
 
-    # TODO: Fix with httpx HTTP/2 headers
     # Note: infra generally inserts extra headers (eg, content type and length, user-agent, accept)
-    extra_headers_count = (
-        infra.clients.CCFClient.default_impl_type.extra_headers_count()
+    extra_headers_count = infra.clients.CCFClient.default_impl_type.extra_headers_count(
+        args.http2
     )
     for s in get_sizes(args.max_http_headers_count, args.http2):
         LOG.info(f"Verifying on cap on max headers count, sending {s} headers")

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -747,7 +747,7 @@ def test_metrics(network, args):
 
 @reqs.description("Read historical state")
 @reqs.supports_methods("/app/log/private", "/app/log/private/historical")
-@reqs.no_http2()
+@reqs.no_http2()  # TODO: Remove?
 @app.scoped_txs()
 def test_historical_query(network, args):
     network.txs.issue(network, number_txs=2)
@@ -1158,7 +1158,7 @@ def test_forwarding_frontends_without_app_prefix(network, args):
 @reqs.description("Testing signed queries with escaped queries")
 @reqs.installed_package("samples/apps/logging/liblogging")
 @reqs.at_least_n_nodes(2)
-@reqs.no_http2()
+@reqs.no_http2()  # TODO: Remove?
 def test_signed_escapes(network, args):
     node = network.find_node_by_role()
     with node.client("user0", "user0") as c:
@@ -1459,7 +1459,7 @@ def test_random_receipts(
 
 @reqs.description("Test basic app liveness")
 @reqs.at_least_n_nodes(1)
-@reqs.no_http2()
+@reqs.no_http2()  # TODO: Remove?
 @app.scoped_txs()
 def test_liveness(network, args):
     network.txs.issue(
@@ -1678,24 +1678,24 @@ def run_parsing_errors(args):
 if __name__ == "__main__":
     cr = ConcurrentRunner()
 
-    cr.add(
-        "js",
-        run,
-        package="libjs_generic",
-        nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-        initial_user_count=4,
-        initial_member_count=2,
-    )
+    # cr.add(
+    #     "js",
+    #     run,
+    #     package="libjs_generic",
+    #     nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+    #     initial_user_count=4,
+    #     initial_member_count=2,
+    # )
 
-    cr.add(
-        "cpp",
-        run,
-        package="samples/apps/logging/liblogging",
-        js_app_bundle=None,
-        nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-        initial_user_count=4,
-        initial_member_count=2,
-    )
+    # cr.add(
+    #     "cpp",
+    #     run,
+    #     package="samples/apps/logging/liblogging",
+    #     js_app_bundle=None,
+    #     nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+    #     initial_user_count=4,
+    #     initial_member_count=2,
+    # )
 
     cr.add(
         "common",
@@ -1705,27 +1705,27 @@ if __name__ == "__main__":
     )
 
     # Run illegal traffic tests in separate runners, to reduce total serial runtime
-    if not cr.args.http2:
-        cr.add(
-            "js_illegal",
-            run_parsing_errors,
-            package="libjs_generic",
-            nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-        )
+    # if not cr.args.http2:
+    #     cr.add(
+    #         "js_illegal",
+    #         run_parsing_errors,
+    #         package="libjs_generic",
+    #         nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+    #     )
 
-        cr.add(
-            "cpp_illegal",
-            run_parsing_errors,
-            package="samples/apps/logging/liblogging",
-            nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-        )
+    #     cr.add(
+    #         "cpp_illegal",
+    #         run_parsing_errors,
+    #         package="samples/apps/logging/liblogging",
+    #         nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+    #     )
 
-    # This is just for the UDP echo test for now
-    cr.add(
-        "udp",
-        run_udp_tests,
-        package="samples/apps/logging/liblogging",
-        nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-    )
+    # # This is just for the UDP echo test for now
+    # cr.add(
+    #     "udp",
+    #     run_udp_tests,
+    #     package="samples/apps/logging/liblogging",
+    #     nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+    # )
 
     cr.run()

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -189,7 +189,15 @@ def test_illegal(network, args):
 
     def send_bad_raw_content(content):
         nonlocal additional_parsing_errors
-        response = send_raw_content(content)
+        try:
+            response = send_raw_content(content)
+        except http.client.RemoteDisconnected:
+            assert args.http2, "HTTP/2 interface should close session without error"
+            additional_parsing_errors += 1
+            return
+        else:
+            assert not args.http2, "HTTP/1.1 interface should return valid error"
+
         response_body = response.read()
         LOG.warning(response_body)
         # If request parsing error, the interface metrics should report it
@@ -236,22 +244,26 @@ def test_illegal(network, args):
         == initial_parsing_errors + additional_parsing_errors
     )
 
-    good_content = b"GET /node/state HTTP/1.1\r\n\r\n"
-    response = send_raw_content(good_content)
-    assert response.status == http.HTTPStatus.OK, (response.status, response.read())
-    send_corrupt_variations(good_content)
+    if not args.http2:
+        good_content = b"GET /node/state HTTP/1.1\r\n\r\n"
+        response = send_raw_content(good_content)
+        assert response.status == http.HTTPStatus.OK, (response.status, response.read())
+        send_corrupt_variations(good_content)
 
     # Valid transactions are still accepted
     network.txs.issue(
         network=network,
         number_txs=1,
     )
-    network.txs.issue(
-        network=network,
-        number_txs=1,
-        on_backup=True,
-    )
-    network.txs.verify()
+
+    # HTTP/2 does not support forwarding
+    if not args.http2:
+        network.txs.issue(
+            network=network,
+            number_txs=1,
+            on_backup=True,
+        )
+        network.txs.verify()
 
     return network
 
@@ -289,18 +301,20 @@ def test_protocols(network, args):
     )
     expected_response_body, status_code, http_version = parse_result_out(res)
     assert status_code == "200", status_code
-    assert http_version == "1.1", http_version
+    assert http_version == "2" if args.http2 else "1.1", http_version
 
-    # Test additional protocols with curl
-    for protocol, expected_result in {
-        # HTTP/1.x requests succeed, as HTTP/1.1
-        "--http1.0": {"http_status": "200", "http_version": "1.1"},
-        "--http1.1": {"http_status": "200", "http_version": "1.1"},
+    protocols = {
         # WebSockets upgrade request is ignored
-        "websockets": {"extra_args": [], "http_status": "200", "http_version": "1.1"},
-        # TLS handshake negotiates HTTP/1.1
-        "--http2": {"http_status": "200", "http_version": "1.1"},
-        "--http2-prior-knowledge": {"http_status": "200", "http_version": "1.1"},
+        "websockets": {
+            "extra_args": [
+                "-H",
+                "Upgrade: websocket",
+                "-H",
+                "Connection: Upgrade",
+            ],
+            "http_status": "200",
+            "http_version": "1.1",
+        },
         # HTTP3 is not supported by curl _or_ CCF
         "--http3": {
             "errors": [
@@ -308,7 +322,39 @@ def test_protocols(network, args):
                 "option --http3: is unknown",
             ]
         },
-    }.items():
+    }
+    if args.http2:
+        protocols.update(
+            {
+                # HTTP/1.x requests fail with closed connection, as HTTP/2
+                "--http1.0": {"errors": ["Empty reply from server"]},
+                "--http1.1": {"errors": ["Empty reply from server"]},
+                # TLS handshake negotiates HTTP/2
+                "--http2": {"http_status": "200", "http_version": "1.1"},
+                "--http2-prior-knowledge": {
+                    "http_status": "200",
+                    "http_version": "1.1",
+                },
+            }
+        )
+    else:  # HTTP/1.1
+        protocols.update(
+            {
+                # HTTP/1.x requests succeed, as HTTP/1.1
+                "--http1.0": {"http_status": "200", "http_version": "1.1"},
+                "--http1.1": {"http_status": "200", "http_version": "1.1"},
+                # TLS handshake negotiates HTTP/1.1
+                "--http2": {"http_status": "200", "http_version": "1.1"},
+                "--http2-prior-knowledge": {
+                    "http_status": "200",
+                    "http_version": "1.1",
+                },
+            }
+        )
+
+    # Test additional protocols with curl
+    for protocol, expected_result in protocols.items():
+        LOG.debug(protocol)
         cmd = ["curl", *common_options]
         if "extra_args" in expected_result:
             cmd.extend(expected_result["extra_args"])
@@ -321,7 +367,7 @@ def test_protocols(network, args):
                 response_body == expected_response_body
             ), f"{response_body}\n !=\n{expected_response_body}"
             assert status_code == "200", status_code
-            assert http_version == "1.1", http_version
+            assert http_version == "2" if args.http2 else "1.1", http_version
         else:
             assert res.returncode != 0, res.returncode
             err = res.stderr.decode()
@@ -333,12 +379,14 @@ def test_protocols(network, args):
         network=network,
         number_txs=1,
     )
-    network.txs.issue(
-        network=network,
-        number_txs=1,
-        on_backup=True,
-    )
-    network.txs.verify()
+    # HTTP/2 does not support forwarding
+    if not args.http2:
+        network.txs.issue(
+            network=network,
+            number_txs=1,
+            on_backup=True,
+        )
+        network.txs.verify()
 
     return network
 
@@ -747,7 +795,7 @@ def test_metrics(network, args):
 
 @reqs.description("Read historical state")
 @reqs.supports_methods("/app/log/private", "/app/log/private/historical")
-@reqs.no_http2()  # TODO: Remove?
+@reqs.no_http2()
 @app.scoped_txs()
 def test_historical_query(network, args):
     network.txs.issue(network, number_txs=2)
@@ -1158,7 +1206,6 @@ def test_forwarding_frontends_without_app_prefix(network, args):
 @reqs.description("Testing signed queries with escaped queries")
 @reqs.installed_package("samples/apps/logging/liblogging")
 @reqs.at_least_n_nodes(2)
-@reqs.no_http2()  # TODO: Remove?
 def test_signed_escapes(network, args):
     node = network.find_node_by_role()
     with node.client("user0", "user0") as c:
@@ -1459,7 +1506,7 @@ def test_random_receipts(
 
 @reqs.description("Test basic app liveness")
 @reqs.at_least_n_nodes(1)
-@reqs.no_http2()  # TODO: Remove?
+@reqs.no_http2()
 @app.scoped_txs()
 def test_liveness(network, args):
     network.txs.issue(
@@ -1678,24 +1725,24 @@ def run_parsing_errors(args):
 if __name__ == "__main__":
     cr = ConcurrentRunner()
 
-    # cr.add(
-    #     "js",
-    #     run,
-    #     package="libjs_generic",
-    #     nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-    #     initial_user_count=4,
-    #     initial_member_count=2,
-    # )
+    cr.add(
+        "js",
+        run,
+        package="libjs_generic",
+        nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+        initial_user_count=4,
+        initial_member_count=2,
+    )
 
-    # cr.add(
-    #     "cpp",
-    #     run,
-    #     package="samples/apps/logging/liblogging",
-    #     js_app_bundle=None,
-    #     nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-    #     initial_user_count=4,
-    #     initial_member_count=2,
-    # )
+    cr.add(
+        "cpp",
+        run,
+        package="samples/apps/logging/liblogging",
+        js_app_bundle=None,
+        nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+        initial_user_count=4,
+        initial_member_count=2,
+    )
 
     cr.add(
         "common",
@@ -1705,27 +1752,26 @@ if __name__ == "__main__":
     )
 
     # Run illegal traffic tests in separate runners, to reduce total serial runtime
-    # if not cr.args.http2:
-    #     cr.add(
-    #         "js_illegal",
-    #         run_parsing_errors,
-    #         package="libjs_generic",
-    #         nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-    #     )
+    cr.add(
+        "js_illegal",
+        run_parsing_errors,
+        package="libjs_generic",
+        nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+    )
 
-    #     cr.add(
-    #         "cpp_illegal",
-    #         run_parsing_errors,
-    #         package="samples/apps/logging/liblogging",
-    #         nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-    #     )
+    cr.add(
+        "cpp_illegal",
+        run_parsing_errors,
+        package="samples/apps/logging/liblogging",
+        nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+    )
 
-    # # This is just for the UDP echo test for now
-    # cr.add(
-    #     "udp",
-    #     run_udp_tests,
-    #     package="samples/apps/logging/liblogging",
-    #     nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-    # )
+    # This is just for the UDP echo test for now
+    cr.add(
+        "udp",
+        run_udp_tests,
+        package="samples/apps/logging/liblogging",
+        nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+    )
 
     cr.run()

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1206,6 +1206,7 @@ def test_forwarding_frontends_without_app_prefix(network, args):
 @reqs.description("Testing signed queries with escaped queries")
 @reqs.installed_package("samples/apps/logging/liblogging")
 @reqs.at_least_n_nodes(2)
+@reqs.no_http2()
 def test_signed_escapes(network, args):
     node = network.find_node_by_role()
     with node.client("user0", "user0") as c:

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -633,7 +633,7 @@ class HttpxClient:
             raise TimeoutError from exc
         except httpx.ConnectError as exc:
             raise CCFConnectionException from exc
-        except (httpx.WriteError, httpx.ReadError) as exc:
+        except (httpx.WriteError, httpx.ReadError, httpx.RemoteProtocolError) as exc:
             raise CCFIOException from exc
         except Exception as exc:
             raise RuntimeError(

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -508,12 +508,21 @@ class CurlClient:
         pass
 
     @staticmethod
-    def extra_headers_count():
+    def extra_headers_count(http2=False):
         # curl inserts the following headers in every request
-        #  host: <address>
-        #  user-agent: curl/<version>
-        #  accept: */*
-        return 3
+        if http2:
+            #  :method: GET/POST
+            #  :authority: <address>
+            #  :scheme: https
+            #  :path: /path
+            #  accept: */*
+            #  user-agent: curl/<version>
+            return 6
+        else:
+            #  host: <address>
+            #  user-agent: curl/<version>
+            #  accept: */*
+            return 3
 
 
 class HttpxClient:
@@ -646,14 +655,24 @@ class HttpxClient:
         self.session.close()
 
     @staticmethod
-    def extra_headers_count():
+    def extra_headers_count(http2=False):
         # httpx inserts the following headers in every request
-        #  host: <address>
-        #  accept: */*
-        #  accept-encoding: gzip, deflate, br
-        #  connection: keep-alive
-        #  user-agent: python-httpx/<version>
-        return 5
+        if http2:
+            #  :method: GET/POST
+            #  :authority: <address>
+            #  :scheme: https
+            #  :path: /path
+            #  accept: */*
+            #  accept-encoding: gzip, deflate, br
+            #  user-agent: python-httpx/<version>
+            return 7
+        else:
+            #  host: <address>
+            #  accept: */*
+            #  accept-encoding: gzip, deflate, br
+            #  connection: keep-alive
+            #  user-agent: python-httpx/<version>
+            return 5
 
 
 class RawSocketClient:


### PR DESCRIPTION
Part of #3342 

This brings HTTP/2 in line with HTTP/1.1, with maximum request payload and header sizes now being enforced, and parsing errors being reported correctly. 

I've also re-enabled some tests in `e2e_logging.py` that were marked as `no_http2`.