### PR TITLE
Avoid rewriting node info when `retired_committed` is already set

### DIFF
--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -645,23 +645,17 @@ namespace ccf
         // This endpoint should only be called internally once it is certain
         // that all nodes recorded as Retired will no longer issue transactions.
         auto nodes = ctx.tx.rw(network.nodes);
-        auto node_endorsed_certificates =
-          ctx.tx.rw(network.node_endorsed_certificates);
-        nodes->foreach([this, &nodes, &node_endorsed_certificates](
-                         const auto& node_id, const auto& node_info) {
+        nodes->foreach([this, &nodes](const auto& node_id, auto node_info) {
           if (
             node_info.status == ccf::NodeStatus::RETIRED &&
-            node_id != this->context.get_node_id())
+            node_id != this->context.get_node_id() &&
+            !node_info.retired_committed)
           {
             // Set retired_committed on nodes for which RETIRED status
             // has been committed. This endpoint is only triggered for a
             // a given node once their retirement has been committed.
-            auto node = nodes->get(node_id);
-            if (node.has_value())
-            {
-              node->retired_committed = true;
-              nodes->put(node_id, node.value());
-            }
+            node_info.retired_committed = true;
+            nodes->put(node_id, node_info);
 
             LOG_DEBUG_FMT("Setting retired_committed on node {}", node_id);
           }


### PR DESCRIPTION
The previous implementation called `nodes->put` inside `nodes->foreach`, even when it was writing the same data that previously existed. This could lead to a lot of redundant writes, linearly growing with the number of retired nodes in the service's history if they are not manually pruned by calling `DELETE /network/nodes/{node_id}`.

I've simplified the implementation and believe the additional `->get()` was unnecessary, but let me know if I'm missing something. I'd like to document/test a way to detect this pattern in future (monitor trend of size of largest write to ledger?), but I think its worth getting in this fix first.