### PR TITLE
Align SNP job triggers

### DIFF
--- a/.azure_pipelines_snp.yml
+++ b/.azure_pipelines_snp.yml
@@ -7,7 +7,8 @@ pr:
       - scripts/azure_deployment/*
       - .github/workflows/build-ci-container.yml
       - .azure_pipelines_snp.yml
-      - .azure-pipelines-templates/*
+      - .azure-pipelines-templates/deploy_aci.yml
+      - .azure-pipelines-templates/test_on_remote.yml
       - .snpcc_canary
 
 trigger:


### PR DESCRIPTION
Previously, a change under .azure-pipelines-templates/* would trigger the SNP test job, attempting to deploy an image the image build job never produced, because its trigger is more restrictive.

This PR fixes that by aligning both triggers.