### PR TITLE
Draft: Move SNP deployments back to `eastus2euap`

### DIFF
--- a/.azure-pipelines-templates/deploy_aci.yml
+++ b/.azure-pipelines-templates/deploy_aci.yml
@@ -71,7 +71,7 @@ jobs:
           python3.8 scripts/azure_deployment/arm_template.py deploy aci \
             --subscription-id $(CCF_AZURE_SUBSCRIPTION_ID) \
             --resource-group ccf-aci \
-            --region northeurope \
+            --region eastus2euap \
             --aci-type dynamic-agent \
             --deployment-name ci-$(Build.BuildNumber) \
             --aci-image ccfmsrc.azurecr.io/ccf/ci:pr-$(wait_for_image.gitSha) \
@@ -138,7 +138,7 @@ jobs:
               python3.8 scripts/azure_deployment/arm_template.py deploy aci \
                 --subscription-id $(CCF_AZURE_SUBSCRIPTION_ID) \
                 --resource-group ccf-aci \
-                --region northeurope \
+                --region eastus2euap \
                 --aci-type dynamic-agent \
                 --deployment-name ci-$(Build.BuildNumber)-secondaries \
                 --aci-image ccfmsrc.azurecr.io/ccf/ci:pr-$(wait_for_image.gitSha) \


### PR DESCRIPTION
To find out whether the changes described in https://github.com/microsoft/CCF/issues/5164 have been rolled out to `eastus2euap` to test new configuration. 