### PR TITLE
Update Dockerfiles to use Ubuntu MCR mirror

### DIFF
--- a/docker/app_dev
+++ b/docker/app_dev
@@ -4,17 +4,17 @@
 ARG platform=sgx
 
 # SGX
-FROM ubuntu:20.04 AS base-sgx
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:20.04 AS base-sgx
 
 WORKDIR /
 COPY ./docker/sgx_deps_pin.sh /
 RUN ./sgx_deps_pin.sh && rm /sgx_deps_pin.sh
 
 # SNP
-FROM ubuntu:20.04 AS base-snp
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:20.04 AS base-snp
 
 # Virtual
-FROM ubuntu:20.04 AS base-virtual
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:20.04 AS base-virtual
 
 # Final dev image
 FROM base-${platform} AS final

--- a/docker/app_run
+++ b/docker/app_run
@@ -4,17 +4,17 @@
 ARG platform=sgx
 
 # SGX
-FROM ubuntu:20.04 AS base-sgx
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:20.04 AS base-sgx
 
 WORKDIR /
 COPY ./docker/sgx_deps_pin.sh /
 RUN ./sgx_deps_pin.sh && rm ./sgx_deps_pin.sh
 
 # SNP
-FROM ubuntu:20.04 AS base-snp
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:20.04 AS base-snp
 
 # Virtual
-FROM ubuntu:20.04 AS base-virtual
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:20.04 AS base-virtual
 
 # Final runtime image
 FROM base-${platform} AS final

--- a/docker/ccf_ci
+++ b/docker/ccf_ci
@@ -4,17 +4,17 @@
 ARG platform=sgx
 
 # SGX
-FROM ubuntu:20.04 AS base-sgx
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:20.04 AS base-sgx
 
 WORKDIR /
 COPY ./docker/sgx_deps_pin.sh /
 RUN ./sgx_deps_pin.sh && rm ./sgx_deps_pin.sh
 
 # SNP
-FROM ubuntu:20.04 AS base-snp
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:20.04 AS base-snp
 
 # Virtual
-FROM ubuntu:20.04 AS base-virtual
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:20.04 AS base-virtual
 
 # Final CCF CI image
 FROM base-${platform} AS final


### PR DESCRIPTION
These images are the same (see below), but we prefer relying on MCR mirror to reduce dependency of third-party services.

```
$ docker pull ubuntu:20.04
20.04: Pulling from library/ubuntu
ca1778b69356: Already exists 
Digest: sha256:db8bf6f4fb351aa7a26e27ba2686cf35a6a409f65603e59d4c203e58387dc6b3
Status: Downloaded newer image for ubuntu:20.04
docker.io/library/ubuntu:20.04

$ docker pull mcr.microsoft.com/mirror/docker/library/ubuntu:20.04
20.04: Pulling from mirror/docker/library/ubuntu
Digest: sha256:db8bf6f4fb351aa7a26e27ba2686cf35a6a409f65603e59d4c203e58387dc6b3
Status: Downloaded newer image for mcr.microsoft.com/mirror/docker/library/ubuntu:20.04
mcr.microsoft.com/mirror/docker/library/ubuntu:20.04
```