### PR TITLE
Documentation: Point from C++ crypto page to JS crypto API

### DIFF
--- a/doc/build_apps/crypto.rst
+++ b/doc/build_apps/crypto.rst
@@ -3,6 +3,7 @@ Cryptography API
 
 For convenience, CCF provides access to commonly used cryptographic primitives to applications.
 
+.. note:: This page describes the C++ API. For the API for TypeScript/JavaScript applications, see :typedoc:module:`ccf-app/crypto`.
 
 Hashing
 -------


### PR DESCRIPTION
There are various places where our docs are a little unclear. They were initially written to focus on the C++ API, and we should do a pass to rebalance/redirect to the JS equivalents where appropriate. This is one of the lowest hanging fruits.