### PR TITLE
Fix `clang-version` in playbook

### DIFF
--- a/getting_started/setup_vm/ccf-dev.yml
+++ b/getting_started/setup_vm/ccf-dev.yml
@@ -1,6 +1,7 @@
 - hosts: localhost
   vars:
     platform: "sgx"
+    clang_version: "10"
   tasks:
     - import_role:
         name: intel


### PR DESCRIPTION
`ccf-dev.yml` playbook fails due to undefined `clang_version` variable