### PR TITLE
Add support for external service CSRs in ACME client

### DIFF
--- a/include/ccf/http_responder.h
+++ b/include/ccf/http_responder.h
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ccf/http_consts.h"
 #include "ccf/http_header_map.h"
 #include "ccf/odata_error.h"
 

--- a/src/node/acme_client.h
+++ b/src/node/acme_client.h
@@ -1096,9 +1096,10 @@ namespace ACME
         this);
     }
 
-    virtual std::vector<uint8_t> get_service_csr() {
+    virtual std::vector<uint8_t> get_service_csr()
+    {
       auto r = service_key->create_csr_der(
-      "CN=" + config.service_dns_name, {{config.service_dns_name, false}});
+        "CN=" + config.service_dns_name, {{config.service_dns_name, false}});
       return r;
     }
 

--- a/src/node/acme_client.h
+++ b/src/node/acme_client.h
@@ -1096,6 +1096,12 @@ namespace ACME
         this);
     }
 
+    virtual std::vector<uint8_t> get_service_csr() {
+      auto r = service_key->create_csr_der(
+      "CN=" + config.service_dns_name, {{config.service_dns_name, false}});
+      return r;
+    }
+
     void request_finalization(const std::string& order_url)
     {
       if (nonces.empty())
@@ -1119,8 +1125,7 @@ namespace ACME
         auto header =
           mk_kid_header(order->account_url, nonce, order->finalize_url);
 
-        auto csr = service_key->create_csr_der(
-          "CN=" + config.service_dns_name, {{config.service_dns_name, false}});
+        auto csr = get_service_csr();
 
         nlohmann::json payload = {{"csr", crypto::b64url_from_raw(csr, false)}};
 


### PR DESCRIPTION
This adds support for external service CSRs in the ACME client. This is required when ACME requests are run on behalf of another node (e.g. in aDNS). 