### PR TITLE
TLA+ spec - each reconfiguration must change the set of servers

### DIFF
--- a/tla/ccfraft.tla
+++ b/tla/ccfraft.tla
@@ -564,6 +564,8 @@ ChangeConfiguration(i, newConfiguration) ==
     /\ newConfiguration \subseteq Servers
     \* Configuration is not equal to current configuration
     /\ newConfiguration /= CurrentConfiguration(i)
+    \* Configuration is not equal to the previous pending configuration
+    /\ newConfiguration /= MaxConfiguration(i)
     \* Keep track of running reconfigurations to limit state space
     /\ reconfigurationCount' = reconfigurationCount + 1
     /\ removedFromConfiguration' = removedFromConfiguration \cup (CurrentConfiguration(i) \ newConfiguration)


### PR DESCRIPTION
Spotted whilst looking at the trace in https://github.com/microsoft/CCF/issues/4472#issuecomment-1494733529. This patch ensures that a leader cannot create a reconfiguration txn with the same set of servers as the last reconfiguration txn, even if this previous txn is not yet committed.