### PR TITLE
Remove unnecessary condition

### DIFF
--- a/tla/ccfraft.tla
+++ b/tla/ccfraft.tla
@@ -450,7 +450,7 @@ AppendEntries(i, j) ==
     /\ state[i] = Leader
     /\ i /= j
     \* AppendEntries must be sent for historical entries, unless
-    \* snapshots are used. Whether the node as in configuration at
+    \* snapshots are used. Whether the node is in configuration at
     \* that index makes no difference.
     \* /\ IsInServerSetForIndex(j, i, nextIndex[i][j])
     \* There must be an index to send

--- a/tla/ccfraft.tla
+++ b/tla/ccfraft.tla
@@ -449,8 +449,10 @@ AppendEntries(i, j) ==
     \* No messages to itself and sender is primary
     /\ state[i] = Leader
     /\ i /= j
-    \* Recipient must exist in one configuration relevant to that index
-    /\ IsInServerSetForIndex(j, i, nextIndex[i][j])
+    \* AppendEntries must be sent for historical entries, unless
+    \* snapshots are used. Whether the node as in configuration at
+    \* that index makes no difference.
+    \* /\ IsInServerSetForIndex(j, i, nextIndex[i][j])
     \* There must be an index to send
     /\ Len(log[i]) >= nextIndex[i][j]
     /\ LET prevLogIndex == nextIndex[i][j] - 1


### PR DESCRIPTION
Change to address issue found by @lemmy, model checking does not seem adversely affected:

```
$ ./tlc.sh MCccfraftWithReconfig.tla -config MCccfraft.cfg
TLC2 Version 2.18 of Day Month 20?? (rev: 30cab3d)
Running breadth-first search Model-Checking with fp 70 and seed 6400660138401708556 with 32 workers on 32 cores with 1963MB heap and 64MB offheap memory [pid: 6399] (Linux 5.4.0-1104-azure amd64, Microsoft 17.0.6 x86_64, MSBDiskFPSet, DiskStateQueue).
Parsing file /workspaces/CCF/tla/MCccfraftWithReconfig.tla
Parsing file /workspaces/CCF/tla/ccfraft.tla
Parsing file /tmp/tlc-7914316506238689958/TLC.tla (jar:file:/workspaces/CCF/tla/tla2tools.jar!/tla2sany/StandardModules/TLC.tla)
Parsing file /tmp/tlc-7914316506238689958/_TLCTrace.tla (jar:file:/workspaces/CCF/tla/tla2tools.jar!/tla2sany/StandardModules/_TLCTrace.tla)
Parsing file /tmp/tlc-7914316506238689958/Naturals.tla (jar:file:/workspaces/CCF/tla/tla2tools.jar!/tla2sany/StandardModules/Naturals.tla)
Parsing file /tmp/tlc-7914316506238689958/FiniteSets.tla (jar:file:/workspaces/CCF/tla/tla2tools.jar!/tla2sany/StandardModules/FiniteSets.tla)
Parsing file /tmp/tlc-7914316506238689958/Sequences.tla (jar:file:/workspaces/CCF/tla/tla2tools.jar!/tla2sany/StandardModules/Sequences.tla)
Parsing file /tmp/tlc-7914316506238689958/FiniteSetsExt.tla (jar:file:/workspaces/CCF/tla/CommunityModules-deps.jar!/FiniteSetsExt.tla)
Parsing file /tmp/tlc-7914316506238689958/SequencesExt.tla (jar:file:/workspaces/CCF/tla/CommunityModules-deps.jar!/SequencesExt.tla)
Parsing file /tmp/tlc-7914316506238689958/Functions.tla (jar:file:/workspaces/CCF/tla/CommunityModules-deps.jar!/Functions.tla)
Parsing file /tmp/tlc-7914316506238689958/Folds.tla (jar:file:/workspaces/CCF/tla/CommunityModules-deps.jar!/Folds.tla)
Parsing file /tmp/tlc-7914316506238689958/TLCExt.tla (jar:file:/workspaces/CCF/tla/tla2tools.jar!/tla2sany/StandardModules/TLCExt.tla)
Semantic processing of module Naturals
Semantic processing of module Sequences
Semantic processing of module FiniteSets
Semantic processing of module TLC
Semantic processing of module Folds
Semantic processing of module Functions
Semantic processing of module FiniteSetsExt
Semantic processing of module SequencesExt
Semantic processing of module ccfraft
Semantic processing of module TLCExt
Semantic processing of module _TLCTrace
Semantic processing of module MCccfraftWithReconfig
Starting... (2023-03-20 18:10:56)
Computing initial states...
Computed 2 initial states...
Finished computing initial states: 3 distinct states generated at 2023-03-20 18:10:56.
Progress(27) at 2023-03-20 18:10:59: 186,668 states generated (186,668 s/min), 96,912 distinct states found (96,912 ds/min), 11,504 states left on queue.
Model checking completed. No error has been found.
  Estimates of the probability that TLC did not check all reachable states
  because two distinct states had the same fingerprint:
  calculated (optimistic):  val = 2.1E-8
  based on the actual fingerprints:  val = 8.0E-9
1318648 states generated, 449100 distinct states found, 0 states left on queue.
The depth of the complete state graph search is 57.
The average outdegree of the complete state graph is 1 (minimum is 0, the maximum 7 and the 95th percentile is 3).
Finished in 10s at (2023-03-20 18:11:05)
```

```
$ ./tlc.sh MCccfraft.tla
TLC2 Version 2.18 of Day Month 20?? (rev: 30cab3d)
Running breadth-first search Model-Checking with fp 91 and seed 8836493994359060953 with 32 workers on 32 cores with 1963MB heap and 64MB offheap memory [pid: 5990] (Linux 5.4.0-1104-azure amd64, Microsoft 17.0.6 x86_64, MSBDiskFPSet, DiskStateQueue).
Parsing file /workspaces/CCF/tla/MCccfraft.tla
Parsing file /workspaces/CCF/tla/ccfraft.tla
Parsing file /tmp/tlc-18113571326723343442/TLC.tla (jar:file:/workspaces/CCF/tla/tla2tools.jar!/tla2sany/StandardModules/TLC.tla)
Parsing file /tmp/tlc-18113571326723343442/_TLCTrace.tla (jar:file:/workspaces/CCF/tla/tla2tools.jar!/tla2sany/StandardModules/_TLCTrace.tla)
Parsing file /tmp/tlc-18113571326723343442/Naturals.tla (jar:file:/workspaces/CCF/tla/tla2tools.jar!/tla2sany/StandardModules/Naturals.tla)
Parsing file /tmp/tlc-18113571326723343442/FiniteSets.tla (jar:file:/workspaces/CCF/tla/tla2tools.jar!/tla2sany/StandardModules/FiniteSets.tla)
Parsing file /tmp/tlc-18113571326723343442/Sequences.tla (jar:file:/workspaces/CCF/tla/tla2tools.jar!/tla2sany/StandardModules/Sequences.tla)
Parsing file /tmp/tlc-18113571326723343442/FiniteSetsExt.tla (jar:file:/workspaces/CCF/tla/CommunityModules-deps.jar!/FiniteSetsExt.tla)
Parsing file /tmp/tlc-18113571326723343442/SequencesExt.tla (jar:file:/workspaces/CCF/tla/CommunityModules-deps.jar!/SequencesExt.tla)
Parsing file /tmp/tlc-18113571326723343442/Functions.tla (jar:file:/workspaces/CCF/tla/CommunityModules-deps.jar!/Functions.tla)
Parsing file /tmp/tlc-18113571326723343442/Folds.tla (jar:file:/workspaces/CCF/tla/CommunityModules-deps.jar!/Folds.tla)
Parsing file /tmp/tlc-18113571326723343442/TLCExt.tla (jar:file:/workspaces/CCF/tla/tla2tools.jar!/tla2sany/StandardModules/TLCExt.tla)
Semantic processing of module Naturals
Semantic processing of module Sequences
Semantic processing of module FiniteSets
Semantic processing of module TLC
Semantic processing of module Folds
Semantic processing of module Functions
Semantic processing of module FiniteSetsExt
Semantic processing of module SequencesExt
Semantic processing of module ccfraft
Semantic processing of module TLCExt
Semantic processing of module _TLCTrace
Semantic processing of module MCccfraft
Starting... (2023-03-20 18:10:17)
Computing initial states...
Computed 2 initial states...
Computed 4 initial states...
Finished computing initial states: 7 states generated, with 5 of them distinct at 2023-03-20 18:10:17.
Model checking completed. No error has been found.
  Estimates of the probability that TLC did not check all reachable states
  because two distinct states had the same fingerprint:
  calculated (optimistic):  val = 1.8E-10
  based on the actual fingerprints:  val = 5.1E-11
127352 states generated, 35388 distinct states found, 0 states left on queue.
The depth of the complete state graph search is 34.
The average outdegree of the complete state graph is 1 (minimum is 0, the maximum 7 and the 95th percentile is 2).
Finished in 02s at (2023-03-20 18:10:19)
```