### PR TITLE
External executor: disable `WikiCacher` test

### DIFF
--- a/tests/suite/test_requirements.py
+++ b/tests/suite/test_requirements.py
@@ -162,6 +162,13 @@ def not_snp(reason=None):
     return ensure_reqs(check)
 
 
+def test_disabled(reason=None):
+    def check(network, args, *nargs, **kwargs):
+        raise TestRequirementsNotMet(f"Disabled test (reason: {reason})")
+
+    return ensure_reqs(check)
+
+
 def recover(number_txs=5):
     # Runs some transactions before recovering the network and guarantees that all
     # transactions are successfully recovered


### PR DESCRIPTION
The `WikiCacher` external executor makes requests to Wikipedia and so can be flaky in our CI. This PR disables the single `WikiCacher` executor test, and replaces it with the `LoggingExecutor` wherever possible. 