### PR TITLE
Support action style (`:`) templated paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,6 +514,16 @@ if(BUILD_TESTS)
     )
 
     add_unit_test(
+      endpoint_registry_test
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/endpoints/test/endpoint_registry.cpp
+    )
+    target_link_libraries(
+      endpoint_registry_test
+      PRIVATE 
+      ccf_endpoints.host
+    )
+
+    add_unit_test(
       tx_status_test
       ${CMAKE_CURRENT_SOURCE_DIR}/src/node/rpc/test/tx_status_test.cpp
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -517,11 +517,7 @@ if(BUILD_TESTS)
       endpoint_registry_test
       ${CMAKE_CURRENT_SOURCE_DIR}/src/endpoints/test/endpoint_registry.cpp
     )
-    target_link_libraries(
-      endpoint_registry_test
-      PRIVATE 
-      ccf_endpoints.host
-    )
+    target_link_libraries(endpoint_registry_test PRIVATE ccf_endpoints.host)
 
     add_unit_test(
       tx_status_test

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -377,8 +377,11 @@ endif()
 # CCF endpoints libs
 if(COMPILE_TARGET STREQUAL "sgx")
   add_enclave_library(ccf_endpoints.enclave "${CCF_ENDPOINTS_SOURCES}")
-  target_link_libraries(ccf_endpoints.enclave PUBLIC qcbor.enclave)
-  target_link_libraries(ccf_endpoints.enclave PUBLIC t_cose.enclave)
+  target_link_libraries(
+    ccf_endpoints.enclave
+    PUBLIC qcbor.enclave t_cose.enclave http_parser.enclave ccfcrypto.enclave
+           ccf_kv.enclave
+  )
   add_warning_checks(ccf_endpoints.enclave)
   install(
     TARGETS ccf_endpoints.enclave
@@ -387,8 +390,10 @@ if(COMPILE_TARGET STREQUAL "sgx")
   )
 elseif(COMPILE_TARGET STREQUAL "snp")
   add_host_library(ccf_endpoints.snp "${CCF_ENDPOINTS_SOURCES}")
-  target_link_libraries(ccf_endpoints.snp PUBLIC qcbor.snp)
-  target_link_libraries(ccf_endpoints.snp PUBLIC t_cose.snp)
+  target_link_libraries(
+    ccf_endpoints.snp PUBLIC qcbor.snp t_cose.snp http_parser.snp ccfcrypto.snp
+                             ccf_kv.snp
+  )
   add_san(ccf_endpoints.snp)
   add_warning_checks(ccf_endpoints.snp)
   install(
@@ -399,8 +404,10 @@ elseif(COMPILE_TARGET STREQUAL "snp")
 endif()
 
 add_host_library(ccf_endpoints.host "${CCF_ENDPOINTS_SOURCES}")
-target_link_libraries(ccf_endpoints.host PUBLIC qcbor.host)
-target_link_libraries(ccf_endpoints.host PUBLIC t_cose.host)
+target_link_libraries(
+  ccf_endpoints.host PUBLIC qcbor.host t_cose.host http_parser.host
+                            ccfcrypto.host ccf_kv.host
+)
 add_san(ccf_endpoints.host)
 add_warning_checks(ccf_endpoints.host)
 

--- a/src/endpoints/endpoint_registry.cpp
+++ b/src/endpoints/endpoint_registry.cpp
@@ -120,6 +120,19 @@ namespace ccf::endpoints
           "Invalid templated path - missing closing curly bracket: {}", uri));
       }
 
+      if (template_end + 1 != regex_s.size())
+      {
+        const auto next_char = regex_s[template_end + 1];
+        if (!(next_char == '/' || next_char == ':'))
+        {
+          throw std::logic_error(fmt::format(
+            "Invalid templated path - illegal character ({}) following "
+            "template: {}",
+            next_char,
+            uri));
+        }
+      }
+
       spec.template_component_names.push_back(
         regex_s.substr(template_start + 1, template_end - template_start - 1));
       regex_s.replace(

--- a/src/endpoints/endpoint_registry.cpp
+++ b/src/endpoints/endpoint_registry.cpp
@@ -117,7 +117,7 @@ namespace ccf::endpoints
     {
       if (template_start != 0)
       {
-        const auto prev_char = regex_s[template_start-1];
+        const auto prev_char = regex_s[template_start - 1];
         if (allowed_delimiters.find(prev_char) == std::string::npos)
         {
           throw std::logic_error(fmt::format(
@@ -153,6 +153,15 @@ namespace ccf::endpoints
       regex_s.replace(
         template_start, template_end - template_start + 1, "([^/]+)");
       template_start = regex_s.find_first_of('{', template_start + 1);
+    }
+
+    auto& names = spec.template_component_names;
+    if (std::unique(names.begin(), names.end()) != names.end())
+    {
+      throw std::logic_error(fmt::format(
+        "Invalid templated path - duplicated component names ({}): {}",
+        fmt::join(names, ", "),
+        uri));
     }
 
     LOG_TRACE_FMT("Parsed a templated endpoint: {} became {}", uri, regex_s);

--- a/src/endpoints/endpoint_registry.cpp
+++ b/src/endpoints/endpoint_registry.cpp
@@ -109,10 +109,25 @@ namespace ccf::endpoints
 
     PathTemplateSpec spec;
 
+    const std::string allowed_delimiters = "/:";
+
     std::string regex_s(uri);
     template_start = regex_s.find_first_of('{');
     while (template_start != std::string::npos)
     {
+      if (template_start != 0)
+      {
+        const auto prev_char = regex_s[template_start-1];
+        if (allowed_delimiters.find(prev_char) == std::string::npos)
+        {
+          throw std::logic_error(fmt::format(
+            "Invalid templated path - illegal character ({}) preceding "
+            "template: {}",
+            prev_char,
+            uri));
+        }
+      }
+
       const auto template_end = regex_s.find_first_of('}', template_start);
       if (template_end == std::string::npos)
       {
@@ -123,7 +138,7 @@ namespace ccf::endpoints
       if (template_end + 1 != regex_s.size())
       {
         const auto next_char = regex_s[template_end + 1];
-        if (!(next_char == '/' || next_char == ':'))
+        if (allowed_delimiters.find(next_char) == std::string::npos)
         {
           throw std::logic_error(fmt::format(
             "Invalid templated path - illegal character ({}) following "

--- a/src/endpoints/test/endpoint_registry.cpp
+++ b/src/endpoints/test/endpoint_registry.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include "ccf/endpoint_registry.h"
+
+#include <doctest/doctest.h>
+
+std::optional<ccf::endpoints::PathTemplateSpec> require_parsed_components(
+  const std::string& s, const std::vector<std::string>& expected_components)
+{
+  using namespace ccf::endpoints;
+
+  std::optional<PathTemplateSpec> spec;
+  REQUIRE_NOTHROW(spec = PathTemplateSpec::parse(s));
+
+  if (expected_components.size() == 0)
+  {
+    REQUIRE(!spec.has_value());
+  }
+  else
+  {
+    REQUIRE(spec.has_value());
+    REQUIRE(spec->template_component_names == expected_components);
+  }
+
+  return spec;
+}
+
+TEST_CASE("Foo")
+{
+  logger::config::default_init();
+
+  for (const std::string prefix : {"", "/hello", "/foo/bar/baz"})
+  {
+    require_parsed_components(prefix + "/bob", {});
+    require_parsed_components(prefix + "/{name}", {"name"});
+    require_parsed_components(prefix + "/{name}/world", {"name"});
+    require_parsed_components(prefix + "/{name}/{place}", {"name", "place"});
+
+    require_parsed_components(prefix + "/{name}:do", {"name"});
+    require_parsed_components(prefix + "/{name}:do/world", {"name"});
+    require_parsed_components(prefix + "/{name}:do/{place}", {"name", "place"});
+
+    require_parsed_components(prefix + "/bob:{action}", {"action"});
+    require_parsed_components(prefix + "/bob:{action}/world", {"action"});
+    require_parsed_components(
+      prefix + "/bob:{action}/{place}", {"action", "place"});
+
+    require_parsed_components(prefix + "/{name}:{action}", {"name", "action"});
+    require_parsed_components(
+      prefix + "/{name}:{action}/world", {"name", "action"});
+    require_parsed_components(
+      prefix + "/{name}:{action}/{place}", {"name", "action", "place"});
+  }
+
+  // ccf::endpoints::PathTemplateSpec::parse("/hello/what{name}ishappening/world");
+  // ccf::endpoints::PathTemplateSpec::parse("/hello/{name}:ishappening/world");
+}

--- a/src/endpoints/test/endpoint_registry.cpp
+++ b/src/endpoints/test/endpoint_registry.cpp
@@ -6,11 +6,11 @@
 
 #include <doctest/doctest.h>
 
-std::optional<ccf::endpoints::PathTemplateSpec> require_parsed_components(
+using namespace ccf::endpoints;
+
+std::optional<PathTemplateSpec> require_parsed_components(
   const std::string& s, const std::vector<std::string>& expected_components)
 {
-  using namespace ccf::endpoints;
-
   std::optional<PathTemplateSpec> spec;
   REQUIRE_NOTHROW(spec = PathTemplateSpec::parse(s));
 
@@ -27,16 +27,32 @@ std::optional<ccf::endpoints::PathTemplateSpec> require_parsed_components(
   return spec;
 }
 
-TEST_CASE("Foo")
+TEST_CASE("URL template parsing")
 {
   logger::config::default_init();
+
+  std::optional<PathTemplateSpec> parsed;
+  std::string path;
+  std::smatch match;
 
   for (const std::string prefix : {"", "/hello", "/foo/bar/baz"})
   {
     require_parsed_components(prefix + "/bob", {});
     require_parsed_components(prefix + "/{name}", {"name"});
     require_parsed_components(prefix + "/{name}/world", {"name"});
-    require_parsed_components(prefix + "/{name}/{place}", {"name", "place"});
+
+    auto parsed =
+      require_parsed_components(prefix + "/{name}/{place}", {"name", "place"});
+
+    path = prefix + "/alice/spain";
+    REQUIRE(std::regex_match(path, match, parsed->template_regex));
+    REQUIRE(match[1].str() == "alice");
+    REQUIRE(match[2].str() == "spain");
+
+    path = prefix + "/alice:jump/spain";
+    REQUIRE(std::regex_match(path, match, parsed->template_regex));
+    REQUIRE(match[1].str() == "alice:jump");
+    REQUIRE(match[2].str() == "spain");
 
     require_parsed_components(prefix + "/{name}:do", {"name"});
     require_parsed_components(prefix + "/{name}:do/world", {"name"});
@@ -50,10 +66,32 @@ TEST_CASE("Foo")
     require_parsed_components(prefix + "/{name}:{action}", {"name", "action"});
     require_parsed_components(
       prefix + "/{name}:{action}/world", {"name", "action"});
-    require_parsed_components(
+
+    parsed = require_parsed_components(
       prefix + "/{name}:{action}/{place}", {"name", "action", "place"});
+
+    path = prefix + "/alice/spain";
+    REQUIRE_FALSE(std::regex_match(path, match, parsed->template_regex));
+
+    path = prefix + "/alice:jump/spain";
+    REQUIRE(std::regex_match(path, match, parsed->template_regex));
+    REQUIRE(match[1].str() == "alice");
+    REQUIRE(match[2].str() == "jump");
+    REQUIRE(match[3].str() == "spain");
   }
 
-  // ccf::endpoints::PathTemplateSpec::parse("/hello/what{name}ishappening/world");
-  // ccf::endpoints::PathTemplateSpec::parse("/hello/{name}:ishappening/world");
+  REQUIRE_THROWS(PathTemplateSpec::parse("/foo{id}"));
+  REQUIRE_THROWS(PathTemplateSpec::parse("/foo{id}bar"));
+  REQUIRE_THROWS(PathTemplateSpec::parse("/{id}bar"));
+  REQUIRE_THROWS(PathTemplateSpec::parse("/{id}-{name}"));
+  REQUIRE_THROWS(PathTemplateSpec::parse("/id{id}"));
+  REQUIRE_THROWS(PathTemplateSpec::parse("/foo{id}:"));
+  REQUIRE_THROWS(PathTemplateSpec::parse("/foo{id}/bar"));
+  REQUIRE_THROWS(PathTemplateSpec::parse("/foo/{id}bar"));
+  REQUIRE_THROWS(PathTemplateSpec::parse("/foo/id{id}:bar"));
+
+  REQUIRE_THROWS(PathTemplateSpec::parse("/{id}/{id}"));
+  REQUIRE_THROWS(PathTemplateSpec::parse("/foo/{id}/{id}"));
+  REQUIRE_THROWS(PathTemplateSpec::parse("/{id}/foo/{id}"));
+  REQUIRE_THROWS(PathTemplateSpec::parse("/{id}/{id}/foo"));
 }


### PR DESCRIPTION
Resolves #5224.

This was partially supported previously. This PR makes the parser a little stricter to ensure reasonable parsing for the kind of paths we actually care about, eg

```
 /{id}:withdraw
 /{id}:{action}
 /commit:{action}
```

anywhere in the path. Each end of each template must be delimited by either an end of the string, or one of the characters `:` or `/`.