### PR TITLE
Fix binary_dir arg on sandbox ssh remote

### DIFF
--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -146,6 +146,7 @@ class SSHRemote(CmdMixin):
         common_dir,
         env=None,
         pid_file=None,
+        binary_dir=".",
     ):
         """
         Runs a command on a remote host, through an SSH connection. A temporary


### PR DESCRIPTION
Missed this in #4767