### PR TITLE
[release/2.x] Cherry pick: Upgrade to Open Enclave 0.18.5 (#5004)

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -7,7 +7,7 @@ trigger:
 
 jobs:
   - job: build_and_publish_docs
-    container: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
+    container: ccfmsrc.azurecr.io/ccf/ci:14-02-2023-virtual
     pool:
       vmImage: ubuntu-20.04
 

--- a/.azure-pipelines-quictls.yml
+++ b/.azure-pipelines-quictls.yml
@@ -17,7 +17,7 @@ parameters:
 
 jobs:
   - job: build_quictls
-    container: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
+    container: ccfmsrc.azurecr.io/ccf/ci:14-02-2023-virtual
     pool: 1es-dv4-focal
 
     strategy:

--- a/.azure-pipelines-templates/cmake.yml
+++ b/.azure-pipelines-templates/cmake.yml
@@ -3,14 +3,14 @@ parameters:
   target: ""
 
 steps:
-  - script: |
-      set -ex
-      tests/sgxinfo.sh
-      cat /proc/cpuinfo | grep flags | uniq
-    displayName: Platform Info
-    condition: succeededOrFailed()
-
   - ${{ if eq(parameters.target, 'SGX') }}:
+      - script: |
+          set -ex
+          tests/sgxinfo.sh
+          cat /proc/cpuinfo | grep flags | uniq
+        displayName: Platform Info
+        condition: succeededOrFailed()
+
       - script: |
           set -ex
           sudo groupadd -fg $(/usr/bin/stat -Lc '%g' /dev/sgx/provision) sgx_prv

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -26,12 +26,12 @@ schedules:
 
 resources:
   containers:
-    - container: nosgx
-      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
+    - container: virtual
+      image: ccfmsrc.azurecr.io/ccf/ci:14-02-2023-virtual
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
+      image: ccfmsrc.azurecr.io/ccf/ci:14-02-2023-sgx
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /lib/modules:/lib/modules:ro
 
 variables:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -26,7 +26,7 @@ schedules:
 
 resources:
   containers:
-    - container: virtual
+    - container: nosgx
       image: ccfmsrc.azurecr.io/ccf/ci:14-02-2023-virtual
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -27,7 +27,7 @@ schedules:
 resources:
   containers:
     - container: nosgx
-      image: ccfmsrc.azurecr.io/ccf/ci:14-02-2023-virtual
+      image: ccfmsrc.azurecr.io/ccf/ci:14-02-2023-sgx
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: sgx

--- a/.daily.yml
+++ b/.daily.yml
@@ -22,12 +22,12 @@ schedules:
 
 resources:
   containers:
-    - container: nosgx
-      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
+    - container: virtual
+      image: ccfmsrc.azurecr.io/ccf/ci:14-02-2023-virtual
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
+      image: ccfmsrc.azurecr.io/ccf/ci:14-02-2023-sgx
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx
 
 jobs:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "CCF Development Environment",
-  "image": "ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx",
+  "image": "ccfmsrc.azurecr.io/ccf/ci:14-02-2023-virtual",
   "runArgs": [],
   "extensions": ["ms-vscode.cpptools", "ms-python.python"]
 }

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
+    container: ccfmsrc.azurecr.io/ccf/ci:14-02-2023-virtual
 
     steps:
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -15,9 +15,9 @@ pr:
 
 resources:
   containers:
-    - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
-      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /dev/shm:/tmp/ccache
+    - container: virtual
+      image: ccfmsrc.azurecr.io/ccf/ci:14-02-2023-virtual
+      options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
 jobs:
   - template: .azure-pipelines-templates/common.yml

--- a/.stress.yml
+++ b/.stress.yml
@@ -21,7 +21,7 @@ schedules:
 resources:
   containers:
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci:oe-0.18.4-dcap-ql-dev-sgx
+      image: ccfmsrc.azurecr.io/ccf/ci:14-02-2023-sgx
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.16]
+
+[2.0.16]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.16
+
+### Dependencies
+
+- Upgraded OpenEnclave to [0.18.5](https://github.com/openenclave/openenclave/releases/tag/v0.18.5).
+
 ## [2.0.15]
 
 [2.0.15]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.15

--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -19,7 +19,7 @@ endif()
 
 # CPack variables for Debian packages
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-    "open-enclave (>=0.18.4), libuv1 (>= 1.34.2), libc++1-10, libc++abi1-10, openssl (>=1.1.1)"
+    "open-enclave (>=0.18.5), libuv1 (>= 1.34.2), libc++1-10, libc++abi1-10, openssl (>=1.1.1)"
 )
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 

--- a/getting_started/setup_vm/roles/openenclave/vars/common.yml
+++ b/getting_started/setup_vm/roles/openenclave/vars/common.yml
@@ -1,6 +1,6 @@
-oe_ver: "0.18.4"
+oe_ver: "0.18.5"
 # Usually the same, except for rc, where ver is -rc and ver_ is _rc
-oe_ver_: "0.18.4"
+oe_ver_: "0.18.5"
 
 # Source install
 workspace: "/tmp/"


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Upgrade to Open Enclave 0.18.5 (#5004)](https://github.com/microsoft/CCF/pull/5004)