### PR TITLE
[release/4.x] Cherry pick: JS runtime traces in responses (#5237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.0.1]
+
+[4.0.1]: https://github.com/microsoft/CCF/releases/tag/ccf-4.0.1
+
+- The `set_js_runtime_options` action now accepts `return_exception_details` and `log_exception_details` boolean options, which set the corresponding keys in the `public:ccf.gov.js_runtime_options` KV map. When enabled, a stack trace is respectively returned to the caller, and emitted to the log, on uncaught JS exceptions in application code.
+
+## Changed
+
+- For security reasons, OpenSSL `>=1.1.1f` must be first installed on the system (Ubuntu) before installing the CCF Debian package (#5227).
+
 ## [4.0.0]
 
 In order to upgrade an existing 3.x service to 4.x, CCF must be on the latest 3.x version (at least 3.0.10). For more information, see [our documentation](https://microsoft.github.io/CCF/main/operations/code_upgrade.html)

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -309,6 +309,9 @@
       },
       "JSRuntimeOptions": {
         "properties": {
+          "log_exception_details": {
+            "$ref": "#/components/schemas/boolean"
+          },
           "max_execution_time_ms": {
             "$ref": "#/components/schemas/uint64"
           },
@@ -317,6 +320,9 @@
           },
           "max_stack_bytes": {
             "$ref": "#/components/schemas/uint64"
+          },
+          "return_exception_details": {
+            "$ref": "#/components/schemas/boolean"
           }
         },
         "required": [
@@ -1264,7 +1270,7 @@
   "info": {
     "description": "This API is used to submit and query proposals which affect CCF's public governance tables.",
     "title": "CCF Governance API",
-    "version": "4.0.0"
+    "version": "4.1.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/include/ccf/odata_error.h
+++ b/include/ccf/odata_error.h
@@ -7,23 +7,37 @@
 
 namespace ccf
 {
-  struct ODataErrorDetails
+  struct ODataAuthErrorDetails
   {
     std::string auth_policy;
     std::string code;
     std::string message;
 
-    bool operator==(const ODataErrorDetails&) const = default;
+    bool operator==(const ODataAuthErrorDetails&) const = default;
   };
 
-  DECLARE_JSON_TYPE(ODataErrorDetails);
-  DECLARE_JSON_REQUIRED_FIELDS(ODataErrorDetails, auth_policy, code, message);
+  DECLARE_JSON_TYPE(ODataAuthErrorDetails);
+  DECLARE_JSON_REQUIRED_FIELDS(
+    ODataAuthErrorDetails, auth_policy, code, message);
+
+  struct ODataJSExceptionDetails
+  {
+    std::string code;
+    std::string message;
+    std::optional<std::string> trace;
+
+    bool operator==(const ODataJSExceptionDetails&) const = default;
+  };
+
+  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(ODataJSExceptionDetails);
+  DECLARE_JSON_REQUIRED_FIELDS(ODataJSExceptionDetails, code, message);
+  DECLARE_JSON_OPTIONAL_FIELDS(ODataJSExceptionDetails, trace);
 
   struct ODataError
   {
     std::string code;
     std::string message;
-    std::vector<ODataErrorDetails> details = {};
+    std::vector<nlohmann::json> details = {};
   };
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(ODataError);
@@ -97,6 +111,7 @@ namespace ccf
     ERROR(ProposalReplay)
     ERROR(ProposalCreatedTooLongAgo)
     ERROR(InvalidCreatedAt)
+    ERROR(JSException)
 
     // node-to-node (/join and /create):
     ERROR(ConsensusTypeMismatch)

--- a/include/ccf/rpc_context.h
+++ b/include/ccf/rpc_context.h
@@ -159,7 +159,7 @@ namespace ccf
       http_status status,
       const std::string& code,
       std::string&& msg,
-      const std::vector<ccf::ODataErrorDetails>& details = {}) = 0;
+      const std::vector<nlohmann::json>& details = {}) = 0;
 
     /// Construct error response, formatted according to the request content
     /// type (either JSON OData-formatted or gRPC error)

--- a/include/ccf/service/tables/jsengine.h
+++ b/include/ccf/service/tables/jsengine.h
@@ -14,11 +14,22 @@ namespace ccf
     size_t max_stack_bytes;
     /// @brief max execution time for QuickJS
     uint64_t max_execution_time_ms;
+    /// @brief emit exception details to the log
+    /// NOTE: this is a security risk as it may leak sensitive information
+    ///       to anyone with access to the application log, which is
+    ///       unprotected.
+    bool log_exception_details = false;
+    /// @brief return exception details in the response
+    /// NOTE: this is a security risk as it may leak sensitive information,
+    ///       albeit to the caller only.
+    bool return_exception_details = false;
   };
 
-  DECLARE_JSON_TYPE(JSRuntimeOptions)
+  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(JSRuntimeOptions)
   DECLARE_JSON_REQUIRED_FIELDS(
     JSRuntimeOptions, max_heap_bytes, max_stack_bytes, max_execution_time_ms)
+  DECLARE_JSON_OPTIONAL_FIELDS(
+    JSRuntimeOptions, log_exception_details, return_exception_details);
 
   using JSEngine = ServiceValue<JSRuntimeOptions>;
 

--- a/samples/constitutions/default/actions.js
+++ b/samples/constitutions/default/actions.js
@@ -783,6 +783,16 @@ const actions = new Map([
           "integer",
           "max_execution_time_ms"
         );
+        checkType(
+          args.log_exception_details,
+          "boolean?",
+          "log_exception_details"
+        );
+        checkType(
+          args.return_exception_details,
+          "boolean?",
+          "return_exception_details"
+        );
       },
       function (args) {
         const js_engine_map = ccf.kv["public:ccf.gov.js_runtime_options"];

--- a/src/apps/js_generic/js_generic_base.cpp
+++ b/src/apps/js_generic/js_generic_base.cpp
@@ -307,18 +307,36 @@ namespace ccfapp
       {
         bool time_out = ctx.interrupt_data.request_timed_out;
         std::string error_msg = "Exception thrown while executing.";
-
-        js::js_dump_error(ctx);
-
         if (time_out)
         {
           error_msg = "Operation took too long to complete.";
         }
 
-        endpoint_ctx.rpc_ctx->set_error(
-          HTTP_STATUS_INTERNAL_SERVER_ERROR,
-          ccf::errors::InternalError,
-          std::move(error_msg));
+        auto [reason, trace] = js::js_error_message(ctx);
+
+        if (rt.log_exception_details)
+        {
+          CCF_APP_FAIL("{}: {}", reason, trace.value_or("<no trace>"));
+        }
+
+        if (rt.return_exception_details)
+        {
+          std::vector<nlohmann::json> details = {
+            ODataJSExceptionDetails{ccf::errors::JSException, reason, trace}};
+          endpoint_ctx.rpc_ctx->set_error(
+            HTTP_STATUS_INTERNAL_SERVER_ERROR,
+            ccf::errors::InternalError,
+            std::move(error_msg),
+            std::move(details));
+        }
+        else
+        {
+          endpoint_ctx.rpc_ctx->set_error(
+            HTTP_STATUS_INTERNAL_SERVER_ERROR,
+            ccf::errors::InternalError,
+            std::move(error_msg));
+        }
+
         return;
       }
 

--- a/src/js/wrap.cpp
+++ b/src/js/wrap.cpp
@@ -176,6 +176,9 @@ namespace ccf::js
       stack_size = js_runtime_options.value().max_stack_bytes;
       max_exec_time = std::chrono::milliseconds{
         js_runtime_options.value().max_execution_time_ms};
+      log_exception_details = js_runtime_options.value().log_exception_details;
+      return_exception_details =
+        js_runtime_options.value().return_exception_details;
     }
 
     JS_SetMaxStackSize(rt, stack_size);

--- a/src/js/wrap.h
+++ b/src/js/wrap.h
@@ -243,6 +243,9 @@ namespace ccf::js
     std::chrono::milliseconds max_exec_time = default_max_execution_time;
 
   public:
+    bool log_exception_details = false;
+    bool return_exception_details = false;
+
     Runtime(kv::Tx* tx);
     ~Runtime();
 

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -244,7 +244,7 @@ namespace ccf
       std::unique_ptr<AuthnIdentity> identity = nullptr;
 
       std::string auth_error_reason;
-      std::vector<ccf::ODataErrorDetails> error_details;
+      std::vector<ODataAuthErrorDetails> error_details;
       for (const auto& policy : endpoint->authn_policies)
       {
         identity = policy->authenticate(tx, ctx, auth_error_reason);
@@ -255,10 +255,10 @@ namespace ccf
         else
         {
           // Collate error details
-          error_details.push_back(
-            {policy->get_security_scheme_name(),
-             ccf::errors::InvalidAuthenticationInfo,
-             auth_error_reason});
+          error_details.emplace_back(ODataAuthErrorDetails{
+            policy->get_security_scheme_name(),
+            ccf::errors::InvalidAuthenticationInfo,
+            auth_error_reason});
         }
       }
 
@@ -269,11 +269,16 @@ namespace ccf
           ctx, std::move(auth_error_reason));
         // Return collated error details for the auth policies
         // declared in the request
+        std::vector<nlohmann::json> json_details;
+        for (auto& details : error_details)
+        {
+          json_details.push_back(details);
+        }
         ctx->set_error(
           HTTP_STATUS_UNAUTHORIZED,
           ccf::errors::InvalidAuthenticationInfo,
           "Invalid authentication credentials.",
-          error_details);
+          std::move(json_details));
         update_metrics(ctx);
       }
 

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -606,7 +606,7 @@ namespace ccf
       openapi_info.description =
         "This API is used to submit and query proposals which affect CCF's "
         "public governance tables.";
-      openapi_info.document_version = "4.0.0";
+      openapi_info.document_version = "4.1.0";
     }
 
     static std::optional<MemberId> get_caller_member_id(

--- a/src/node/rpc/rpc_context_impl.h
+++ b/src/node/rpc/rpc_context_impl.h
@@ -76,7 +76,7 @@ namespace ccf
       http_status status,
       const std::string& code,
       std::string&& msg,
-      const std::vector<ccf::ODataErrorDetails>& details = {}) override
+      const std::vector<nlohmann::json>& details = {}) override
     {
       auto content_type = get_request_header(http::headers::CONTENT_TYPE);
       if (

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -528,13 +528,21 @@ class Consortium:
         return self.vote_using_majority(remote_node, proposal, careful_vote, timeout=30)
 
     def set_js_runtime_options(
-        self, remote_node, max_heap_bytes, max_stack_bytes, max_execution_time_ms
+        self,
+        remote_node,
+        max_heap_bytes,
+        max_stack_bytes,
+        max_execution_time_ms,
+        log_exception_details=False,
+        return_exception_details=False,
     ):
         proposal_body, careful_vote = self.make_proposal(
             "set_js_runtime_options",
             max_heap_bytes=max_heap_bytes,
             max_stack_bytes=max_stack_bytes,
             max_execution_time_ms=max_execution_time_ms,
+            log_exception_details=log_exception_details,
+            return_exception_details=return_exception_details,
         )
         proposal = self.get_any_active_member().propose(remote_node, proposal_body)
         return self.vote_using_majority(remote_node, proposal, careful_vote)

--- a/tests/js-modules/modules.py
+++ b/tests/js-modules/modules.py
@@ -1007,6 +1007,76 @@ def test_js_execution_time(network, args):
     return network
 
 
+@reqs.description("Test JS exception output")
+def test_js_exception_output(network, args):
+    primary, _ = network.find_nodes()
+
+    with primary.client("user0") as c:
+        r = c.get("/node/js_metrics")
+        body = r.body.json()
+        default_max_heap_size = body["max_heap_size"]
+        default_max_stack_size = body["max_stack_size"]
+        default_max_execution_time = body["max_execution_time"]
+
+        r = c.get("/app/throw")
+        assert r.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR, r.status_code
+        body = r.body.json()
+        assert body["error"]["code"] == "InternalError"
+        assert body["error"]["message"] == "Exception thrown while executing."
+        assert "details" not in body["error"]
+
+        network.consortium.set_js_runtime_options(
+            primary,
+            max_heap_bytes=default_max_heap_size,
+            max_stack_bytes=default_max_stack_size,
+            max_execution_time_ms=default_max_execution_time,
+            return_exception_details=True,
+        )
+        r = c.get("/app/throw")
+        assert r.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR, r.status_code
+        body = r.body.json()
+        assert body["error"]["code"] == "InternalError"
+        assert body["error"]["message"] == "Exception thrown while executing."
+        assert body["error"]["details"][0]["code"] == "JSException"
+        assert body["error"]["details"][0]["message"] == "Error: test error: 42"
+        assert (
+            body["error"]["details"][0]["trace"]
+            == "    at nested (endpoints/rpc.js:27)\n    at throwError (endpoints/rpc.js:29)\n"
+        )
+
+        network.consortium.set_js_runtime_options(
+            primary,
+            max_heap_bytes=default_max_heap_size,
+            max_stack_bytes=default_max_stack_size,
+            max_execution_time_ms=default_max_execution_time,
+            return_exception_details=False,
+        )
+
+        r = c.get("/app/throw")
+        assert r.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR, r.status_code
+        body = r.body.json()
+        assert body["error"]["code"] == "InternalError"
+        assert body["error"]["message"] == "Exception thrown while executing."
+        assert "details" not in body["error"]
+
+        network.consortium.set_js_runtime_options(
+            primary,
+            max_heap_bytes=default_max_heap_size,
+            max_stack_bytes=default_max_stack_size,
+            max_execution_time_ms=default_max_execution_time,
+            log_exception_details=True,
+        )
+
+        r = c.get("/app/throw")
+        assert r.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR, r.status_code
+        body = r.body.json()
+        assert body["error"]["code"] == "InternalError"
+        assert body["error"]["message"] == "Exception thrown while executing."
+        assert "details" not in body["error"]
+
+    return network
+
+
 def run(args):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
@@ -1019,6 +1089,7 @@ def run(args):
         network = test_set_js_runtime(network, args)
         network = test_npm_app(network, args)
         network = test_js_execution_time(network, args)
+        network = test_js_exception_output(network, args)
 
 
 if __name__ == "__main__":

--- a/tests/npm-app/app.json
+++ b/tests/npm-app/app.json
@@ -1255,6 +1255,35 @@
           }
         }
       }
+    },
+    "/throw": {
+      "get": {
+        "js_module": "endpoints/rpc.js",
+        "js_function": "throwError",
+        "forwarding_required": "sometimes",
+        "authn_policies": ["user_cert"],
+        "mode": "readonly",
+        "openapi": {
+          "requestBody": {
+            "required": false,
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {}
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/tests/npm-app/src/endpoints/rpc.ts
+++ b/tests/npm-app/src/endpoints/rpc.ts
@@ -27,3 +27,10 @@ export function getApplyWrites(request: ccfapp.Request): ccfapp.Response {
     body: v,
   };
 }
+
+export function throwError(request: ccfapp.Request): ccfapp.Response {
+  function nested(arg: number) {
+    throw new Error(`test error: ${arg}`);
+  }
+  nested(42);
+}


### PR DESCRIPTION
Backports the following commits to `release/4.x`:
 - [JS runtime traces in responses (#5237)](https://github.com/microsoft/CCF/pull/5237)