### PR TITLE
[release/3.x] Cherry pick: Avoid rewriting node info when `retired_committed` is already set (#5094)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.10]
+
+[3.0.10]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.10
+
+### Changed
+
+- Avoid rewriting node info when `retired_committed` is already set (#5094).
+
 ## [3.0.9]
 
 [3.0.9]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.9

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -638,23 +638,17 @@ namespace ccf
         // This endpoint should only be called internally once it is certain
         // that all nodes recorded as Retired will no longer issue transactions.
         auto nodes = ctx.tx.rw(network.nodes);
-        auto node_endorsed_certificates =
-          ctx.tx.rw(network.node_endorsed_certificates);
-        nodes->foreach([this, &nodes, &node_endorsed_certificates](
-                         const auto& node_id, const auto& node_info) {
+        nodes->foreach([this, &nodes](const auto& node_id, auto node_info) {
           if (
             node_info.status == ccf::NodeStatus::RETIRED &&
-            node_id != this->context.get_node_id())
+            node_id != this->context.get_node_id() &&
+            !node_info.retired_committed)
           {
             // Set retired_committed on nodes for which RETIRED status
             // has been committed. This endpoint is only triggered for a
             // a given node once their retirement has been committed.
-            auto node = nodes->get(node_id);
-            if (node.has_value())
-            {
-              node->retired_committed = true;
-              nodes->put(node_id, node.value());
-            }
+            node_info.retired_committed = true;
+            nodes->put(node_id, node_info);
 
             LOG_DEBUG_FMT("Setting retired_committed on node {}", node_id);
           }


### PR DESCRIPTION
Backports the following commits to `release/3.x`:
 - [Avoid rewriting node info when `retired_committed` is already set (#5094)](https://github.com/microsoft/CCF/pull/5094)