### PR TITLE
[release/2.x] Cherry pick: Update cryptography requirement from ==38.* to ==39.* in /python (#4792)

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,3 @@
 loguru >= 0.5, == 0.*
-cryptography == 38.*
+cryptography == 39.*
 string-color >= 1.2.1


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Update cryptography requirement from ==38.* to ==39.* in /python (#4792)](https://github.com/microsoft/CCF/pull/4792)