### PR TITLE
Unpin mistune

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -11,6 +11,3 @@ furo
 # docutils 0.17.0 causes "AttributeError: module 
 # 'docutils.nodes' has no attribute 'meta'" error when building doc
 docutils==0.18.*
-# mistune 2.0.0-rc1 causes "AttributeError: module 'mistune'
-# has no attribute 'BlockGrammar'" error when building doc
-mistune<2.0.0


### PR DESCRIPTION
`0.8.0` release of `sphinxcontrib.openapi` fails with this old pin, seems to build successfully when unpinned.

Link to failing run here: https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=60545&view=logs&j=f1fd332c-cd58-5ba4-fc7d-3c1d3a3f0cd3&t=f54bbde7-05c8-5993-df05-3aa12461823d&l=189