### PR TITLE
Raise clang version requirement to 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The built-in authentication policies for JWTs and certs will now enforce expiry times, based on the current time received from the host. JWTs must contain "nbf" and "exp" claims, and if those are outside the current time then the request will get an authentication error (#4786).
 - `ccf.crypto.sign()` previously returned DER-encoded ECDSA signatures and now returns IEEE P1363 encoded signatures, aligning with the behavior of the Web Crypto API and `ccf.crypto.verifySignature()` (#4829).
 - Proposals authenticated with COSE Sign1 must now contain a `ccf.gov.msg.created_at` header parameter, set to a positive integer number of seconds since epoch. This timestamp is used to detect potential proposal replay. The `ccf_cose_sign1*` scripts have been updated accordingly and require a `--ccf-gov-msg-created_at`.
+- Updated Clang version requirement to >= 10 in cmake.
 
 ### Added
 

--- a/cmake/preproject.cmake
+++ b/cmake/preproject.cmake
@@ -3,7 +3,7 @@
 
 # Note: this needs to be done before project(), otherwise CMAKE_*_COMPILER is
 # already set by CMake. If the user has not expressed any choice, we attempt to
-# default to Clang >= 8 If they have expressed even a partial choice, the usual
+# default to Clang >= 10 If they have expressed even a partial choice, the usual
 # CMake selection logic applies. If we cannot find both a suitable clang and a
 # suitable clang++, the usual CMake selection logic applies
 if((NOT CMAKE_C_COMPILER)
@@ -11,12 +11,12 @@ if((NOT CMAKE_C_COMPILER)
    AND "$ENV{CC}" STREQUAL ""
    AND "$ENV{CXX}" STREQUAL ""
 )
-  find_program(FOUND_CMAKE_C_COMPILER NAMES clang-10 clang-8)
-  find_program(FOUND_CMAKE_CXX_COMPILER NAMES clang++-10 clang++-8)
+  find_program(FOUND_CMAKE_C_COMPILER NAMES clang-10)
+  find_program(FOUND_CMAKE_CXX_COMPILER NAMES clang++-10)
   if(NOT (FOUND_CMAKE_C_COMPILER AND FOUND_CMAKE_CXX_COMPILER))
     message(
       WARNING
-        "Clang >= 8 not found, will use default compiler. "
+        "Clang >= 10 not found, will use default compiler. "
         "Override the compiler by setting CC and CXX environment variables."
     )
   else()
@@ -28,8 +28,8 @@ if((NOT CMAKE_C_COMPILER)
 endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-  if(CMAKE_C_COMPILER_VERSION VERSION_LESS 8)
-    message(WARNING "CCF officially supports Clang >= 8 only, "
+  if(CMAKE_C_COMPILER_VERSION VERSION_LESS 10)
+    message(WARNING "CCF officially supports Clang >= 10 only, "
                     "but your Clang version (${CMAKE_C_COMPILER_VERSION}) "
                     "is older than that. Build problems may occur."
     )


### PR DESCRIPTION
We should have done this early in the 2.x cycle, but we seem to have forgotten.