### PR TITLE
[release/3.x] Cherry pick: Add `enableUntrustedDateTime` to JS API (#4838)

### DIFF
--- a/3rdparty/exported/quickjs/quickjs-time.h
+++ b/3rdparty/exported/quickjs/quickjs-time.h
@@ -1,13 +1,6 @@
 #pragma once
 
-int qjs_gettimeofday(struct timeval* tv, void* tz)
-{
-  if (tv != NULL)
-  {
-    memset(tv, 0, sizeof(struct timeval));
-  }
-  return 0;
-}
+extern int qjs_gettimeofday(struct JSContext* ctx, struct timeval* tv, void* tz);
 
 struct tm* qjs_localtime_r(const time_t* timep, struct tm* result)
 {
@@ -18,5 +11,6 @@ struct tm* qjs_localtime_r(const time_t* timep, struct tm* result)
   return 0;
 }
 
-#define gettimeofday qjs_gettimeofday
+// NB: Capturing JSContext* ctx that is assumed to exist at callsite!
+#define gettimeofday(tv, tz) qjs_gettimeofday(ctx, tv, tz)
 #define localtime_r qjs_localtime_r

--- a/3rdparty/exported/quickjs/quickjs.c
+++ b/3rdparty/exported/quickjs/quickjs.c
@@ -48,7 +48,11 @@
 #include "libbf.h"
 #endif
 
+// vvv CCF Patch vvv
+// Shim the implementations of gettimeofday and localtime_r to work within the
+// enclave
 #include "quickjs-time.h"
+// ^^^ CCF Patch ^^^
 
 #define OPTIMIZE         1
 #define SHORT_OPCODES    1
@@ -36165,7 +36169,10 @@ int JS_SetModuleExportList(JSContext *ctx, JSModuleDef *m,
     return 0;
 }
 
+// vvv CCF Patch vvv
+// Add functions to expose module exports
 #include "quickjs-exports.c"
+// ^^^ CCF Patch ^^^
 
 /* Note: 'func_obj' is not necessarily a constructor */
 static void JS_SetConstructor2(JSContext *ctx,
@@ -48191,7 +48198,12 @@ static JSValue get_date_string(JSContext *ctx, JSValueConst this_val,
 }
 
 /* OS dependent: return the UTC time in ms since 1970. */
-static int64_t date_now(void) {
+// vvv CCF Patch vvv
+// Implement date_now as a macro, to additionally capture ctx argument from
+// callsite
+#define date_now() _date_now(ctx)
+static int64_t _date_now(JSContext* ctx) {
+// ^^^ CCF Patch ^^^
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return (int64_t)tv.tv_sec * 1000 + (tv.tv_usec / 1000);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- `ccf.crypto.sign()` previously returned DER-encoded ECDSA signatures and now returns IEEE P1363 encoded signatures, aligning with the behavior of the Web Crypto API and `ccf.crypto.verifySignature()` (#4829).
+- `ccf.crypto.sign()` previously returned DER-encoded ECDSA signatures and now returns IEEE P1363 encoded signatures, aligning with the behavior of the Web Crypto API and `ccf.crypto.verifySignature()` (#4829).### Added
+- Added `ccf.enableUntrustedDateTime` to JS API. After calling `ccf.enableUntrustedDateTime(true)`, the `Date` global object will use the untrusted host time to retrieve the current time.
+
 
 ## [3.0.3]
 

--- a/doc/build_apps/js_app_bundle.rst
+++ b/doc/build_apps/js_app_bundle.rst
@@ -119,6 +119,15 @@ See the following handler from the example app bundle in the :ccf_repo:`tests/js
 .. literalinclude:: ../../tests/js-app-bundle/src/math.js
    :language: js
 
+Accessing the current date and time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Code executing inside the enclave does not have access to a trusted time source. To prevent accidental errors (eg - relying on an in-enclave timestamp for tamper-proof ordering), the standard ``Date`` API is stubbed out by default - ``Date.now()`` will always return ``0``.
+
+In many places where timestamps are desired, they should come from the outside with user requests - the accuracy of this timestamp is then considered a claim by a specific user, and the application logic is a purely functional transformation of those external inputs which does not generate unique claims of its own.
+
+To ease porting of existing apps, and for logging scenarios, there is an option to retrieve the current time from the host. When the executing CCF node is run by an honest operator this will be kept up-to-date, but the accuracy of this is not covered by any attestation and as such these times should not be relied upon. To enable use of this untrusted time, call ``ccf.enableUntrustedDateTime(true)`` at any point in your application code, including at the global scope. After this is enabled, calls to ``Date.now()`` will retrieve the current time as specified by the untrusted host. This behaviour can also be revoked by a call to ``ccf.enableUntrustedDateTime(false)``, allowing the untrusted behaviour to be tightly scoped, and explicitly opted in to at each call point.
+
 Deployment
 ----------
 

--- a/js/ccf-app/src/global.ts
+++ b/js/ccf-app/src/global.ts
@@ -641,6 +641,17 @@ export interface CCF {
   historicalState?: HistoricalState;
 
   historical: CCFHistorical;
+
+  /**
+   * Toggles implementation of Date global API between using untrusted host time
+   * and returning 0 (default).
+   *
+   * Returns previous value, allowing a global default to be maintained.
+   *
+   * @param enable If true, then subsequent calls to Date.now() will return untrusted
+   * host time
+   */
+  enableUntrustedDateTime(enable: boolean): boolean;
 }
 
 export const openenclave: OpenEnclave = (<any>globalThis).openenclave;

--- a/js/ccf-app/src/polyfill.ts
+++ b/js/ccf-app/src/polyfill.ts
@@ -522,6 +522,10 @@ class CCFPolyfill implements CCF {
   isValidX509CertChain(chain: string, trusted: string): boolean {
     return this.crypto.isValidX509CertChain(chain, trusted);
   }
+
+  enableUntrustedDateTime(enable: boolean): boolean {
+    throw new Error("Not implemented");
+  }
 }
 
 (<any>globalThis).ccf = new CCFPolyfill();

--- a/src/js/wrap.h
+++ b/src/js/wrap.h
@@ -237,7 +237,7 @@ namespace ccf::js
 
   class Runtime
   {
-    JSRuntime* rt;
+    JSRuntime* rt = nullptr;
 
   public:
     Runtime(kv::Tx* tx);
@@ -258,6 +258,7 @@ namespace ccf::js
   public:
     const TxAccess access;
     UntrustedHostTime host_time;
+    bool implement_untrusted_time = false;
 
     Context(JSRuntime* rt, TxAccess acc) : access(acc)
     {

--- a/tests/js-api/app.json
+++ b/tests/js-api/app.json
@@ -61,6 +61,16 @@
         "mode": "readonly",
         "openapi": {}
       }
+    },
+    "/time_now": {
+      "get": {
+        "js_module": "endpoints.js",
+        "js_function": "time_now",
+        "forwarding_required": "never",
+        "authn_policies": ["no_auth"],
+        "mode": "readonly",
+        "openapi": {}
+      }
     }
   }
 }

--- a/tests/js-api/src/endpoints.js
+++ b/tests/js-api/src/endpoints.js
@@ -10,3 +10,25 @@ export function make_randoms(request) {
     },
   };
 }
+
+ccf.enableUntrustedDateTime(true);
+
+export function time_now(request) {
+  const original = new Date();
+
+  const prev_setting = ccf.enableUntrustedDateTime(false);
+  const definitely_1970 = new Date();
+
+  ccf.enableUntrustedDateTime(true);
+  const definitely_now = new Date();
+
+  ccf.enableUntrustedDateTime(prev_setting);
+
+  return {
+    body: {
+      default: original.toISOString(),
+      definitely_1970: definitely_1970.toISOString(),
+      definitely_now: definitely_now.toISOString(),
+    },
+  };
+}

--- a/tests/js-custom-authorization/custom_authorization.py
+++ b/tests/js-custom-authorization/custom_authorization.py
@@ -13,6 +13,7 @@ import tempfile
 import base64
 import json
 import infra.jwt_issuer
+import datetime
 from e2e_logging import test_multi_auth
 from http import HTTPStatus
 

--- a/tests/js-custom-authorization/custom_authorization.py
+++ b/tests/js-custom-authorization/custom_authorization.py
@@ -476,6 +476,29 @@ def test_request_object_api(network, args):
     return network
 
 
+@reqs.description("Test Date API")
+def test_datetime_api(network, args):
+    primary, _ = network.find_nodes()
+
+    with primary.client() as c:
+        r = c.get("/time_now")
+        local_time = datetime.datetime.now(datetime.timezone.utc)
+        assert r.status_code == http.HTTPStatus.OK, r
+        body = r.body.json()
+        assert body["default"] == body["definitely_now"], body
+        # Python datetime "ISO" doesn't parse Z suffix, so replace it
+        definitely_now = body["definitely_now"].replace("Z", "+00:00")
+        service_time = datetime.datetime.fromisoformat(definitely_now)
+        diff = (local_time - service_time).total_seconds()
+        # Assume less than 1 second of clock skew + execution time
+        assert abs(diff) < 1, diff
+
+        definitely_1970 = body["definitely_1970"].replace("Z", "+00:00")
+        local_epoch_start = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
+        service_epoch_start = datetime.datetime.fromisoformat(definitely_1970)
+        assert local_epoch_start == service_epoch_start, service_epoch_start
+
+
 def run_api(args):
     test_random_api(args)
 
@@ -484,6 +507,7 @@ def run_api(args):
     ) as network:
         network.start_and_open(args)
         network = test_request_object_api(network, args)
+        network = test_datetime_api(network, args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Backports the following commits to `release/3.x`:
 - [Add `enableUntrustedDateTime` to JS API (#4838)](https://github.com/microsoft/CCF/pull/4838)