### PR TITLE
[release/4.x] Cherry pick: Ensure e2e HTTP limit args are passed all the way through to the nodes (#5348)

### DIFF
--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -22,16 +22,8 @@ def nodes(args, n):
     return [
         infra.interfaces.HostSpec(
             rpc_interfaces={
-                infra.interfaces.PRIMARY_RPC_INTERFACE: infra.interfaces.RPCInterface(
-                    max_open_sessions_soft=args.max_open_sessions,
-                    max_open_sessions_hard=args.max_open_sessions_hard,
-                    max_http_body_size=args.max_http_body_size,
-                    max_http_header_size=args.max_http_header_size,
-                    max_http_headers_count=args.max_http_headers_count,
-                    forwarding_timeout_ms=args.forwarding_timeout_ms,
-                    app_protocol=infra.interfaces.AppProtocol.HTTP2
-                    if args.http2
-                    else infra.interfaces.AppProtocol.HTTP1,
+                infra.interfaces.PRIMARY_RPC_INTERFACE: infra.interfaces.RPCInterface.from_args(
+                    args
                 )
             }
         )
@@ -371,6 +363,7 @@ def cli_args(add=lambda x: None, parser=None, accept_unknown=False):
         "--max-http-headers-count",
         help="Maximum number of headers in single HTTP request",
         default=256,
+        type=int,
     )
     parser.add_argument(
         "--http2",

--- a/tests/infra/interfaces.py
+++ b/tests/infra/interfaces.py
@@ -105,6 +105,32 @@ class RPCInterface(Interface):
     app_protocol: AppProtocol = AppProtocol.HTTP1
 
     @staticmethod
+    def from_args(args):
+        return RPCInterface(
+            max_open_sessions_soft=args.max_open_sessions,
+            max_open_sessions_hard=args.max_open_sessions_hard,
+            max_http_body_size=args.max_http_body_size,
+            max_http_header_size=args.max_http_header_size,
+            max_http_headers_count=args.max_http_headers_count,
+            forwarding_timeout_ms=args.forwarding_timeout_ms,
+            app_protocol="HTTP2" if args.http2 else "HTTP1",
+        )
+
+    def parse_from_str(self, s):
+        # Format: local|ssh(,tcp|udp)://hostname:port
+
+        self.protocol, address = s.split("://")
+        self.transport = DEFAULT_TRANSPORT_PROTOCOL
+        if "," in self.protocol:
+            self.protocol, self.transport = self.protocol.split(",")
+
+        if "," in address:
+            address, published_address = address.split(",")
+            self.public_host, self.public_port = split_netloc(published_address)
+
+        self.host, self.port = split_netloc(address)
+
+    @staticmethod
     def to_json(interface):
         http_config = {
             "max_body_size": str(interface.max_http_body_size),
@@ -192,31 +218,5 @@ class HostSpec:
             rpc_interfaces={
                 name: RPCInterface.from_json(rpc_interface)
                 for name, rpc_interface in rpc_interfaces_json.items()
-            }
-        )
-
-    @staticmethod
-    def from_str(s, http2=False):
-        # Format: local|ssh(,tcp|udp)://hostname:port
-        protocol, address = s.split("://")
-        transport = DEFAULT_TRANSPORT_PROTOCOL
-        if "," in protocol:
-            protocol, transport = protocol.split(",")
-        pub_host, pub_port = None, None
-        if "," in address:
-            address, published_address = address.split(",")
-            pub_host, pub_port = split_netloc(published_address)
-        host, port = split_netloc(address)
-        return HostSpec(
-            rpc_interfaces={
-                PRIMARY_RPC_INTERFACE: RPCInterface(
-                    protocol=protocol,
-                    transport=transport,
-                    host=host,
-                    port=port,
-                    public_host=pub_host,
-                    public_port=pub_port,
-                    app_protocol=AppProtocol.HTTP2 if http2 else AppProtocol.HTTP1,
-                )
             }
         )

--- a/tests/infra/interfaces.py
+++ b/tests/infra/interfaces.py
@@ -113,7 +113,7 @@ class RPCInterface(Interface):
             max_http_header_size=args.max_http_header_size,
             max_http_headers_count=args.max_http_headers_count,
             forwarding_timeout_ms=args.forwarding_timeout_ms,
-            app_protocol="HTTP2" if args.http2 else "HTTP1",
+            app_protocol=AppProtocol.HTTP2 if args.http2 else AppProtocol.HTTP1,
         )
 
     def parse_from_str(self, s):

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -291,6 +291,14 @@ class Network:
         perf = (
             (str(node_id) in self.perf_nodes) if self.perf_nodes is not None else False
         )
+
+        if isinstance(host, str):
+            interface = infra.interfaces.RPCInterface()
+            interface.parse_from_str(host)
+            host = infra.interfaces.HostSpec(
+                rpc_interfaces={infra.interfaces.PRIMARY_RPC_INTERFACE: interface}
+            )
+
         node = infra.node.Node(
             node_id,
             host,

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -152,7 +152,7 @@ class Node:
         requires_docker_remote = nodes_in_container or os.getenv("CONTAINER_NODES")
 
         if isinstance(self.host, str):
-            self.host = infra.interfaces.HostSpec.from_str(self.host)
+            raise ValueError("Translate host to HostSpec before you get here")
 
         for interface_name, rpc_interface in self.host.rpc_interfaces.items():
             # Main RPC interface determines remote implementation

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -791,7 +791,10 @@ class CCFRemote(object):
             exe_files += [config_file]
 
             with open(config_file, "w", encoding="utf-8") as f:
-                f.write(output)
+                # Parse and re-emit output to produce consistently formatted (indented) JSON.
+                # This will also ensure the render produced valid JSON
+                j = json.loads(output)
+                json.dump(j, f, indent=2)
 
         exe_files += [self.BIN, enclave_file] + self.DEPS
         data_files += [self.ledger_dir] if self.ledger_dir else []

--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -25,10 +25,16 @@ def run(args):
                 )
             ]
     else:
-        hosts = args.node or DEFAULT_NODES
-        hosts = [
-            infra.interfaces.HostSpec.from_str(node, http2=args.http2) for node in hosts
-        ]
+        host_descs = args.node or DEFAULT_NODES
+        hosts = []
+        for host_desc in host_descs:
+            interface = infra.interfaces.RPCInterface.from_args(args)
+            interface.parse_from_str(host_desc)
+            hosts.append(
+                infra.interfaces.HostSpec(
+                    rpc_interfaces={infra.interfaces.PRIMARY_RPC_INTERFACE: interface}
+                )
+            )
 
     if not args.verbose:
         LOG.remove()


### PR DESCRIPTION
Backports the following commits to `release/4.x`:
 - [Ensure e2e HTTP limit args are passed all the way through to the nodes (#5348)](https://github.com/microsoft/CCF/pull/5348)