### PR TITLE
Update CodeQL GitHub Actions steps to v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
@@ -43,7 +43,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       #- name: Autobuild
-      #  uses: github/codeql-action/autobuild@v1
+      #  uses: github/codeql-action/autobuild@v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -71,4 +71,4 @@ jobs:
           make
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
v1 is deprecated:

https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/

And our workflow is failing:

https://github.com/microsoft/CCF/actions/workflows/codeql-analysis.yml

Hopefully these things are related, else I'll chase down the next fix.