### PR TITLE
Docs: update instructions for different platforms

### DIFF
--- a/doc/build_apps/get_started.rst
+++ b/doc/build_apps/get_started.rst
@@ -40,53 +40,49 @@ Please follow `ccf-app-template build process <https://github.com/microsoft/ccf-
 Testing your Application
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are several approaches to run and test your application
+There are several approaches to run and test your application.
 
-Run app: Using Sandbox.sh
-^^^^^^^^^^^^^^^^^^^^^^^^^
+.. tab:: CCF sandbox
 
--  Running the `sandbox.sh` script automatically starts a CCF network and deploys your application on it. The app is up and ready to receive calls and the initial governance steps are done for you
--  Support both ccf network types [virtual - enclave (TEE hardware)]
--  No initial governance steps required
+   -  Running the `sandbox.sh` script automatically starts a CCF network and deploys your application on it. The app is up and ready to receive calls and the initial governance steps are done for you
+   -  Support both ccf network types [virtual - enclave (TEE hardware)]
+   -  No initial governance steps required
 
-   -  :doc:`/build_apps/run_app`
-   -  `CCF Application template repository <https://github.com/microsoft/ccf-app-template#run-js-app>`__
+      -  :doc:`/build_apps/run_app`
+      -  `CCF Application template repository <https://github.com/microsoft/ccf-app-template#run-js-app>`__
 
-Run app: Using Docker
-^^^^^^^^^^^^^^^^^^^^^
+.. tab:: Docker
 
--  A CCF network can be started using Docker containers; please check the `docker file samples <https://github.com/microsoft/ccf-app-template/tree/main/docker>`__
--  Support both ccf network types [virtual - enclave (TEE hardware)]
--  Initial governance steps are required to initialize, deploy your app, and start the network. `check Network governance section <https://github.com/microsoft/ccf-app-template#network-governance>`__
+   -  A CCF network can be started using Docker containers; please check the `docker file samples <https://github.com/microsoft/ccf-app-template/tree/main/docker>`__
+   -  Support both ccf network types [virtual - enclave (TEE hardware)]
+   -  Initial governance steps are required to initialize, deploy your app, and start the network. `check Network governance section <https://github.com/microsoft/ccf-app-template#network-governance>`__
 
-   -  Start a CCF network using docker files. please follow `ccf-app-template <https://github.com/microsoft/ccf-app-template#docker>`__
-   -  The network is started with one node and one member, you need to
-      execute the initial governance steps to initialize the network, `check Network governance section <https://github.com/microsoft/ccf-app-template#network-governance>`__
+      -  Start a CCF network using docker files. please follow `ccf-app-template <https://github.com/microsoft/ccf-app-template#docker>`__
+      -  The network is started with one node and one member, you need to
+         execute the initial governance steps to initialize the network, `check Network governance section <https://github.com/microsoft/ccf-app-template#network-governance>`__
 
-Run app: Using ``cchost`` on a VM
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. tab:: VM
 
--  The application can be tested using `cchost` and :doc:`CCF config file </operations/configuration>`,
-   To Start a test CCF network on a Linux environment, it requires :doc:`CCF to be intalled </build_apps/install_bin>`
-   or you can create a ready CCF VM using `Creating a Virtual Machine in Azure to run CCF <https://github.com/microsoft/CCF/blob/main/getting_started/azure_vm/README.md>`__
--  Support both ccf network types [virtual - enclave (TEE hardware)]
--  Initial governance steps are required to initialize, deploy your app, and start the network. `check Network governance section <https://github.com/microsoft/ccf-app-template#network-governance>`__
+   -  The application can be tested using ``cchost`` and :doc:`CCF config file </operations/configuration>`,
+      To Start a test CCF network on a Linux environment, it requires :doc:`CCF to be intalled </build_apps/install_bin>`
+      or you can create a ready CCF VM using `Creating a Virtual Machine in Azure to run CCF <https://github.com/microsoft/CCF/blob/main/getting_started/azure_vm/README.md>`__
+   -  Support both ccf network types [virtual - enclave (TEE hardware)]
+   -  Initial governance steps are required to initialize, deploy your app, and start the network. `check Network governance section <https://github.com/microsoft/ccf-app-template#network-governance>`__
 
-   -  Start a CCF network using cchost and :doc:`CCF node config file </operations/configuration>`. please follow `ccf-app-template <https://github.com/microsoft/ccf-app-template#bare-vm>`__
-   -  The network is started with one node and one member, you need to execute the initial governance steps to initialize the network, `check Network governance section <https://github.com/microsoft/ccf-app-template#network-governance>`__
+      -  Start a CCF network using cchost and :doc:`CCF node config file </operations/configuration>`. please follow `ccf-app-template <https://github.com/microsoft/ccf-app-template#bare-vm>`__
+      -  The network is started with one node and one member, you need to execute the initial governance steps to initialize the network, `check Network governance section <https://github.com/microsoft/ccf-app-template#network-governance>`__
 
-Run app: Using Managed CCF
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. tab:: Managed CCF
 
--  To test your application using Managed CCF, you can create `Azure Managed CCF <https://techcommunity.microsoft.com/t5/azure-confidential-computing/microsoft-introduces-preview-of-azure-managed-confidential/ba-p/3648986>`__ service on your subscription, the service will create a ready CCF network
--  Support only a ccf network in enclave mode (TEE hardware)
--  No initial governance steps required to start up your network, but you need to use governance to propose your application
+   -  To test your application using Managed CCF, you can create `Azure Managed CCF <https://techcommunity.microsoft.com/t5/azure-confidential-computing/microsoft-introduces-preview-of-azure-managed-confidential/ba-p/3648986>`__ service on your subscription, the service will create a ready CCF network
+   -  Support only a ccf network in enclave mode (TEE hardware)
+   -  No initial governance steps required to start up your network, but you need to use governance to propose your application
 
-   -  First, create the network’s initial member certificate, please check :doc:`Certificates generation </governance/adding_member>`
-   -  Create a new Azure Managed CCF serivce (the initial member certificate required as input)
-   -  Build the application and create a :ref:`build_apps/js_app_bundle:Deployment` proposal
-   -  Deploy the application proposal, :ref:`governance/proposals:Submitting a New Proposal`
-   -  Create and submit proposal for :ref:`governance/open_network:Adding Users` 
+      -  First, create the network’s initial member certificate, please check :doc:`Certificates generation </governance/adding_member>`
+      -  Create a new Azure Managed CCF serivce (the initial member certificate required as input)
+      -  Build the application and create a :ref:`build_apps/js_app_bundle:Deployment` proposal
+      -  Deploy the application proposal, :ref:`governance/proposals:Submitting a New Proposal`
+      -  Create and submit proposal for :ref:`governance/open_network:Adding Users` 
 
 Testing: Application Endpoints
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/build_apps/install_bin.rst
+++ b/doc/build_apps/install_bin.rst
@@ -31,35 +31,98 @@ Install
 
 CCF releases are available on the `GitHub repository release page <https://github.com/microsoft/CCF/releases>`_.
 
-The CCF Debian package (``ccf_<platform>_<version>_amd64.deb``) contains the libraries and utilities to start a CCF service and build CCF applications. CCF can be installed as follows:
+The CCF Debian package (``ccf_<platform>_<version>_amd64.deb``) contains the libraries and utilities to start a CCF service and build CCF applications. CCF can be installed as follows, for the ``SGX``, ``SNP`` and ``Virtual`` platforms:
 
-.. code-block:: bash
+.. tab:: SGX
 
-    # Set CCF_VERSION to most recent LTS release
-    $ export CCF_VERSION=$(curl -ILs -o /dev/null -w %{url_effective} https://github.com/microsoft/CCF/releases/latest | sed 's/^.*ccf-//')
-    # Set CCF_PLATFORM to virtual, which allows running on any amd64-compatible hardware but does not provide security guarantees. Choose sgx or snp to use the relevant TEE instead.
-    $ export CCF_PLATFORM=virtual
-    # Alternatively, set this manually, e.g.
-    # export CCF_VERSION=1.0.0
-    $ wget https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/ccf_${CCF_PLATFORM}_${CCF_VERSION}_amd64.deb
-    $ sudo apt install ./ccf_${CCF_PLATFORM}_${CCF_VERSION}_amd64.deb
+    .. code-block:: bash
 
-Assuming that CCF was installed under ``/opt``, the following commands can be run to verify that CCF was installed successfully:
+        # Set CCF_VERSION to most recent LTS release
+        $ export CCF_VERSION=$(curl -ILs -o /dev/null -w %{url_effective} https://github.com/microsoft/CCF/releases/latest | sed 's/^.*ccf-//')
+        # Alternatively, set this manually, e.g.:
+        # export CCF_VERSION=4.0.0
+        $ wget https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/ccf_sgx_${CCF_VERSION}_amd64.deb
+        $ sudo apt install ./ccf_sgx_${CCF_VERSION}_amd64.deb
 
-.. code-block:: bash
+    .. tip:: A separate `unsafe` package (``ccf_sgx_unsafe_<version>_amd64.deb``) with extremely verbose logging is also provided for troubleshooting purposes. Its version always ends in ``unsafe`` to make it easily distinguishable. The extent of the logging in these packages mean that they cannot be relied upon to offer confidentiality and integrity guarantees. They should never be used for production purposes.
 
-    $ /opt/ccf_virtual/bin/cchost --version
-    CCF host: ccf-<version>
+    Assuming that CCF was installed under ``/opt``, the following commands can be run to verify that CCF was installed successfully:
 
-    $ /opt/ccf_virtual/bin/sandbox.sh
-    No package/app specified. Defaulting to installed JS logging app
-    Setting up Python environment...
-    Python environment successfully setup
-    [16:10:16.552] Starting 1 CCF node...
-    [16:10:16.552] Virtual mode enabled
-    [16:10:23.349] Started CCF network with the following nodes:
-    [16:10:23.350]   Node [0] = https://127.0.0.1:8000
-    ...
+    .. code-block:: bash
+
+        $ /opt/ccf_sgx/bin/cchost --version
+        CCF host: ccf-<version>
+        Platform: SGX
+
+        $ /opt/ccf_sgx/bin/sandbox.sh
+        No package/app specified. Defaulting to installed JS logging app
+        Setting up Python environment...
+        Python environment successfully setup
+        [16:10:16.552] Starting 1 CCF node...
+        [16:10:23.349] Started CCF network with the following nodes:
+        [16:10:23.350]   Node [0] = https://127.0.0.1:8000
+        ...
+
+.. tab:: SNP
+
+    .. code-block:: bash
+
+        # Set CCF_VERSION to most recent LTS release
+        $ export CCF_VERSION=$(curl -ILs -o /dev/null -w %{url_effective} https://github.com/microsoft/CCF/releases/latest | sed 's/^.*ccf-//')
+        # Alternatively, set this manually, e.g.:
+        # export CCF_VERSION=4.0.0
+        $ wget https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/ccf_snp_${CCF_VERSION}_amd64.deb
+        $ sudo apt install ./ccf_snp_${CCF_VERSION}_amd64.deb
+
+        
+    Assuming that CCF was installed under ``/opt``, the following commands can be run to verify that CCF was installed successfully:
+
+    .. code-block:: bash
+
+        $ /opt/ccf_snp/bin/cchost --version
+        CCF host: ccf-<version>
+        Platform: SNP
+
+        $ /opt/ccf_snp/bin/sandbox.sh
+        No package/app specified. Defaulting to installed JS logging app
+        Setting up Python environment...
+        Python environment successfully setup
+        [16:10:16.552] Starting 1 CCF node...
+        [16:10:23.349] Started CCF network with the following nodes:
+        [16:10:23.350]   Node [0] = https://127.0.0.1:8000
+        ...
+
+.. tab:: Virtual
+
+    .. code-block:: bash
+
+        # Set CCF_VERSION to most recent LTS release
+        $ export CCF_VERSION=$(curl -ILs -o /dev/null -w %{url_effective} https://github.com/microsoft/CCF/releases/latest | sed 's/^.*ccf-//')
+        # Alternatively, set this manually, e.g.:
+        # export CCF_VERSION=4.0.0
+        $ wget https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/ccf_virtual_${CCF_VERSION}_amd64.deb
+        $ sudo apt install ./ccf_virtual_${CCF_VERSION}_amd64.deb
+
+    .. warning:: Virtual mode does not provide any security guarantees and should be used for development purposes only.
+        
+    Assuming that CCF was installed under ``/opt``, the following commands can be run to verify that CCF was installed successfully:
+
+    .. code-block:: bash
+
+        $ /opt/ccf_virtual/bin/cchost --version
+        CCF host: ccf-<version>
+        Platform: Virtual
+
+        $ /opt/ccf_virtual/bin/sandbox.sh
+        No package/app specified. Defaulting to installed JS logging app
+        Setting up Python environment...
+        Python environment successfully setup
+        [16:10:16.552] Starting 1 CCF node...
+        [16:10:16.552] Virtual mode enabled
+        [16:10:23.349] Started CCF network with the following nodes:
+        [16:10:23.350]   Node [0] = https://127.0.0.1:8000
+        ...
+
 
 The CCF install notably contains:
 
@@ -73,18 +136,25 @@ The CCF install notably contains:
 Uninstall
 ---------
 
-To remove a virtual installation of CCF, run:
+To remove an installation of CCF, run:
 
-.. code-block:: bash
+.. tab:: SGX
 
-    $ sudo apt remove ccf_virtual
+    .. code-block:: bash
 
-Unsafe Packages
----------------
+        $ sudo apt remove ccf_sgx
 
-Separate packages (``ccf_<platform>_unsafe_<version>_amd64.deb``) with extremely verbose logging are provided for troubleshooting purposes. Their version always end in ``unsafe`` to make them easily distinguishable.
+.. tab:: SNP
 
-The extent of the logging in these packages mean that they cannot be relied upon to offer confidentiality and integrity guarantees. They should never be used for production purposes.
+    .. code-block:: bash
+
+        $ sudo apt remove ccf_snp
+
+.. tab:: Virtual
+
+    .. code-block:: bash
+
+        $ sudo apt remove ccf_virtual
 
 From Source
 -----------
@@ -94,8 +164,23 @@ To build and install CCF from source, please see :doc:`/contribute/build_ccf`.
 In Azure
 --------
 
-CCF can be installed on an Azure Virtual Machine by running a single script;
+CCF can be installed on an Azure Virtual Machine by running a single script:
 
-.. code-block:: bash
+.. tab:: SGX
 
-    <ccf_path>/getting_started/azure_vm/install_ccf_on_azure_vm.sh
+    .. code-block:: bash
+
+        $ /opt/ccf_sgx/getting_started/azure_vm/install_ccf_on_azure_vm.sh
+
+.. tab:: SNP
+
+    .. code-block:: bash
+
+        $ /opt/ccf_snp/getting_started/azure_vm/install_ccf_on_azure_vm.sh
+
+.. tab:: Virtual
+
+    .. code-block:: bash
+
+        $ /opt/ccf_virtual/getting_started/azure_vm/install_ccf_on_azure_vm.sh
+

--- a/doc/build_apps/install_bin.rst
+++ b/doc/build_apps/install_bin.rst
@@ -6,25 +6,38 @@ Install CCF
 Requirements
 ------------
 
-CCF builds and runs on Linux. It is primarily developed and tested on Ubuntu 20.04, with Clang 10.
-Running CCF with full security guarantees requires :term:`SGX` hardware with :term:`FLC`.
+CCF builds and runs on Linux. It is primarily developed and tested on Ubuntu 20.04.
+The dependencies required to build and run CCF apps can be conveniently installed using the ``ansible`` playbooks in the CCF repository or `Install`_, depending on the target TEE platform:
 
-.. note::
+.. tab:: SGX
 
-    A `virtual` version of CCF can also be run on hardware that does not support SGX. The `virtual` mode provides no security guarantee and is only useful for development and prototyping.
+    Running CCF with full security guarantees requires :term:`SGX` hardware with :term:`FLC`.
+    CCF on SGX requires the following dependencies to be first installed on your system:
 
-CCF requires the following dependencies to be first installed on your system:
+    - :term:`Intel SGX PSW`
+    - :term:`Azure DCAP`
+    - :term:`Open Enclave`
 
-- :term:`Intel SGX PSW`
-- :term:`Azure DCAP`
-- :term:`Open Enclave`
+    .. code-block:: bash
 
-These dependencies can be conveniently installed using the ``ansible`` playbooks in the CCF repository or `Install`_:
+        $ cd <ccf_path>/getting_started/setup_vm/
+        $ ./run.sh app-dev.yml --extra-vars "platform=sgx" --extra-vars "clang_version=10"
 
-.. code-block:: bash
+.. tab:: SNP
 
-    $ cd <ccf_path>/getting_started/setup_vm/
-    $ ./run.sh app-dev.yml
+    .. code-block:: bash
+
+        $ cd <ccf_path>/getting_started/setup_vm/
+        $ ./run.sh app-dev.yml --extra-vars "platform=snp" --extra-vars "clang_version=15"
+
+.. tab:: Virtual
+
+    .. warning:: The `virtual` version of CCF can also be run on hardware that does not support SGX/SNP. Virtual mode does not provide any security guarantees and should be used for development purposes only.
+
+    .. code-block:: bash
+
+        $ cd <ccf_path>/getting_started/setup_vm/
+        $ ./run.sh app-dev.yml --extra-vars "platform=virtual" --extra-vars "clang_version=15"
 
 Install
 -------
@@ -123,6 +136,7 @@ The CCF Debian package (``ccf_<platform>_<version>_amd64.deb``) contains the lib
         [16:10:23.350]   Node [0] = https://127.0.0.1:8000
         ...
 
+------------
 
 The CCF install notably contains:
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -64,6 +64,7 @@ extensions = [
     "sphinxcontrib.openapi",
     "sphinx_panels",
     "sphinx.ext.extlinks",
+    "sphinx_inline_tabs",
 ]
 
 autosectionlabel_prefix_document = True

--- a/doc/operations/run_setup.rst
+++ b/doc/operations/run_setup.rst
@@ -4,28 +4,90 @@ Setup CCF Runtime Environment
 Environment Setup
 -----------------
 
-First, checkout the CCF repository or :doc:`/build_apps/install_bin`.
+First, follow the steps described in :doc:`/build_apps/install_bin`.
 
 Then, to quickly set up the dependencies necessary to start CCF applications, simply run:
 
-.. code-block:: bash
+.. tab:: SGX
 
-    $ cd <ccf_path>/getting_started/setup_vm
-    $ ./run.sh app-run.yml
+    .. code-block:: bash
 
-Runtime Container
------------------
+        $ cd /opt/ccf_sgx/getting_started/setup_vm
+        $ ./run.sh app-run.yml --extra-vars "platform=sgx" --extra-vars "clang_version=10"
 
-The ``mcr.microsoft.com/ccf/app/run`` container can be run to setup an environment containing the ``cchost`` binary and the associated dependencies.
+.. tab:: SNP
 
-The pre-built container can be obtained from the ``mcr.microsoft.com/ccf/app/run`` image on Azure Container Registry:
+    .. code-block:: bash
 
-.. code-block:: bash
+        $ cd /opt/ccf_snp/getting_started/setup_vm
+        $ ./run.sh app-run.yml --extra-vars "platform=snp" --extra-vars "clang_version=15"
 
-    $ export VERSION="3.0.0"
-    $ export PLATFORM="sgx" # One of sgx, snp or virtual
-    $ docker pull mcr.microsoft.com/ccf/app/run:$VERSION-$PLATFORM
+.. tab:: Virtual
 
-The container does not contain any particular CCF enclave application, and may be helpful when deploying CCF nodes via docker, k8s, etc. It is up to the operator(s) to mount the appropriate CCF enclave application and start and manage the CCF node.
+    .. code-block:: bash
 
-.. note:: That image is optimised for size above all. If you need an image that comes with peripheral utilities, you probably want the :ref:`Build Container <contribute/build_setup:Build Container>` instead.
+        $ cd /opt/ccf_virtual/getting_started/setup_vm
+        $ ./run.sh app-run.yml --extra-vars "platform=virtual" --extra-vars "clang_version=15"
+
+
+Runtime Containers
+------------------
+
+Pre-built runtime container images can be obtained from the `Microsoft Artifact Registry <https://mcr.microsoft.com/en-us/catalog?search=ccf>`_. Note that none of these images are tagged as ``latest`` and so a specific version must always be specified on pull.
+
+The runtime images do not contain any particular CCF application, and may be helpful when deploying CCF nodes via Docker, Kubernetes, etc. It is up to the operator(s) to launch the appropriate CCF application and start and manage the CCF node.
+
+.. note:: The runtime images are optimised for size above all. If you need an image that comes with peripheral utilities, you probably want the :ref:`Build Container <contribute/build_setup:Build Container>` instead.
+
+C++ Apps
+~~~~~~~~
+
+The ``mcr.microsoft.com/ccf/app/run`` container can be run to deploy C++ apps. It contains the ``cchost`` binary and the dependencies required to spin up a CCF node.
+
+.. tab:: SGX
+
+    .. code-block:: bash
+
+        $ export VERSION="4.0.0"
+        $ docker pull mcr.microsoft.com/ccf/app/run:$VERSION-sgx
+
+.. tab:: SNP
+
+    .. code-block:: bash
+
+        $ export VERSION="4.0.0"
+        $ docker pull mcr.microsoft.com/ccf/app/run:$VERSION-snp
+
+.. tab:: Virtual
+
+    .. code-block:: bash
+
+        $ export VERSION="4.0.0"
+        $ docker pull mcr.microsoft.com/ccf/app/run:$VERSION-virtual
+
+
+JavaScript/TypeScript Apps
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``mcr.microsoft.com/ccf/app/run`` container can be run to deploy JavaScript/TypeScripts apps. It contains the ``cchost`` binary, the ``libjs_generic`` native application to run JavaScript/TypeScript apps, and the dependencies required to spin up a CCF node.
+
+.. tab:: SGX
+
+    .. code-block:: bash
+
+        $ export VERSION="4.0.0"
+        $ docker pull mcr.microsoft.com/ccf/app/run-js:$VERSION-sgx
+
+.. tab:: SNP
+
+    .. code-block:: bash
+
+        $ export VERSION="4.0.0"
+        $ docker pull mcr.microsoft.com/ccf/app/run-js:$VERSION-snp
+
+.. tab:: Virtual
+
+    .. code-block:: bash
+
+        $ export VERSION="4.0.0"
+        $ docker pull mcr.microsoft.com/ccf/app/run-js:$VERSION-virtual

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -7,6 +7,7 @@ sphinx-multiversion
 sphinx-copybutton
 sphinxcontrib.openapi
 sphinx-panels
+sphinx-inline-tabs
 furo
 # docutils 0.17.0 causes "AttributeError: module 
 # 'docutils.nodes' has no attribute 'meta'" error when building doc


### PR DESCRIPTION
This PR updates the documentation to reflect the recent support for different TEE platforms and different versions of `clang`. 

To keep the rendered documentation concise, we now also make use of [`sphinx-inline-tags`](https://sphinx-inline-tabs.readthedocs.io/en/latest/usage.html). 

