### PR TITLE
Downgrade confcom to 0.2.6 to avoid CI failure

### DIFF
--- a/.azure-pipelines-templates/azure_cli.yml
+++ b/.azure-pipelines-templates/azure_cli.yml
@@ -5,8 +5,8 @@ steps:
       # After the extension being in public preview, we can install the latest version automatically
       # by `az extension update --name confcom`.
       # But for now we need to manually manage the version. 
-      az extension add --source https://acccliazext.blob.core.windows.net/confcom/confcom-0.2.9-py3-none-any.whl -y
-      # Workaround of bug in v0.2.9
+      az extension add --source https://acccliazext.blob.core.windows.net/confcom/confcom-0.2.6-py3-none-any.whl -y
+      # Workaround of bug in v0.2.6
       sudo chmod +x /opt/az/azcliextensions/confcom/azext_confcom/bin/dmverity-vhd
       az login --service-principal -u ${{ parameters.app_id }} -p ${{ parameters.service_principal_password }} --tenant ${{ parameters.tenant }}
     name: setup_azure_cli


### PR DESCRIPTION
0.2.9 fails
```
RuntimeError: Generating security policy failed with status code 1: /opt/az/lib/python3.10/site-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
```

https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=64586&view=logs&j=b406b919-62d2-5750-bc8d-d446fee5d947&t=6a3b144b-9708-57a0-a920-f77d8a10714e&l=100
