### PR TITLE
Avoid taking too-early dependency on `previous_signature_seqno`

### DIFF
--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -423,7 +423,7 @@ namespace kv
       const kv::TxID& tx_id, kv::Term term_of_next_version_) = 0;
     virtual void compact(Version v) = 0;
     virtual void set_term(kv::Term) = 0;
-    virtual std::vector<uint8_t> serialise_tree(size_t from, size_t to) = 0;
+    virtual std::vector<uint8_t> serialise_tree(size_t to) = 0;
     virtual void set_endorsed_certificate(const crypto::Pem& cert) = 0;
     virtual void start_signature_emit_timer() = 0;
   };

--- a/src/node/test/snapshotter.cpp
+++ b/src/node/test/snapshotter.cpp
@@ -118,7 +118,7 @@ bool record_signature(
   bool requires_snapshot = snapshotter->record_committable(idx);
   snapshotter->record_signature(
     idx, dummy_signature, kv::test::PrimaryNodeId, node_cert);
-  snapshotter->record_serialised_tree(idx, history->serialise_tree(1, idx));
+  snapshotter->record_serialised_tree(idx, history->serialise_tree(idx));
 
   return requires_snapshot;
 }
@@ -464,7 +464,7 @@ TEST_CASE("Rekey ledger while snapshot is in progress")
     auto trees =
       tx.rw<ccf::SerialisedMerkleTree>(ccf::Tables::SERIALISED_MERKLE_TREE);
     sigs->put({kv::test::PrimaryNodeId, 0, 0, {}, {}, {}, {}});
-    auto tree = history->serialise_tree(1, snapshot_idx - 1);
+    auto tree = history->serialise_tree(snapshot_idx - 1);
     trees->put(tree);
     tx.commit();
 


### PR DESCRIPTION
Fixing a crash noticed while testing #5306. Specifically, when running an SGX build with >5 threads, we'd see a crash during serialisation:

```
2023-06-21T13:36:35.874589Z -0.008 1   [fail ] ../src/kv/committable_tx.h:244       | Error during serialisation
2023-06-21T13:36:35.874664Z -0.008 1   [fail ] ../src/kv/committable_tx.h:245       | Error during serialisation: invalid leaf indices
2023-06-21T13:36:35.874688Z -0.008 1   [fatal] ../src/node/rpc/frontend.h:639       | Failed to serialise
```

With a bit more logging and chasing up the stack, what's actually happening here is that a `MerkleTreeHistoryPendingTx` _S_ has been scheduled but stalled for a while, and in the interim a different signature has arrived, committed, and been compacted, flushing the merkle tree past the `previous_signature_seqno` grabbed by _S_ (which is then used as the `from` argument when serialising a range of the merkle tree). We don't have any kind of locking between that acquisition and useage, so the value might be unsafe to use by then.

We discussed a few ways to add locking or acquire this `from` index later. This fix is a simple approach for safety which hopefully doesn't impact perf too much: rather than trying to produce signatures which span precisely the range from the previous signature to this signature (the minimal amount we can safely sign, but requiring atomic knowledge of the previous signature), we err on the side of signing too much and always sign the entire unflushed tree. This may lead to redundant signatures, but is a trivial way to ensure the `from` index is discovered (cheaply) under serialise's tree-state lock.