### PR TITLE
Docs: Disable link checks

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -28,15 +28,18 @@ jobs:
         parameters:
           cmake_args: "-DCOMPILE_TARGET=virtual"
 
-      - script: |
-          set -ex
-          python3.8 -m venv env
-          source env/bin/activate
-          pip install wheel
-          pip install -U -r doc/requirements.txt
-          pip install -U -e ./python
-          sphinx-build -b linkcheck doc build/html
-        displayName: Link checks
+      # Note: Link checks are disabled for now as often lead to intermittent
+      # false positives (e.g. a third-party website being down) that may block
+      # releases
+      # - script: |
+      #     set -ex
+      #     python3.8 -m venv env
+      #     source env/bin/activate
+      #     pip install wheel
+      #     pip install -U -r doc/requirements.txt
+      #     pip install -U -e ./python
+      #     sphinx-build -b linkcheck doc build/html
+      #   displayName: Link checks
 
       # Only the main branch builds and publishes the versioned documentation.
       # This is because the configuration of the docs (e.g. theme) will change


### PR DESCRIPTION
Link checks lead to intermittent false positives that can (and do!) block PRs to be merged. While it was useful to run it once and fix links then, running it for every commit is overkill. I've left it commented out so that it's easy to run it again in the future (e.g. before a major release). 