### PR TITLE
Add explicit dependency between proto libraries

### DIFF
--- a/src/apps/external_executor/protobuf/CMakeLists.txt
+++ b/src/apps/external_executor/protobuf/CMakeLists.txt
@@ -77,6 +77,8 @@ endforeach()
 # Add dependencies between proto libraries
 if(COMPILE_TARGET STREQUAL "sgx")
   target_link_libraries(kv.proto.enclave PUBLIC http.proto.enclave)
+  target_link_libraries(historical.proto.enclave PUBLIC kv.proto.enclave)
 else()
   target_link_libraries(kv.proto.virtual PUBLIC http.proto.virtual)
+  target_link_libraries(historical.proto.virtual PUBLIC kv.proto.virtual)
 endif()


### PR DESCRIPTION
CodeQL failing: https://github.com/microsoft/CCF/actions/runs/3902624547/jobs/6665906758#step:6:432

Looks like this dependency is somehow always present with Ninja, but not with Make?

So we could repro with:

```
$ mkdir build.make
$ cd build.make
$ cmake ..
$ make historical.proto.enclave
[  0%] Generate C++ source files from protobuf file historical.proto
Scanning dependencies of target historical.proto.enclave
[  0%] Building CXX object src/apps/external_executor/protobuf/CMakeFiles/historical.proto.enclave.dir/historical.pb.cc.o
In file included from /data/src/1.CCF/build.make/src/apps/external_executor/protobuf/historical.pb.cc:4:
/data/src/1.CCF/build.make/src/apps/external_executor/protobuf/historical.pb.h:31:10: fatal error: 'kv.pb.h' file not found
#include "kv.pb.h"
         ^~~~~~~~~
1 error generated.
make[3]: *** [src/apps/external_executor/protobuf/CMakeFiles/historical.proto.enclave.dir/build.make:70: src/apps/external_executor/protobuf/CMakeFiles/historical.proto.enclave.dir/historical.pb.cc.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:3314: src/apps/external_executor/protobuf/CMakeFiles/historical.proto.enclave.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:3321: src/apps/external_executor/protobuf/CMakeFiles/historical.proto.enclave.dir/rule] Error 2
make: *** [Makefile:1497: historical.proto.enclave] Error 2
```

Resolved by adding explicit dependency.