### PR TITLE
Upgrade httpx pin on release/2.x

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -13,6 +13,6 @@ docker
 better_exceptions
 pyasn1
 Jinja2
-httpx == 0.21.*
+httpx == 0.23.*
 locust
 pyOpenSSL


### PR DESCRIPTION
This is only used for testing, but flagged by CG because of https://security-tracker.debian.org/tracker/CVE-2021-41945.