### PR TITLE
Python virtual environment for Attestation Container CI

### DIFF
--- a/.azure-pipelines-attestation-container.yml
+++ b/.azure-pipelines-attestation-container.yml
@@ -9,6 +9,7 @@ pr:
       - .azure_pipelines_attestation_container.yml
       - .azure-pipelines-templates/deploy_attestation_container.yml
       - .azure-pipelines-templates/test_attestation_container.yml
+      - scripts/azure_deployment/*
 
 trigger:
   - main

--- a/.azure-pipelines-templates/azure_cli.yml
+++ b/.azure-pipelines-templates/azure_cli.yml
@@ -4,4 +4,4 @@ steps:
       curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
       az login --service-principal -u ${{ parameters.app_id }} -p ${{ parameters.service_principal_password }} --tenant ${{ parameters.tenant }}
     name: setup_azure_cli
-    displayName: "Install Azure CLI, login, and install Python Packages"
+    displayName: "Install Azure CLI and login"

--- a/.azure-pipelines-templates/deploy_attestation_container.yml
+++ b/.azure-pipelines-templates/deploy_attestation_container.yml
@@ -35,6 +35,9 @@ jobs:
 
       - script: |
           set -ex
+          python3.8 -m venv ./scripts/azure_deployment/.env
+          source ./scripts/azure_deployment/.env/bin/activate
+          pip install -r ./scripts/azure_deployment/requirements.txt
           python3.8 scripts/azure_deployment/arm_template.py deploy aci --subscription-id $(CCF_AZURE_SUBSCRIPTION_ID) --resource-group attestationContainer --aci-type dynamic-agent --deployment-name ci-$(Build.BuildNumber) --attestation-container-e2e True > ~/aci_ips
           # Escape newlines: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/set-variables-scripts?view=azure-devops&tabs=bash
           escape_data() {
@@ -66,6 +69,9 @@ jobs:
 
       - script: |
           set -ex
+          python3.8 -m venv ./scripts/azure_deployment/.env
+          source ./scripts/azure_deployment/.env/bin/activate
+          pip install -r ./scripts/azure_deployment/requirements.txt
           python3.8 scripts/azure_deployment/arm_template.py remove aci --subscription-id $(CCF_AZURE_SUBSCRIPTION_ID) --resource-group attestationContainer --aci-type dynamic-agent --deployment-name ci-$(Build.BuildNumber)
         name: cleanup_aci
         displayName: "Delete the ACI and Azure Deployment"

--- a/.azure-pipelines-templates/deploy_attestation_container.yml
+++ b/.azure-pipelines-templates/deploy_attestation_container.yml
@@ -38,7 +38,7 @@ jobs:
           python3.8 -m venv ./scripts/azure_deployment/.env
           source ./scripts/azure_deployment/.env/bin/activate
           pip install -r ./scripts/azure_deployment/requirements.txt
-          python3.8 scripts/azure_deployment/arm_template.py deploy aci --subscription-id $(CCF_AZURE_SUBSCRIPTION_ID) --resource-group attestationContainer --aci-type dynamic-agent --deployment-name ci-$(Build.BuildNumber) --attestation-container-e2e True > ~/aci_ips
+          python3.8 scripts/azure_deployment/arm_template.py deploy aci --subscription-id $(CCF_AZURE_SUBSCRIPTION_ID) --resource-group attestationContainer --aci-type dynamic-agent --deployment-name ci-$(Build.BuildNumber) --attestation-container-e2e > ~/aci_ips
           # Escape newlines: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/set-variables-scripts?view=azure-devops&tabs=bash
           escape_data() {
           local data=$1

--- a/scripts/azure_deployment/arm_aci.py
+++ b/scripts/azure_deployment/arm_aci.py
@@ -205,31 +205,6 @@ def make_aci_deployment(parser: ArgumentParser) -> Deployment:
         "resources": [],
     }
 
-    if not args.attestation_container_e2e:
-        deployment_name = args.deployment_name
-        container_name = args.deployment_name
-        container_image = args.aci_image
-        command = make_dev_container_command(args)
-        with_volume = args.aci_file_share_name is not None
-        containers = [
-            make_dev_container(
-                i, container_name, container_image, command, args.ports, with_volume
-            )
-            for i in range(args.count)
-        ]
-    else:
-        container_image = f"attestationcontainerregistry.azurecr.io/attestation-container:{args.deployment_name}"
-        deployment_name = f"{args.deployment_name}-business-logic"
-        container_name = f"{args.deployment_name}-attestation-container"
-        command = make_attestation_container_command(args)
-        args.ports.append(ATTESTATION_CONTAINER_PORT)
-        with_volume = False
-        containers = [
-            make_attestation_container(
-                container_name, container_image, command, args.ports
-            )
-        ]
-
     container_group_properties = {
         "sku": "Standard",
         "containers": containers,
@@ -242,30 +217,55 @@ def make_aci_deployment(parser: ArgumentParser) -> Deployment:
         "osType": "Linux",
     }
 
-    if args.aci_file_share_name is not None and not args.attestation_container_e2e:
-        container_group_properties["volumes"] = [
-            {
-                "name": "ccfcivolume",
-                "azureFile": {
-                    "shareName": args.aci_file_share_name,
-                    "storageAccountName": args.aci_file_share_account_name,
-                    "storageAccountKey": args.aci_storage_account_key,
-                },
-            }
+    if not args.attestation_container_e2e:
+        deployment_name = args.deployment_name
+        container_name = args.deployment_name
+        container_image = args.aci_image
+        command = make_dev_container_command(args)
+        with_volume = args.aci_file_share_name is not None
+        containers = [
+            make_dev_container(
+                i, container_name, container_image, command, args.ports, with_volume
+            )
+            for i in range(args.count)
         ]
 
-    if not args.non_confidential:
-        if args.security_policy_file is not None:
-            with open(args.security_policy_file, "r") as f:
-                security_policy = f.read()
-        else:
-            # Otherwise, default to most permissive policy
-            security_policy = DEFAULT_REGO_SECURITY_POLICY
+        if args.aci_file_share_name is not None:
+            container_group_properties["volumes"] = [
+                {
+                    "name": "ccfcivolume",
+                    "azureFile": {
+                        "shareName": args.aci_file_share_name,
+                        "storageAccountName": args.aci_file_share_account_name,
+                        "storageAccountKey": args.aci_storage_account_key,
+                    },
+                }
+            ]
 
-        container_group_properties["confidentialComputeProperties"] = {
-            "isolationType": "SevSnp",
-            "ccePolicy": base64.b64encode(security_policy.encode()).decode(),
-        }
+        if not args.non_confidential:
+            if args.security_policy_file is not None:
+                with open(args.security_policy_file, "r") as f:
+                    security_policy = f.read()
+            else:
+                # Otherwise, default to most permissive policy
+                security_policy = DEFAULT_REGO_SECURITY_POLICY
+
+            container_group_properties["confidentialComputeProperties"] = {
+                "isolationType": "SevSnp",
+                "ccePolicy": base64.b64encode(security_policy.encode()).decode(),
+            }
+    else:
+        container_image = f"attestationcontainerregistry.azurecr.io/attestation-container:{args.deployment_name}"
+        deployment_name = f"{args.deployment_name}-business-logic"
+        container_name = f"{args.deployment_name}-attestation-container"
+        command = make_attestation_container_command(args)
+        args.ports.append(ATTESTATION_CONTAINER_PORT)
+        with_volume = False
+        containers = [
+            make_attestation_container(
+                container_name, container_image, command, args.ports
+            )
+        ]
 
     container_group = {
         "type": "Microsoft.ContainerInstance/containerGroups",

--- a/scripts/azure_deployment/arm_aci.py
+++ b/scripts/azure_deployment/arm_aci.py
@@ -217,7 +217,7 @@ def make_aci_deployment(parser: ArgumentParser) -> Deployment:
         "initContainers": [],
         "restartPolicy": "Never",
         "ipAddress": {
-            "ports": [{"protocol": "TCP", "port": p} for p in args.ports],
+            "ports": [{"protocol": "TCP", "port": p} for p in ports],
             "type": "Public",
         },
         "osType": "Linux",

--- a/scripts/azure_deployment/arm_aci.py
+++ b/scripts/azure_deployment/arm_aci.py
@@ -263,10 +263,6 @@ def make_aci_deployment(parser: ArgumentParser) -> Deployment:
 
     arm_template["resources"].append(container_group)
 
-    import json
-
-    print(json.dumps(arm_template, indent=2))
-
     return Deployment(
         properties=DeploymentProperties(
             mode=DeploymentMode.INCREMENTAL, parameters={}, template=arm_template

--- a/scripts/azure_deployment/arm_aci.py
+++ b/scripts/azure_deployment/arm_aci.py
@@ -230,14 +230,6 @@ def make_aci_deployment(parser: ArgumentParser) -> Deployment:
             )
         ]
 
-    container_group = {
-        "type": "Microsoft.ContainerInstance/containerGroups",
-        "apiVersion": "2022-04-01-preview",
-        "name": deployment_name,
-        "location": args.region,
-        "properties": container_group_properties,
-    }
-
     container_group_properties = {
         "sku": "Standard",
         "containers": containers,
@@ -248,6 +240,14 @@ def make_aci_deployment(parser: ArgumentParser) -> Deployment:
             "type": "Public",
         },
         "osType": "Linux",
+    }
+
+    container_group = {
+        "type": "Microsoft.ContainerInstance/containerGroups",
+        "apiVersion": "2022-04-01-preview",
+        "name": deployment_name,
+        "location": args.region,
+        "properties": container_group_properties,
     }
 
     if args.aci_file_share_name is not None:

--- a/scripts/azure_deployment/arm_aci.py
+++ b/scripts/azure_deployment/arm_aci.py
@@ -235,13 +235,6 @@ def make_aci_deployment(parser: ArgumentParser) -> Deployment:
             }
         ]
 
-    common_resource_properties = {
-        "sku": "Standard",
-        "initContainers": [],
-        "restartPolicy": "Never",
-        "osType": "Linux",
-    }
-
     if not args.non_confidential:
         if args.security_policy_file is not None:
             with open(args.security_policy_file, "r") as f:
@@ -250,7 +243,7 @@ def make_aci_deployment(parser: ArgumentParser) -> Deployment:
             # Otherwise, default to most permissive policy
             security_policy = DEFAULT_REGO_SECURITY_POLICY
 
-        common_resource_properties["confidentialComputeProperties"] = {
+        container_group_properties["confidentialComputeProperties"] = {
             "isolationType": "SevSnp",
             "ccePolicy": base64.b64encode(security_policy.encode()).decode(),
         }

--- a/scripts/azure_deployment/arm_aci.py
+++ b/scripts/azure_deployment/arm_aci.py
@@ -185,14 +185,16 @@ def make_aci_deployment(parser: ArgumentParser) -> Deployment:
     }
 
     deployment_name = args.deployment_name
+    container_name = args.deployment_name
     container_image = args.aci_image
     containers_count = args.count
     with_volume = args.aci_file_share_name is not None
     ports = args.ports
 
     if args.attestation_container_e2e:
-        container_image = f"attestationcontainerregistry.azurecr.io/attestation-container:{args.deployment_name}"
-        deployment_name = f"{args.deployment_name}-attestation-container"
+        container_image = f"attestationcontainerregistry.azurecr.io/attestation-container:{container_name}"
+        deployment_name = f"{container_name}-business-logic"
+        container_name = f"{container_name}-attestation-container"
         ports.append(ATTESTATION_CONTAINER_PORT)
         containers_count = 1
         with_volume = False
@@ -200,7 +202,7 @@ def make_aci_deployment(parser: ArgumentParser) -> Deployment:
     containers = [
         make_dev_container_template(
             i,
-            deployment_name,
+            container_name,
             container_image,
             make_dev_container_command(args),
             ports,


### PR DESCRIPTION
Since https://github.com/microsoft/CCF/pull/4840, we rely on a Python virtual environment to install the specific and recent versions of the Azure Python SDK libraries. These also need to be installed before running the `arm_template.py` script in the Attestation Container CI. 

Also reenabled deployment of attestation container that was nuked by a merge conflict in #4840 