### PR TITLE
Fix documented options for `--consensus` in `sandbox.sh` and `e2e_args.py`

### DIFF
--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -183,7 +183,7 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         "--consensus",
         help="Consensus",
         default="CFT",
-        choices=("CFT"),
+        choices=("CFT",),
     )
     parser.add_argument(
         "--worker-threads",


### PR DESCRIPTION
```
 --consensus {C,F,T}   Consensus (default: CFT)
```

=>

```
  --consensus {CFT}     Consensus (default: CFT)
```