### PR TITLE
Update tls_client.h exception handling has been added

### DIFF
--- a/src/clients/tls_client.h
+++ b/src/clients/tls_client.h
@@ -128,7 +128,12 @@ namespace client
       ctx(TLS_client_method()),
       bio(ctx)
     {
-      init();
+      try {
+        init();
+      } catch (const std::exception& e) {
+        connected = false;
+        throw;
+      }
     }
 
     TlsClient(const TlsClient& c) :
@@ -139,7 +144,12 @@ namespace client
       ctx(TLS_client_method()),
       bio(ctx)
     {
-      init();
+      try {
+        init();
+      } catch (const std::exception& e) {
+        connected = false;
+        throw;
+      }
     }
 
     virtual ~TlsClient() {}


### PR DESCRIPTION
In this code version, exception handling has been added to the TlsClient constructor. If the initialization fails, such as when calling init(), an exception will be thrown, and the connected flag will be set to false.