### PR TITLE
Fix for `auth` e2e test: Allow for execution time difference between timestamps

### DIFF
--- a/tests/js-custom-authorization/custom_authorization.py
+++ b/tests/js-custom-authorization/custom_authorization.py
@@ -569,15 +569,22 @@ def test_datetime_api(network, args):
         local_time = datetime.datetime.now(datetime.timezone.utc)
         assert r.status_code == http.HTTPStatus.OK, r
         body = r.body.json()
-        assert body["default"] == body["definitely_now"], body
+
         # Python datetime "ISO" doesn't parse Z suffix, so replace it
+        default = body["default"].replace("Z", "+00:00")
         definitely_now = body["definitely_now"].replace("Z", "+00:00")
+        definitely_1970 = body["definitely_1970"].replace("Z", "+00:00")
+
+        # Assume less than 2ms of execution time between grabbing timestamps, and confirm that default call gets real timestamp from global activation
+        default_time = datetime.datetime.fromisoformat(default)
         service_time = datetime.datetime.fromisoformat(definitely_now)
-        diff = (local_time - service_time).total_seconds()
+        diff = (service_time - default_time).total_seconds()
+        assert diff < 0.002, diff
+
         # Assume less than 1 second of clock skew + execution time
+        diff = (local_time - service_time).total_seconds()
         assert abs(diff) < 1, diff
 
-        definitely_1970 = body["definitely_1970"].replace("Z", "+00:00")
         local_epoch_start = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
         service_epoch_start = datetime.datetime.fromisoformat(definitely_1970)
         assert local_epoch_start == service_epoch_start, service_epoch_start


### PR DESCRIPTION
Fixes a failure noticed in the CI here:
https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=62466&view=logs&j=fff884fa-70f7-5142-c642-c9647ff4218c&t=002ec585-ff09-575c-f94f-67274e66fb5c&l=25045

```
53: 2023-01-30 03:22:37.160 | ERROR    | {api} infra.runner:log_exception:214 - Failure in api: AssertionError({'default': '2023-01-30T03:22:36.821Z', 'definitely_1970': '1970-01-01T00:00:00.000Z', 'definitely_now': '2023-01-30T03:22:36.822Z'})
53: Traceback (most recent call last):
53: 
53:   File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
53:     self.run()
53:     └ <Thread(api, started 140403391051520)>
53:   File "/usr/lib/python3.8/threading.py", line 870, in run
53:     self._target(*self._args, **self._kwargs)
53:     │             │             └ <Thread(api, started 140403391051520)>
53:     │             └ <Thread(api, started 140403391051520)>
53:     └ <Thread(api, started 140403391051520)>
53:   File "/__w/1/s/tests/js-custom-authorization/custom_authorization.py", line 511, in run_api
53:     network = test_datetime_api(network, args)
53:     │         │                 │        └ Namespace(binary_dir='/__w/1/s/build', ccf_version=None, common_read_only_ledger_dir=None, config_file=None, consensus='CFT', co...
53:     │         │                 └ <infra.network.Network object at 0x7fb238403a60>
53:     │         └ <function test_datetime_api at 0x7fb2385125e0>
53:     └ <infra.network.Network object at 0x7fb238403a60>
53:   File "/__w/1/s/tests/suite/test_requirements.py", line 21, in wrapper
53:     return func(*args, **kwargs)
53:            │     │       └ {}
53:            │     └ (<infra.network.Network object at 0x7fb238403a60>, Namespace(binary_dir='/__w/1/s/build', ccf_version=None, common_read_only_led...
53:            └ <function test_datetime_api at 0x7fb238512550>
53:   File "/__w/1/s/tests/js-custom-authorization/custom_authorization.py", line 489, in test_datetime_api
53:     assert body["default"] == body["definitely_now"], body
53:            │                  │                       └ {'default': '2023-01-30T03:22:36.821Z', 'definitely_1970': '1970-01-01T00:00:00.000Z', 'definitely_now': '2023-01-30T03:22:36.82...
53:            │                  └ {'default': '2023-01-30T03:22:36.821Z', 'definitely_1970': '1970-01-01T00:00:00.000Z', 'definitely_now': '2023-01-30T03:22:36.82...
53:            └ {'default': '2023-01-30T03:22:36.821Z', 'definitely_1970': '1970-01-01T00:00:00.000Z', 'definitely_now': '2023-01-30T03:22:36.82...
53: 
53: AssertionError: {'default': '2023-01-30T03:22:36.821Z', 'definitely_1970': '1970-01-01T00:00:00.000Z', 'definitely_now': '2023-01-30T03:22:36.822Z'}
53: 
53: Traceback (most recent call last):
53:   File "/__w/1/s/tests/js-custom-authorization/custom_authorization.py", line 554, in <module>
53:     cr.run()
53:     └ <infra.runner.ConcurrentRunner object at 0x7fb23850e6d0>
53:   File "/__w/1/s/tests/infra/runner.py", line 294, in run
53:     raise Exception(FAILURES)
53:                     └ ["Failure in api: AssertionError({'default': '2023-01-30T03:22:36.821Z', 'definitely_1970': '1970-01-01T00:00:00.000Z', 'definit...
53: Exception: ["Failure in api: AssertionError({'default': '2023-01-30T03:22:36.821Z', 'definitely_1970': '1970-01-01T00:00:00.000Z', 'definitely_now': '2023-01-30T03:22:36.822Z'})"]
43/59 Test #53: auth .............................***Failed    8.82 sec
```

This is comparing 2 timestamps obtained from calling `new Date()` in JS. I'd incorrectly believed that in a single endpoint execution, these would be constant (while we're singlethreaded) but that's not true - the active _host_ thread will continue to update this time. So the test needs to handle the potential execution time between these 2 calls. This is usually only a few microseconds, but that may span a millisecond boundary and show up as a 1ms diff (as in the failing log). To be extra safe, we allow 2ms.