### PR TITLE
Fix container image generation for `4.0.0-rc2`

### DIFF
--- a/cmake/preproject.cmake
+++ b/cmake/preproject.cmake
@@ -11,8 +11,13 @@ if((NOT CMAKE_C_COMPILER)
    AND "$ENV{CC}" STREQUAL ""
    AND "$ENV{CXX}" STREQUAL ""
 )
-  find_program(FOUND_CMAKE_C_COMPILER NAMES clang-15 clang-11)
-  find_program(FOUND_CMAKE_CXX_COMPILER NAMES clang++-15 clang++-11)
+  if("${COMPILE_TARGET}" STREQUAL "sgx")
+    find_program(FOUND_CMAKE_C_COMPILER NAMES clang-11)
+    find_program(FOUND_CMAKE_CXX_COMPILER NAMES clang++-11)
+  else()
+    find_program(FOUND_CMAKE_C_COMPILER NAMES clang-15)
+    find_program(FOUND_CMAKE_CXX_COMPILER NAMES clang++-15)
+  endif()
   if(NOT (FOUND_CMAKE_C_COMPILER AND FOUND_CMAKE_CXX_COMPILER))
     message(
       WARNING

--- a/getting_started/setup_vm/app-run.yml
+++ b/getting_started/setup_vm/app-run.yml
@@ -20,5 +20,13 @@
         name: az_dcap
         tasks_from: install.yml
     - import_role:
+        name: openenclave
+        tasks_from: binary_install.yml
+      when: platform == "sgx"
+    - import_role:
+        name: openenclave
+        tasks_from: install_host_verify.yml
+      when: platform != "sgx"
+    - import_role:
         name: ccf_install
         tasks_from: deb_install.yml


### PR DESCRIPTION
The `app_run` playbook relied on the `open-enclave` debian package being published to https://ubuntu.pkgs.org/20.04/microsoft-prod-amd64/ (then automatically installed via `apt-get install ccf_*`) but the package isn't published for Open Enclave release candidates. We now install `open-enclave` (or `open-enclave-hostverify`) via GitHub in the `app_run` playbook.