### PR TITLE
Experimental: support for custom protocols

### DIFF
--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -68,8 +68,7 @@
                 "description": "The RPC protocol used (udp | tcp)"
               },
               "app_protocol": {
-                "type": "string",
-                "enum": ["HTTP1", "HTTP2", "Custom"],
+                "type": "string",                
                 "default": "HTTP1",
                 "description": "The application protocol used by all sessions on this interface"
               },

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -68,7 +68,7 @@
                 "description": "The RPC protocol used (udp | tcp)"
               },
               "app_protocol": {
-                "type": "string",                
+                "type": "string",
                 "default": "HTTP1",
                 "description": "The application protocol used by all sessions on this interface"
               },

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -13,19 +13,29 @@
         },
         "platform": {
           "type": "string",
-          "enum": ["SGX", "SNP", "Virtual"],
+          "enum": [
+            "SGX",
+            "SNP",
+            "Virtual"
+          ],
           "default": "SGX",
           "description": "Trusted Execution Environment platform"
         },
         "type": {
           "type": "string",
-          "enum": ["Release", "Debug", "Virtual"],
+          "enum": [
+            "Release",
+            "Debug",
+            "Virtual"
+          ],
           "default": "Release",
           "description": "Type of enclave application (only if platform is SGX). \"Virtual\" is deprecated (use ``platform`` instead)"
         }
       },
       "description": "This section includes configuration for the enclave application launched by this node",
-      "required": ["file"],
+      "required": [
+        "file"
+      ],
       "additionalProperties": false
     },
     "network": {
@@ -45,7 +55,9 @@
             }
           },
           "description": "Address (host:port) to listen on for incoming node-to-node connections (e.g. internal consensus messages)",
-          "required": ["bind_address"],
+          "required": [
+            "bind_address"
+          ],
           "additionalProperties": false
         },
         "rpc_interfaces": {
@@ -69,7 +81,11 @@
               },
               "app_protocol": {
                 "type": "string",
-                "enum": ["HTTP1", "HTTP2"],
+                "enum": [
+                  "HTTP1",
+                  "HTTP2",
+                  "Custom"
+                ],
                 "default": "HTTP1",
                 "description": "The application protocol used by all sessions on this interface"
               },
@@ -125,7 +141,12 @@
                 "properties": {
                   "authority": {
                     "type": "string",
-                    "enum": ["Node", "Service", "ACME", "Unsecured"],
+                    "enum": [
+                      "Node",
+                      "Service",
+                      "ACME",
+                      "Unsecured"
+                    ],
                     "default": "Service",
                     "description": "The type of endorsement for the TLS certificate used in client sessions. If the endorsement is not available, client sessions will be terminated, before the TLS handshake is complete. 'Node' means self-signed, 'Service' means service-endorsed, 'ACME' means an ACME-capable CA, 'Unsecured' means unencrypted traffic and no endorsement authority"
                   },
@@ -136,7 +157,9 @@
                 },
                 "oneOf": [
                   {
-                    "required": ["acme_configuration"]
+                    "required": [
+                      "acme_configuration"
+                    ]
                   },
                   {
                     "not": {
@@ -148,7 +171,9 @@
                     }
                   }
                 ],
-                "required": ["authority"],
+                "required": [
+                  "authority"
+                ],
                 "additionalProperties": false
               },
               "accepted_endpoints": {
@@ -164,7 +189,9 @@
                 "description": "Timeout for forwarded RPC calls (in milliseconds)"
               }
             },
-            "required": ["bind_address"]
+            "required": [
+              "bind_address"
+            ]
           },
           "description": "Interfaces to listen on for incoming client TLS connections, as a dictionary from unique interface name to RPC interface information"
         },
@@ -233,7 +260,10 @@
         }
       },
       "description": "This section includes configuration for the interfaces a node listens on (for both client and node-to-node communications)",
-      "required": ["node_to_node_interface", "rpc_interfaces"],
+      "required": [
+        "node_to_node_interface",
+        "rpc_interfaces"
+      ],
       "additionalProperties": false
     },
     "command": {
@@ -241,7 +271,11 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["Start", "Join", "Recover"],
+          "enum": [
+            "Start",
+            "Join",
+            "Recover"
+          ],
           "description": "Type of CCF node"
         },
         "service_certificate_file": {
@@ -287,15 +321,23 @@
                           "description": "Path to member x509 identity certificate (PEM)"
                         },
                         "encryption_public_key_file": {
-                          "type": ["string", "null"],
+                          "type": [
+                            "string",
+                            "null"
+                          ],
                           "description": "Path to member encryption public key (PEM)"
                         },
                         "data_json_file": {
-                          "type": ["string", "null"],
+                          "type": [
+                            "string",
+                            "null"
+                          ],
                           "description": "Path to member data file (JSON)"
                         }
                       },
-                      "required": ["certificate_file"],
+                      "required": [
+                        "certificate_file"
+                      ],
                       "additionalProperties": false
                     },
                     "description": "List of initial consortium members files, including identity certificates, public encryption keys and member data files"
@@ -327,15 +369,22 @@
                         "minimum": 1
                       }
                     },
-                    "required": ["recovery_threshold"],
+                    "required": [
+                      "recovery_threshold"
+                    ],
                     "additionalProperties": false
                   }
                 },
-                "required": ["constitution_files", "members"],
+                "required": [
+                  "constitution_files",
+                  "members"
+                ],
                 "additionalProperties": false
               }
             },
-            "required": ["start"]
+            "required": [
+              "start"
+            ]
           }
         },
         {
@@ -361,11 +410,15 @@
                     "description": "Interval (time string) at which the node sends join requests to the existing service. This should be less than the value of 'consensus.election_timeout' set on the primary node of the existing service to join"
                   }
                 },
-                "required": ["target_rpc_address"],
+                "required": [
+                  "target_rpc_address"
+                ],
                 "additionalProperties": false
               }
             },
-            "required": ["join"]
+            "required": [
+              "join"
+            ]
           }
         },
         {
@@ -392,7 +445,9 @@
                     "description": "Path to the previous service certificate (PEM) file"
                   }
                 },
-                "required": ["previous_service_identity_file"],
+                "required": [
+                  "previous_service_identity_file"
+                ],
                 "additionalProperties": false
               }
             }
@@ -400,7 +455,9 @@
         }
       ],
       "description": "This section includes configuration of how the node should start (either start, join or recover) and associated information",
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "node_certificate": {
       "type": "object",
@@ -419,7 +476,10 @@
         },
         "curve_id": {
           "type": "string",
-          "enum": ["Secp384R1", "Secp256R1"],
+          "enum": [
+            "Secp384R1",
+            "Secp256R1"
+          ],
           "default": "Secp384R1",
           "description": "Elliptic curve to use for node identity key"
         },
@@ -434,7 +494,10 @@
       "additionalProperties": false
     },
     "node_data_json_file": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Path to file (JSON) containing initial node data. It is intended to store correlation IDs describing the node's deployment, such as a VM name or Pod identifier"
     },
     "attestation": {
@@ -444,12 +507,17 @@
           "type": "object",
           "properties": {
             "security_context_directory": {
-              "type": ["string", "null"],
+              "type": [
+                "string",
+                "null"
+              ],
               "description": "Name of environment variable (e.g. ``UVM_SECURITY_CONTEXT_DIR``) specifying the directory containing the security context files (i.e. ``host-amd-cert-base64``, ``security-policy-base64`` and ``reference-info-base64``)."
             }
           },
           "description": "Environment variables required to provide best auditability and serviceability for Azure Container Instance deployments (SEV-SNP only)",
-          "required": ["security_context_directory"],
+          "required": [
+            "security_context_directory"
+          ],
           "additionalProperties": false
         },
         "snp_endorsements_servers": {
@@ -459,7 +527,10 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["Azure", "AMD"],
+                "enum": [
+                  "Azure",
+                  "AMD"
+                ],
                 "default": "Azure",
                 "description": "Type of server used to retrieve attestation report endorsement certificates (SEV-SNP only)"
               },
@@ -468,7 +539,9 @@
                 "description": "Server URLs used to retrieve attestation report endorsement certificates, e.g. \"kdsintf.amd.com\" (SEV-SNP only)"
               }
             },
-            "required": ["url"],
+            "required": [
+              "url"
+            ],
             "additionalProperties": false
           },
           "description": "List of servers used to retrieve attestation report endorsement certificates (SEV-SNP only). The first server in the list is always used and other servers are only specified as fallback. If set, endorsements from ``environment.security_context_directory`` are ignored"
@@ -478,7 +551,10 @@
       "additionalProperties": false
     },
     "service_data_json_file": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Path to file (JSON) containing initial service data. It is used when the node starts in 'Start' or 'Recover' mode and is intended to store arbitrary information about the service"
     },
     "ledger": {
@@ -520,7 +596,10 @@
           "minimum": 1
         },
         "read_only_directory": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Path to read-only snapshots directory"
         }
       },
@@ -532,13 +611,22 @@
       "properties": {
         "host_level": {
           "type": "string",
-          "enum": ["Trace", "Debug", "Info", "Fail", "Fatal"],
+          "enum": [
+            "Trace",
+            "Debug",
+            "Info",
+            "Fail",
+            "Fatal"
+          ],
           "default": "Info",
           "description": "Logging level for the untrusted host. Note: while it is possible to set the host log level at startup, it is deliberately not possible to change the log level of the enclave without rebuilding it and changing its code identity"
         },
         "format": {
           "type": "string",
-          "enum": ["Text", "Json"],
+          "enum": [
+            "Text",
+            "Json"
+          ],
           "default": "Text",
           "description": "If 'json', node logs will be formatted as JSON"
         }
@@ -629,7 +717,10 @@
       "description": "Maximum duration of I/O operations (ledger and snapshots) after which slow operations will be logged to node log"
     },
     "node_client_interface": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Address to bind to for node-to-node client connections. If unspecified, this is automatically assigned by the OS. This option is particularly useful for testing purposes (e.g. establishing network partitions between nodes)"
     },
     "client_connection_timeout": {
@@ -676,6 +767,10 @@
       "minimum": 0
     }
   },
-  "required": ["enclave", "network", "command"],
+  "required": [
+    "enclave",
+    "network",
+    "command"
+  ],
   "additionalProperties": false
 }

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -13,29 +13,19 @@
         },
         "platform": {
           "type": "string",
-          "enum": [
-            "SGX",
-            "SNP",
-            "Virtual"
-          ],
+          "enum": ["SGX", "SNP", "Virtual"],
           "default": "SGX",
           "description": "Trusted Execution Environment platform"
         },
         "type": {
           "type": "string",
-          "enum": [
-            "Release",
-            "Debug",
-            "Virtual"
-          ],
+          "enum": ["Release", "Debug", "Virtual"],
           "default": "Release",
           "description": "Type of enclave application (only if platform is SGX). \"Virtual\" is deprecated (use ``platform`` instead)"
         }
       },
       "description": "This section includes configuration for the enclave application launched by this node",
-      "required": [
-        "file"
-      ],
+      "required": ["file"],
       "additionalProperties": false
     },
     "network": {
@@ -55,9 +45,7 @@
             }
           },
           "description": "Address (host:port) to listen on for incoming node-to-node connections (e.g. internal consensus messages)",
-          "required": [
-            "bind_address"
-          ],
+          "required": ["bind_address"],
           "additionalProperties": false
         },
         "rpc_interfaces": {
@@ -81,11 +69,7 @@
               },
               "app_protocol": {
                 "type": "string",
-                "enum": [
-                  "HTTP1",
-                  "HTTP2",
-                  "Custom"
-                ],
+                "enum": ["HTTP1", "HTTP2", "Custom"],
                 "default": "HTTP1",
                 "description": "The application protocol used by all sessions on this interface"
               },
@@ -141,12 +125,7 @@
                 "properties": {
                   "authority": {
                     "type": "string",
-                    "enum": [
-                      "Node",
-                      "Service",
-                      "ACME",
-                      "Unsecured"
-                    ],
+                    "enum": ["Node", "Service", "ACME", "Unsecured"],
                     "default": "Service",
                     "description": "The type of endorsement for the TLS certificate used in client sessions. If the endorsement is not available, client sessions will be terminated, before the TLS handshake is complete. 'Node' means self-signed, 'Service' means service-endorsed, 'ACME' means an ACME-capable CA, 'Unsecured' means unencrypted traffic and no endorsement authority"
                   },
@@ -157,9 +136,7 @@
                 },
                 "oneOf": [
                   {
-                    "required": [
-                      "acme_configuration"
-                    ]
+                    "required": ["acme_configuration"]
                   },
                   {
                     "not": {
@@ -171,9 +148,7 @@
                     }
                   }
                 ],
-                "required": [
-                  "authority"
-                ],
+                "required": ["authority"],
                 "additionalProperties": false
               },
               "accepted_endpoints": {
@@ -189,9 +164,7 @@
                 "description": "Timeout for forwarded RPC calls (in milliseconds)"
               }
             },
-            "required": [
-              "bind_address"
-            ]
+            "required": ["bind_address"]
           },
           "description": "Interfaces to listen on for incoming client TLS connections, as a dictionary from unique interface name to RPC interface information"
         },
@@ -260,10 +233,7 @@
         }
       },
       "description": "This section includes configuration for the interfaces a node listens on (for both client and node-to-node communications)",
-      "required": [
-        "node_to_node_interface",
-        "rpc_interfaces"
-      ],
+      "required": ["node_to_node_interface", "rpc_interfaces"],
       "additionalProperties": false
     },
     "command": {
@@ -271,11 +241,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "Start",
-            "Join",
-            "Recover"
-          ],
+          "enum": ["Start", "Join", "Recover"],
           "description": "Type of CCF node"
         },
         "service_certificate_file": {
@@ -321,23 +287,15 @@
                           "description": "Path to member x509 identity certificate (PEM)"
                         },
                         "encryption_public_key_file": {
-                          "type": [
-                            "string",
-                            "null"
-                          ],
+                          "type": ["string", "null"],
                           "description": "Path to member encryption public key (PEM)"
                         },
                         "data_json_file": {
-                          "type": [
-                            "string",
-                            "null"
-                          ],
+                          "type": ["string", "null"],
                           "description": "Path to member data file (JSON)"
                         }
                       },
-                      "required": [
-                        "certificate_file"
-                      ],
+                      "required": ["certificate_file"],
                       "additionalProperties": false
                     },
                     "description": "List of initial consortium members files, including identity certificates, public encryption keys and member data files"
@@ -369,22 +327,15 @@
                         "minimum": 1
                       }
                     },
-                    "required": [
-                      "recovery_threshold"
-                    ],
+                    "required": ["recovery_threshold"],
                     "additionalProperties": false
                   }
                 },
-                "required": [
-                  "constitution_files",
-                  "members"
-                ],
+                "required": ["constitution_files", "members"],
                 "additionalProperties": false
               }
             },
-            "required": [
-              "start"
-            ]
+            "required": ["start"]
           }
         },
         {
@@ -410,15 +361,11 @@
                     "description": "Interval (time string) at which the node sends join requests to the existing service. This should be less than the value of 'consensus.election_timeout' set on the primary node of the existing service to join"
                   }
                 },
-                "required": [
-                  "target_rpc_address"
-                ],
+                "required": ["target_rpc_address"],
                 "additionalProperties": false
               }
             },
-            "required": [
-              "join"
-            ]
+            "required": ["join"]
           }
         },
         {
@@ -445,9 +392,7 @@
                     "description": "Path to the previous service certificate (PEM) file"
                   }
                 },
-                "required": [
-                  "previous_service_identity_file"
-                ],
+                "required": ["previous_service_identity_file"],
                 "additionalProperties": false
               }
             }
@@ -455,9 +400,7 @@
         }
       ],
       "description": "This section includes configuration of how the node should start (either start, join or recover) and associated information",
-      "required": [
-        "type"
-      ]
+      "required": ["type"]
     },
     "node_certificate": {
       "type": "object",
@@ -476,10 +419,7 @@
         },
         "curve_id": {
           "type": "string",
-          "enum": [
-            "Secp384R1",
-            "Secp256R1"
-          ],
+          "enum": ["Secp384R1", "Secp256R1"],
           "default": "Secp384R1",
           "description": "Elliptic curve to use for node identity key"
         },
@@ -494,10 +434,7 @@
       "additionalProperties": false
     },
     "node_data_json_file": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "description": "Path to file (JSON) containing initial node data. It is intended to store correlation IDs describing the node's deployment, such as a VM name or Pod identifier"
     },
     "attestation": {
@@ -507,17 +444,12 @@
           "type": "object",
           "properties": {
             "security_context_directory": {
-              "type": [
-                "string",
-                "null"
-              ],
+              "type": ["string", "null"],
               "description": "Name of environment variable (e.g. ``UVM_SECURITY_CONTEXT_DIR``) specifying the directory containing the security context files (i.e. ``host-amd-cert-base64``, ``security-policy-base64`` and ``reference-info-base64``)."
             }
           },
           "description": "Environment variables required to provide best auditability and serviceability for Azure Container Instance deployments (SEV-SNP only)",
-          "required": [
-            "security_context_directory"
-          ],
+          "required": ["security_context_directory"],
           "additionalProperties": false
         },
         "snp_endorsements_servers": {
@@ -527,10 +459,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "Azure",
-                  "AMD"
-                ],
+                "enum": ["Azure", "AMD"],
                 "default": "Azure",
                 "description": "Type of server used to retrieve attestation report endorsement certificates (SEV-SNP only)"
               },
@@ -539,9 +468,7 @@
                 "description": "Server URLs used to retrieve attestation report endorsement certificates, e.g. \"kdsintf.amd.com\" (SEV-SNP only)"
               }
             },
-            "required": [
-              "url"
-            ],
+            "required": ["url"],
             "additionalProperties": false
           },
           "description": "List of servers used to retrieve attestation report endorsement certificates (SEV-SNP only). The first server in the list is always used and other servers are only specified as fallback. If set, endorsements from ``environment.security_context_directory`` are ignored"
@@ -551,10 +478,7 @@
       "additionalProperties": false
     },
     "service_data_json_file": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "description": "Path to file (JSON) containing initial service data. It is used when the node starts in 'Start' or 'Recover' mode and is intended to store arbitrary information about the service"
     },
     "ledger": {
@@ -596,10 +520,7 @@
           "minimum": 1
         },
         "read_only_directory": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "description": "Path to read-only snapshots directory"
         }
       },
@@ -611,22 +532,13 @@
       "properties": {
         "host_level": {
           "type": "string",
-          "enum": [
-            "Trace",
-            "Debug",
-            "Info",
-            "Fail",
-            "Fatal"
-          ],
+          "enum": ["Trace", "Debug", "Info", "Fail", "Fatal"],
           "default": "Info",
           "description": "Logging level for the untrusted host. Note: while it is possible to set the host log level at startup, it is deliberately not possible to change the log level of the enclave without rebuilding it and changing its code identity"
         },
         "format": {
           "type": "string",
-          "enum": [
-            "Text",
-            "Json"
-          ],
+          "enum": ["Text", "Json"],
           "default": "Text",
           "description": "If 'json', node logs will be formatted as JSON"
         }
@@ -717,10 +629,7 @@
       "description": "Maximum duration of I/O operations (ledger and snapshots) after which slow operations will be logged to node log"
     },
     "node_client_interface": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "description": "Address to bind to for node-to-node client connections. If unspecified, this is automatically assigned by the OS. This option is particularly useful for testing purposes (e.g. establishing network partitions between nodes)"
     },
     "client_connection_timeout": {
@@ -767,10 +676,6 @@
       "minimum": 0
     }
   },
-  "required": [
-    "enclave",
-    "network",
-    "command"
-  ],
+  "required": ["enclave", "network", "command"],
   "additionalProperties": false
 }

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -591,7 +591,8 @@
               "app_protocol": {
                 "enum": [
                   "HTTP1",
-                  "HTTP2"
+                  "HTTP2",
+                  "Custom"
                 ],
                 "type": "string"
               },

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -589,11 +589,6 @@
                 "type": "array"
               },
               "app_protocol": {
-                "enum": [
-                  "HTTP1",
-                  "HTTP2",
-                  "Custom"
-                ],
                 "type": "string"
               },
               "bind_address": {
@@ -696,10 +691,6 @@
                   "type": "array"
                 },
                 "app_protocol": {
-                  "enum": [
-                    "HTTP1",
-                    "HTTP2"
-                  ],
                   "type": "string"
                 },
                 "bind_address": {
@@ -1271,7 +1262,7 @@
   "info": {
     "description": "This API is used to submit and query proposals which affect CCF's public governance tables.",
     "title": "CCF Governance API",
-    "version": "4.1.0"
+    "version": "4.1.1"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -16,7 +16,8 @@
       "ApplicationProtocol": {
         "enum": [
           "HTTP1",
-          "HTTP2"
+          "HTTP2",
+          "Custom"
         ],
         "type": "string"
       },

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -13,14 +13,6 @@
       }
     },
     "schemas": {
-      "ApplicationProtocol": {
-        "enum": [
-          "HTTP1",
-          "HTTP2",
-          "Custom"
-        ],
-        "type": "string"
-      },
       "Authority": {
         "enum": [
           "Node",
@@ -563,7 +555,7 @@
             "$ref": "#/components/schemas/string_array"
           },
           "app_protocol": {
-            "$ref": "#/components/schemas/ApplicationProtocol"
+            "$ref": "#/components/schemas/string"
           },
           "bind_address": {
             "$ref": "#/components/schemas/string"
@@ -909,7 +901,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "4.2.0"
+    "version": "4.2.1"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/include/ccf/node/acme_subsystem_interface.h
+++ b/include/ccf/node/acme_subsystem_interface.h
@@ -8,7 +8,6 @@
 #include "ccf/node_subsystem_interface.h"
 #include "ccf/service/acme_client_config.h"
 #include "ccf/service/node_info_network.h"
-#include "node/rpc/node_interface.h"
 
 #include <optional>
 #include <string>

--- a/include/ccf/node/acme_subsystem_interface.h
+++ b/include/ccf/node/acme_subsystem_interface.h
@@ -44,7 +44,7 @@ namespace ccf
         const http::HeaderMap&,
         const std::vector<uint8_t>&)> callback,
       const std::vector<std::string>& ca_certs = {},
-      ccf::ApplicationProtocol app_protocol = ccf::ApplicationProtocol::HTTP1,
+      const std::string& app_protocol = "HTTP1",
       bool use_node_client_certificate = false) = 0;
 
     virtual AbstractNodeState& get_node_state() = 0;

--- a/include/ccf/node/acme_subsystem_interface.h
+++ b/include/ccf/node/acme_subsystem_interface.h
@@ -8,6 +8,7 @@
 #include "ccf/node_subsystem_interface.h"
 #include "ccf/service/acme_client_config.h"
 #include "ccf/service/node_info_network.h"
+#include "node/rpc/node_interface.h"
 
 #include <optional>
 #include <string>
@@ -46,5 +47,7 @@ namespace ccf
       const std::vector<std::string>& ca_certs = {},
       ccf::ApplicationProtocol app_protocol = ccf::ApplicationProtocol::HTTP1,
       bool use_node_client_certificate = false) = 0;
+
+    virtual AbstractNodeState& get_node_state() = 0;
   };
 }

--- a/include/ccf/node/session.h
+++ b/include/ccf/node/session.h
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include <cstdint>
+#include <span>
+
+namespace ccf
+{
+  class Session
+  {
+  public:
+    virtual ~Session() = default;
+
+    virtual void handle_incoming_data(std::span<const uint8_t> data) = 0;
+    virtual void send_data(std::span<const uint8_t> data) = 0;
+    virtual void close_session() = 0;
+  };
+}

--- a/include/ccf/research/custom_protocol_subsystem_interface.h
+++ b/include/ccf/research/custom_protocol_subsystem_interface.h
@@ -32,10 +32,13 @@ namespace ccf
     }
 
     virtual void install(
-      const NodeInfoNetwork::RpcInterfaceID& interface_id,
-      CreateSessionFn create_session_f) = 0;
+      const std::string& protocol_name, CreateSessionFn create_session_f) = 0;
 
-    virtual void uninstall(
-      const NodeInfoNetwork::RpcInterfaceID& interface_id) = 0;
+    virtual void uninstall(const std::string& protocol_name) = 0;
+
+    virtual std::shared_ptr<Session> create_session(
+      const std::string& protocol_name,
+      tls::ConnID conn_id,
+      const std::unique_ptr<tls::Context>&& ctx) = 0;
   };
 }

--- a/include/ccf/service/node_info_network.h
+++ b/include/ccf/service/node_info_network.h
@@ -26,17 +26,7 @@ namespace ccf
      {Authority::ACME, "ACME"},
      {Authority::UNSECURED, "Unsecured"}});
 
-  enum class ApplicationProtocol
-  {
-    HTTP1,
-    HTTP2,
-    CUSTOM
-  };
-  DECLARE_JSON_ENUM(
-    ApplicationProtocol,
-    {{ApplicationProtocol::HTTP1, "HTTP1"},
-     {ApplicationProtocol::HTTP2, "HTTP2"},
-     {ApplicationProtocol::CUSTOM, "Custom"}});
+  using ApplicationProtocol = std::string;
 
   struct Endorsement
   {

--- a/include/ccf/service/node_info_network.h
+++ b/include/ccf/service/node_info_network.h
@@ -29,12 +29,14 @@ namespace ccf
   enum class ApplicationProtocol
   {
     HTTP1,
-    HTTP2
+    HTTP2,
+    CUSTOM
   };
   DECLARE_JSON_ENUM(
     ApplicationProtocol,
     {{ApplicationProtocol::HTTP1, "HTTP1"},
-     {ApplicationProtocol::HTTP2, "HTTP2"}});
+     {ApplicationProtocol::HTTP2, "HTTP2"},
+     {ApplicationProtocol::CUSTOM, "Custom"}});
 
   struct Endorsement
   {

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -3,6 +3,8 @@
 #pragma once
 #include "ccf/app_interface.h"
 #include "ccf/ds/logger.h"
+#include "ccf/node_context.h"
+#include "ccf/node_subsystem_interface.h"
 #include "ccf/pal/enclave.h"
 #include "ccf/pal/mem.h"
 #include "ds/oversized.h"
@@ -17,6 +19,7 @@
 #include "node/node_state.h"
 #include "node/node_types.h"
 #include "node/rpc/acme_subsystem.h"
+#include "node/rpc/custom_protocol_subsystem.h"
 #include "node/rpc/forwarder.h"
 #include "node/rpc/gov_effects.h"
 #include "node/rpc/host_processes.h"
@@ -149,6 +152,10 @@ namespace ccf
         std::make_shared<ccf::NodeConfigurationSubsystem>(*node));
 
       context->install_subsystem(std::make_shared<ccf::ACMESubsystem>(*node));
+
+      auto cpss = std::make_shared<ccf::CustomProtocolSubsystem>(*node);
+      context->install_subsystem(cpss);
+      rpcsessions->set_custom_protocol_subsystem(cpss);
 
       LOG_TRACE_FMT("Creating RPC actors / ffi");
       rpc_map->register_frontend<ccf::ActorsType::members>(

--- a/src/enclave/session.h
+++ b/src/enclave/session.h
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ccf/node/session.h"
 #include "ds/thread_messaging.h"
 #include "tls/msg_types.h"
 
@@ -9,16 +10,6 @@
 
 namespace ccf
 {
-  class Session
-  {
-  public:
-    virtual ~Session() = default;
-
-    virtual void handle_incoming_data(std::span<const uint8_t> data) = 0;
-    virtual void send_data(std::span<const uint8_t> data) = 0;
-    virtual void close_session() = 0;
-  };
-
   class ThreadedSession : public Session,
                           public std::enable_shared_from_this<ThreadedSession>
   {

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -350,7 +350,7 @@ int main(int argc, char** argv)
     // from the same abstract class.
     asynchost::RPCConnections<asynchost::UDP> rpc_udp(
       writer_factory, idGen, config.client_connection_timeout);
-    rpc_udp.register_quic_message_handlers(bp.get_dispatcher());
+    rpc_udp.register_udp_message_handlers(bp.get_dispatcher());
 
     ResolvedAddresses resolved_rpc_addresses;
     for (auto& [name, interface] : config.network.rpc_interfaces)

--- a/src/host/rpc_connections.h
+++ b/src/host/rpc_connections.h
@@ -190,7 +190,7 @@ namespace asynchost
         if constexpr (isUDP<ConnType>())
         {
           RINGBUFFER_WRITE_MESSAGE(
-            quic::quic_start, parent.to_enclave, peer_id, interface_name);
+            udp::start, parent.to_enclave, peer_id, interface_name);
           return;
         }
       }
@@ -200,11 +200,11 @@ namespace asynchost
         // UDP connections don't have clients, it's all done in the server
         if constexpr (isUDP<ConnType>())
         {
-          auto [addr_family, addr_data] = quic::sockaddr_encode(addr);
+          auto [addr_family, addr_data] = udp::sockaddr_encode(addr);
 
           LOG_DEBUG_FMT("rpc udp read into ring buffer {}: {}", id, len);
           RINGBUFFER_WRITE_MESSAGE(
-            quic::quic_inbound,
+            udp::inbound,
             parent.to_enclave,
             id,
             addr_family,
@@ -388,18 +388,19 @@ namespace asynchost
           close(id);
         });
     }
-    void register_quic_message_handlers(
+
+    void register_udp_message_handlers(
       messaging::Dispatcher<ringbuffer::Message>& disp)
     {
       DISPATCHER_SET_MESSAGE_HANDLER(
-        disp, quic::quic_outbound, [this](const uint8_t* data, size_t size) {
+        disp, udp::outbound, [this](const uint8_t* data, size_t size) {
           auto [id, addr_family, addr_data, body] =
-            ringbuffer::read_message<quic::quic_outbound>(data, size);
+            ringbuffer::read_message<udp::outbound>(data, size);
 
           ConnID connect_id = (ConnID)id;
           LOG_DEBUG_FMT("rpc write from enclave {}: {}", connect_id, body.size);
 
-          auto addr = quic::sockaddr_decode(addr_family, addr_data);
+          auto addr = udp::sockaddr_decode(addr_family, addr_data);
           write(connect_id, body.size, body.data, addr);
         });
     }

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -2628,7 +2628,7 @@ namespace ccf
         bool(http_status status, http::HeaderMap&&, std::vector<uint8_t>&&)>
         callback,
       const std::vector<std::string>& ca_certs = {},
-      ccf::ApplicationProtocol app_protocol = ccf::ApplicationProtocol::HTTP1,
+      const std::string& app_protocol = "HTTP1",
       bool authenticate_as_node_client_certificate = false) override
     {
       std::optional<crypto::Pem> client_cert = std::nullopt;

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -2655,5 +2655,15 @@ namespace ccf
         });
       client->send_request(std::move(req));
     }
+
+    virtual std::shared_ptr<kv::Store> get_store() override
+    {
+      return network.tables;
+    }
+
+    virtual ringbuffer::AbstractWriterFactory& get_writer_factory() override
+    {
+      return writer_factory;
+    }
   };
 }

--- a/src/node/rpc/acme_subsystem.h
+++ b/src/node/rpc/acme_subsystem.h
@@ -63,7 +63,7 @@ namespace ccf
         const http::HeaderMap&,
         const std::vector<uint8_t>&)> callback,
       const std::vector<std::string>& ca_certs = {},
-      ccf::ApplicationProtocol app_protocol = ccf::ApplicationProtocol::HTTP1,
+      const std::string& app_protocol = "HTTP1",
       bool authenticate_as_node_client_certificate = false) override
     {
       llhttp_method_t m = http_method_from_str(method.c_str());

--- a/src/node/rpc/acme_subsystem.h
+++ b/src/node/rpc/acme_subsystem.h
@@ -85,5 +85,10 @@ namespace ccf
         app_protocol,
         authenticate_as_node_client_certificate);
     }
+
+    virtual AbstractNodeState& get_node_state() override
+    {
+      return node_state;
+    }
   };
 }

--- a/src/node/rpc/custom_protocol_subsystem.h
+++ b/src/node/rpc/custom_protocol_subsystem.h
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ccf/node/session.h"
+#include "ccf/rpc_context.h"
+#include "ccf/service/node_info_network.h"
+#include "node/rpc/custom_protocol_subsystem_interface.h"
+#include "node/rpc/node_interface.h"
+
+#include <functional>
+#include <memory>
+
+namespace ccf
+{
+  class CustomProtocolSubsystem : public CustomProtocolSubsystemInterface
+  {
+  protected:
+    AbstractNodeState& node_state;
+
+  public:
+    std::map<NodeInfoNetwork::RpcInterfaceID, create_session_ft>
+      session_creation_functions;
+
+    CustomProtocolSubsystem(AbstractNodeState& node_state_) :
+      node_state(node_state_)
+    {}
+
+    virtual void install(
+      const NodeInfoNetwork::RpcInterfaceID& interface_id,
+      create_session_ft create_session_f) override
+    {
+      session_creation_functions[interface_id] = create_session_f;
+    }
+
+    virtual void uninstall(
+      const NodeInfoNetwork::RpcInterfaceID& interface_id) override
+    {
+      session_creation_functions.erase(interface_id);
+    }
+  };
+}

--- a/src/node/rpc/custom_protocol_subsystem_interface.h
+++ b/src/node/rpc/custom_protocol_subsystem_interface.h
@@ -21,9 +21,8 @@ namespace ccf
   class CustomProtocolSubsystemInterface : public AbstractNodeSubSystem
   {
   public:
-    typedef std::function<std::shared_ptr<Session>(
-      tls::ConnID, const std::unique_ptr<tls::Context>&&)>
-      create_session_ft;
+    using CreateSessionFn = std::function<std::shared_ptr<Session>(
+      tls::ConnID, const std::unique_ptr<tls::Context>&&)>;
 
     virtual ~CustomProtocolSubsystemInterface() = default;
 

--- a/src/node/rpc/custom_protocol_subsystem_interface.h
+++ b/src/node/rpc/custom_protocol_subsystem_interface.h
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ccf/node/session.h"
+#include "ccf/node_subsystem_interface.h"
+#include "ccf/rpc_context.h"
+#include "ccf/service/node_info_network.h"
+
+#include <functional>
+#include <memory>
+
+namespace tls
+{
+  class Context;
+  using ConnID = int64_t;
+}
+
+namespace ccf
+{
+  class CustomProtocolSubsystemInterface : public AbstractNodeSubSystem
+  {
+  public:
+    typedef std::function<std::shared_ptr<Session>(
+      tls::ConnID, const std::unique_ptr<tls::Context>&&)>
+      create_session_ft;
+
+    virtual ~CustomProtocolSubsystemInterface() = default;
+
+    static char const* get_subsystem_name()
+    {
+      return "Custom Protocol";
+    }
+
+    virtual void install(
+      const NodeInfoNetwork::RpcInterfaceID& interface_id,
+      create_session_ft create_session_f) = 0;
+
+    virtual void uninstall(
+      const NodeInfoNetwork::RpcInterfaceID& interface_id) = 0;
+  };
+}

--- a/src/node/rpc/custom_protocol_subsystem_interface.h
+++ b/src/node/rpc/custom_protocol_subsystem_interface.h
@@ -34,7 +34,7 @@ namespace ccf
 
     virtual void install(
       const NodeInfoNetwork::RpcInterfaceID& interface_id,
-      create_session_ft create_session_f) = 0;
+      CreateSessionFn create_session_f) = 0;
 
     virtual void uninstall(
       const NodeInfoNetwork::RpcInterfaceID& interface_id) = 0;

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -606,7 +606,7 @@ namespace ccf
       openapi_info.description =
         "This API is used to submit and query proposals which affect CCF's "
         "public governance tables.";
-      openapi_info.document_version = "4.1.0";
+      openapi_info.document_version = "4.1.1";
     }
 
     static std::optional<MemberId> get_caller_member_id(

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -373,7 +373,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
-      openapi_info.document_version = "4.2.0";
+      openapi_info.document_version = "4.2.1";
     }
 
     void init_handlers() override

--- a/src/node/rpc/node_interface.h
+++ b/src/node/rpc/node_interface.h
@@ -11,6 +11,7 @@
 #include "common/configuration.h"
 #include "http/http_builder.h"
 #include "http/http_parser.h"
+#include "kv/store.h"
 #include "node/rpc/gov_effects_interface.h"
 #include "node/rpc/node_operation_interface.h"
 #include "node/session_metrics.h"
@@ -71,5 +72,8 @@ namespace ccf
       const std::vector<std::string>& ca_certs = {},
       ccf::ApplicationProtocol app_protocol = ccf::ApplicationProtocol::HTTP1,
       bool use_node_client_certificate = false) = 0;
+
+    virtual std::shared_ptr<kv::Store> get_store() = 0;
+    virtual ringbuffer::AbstractWriterFactory& get_writer_factory() = 0;
   };
 }

--- a/src/node/rpc/node_interface.h
+++ b/src/node/rpc/node_interface.h
@@ -70,7 +70,7 @@ namespace ccf
         bool(http_status status, http::HeaderMap&&, std::vector<uint8_t>&&)>
         callback,
       const std::vector<std::string>& ca_certs = {},
-      ccf::ApplicationProtocol app_protocol = ccf::ApplicationProtocol::HTTP1,
+      const std::string& app_protocol = "HTTP1",
       bool use_node_client_certificate = false) = 0;
 
     virtual std::shared_ptr<kv::Store> get_store() = 0;

--- a/src/node/test/node_info_json.cpp
+++ b/src/node/test/node_info_json.cpp
@@ -23,11 +23,11 @@ TEST_CASE("Multiple versions of NodeInfoNetwork")
   current.rpc_interfaces.emplace(
     first_rpc_name,
     ccf::NodeInfoNetwork::NetInterface{
-      rpc_a, rpc_a_pub, "tcp", ccf::ApplicationProtocol::HTTP1, 100, 200});
+      rpc_a, rpc_a_pub, "tcp", "HTTP1", 100, 200});
   current.rpc_interfaces.emplace(
     second_rpc_name,
     ccf::NodeInfoNetwork::NetInterface{
-      rpc_b, rpc_b_pub, "udp", ccf::ApplicationProtocol::HTTP2, 300, 400});
+      rpc_b, rpc_b_pub, "udp", "HTTP2", 300, 400});
 
   ccf::NodeInfoNetwork_v1 v1;
   std::tie(v1.nodehost, v1.nodeport) = ccf::split_net_address(node);

--- a/src/quic/msg_types.h
+++ b/src/quic/msg_types.h
@@ -4,22 +4,17 @@
 
 #include "ds/ring_buffer_types.h"
 
-namespace quic
+#include <sys/socket.h>
+
+namespace udp
 {
   using ConnID = int64_t;
 
-  /// QUIC-related ringbuffer messages, UDP doesn't have sessions
-  /// The body of each message will begin with a connection ID
   enum : ringbuffer::Message
   {
-    /// Does nothing but registers the interface name to listen. Host -> Enclave
-    DEFINE_RINGBUFFER_MSG_TYPE(quic_start),
-
-    /// Data read from socket, to be read inside enclave. Host -> Enclave
-    DEFINE_RINGBUFFER_MSG_TYPE(quic_inbound),
-
-    /// Data sent from the enclave, to be written to socket. Enclave -> Host
-    DEFINE_RINGBUFFER_MSG_TYPE(quic_outbound),
+    DEFINE_RINGBUFFER_MSG_TYPE(start),
+    DEFINE_RINGBUFFER_MSG_TYPE(inbound),
+    DEFINE_RINGBUFFER_MSG_TYPE(outbound),
   };
 
   static std::tuple<short, std::vector<uint8_t>> sockaddr_encode(sockaddr& addr)
@@ -40,16 +35,27 @@ namespace quic
   }
 }
 
-DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(quic::quic_start, quic::ConnID, std::string);
+DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(udp::start, udp::ConnID, std::string);
 DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(
-  quic::quic_inbound,
-  quic::ConnID,
-  short,
-  std::vector<uint8_t>,
-  serializer::ByteRange);
+  udp::inbound, int64_t, short, std::vector<uint8_t>, serializer::ByteRange);
 DECLARE_RINGBUFFER_MESSAGE_PAYLOAD(
-  quic::quic_outbound,
-  quic::ConnID,
-  short,
-  std::vector<uint8_t>,
-  serializer::ByteRange);
+  udp::outbound, int64_t, short, std::vector<uint8_t>, serializer::ByteRange);
+
+namespace quic
+{
+  using ConnID = udp::ConnID;
+
+  /// QUIC-related ringbuffer messages, UDP doesn't have sessions
+  /// The body of each message will begin with a connection ID
+  enum : ringbuffer::Message
+  {
+    /// Does nothing but registers the interface name to listen. Host -> Enclave
+    quic_start = udp::start,
+
+    /// Data read from socket, to be read inside enclave. Host -> Enclave
+    quic_inbound = udp::inbound,
+
+    /// Data sent from the enclave, to be written to socket. Enclave -> Host
+    quic_outbound = udp::outbound
+  };
+}

--- a/src/quic/quic_session.h
+++ b/src/quic/quic_session.h
@@ -330,7 +330,7 @@ namespace quic
 
     int handle_send(const uint8_t* buf, size_t len, sockaddr addr)
     {
-      auto [addr_family, addr_data] = quic::sockaddr_encode(addr);
+      auto [addr_family, addr_data] = udp::sockaddr_encode(addr);
 
       // Either write all of the data or none of it.
       auto wrote = RINGBUFFER_TRY_WRITE_MESSAGE(
@@ -431,7 +431,7 @@ namespace quic
       auto msg = std::make_unique<threading::Tmsg<SendRecvMsg>>(&recv_cb);
       msg->data.self = this->shared_from_this();
       msg->data.data.assign(body.data, body.data + body.size);
-      msg->data.addr = quic::sockaddr_decode(addr_family, addr_data);
+      msg->data.addr = udp::sockaddr_decode(addr_family, addr_data);
 
       threading::ThreadMessaging::instance().add_task(
         execution_thread, std::move(msg));

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1775,9 +1775,7 @@ def run(args):
         for interface_name, host in additional_interfaces(local_node_id).items():
             node_host.rpc_interfaces[interface_name] = infra.interfaces.RPCInterface(
                 host=host,
-                app_protocol=infra.interfaces.AppProtocol.HTTP2
-                if args.http2
-                else infra.interfaces.AppProtocol.HTTP1,
+                app_protocol="HTTP2" if args.http2 else "HTTP1",
             )
 
     txs = app.LoggingTxs("user0")

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1746,6 +1746,7 @@ def test_basic_constraints(network, args):
 def run_udp_tests(args):
     # Register secondary interface as an UDP socket on all nodes
     udp_interface = infra.interfaces.make_secondary_interface("udp", "udp_interface")
+    udp_interface["udp_interface"].app_protocol = "QUIC"
     for node in args.nodes:
         node.rpc_interfaces.update(udp_interface)
 

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -29,9 +29,7 @@ def nodes(args, n):
                     max_http_header_size=args.max_http_header_size,
                     max_http_headers_count=args.max_http_headers_count,
                     forwarding_timeout_ms=args.forwarding_timeout_ms,
-                    app_protocol=infra.interfaces.AppProtocol.HTTP2
-                    if args.http2
-                    else infra.interfaces.AppProtocol.HTTP1,
+                    app_protocol="HTTP2" if args.http2 else "HTTP1",
                 )
             }
         )

--- a/tests/infra/interfaces.py
+++ b/tests/infra/interfaces.py
@@ -51,6 +51,7 @@ class EndorsementAuthority(Enum):
 class AppProtocol(Enum):
     HTTP1 = auto()
     HTTP2 = auto()
+    Custom = auto()
 
 
 @dataclass

--- a/tests/infra/interfaces.py
+++ b/tests/infra/interfaces.py
@@ -48,12 +48,6 @@ class EndorsementAuthority(Enum):
     Unsecured = auto()
 
 
-class AppProtocol(Enum):
-    HTTP1 = auto()
-    HTTP2 = auto()
-    Custom = auto()
-
-
 @dataclass
 class Endorsement:
     authority: EndorsementAuthority = EndorsementAuthority.Service
@@ -103,7 +97,7 @@ class RPCInterface(Interface):
     acme_configuration: Optional[str] = None
     accepted_endpoints: Optional[str] = None
     forwarding_timeout_ms: Optional[int] = None
-    app_protocol: AppProtocol = AppProtocol.HTTP1
+    app_protocol: str = "HTTP1"
 
     @staticmethod
     def to_json(interface):
@@ -112,7 +106,7 @@ class RPCInterface(Interface):
             "max_header_size": str(interface.max_http_header_size),
             "max_headers_count": interface.max_http_headers_count,
         }
-        if interface.app_protocol == AppProtocol.HTTP2:
+        if interface.app_protocol == "HTTP2":
             http_config.update(
                 {
                     "max_concurrent_streams_count": interface.max_concurrent_streams_count,
@@ -123,7 +117,7 @@ class RPCInterface(Interface):
         r = {
             "bind_address": make_address(interface.host, interface.port),
             "protocol": f"{interface.transport}",
-            "app_protocol": interface.app_protocol.name,
+            "app_protocol": interface.app_protocol,
             "published_address": f"{interface.public_host}:{interface.public_port or 0}",
             "max_open_sessions_soft": interface.max_open_sessions_soft,
             "max_open_sessions_hard": interface.max_open_sessions_hard,
@@ -217,7 +211,7 @@ class HostSpec:
                     port=port,
                     public_host=pub_host,
                     public_port=pub_port,
-                    app_protocol=AppProtocol.HTTP2 if http2 else AppProtocol.HTTP1,
+                    app_protocol="HTTP2" if http2 else "HTTP1",
                 )
             }
         )

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -642,7 +642,7 @@ class Node:
         akwargs["protocol"] = (
             kwargs.get("protocol") if "protocol" in kwargs else "https"
         )
-        if rpc_interface.app_protocol == infra.interfaces.AppProtocol.HTTP2:
+        if rpc_interface.app_protocol == "HTTP2":
             akwargs["http1"] = False
             akwargs["http2"] = True
 


### PR DESCRIPTION
This adds support for custom TCP and UDP protocols. It is used via a new subsystem, which should make it easy to either keep it private for now, or to clearly mark it as experimental (in docs, but perhaps also by moving it to `include/ccf/experimental`?).