### PR TITLE
Remove noisy recovery log line

### DIFF
--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -379,15 +379,6 @@ namespace ccf
             {
               case consensus::LedgerRequestPurpose::Recovery:
               {
-                if (from_seqno != to_seqno)
-                {
-                  LOG_FAIL_FMT(
-                    "Unexpected range for Recovery response "
-                    "ledger_no_entry_range: {}->{} "
-                    "(expected single ledger entry)",
-                    from_seqno,
-                    to_seqno);
-                }
                 node->recover_ledger_end();
                 break;
               }


### PR DESCRIPTION
This line was always wrongly printed at the end of the recovery of the public ledger. This shouldn't be printed as the enclave now requests batches of 100 entries to the host and so on the last request to the host, `ledger_no_entry_range` is returned, with `to_seqno = from_seqno + 100`, which triggers this incorrect log line. 