### PR TITLE
Check validity times in default auth policies

### DIFF
--- a/include/ccf/ds/json.h
+++ b/include/ccf/ds/json.h
@@ -31,6 +31,11 @@ public:
       "#/{}",
       fmt::join(pointer_elements.crbegin(), pointer_elements.crend(), "/"));
   }
+
+  std::string describe() const
+  {
+    return fmt::format("At {}: {}", pointer(), what());
+  }
 };
 
 namespace std

--- a/src/endpoints/authentication/cert_auth.cpp
+++ b/src/endpoints/authentication/cert_auth.cpp
@@ -128,10 +128,11 @@ namespace ccf
       return nullptr;
     }
 
-    if (!is_cert_valid_now(caller_cert, error_reason))
-    {
-      return nullptr;
-    }
+    // TODO: I guess we never want to care about time for these certs?
+    // if (!is_cert_valid_now(caller_cert, error_reason))
+    // {
+    //   return nullptr;
+    // }
 
     auto node_caller_id = compute_node_id_from_cert_der(caller_cert);
 

--- a/src/endpoints/authentication/jwt_auth.cpp
+++ b/src/endpoints/authentication/jwt_auth.cpp
@@ -5,6 +5,7 @@
 
 #include "ccf/rpc_context.h"
 #include "ccf/service/tables/jwt.h"
+#include "enclave/enclave_time.h"
 #include "http/http_jwt.h"
 
 namespace ccf
@@ -16,32 +17,56 @@ namespace ccf
   {
     const auto& headers = ctx->get_request_headers();
 
-    const auto token = http::JwtVerifier::extract_token(headers, error_reason);
+    const auto token_opt =
+      http::JwtVerifier::extract_token(headers, error_reason);
 
-    if (token.has_value())
+    if (token_opt.has_value())
     {
+      auto& token = token_opt.value();
       auto keys =
         tx.ro<JwtPublicSigningKeys>(ccf::Tables::JWT_PUBLIC_SIGNING_KEYS);
       auto key_issuers = tx.ro<JwtPublicSigningKeyIssuer>(
         ccf::Tables::JWT_PUBLIC_SIGNING_KEY_ISSUER);
-      const auto key_id = token.value().header_typed.kid;
+      const auto key_id = token.header_typed.kid;
       const auto token_key = keys->get(key_id);
       if (!token_key.has_value())
       {
         error_reason = "JWT signing key not found";
       }
       else if (!http::JwtVerifier::validate_token_signature(
-                 token.value(), token_key.value()))
+                 token, token_key.value()))
       {
         error_reason = "JWT signature is invalid";
       }
       else
       {
-        auto identity = std::make_unique<JwtAuthnIdentity>();
-        identity->key_issuer = key_issuers->get(key_id).value();
-        identity->header = std::move(token->header);
-        identity->payload = std::move(token->payload);
-        return identity;
+        // Check that the Not Before and Expiration Time claims are valid
+        const size_t time_now =
+          std::chrono::duration_cast<std::chrono::seconds>(
+            ccf::get_enclave_time())
+            .count();
+        if (time_now < token.payload_typed.nbf)
+        {
+          error_reason = fmt::format(
+            "Current time {} is before token's Not Before claim {}",
+            time_now,
+            token.payload_typed.nbf);
+        }
+        else if (time_now > token.payload_typed.exp)
+        {
+          error_reason = fmt::format(
+            "Current time {} is after token's Expiration Time claim {}",
+            time_now,
+            token.payload_typed.exp);
+        }
+        else
+        {
+          auto identity = std::make_unique<JwtAuthnIdentity>();
+          identity->key_issuer = key_issuers->get(key_id).value();
+          identity->header = std::move(token.header);
+          identity->payload = std::move(token.payload);
+          return identity;
+        }
       }
     }
 

--- a/src/http/http_jwt.h
+++ b/src/http/http_jwt.h
@@ -28,6 +28,14 @@ namespace http
   DECLARE_JSON_TYPE(JwtHeader)
   DECLARE_JSON_REQUIRED_FIELDS(JwtHeader, alg, kid)
 
+  struct JwtPayload
+  {
+    size_t nbf;
+    size_t exp;
+  };
+  DECLARE_JSON_TYPE(JwtPayload)
+  DECLARE_JSON_REQUIRED_FIELDS(JwtPayload, nbf, exp)
+
   class JwtVerifier
   {
   public:
@@ -36,6 +44,7 @@ namespace http
       nlohmann::json header;
       JwtHeader header_typed;
       nlohmann::json payload;
+      JwtPayload payload_typed;
       std::vector<uint8_t> signature;
       std::string_view signed_content;
     };
@@ -116,14 +125,30 @@ namespace http
       {
         header_typed = header.get<JwtHeader>();
       }
-      catch (const nlohmann::json::exception& e)
+      catch (const JsonParseError& e)
       {
         error_reason =
-          fmt::format("JWT header does not follow schema: {}", e.what());
+          fmt::format("JWT header does not follow schema: {}", e.describe());
+        return std::nullopt;
+      }
+      JwtPayload payload_typed;
+      try
+      {
+        payload_typed = payload.get<JwtPayload>();
+      }
+      catch (const JsonParseError& e)
+      {
+        error_reason =
+          fmt::format("JWT payload is missing required field: {}", e.describe());
         return std::nullopt;
       }
       Token parsed = {
-        header, header_typed, payload, signature_raw, signed_content};
+        header,
+        header_typed,
+        payload,
+        payload_typed,
+        signature_raw,
+        signed_content};
       return parsed;
     }
 

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -590,7 +590,7 @@ namespace ccf
           ctx->set_error(
             HTTP_STATUS_BAD_REQUEST,
             ccf::errors::InvalidInput,
-            fmt::format("At {}: {}", e.pointer(), e.what()));
+            e.describe());
           update_metrics(ctx);
           return;
         }

--- a/tests/infra/crypto.py
+++ b/tests/infra/crypto.py
@@ -111,13 +111,21 @@ def generate_eddsa_keypair() -> Tuple[str, str]:
 
 
 def generate_cert(
-    priv_key_pem: str, cn=None, issuer_priv_key_pem=None, issuer_cn=None, ca=False
+    priv_key_pem: str,
+    cn=None,
+    issuer_priv_key_pem=None,
+    issuer_cn=None,
+    ca=False,
+    valid_from=None,
+    validity_days=10,
 ) -> str:
     cn = cn or "dummy"
     if issuer_priv_key_pem is None:
         issuer_priv_key_pem = priv_key_pem
     if issuer_cn is None:
         issuer_cn = cn
+    if valid_from is None:
+        valid_from = datetime.datetime.utcnow()
     priv = load_pem_private_key(priv_key_pem.encode("ascii"), None, default_backend())
     pub = priv.public_key()
     issuer_priv = load_pem_private_key(
@@ -139,8 +147,8 @@ def generate_cert(
         .issuer_name(issuer)
         .public_key(pub)
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.datetime.utcnow())
-        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=10))
+        .not_valid_before(valid_from)
+        .not_valid_after(valid_from + datetime.timedelta(days=validity_days))
     )
     if ca:
         builder = builder.add_extension(

--- a/tests/infra/jwt_issuer.py
+++ b/tests/infra/jwt_issuer.py
@@ -184,7 +184,16 @@ class JwtIssuer:
         return self.server
 
     def issue_jwt(self, kid=TEST_JWT_KID, claims=None):
-        return infra.crypto.create_jwt(claims or {}, self.key_priv_pem, kid)
+        claims = claims or {}
+        # JWT times format NumericDate, which is a JSON numeric value counting seconds sine the epoch
+        now = int(time.time())
+        if "nbf" not in claims:
+            # Insert default Not Before claim, valid from ~10 seconds ago
+            claims["nbf"] = now - 10
+        if "exp" not in claims:
+            # Insert default Expiration Time claim, valid for ~1hr
+            claims["exp"] = now + 3600
+        return infra.crypto.create_jwt(claims, self.key_priv_pem, kid)
 
     def wait_for_refresh(self, network, kid=TEST_JWT_KID):
         timeout = self.refresh_interval * 3

--- a/tests/js-authentication/app.json
+++ b/tests/js-authentication/app.json
@@ -1,5 +1,15 @@
 {
   "endpoints": {
+    "/cert": {
+      "get": {
+        "js_module": "endpoints.js",
+        "js_function": "cert",
+        "forwarding_required": "always",
+        "authn_policies": ["user_cert"],
+        "mode": "readonly",
+        "openapi": {}
+      }
+    },
     "/jwt": {
       "get": {
         "js_module": "endpoints.js",

--- a/tests/js-authentication/src/endpoints.js
+++ b/tests/js-authentication/src/endpoints.js
@@ -1,3 +1,9 @@
+export function cert(request) {
+  console.log("Caller cert is:");
+  console.log(JSON.stringify(request.caller.cert));
+  return { body: request.caller.cert };
+}
+
 export function jwt(request) {
   console.log("JWT payload is:");
   console.log(JSON.stringify(request.caller.jwt.payload));

--- a/tests/js-custom-authorization/custom_authorization.py
+++ b/tests/js-custom-authorization/custom_authorization.py
@@ -14,6 +14,7 @@ import base64
 import json
 import time
 import infra.jwt_issuer
+import datetime
 from e2e_logging import test_multi_auth
 from http import HTTPStatus
 
@@ -79,6 +80,61 @@ def run_limits(args):
         network = test_heap_size_limit(network, args)
 
 
+@reqs.description("Cert authentication")
+def test_cert_auth(network, args):
+    def create_keypair(local_id, valid_from, validity_days):
+        privk_pem, _ = infra.crypto.generate_ec_keypair()
+        with open(os.path.join(network.common_dir, f"{local_id}_privk.pem"), "w") as f:
+            f.write(privk_pem)
+
+        cert = infra.crypto.generate_cert(
+            privk_pem,
+            valid_from=valid_from,
+            validity_days=validity_days,
+        )
+        with open(os.path.join(network.common_dir, f"{local_id}_cert.pem"), "w") as f:
+            f.write(cert)
+
+    primary, _ = network.find_primary()
+
+    LOG.info("User with old cert cannot call user-authenticated endpoint")
+    local_user_id = "in_the_past"
+    create_keypair(
+        local_user_id, datetime.datetime.utcnow() - datetime.timedelta(days=50), 3
+    )
+    network.consortium.add_user(primary, local_user_id)
+
+    with primary.client(local_user_id) as c:
+        r = c.get("/app/cert")
+        assert r.status_code == HTTPStatus.UNAUTHORIZED, r
+        assert "Not After" in r.body.json()["error"]["details"][0]["message"], r
+
+    LOG.info("User with future cert cannot call user-authenticated endpoint")
+    local_user_id = "in_the_future"
+    create_keypair(
+        local_user_id, datetime.datetime.utcnow() + datetime.timedelta(days=50), 3
+    )
+    network.consortium.add_user(primary, local_user_id)
+
+    with primary.client(local_user_id) as c:
+        r = c.get("/app/cert")
+        assert r.status_code == HTTPStatus.UNAUTHORIZED, r
+        assert "Not Before" in r.body.json()["error"]["details"][0]["message"], r
+
+    LOG.info("No leeway added to cert time evaluation")
+    local_user_id = "just_expired"
+    valid_from = datetime.datetime.utcnow() - datetime.timedelta(days=1, seconds=2)
+    create_keypair(local_user_id, valid_from, 1)
+    network.consortium.add_user(primary, local_user_id)
+
+    with primary.client(local_user_id) as c:
+        r = c.get("/app/cert")
+        assert r.status_code == HTTPStatus.UNAUTHORIZED, r
+        assert "Not After" in r.body.json()["error"]["details"][0]["message"], r
+
+    return network
+
+
 @reqs.description("JWT authentication")
 def test_jwt_auth(network, args):
     primary, _ = network.find_nodes()
@@ -136,7 +192,7 @@ def test_jwt_auth(network, args):
     return network
 
 
-@reqs.description("Roled-based access")
+@reqs.description("Role-based access")
 def test_role_based_access(network, args):
     primary, _ = network.find_nodes()
 
@@ -227,6 +283,7 @@ def run_authn(args):
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
     ) as network:
         network.start_and_open(args)
+        network = test_cert_auth(network, args)
         network = test_jwt_auth(network, args)
         network = test_multi_auth(network, args)
         network = test_role_based_access(network, args)


### PR DESCRIPTION
Resolves #4785.

We avoid using the untrusted host time in most framework code, as the threat model permits it to be manipulated by a malicious host. This leads to surprising permissiveness in some of our crypto validation, for instance accepting JWTs and certs which are expired. Using the untrusted host time here isn't a significant change in a malicious host's power - it allows them to DoS a caller by advancing the node's perception of time such that the caller's authentication is expired, but they cannot target this at a single user (affects the whole node), and they can likely build a more-targeted DoS already (by selectively dropping traffic). It is however a breaking change to the behaviour of these auth policies, which may now return auth errors for test info that they previously accepted.

TODO:
- [ ] CHANGELOG