### PR TITLE
Docs: re-enable logo and diagram orientation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -120,7 +120,10 @@ html_theme = "furo"
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-html_theme_options = {}
+html_theme_options = {
+    "light_logo": "ccf.svg",
+    "dark_logo": "ccf.svg",
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/doc/operations/code_upgrade.rst
+++ b/doc/operations/code_upgrade.rst
@@ -22,7 +22,7 @@ Procedure
 
 .. mermaid::
 
-    graph TB;
+    graph LR;
         classDef Primary stroke-width:4px
 
         subgraph Service
@@ -158,7 +158,7 @@ Procedure
 
 .. mermaid::
 
-    graph TB;
+    graph LR;
         classDef NewNode fill:Turquoise
         classDef Primary stroke-width:4px
 


### PR DESCRIPTION
Minor docs PR to re-enable the display of the CCF logo, and change the orientation of a couple of diagrams.