### PR TITLE
Run join_old_snapshot test outside after other network cleanup

### DIFF
--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -794,7 +794,7 @@ def run_all(args):
         test_service_config_endpoint(network, args)
         test_node_certificates_validity_period(network, args)
         test_add_node_invalid_validity_period(network, args)
-        run_join_old_snapshot(args)
+    run_join_old_snapshot(args)
 
 
 def run_join_old_snapshot(args):


### PR DESCRIPTION
The test creates it's own network which currently lives alongside the network created for all other tests

Spun out from #4708 and therefore also contributes to https://github.com/microsoft/CCF/issues/4190