### PR TITLE
Allow applications to add .well-known endpoints.

### DIFF
--- a/include/ccf/actors.h
+++ b/include/ccf/actors.h
@@ -12,7 +12,7 @@ namespace ccf
     members = 0,
     users,
     nodes,
-    well_known,
+    acme_challenge,
     // not to be used
     unknown
   };
@@ -21,7 +21,7 @@ namespace ccf
   {
     if (
       actor != "gov" && actor != "app" && actor != "node" &&
-      actor != ".well-known")
+      actor != ".well-known/acme-challenge")
     {
       return false;
     }
@@ -44,9 +44,9 @@ namespace ccf
       {
         return "node";
       }
-      case ActorsType::well_known:
+      case ActorsType::acme_challenge:
       {
-        return ".well-known";
+        return ".well-known/acme-challenge";
       }
       default:
       {

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -165,7 +165,7 @@ namespace ccf
       // Note: for ACME challenges, the well-known frontend should really only
       // listen on the interface specified in the ACMEClientConfig, but we don't
       // have support for frontends restricted to particular interfaces yet.
-      rpc_map->register_frontend<ccf::ActorsType::well_known>(
+      rpc_map->register_frontend<ccf::ActorsType::acme_challenge>(
         std::make_unique<ccf::ACMERpcFrontend>(network, *context));
 
       ccf::js::register_ffi_plugins(ccfapp::get_js_plugins());

--- a/src/http/http_rpc_context.h
+++ b/src/http/http_rpc_context.h
@@ -305,8 +305,25 @@ namespace http
       return std::nullopt;
     }
 
-    const auto actor = path.substr(first_slash + 1, second_slash - 1);
-    const auto remaining_path = path.substr(second_slash);
+    auto actor = path.substr(first_slash + 1, second_slash - first_slash - 1);
+    auto remaining_path = path.substr(second_slash);
+
+    // The "actor" is generally just a single path component, eg. `gov` or
+    // `node`.  We make an exception for .well-known paths however, which use
+    // two components, ie. `.well-known/acme-challenge`. This restricts the
+    // ACME frontend to just that particular sub-directory, and allows the
+    // application to handle other .well-known paths.
+    if (actor == ".well-known")
+    {
+      const auto third_slash = path.find_first_of('/', second_slash + 1);
+      if (third_slash == std::string::npos)
+      {
+        return std::nullopt;
+      }
+
+      actor = path.substr(first_slash + 1, third_slash - first_slash - 1);
+      remaining_path = path.substr(third_slash);
+    }
 
     if (actor.empty() || remaining_path.empty())
     {
@@ -317,10 +334,6 @@ namespace http
     if (ccf::is_valid_actor(actor))
     {
       ctx.set_method(remaining_path);
-    }
-    else
-    {
-      ctx.set_method(path);
     }
     return actor;
   }

--- a/src/node/acme_challenge_frontend.h
+++ b/src/node/acme_challenge_frontend.h
@@ -16,7 +16,8 @@ namespace ccf
   public:
     ACMERpcEndpoints(
       NetworkState& network, ccfapp::AbstractNodeContext& context) :
-      CommonEndpointRegistry(get_actor_prefix(ActorsType::well_known), context)
+      CommonEndpointRegistry(
+        get_actor_prefix(ActorsType::acme_challenge), context)
     {
       auto handler = [this](auto& ctx) {
         http_status response_status = HTTP_STATUS_INTERNAL_SERVER_ERROR;
@@ -60,8 +61,7 @@ namespace ccf
         ctx.rpc_ctx->set_response_body(std::move(response_body));
       };
 
-      make_endpoint(
-        "/acme-challenge/{token}", HTTP_GET, handler, no_auth_required)
+      make_endpoint("/{token}", HTTP_GET, handler, no_auth_required)
         .set_forwarding_required(endpoints::ForwardingRequired::Never)
         .set_auto_schema<void, std::string>()
         .install();

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1324,7 +1324,7 @@ namespace ccf
           std::find(interfaces->begin(), interfaces->end(), iname) !=
             interfaces->end())
         {
-          auto challenge_frontend = find_well_known_frontend();
+          auto challenge_frontend = find_acme_challenge_frontend();
 
           const std::string& cfg_name =
             *interface.endorsement->acme_configuration;
@@ -1806,23 +1806,21 @@ namespace ccf
       return find_frontend(ActorsType::members)->is_open();
     }
 
-    std::shared_ptr<ACMERpcFrontend> find_well_known_frontend()
+    std::shared_ptr<ACMERpcFrontend> find_acme_challenge_frontend()
     {
-      auto well_known_opt = rpc_map->find(ActorsType::well_known);
-      if (!well_known_opt)
+      auto acme_challenge_opt = rpc_map->find(ActorsType::acme_challenge);
+      if (!acme_challenge_opt)
       {
         throw std::runtime_error("Missing ACME challenge frontend");
       }
-      // At this time, only the ACME challenge frontend uses the well-known
-      // actor prefix.
-      return std::static_pointer_cast<ACMERpcFrontend>(*well_known_opt);
+      return std::static_pointer_cast<ACMERpcFrontend>(*acme_challenge_opt);
     }
 
-    void open_well_known_frontend()
+    void open_acme_challenge_frontend()
     {
       if (config.network.acme && !config.network.acme->configurations.empty())
       {
-        auto fe = find_frontend(ActorsType::well_known);
+        auto fe = find_frontend(ActorsType::acme_challenge);
         if (fe)
         {
           fe->open();
@@ -2507,7 +2505,7 @@ namespace ccf
         return;
       }
 
-      open_well_known_frontend();
+      open_acme_challenge_frontend();
 
       const auto& ifaces = config.network.rpc_interfaces;
       num_acme_interfaces =


### PR DESCRIPTION
The ACME frontend was binding to the entire `.well-known` directory, intercepting any requests make to it, including to paths outside of the particular `acme-challenge` sub-directory.

This was preventing applications from handling any paths inside the `.well-known`, which may be necessary to implement certain protocols, such as did:web.

The code to extract the actor name from an incoming request is special cased for the .well-known directory, in which case it will include the second path component in the actor's name. THe ACME frontend's actor is now the full `.well-known/acme-challenge`.

We did consider implementing this by instead moving the ACME endpoints into the CommonEndpointRegistry, indirectly making them part of the application frontend, and removing the .well-known actor. Unfortunately this would make the endpoints accessible only once the application frontend has been opened, which would prevent a service from obtaining an ACME certificate early in its lifecycle.

Fixes #4810