### PR TITLE
Attestation container: Fix `create_container` policy

### DIFF
--- a/scripts/azure_deployment/arm_aci.py
+++ b/scripts/azure_deployment/arm_aci.py
@@ -408,6 +408,8 @@ def make_aci_deployment(args: Namespace) -> Deployment:
                     lines = [
                         'exec_in_container := {"allowed": true}\n'
                         if l.startswith("exec_in_container")
+                        else 'create_container := {"allowed": true}\n'
+                        if l.startswith("create_container")
                         else l
                         for l in lines
                     ]


### PR DESCRIPTION
Attempt to fix broken attestation container deployment on ACI.