### PR TITLE
Fix running SNP pipeline against PR manually

### DIFF
--- a/.azure-pipelines-templates/deploy_aci.yml
+++ b/.azure-pipelines-templates/deploy_aci.yml
@@ -22,9 +22,10 @@ jobs:
           set -ex
           RETRIES=500
           HEAD_SHA=`git rev-parse HEAD`
-          if [ $(System.PullRequest.PullRequestId) != "" ]; then
+          if [ $(Build.SourceBranchName) == "merge" ]; then
             # If this is the case, we're running in a PR, and the SHA we really want is in the
             # commit message of the last commit (which merges it into target)
+            echo "Running in a PR, getting the SHA from the commit message"
             LAST_COMMIT=(`git log -1 --pretty=%B`)
             HEAD_SHA=${LAST_COMMIT[1]}
           fi


### PR DESCRIPTION
When running the SNP pipeline manually for a PR, the PR id field isn't populated so the pipeline treats it like a run on a non-pr branch, meaning it gets the latest SHA from the merge branch rather than from the merge commit message as expected.

Fix is to look for the merge branch instead