### PR TITLE
[release/3.x] Cherry pick: Remove non-clang15 SNP/Virtual containers (#5316) | Update ADO virtual pools | Update SGX pools to new subscription | Update to CI pool in new subscription | Migrate to new RG

### DIFF
--- a/.azure-pipelines-quictls.yml
+++ b/.azure-pipelines-quictls.yml
@@ -17,8 +17,8 @@ parameters:
 
 jobs:
   - job: build_quictls
-    container: ccfmsrc.azurecr.io/ccf/ci:14-02-2023-2-virtual
-    pool: 1es-dv4-focal
+    container: ccfmsrc.azurecr.io/ccf/ci:27-04-2023-clang15
+    pool: ado-virtual-ccf-sub
 
     strategy:
       matrix:

--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -2,10 +2,10 @@ parameters:
   env:
     Virtual:
       container: virtual
-      pool: 1es-dv4-focal
+      pool: ado-virtual-ccf-sub
     SGX:
       container: sgx
-      pool: 1es-DC16s_v3-focal
+      pool: ado-sgx-ccf-sub
 
   build:
     common:

--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -13,7 +13,8 @@ parameters:
       container: sgx
       pool: ado-sgx-ccf-sub
     SNPCC:
-      pool: sev-snp-pool
+      container: snp
+      pool: ado-virtual-ccf-sub
 
   build:
     common:

--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -8,10 +8,10 @@ parameters:
         vmImage: ubuntu-20.04
     Virtual:
       container: virtual
-      pool: 1es-dv4-focal
+      pool: ado-virtual-ccf-sub
     SGX:
       container: sgx
-      pool: 1es-DC16s_v3-focal
+      pool: ado-sgx-ccf-sub
     SNPCC:
       pool: sev-snp-pool
 

--- a/.azure-pipelines-templates/stress-matrix.yml
+++ b/.azure-pipelines-templates/stress-matrix.yml
@@ -4,7 +4,7 @@ jobs:
       target: SGX
       env:
         container: sgx
-        pool: 1es-DC16s_v3-focal
+        pool: ado-sgx-ccf-sub
       cmake_args: "-DCOMPILE_TARGET=sgx"
       suffix: "StressTest"
       artifact_name: "StressTest"

--- a/.daily.yml
+++ b/.daily.yml
@@ -25,7 +25,7 @@ schedules:
 resources:
   containers:
     - container: virtual
-      image: ccfmsrc.azurecr.io/ccf/ci:14-02-2023-2-virtual
+      image: ccfmsrc.azurecr.io/ccf/ci:27-04-2023-virtual-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE
 
     - container: sgx

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
   "name": "CCF Development Environment",
-  "image": "ccfmsrc.azurecr.io/ccf/ci:14-02-2023-2-virtual",
+  "image": "ccfmsrc.azurecr.io/ccf/ci:27-04-2023-virtual-clang15",
   "runArgs": [],
-  "extensions": ["ms-vscode.cpptools", "ms-python.python"]
+  "extensions": [
+    "ms-vscode.cpptools",
+    "ms-python.python"
+  ]
 }

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: ccfmsrc.azurecr.io/ccf/ci:14-02-2023-2-virtual
+    container: ccfmsrc.azurecr.io/ccf/ci:27-04-2023-virtual-clang15
 
     steps:
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/ci-containers.yml
+++ b/.github/workflows/ci-containers.yml
@@ -24,11 +24,8 @@ jobs:
       - name: Build CCF CI sgx container
         run: docker build -f docker/ccf_ci . --build-arg="platform=sgx" -t $ACR_REGISTRY/ccf/ci:${{steps.tref.outputs.tag}}-sgx
 
-      - name: Build CCF CI snp container
-        run: docker build -f docker/ccf_ci . --build-arg="platform=snp" -t $ACR_REGISTRY/ccf/ci:${{steps.tref.outputs.tag}}-snp
-
-      - name: Build CCF CI virtual container
-        run: docker build -f docker/ccf_ci . --build-arg="platform=virtual" -t $ACR_REGISTRY/ccf/ci:${{steps.tref.outputs.tag}}-virtual
+      - name: Build CCF CI virtual clang 15 container
+        run: docker build -f docker/ccf_ci . --build-arg="platform=virtual" --build-arg="clang_version=15" -t $ACR_REGISTRY/ccf/ci:${{steps.tref.outputs.tag}}-virtual-clang15
 
       - name: Log in
         run: docker login -u $ACR_TOKEN_NAME -p ${{ secrets.ACR_CI_PUSH_TOKEN_PASSWORD }} $ACR_REGISTRY

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -28,7 +28,8 @@ jobs:
       env:
         container: virtual
         pool: ado-virtual-ccf-sub
-      cmake_args: "-DCOMPILE_TARGET=virtual -DWORKER_THREADS=2 -DENABLE_2TX_RECONFIG=ON"
+      cmake_args: "-DCOMPILE_TARGET=virtual -DWORKER_THREADS=2"
+      cmake_env: "CC=`which clang-15` CXX=`which clang++-15`"
       suffix: "MultiThread"
       artifact_name: "MultiThread"
       ctest_filter: '-LE "perf"'

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -27,7 +27,7 @@ jobs:
       target: Virtual
       env:
         container: virtual
-        pool: 1es-dv4-focal
+        pool: ado-virtual-ccf-sub
       cmake_args: "-DCOMPILE_TARGET=virtual -DWORKER_THREADS=2 -DENABLE_2TX_RECONFIG=ON"
       suffix: "MultiThread"
       artifact_name: "MultiThread"


### PR DESCRIPTION
Backports the following commits to `release/3.x`:
 - [Remove non-clang15 SNP/Virtual containers (#5316)](https://github.com/microsoft/CCF/pull/5345)
 - [Update ADO virtual pools](https://github.com/microsoft/CCF/pull/5345)
 - [Update SGX pools to new subscription](https://github.com/microsoft/CCF/pull/5345)
 - [Update to CI pool in new subscription](https://github.com/microsoft/CCF/pull/5345)
 - [Migrate to new RG](https://github.com/microsoft/CCF/pull/5345)