### PR TITLE
Disable `release/2.x` CI and doc generation

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -23,7 +23,7 @@ schedules:
         - main
         - "release/*"
       exclude:
-        - "release/1.x"
+        - "release/[1-2].x"
     always: true
 
 resources:

--- a/.azure_pipelines_snp.yml
+++ b/.azure_pipelines_snp.yml
@@ -17,8 +17,7 @@ trigger:
       - main
       - "release/*"
     exclude:
-      - "release/1.x"
-      - "release/2.x"
+      - "release/[1-2].x"
 
 schedules:
   - cron: "0 9-18/3 * * Mon-Fri"

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,7 +1,7 @@
 {
   "repoOwner": "microsoft",
   "repoName": "ccf",
-  "targetBranchChoices": ["release/2.x"],
+  "targetBranchChoices": ["release/3.x", "release/4.x"],
   "branchLabelMapping": {
     "^(.+)-todo$": "release/$1"
   },

--- a/.daily.yml
+++ b/.daily.yml
@@ -19,7 +19,7 @@ schedules:
         - main
         - "release/*"
       exclude:
-        - "release/1.x"
+        - "release/[1-2].x"
     always: true
 
 resources:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -221,13 +221,13 @@ breathe_default_project = "CCF"
 # Set up multiversion extension
 
 smv_tag_whitelist = None
-smv_branch_whitelist = r"^(main)|(release\/([2-9]|\d\d\d*)\.x)$"
+smv_branch_whitelist = r"^(main)|(release\/([3-9]|\d\d\d*)\.x)$"
 smv_remote_whitelist = None
 smv_outputdir_format = "{ref.name}"
 
 assert re.match(smv_branch_whitelist, "main")
 assert not re.match(smv_branch_whitelist, "release/1.x")
-assert re.match(smv_branch_whitelist, "release/2.x")
+assert not re.match(smv_branch_whitelist, "release/2.x")
 assert re.match(smv_branch_whitelist, "release/100.x")
 assert not re.match(smv_branch_whitelist, "release/1.x_feature")
 


### PR DESCRIPTION
CCF [2.x is now end of life](https://microsoft.github.io/CCF/main/build_apps/release_policy.html#support-calendar) so this PR disables CI pipelines and documentation generation for `release/2.x`. 