### PR TITLE
HTTP/2: return error for to-be-forwarded requests

### DIFF
--- a/include/ccf/odata_error.h
+++ b/include/ccf/odata_error.h
@@ -55,6 +55,7 @@ namespace ccf
     // Generic errors
     ERROR(AuthorizationFailed)
     ERROR(InternalError)
+    ERROR(NotImplemented)
     ERROR(InvalidAuthenticationInfo)
     ERROR(InvalidHeaderValue)
     ERROR(InvalidInput)

--- a/src/http/http2_callbacks.h
+++ b/src/http/http2_callbacks.h
@@ -190,7 +190,6 @@ namespace http2
       configuration.max_header_size.value_or(http::default_max_header_size);
     if (namelen > max_header_size)
     {
-      LOG_FAIL_FMT("Large key length: {}", namelen);
       throw http::RequestHeaderTooLargeException(
         fmt::format(
           "Header key for '{}' is too large (max size allowed: {})",
@@ -201,7 +200,6 @@ namespace http2
 
     if (valuelen > max_header_size)
     {
-      LOG_FAIL_FMT("Large value length: {}", valuelen);
       throw http::RequestHeaderTooLargeException(
         fmt::format(
           "Header value for '{}' is too large (max size allowed: {})",

--- a/src/http/http2_session.h
+++ b/src/http/http2_session.h
@@ -375,6 +375,7 @@ namespace http
         {
           rpc_ctx = std::make_shared<HttpRpcContext>(
             session_ctx,
+            ccf::HttpVersion::HTTP2,
             verb,
             url,
             std::move(headers),

--- a/src/http/http2_session.h
+++ b/src/http/http2_session.h
@@ -350,7 +350,6 @@ namespace http
       {
         if (error_reporter)
         {
-          LOG_FAIL_FMT("Report error");
           error_reporter->report_request_payload_too_large_error(session_id);
         }
 
@@ -369,7 +368,6 @@ namespace http
       {
         if (error_reporter)
         {
-          LOG_FAIL_FMT("Reporting request header too large on {}", session_id);
           error_reporter->report_request_header_too_large_error(session_id);
         }
 

--- a/src/http/http_rpc_context.h
+++ b/src/http/http_rpc_context.h
@@ -94,13 +94,14 @@ namespace http
   public:
     HttpRpcContext(
       std::shared_ptr<ccf::SessionContext> s,
+      ccf::HttpVersion http_version,
       llhttp_method verb_,
       const std::string_view& url_,
       const http::HeaderMap& headers_,
       const std::vector<uint8_t>& body_,
       const std::shared_ptr<HTTPResponder>& responder_ = nullptr,
       const std::vector<uint8_t>& raw_request_ = {}) :
-      RpcContextImpl(s),
+      RpcContextImpl(s, http_version),
       verb(verb_),
       url(url_),
       request_headers(headers_),
@@ -371,7 +372,14 @@ namespace ccf
     const auto& msg = processor.received.front();
 
     return std::make_shared<http::HttpRpcContext>(
-      s, msg.method, msg.url, msg.headers, msg.body, nullptr, packed);
+      s,
+      ccf::HttpVersion::HTTP1,
+      msg.method,
+      msg.url,
+      msg.headers,
+      msg.body,
+      nullptr,
+      packed);
   }
 
   inline std::shared_ptr<http::HttpRpcContext> make_fwd_rpc_context(

--- a/src/http/http_session.h
+++ b/src/http/http_session.h
@@ -211,7 +211,12 @@ namespace http
         try
         {
           rpc_ctx = std::make_shared<HttpRpcContext>(
-            session_ctx, verb, url, std::move(headers), std::move(body));
+            session_ctx,
+            ccf::HttpVersion::HTTP1,
+            verb,
+            url,
+            std::move(headers),
+            std::move(body));
         }
         catch (std::exception& e)
         {

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -284,6 +284,17 @@ namespace ccf
       kv::ReadOnlyTx& tx,
       const endpoints::EndpointDefinitionPtr& endpoint)
     {
+      // HTTP/2 does not support forwarding
+      if (ctx->get_http_version() == HttpVersion::HTTP2)
+      {
+        ctx->set_error(
+          HTTP_STATUS_NOT_IMPLEMENTED,
+          ccf::errors::NotImplemented,
+          "Request cannot be forwarded to primary on HTTP/2 interface.");
+        update_metrics(ctx);
+        return;
+      }
+
       if (!cmd_forwarder || !consensus)
       {
         ctx->set_error(

--- a/src/node/rpc/rpc_context_impl.h
+++ b/src/node/rpc/rpc_context_impl.h
@@ -7,7 +7,6 @@
 
 namespace ccf
 {
-  // TODO: Move to http namespace
   enum class HttpVersion
   {
     HTTP1 = 0,

--- a/src/node/rpc/rpc_context_impl.h
+++ b/src/node/rpc/rpc_context_impl.h
@@ -7,6 +7,13 @@
 
 namespace ccf
 {
+  // TODO: Move to http namespace
+  enum class HttpVersion
+  {
+    HTTP1 = 0,
+    HTTP2
+  };
+
   // Partial implementation of RpcContext, private to the framework (not visible
   // to apps). Serves 2 purposes:
   // - Default implementation of simple methods accessing member fields
@@ -15,11 +22,17 @@ namespace ccf
   {
   protected:
     std::shared_ptr<SessionContext> session;
+    HttpVersion http_version;
 
     std::shared_ptr<void> user_data;
 
   public:
-    RpcContextImpl(const std::shared_ptr<SessionContext>& s) : session(s) {}
+    RpcContextImpl(
+      const std::shared_ptr<SessionContext>& s,
+      HttpVersion v = HttpVersion::HTTP1) :
+      session(s),
+      http_version(v)
+    {}
 
     std::shared_ptr<SessionContext> get_session_context() const override
     {
@@ -52,6 +65,11 @@ namespace ccf
     virtual const ccf::PathParams& get_decoded_request_path_params() override
     {
       return decoded_path_params;
+    }
+
+    HttpVersion get_http_version() const
+    {
+      return http_version;
     }
 
     bool is_create_request = false;

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1649,36 +1649,36 @@ def run(args):
     ) as network:
         network.start_and_open(args)
 
-        # test(network, args)
-        # test_remove(network, args)
-        # test_clear(network, args)
-        # test_record_count(network, args)
+        test(network, args)
+        test_remove(network, args)
+        test_clear(network, args)
+        test_record_count(network, args)
         test_forwarding_frontends(network, args)
-        # test_forwarding_frontends_without_app_prefix(network, args)
-        # test_signed_escapes(network, args)
-        # test_user_data_ACL(network, args)
-        # test_cert_prefix(network, args)
-        # test_anonymous_caller(network, args)
-        # test_multi_auth(network, args)
-        # test_custom_auth(network, args)
-        # test_custom_auth_safety(network, args)
-        # test_raw_text(network, args)
-        # test_historical_query(network, args)
-        # test_historical_query_range(network, args)
-        # test_view_history(network, args)
-        # test_metrics(network, args)
-        # test_empty_path(network, args)
-        # test_post_local_commit_failure(network, args)
-        # test_committed_index(network, args)
-        # test_liveness(network, args)
-        # test_rekey(network, args)
-        # test_liveness(network, args)
-        # test_random_receipts(network, args, False)
-        # if args.package == "samples/apps/logging/liblogging":
-        #     test_receipts(network, args)
-        #     test_historical_query_sparse(network, args)
-        # test_historical_receipts(network, args)
-        # test_historical_receipts_with_claims(network, args)
+        test_forwarding_frontends_without_app_prefix(network, args)
+        test_signed_escapes(network, args)
+        test_user_data_ACL(network, args)
+        test_cert_prefix(network, args)
+        test_anonymous_caller(network, args)
+        test_multi_auth(network, args)
+        test_custom_auth(network, args)
+        test_custom_auth_safety(network, args)
+        test_raw_text(network, args)
+        test_historical_query(network, args)
+        test_historical_query_range(network, args)
+        test_view_history(network, args)
+        test_metrics(network, args)
+        test_empty_path(network, args)
+        test_post_local_commit_failure(network, args)
+        test_committed_index(network, args)
+        test_liveness(network, args)
+        test_rekey(network, args)
+        test_liveness(network, args)
+        test_random_receipts(network, args, False)
+        if args.package == "samples/apps/logging/liblogging":
+            test_receipts(network, args)
+            test_historical_query_sparse(network, args)
+        test_historical_receipts(network, args)
+        test_historical_receipts_with_claims(network, args)
 
 
 def run_parsing_errors(args):
@@ -1700,14 +1700,14 @@ def run_parsing_errors(args):
 if __name__ == "__main__":
     cr = ConcurrentRunner()
 
-    # cr.add(
-    #     "js",
-    #     run,
-    #     package="libjs_generic",
-    #     nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-    #     initial_user_count=4,
-    #     initial_member_count=2,
-    # )
+    cr.add(
+        "js",
+        run,
+        package="libjs_generic",
+        nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+        initial_user_count=4,
+        initial_member_count=2,
+    )
 
     cr.add(
         "cpp",
@@ -1719,35 +1719,35 @@ if __name__ == "__main__":
         initial_member_count=2,
     )
 
-    # cr.add(
-    #     "common",
-    #     e2e_common_endpoints.run,
-    #     package="samples/apps/logging/liblogging",
-    #     nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-    # )
+    cr.add(
+        "common",
+        e2e_common_endpoints.run,
+        package="samples/apps/logging/liblogging",
+        nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+    )
 
-    # # Run illegal traffic tests in separate runners, to reduce total serial runtime
-    # if not cr.args.http2:
-    #     cr.add(
-    #         "js_illegal",
-    #         run_parsing_errors,
-    #         package="libjs_generic",
-    #         nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-    #     )
+    # Run illegal traffic tests in separate runners, to reduce total serial runtime
+    if not cr.args.http2:
+        cr.add(
+            "js_illegal",
+            run_parsing_errors,
+            package="libjs_generic",
+            nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+        )
 
-    #     cr.add(
-    #         "cpp_illegal",
-    #         run_parsing_errors,
-    #         package="samples/apps/logging/liblogging",
-    #         nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-    #     )
+        cr.add(
+            "cpp_illegal",
+            run_parsing_errors,
+            package="samples/apps/logging/liblogging",
+            nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+        )
 
-    # # This is just for the UDP echo test for now
-    # cr.add(
-    #     "udp",
-    #     run_udp_tests,
-    #     package="samples/apps/logging/liblogging",
-    #     nodes=infra.e2e_args.max_nodes(cr.args, f=0),
-    # )
+    # This is just for the UDP echo test for now
+    cr.add(
+        "udp",
+        run_udp_tests,
+        package="samples/apps/logging/liblogging",
+        nodes=infra.e2e_args.max_nodes(cr.args, f=0),
+    )
 
     cr.run()

--- a/tests/infra/logging_app.py
+++ b/tests/infra/logging_app.py
@@ -16,6 +16,17 @@ from ccf.tx_id import TxID
 from loguru import logger as LOG
 
 
+class LoggingTxsIssueException(Exception):
+    """
+    Exception raised if a LoggingTxs instance cannot successfully issue a
+    new entry.
+    """
+
+    def __init__(self, response, *args, **kwargs):
+        super(LoggingTxsIssueException, self).__init__(*args, **kwargs)
+        self.response = response
+
+
 class LoggingTxsVerifyException(Exception):
     """
     Exception raised if a LoggingTxs instance cannot successfully verify all
@@ -151,6 +162,8 @@ class LoggingTxs:
                         headers=headers,
                         log_capture=log_capture,
                     )
+                    if rep_priv.status_code != http.HTTPStatus.OK:
+                        raise LoggingTxsIssueException(rep_priv)
                     assert rep_priv.status_code == http.HTTPStatus.OK, rep_priv
                     self.priv[target_idx].append(
                         {
@@ -184,7 +197,8 @@ class LoggingTxs:
                         headers=headers,
                         log_capture=log_capture,
                     )
-                    assert rep_pub.status_code == http.HTTPStatus.OK, rep_pub
+                    if rep_pub.status_code != http.HTTPStatus.OK:
+                        raise LoggingTxsIssueException(rep_priv)
                     self.pub[target_idx].append(
                         {
                             "msg": pub_msg,

--- a/tests/infra/member.py
+++ b/tests/infra/member.py
@@ -21,20 +21,15 @@ class MemberEndpointException(Exception):
 
 
 class NoRecoveryShareFound(MemberEndpointException):
-    def __init__(self, *args, **kwargs):
-        super(NoRecoveryShareFound, self).__init__(*args, **kwargs)
+    pass
 
 
 class UnauthenticatedMember(MemberEndpointException):
     """Member is not known by the service"""
 
-    def __init__(self, *args, **kwargs):
-        super(UnauthenticatedMember, self).__init__(*args, **kwargs)
-
 
 class AckException(MemberEndpointException):
-    def __init__(self, *args, **kwargs):
-        super(AckException, self).__init__(*args, **kwargs)
+    pass
 
 
 class MemberStatus(Enum):


### PR DESCRIPTION
Part of #3342 

As there are no current plans to support client request forwarding for HTTP/2 interfaces, we now return an error for such requests rather than forwarding the request to the primary node and inevitably timing out (as the HTTP/2 response cannot be serialised by the primary node and sent back to the client). 