### PR TITLE
Update to pylint 2.16.0 - remove uses of `raise Exception`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -499,5 +499,5 @@ preferred-modules=
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception

--- a/python/ccf/merkletree.py
+++ b/python/ccf/merkletree.py
@@ -32,7 +32,9 @@ class MerkleTree(object):
     def get_merkle_root(self) -> bytes:
         # Always make tree before getting root
         self._make_tree()
-        assert self.levels is not None, "Unexpected error while getting root. MerkleTree has no levels."
+        assert (
+            self.levels is not None
+        ), "Unexpected error while getting root. MerkleTree has no levels."
 
         return self.levels[0][0]
 
@@ -41,7 +43,9 @@ class MerkleTree(object):
         # number of leaves on the level
         number_of_leaves_on_current_level = len(self.levels[0])
 
-        assert number_of_leaves_on_current_level > 1, "Merkle Tree should have more than one leaf at every level"
+        assert (
+            number_of_leaves_on_current_level > 1
+        ), "Merkle Tree should have more than one leaf at every level"
 
         if (
             number_of_leaves_on_current_level % 2 == 1

--- a/python/ccf/merkletree.py
+++ b/python/ccf/merkletree.py
@@ -32,10 +32,7 @@ class MerkleTree(object):
     def get_merkle_root(self) -> bytes:
         # Always make tree before getting root
         self._make_tree()
-        if self.levels is None:
-            raise Exception(
-                "Unexpected error while getting root. MerkleTree has no levels."
-            )
+        assert self.levels is not None, "Unexpected error while getting root. MerkleTree has no levels."
 
         return self.levels[0][0]
 
@@ -44,8 +41,7 @@ class MerkleTree(object):
         # number of leaves on the level
         number_of_leaves_on_current_level = len(self.levels[0])
 
-        if number_of_leaves_on_current_level == 1:
-            raise Exception("Merkle Tree should have more than one leaf at every level")
+        assert number_of_leaves_on_current_level > 1, "Merkle Tree should have more than one leaf at every level"
 
         if (
             number_of_leaves_on_current_level % 2 == 1

--- a/tests/acme_endorsement.py
+++ b/tests/acme_endorsement.py
@@ -85,13 +85,11 @@ def wait_for_certificates(
                     c.connect((iface.host, iface.port))
                     cert_der = c.getpeercert(binary_form=True)
                     cert = load_der_x509_certificate(cert_der, default_backend())
-                    if cert.subject.rfc4514_string() != "CN=" + network_name:
-                        raise Exception("Common name mismatch")
+                    assert cert.subject.rfc4514_string() == f"CN={network_name}"
                     cert_public_key = cert.public_key().public_bytes(
                         encoding=Encoding.PEM, format=PublicFormat.SubjectPublicKeyInfo
                     )
-                    if network_public_key != cert_public_key:
-                        raise Exception("Public key mismatch")
+                    assert network_public_key == cert_public_key
                     num_ok += 1
                 except Exception as ex:
                     LOG.trace(f"Likely expected exception: {ex}")
@@ -239,7 +237,7 @@ def run_pebble(args):
     network_name = "my-network.ccf.dev"
 
     if not os.path.exists(binary_filename) or not os.path.exists(mock_dns_filename):
-        raise Exception("pebble not found; run playbooks to install it")
+        raise FileNotFoundError("pebble not found; run playbooks to install it")
 
     config = {
         "pebble": {

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -675,20 +675,16 @@ class Network:
             ledger_files = set(ledger_files)
 
             if last_ledger_seqno > longest_ledger_seqno:
-                if longest_ledger_files and not longest_ledger_files.issubset(
+                assert longest_ledger_files is None or longest_ledger_files.issubset(
                     ledger_files
-                ):
-                    raise Exception(
-                        f"Ledger files on node {longest_ledger_node.local_node_id} do not match files on node {node.local_node_id}: {longest_ledger_files}, expected subset of {ledger_files}, diff: {ledger_files - longest_ledger_files}"
-                    )
+                ), f"Ledger files on node {longest_ledger_node.local_node_id} do not match files on node {node.local_node_id}: {longest_ledger_files}, expected subset of {ledger_files}, diff: {ledger_files - longest_ledger_files}"
                 longest_ledger_files = ledger_files
                 longest_ledger_node = node
                 longest_ledger_seqno = last_ledger_seqno
             else:
-                if not ledger_files.issubset(longest_ledger_files):
-                    raise Exception(
-                        f"Ledger files on node {node.local_node_id} do not match files on node {longest_ledger_node.local_node_id}: {ledger_files}, expected subset of {longest_ledger_files}, diff: {longest_ledger_files - ledger_files}"
-                    )
+                assert ledger_files.issubset(
+                    longest_ledger_files
+                ), f"Ledger files on node {node.local_node_id} do not match files on node {longest_ledger_node.local_node_id}: {ledger_files}, expected subset of {longest_ledger_files}, diff: {longest_ledger_files - ledger_files}"
 
         if longest_ledger_files:
             LOG.info(

--- a/tests/infra/piccolo_driver.py
+++ b/tests/infra/piccolo_driver.py
@@ -47,8 +47,7 @@ def filter_nodes(primary, backups, filter_type):
     if filter_type == "primary":
         return [primary]
     elif filter_type == "backups":
-        if not backups:
-            raise Exception("--send-tx-to backups but no backup was found")
+        assert backups, "--send-tx-to backups but no backup was found"
         return backups
     else:
         return [primary] + backups
@@ -149,10 +148,7 @@ def run(get_command, args):
         clients = []
         client_hosts = []
         if args.one_client_per_backup:
-            if not backups:
-                raise Exception(
-                    "--one-client-per-backup was set but no backup was found"
-                )
+            assert backups, "--one-client-per-backup was set but no backup was found"
             client_hosts = ["localhost"] * len(backups)
         else:
             if args.client_nodes:

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -1062,7 +1062,7 @@ class CCFRemote(object):
                 retry_count += 1
                 time.sleep(0.1)
 
-        raise Exception(
+        raise TimeoutError(
             f"Error copying files from {directory} after {retry_count} retries"
         )
 

--- a/tests/infra/runner.py
+++ b/tests/infra/runner.py
@@ -38,8 +38,7 @@ def filter_nodes(primary, backups, filter_type):
     if filter_type == "primary":
         return [primary]
     elif filter_type == "backups":
-        if not backups:
-            raise Exception("--send-tx-to backups but no backup was found")
+        assert backups, "--send-tx-to backups but no backup was found"
         return backups
     else:
         return [primary] + backups
@@ -103,10 +102,7 @@ def run(get_command, args):
         clients = []
         client_hosts = []
         if args.one_client_per_backup:
-            if not backups:
-                raise Exception(
-                    "--one-client-per-backup was set but no backup was found"
-                )
+            assert backups, "--one-client-per-backup was set but no backup was found"
             client_hosts = ["localhost"] * len(backups)
         else:
             if args.client_nodes:
@@ -285,4 +281,4 @@ class ConcurrentRunner:
                 thread.join()
 
         if FAILURES:
-            raise Exception(FAILURES)
+            raise RuntimeError(FAILURES)

--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -497,7 +497,7 @@ def test_learner_does_not_take_part(network, args):
         except TimeoutError:
             LOG.info("Trust node proposal did not commit as expected")
         else:
-            raise Exception("Trust node proposal committed unexpectedly")
+            raise AssertionError("Trust node proposal committed unexpectedly")
 
         LOG.info("Majority partition can make progress")
         partition_primary, _ = network.wait_for_new_primary(primary, nodes=f_backups)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -70,8 +70,7 @@ def wait_for_reconfiguration_to_complete(network, timeout=10):
                     LOG.info(f"expected RPC failure because of: {ex}")
         time.sleep(0.5)
         LOG.info(f"max num configs: {max_num_configs}, max rid: {max_rid}")
-        if time.time() > end_time:
-            raise Exception("Reconfiguration did not complete in time")
+        assert time.time() <= end_time, "Reconfiguration did not complete in time"
 
 
 @reqs.description("Adding a node with invalid target service certificate")
@@ -165,7 +164,7 @@ def test_add_node_invalid_validity_period(network, args):
             "As expected, node could not be trusted since its certificate validity period is invalid"
         )
     else:
-        raise Exception(
+        raise AssertionError(
             "Node should not be trusted if its certificate validity period is invalid"
         )
     return network


### PR DESCRIPTION
New Pylint release: https://github.com/PyCQA/pylint/releases/tag/v2.16.0

Flags any instance of `raise Exception` as too broad.

Have replaced these, mostly with equivalent assertions.