### PR TITLE
Update SEV-SNP ACI file share to North Europe

### DIFF
--- a/.azure-pipelines-templates/deploy_aci.yml
+++ b/.azure-pipelines-templates/deploy_aci.yml
@@ -77,7 +77,7 @@ jobs:
             --aci-image ccfmsrc.azurecr.io/ccf/ci:pr-$(wait_for_image.gitSha) \
             --ports 22 \
             --aci-file-share-name ccfcishare \
-            --aci-file-share-account-name ccfcistorage \
+            --aci-file-share-account-name ccfcistoragenortheurope \
             --aci-storage-account-key $(CCF_AZURE_STORAGE_KEY) \
             --aci-setup-timeout 300 \
             --aci-private-key-b64 $(sshKey) \
@@ -128,7 +128,7 @@ jobs:
                 --ports 22 \
                 --count ${{ parameters.secondaries.count }} \
                 --aci-file-share-name ccfcishare \
-                --aci-file-share-account-name ccfcistorage \
+                --aci-file-share-account-name ccfcistoragenortheurope \
                 --aci-setup-timeout 600 \
                 --aci-storage-account-key $(CCF_AZURE_STORAGE_KEY) \
                 --out template.json > ~/secondary_aci_ips


### PR DESCRIPTION
Following #4977, this attaches a new file share to the ACI containers that's located in the same region.