### PR TITLE
Disable external executor test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1025,13 +1025,6 @@ if(BUILD_TESTS)
     CONSENSUS cft
     LABEL perf
   )
-
-  add_e2e_test(
-    NAME external_executor_test
-    PYTHON_SCRIPT
-      ${CMAKE_SOURCE_DIR}/tests/external_executor/external_executor.py
-    CONSENSUS ${CONSENSUS_FILTER}
-  )
 endif()
 
 # Generate and install CMake export file for consumers using CMake


### PR DESCRIPTION
This test keeps failing on access to external resources (wikipedia in this case), but external executors aren't supported in 3.x, and we don't need to hold up the release for that.