### PR TITLE
Increase datetime API test timeout

### DIFF
--- a/tests/js-custom-authorization/custom_authorization.py
+++ b/tests/js-custom-authorization/custom_authorization.py
@@ -575,11 +575,11 @@ def test_datetime_api(network, args):
         definitely_now = body["definitely_now"].replace("Z", "+00:00")
         definitely_1970 = body["definitely_1970"].replace("Z", "+00:00")
 
-        # Assume less than 2ms of execution time between grabbing timestamps, and confirm that default call gets real timestamp from global activation
+        # Assume less than 5ms of execution time between grabbing timestamps, and confirm that default call gets real timestamp from global activation
         default_time = datetime.datetime.fromisoformat(default)
         service_time = datetime.datetime.fromisoformat(definitely_now)
         diff = (service_time - default_time).total_seconds()
-        assert diff < 0.002, diff
+        assert diff < 0.005, diff
 
         # Assume less than 1 second of clock skew + execution time
         diff = (local_time - service_time).total_seconds()


### PR DESCRIPTION
This 2ms seemed like it should be enough, but has been hit at least once in the CI:

https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=65843&view=logs&j=8f3dc89c-3708-5926-47e7-27120a268dab&t=bb1a7e6d-8f5b-56e4-638c-b498b20b4b62&l=13973

Increasing this limit further to account for: debug builds, multi-test contention, random-CI-machine-contention, unknown unknowns.