### PR TITLE
[release/2.x] Cherry pick: Avoid rewriting node info when `retired_committed` is already set (#5094)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.18]
+
+[2.0.18]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.18
+
+### Changed
+
+- Avoid rewriting node info when `retired_committed` is already set (#5094).
+
 ## [2.0.17]
 
 [2.0.17]: https://github.com/microsoft/CCF/releases/tag/ccf-2.0.17


### PR DESCRIPTION
Backports the following commits to `release/2.x`:
 - [Avoid rewriting node info when `retired_committed` is already set (#5094)](https://github.com/microsoft/CCF/pull/5094)