### PR TITLE
[release/3.x] Cherry pick: Use p1363 encoding for sign() JS API with ECDSA (#4829)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased 
+
+### Changed
+
+- `ccf.crypto.sign()` previously returned DER-encoded ECDSA signatures and now returns IEEE P1363 encoded signatures, aligning with the behavior of the Web Crypto API and `ccf.crypto.verifySignature()` (#4829).
+
 ## [3.0.3]
 
 [3.0.3]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.3

--- a/js/ccf-app/test/polyfill.test.ts
+++ b/js/ccf-app/test/polyfill.test.ts
@@ -166,6 +166,19 @@ describe("polyfill", function () {
         );
       }
 
+      // Also `signature` should be verified successfully with the JS API
+      assert.isTrue(
+        ccf.crypto.verifySignature(
+          {
+            name: "RSASSA-PKCS1-v1_5",
+            hash: "SHA-256",
+          },
+          publicKey,
+          signature,
+          data
+        )
+      );
+
       {
         const verifier = crypto.createVerify("SHA256");
         verifier.update("bar");
@@ -218,6 +231,19 @@ describe("polyfill", function () {
         );
       }
 
+      // Also `signature` should be verified successfully with the JS API
+      assert.isTrue(
+        ccf.crypto.verifySignature(
+          {
+            name: "ECDSA",
+            hash: "SHA-256",
+          },
+          publicKey,
+          signature,
+          data
+        )
+      );
+
       {
         const verifier = crypto.createVerify("SHA256");
         verifier.update("bar");
@@ -259,6 +285,18 @@ describe("polyfill", function () {
           new Uint8Array(data),
           publicKey,
           new Uint8Array(signature)
+        )
+      );
+
+      // Also `signature` should be verified successfully with the JS API
+      assert.isTrue(
+        ccf.crypto.verifySignature(
+          {
+            name: "EdDSA",
+          },
+          publicKey,
+          signature,
+          data
         )
       );
 

--- a/src/crypto/ecdsa.h
+++ b/src/crypto/ecdsa.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "crypto/openssl/openssl_wrappers.h"
+#include "crypto/openssl/public_key.h"
 
 #include <openssl/bn.h>
 #include <openssl/ecdsa.h>
@@ -61,5 +62,26 @@ namespace crypto
     auto half_size = signature.size() / 2;
     return ecdsa_sig_from_r_s(
       signature.data(), half_size, signature.data() + half_size, half_size);
+  }
+
+  std::vector<uint8_t> ecdsa_sig_der_to_p1363(
+    const std::vector<uint8_t>& signature, CurveID curveId)
+  {
+    auto sig_ptr = signature.data();
+    OpenSSL::Unique_ECDSA_SIG ecdsa_sig(
+      d2i_ECDSA_SIG(NULL, &sig_ptr, signature.size()));
+    // r and s are managed by Unique_ECDSA_SIG object, so we shouldn't use
+    // Unique_BIGNUM for them
+    const BIGNUM* r = ECDSA_SIG_get0_r(ecdsa_sig);
+    const BIGNUM* s = ECDSA_SIG_get0_s(ecdsa_sig);
+    const int nid = PublicKey_OpenSSL::get_openssl_group_id(curveId);
+    OpenSSL::Unique_EC_GROUP ec_group(nid);
+    const int group_order_bits = EC_GROUP_order_bits(ec_group);
+    OpenSSL::CHECKPOSITIVE(group_order_bits);
+    const size_t n = (group_order_bits + 7) / 8;
+    std::vector<uint8_t> sig_p1363(n * 2);
+    OpenSSL::CHECKEQUAL(n, BN_bn2binpad(r, sig_p1363.data(), n));
+    OpenSSL::CHECKEQUAL(n, BN_bn2binpad(s, sig_p1363.data() + n, n));
+    return sig_p1363;
   }
 }

--- a/src/crypto/openssl/openssl_wrappers.h
+++ b/src/crypto/openssl/openssl_wrappers.h
@@ -78,6 +78,26 @@ namespace crypto
       }
     }
 
+    // Throws if values are not equal
+    inline void CHECKEQUAL(int expect, int actual)
+    {
+      if (expect != actual)
+      {
+        unsigned long ec = ERR_get_error();
+        throw std::runtime_error(
+          fmt::format("OpenSSL error: {}", error_string(ec)));
+      }
+    }
+
+    // Throws if value is not positive
+    inline void CHECKPOSITIVE(int val)
+    {
+      if (val <= 0)
+      {
+        throw std::runtime_error("OpenSSL error: expected positive value");
+      }
+    }
+
     /*
      * Unique pointer wrappers for SSL objects, with SSL' specific constructors
      * and destructors. Some objects need special functionality, others are just
@@ -281,6 +301,9 @@ namespace crypto
       : public Unique_SSL_OBJECT<ECDSA_SIG, ECDSA_SIG_new, ECDSA_SIG_free>
     {
       using Unique_SSL_OBJECT::Unique_SSL_OBJECT;
+      Unique_ECDSA_SIG(ECDSA_SIG* ecdsa_sig) :
+        Unique_SSL_OBJECT(ecdsa_sig, ECDSA_SIG_free)
+      {}
     };
 
     struct Unique_BIGNUM : public Unique_SSL_OBJECT<BIGNUM, BN_new, BN_free>

--- a/src/js/crypto.cpp
+++ b/src/js/crypto.cpp
@@ -601,7 +601,9 @@ namespace ccf::js
       {
         std::vector<uint8_t> contents(data, data + data_size);
         auto key_pair = crypto::make_key_pair(key);
-        auto sig = key_pair->sign(contents, mdtype);
+        auto sig_der = key_pair->sign(contents, mdtype);
+        auto sig =
+          crypto::ecdsa_sig_der_to_p1363(sig_der, key_pair->get_curve_id());
         return JS_NewArrayBufferCopy(ctx, sig.data(), sig.size());
       }
       else if (algo_name == "RSASSA-PKCS1-v1_5")

--- a/tests/js-modules/modules.py
+++ b/tests/js-modules/modules.py
@@ -574,11 +574,24 @@ def test_npm_app(network, args):
         assert r.status_code == http.HTTPStatus.OK, r.status_code
 
         signature = r.body.data()
-        infra.crypto.verify_signature(signature, data, key_pub_pem, algorithm["hash"])
+        infra.crypto.verify_signature(algorithm, signature, data, key_pub_pem)
+
+        # Also verify with the JS API
+        r = c.post(
+            "/app/verifySignature",
+            {
+                "algorithm": algorithm,
+                "key": key_pub_pem,
+                "signature": b64encode(signature).decode(),
+                "data": b64encode(data).decode(),
+            },
+        )
+        assert r.status_code == http.HTTPStatus.OK, r.status_code
+        assert r.body.json() == True, r.body
 
         try:
             infra.crypto.verify_signature(
-                signature, "bar".encode(), key_pub_pem, algorithm["hash"]
+                algorithm, signature, "bar".encode(), key_pub_pem
             )
             assert False, "verify_signature() should throw"
         except InvalidSignature:
@@ -600,13 +613,24 @@ def test_npm_app(network, args):
             assert r.status_code == http.HTTPStatus.OK, r.status_code
 
             signature = r.body.data()
-            infra.crypto.verify_signature(
-                signature, data, key_pub_pem, algorithm["hash"]
+            infra.crypto.verify_signature(algorithm, signature, data, key_pub_pem)
+
+            # Also verify with the JS API
+            r = c.post(
+                "/app/verifySignature",
+                {
+                    "algorithm": algorithm,
+                    "key": key_pub_pem,
+                    "signature": b64encode(signature).decode(),
+                    "data": b64encode(data).decode(),
+                },
             )
+            assert r.status_code == http.HTTPStatus.OK, r.status_code
+            assert r.body.json() == True, r.body
 
             try:
                 infra.crypto.verify_signature(
-                    signature, "bar".encode(), key_pub_pem, algorithm["hash"]
+                    algorithm, signature, "bar".encode(), key_pub_pem
                 )
                 assert False, "verify_signature() should throw"
             except InvalidSignature:
@@ -626,10 +650,25 @@ def test_npm_app(network, args):
         assert r.status_code == http.HTTPStatus.OK, r.status_code
 
         signature = r.body.data()
-        infra.crypto.verify_signature(signature, data, key_pub_pem)
+        infra.crypto.verify_signature(algorithm, signature, data, key_pub_pem)
+
+        # Also verify with the JS API
+        r = c.post(
+            "/app/verifySignature",
+            {
+                "algorithm": algorithm,
+                "key": key_pub_pem,
+                "signature": b64encode(signature).decode(),
+                "data": b64encode(data).decode(),
+            },
+        )
+        assert r.status_code == http.HTTPStatus.OK, r.status_code
+        assert r.body.json() == True, r.body
 
         try:
-            infra.crypto.verify_signature(signature, "bar".encode(), key_pub_pem)
+            infra.crypto.verify_signature(
+                algorithm, signature, "bar".encode(), key_pub_pem
+            )
             assert False, "verify_signature() should throw"
         except InvalidSignature:
             pass


### PR DESCRIPTION
Backports the following commits to `release/3.x`:
 - [Use p1363 encoding for sign() JS API with ECDSA (#4829)](https://github.com/microsoft/CCF/pull/4829)