### PR TITLE
Fix rendering on mermaid diagrams in docs when using auto theme

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -21,3 +21,11 @@ body[data-theme="dark"] .mermaid
 {
   background-color: #ffffff
 }
+
+@media (prefers-color-scheme: dark)
+{
+  body[data-theme="auto"] .mermaid
+  {
+    background-color: #ffffff
+  }
+}


### PR DESCRIPTION
Resolves #5129.

The hack I added previously to make mermaid diagrams visible ("if the theme is `dark`, set the `background-colour` of all mermaid elements to `0xffffff`") missed a case - when the theme is `auto` and that produces a dark background because of the browser's/OS's preferences. This adds a similar override in the CSS for this case as well.