### PR TITLE
Only set low timeouts when we expect `wait_for_new_primary` to fail

### DIFF
--- a/tests/election.py
+++ b/tests/election.py
@@ -37,7 +37,7 @@ def test_kill_primary_no_reqs(network, args):
 
     old_primary.stop()
 
-    new_primary, _ = network.wait_for_new_primary(old_primary, timeout_multiplier=5)
+    new_primary, _ = network.wait_for_new_primary(old_primary)
 
     with new_primary.client() as c:
         # Get the current view history
@@ -220,14 +220,23 @@ def run(args):
 
                 network.wait_for_all_nodes_to_commit(tx_id=TxID(res.view, res.seqno))
 
-                try:
+                if node_to_stop == nodes_to_stop - 1:
+                    # Killing this node goes past the service's fault tolerance threshold, so no primary can now be elected
+                    primary.stop()
+
+                    try:
+                        # Use smaller timeout multiplier since we expect the service to be stuck, so must wait this long
+                        network.wait_for_new_primary(
+                            primary,
+                            timeout_multiplier=5,
+                        )
+                    except PrimaryNotFound:
+                        primary_is_known = False
+                    else:
+                        assert False, "Expected no primary to be found!"
+                else:
                     test_kill_primary_no_reqs(network, args)
                     test_commit_view_history(network, args)
-                except PrimaryNotFound:
-                    if node_to_stop < nodes_to_stop - 1:
-                        raise
-                    else:
-                        primary_is_known = False
 
             assert not primary_is_known, "Primary is still known"
             LOG.success("Test ended successfully.")


### PR DESCRIPTION
Opening for discussion.

I think there's a risk in #4797 reducing the wait time in non-failing cases to. This may introduce the occasional failures we saw before #4778 applied a uniform election timeout to all instances that we expect to pass.

This is an alternative implementation with the same goal - reduce the amount of time we wait for a new primary _when we expect this wait to fail_, to reduce the total test runtime.