### PR TITLE
Separate SSH key generation into independent job

### DIFF
--- a/.azure-pipelines-templates/deploy_aci.yml
+++ b/.azure-pipelines-templates/deploy_aci.yml
@@ -1,6 +1,23 @@
 jobs:
+  - job: generate_ssh_key
+    displayName: "Generate SSH Key"
+    variables:
+      Codeql.SkipTaskAutoInjection: true
+      skipComponentGovernanceDetection: true
+    pool:
+      vmImage: ubuntu-20.04
+    steps:
+      - script: |
+          set -ex
+          ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa -N ""
+          echo "##vso[task.setvariable variable=sshKey;isOutput=true;issecret=true]`base64 -w 0 ~/.ssh/id_rsa`"
+        name: generate_ssh_key
+        displayName: "Generate SSH Key"
+
   - job: deploy_aci
     displayName: "Deploy ACI"
+    dependsOn:
+      - generate_ssh_key
     variables:
       Codeql.SkipTaskAutoInjection: true
       skipComponentGovernanceDetection: true
@@ -12,12 +29,9 @@ jobs:
         name: print_env
         displayName: "Print Environment Variables"
 
-      - script: |
-          set -ex
-          ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa -N ""
-          echo "##vso[task.setvariable variable=hostPrivKey;isOutput=true;issecret=true]`base64 -w 0 ~/.ssh/id_rsa`"
-        name: generate_ssh_key
-        displayName: "Generate SSH Key"
+      - template: install_ssh_key.yml
+        parameters:
+          ssh_key: $[ dependencies.generate_ssh_key.outputs['generate_ssh_key.sshKey'] ]
 
       - template: azure_cli.yml
         parameters:
@@ -71,12 +85,12 @@ jobs:
     pool:
       vmImage: ubuntu-20.04
     dependsOn:
+      - generate_ssh_key
       - deploy_aci
       - ${{ parameters.used_by }}
     condition: always()
     variables:
       IpAddresses: $[ dependencies.deploy_aci.outputs['deploy_aci.ipAddresses'] ]
-      HOST_PRIVATE_KEY: $[ dependencies.deploy_aci.outputs['generate_ssh_key.hostPrivKey'] ]
     steps:
       - template: azure_cli.yml
         parameters:
@@ -86,7 +100,7 @@ jobs:
 
       - template: install_ssh_key.yml
         parameters:
-          host_private_key: $(HOST_PRIVATE_KEY)
+          ssh_key: $[ dependencies.generate_ssh_key.outputs['generate_ssh_key.sshKey'] ]
 
       - script: |
           set -ex

--- a/.azure-pipelines-templates/deploy_aci.yml
+++ b/.azure-pipelines-templates/deploy_aci.yml
@@ -21,6 +21,7 @@ jobs:
     variables:
       Codeql.SkipTaskAutoInjection: true
       skipComponentGovernanceDetection: true
+      sshKey: $[ dependencies.generate_ssh_key.outputs['generate_ssh_key.sshKey'] ]
     pool:
       vmImage: ubuntu-20.04
     steps:
@@ -31,7 +32,7 @@ jobs:
 
       - template: install_ssh_key.yml
         parameters:
-          ssh_key: $[ dependencies.generate_ssh_key.outputs['generate_ssh_key.sshKey'] ]
+          ssh_key: $(sshKey)
 
       - template: azure_cli.yml
         parameters:
@@ -91,6 +92,7 @@ jobs:
     condition: always()
     variables:
       IpAddresses: $[ dependencies.deploy_aci.outputs['deploy_aci.ipAddresses'] ]
+      sshKey: $[ dependencies.generate_ssh_key.outputs['generate_ssh_key.sshKey'] ]
     steps:
       - template: azure_cli.yml
         parameters:
@@ -100,7 +102,7 @@ jobs:
 
       - template: install_ssh_key.yml
         parameters:
-          ssh_key: $[ dependencies.generate_ssh_key.outputs['generate_ssh_key.sshKey'] ]
+          ssh_key: $(sshKey)
 
       - script: |
           set -ex

--- a/.azure-pipelines-templates/install_ssh_key.yml
+++ b/.azure-pipelines-templates/install_ssh_key.yml
@@ -4,7 +4,6 @@ steps:
       mkdir ~/.ssh
       echo ${{ parameters.ssh_key }} | base64 -d > ~/.ssh/id_rsa
       sudo chmod 600 ~/.ssh/id_rsa
-      sudo cat ~/.ssh/id_rsa
       sudo ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
       sudo chmod 600 ~/.ssh/id_rsa.pub
     name: setup_key

--- a/.azure-pipelines-templates/install_ssh_key.yml
+++ b/.azure-pipelines-templates/install_ssh_key.yml
@@ -4,7 +4,8 @@ steps:
       mkdir ~/.ssh
       echo ${{ parameters.ssh_key }} | base64 -d > ~/.ssh/id_rsa
       sudo chmod 600 ~/.ssh/id_rsa
-      ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
+      sudo cat ~/.ssh/id_rsa
+      sudo ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
       sudo chmod 600 ~/.ssh/id_rsa.pub
     name: setup_key
     displayName: "Install SSH Key from Deployment Step"

--- a/.azure-pipelines-templates/install_ssh_key.yml
+++ b/.azure-pipelines-templates/install_ssh_key.yml
@@ -4,5 +4,7 @@ steps:
       mkdir ~/.ssh
       echo ${{ parameters.ssh_key }} | base64 -d > ~/.ssh/id_rsa
       sudo chmod 600 ~/.ssh/id_rsa
+      ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
+      sudo chmod 600 ~/.ssh/id_rsa.pub
     name: setup_key
     displayName: "Install SSH Key from Deployment Step"

--- a/.azure-pipelines-templates/install_ssh_key.yml
+++ b/.azure-pipelines-templates/install_ssh_key.yml
@@ -1,8 +1,11 @@
+variables:
+  ssh_key: ${{ parameters.ssh_key }}
+
 steps:
   - script: |
       set -ex
       mkdir ~/.ssh
-      echo ${{ parameters.ssh_key }} | base64 -d > ~/.ssh/id_rsa
+      echo $(ssh_key) | base64 -d > ~/.ssh/id_rsa
       sudo chmod 600 ~/.ssh/id_rsa
     name: setup_key
     displayName: "Install SSH Key from Deployment Step"

--- a/.azure-pipelines-templates/install_ssh_key.yml
+++ b/.azure-pipelines-templates/install_ssh_key.yml
@@ -2,7 +2,7 @@ steps:
   - script: |
       set -ex
       mkdir ~/.ssh
-      echo ${{ parameters.host_private_key }} | base64 -d > ~/.ssh/id_rsa
+      echo ${{ parameters.ssh_key }} | base64 -d > ~/.ssh/id_rsa
       sudo chmod 600 ~/.ssh/id_rsa
     name: setup_key
     displayName: "Install SSH Key from Deployment Step"

--- a/.azure-pipelines-templates/install_ssh_key.yml
+++ b/.azure-pipelines-templates/install_ssh_key.yml
@@ -1,11 +1,8 @@
-variables:
-  ssh_key: ${{ parameters.ssh_key }}
-
 steps:
   - script: |
       set -ex
       mkdir ~/.ssh
-      echo $(ssh_key) | base64 -d > ~/.ssh/id_rsa
+      echo ${{ parameters.ssh_key }} | base64 -d > ~/.ssh/id_rsa
       sudo chmod 600 ~/.ssh/id_rsa
     name: setup_key
     displayName: "Install SSH Key from Deployment Step"

--- a/.azure-pipelines-templates/test_on_remote.yml
+++ b/.azure-pipelines-templates/test_on_remote.yml
@@ -12,13 +12,14 @@ jobs:
     timeoutInMinutes: 120
     variables:
       RUN_ON: ${{ parameters.run_on }}
+      sshKey: ${{ parameters.ssh_key }}
       Codeql.SkipTaskAutoInjection: true
       skipComponentGovernanceDetection: true
 
     steps:
       - template: install_ssh_key.yml
         parameters:
-          ssh_key: $[ dependencies.generate_ssh_key.outputs['generate_ssh_key.sshKey'] ]
+          ssh_key: $(sshKey)
 
       - script: |
           set -ex

--- a/.azure-pipelines-templates/test_on_remote.yml
+++ b/.azure-pipelines-templates/test_on_remote.yml
@@ -12,14 +12,13 @@ jobs:
     timeoutInMinutes: 120
     variables:
       RUN_ON: ${{ parameters.run_on }}
-      HOST_PRIVATE_KEY: ${{ parameters.host_private_key }}
       Codeql.SkipTaskAutoInjection: true
       skipComponentGovernanceDetection: true
 
     steps:
       - template: install_ssh_key.yml
         parameters:
-          host_private_key: $(HOST_PRIVATE_KEY)
+          ssh_key: $[ dependencies.generate_ssh_key.outputs['generate_ssh_key.sshKey'] ]
 
       - script: |
           set -ex

--- a/.azure_pipelines_snp.yml
+++ b/.azure_pipelines_snp.yml
@@ -43,4 +43,4 @@ jobs:
         - generate_ssh_key
         - deploy_aci
       run_on: $[ dependencies.deploy_aci.outputs['deploy_aci.ipAddresses'] ]
-      host_private_key: $[ dependencies.deploy_aci.outputs['generate_ssh_key.hostPrivKey'] ]
+      ssh_key: $[ dependencies.generate_ssh_key.outputs['generate_ssh_key.ssh_key'] ]

--- a/.azure_pipelines_snp.yml
+++ b/.azure_pipelines_snp.yml
@@ -39,6 +39,8 @@ jobs:
     parameters:
       job_name: test_snp
       display_name: "Test SNP"
-      depends_on: deploy_aci
+      depends_on:
+        - generate_ssh_key
+        - deploy_aci
       run_on: $[ dependencies.deploy_aci.outputs['deploy_aci.ipAddresses'] ]
       host_private_key: $[ dependencies.deploy_aci.outputs['generate_ssh_key.hostPrivKey'] ]

--- a/.azure_pipelines_snp.yml
+++ b/.azure_pipelines_snp.yml
@@ -43,4 +43,4 @@ jobs:
         - generate_ssh_key
         - deploy_aci
       run_on: $[ dependencies.deploy_aci.outputs['deploy_aci.ipAddresses'] ]
-      ssh_key: $[ dependencies.generate_ssh_key.outputs['generate_ssh_key.ssh_key'] ]
+      ssh_key: $[ dependencies.generate_ssh_key.outputs['generate_ssh_key.sshKey'] ]


### PR DESCRIPTION
This will allow multiple concurrent jobs to use the same SSH key without one having to wait on the other

Specifically, useful for when we deploy secondary ACIs and want to install the key on those machines without having to wait on primary deployment