### PR TITLE
Remove gdb install

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,6 +27,5 @@
     "ghcr.io/devcontainers/features/docker-from-docker:1": {
       "version": "latest"
     }
-  },
-  "postCreateCommand": "DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install gdb -y"
+  }
 }


### PR DESCRIPTION
This is mainly prompted by the fact that apt update does not seem to work today as a result of the nodejs apt repo being in a bad state.

More generally though, imposing the time this takes on all users seems unwarranted. lldb works much better than gdb on our builds.