### PR TITLE
Fix TSAN warning in tls_test's test code

### DIFF
--- a/src/tls/test/main.cpp
+++ b/src/tls/test/main.cpp
@@ -164,7 +164,7 @@ long recv(
 
 /// Performs a TLS handshake, looping until there's nothing more to read/write.
 /// Returns 0 on success, throws a runtime error with SSL error str on failure.
-int handshake(Context* ctx, bool& keep_going)
+int handshake(Context* ctx, std::atomic<bool>& keep_going)
 {
   while (keep_going)
   {
@@ -333,7 +333,7 @@ void run_test_case(
   server.set_bio(&pipe, send<TestPipe::SERVER>, recv<TestPipe::SERVER>);
   client.set_bio(&pipe, send<TestPipe::CLIENT>, recv<TestPipe::CLIENT>);
 
-  bool keep_going = true;
+  std::atomic<bool> keep_going = true;
   std::optional<std::runtime_error> client_exception, server_exception;
 
   // Create a thread for the client handshake

--- a/tsan_env_suppressions
+++ b/tsan_env_suppressions
@@ -4,9 +4,6 @@
 # Awkward usages of '*' in this file like '/ds/*ring_buffer.h' are necessary to handle the cases where tsan thinks
 # src/ds/ring_buffer.h as src/ds/test/../ring_buffer.h for example
 
-# For kv_test
-race:*src/tls/test/main.cpp
-
 # For partitions_test
 deadlock:*/store.h
 deadlock:*/untyped_map.h


### PR DESCRIPTION
Fix following error in tls_test. It's just about fixing test code itself.


```
LLVMSymbolizer: error reading file: No such file or directory
==================
WARNING: ThreadSanitizer: data race (pid=4174)
  Write of size 1 at 0x7ffd8be844c7 by thread T9:
    #0 run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_2::operator()() const /home/takurosato/CCF/build/../src/tls/test/main.cpp:349:18 (tls_test+0x1616ae) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #1 decltype(std::declval<run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_2>()()) std::__1::__invoke[abi:v15007]<run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_2>(run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_2&&) /usr/lib/llvm-15/bin/../include/c++/v1/__functional/invoke.h:394:23 (tls_test+0x161105) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #2 void std::__1::__thread_execute[abi:v15007]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_2>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_2>&, std::__1::__tuple_indices<>) /usr/lib/llvm-15/bin/../include/c++/v1/thread:284:5 (tls_test+0x1610bd) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #3 void* std::__1::__thread_proxy[abi:v15007]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_2>>(void*) /usr/lib/llvm-15/bin/../include/c++/v1/thread:295:5 (tls_test+0x160d2f) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)

  Previous read of size 1 at 0x7ffd8be844c7 by thread T10:
    #0 handshake(tls::Context*, bool&) /home/takurosato/CCF/build/../src/tls/test/main.cpp:169:10 (tls_test+0x13c4ed) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #1 run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_3::operator()() const /home/takurosato/CCF/build/../src/tls/test/main.cpp:359:11 (tls_test+0x1623cc) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #2 decltype(std::declval<run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_3>()()) std::__1::__invoke[abi:v15007]<run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_3>(run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_3&&) /usr/lib/llvm-15/bin/../include/c++/v1/__functional/invoke.h:394:23 (tls_test+0x161f75) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #3 void std::__1::__thread_execute[abi:v15007]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_3>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_3>&, std::__1::__tuple_indices<>) /usr/lib/llvm-15/bin/../include/c++/v1/thread:284:5 (tls_test+0x161f2d) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #4 void* std::__1::__thread_proxy[abi:v15007]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_3>>(void*) /usr/lib/llvm-15/bin/../include/c++/v1/thread:295:5 (tls_test+0x161b9f) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)

  Location is stack of main thread.

  Location is global '??' at 0x7ffd8be68000 ([stack]+0x1c4c7)

  Thread T9 (tid=4184, running) created by main thread at:
    #0 pthread_create <null> (tls_test+0xa866d) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #1 std::__1::__libcpp_thread_create[abi:v15007](unsigned long*, void* (*)(void*), void*) /usr/lib/llvm-15/bin/../include/c++/v1/__threading_support:376:10 (tls_test+0x20e229) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #2 std::__1::thread::thread<run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_2, void>(run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_2&&) /usr/lib/llvm-15/bin/../include/c++/v1/thread:311:16 (tls_test+0x1420ef) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #3 run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>) /home/takurosato/CCF/build/../src/tls/test/main.cpp:340:10 (tls_test+0x13eb09) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #4 DOCTEST_ANON_FUNC_22() /home/takurosato/CCF/build/../src/tls/test/main.cpp:530:3 (tls_test+0x143f44) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #5 doctest::Context::run() /home/takurosato/CCF/build/../3rdparty/test/doctest/doctest.h:7007:21 (tls_test+0x13aace) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #6 main /home/takurosato/CCF/build/../3rdparty/test/doctest/doctest.h:7085:71 (tls_test+0x13c3f7) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)

  Thread T10 (tid=4185, running) created by main thread at:
    #0 pthread_create <null> (tls_test+0xa866d) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #1 std::__1::__libcpp_thread_create[abi:v15007](unsigned long*, void* (*)(void*), void*) /usr/lib/llvm-15/bin/../include/c++/v1/__threading_support:376:10 (tls_test+0x20e229) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #2 std::__1::thread::thread<run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_3, void>(run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_3&&) /usr/lib/llvm-15/bin/../include/c++/v1/thread:311:16 (tls_test+0x1422ab) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #3 run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>) /home/takurosato/CCF/build/../src/tls/test/main.cpp:355:10 (tls_test+0x13eb4b) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #4 DOCTEST_ANON_FUNC_22() /home/takurosato/CCF/build/../src/tls/test/main.cpp:530:3 (tls_test+0x143f44) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #5 doctest::Context::run() /home/takurosato/CCF/build/../3rdparty/test/doctest/doctest.h:7007:21 (tls_test+0x13aace) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)
    #6 main /home/takurosato/CCF/build/../3rdparty/test/doctest/doctest.h:7085:71 (tls_test+0x13c3f7) (BuildId: 7a82364ef6ed0ee2e4880a1cb27f265bcea6e148)

SUMMARY: ThreadSanitizer: data race /home/takurosato/CCF/build/../src/tls/test/main.cpp:349:18 in run_test_case(unsigned char const*, unsigned long, unsigned char const*, unsigned long, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>, std::__1::unique_ptr<tls::Cert, std::__1::default_delete<tls::Cert>>)::$_2::operator()() const
==================
===============================================================================
[doctest] test cases:   9 |   9 passed | 0 failed | 0 skipped
[doctest] assertions: 457 | 457 passed | 0 failed |
[doctest] Status: SUCCESS!
ThreadSanitizer: reported 1 warnings
```