### PR TITLE
Reduce time waiting for new primary in election test

### DIFF
--- a/tests/election.py
+++ b/tests/election.py
@@ -37,7 +37,7 @@ def test_kill_primary_no_reqs(network, args):
 
     old_primary.stop()
 
-    new_primary, _ = network.wait_for_new_primary(old_primary)
+    new_primary, _ = network.wait_for_new_primary(old_primary, timeout_multiplier=5)
 
     with new_primary.client() as c:
         # Get the current view history


### PR DESCRIPTION
The `election_test` currently waits up to 15 times (`DEFAULT_TIMEOUT_MULTIPLIER` in `network.py`) the election timeout before declaring an election as unsuccessful. This is useful when waiting for elections during/after network partitions, but less so in the last iteration of the election test when we know for sure an election will not converge as we have killed more than `f` nodes. This PR reduces the time waiting for an unsuccessful election in this test only, shaving off 15 secs from the total `ctest` runtime. 