### PR TITLE
Separate leadership and membership state in raft_driver logging.

### DIFF
--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -412,22 +412,21 @@ public:
   void state_one(ccf::NodeId node_id)
   {
     auto raft = _nodes.at(node_id).raft;
-    RAFT_DRIVER_OUT << fmt::format(
-                         "  Note right of {}: {} @{}.{} (committed {})",
-                         node_id,
-                         raft->is_backup() ?
-                           "F" :
-                           (raft->is_candidate() ?
-                              "C" :
-                              (raft->is_retired() ?
-                                 "R" :
-                                 (raft->is_learner() ?
-                                    "L" :
-                                    (raft->is_primary() ? "P" : "?")))),
-                         raft->get_view(),
-                         raft->get_last_idx(),
-                         raft->get_committed_seqno())
-                    << std::endl;
+    RAFT_DRIVER_OUT
+      << fmt::format(
+           "  Note right of {}: leadership {} membership {} @{}.{} (committed "
+           "{})",
+           node_id,
+           raft->is_backup() ?
+             "F" :
+             (raft->is_candidate() ? "C" : (raft->is_primary() ? "P" : "?")),
+           raft->is_retiring() ?
+             "Ri" :
+             (raft->is_retired() ? "R" : (raft->is_learner() ? "L" : "A")),
+           raft->get_view(),
+           raft->get_last_idx(),
+           raft->get_committed_seqno())
+      << std::endl;
   }
 
   void state_all()


### PR DESCRIPTION
[Separate leadership and membership state in raft_driver logging.](https://github.com/microsoft/CCF/commit/783c22e89433c8ca1393fcdc341cd56e156522d3)