### PR TITLE
Change deployment region for ACI to WestEurope

### DIFF
--- a/scripts/azure_deployment/arm_aci.py
+++ b/scripts/azure_deployment/arm_aci.py
@@ -202,7 +202,7 @@ def make_aci_deployment(parser: ArgumentParser) -> Deployment:
         "--region",
         help="Region to deploy to",
         type=str,
-        default="eastus2euap",
+        default="westeurope",
     )
     parser.add_argument(
         "--ports",


### PR DESCRIPTION
Deployments to EastUS2euap seem to be failing today so attempting to temporarily deploy to WestEurope instead. 