### PR TITLE
Infra: fix for full test suite error

### DIFF
--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -701,7 +701,7 @@ class Network:
         if not skip_verification and self.txs is not None:
             LOG.info("Verifying that all committed txs can be read before shutdown")
             log_capture = []
-            self.txs.verify(log_capture=log_capture)
+            self.txs.verify(network=self, log_capture=log_capture)
             self.txs.verify_range(log_capture=log_capture)
             if verbose_verification:
                 flush_info(log_capture, None)


### PR DESCRIPTION
Fix a bug triggered by the full test suite here: https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=64801&view=logs&j=77890be3-fbd3-52a1-2c40-e5bc14cbbdef&t=37e815a4-02f1-50e0-9ecd-dc1a864da067&l=17120 when the `test_recover_service_aborted` test was scheduled first. 