### PR TITLE
Fix azure pipeline variable

### DIFF
--- a/.azure-pipelines-templates/deploy_attestation_container.yml
+++ b/.azure-pipelines-templates/deploy_attestation_container.yml
@@ -95,7 +95,7 @@ jobs:
 
       - script: |
           set -ex
-          az acr repository delete --name attestationcontainerregistry --image attestation-container:$image_version --yes
+          az acr repository delete --name attestationcontainerregistry --image attestation-container:$(image_version) --yes
 
         name: cleanup_container_image
         displayName: "Delete the container image"


### PR DESCRIPTION
Fix a bug found in https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=60945&view=logs&j=8475f160-5334-5e18-a167-ddf3956b7080&t=27153a35-fbab-5bbd-ba43-b73eac114b6d.

Previously the image deletion command was:
```bash
az acr repository delete --name attestationcontainerregistry --image attestation-container: --yes # image tag is missing
```
Now:
```bash
az acr repository delete --name attestationcontainerregistry --image attestation-container:<tag> --yes
```

As discussed [here](https://github.com/microsoft/CCF/pull/4694#discussion_r1068269446), this code will be changed again soon, but it's a temporary fix to prevent the failure


