### PR TITLE
Disable flaky indexing test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -947,13 +947,12 @@ if(BUILD_TESTS)
       historical_queries_test PRIVATE http_parser.host sss.host ccf_kv.host
     )
 
-    add_unit_test(
-      indexing_test ${CMAKE_CURRENT_SOURCE_DIR}/src/indexing/test/indexing.cpp
-      ${CMAKE_CURRENT_SOURCE_DIR}/src/indexing/test/lfs.cpp
-    )
-    target_link_libraries(
-      indexing_test PRIVATE ccf_endpoints.host sss.host ccf_kv.host
-    )
+    # Temporarily disabled flaky test
+    # https://github.com/microsoft/CCF/issues/4403 add_unit_test( indexing_test
+    # ${CMAKE_CURRENT_SOURCE_DIR}/src/indexing/test/indexing.cpp
+    # ${CMAKE_CURRENT_SOURCE_DIR}/src/indexing/test/lfs.cpp )
+    # target_link_libraries( indexing_test PRIVATE ccf_endpoints.host sss.host
+    # ccf_kv.host )
 
     add_unit_test(
       snapshot_test ${CMAKE_CURRENT_SOURCE_DIR}/src/node/test/snapshot.cpp


### PR DESCRIPTION
Disabling this test for now to avoid flaky CI.

See https://github.com/microsoft/CCF/issues/4403