### PR TITLE
Handle SNP CI on days where there are no merges

### DIFF
--- a/.azure_pipelines_snp.yml
+++ b/.azure_pipelines_snp.yml
@@ -4,6 +4,7 @@ pr:
       - main
   paths:
     include:
+      - .github/workflows/build-ci-container.yml
       - .azure_pipelines_snp.yml
       - .azure-pipelines-templates/deploy_aci.yml
       - .azure-pipelines-templates/test_on_remote.yml

--- a/.github/workflows/build-ci-container.yml
+++ b/.github/workflows/build-ci-container.yml
@@ -16,12 +16,8 @@ on:
     branches:
       - main
       - release/3.x
-    paths:
-      - .github/workflows/build-ci-container.yml
-      - .azure_pipelines_snp.yml
-      - .azure-pipelines-templates/deploy_aci.yml
-      - .azure-pipelines-templates/test_on_remote.yml
-      - .snpcc_canary
+  schedule:
+    - cron: "0 9 * * Mon-Fri"
 
 env:
   ACR_REGISTRY: ccfmsrc.azurecr.io


### PR DESCRIPTION
If we have a day where there are no merges onto main, we never build an image for SNP CI, and since we cleanup images at the end of each day this would mean the regular run on SNP CI has no images to use

Fix is to run the build CI job at the start of each day

Also run CI on every push even if it doesn't touch SNP files so that the regular SNP run will also have the correct image