### PR TITLE
[release/3.x] Cherry pick: Efficient jwt refresh (#5027)

### DIFF
--- a/src/node/rpc/jwt_management.h
+++ b/src/node/rpc/jwt_management.h
@@ -187,11 +187,32 @@ namespace ccf
       return false;
     }
 
-    remove_jwt_public_signing_keys(tx, issuer);
+    std::set<std::string> existing_kids;
+    key_issuer->foreach(
+      [&existing_kids, &issuer](const auto& kid, const auto& issuer_) {
+        if (issuer_ == issuer)
+        {
+          existing_kids.insert(kid);
+        }
+        return true;
+      });
+
     for (auto& [kid, der] : new_keys)
     {
-      keys->put(kid, der);
-      key_issuer->put(kid, issuer);
+      if (!existing_kids.contains(kid))
+      {
+        keys->put(kid, der);
+        key_issuer->put(kid, issuer);
+      }
+    }
+
+    for (auto& kid : existing_kids)
+    {
+      if (!new_keys.contains(kid))
+      {
+        keys->remove(kid);
+        key_issuer->remove(kid);
+      }
     }
 
     return true;

--- a/tests/infra/jwt_issuer.py
+++ b/tests/infra/jwt_issuer.py
@@ -10,6 +10,7 @@ from contextlib import AbstractContextManager
 import tempfile
 import json
 import time
+import uuid
 from infra.log_capture import flush_info
 from loguru import logger as LOG
 
@@ -100,7 +101,6 @@ class OpenIDProviderServer(AbstractContextManager):
 
 class JwtIssuer:
     TEST_JWT_ISSUER_NAME = "test_jwt_issuer"
-    TEST_JWT_KID = "test_jwt_kid"
     TEST_CA_BUNDLE_NAME = "test_ca_bundle_name"
 
     def _generate_cert(self, cn=None):
@@ -112,6 +112,7 @@ class JwtIssuer:
         self, name=TEST_JWT_ISSUER_NAME, cert=None, refresh_interval=3, cn=None
     ):
         self.name = name
+        self.default_kid = f"{uuid.uuid4()}"
         self.server = None
         self.refresh_interval = refresh_interval
         # Auto-refresh ON if issuer name starts with "https://"
@@ -125,10 +126,13 @@ class JwtIssuer:
         else:
             self.cert_pem = cert
 
-    def refresh_keys(self, kid=TEST_JWT_KID):
+    def refresh_keys(self, kid=None):
+        if not kid:
+            self.default_kid = f"{uuid.uuid4()}"
+        kid_ = kid or self.default_kid
         (self.key_priv_pem, self.key_pub_pem), self.cert_pem = self._generate_cert()
         if self.server:
-            self.server.set_jwks(self.create_jwks(kid))
+            self.server.set_jwks(self.create_jwks(kid_))
 
     def _create_jwks(self, kid, test_invalid_is_key=False):
         der_b64 = base64.b64encode(
@@ -138,8 +142,9 @@ class JwtIssuer:
         ).decode("ascii")
         return {"kty": "RSA", "kid": kid, "x5c": [der_b64]}
 
-    def create_jwks(self, kid=TEST_JWT_KID, test_invalid_is_key=False):
-        return {"keys": [self._create_jwks(kid, test_invalid_is_key)]}
+    def create_jwks(self, kid=None, test_invalid_is_key=False):
+        kid_ = kid or self.default_kid
+        return {"keys": [self._create_jwks(kid_, test_invalid_is_key)]}
 
     def create_jwks_for_kids(self, kids):
         jwks = {}
@@ -148,7 +153,8 @@ class JwtIssuer:
             jwks["keys"].append(self._create_jwks(kid))
         return jwks
 
-    def register(self, network, kid=TEST_JWT_KID, ca_bundle_name=TEST_CA_BUNDLE_NAME):
+    def register(self, network, kid=None, ca_bundle_name=TEST_CA_BUNDLE_NAME):
+        kid_ = kid or self.default_kid
         primary, _ = network.find_primary()
 
         if self.auto_refresh:
@@ -171,23 +177,35 @@ class JwtIssuer:
             network.consortium.set_jwt_issuer(primary, metadata_fp.name)
 
         with tempfile.NamedTemporaryFile(prefix="ccf", mode="w+") as jwks_fp:
-            json.dump(self.create_jwks(kid), jwks_fp)
+            json.dump(self.create_jwks(kid_), jwks_fp)
             jwks_fp.flush()
             network.consortium.set_jwt_public_signing_keys(
                 primary, full_name, jwks_fp.name
             )
 
-    def start_openid_server(self, port=0, kid=TEST_JWT_KID):
+    def start_openid_server(self, port=0, kid=None):
+        kid_ = kid or self.default_kid
         self.server = OpenIDProviderServer(
-            port, self.tls_priv, self.tls_cert, self.create_jwks(kid)
+            port, self.tls_priv, self.tls_cert, self.create_jwks(kid_)
         )
         return self.server
 
-    def issue_jwt(self, kid=TEST_JWT_KID, claims=None):
-        return infra.crypto.create_jwt(claims or {}, self.key_priv_pem, kid)
+    def issue_jwt(self, kid=None, claims=None):
+        claims = claims or {}
+        kid_ = kid or self.default_kid
+        # JWT formats times as NumericDate, which is a JSON numeric value counting seconds sine the epoch
+        now = int(time.time())
+        if "nbf" not in claims:
+            # Insert default Not Before claim, valid from ~10 seconds ago
+            claims["nbf"] = now - 10
+        if "exp" not in claims:
+            # Insert default Expiration Time claim, valid for ~1hr
+            claims["exp"] = now + 3600
+        return infra.crypto.create_jwt(claims, self.key_priv_pem, kid_)
 
-    def wait_for_refresh(self, network, kid=TEST_JWT_KID):
+    def wait_for_refresh(self, network, kid=None):
         timeout = self.refresh_interval * 3
+        kid_ = kid or self.default_kid
         LOG.info(f"Waiting {timeout}s for JWT key refresh")
         primary, _ = network.find_nodes()
         end_time = time.time() + timeout
@@ -196,10 +214,11 @@ class JwtIssuer:
                 logs = []
                 r = c.get("/gov/jwt_keys/all", log_capture=logs)
                 assert r.status_code == 200, r
-                stored_cert = r.body.json()[kid]["cert"]
-                if self.cert_pem == stored_cert:
-                    flush_info(logs)
-                    return
+                if kid_ in r.body.json():
+                    stored_cert = r.body.json()[kid_]["cert"]
+                    if self.cert_pem == stored_cert:
+                        flush_info(logs)
+                        return
                 time.sleep(0.1)
         flush_info(logs)
         raise TimeoutError(

--- a/tests/js-modules/modules.py
+++ b/tests/js-modules/modules.py
@@ -954,7 +954,7 @@ def test_js_execution_time(network, args):
     LOG.info("Store JWT signing keys")
     jwt_key_priv_pem, _ = infra.crypto.generate_rsa_keypair(2048)
     jwt_cert_pem = infra.crypto.generate_cert(jwt_key_priv_pem)
-    jwt_kid = "my_key_id"
+    jwt_kid = "my_other_key_id"
     issuer = "https://example.issuer"
     with tempfile.NamedTemporaryFile(prefix="ccf", mode="w+") as metadata_fp:
         jwt_cert_der = infra.crypto.cert_pem_to_der(jwt_cert_pem)

--- a/tests/jwt_test.py
+++ b/tests/jwt_test.py
@@ -16,6 +16,8 @@ from infra.runner import ConcurrentRunner
 import ca_certs
 import ssl
 import socket
+import ccf.ledger
+from ccf.tx_id import TxID
 
 from loguru import logger as LOG
 
@@ -71,7 +73,7 @@ def test_jwt_without_key_policy(network, args):
     primary, _ = network.find_nodes()
 
     issuer = infra.jwt_issuer.JwtIssuer("my_issuer")
-    kid = "my_kid"
+    kid = "my_kid_not_key_policy"
 
     LOG.info("Try to add JWT signing key without matching issuer")
     with tempfile.NamedTemporaryFile(prefix="ccf", mode="w+") as jwks_fp:
@@ -186,7 +188,7 @@ def test_jwt_with_sgx_key_policy(network, args):
     with open(oe_cert_path, encoding="utf-8") as f:
         oe_cert_pem = f.read()
 
-    kid = "my_kid"
+    kid = "my_kid_with_policy"
     issuer = infra.jwt_issuer.JwtIssuer("my_issuer", oe_cert_pem)
 
     oesign = os.path.join(args.oe_binary, "oesign")
@@ -436,17 +438,101 @@ def test_jwt_key_auto_refresh(network, args):
 
         with_timeout(check_has_failures, timeout=5)
 
-        LOG.info("Check that JWT refresh has less successes than attempts")
+        LOG.info("Check that JWT refresh has fewer successes than attempts")
         m = get_jwt_metrics(network)
         assert m["attempts"] > m["successes"], m["attempts"]
 
     LOG.info("Restart OpenID endpoint server with new keys")
     kid2 = "the_kid_2"
-    issuer.refresh_keys()
+    issuer.refresh_keys(kid2)
     with issuer.start_openid_server(issuer_port, kid2):
         LOG.info("Check that keys got refreshed")
         with_timeout(lambda: check_kv_jwt_key_matches(network, kid, None), timeout=5)
         check_kv_jwt_key_matches(network, kid2, issuer.cert_pem)
+
+    return network
+
+
+@reqs.description("JWT with auto_refresh enabled, check for duplicate entries")
+def test_jwt_key_auto_refresh_entries(network, args):
+    primary, _ = network.find_nodes()
+
+    ca_cert_bundle_name = "jwt"
+    kid = "the_kid_no_duplicates"
+    issuer_host = "localhost"
+    issuer_port = args.issuer_port
+
+    issuer = infra.jwt_issuer.JwtIssuer(
+        f"https://{issuer_host}:{issuer_port}", cn=issuer_host
+    )
+
+    LOG.info("Add CA cert for JWT issuer")
+    with tempfile.NamedTemporaryFile(prefix="ccf", mode="w+") as ca_cert_bundle_fp:
+        ca_cert_bundle_fp.write(issuer.tls_cert)
+        ca_cert_bundle_fp.flush()
+        network.consortium.set_ca_cert_bundle(
+            primary, ca_cert_bundle_name, ca_cert_bundle_fp.name
+        )
+
+    LOG.info("Start OpenID endpoint server")
+    with issuer.start_openid_server(issuer_port, kid):
+        LOG.info("Add JWT issuer with auto-refresh")
+        with tempfile.NamedTemporaryFile(prefix="ccf", mode="w+") as metadata_fp:
+            json.dump(
+                {
+                    "issuer": issuer.name,
+                    "auto_refresh": True,
+                    "ca_cert_bundle_name": ca_cert_bundle_name,
+                },
+                metadata_fp,
+            )
+            metadata_fp.flush()
+            network.consortium.set_jwt_issuer(primary, metadata_fp.name)
+
+            LOG.info("Check that keys got refreshed")
+            # Note: refresh interval is set to 1s, see network args below.
+            with_timeout(
+                lambda: check_kv_jwt_key_matches(network, kid, issuer.cert_pem),
+                timeout=5,
+            )
+
+        LOG.info("Check that JWT refresh has attempts and successes")
+        m = get_jwt_metrics(network)
+        attempts = m["attempts"]
+        successes = m["successes"]
+        assert attempts > 0, attempts
+        assert successes > 0, successes
+
+        # Wait long enough for at least one refresh to take place
+        time.sleep(args.jwt_key_refresh_interval_s)
+
+        m = get_jwt_metrics(network)
+        assert m["attempts"] > attempts, m["attempts"]
+        assert m["successes"] > successes, m["successes"]
+
+        # Force chunking
+        network.get_latest_ledger_public_state()
+        # Check that despite refreshing JWTs multiple times, only a single
+        # transaction was created for this kid.
+        ledger_directories = primary.remote.ledger_paths()
+        ledger = ccf.ledger.Ledger(ledger_directories)
+
+        last_key_refresh = None
+        for chunk in ledger:
+            for tx in chunk:
+                txid = TxID(tx.gcm_header.view, tx.gcm_header.seqno)
+                tables = tx.get_public_domain().get_tables()
+                if "public:ccf.gov.jwt.public_signing_keys" in tables:
+                    pub_keys = tables["public:ccf.gov.jwt.public_signing_keys"]
+                    if kid.encode() in pub_keys:
+                        if last_key_refresh is None:
+                            LOG.info(f"Refresh found for kid: {kid} at {txid}")
+                            last_key_refresh = txid
+                        else:
+                            assert (
+                                last_key_refresh == txid
+                            ), "Duplicate JWT refresh transaction"
+        assert last_key_refresh, "Missing JWT refresh transaction"
 
     return network
 
@@ -456,7 +542,7 @@ def test_jwt_key_initial_refresh(network, args):
     primary, _ = network.find_nodes()
 
     ca_cert_bundle_name = "jwt"
-    kid = "my_kid"
+    kid = f"my_kid_autorefresh_{primary.local_node_id}"
     issuer_host = "localhost"
     issuer_port = args.issuer_port
 
@@ -532,8 +618,6 @@ def test_jwt_key_refresh_aad(network, args):
         network.consortium.set_jwt_issuer(primary, metadata_fp.name)
 
     LOG.info("Check that keys got refreshed")
-    # Auto-refresh interval has been set to a large value so that it doesn't happen within the timeout.
-    # This is testing the one-off refresh after adding a new issuer.
     with_timeout(lambda: check_kv_jwt_keys_not_empty(network, issuer), timeout=5)
 
 
@@ -542,7 +626,7 @@ def with_timeout(fn, timeout):
     while True:
         try:
             return fn()
-        except Exception:
+        except (TimeoutError, AssertionError):
             if time.time() - t0 < timeout:
                 time.sleep(0.1)
             else:
@@ -568,6 +652,7 @@ def run_auto(args):
         test_jwt_key_auto_refresh(network, args)
         # Check that we can refresh keys for AAD endpoint
         test_jwt_key_refresh_aad(network, args)
+        test_jwt_key_auto_refresh_entries(network, args)
 
 
 def run_manual(args):


### PR DESCRIPTION
Backports the following commits to `release/3.x`:
 - [Efficient jwt refresh (#5027)](https://github.com/microsoft/CCF/pull/5027)