### PR TITLE
Format with Prettier 3.0.0

### DIFF
--- a/js/ccf-app/src/consensus.ts
+++ b/js/ccf-app/src/consensus.ts
@@ -14,21 +14,21 @@ import { ccf } from "./global.js";
  * @inheritDoc global!CCFConsensus.getLastCommittedTxId
  */
 export const getLastCommittedTxId = ccf.consensus.getLastCommittedTxId.bind(
-  ccf.consensus
+  ccf.consensus,
 );
 
 /**
  * @inheritDoc global!CCFConsensus.getStatusForTxId
  */
 export const getStatusForTxId = ccf.consensus.getStatusForTxId.bind(
-  ccf.consensus
+  ccf.consensus,
 );
 
 /**
  * @inheritDoc global!CCFConsensus.getViewForSeqno
  */
 export const getViewForSeqno = ccf.consensus.getViewForSeqno.bind(
-  ccf.consensus
+  ccf.consensus,
 );
 
 export { TransactionStatus } from "./global";

--- a/js/ccf-app/src/converters.ts
+++ b/js/ccf-app/src/converters.ts
@@ -400,7 +400,7 @@ export const string: DataConverter<string> = new StringConverter();
  * ```
  */
 export const json: <T extends JsonCompatible<T>>() => DataConverter<T> = <
-  T extends JsonCompatible<T>
+  T extends JsonCompatible<T>,
 >() => new JSONConverter<T>();
 
 /**
@@ -423,9 +423,9 @@ export const json: <T extends JsonCompatible<T>>() => DataConverter<T> = <
  * @param clazz The TypedArray class, for example `Uint8Array`.
  */
 export const typedArray: <T extends TypedArray>(
-  clazz: TypedArrayConstructor<T>
+  clazz: TypedArrayConstructor<T>,
 ) => DataConverter<T> = <T extends TypedArray>(
-  clazz: TypedArrayConstructor<T>
+  clazz: TypedArrayConstructor<T>,
 ) => new TypedArrayConverter(clazz);
 
 /**

--- a/js/ccf-app/src/endpoints.ts
+++ b/js/ccf-app/src/endpoints.ts
@@ -259,7 +259,7 @@ export interface Response<T extends ResponseBodyType<T> = any> {
  */
 export type EndpointFn<
   A extends JsonCompatible<A> = any,
-  B extends ResponseBodyType<B> = any
+  B extends ResponseBodyType<B> = any,
 > = (request: Request<A>) => Response<B>;
 
 /**

--- a/js/ccf-app/src/global.ts
+++ b/js/ccf-app/src/global.ts
@@ -44,7 +44,7 @@ export interface KvMap {
   delete(key: ArrayBuffer): void;
   clear(): void;
   forEach(
-    callback: (value: ArrayBuffer, key: ArrayBuffer, kvmap: KvMap) => void
+    callback: (value: ArrayBuffer, key: ArrayBuffer, kvmap: KvMap) => void,
   ): void;
   size: number;
 }
@@ -326,7 +326,7 @@ export interface CCFCrypto {
   sign(
     algorithm: SigningAlgorithm,
     key: string,
-    plaintext: ArrayBuffer
+    plaintext: ArrayBuffer,
   ): ArrayBuffer;
 
   /**
@@ -343,7 +343,7 @@ export interface CCFCrypto {
     algorithm: SigningAlgorithm,
     key: string,
     signature: ArrayBuffer,
-    plaintext: ArrayBuffer
+    plaintext: ArrayBuffer,
   ): boolean;
 
   /**
@@ -384,7 +384,7 @@ export interface CCFCrypto {
   wrapKey(
     key: ArrayBuffer,
     wrappingKey: ArrayBuffer,
-    wrapAlgo: WrapAlgoParams
+    wrapAlgo: WrapAlgoParams,
   ): ArrayBuffer;
 
   /**
@@ -582,7 +582,7 @@ export interface CCFHistorical {
     handle: number,
     startSeqno: number,
     endSeqno: number,
-    secondsUntilExpiry: number
+    secondsUntilExpiry: number,
   ): HistoricalState[] | null;
 
   /** Drop cached states for the given handle.
@@ -648,7 +648,7 @@ export interface CCF {
   wrapKey(
     key: ArrayBuffer,
     wrappingKey: ArrayBuffer,
-    wrapAlgo: WrapAlgoParams
+    wrapAlgo: WrapAlgoParams,
   ): ArrayBuffer;
 
   /**
@@ -736,6 +736,6 @@ export interface OpenEnclave {
   verifyOpenEnclaveEvidence(
     format: string | undefined,
     evidence: ArrayBuffer,
-    endorsements?: ArrayBuffer
+    endorsements?: ArrayBuffer,
   ): EvidenceClaims;
 }

--- a/js/ccf-app/src/historical.ts
+++ b/js/ccf-app/src/historical.ts
@@ -45,7 +45,7 @@ export const getStateRange = ccf.historical.getStateRange.bind(ccf.historical);
  * @inheritDoc global!CCFHistorical.dropCachedStates
  */
 export const dropCachedStates = ccf.historical.dropCachedStates.bind(
-  ccf.historical
+  ccf.historical,
 );
 
 export { HistoricalState, Receipt, Proof, ProofElement } from "./global";

--- a/js/ccf-app/src/kv.ts
+++ b/js/ccf-app/src/kv.ts
@@ -44,7 +44,7 @@ export class TypedKvMap<K, V> {
   constructor(
     private kv: KvMap,
     private kt: DataConverter<K>,
-    private vt: DataConverter<V>
+    private vt: DataConverter<V>,
   ) {}
 
   has(key: K): boolean {
@@ -76,7 +76,7 @@ export class TypedKvMap<K, V> {
     this.kv.forEach(function (
       raw_v: ArrayBuffer,
       raw_k: ArrayBuffer,
-      table: KvMap
+      table: KvMap,
     ) {
       callback(vt.decode(raw_v), kt.decode(raw_k), typedMap);
     });
@@ -103,7 +103,7 @@ export class TypedKvMap<K, V> {
 export function typedKv<K, V>(
   nameOrMap: string | KvMap,
   kt: DataConverter<K>,
-  vt: DataConverter<V>
+  vt: DataConverter<V>,
 ) {
   const kvMap = typeof nameOrMap === "string" ? ccf.kv[nameOrMap] : nameOrMap;
   return new TypedKvMap(kvMap, kt, vt);

--- a/js/ccf-app/src/polyfill.ts
+++ b/js/ccf-app/src/polyfill.ts
@@ -66,7 +66,7 @@ class KvMapPolyfill implements KvMap {
     this.map.clear();
   }
   forEach(
-    callback: (value: ArrayBuffer, key: ArrayBuffer, kvmap: KvMap) => void
+    callback: (value: ArrayBuffer, key: ArrayBuffer, kvmap: KvMap) => void,
   ): void {
     this.map.forEach((value, key, _) => {
       callback(value, unbase64(key), this);
@@ -106,7 +106,7 @@ class CCFPolyfill implements CCF {
       handle: number,
       startSeqno: number,
       endSeqno: number,
-      secondsUntilExpiry: number
+      secondsUntilExpiry: number,
     ) {
       throw new Error("Not implemented");
     },
@@ -129,7 +129,7 @@ class CCFPolyfill implements CCF {
     sign(
       algorithm: SigningAlgorithm,
       key: string,
-      data: ArrayBuffer
+      data: ArrayBuffer,
     ): ArrayBuffer {
       let padding = undefined;
       const privKey = jscrypto.createPrivateKey(key);
@@ -166,7 +166,7 @@ class CCFPolyfill implements CCF {
       algorithm: SigningAlgorithm,
       key: string,
       signature: ArrayBuffer,
-      data: ArrayBuffer
+      data: ArrayBuffer,
     ): boolean {
       let padding = undefined;
       const pubKey = jscrypto.createPublicKey(key);
@@ -192,7 +192,7 @@ class CCFPolyfill implements CCF {
           null,
           new Uint8Array(data),
           pubKey,
-          new Uint8Array(signature)
+          new Uint8Array(signature),
         );
       }
       const hashAlg = (algorithm.hash as string).replace("-", "").toLowerCase();
@@ -204,7 +204,7 @@ class CCFPolyfill implements CCF {
           dsaEncoding: "ieee-p1363",
           padding: padding,
         },
-        new Uint8Array(signature)
+        new Uint8Array(signature),
       );
     },
     generateAesKey(size: number): ArrayBuffer {
@@ -259,7 +259,7 @@ class CCFPolyfill implements CCF {
     wrapKey(
       key: ArrayBuffer,
       wrappingKey: ArrayBuffer,
-      parameters: WrapAlgoParams
+      parameters: WrapAlgoParams,
     ): ArrayBuffer {
       if (parameters.name === "RSA-OAEP") {
         return nodeBufToArrBuf(
@@ -272,18 +272,18 @@ class CCFPolyfill implements CCF {
                 : undefined,
               padding: jscrypto.constants.RSA_PKCS1_OAEP_PADDING,
             },
-            new Uint8Array(key)
-          )
+            new Uint8Array(key),
+          ),
         );
       } else if (parameters.name === "AES-KWP") {
         const iv = Buffer.from("A65959A6", "hex"); // defined in RFC 5649
         const cipher = jscrypto.createCipheriv(
           "id-aes256-wrap-pad",
           new Uint8Array(wrappingKey),
-          iv
+          iv,
         );
         return nodeBufToArrBuf(
-          Buffer.concat([cipher.update(new Uint8Array(key)), cipher.final()])
+          Buffer.concat([cipher.update(new Uint8Array(key)), cipher.final()]),
         );
       } else if (parameters.name === "RSA-OAEP-AES-KWP") {
         const randomAesKey = this.generateAesKey(parameters.aesKeySize);
@@ -295,7 +295,7 @@ class CCFPolyfill implements CCF {
           name: "AES-KWP",
         });
         return nodeBufToArrBuf(
-          Buffer.concat([Buffer.from(wrap1), Buffer.from(wrap2)])
+          Buffer.concat([Buffer.from(wrap1), Buffer.from(wrap2)]),
         );
       } else {
         throw new Error("unsupported wrapAlgo.name");
@@ -304,7 +304,7 @@ class CCFPolyfill implements CCF {
     digest(algorithm: DigestAlgorithm, data: ArrayBuffer): ArrayBuffer {
       if (algorithm === "SHA-256") {
         return nodeBufToArrBuf(
-          jscrypto.createHash("sha256").update(new Uint8Array(data)).digest()
+          jscrypto.createHash("sha256").update(new Uint8Array(data)).digest(),
         );
       } else {
         throw new Error("unsupported algorithm");
@@ -330,14 +330,14 @@ class CCFPolyfill implements CCF {
         return true;
       } else {
         throw new Error(
-          "X509 validation unsupported, Node.js version too old (< 15.6.0)"
+          "X509 validation unsupported, Node.js version too old (< 15.6.0)",
         );
       }
     },
     isValidX509CertChain(chain: string, trusted: string): boolean {
       if (!("X509Certificate" in jscrypto)) {
         throw new Error(
-          "X509 validation unsupported, Node.js version too old (< 15.6.0)"
+          "X509 validation unsupported, Node.js version too old (< 15.6.0)",
         );
       }
       try {
@@ -349,7 +349,7 @@ class CCFPolyfill implements CCF {
           }
           const pems = items.slice(0, -1).map((p) => p + sep);
           const arr = pems.map(
-            (pem) => new (<any>jscrypto).X509Certificate(pem)
+            (pem) => new (<any>jscrypto).X509Certificate(pem),
           );
           return arr;
         };
@@ -374,7 +374,7 @@ class CCFPolyfill implements CCF {
           }
         }
         throw new Error(
-          "none of the chain certificates are identical to or issued by a trusted certificate"
+          "none of the chain certificates are identical to or issued by a trusted certificate",
         );
       } catch (e: any) {
         console.error(`certificate chain validation failed: ${e.message}`);
@@ -518,7 +518,7 @@ class CCFPolyfill implements CCF {
   wrapKey(
     key: ArrayBuffer,
     wrappingKey: ArrayBuffer,
-    parameters: WrapAlgoParams
+    parameters: WrapAlgoParams,
   ): ArrayBuffer {
     return this.crypto.wrapKey(key, wrappingKey, parameters);
   }
@@ -550,7 +550,7 @@ class OpenEnclavePolyfill implements OpenEnclave {
   verifyOpenEnclaveEvidence(
     format: string | undefined,
     evidence: ArrayBuffer,
-    endorsements?: ArrayBuffer
+    endorsements?: ArrayBuffer,
   ): EvidenceClaims {
     throw new Error("Method not implemented.");
   }

--- a/js/ccf-app/test/converters.test.ts
+++ b/js/ccf-app/test/converters.test.ts
@@ -53,7 +53,7 @@ describe("converters", function () {
     const val = new Uint8Array([42]).buffer;
     assert.deepEqual(
       conv.arrayBuffer.decode(conv.arrayBuffer.encode(val)),
-      val
+      val,
     );
   });
 });

--- a/js/ccf-app/test/crypto.ts
+++ b/js/ccf-app/test/crypto.ts
@@ -12,7 +12,7 @@ function nodeBufToArrBuf(buf: Buffer): ArrayBuffer {
 export function unwrapKey(
   wrappedKey: ArrayBuffer,
   unwrappingKey: ArrayBuffer,
-  unwrapAlgo: WrapAlgoParams
+  unwrapAlgo: WrapAlgoParams,
 ): ArrayBuffer {
   if (unwrapAlgo.name == "RSA-OAEP") {
     return nodeBufToArrBuf(
@@ -22,21 +22,21 @@ export function unwrapKey(
           oaepHash: "sha256",
           padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
         },
-        new Uint8Array(wrappedKey)
-      )
+        new Uint8Array(wrappedKey),
+      ),
     );
   } else if (unwrapAlgo.name == "AES-KWP") {
     const iv = Buffer.from("A65959A6", "hex"); // defined in RFC 5649
     const decipher = crypto.createDecipheriv(
       "id-aes256-wrap-pad",
       new Uint8Array(unwrappingKey),
-      iv
+      iv,
     );
     return nodeBufToArrBuf(
       Buffer.concat([
         decipher.update(new Uint8Array(wrappedKey)),
         decipher.final(),
-      ])
+      ]),
     );
   } else if (unwrapAlgo.name == "RSA-OAEP-AES-KWP") {
     /*
@@ -77,7 +77,7 @@ export function generateSelfSignedCert() {
   cert.publicKey = forge.pki.publicKeyFromPem(keys.publicKey);
   cert.sign(
     forge.pki.privateKeyFromPem(keys.privateKey),
-    forge.md.sha256.create()
+    forge.md.sha256.create(),
   );
   const certPem = forge.pki.certificateToPem(cert);
   return {
@@ -101,7 +101,7 @@ export function generateCertChain(len: number): string[] {
           type: "pkcs8",
           format: "pem",
         },
-      })
+      }),
     );
   }
   const certs = [];
@@ -111,7 +111,7 @@ export function generateCertChain(len: number): string[] {
     const signer = i < len - 1 ? keyPairs[i + 1] : keyPairs[i];
     cert.sign(
       forge.pki.privateKeyFromPem(signer.privateKey),
-      forge.md.sha256.create()
+      forge.md.sha256.create(),
     );
     const certPem = forge.pki.certificateToPem(cert);
     certs.push(certPem);

--- a/js/ccf-app/test/polyfill.test.ts
+++ b/js/ccf-app/test/polyfill.test.ts
@@ -40,7 +40,7 @@ describe("polyfill", function () {
       assert.equal(ccf.crypto.generateAesKey(256).byteLength, 32);
       assert.notDeepEqual(
         ccf.crypto.generateAesKey(256),
-        ccf.crypto.generateAesKey(256)
+        ccf.crypto.generateAesKey(256),
       );
     });
   });
@@ -89,12 +89,12 @@ describe("polyfill", function () {
       const wrapped = ccf.crypto.wrapKey(
         key,
         ccf.strToBuf(wrappingKey.publicKey),
-        wrapAlgo
+        wrapAlgo,
       );
       const unwrapped = unwrapKey(
         wrapped,
         ccf.strToBuf(wrappingKey.privateKey),
-        wrapAlgo
+        wrapAlgo,
       );
       assert.deepEqual(unwrapped, key);
     });
@@ -118,12 +118,12 @@ describe("polyfill", function () {
       const wrapped = ccf.crypto.wrapKey(
         key,
         ccf.strToBuf(wrappingKey.publicKey),
-        wrapAlgo
+        wrapAlgo,
       );
       const unwrapped = unwrapKey(
         wrapped,
         ccf.strToBuf(wrappingKey.privateKey),
-        wrapAlgo
+        wrapAlgo,
       );
       assert.deepEqual(unwrapped, key);
     });
@@ -148,7 +148,7 @@ describe("polyfill", function () {
           hash: "SHA-256",
         },
         privateKey,
-        data
+        data,
       );
 
       {
@@ -161,8 +161,8 @@ describe("polyfill", function () {
               key: publicKey,
               dsaEncoding: "ieee-p1363",
             },
-            new Uint8Array(signature)
-          )
+            new Uint8Array(signature),
+          ),
         );
       }
 
@@ -175,8 +175,8 @@ describe("polyfill", function () {
           },
           publicKey,
           signature,
-          data
-        )
+          data,
+        ),
       );
 
       {
@@ -189,8 +189,8 @@ describe("polyfill", function () {
               key: publicKey,
               dsaEncoding: "ieee-p1363",
             },
-            new Uint8Array(signature)
-          )
+            new Uint8Array(signature),
+          ),
         );
       }
     });
@@ -213,7 +213,7 @@ describe("polyfill", function () {
           hash: "SHA-256",
         },
         privateKey,
-        data
+        data,
       );
 
       {
@@ -226,8 +226,8 @@ describe("polyfill", function () {
               key: publicKey,
               dsaEncoding: "ieee-p1363",
             },
-            new Uint8Array(signature)
-          )
+            new Uint8Array(signature),
+          ),
         );
       }
 
@@ -240,8 +240,8 @@ describe("polyfill", function () {
           },
           publicKey,
           signature,
-          data
-        )
+          data,
+        ),
       );
 
       {
@@ -254,8 +254,8 @@ describe("polyfill", function () {
               key: publicKey,
               dsaEncoding: "ieee-p1363",
             },
-            new Uint8Array(signature)
-          )
+            new Uint8Array(signature),
+          ),
         );
       }
     });
@@ -276,7 +276,7 @@ describe("polyfill", function () {
           name: "EdDSA",
         },
         privateKey,
-        data
+        data,
       );
 
       assert.isTrue(
@@ -284,8 +284,8 @@ describe("polyfill", function () {
           null,
           new Uint8Array(data),
           publicKey,
-          new Uint8Array(signature)
-        )
+          new Uint8Array(signature),
+        ),
       );
 
       // Also `signature` should be verified successfully with the JS API
@@ -296,8 +296,8 @@ describe("polyfill", function () {
           },
           publicKey,
           signature,
-          data
-        )
+          data,
+        ),
       );
 
       assert.isFalse(
@@ -305,8 +305,8 @@ describe("polyfill", function () {
           null,
           new Uint8Array(ccf.strToBuf("bar")),
           publicKey,
-          new Uint8Array(signature)
-        )
+          new Uint8Array(signature),
+        ),
       );
     });
   });
@@ -329,8 +329,8 @@ describe("polyfill", function () {
           },
           cert,
           signature,
-          data
-        )
+          data,
+        ),
       );
       assert.isTrue(
         ccf.crypto.verifySignature(
@@ -340,8 +340,8 @@ describe("polyfill", function () {
           },
           publicKey,
           signature,
-          data
-        )
+          data,
+        ),
       );
       assert.isNotTrue(
         ccf.crypto.verifySignature(
@@ -351,8 +351,8 @@ describe("polyfill", function () {
           },
           cert,
           signature,
-          ccf.strToBuf("bar")
-        )
+          ccf.strToBuf("bar"),
+        ),
       );
       assert.throws(() =>
         ccf.crypto.verifySignature(
@@ -362,8 +362,8 @@ describe("polyfill", function () {
           },
           publicKey,
           signature,
-          data
-        )
+          data,
+        ),
       );
     });
     it("performs ECDSA validation correctly", function () {
@@ -396,8 +396,8 @@ describe("polyfill", function () {
           },
           publicKey,
           signature,
-          data
-        )
+          data,
+        ),
       );
       assert.isNotTrue(
         ccf.crypto.verifySignature(
@@ -407,8 +407,8 @@ describe("polyfill", function () {
           },
           publicKey,
           signature,
-          ccf.strToBuf("bar")
-        )
+          ccf.strToBuf("bar"),
+        ),
       );
       assert.throws(() =>
         ccf.crypto.verifySignature(
@@ -418,8 +418,8 @@ describe("polyfill", function () {
           },
           publicKey,
           signature,
-          data
-        )
+          data,
+        ),
       );
     });
     it("performs EdDSA validation correctly", function () {
@@ -437,7 +437,7 @@ describe("polyfill", function () {
       const signature = crypto.sign(
         null,
         new Uint8Array(data),
-        crypto.createPrivateKey(privateKey)
+        crypto.createPrivateKey(privateKey),
       );
       assert.isTrue(
         ccf.crypto.verifySignature(
@@ -446,8 +446,8 @@ describe("polyfill", function () {
           },
           publicKey,
           signature,
-          data
-        )
+          data,
+        ),
       );
       assert.isNotTrue(
         ccf.crypto.verifySignature(
@@ -456,8 +456,8 @@ describe("polyfill", function () {
           },
           publicKey,
           signature,
-          ccf.strToBuf("bar")
-        )
+          ccf.strToBuf("bar"),
+        ),
       );
       assert.throws(() =>
         ccf.crypto.verifySignature(
@@ -467,8 +467,8 @@ describe("polyfill", function () {
           },
           publicKey,
           signature,
-          data
-        )
+          data,
+        ),
       );
     });
   });

--- a/samples/apps/logging/js/src/logging.js
+++ b/samples/apps/logging/js/src/logging.js
@@ -155,7 +155,7 @@ function get_historical_range_impl(request, isPrivate, nextLinkPrefix) {
     handle,
     range_begin,
     range_end,
-    expiry_seconds
+    expiry_seconds,
   );
   if (states === null) {
     return {
@@ -195,17 +195,17 @@ function get_historical_range_impl(request, isPrivate, nextLinkPrefix) {
     const next_page_start = range_end + 1;
     const next_page_end = Math.min(
       to_seqno,
-      next_page_start + max_seqno_per_page
+      next_page_start + max_seqno_per_page,
     );
     const next_page_handle = makeHandle(
       next_page_start,
       next_page_end,
-      parsedQuery.id
+      parsedQuery.id,
     );
     ccf.historical.getStateRange(
       next_page_handle,
       next_page_start,
-      next_page_end
+      next_page_end,
     );
 
     // NB: This path tells the caller to continue to ask until the end of
@@ -230,7 +230,7 @@ export function get_historical_range(request) {
   return get_historical_range_impl(
     request,
     true,
-    "/app/log/private/historical/range"
+    "/app/log/private/historical/range",
   );
 }
 
@@ -238,7 +238,7 @@ export function get_historical_range_public(request) {
   return get_historical_range_impl(
     request,
     false,
-    "/app/log/public/historical/range"
+    "/app/log/public/historical/range",
   );
 }
 
@@ -305,7 +305,7 @@ export function post_public(request) {
   if (params.record_claim) {
     const claims_digest = ccf.crypto.digest(
       "SHA-256",
-      ccf.strToBuf(params.msg)
+      ccf.strToBuf(params.msg),
     );
     ccf.rpc.setClaimsDigest(claims_digest);
   }
@@ -414,26 +414,26 @@ export function multi_auth(request) {
     lines.push("User TLS cert");
     lines.push(`The caller is a user with ID: ${request.caller.id}`);
     lines.push(
-      `The caller's user data is: ${JSON.stringify(request.caller.data)}`
+      `The caller's user data is: ${JSON.stringify(request.caller.data)}`,
     );
     lines.push(`The caller's cert is:\n${request.caller.cert}`);
   } else if (request.caller.policy === "member_cert") {
     lines.push("Member TLS cert");
     lines.push(`The caller is a member with ID: ${request.caller.id}`);
     lines.push(
-      `The caller's user data is: ${JSON.stringify(request.caller.data)}`
+      `The caller's user data is: ${JSON.stringify(request.caller.data)}`,
     );
     lines.push(`The caller's cert is:\n${request.caller.cert}`);
   } else if (request.caller.policy === "jwt") {
     lines.push("JWT");
     lines.push(
-      `The caller is identified by a JWT issued by: ${request.caller.jwt.keyIssuer}`
+      `The caller is identified by a JWT issued by: ${request.caller.jwt.keyIssuer}`,
     );
     lines.push(
-      `The JWT header is:\n${JSON.stringify(request.caller.jwt.header)}`
+      `The JWT header is:\n${JSON.stringify(request.caller.jwt.header)}`,
     );
     lines.push(
-      `The JWT payload is:\n${JSON.stringify(request.caller.jwt.payload)}`
+      `The JWT payload is:\n${JSON.stringify(request.caller.jwt.payload)}`,
     );
   } else if (request.caller.policy === "no_auth") {
     lines.push("Unauthenticated");

--- a/samples/apps/logging/js_perf/src/logging.js
+++ b/samples/apps/logging/js_perf/src/logging.js
@@ -26,7 +26,7 @@ export function post_private(request) {
   let params = request.body.json();
   ccf.kv["records"].set(
     ccf.strToBuf(params.id.toString()),
-    ccf.strToBuf(params.msg)
+    ccf.strToBuf(params.msg),
   );
   return { body: true };
 }

--- a/samples/constitutions/default/actions.js
+++ b/samples/constitutions/default/actions.js
@@ -8,7 +8,7 @@ class Action {
 function parseUrl(url) {
   // From https://tools.ietf.org/html/rfc3986#appendix-B
   const re = new RegExp(
-    "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
+    "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?",
   );
   const groups = url.match(re);
   if (!groups) {
@@ -146,7 +146,7 @@ function checkJwks(value, field) {
 function checkX509CertBundle(value, field) {
   if (!ccf.crypto.isValidX509CertBundle(value)) {
     throw new Error(
-      `${field} must be a valid X509 certificate (bundle) in PEM format`
+      `${field} must be a valid X509 certificate (bundle) in PEM format`,
     );
   }
 }
@@ -167,7 +167,7 @@ function invalidateOtherOpenProposals(proposalIdToRetain) {
 
 function setServiceCertificateValidityPeriod(validFrom, validityPeriodDays) {
   const rawConfig = ccf.kv["public:ccf.gov.service.config"].get(
-    getSingletonKvKey()
+    getSingletonKvKey(),
   );
   if (rawConfig === undefined) {
     throw new Error("Service configuration could not be found");
@@ -184,13 +184,13 @@ function setServiceCertificateValidityPeriod(validFrom, validityPeriodDays) {
     validityPeriodDays > max_allowed_cert_validity_period_days
   ) {
     throw new Error(
-      `Validity period ${validityPeriodDays} (days) is not allowed: service max allowed is ${max_allowed_cert_validity_period_days} (days)`
+      `Validity period ${validityPeriodDays} (days) is not allowed: service max allowed is ${max_allowed_cert_validity_period_days} (days)`,
     );
   }
 
   const renewed_service_certificate = ccf.network.generateNetworkCertificate(
     validFrom,
-    validityPeriodDays ?? max_allowed_cert_validity_period_days
+    validityPeriodDays ?? max_allowed_cert_validity_period_days,
   );
 
   const serviceInfoTable = "public:ccf.gov.service.info";
@@ -203,7 +203,7 @@ function setServiceCertificateValidityPeriod(validFrom, validityPeriodDays) {
   serviceInfo.cert = renewed_service_certificate;
   ccf.kv[serviceInfoTable].set(
     getSingletonKvKey(),
-    ccf.jsonCompatibleToBuf(serviceInfo)
+    ccf.jsonCompatibleToBuf(serviceInfo),
   );
 }
 
@@ -211,14 +211,14 @@ function setNodeCertificateValidityPeriod(
   nodeId,
   nodeInfo,
   validFrom,
-  validityPeriodDays
+  validityPeriodDays,
 ) {
   if (nodeInfo.certificate_signing_request === undefined) {
     throw new Error(`Node ${nodeId} has no certificate signing request`);
   }
 
   const rawConfig = ccf.kv["public:ccf.gov.service.config"].get(
-    getSingletonKvKey()
+    getSingletonKvKey(),
   );
   if (rawConfig === undefined) {
     throw new Error("Service configuration could not be found");
@@ -235,18 +235,18 @@ function setNodeCertificateValidityPeriod(
     validityPeriodDays > max_allowed_cert_validity_period_days
   ) {
     throw new Error(
-      `Validity period ${validityPeriodDays} (days) is not allowed: service max allowed is ${max_allowed_cert_validity_period_days} (days)`
+      `Validity period ${validityPeriodDays} (days) is not allowed: service max allowed is ${max_allowed_cert_validity_period_days} (days)`,
     );
   }
 
   const endorsed_node_cert = ccf.network.generateEndorsedCertificate(
     nodeInfo.certificate_signing_request,
     validFrom,
-    validityPeriodDays ?? max_allowed_cert_validity_period_days
+    validityPeriodDays ?? max_allowed_cert_validity_period_days,
   );
   ccf.kv["public:ccf.gov.nodes.endorsed_certificates"].set(
     ccf.strToBuf(nodeId),
-    ccf.strToBuf(endorsed_node_cert)
+    ccf.strToBuf(endorsed_node_cert),
   );
 }
 
@@ -267,13 +267,13 @@ function checkRecoveryThreshold(config, new_config) {
 
   if (service.status === "WaitingForRecoveryShares") {
     throw new Error(
-      `Cannot set recovery threshold if service is ${service.status}`
+      `Cannot set recovery threshold if service is ${service.status}`,
     );
   } else if (service.status === "Open") {
     let activeRecoveryMembersCount = getActiveRecoveryMembersCount();
     if (new_config.recovery_threshold > activeRecoveryMembersCount) {
       throw new Error(
-        `Cannot set recovery threshold to ${new_config.recovery_threshold}: recovery threshold would be greater than the number of recovery members ${activeRecoveryMembersCount}`
+        `Cannot set recovery threshold to ${new_config.recovery_threshold}: recovery threshold would be greater than the number of recovery members ${activeRecoveryMembersCount}`,
       );
     }
   }
@@ -290,7 +290,7 @@ function checkReconfigurationType(config, new_config) {
       )
     ) {
       throw new Error(
-        `Cannot change reconfiguration type from ${from} to ${to}.`
+        `Cannot change reconfiguration type from ${from} to ${to}.`,
       );
     }
   }
@@ -329,7 +329,7 @@ function updateServiceConfig(new_config) {
 
   ccf.kv[service_config_table].set(
     getSingletonKvKey(),
-    ccf.jsonCompatibleToBuf(config)
+    ccf.jsonCompatibleToBuf(config),
   );
 
   if (need_recovery_threshold_refresh) {
@@ -347,12 +347,12 @@ const actions = new Map([
       function (args, proposalId) {
         ccf.kv["public:ccf.gov.constitution"].set(
           getSingletonKvKey(),
-          ccf.jsonCompatibleToBuf(args.constitution)
+          ccf.jsonCompatibleToBuf(args.constitution),
         );
 
         // Changing the constitution changes the semantics of any other open proposals, so invalidate them to avoid confusion or malicious vote modification
         invalidateOtherOpenProposals(proposalId);
-      }
+      },
     ),
   ],
   [
@@ -374,17 +374,17 @@ const actions = new Map([
 
         ccf.kv["public:ccf.gov.members.certs"].set(
           rawMemberId,
-          ccf.strToBuf(args.cert)
+          ccf.strToBuf(args.cert),
         );
 
         if (args.encryption_pub_key == null) {
           ccf.kv["public:ccf.gov.members.encryption_public_keys"].delete(
-            rawMemberId
+            rawMemberId,
           );
         } else {
           ccf.kv["public:ccf.gov.members.encryption_public_keys"].set(
             rawMemberId,
-            ccf.strToBuf(args.encryption_pub_key)
+            ccf.strToBuf(args.encryption_pub_key),
           );
         }
 
@@ -393,11 +393,11 @@ const actions = new Map([
         member_info.status = "Accepted";
         ccf.kv["public:ccf.gov.members.info"].set(
           rawMemberId,
-          ccf.jsonCompatibleToBuf(member_info)
+          ccf.jsonCompatibleToBuf(member_info),
         );
 
         const rawSignature = ccf.kv["public:ccf.internal.signatures"].get(
-          getSingletonKvKey()
+          getSingletonKvKey(),
         );
         if (rawSignature === undefined) {
           ccf.kv["public:ccf.gov.members.acks"].set(rawMemberId);
@@ -407,10 +407,10 @@ const actions = new Map([
           ack.state_digest = signature.root;
           ccf.kv["public:ccf.gov.members.acks"].set(
             rawMemberId,
-            ccf.jsonCompatibleToBuf(ack)
+            ccf.jsonCompatibleToBuf(ack),
           );
         }
-      }
+      },
     ),
   ],
   [
@@ -441,7 +441,7 @@ const actions = new Map([
         // to recover the service
         if (isActiveMember && isRecoveryMember) {
           const rawConfig = ccf.kv["public:ccf.gov.service.config"].get(
-            getSingletonKvKey()
+            getSingletonKvKey(),
           );
           if (rawConfig === undefined) {
             throw new Error("Service configuration could not be found");
@@ -452,14 +452,14 @@ const actions = new Map([
             getActiveRecoveryMembersCount() - 1;
           if (activeRecoveryMembersCountAfter < config.recovery_threshold) {
             throw new Error(
-              `Number of active recovery members (${activeRecoveryMembersCountAfter}) would be less than recovery threshold (${config.recovery_threshold})`
+              `Number of active recovery members (${activeRecoveryMembersCountAfter}) would be less than recovery threshold (${config.recovery_threshold})`,
             );
           }
         }
 
         ccf.kv["public:ccf.gov.members.info"].delete(rawMemberId);
         ccf.kv["public:ccf.gov.members.encryption_public_keys"].delete(
-          rawMemberId
+          rawMemberId,
         );
         ccf.kv["public:ccf.gov.members.certs"].delete(rawMemberId);
         ccf.kv["public:ccf.gov.members.acks"].delete(rawMemberId);
@@ -471,7 +471,7 @@ const actions = new Map([
           // remaining active recovery members
           ccf.node.triggerLedgerRekey();
         }
-      }
+      },
     ),
   ],
   [
@@ -492,7 +492,7 @@ const actions = new Map([
         let mi = ccf.bufToJsonCompatible(member_info);
         mi.member_data = args.member_data;
         members_info.set(member_id, ccf.jsonCompatibleToBuf(mi));
-      }
+      },
     ),
   ],
   [
@@ -508,7 +508,7 @@ const actions = new Map([
 
         ccf.kv["public:ccf.gov.users.certs"].set(
           rawUserId,
-          ccf.strToBuf(args.cert)
+          ccf.strToBuf(args.cert),
         );
 
         if (args.user_data !== null && args.user_data !== undefined) {
@@ -516,12 +516,12 @@ const actions = new Map([
           userInfo.user_data = args.user_data;
           ccf.kv["public:ccf.gov.users.info"].set(
             rawUserId,
-            ccf.jsonCompatibleToBuf(userInfo)
+            ccf.jsonCompatibleToBuf(userInfo),
           );
         } else {
           ccf.kv["public:ccf.gov.users.info"].delete(rawUserId);
         }
-      }
+      },
     ),
   ],
   [
@@ -534,7 +534,7 @@ const actions = new Map([
         const user_id = ccf.strToBuf(args.user_id);
         ccf.kv["public:ccf.gov.users.certs"].delete(user_id);
         ccf.kv["public:ccf.gov.users.info"].delete(user_id);
-      }
+      },
     ),
   ],
   [
@@ -552,12 +552,12 @@ const actions = new Map([
           userInfo.user_data = args.user_data;
           ccf.kv["public:ccf.gov.users.info"].set(
             userId,
-            ccf.jsonCompatibleToBuf(userInfo)
+            ccf.jsonCompatibleToBuf(userInfo),
           );
         } else {
           ccf.kv["public:ccf.gov.users.info"].delete(userId);
         }
-      }
+      },
     ),
   ],
   [
@@ -569,7 +569,7 @@ const actions = new Map([
       },
       function (args) {
         updateServiceConfig(args);
-      }
+      },
     ),
   ],
   [
@@ -580,7 +580,7 @@ const actions = new Map([
       },
       function (args) {
         ccf.node.triggerRecoverySharesRefresh();
-      }
+      },
     ),
   ],
   [
@@ -592,7 +592,7 @@ const actions = new Map([
 
       function (args) {
         ccf.node.triggerLedgerRekey();
-      }
+      },
     ),
   ],
   [
@@ -602,22 +602,22 @@ const actions = new Map([
         checkType(
           args.next_service_identity,
           "string",
-          "next service identity (PEM certificate)"
+          "next service identity (PEM certificate)",
         );
         checkX509CertBundle(
           args.next_service_identity,
-          "next_service_identity"
+          "next_service_identity",
         );
 
         checkType(
           args.previous_service_identity,
           "string?",
-          "previous service identity (PEM certificate)"
+          "previous service identity (PEM certificate)",
         );
         if (args.previous_service_identity !== undefined) {
           checkX509CertBundle(
             args.previous_service_identity,
-            "previous_service_identity"
+            "previous_service_identity",
           );
         }
       },
@@ -637,7 +637,7 @@ const actions = new Map([
             args.next_service_identity === undefined)
         ) {
           throw new Error(
-            `Opening a recovering network requires both, the previous and the next service identity`
+            `Opening a recovering network requires both, the previous and the next service identity`,
           );
         }
 
@@ -647,7 +647,7 @@ const actions = new Map([
             : undefined;
         const next_identity = ccf.strToBuf(args.next_service_identity);
         ccf.node.transitionServiceToOpen(previous_identity, next_identity);
-      }
+      },
     ),
   ],
   [
@@ -669,7 +669,7 @@ const actions = new Map([
         checkType(bundle.metadata, "object", prefix);
         checkType(bundle.metadata.endpoints, "object", `${prefix}.endpoints`);
         for (const [url, endpoint] of Object.entries(
-          bundle.metadata.endpoints
+          bundle.metadata.endpoints,
         )) {
           checkType(endpoint, "object", `${prefix}.endpoints["${url}"]`);
           for (const [method, info] of Object.entries(endpoint)) {
@@ -680,24 +680,24 @@ const actions = new Map([
             checkEnum(
               info.mode,
               ["readwrite", "readonly", "historical"],
-              `${prefix2}.mode`
+              `${prefix2}.mode`,
             );
             checkEnum(
               info.forwarding_required,
               ["sometimes", "always", "never"],
-              `${prefix2}.forwarding_required`
+              `${prefix2}.forwarding_required`,
             );
 
             checkType(info.openapi, "object?", `${prefix2}.openapi`);
             checkType(
               info.openapi_hidden,
               "boolean?",
-              `${prefix2}.openapi_hidden`
+              `${prefix2}.openapi_hidden`,
             );
             checkType(
               info.authn_policies,
               "array",
-              `${prefix2}.authn_policies`
+              `${prefix2}.authn_policies`,
             );
             for (const [i, policy] of info.authn_policies.entries()) {
               checkType(policy, "string", `${prefix2}.authn_policies[${i}]`);
@@ -711,7 +711,7 @@ const actions = new Map([
         checkType(
           args.disable_bytecode_cache,
           "boolean?",
-          "disable_bytecode_cache"
+          "disable_bytecode_cache",
         );
       },
       function (args) {
@@ -740,7 +740,7 @@ const actions = new Map([
         }
 
         for (const [url, endpoint] of Object.entries(
-          bundle.metadata.endpoints
+          bundle.metadata.endpoints,
         )) {
           for (const [method, info] of Object.entries(endpoint)) {
             const key = `${method.toUpperCase()} ${url}`;
@@ -751,7 +751,7 @@ const actions = new Map([
             endpointsMap.set(keyBuf, infoBuf);
           }
         }
-      }
+      },
     ),
   ],
   [
@@ -769,7 +769,7 @@ const actions = new Map([
         modulesQuickJsBytecodeMap.clear();
         modulesQuickJsVersionVal.clear();
         endpointsMap.clear();
-      }
+      },
     ),
   ],
   [
@@ -781,23 +781,23 @@ const actions = new Map([
         checkType(
           args.max_execution_time_ms,
           "integer",
-          "max_execution_time_ms"
+          "max_execution_time_ms",
         );
         checkType(
           args.log_exception_details,
           "boolean?",
-          "log_exception_details"
+          "log_exception_details",
         );
         checkType(
           args.return_exception_details,
           "boolean?",
-          "return_exception_details"
+          "return_exception_details",
         );
       },
       function (args) {
         const js_engine_map = ccf.kv["public:ccf.gov.js_runtime_options"];
         js_engine_map.set(getSingletonKvKey(), ccf.jsonCompatibleToBuf(args));
-      }
+      },
     ),
   ],
   [
@@ -806,7 +806,7 @@ const actions = new Map([
       function (args) {},
       function (args) {
         ccf.refreshAppBytecodeCache();
-      }
+      },
     ),
   ],
   [
@@ -822,7 +822,7 @@ const actions = new Map([
         const nameBuf = ccf.strToBuf(name);
         const bundleBuf = ccf.jsonCompatibleToBuf(bundle);
         ccf.kv["public:ccf.gov.tls.ca_cert_bundles"].set(nameBuf, bundleBuf);
-      }
+      },
     ),
   ],
   [
@@ -835,7 +835,7 @@ const actions = new Map([
         const name = args.name;
         const nameBuf = ccf.strToBuf(name);
         ccf.kv["public:ccf.gov.tls.ca_cert_bundles"].delete(nameBuf);
-      }
+      },
     ),
   ],
   [
@@ -851,11 +851,11 @@ const actions = new Map([
           checkType(
             args.key_policy.sgx_claims,
             "object?",
-            "key_policy.sgx_claims"
+            "key_policy.sgx_claims",
           );
           if (args.key_policy.sgx_claims) {
             for (const [name, value] of Object.entries(
-              args.key_policy.sgx_claims
+              args.key_policy.sgx_claims,
             )) {
               checkType(value, "string", `key_policy.sgx_claims["${name}"]`);
             }
@@ -868,7 +868,7 @@ const actions = new Map([
         if (args.auto_refresh) {
           if (!args.ca_cert_bundle_name) {
             throw new Error(
-              "ca_cert_bundle_name is missing but required if auto_refresh is true"
+              "ca_cert_bundle_name is missing but required if auto_refresh is true",
             );
           }
           let url;
@@ -879,12 +879,12 @@ const actions = new Map([
           }
           if (url.scheme != "https") {
             throw new Error(
-              "issuer must be a URL starting with https:// if auto_refresh is true"
+              "issuer must be a URL starting with https:// if auto_refresh is true",
             );
           }
           if (url.query || url.fragment) {
             throw new Error(
-              "issuer must be a URL without query/fragment if auto_refresh is true"
+              "issuer must be a URL without query/fragment if auto_refresh is true",
             );
           }
         }
@@ -895,11 +895,11 @@ const actions = new Map([
           const caCertBundleNameBuf = ccf.strToBuf(args.ca_cert_bundle_name);
           if (
             !ccf.kv["public:ccf.gov.tls.ca_cert_bundles"].has(
-              caCertBundleNameBuf
+              caCertBundleNameBuf,
             )
           ) {
             throw new Error(
-              `No CA cert bundle found with name '${caCertBundleName}'`
+              `No CA cert bundle found with name '${caCertBundleName}'`,
             );
           }
         }
@@ -913,7 +913,7 @@ const actions = new Map([
         const issuerBuf = ccf.strToBuf(issuer);
         const metadataBuf = ccf.jsonCompatibleToBuf(metadata);
         ccf.kv["public:ccf.gov.jwt.issuers"].set(issuerBuf, metadataBuf);
-      }
+      },
     ),
   ],
   [
@@ -933,7 +933,7 @@ const actions = new Map([
         const metadata = ccf.bufToJsonCompatible(metadataBuf);
         const jwks = args.jwks;
         ccf.setJwtPublicSigningKeys(issuer, metadata, jwks);
-      }
+      },
     ),
   ],
   [
@@ -949,7 +949,7 @@ const actions = new Map([
         }
         ccf.kv["public:ccf.gov.jwt.issuers"].delete(issuerBuf);
         ccf.removeJwtPublicSigningKeys(args.issuer);
-      }
+      },
     ),
   ],
   [
@@ -965,7 +965,7 @@ const actions = new Map([
 
         // Adding a new allowed code ID changes the semantics of any other open proposals, so invalidate them to avoid confusion or malicious vote modification
         invalidateOtherOpenProposals(proposalId);
-      }
+      },
     ),
   ],
   [
@@ -979,12 +979,12 @@ const actions = new Map([
         const ALLOWED = ccf.jsonCompatibleToBuf("AllowedToJoin");
         ccf.kv["public:ccf.gov.nodes.snp.measurements"].set(
           measurement,
-          ALLOWED
+          ALLOWED,
         );
 
         // Adding a new allowed measurement changes the semantics of any other open proposals, so invalidate them to avoid confusion or malicious vote modification
         invalidateOtherOpenProposals(proposalId);
-      }
+      },
     ),
   ],
   [
@@ -1007,11 +1007,11 @@ const actions = new Map([
         uvme[args.feed] = { svn: args.svn };
         ccf.kv["public:ccf.gov.nodes.snp.uvm_endorsements"].set(
           ccf.strToBuf(args.did),
-          ccf.jsonCompatibleToBuf(uvme)
+          ccf.jsonCompatibleToBuf(uvme),
         );
         // Adding a new allowed UVM endorsement changes the semantics of any other open proposals, so invalidate them to avoid confusion or malicious vote modification
         invalidateOtherOpenProposals(proposalId);
-      }
+      },
     ),
   ],
   [
@@ -1024,7 +1024,7 @@ const actions = new Map([
         const codeId = ccf.strToBuf(args.executor_code_id);
         const ALLOWED = ccf.jsonCompatibleToBuf("AllowedToExecute");
         ccf.kv["public:ccf.gov.nodes.executor_code_ids"].set(codeId, ALLOWED);
-      }
+      },
     ),
   ],
   [
@@ -1038,12 +1038,12 @@ const actions = new Map([
         // SHA-256 digest is the specified host data
         if (args.security_policy != "") {
           const securityPolicyDigest = ccf.bufToStr(
-            ccf.digest("SHA-256", ccf.strToBuf(args.security_policy))
+            ccf.digest("SHA-256", ccf.strToBuf(args.security_policy)),
           );
           const hostData = ccf.bufToStr(hexStrToBuf(args.host_data));
           if (securityPolicyDigest != hostData) {
             throw new Error(
-              `The hash of raw policy ${securityPolicyDigest} does not match digest ${hostData}`
+              `The hash of raw policy ${securityPolicyDigest} does not match digest ${hostData}`,
             );
           }
         }
@@ -1051,12 +1051,12 @@ const actions = new Map([
       function (args, proposalId) {
         ccf.kv["public:ccf.gov.nodes.snp.host_data"].set(
           ccf.strToBuf(args.host_data),
-          ccf.jsonCompatibleToBuf(args.security_policy)
+          ccf.jsonCompatibleToBuf(args.security_policy),
         );
 
         // Adding a new allowed host data changes the semantics of any other open proposals, so invalidate them to avoid confusion or malicious vote modification
         invalidateOtherOpenProposals(proposalId);
-      }
+      },
     ),
   ],
   [
@@ -1068,7 +1068,7 @@ const actions = new Map([
       function (args) {
         const hostData = ccf.strToBuf(args.host_data);
         ccf.kv["public:ccf.gov.nodes.snp.host_data"].delete(hostData);
-      }
+      },
     ),
   ],
   [
@@ -1080,7 +1080,7 @@ const actions = new Map([
       function (args) {
         const measurement = ccf.strToBuf(args.measurement);
         ccf.kv["public:ccf.gov.nodes.snp.measurements"].delete(measurement);
-      }
+      },
     ),
   ],
   [
@@ -1103,15 +1103,15 @@ const actions = new Map([
         if (Object.keys(uvme).length === 0) {
           // Delete DID if no feed are left
           ccf.kv["public:ccf.gov.nodes.snp.uvm_endorsements"].delete(
-            ccf.strToBuf(args.did)
+            ccf.strToBuf(args.did),
           );
         } else {
           ccf.kv["public:ccf.gov.nodes.snp.uvm_endorsements"].set(
             ccf.strToBuf(args.did),
-            ccf.jsonCompatibleToBuf(uvme)
+            ccf.jsonCompatibleToBuf(uvme),
           );
         }
-      }
+      },
     ),
   ],
   [
@@ -1130,7 +1130,7 @@ const actions = new Map([
         let ni = ccf.bufToJsonCompatible(node_info);
         ni.node_data = args.node_data;
         nodes_info.set(node_id, ccf.jsonCompatibleToBuf(ni));
-      }
+      },
     ),
   ],
   [
@@ -1143,26 +1143,26 @@ const actions = new Map([
           checkType(
             args.validity_period_days,
             "integer",
-            "validity_period_days"
+            "validity_period_days",
           );
           checkBounds(
             args.validity_period_days,
             1,
             null,
-            "validity_period_days"
+            "validity_period_days",
           );
         }
       },
       function (args) {
         const rawConfig = ccf.kv["public:ccf.gov.service.config"].get(
-          getSingletonKvKey()
+          getSingletonKvKey(),
         );
         if (rawConfig === undefined) {
           throw new Error("Service configuration could not be found");
         }
         const serviceConfig = ccf.bufToJsonCompatible(rawConfig);
         const node = ccf.kv["public:ccf.gov.nodes.info"].get(
-          ccf.strToBuf(args.node_id)
+          ccf.strToBuf(args.node_id),
         );
         if (node === undefined) {
           throw new Error(`No such node: ${args.node_id}`);
@@ -1174,7 +1174,7 @@ const actions = new Map([
             ccf.network.getLatestLedgerSecretSeqno();
           ccf.kv["public:ccf.gov.nodes.info"].set(
             ccf.strToBuf(args.node_id),
-            ccf.jsonCompatibleToBuf(nodeInfo)
+            ccf.jsonCompatibleToBuf(nodeInfo),
           );
 
           // Also generate and record service-endorsed node certificate from node CSR
@@ -1189,22 +1189,23 @@ const actions = new Map([
               args.validity_period_days > max_allowed_cert_validity_period_days
             ) {
               throw new Error(
-                `Validity period ${args.validity_period_days} is not allowed: max allowed is ${max_allowed_cert_validity_period_days}`
+                `Validity period ${args.validity_period_days} is not allowed: max allowed is ${max_allowed_cert_validity_period_days}`,
               );
             }
 
             const endorsed_node_cert = ccf.network.generateEndorsedCertificate(
               nodeInfo.certificate_signing_request,
               args.valid_from,
-              args.validity_period_days ?? max_allowed_cert_validity_period_days
+              args.validity_period_days ??
+                max_allowed_cert_validity_period_days,
             );
             ccf.kv["public:ccf.gov.nodes.endorsed_certificates"].set(
               ccf.strToBuf(args.node_id),
-              ccf.strToBuf(endorsed_node_cert)
+              ccf.strToBuf(endorsed_node_cert),
             );
           }
         }
-      }
+      },
     ),
   ],
   [
@@ -1216,7 +1217,7 @@ const actions = new Map([
       function (args) {
         const codeId = ccf.strToBuf(args.code_id);
         ccf.kv["public:ccf.gov.nodes.code_ids"].delete(codeId);
-      }
+      },
     ),
   ],
   [
@@ -1228,7 +1229,7 @@ const actions = new Map([
       function (args) {
         const codeId = ccf.strToBuf(args.executor_code_id);
         ccf.kv["public:ccf.gov.nodes.executor_code_ids"].delete(codeId);
-      }
+      },
     ),
   ],
   [
@@ -1239,14 +1240,14 @@ const actions = new Map([
       },
       function (args) {
         const rawConfig = ccf.kv["public:ccf.gov.service.config"].get(
-          getSingletonKvKey()
+          getSingletonKvKey(),
         );
         if (rawConfig === undefined) {
           throw new Error("Service configuration could not be found");
         }
         const serviceConfig = ccf.bufToJsonCompatible(rawConfig);
         const node = ccf.kv["public:ccf.gov.nodes.info"].get(
-          ccf.strToBuf(args.node_id)
+          ccf.strToBuf(args.node_id),
         );
         if (node === undefined) {
           return;
@@ -1254,16 +1255,16 @@ const actions = new Map([
         const node_obj = ccf.bufToJsonCompatible(node);
         if (node_obj.status === "Pending") {
           ccf.kv["public:ccf.gov.nodes.info"].delete(
-            ccf.strToBuf(args.node_id)
+            ccf.strToBuf(args.node_id),
           );
         } else {
           node_obj.status = "Retired";
           ccf.kv["public:ccf.gov.nodes.info"].set(
             ccf.strToBuf(args.node_id),
-            ccf.jsonCompatibleToBuf(node_obj)
+            ccf.jsonCompatibleToBuf(node_obj),
           );
         }
-      }
+      },
     ),
   ],
   [
@@ -1276,19 +1277,19 @@ const actions = new Map([
           checkType(
             args.validity_period_days,
             "integer",
-            "validity_period_days"
+            "validity_period_days",
           );
           checkBounds(
             args.validity_period_days,
             1,
             null,
-            "validity_period_days"
+            "validity_period_days",
           );
         }
       },
       function (args) {
         const node = ccf.kv["public:ccf.gov.nodes.info"].get(
-          ccf.strToBuf(args.node_id)
+          ccf.strToBuf(args.node_id),
         );
         if (node === undefined) {
           throw new Error(`No such node: ${args.node_id}`);
@@ -1302,9 +1303,9 @@ const actions = new Map([
           args.node_id,
           nodeInfo,
           args.valid_from,
-          args.validity_period_days
+          args.validity_period_days,
         );
-      }
+      },
     ),
   ],
   [
@@ -1316,13 +1317,13 @@ const actions = new Map([
           checkType(
             args.validity_period_days,
             "integer",
-            "validity_period_days"
+            "validity_period_days",
           );
           checkBounds(
             args.validity_period_days,
             1,
             null,
-            "validity_period_days"
+            "validity_period_days",
           );
         }
       },
@@ -1335,11 +1336,11 @@ const actions = new Map([
               nodeId,
               nodeInfo,
               args.valid_from,
-              args.validity_period_days
+              args.validity_period_days,
             );
           }
         });
-      }
+      },
     ),
   ],
   [
@@ -1351,22 +1352,22 @@ const actions = new Map([
           checkType(
             args.validity_period_days,
             "integer",
-            "validity_period_days"
+            "validity_period_days",
           );
           checkBounds(
             args.validity_period_days,
             1,
             null,
-            "validity_period_days"
+            "validity_period_days",
           );
         }
       },
       function (args) {
         setServiceCertificateValidityPeriod(
           args.valid_from,
-          args.validity_period_days
+          args.validity_period_days,
         );
-      }
+      },
     ),
   ],
   [
@@ -1382,7 +1383,7 @@ const actions = new Map([
             ].includes(key)
           ) {
             throw new Error(
-              `Cannot change ${key} via set_service_configuration.`
+              `Cannot change ${key} via set_service_configuration.`,
             );
           }
         }
@@ -1392,18 +1393,18 @@ const actions = new Map([
         checkType(
           args.recent_cose_proposals_window_size,
           "integer?",
-          "recent cose proposals window size"
+          "recent cose proposals window size",
         );
         checkBounds(
           args.recent_cose_proposals_window_size,
           1,
           10000,
-          "recent cose proposals window size"
+          "recent cose proposals window size",
         );
       },
       function (args) {
         updateServiceConfig(args);
-      }
+      },
     ),
   ],
   [
@@ -1412,7 +1413,7 @@ const actions = new Map([
       function (args) {},
       function (args, proposalId) {
         ccf.node.triggerLedgerChunk();
-      }
+      },
     ),
   ],
   [
@@ -1421,7 +1422,7 @@ const actions = new Map([
       function (args) {},
       function (args, proposalId) {
         ccf.node.triggerSnapshot();
-      }
+      },
     ),
   ],
   [
@@ -1431,12 +1432,12 @@ const actions = new Map([
         checkType(
           args.interfaces,
           "array?",
-          "interfaces to refresh the certificates for"
+          "interfaces to refresh the certificates for",
         );
       },
       function (args, proposalId) {
         ccf.node.triggerACMERefresh(args.interfaces);
-      }
+      },
     ),
   ],
   [
@@ -1454,7 +1455,7 @@ const actions = new Map([
           throw new Error("Service identity certificate mismatch");
         }
       },
-      function (args) {}
+      function (args) {},
     ),
   ],
 ]);

--- a/samples/constitutions/default/validate.js
+++ b/samples/constitutions/default/validate.js
@@ -9,7 +9,7 @@ export function validate(input) {
         definition.validate(action.args);
       } catch (e) {
         errors.push(
-          `${action.name} at position ${position} failed validation: ${e}\n${e.stack}`
+          `${action.name} at position ${position} failed validation: ${e}\n${e.stack}`,
         );
       }
     } else {

--- a/samples/constitutions/operator/resolve.js
+++ b/samples/constitutions/operator/resolve.js
@@ -53,7 +53,7 @@ export function resolve(proposal, proposerId, votes) {
 
   // Count member votes.
   const memberVoteCount = votes.filter(
-    (v) => v.vote && !isOperator(v.member_id)
+    (v) => v.vote && !isOperator(v.member_id),
   ).length;
 
   // Count active members, excluding operators.

--- a/samples/constitutions/operator_provisioner/resolve.js
+++ b/samples/constitutions/operator_provisioner/resolve.js
@@ -1,13 +1,13 @@
 function getMemberInfo(memberId) {
   return ccf.bufToJsonCompatible(
-    ccf.kv["public:ccf.gov.members.info"].get(ccf.strToBuf(memberId))
+    ccf.kv["public:ccf.gov.members.info"].get(ccf.strToBuf(memberId)),
   );
 }
 
 function isRecoveryMember(memberId) {
   return (
     ccf.kv["public:ccf.gov.members.encryption_public_keys"].get(
-      ccf.strToBuf(memberId)
+      ccf.strToBuf(memberId),
     ) ?? false
   );
 }
@@ -52,7 +52,7 @@ export function resolve(proposal, proposerId, votes) {
   // Count member votes.
   const memberVoteCount = votes.filter(
     (v) =>
-      v.vote && !isOperatorProvisioner(v.member_id) && !isOperator(v.member_id)
+      v.vote && !isOperatorProvisioner(v.member_id) && !isOperator(v.member_id),
   ).length;
 
   // Count active members, excluding operator provisioners and operators.

--- a/samples/constitutions/test/resolve.js
+++ b/samples/constitutions/test/resolve.js
@@ -1,13 +1,13 @@
 function getMemberInfo(memberId) {
   return ccf.bufToJsonCompatible(
-    ccf.kv["public:ccf.gov.members.info"].get(ccf.strToBuf(memberId))
+    ccf.kv["public:ccf.gov.members.info"].get(ccf.strToBuf(memberId)),
   );
 }
 
 function isRecoveryMember(memberId) {
   return (
     ccf.kv["public:ccf.gov.members.encryption_public_keys"].get(
-      ccf.strToBuf(memberId)
+      ccf.strToBuf(memberId),
     ) ?? false
   );
 }
@@ -66,7 +66,7 @@ export function resolve(proposal, proposer_id, votes) {
     } else if (actions[0].name === "always_accept_if_voted_by_operator") {
       for (const vote of votes) {
         const mi = ccf.kv["public:ccf.gov.members.info"].get(
-          ccf.strToBuf(vote.member_id)
+          ccf.strToBuf(vote.member_id),
         );
         if (mi && ccf.bufToJsonCompatible(mi).member_data.is_operator) {
           return "Accepted";
@@ -75,7 +75,7 @@ export function resolve(proposal, proposer_id, votes) {
       }
     } else if (actions[0].name === "always_accept_if_proposed_by_operator") {
       const mi = ccf.kv["public:ccf.gov.members.info"].get(
-        ccf.strToBuf(proposer_id)
+        ccf.strToBuf(proposer_id),
       );
       if (mi && (ccf.bufToJsonCompatible(mi).member_data ?? {}).is_operator) {
         return "Accepted";

--- a/samples/constitutions/test/test_actions.js
+++ b/samples/constitutions/test/test_actions.js
@@ -2,64 +2,64 @@ actions.set(
   "always_accept_noop",
   new Action(
     function (args) {},
-    function (args) {}
-  )
+    function (args) {},
+  ),
 );
 
 actions.set(
   "always_reject_noop",
   new Action(
     function (args) {},
-    function (args) {}
-  )
+    function (args) {},
+  ),
 );
 
 actions.set(
   "always_accept_with_one_vote",
   new Action(
     function (args) {},
-    function (args) {}
-  )
+    function (args) {},
+  ),
 );
 
 actions.set(
   "always_reject_with_one_vote",
   new Action(
     function (args) {},
-    function (args) {}
-  )
+    function (args) {},
+  ),
 );
 
 actions.set(
   "always_accept_if_voted_by_operator",
   new Action(
     function (args) {},
-    function (args) {}
-  )
+    function (args) {},
+  ),
 );
 
 actions.set(
   "always_accept_if_proposed_by_operator",
   new Action(
     function (args) {},
-    function (args) {}
-  )
+    function (args) {},
+  ),
 );
 
 actions.set(
   "always_accept_with_two_votes",
   new Action(
     function (args) {},
-    function (args) {}
-  )
+    function (args) {},
+  ),
 );
 
 actions.set(
   "always_reject_with_two_votes",
   new Action(
     function (args) {},
-    function (args) {}
-  )
+    function (args) {},
+  ),
 );
 
 actions.set(
@@ -68,8 +68,8 @@ actions.set(
     function (args) {
       checkX509CertBundle(args.pem, "pem");
     },
-    function (args) {}
-  )
+    function (args) {},
+  ),
 );
 
 actions.set(
@@ -80,8 +80,8 @@ actions.set(
     },
     function (args) {
       throw new Error("Error message");
-    }
-  )
+    },
+  ),
 );
 
 actions.set(
@@ -92,8 +92,8 @@ actions.set(
     },
     function (args) {
       return true;
-    }
-  )
+    },
+  ),
 );
 
 actions.set(
@@ -114,9 +114,9 @@ actions.set(
       service["recent_cose_proposals_window_size"] = args.proposal_count;
       ccf.kv[service_config].set(
         getSingletonKvKey(),
-        ccf.jsonCompatibleToBuf(service)
+        ccf.jsonCompatibleToBuf(service),
       );
       return true;
-    }
-  )
+    },
+  ),
 );

--- a/tests/js-authentication/src/endpoints.js
+++ b/tests/js-authentication/src/endpoints.js
@@ -92,7 +92,7 @@ export function put_secret(request) {
   const body = request.body.json();
   ccf.kv[secret_table].set(
     key_of_single_secret,
-    ccf.jsonCompatibleToBuf(body.new_secret)
+    ccf.jsonCompatibleToBuf(body.new_secret),
   );
 
   return {

--- a/tests/js-content-types/src/content_types.js
+++ b/tests/js-content-types/src/content_types.js
@@ -1,7 +1,7 @@
 export function text(request) {
   if (request.headers["content-type"] !== "text/plain")
     throw new Error(
-      "unexpected content-type: " + request.headers["content-type"]
+      "unexpected content-type: " + request.headers["content-type"],
     );
   const text = request.body.text();
   if (text !== "text") throw new Error("unexpected body: " + text);
@@ -11,7 +11,7 @@ export function text(request) {
 export function json(request) {
   if (request.headers["content-type"] !== "application/json")
     throw new Error(
-      "unexpected content type: " + request.headers["content-type"]
+      "unexpected content type: " + request.headers["content-type"],
     );
   const obj = request.body.json();
   if (obj.foo !== "bar") throw new Error("unexpected body: " + obj);
@@ -21,7 +21,7 @@ export function json(request) {
 export function binary(request) {
   if (request.headers["content-type"] !== "application/octet-stream")
     throw new Error(
-      "unexpected content type: " + request.headers["content-type"]
+      "unexpected content type: " + request.headers["content-type"],
     );
   const buf = request.body.arrayBuffer();
   if (buf.byteLength !== 42)
@@ -32,7 +32,7 @@ export function binary(request) {
 export function custom(request) {
   if (request.headers["content-type"] !== "foo/bar")
     throw new Error(
-      "unexpected content type: " + request.headers["content-type"]
+      "unexpected content type: " + request.headers["content-type"],
     );
   const text = request.body.text();
   if (text !== "text") throw new Error("unexpected body: " + text);

--- a/tests/npm-app/build_bundle.js
+++ b/tests/npm-app/build_bundle.js
@@ -48,6 +48,6 @@ const bundle = {
   modules: modules,
 };
 console.log(
-  `Writing bundle containing ${modules.length} modules to ${bundlePath}`
+  `Writing bundle containing ${modules.length} modules to ${bundlePath}`,
 );
 writeFileSync(bundlePath, JSON.stringify(bundle));

--- a/tests/npm-app/src/endpoints/auth.ts
+++ b/tests/npm-app/src/endpoints/auth.ts
@@ -3,7 +3,7 @@ import * as ccfapp from "@microsoft/ccf-app";
 // Note: this is also tested more generically on the multi_auth endpoint
 // of the logging application, but not with TypeScript types.
 export function checkUserCOSESign1Auth(
-  request: ccfapp.Request
+  request: ccfapp.Request,
 ): ccfapp.Response {
   if (request.caller === null || request.caller === undefined) {
     return { status: 401 };

--- a/tests/npm-app/src/endpoints/crypto.ts
+++ b/tests/npm-app/src/endpoints/crypto.ts
@@ -9,7 +9,7 @@ interface CryptoResponse {
 }
 
 export function crypto(
-  request: ccfapp.Request
+  request: ccfapp.Request,
 ): ccfapp.Response<CryptoResponse> {
   // Most functionality of jsrsasign requires keys.
   // Generating a key here is too slow, so we'll just check if the
@@ -23,7 +23,7 @@ interface GenerateAesKeyRequest {
 }
 
 export function generateAesKey(
-  request: ccfapp.Request<GenerateAesKeyRequest>
+  request: ccfapp.Request<GenerateAesKeyRequest>,
 ): ccfapp.Response<ArrayBuffer> {
   return { body: ccfcrypto.generateAesKey(request.body.json().size) };
 }
@@ -39,7 +39,7 @@ export interface GenerateRsaKeyPairResponse {
 }
 
 export function generateRsaKeyPair(
-  request: ccfapp.Request<GenerateRsaKeyPairRequest>
+  request: ccfapp.Request<GenerateRsaKeyPairRequest>,
 ): ccfapp.Response<GenerateRsaKeyPairResponse> {
   const req = request.body.json();
   const res = req.exponent
@@ -58,7 +58,7 @@ export interface GenerateEcdsaKeyPairResponse {
 }
 
 export function generateEcdsaKeyPair(
-  request: ccfapp.Request<GenerateEcdsaKeyPairRequest>
+  request: ccfapp.Request<GenerateEcdsaKeyPairRequest>,
 ): ccfapp.Response<GenerateEcdsaKeyPairResponse> {
   const req = request.body.json();
   const res = ccfcrypto.generateEcdsaKeyPair(req.curve);
@@ -75,7 +75,7 @@ export interface GenerateEddsaKeyPairResponse {
 }
 
 export function generateEddsaKeyPair(
-  request: ccfapp.Request<GenerateEddsaKeyPairRequest>
+  request: ccfapp.Request<GenerateEddsaKeyPairRequest>,
 ): ccfapp.Response<GenerateEddsaKeyPairResponse> {
   const req = request.body.json();
   const res = ccfcrypto.generateEddsaKeyPair(req.curve);
@@ -107,7 +107,7 @@ interface WrapKeyRequest {
 }
 
 export function wrapKey(
-  request: ccfapp.Request<WrapKeyRequest>
+  request: ccfapp.Request<WrapKeyRequest>,
 ): ccfapp.Response<ArrayBuffer> {
   const r = request.body.json();
   const key = b64ToBuf(r.key);
@@ -139,7 +139,7 @@ interface SignRequest {
 }
 
 export function sign(
-  request: ccfapp.Request<SignRequest>
+  request: ccfapp.Request<SignRequest>,
 ): ccfapp.Response<ArrayBuffer> {
   const body = request.body.json();
   const result = ccfcrypto.sign(body.algorithm, body.key, b64ToBuf(body.data));
@@ -156,14 +156,14 @@ interface VerifySignatureRequest {
 }
 
 export function verifySignature(
-  request: ccfapp.Request<VerifySignatureRequest>
+  request: ccfapp.Request<VerifySignatureRequest>,
 ): ccfapp.Response<boolean> {
   const body = request.body.json();
   const result = ccfcrypto.verifySignature(
     body.algorithm,
     body.key,
     b64ToBuf(body.signature),
-    b64ToBuf(body.data)
+    b64ToBuf(body.data),
   );
   return {
     body: result,
@@ -176,7 +176,7 @@ interface DigestRequest {
 }
 
 export function digest(
-  request: ccfapp.Request<DigestRequest>
+  request: ccfapp.Request<DigestRequest>,
 ): ccfapp.Response {
   const body = request.body.json();
   const data = b64ToBuf(body.data);
@@ -186,7 +186,7 @@ export function digest(
 }
 
 export function isValidX509CertBundle(
-  request: ccfapp.Request
+  request: ccfapp.Request,
 ): ccfapp.Response<boolean> {
   const pem = request.body.text();
   return { body: ccfcrypto.isValidX509CertBundle(pem) };
@@ -198,7 +198,7 @@ interface IsValidX509CertChainRequest {
 }
 
 export function isValidX509CertChain(
-  request: ccfapp.Request<IsValidX509CertChainRequest>
+  request: ccfapp.Request<IsValidX509CertChainRequest>,
 ): ccfapp.Response<boolean> {
   const { chain, trusted } = request.body.json();
   return { body: ccfcrypto.isValidX509CertChain(chain, trusted) };
@@ -210,7 +210,7 @@ interface pemToJWKRequest {
 }
 
 export function pubPemToJwk(
-  request: ccfapp.Request<pemToJWKRequest>
+  request: ccfapp.Request<pemToJWKRequest>,
 ): ccfapp.Response {
   const req = request.body.json();
   const res = ccfcrypto.pubPemToJwk(req.pem, req.kid);
@@ -218,7 +218,7 @@ export function pubPemToJwk(
 }
 
 export function pemToJwk(
-  request: ccfapp.Request<pemToJWKRequest>
+  request: ccfapp.Request<pemToJWKRequest>,
 ): ccfapp.Response {
   const req = request.body.json();
   const res = ccfcrypto.pemToJwk(req.pem, req.kid);
@@ -226,7 +226,7 @@ export function pemToJwk(
 }
 
 export function pubRsaPemToJwk(
-  request: ccfapp.Request<pemToJWKRequest>
+  request: ccfapp.Request<pemToJWKRequest>,
 ): ccfapp.Response {
   const req = request.body.json();
   const res = ccfcrypto.pubRsaPemToJwk(req.pem, req.kid);
@@ -234,7 +234,7 @@ export function pubRsaPemToJwk(
 }
 
 export function rsaPemToJwk(
-  request: ccfapp.Request<pemToJWKRequest>
+  request: ccfapp.Request<pemToJWKRequest>,
 ): ccfapp.Response {
   const req = request.body.json();
   const res = ccfcrypto.rsaPemToJwk(req.pem, req.kid);
@@ -242,7 +242,7 @@ export function rsaPemToJwk(
 }
 
 export function pubEddsaPemToJwk(
-  request: ccfapp.Request<pemToJWKRequest>
+  request: ccfapp.Request<pemToJWKRequest>,
 ): ccfapp.Response {
   const req = request.body.json();
   const res = ccfcrypto.pubEddsaPemToJwk(req.pem, req.kid);
@@ -250,7 +250,7 @@ export function pubEddsaPemToJwk(
 }
 
 export function eddsaPemToJwk(
-  request: ccfapp.Request<pemToJWKRequest>
+  request: ccfapp.Request<pemToJWKRequest>,
 ): ccfapp.Response {
   const req = request.body.json();
   const res = ccfcrypto.eddsaPemToJwk(req.pem, req.kid);
@@ -262,7 +262,7 @@ interface JwkToPemRequest {
 }
 
 export function pubJwkToPem(
-  request: ccfapp.Request<JwkToPemRequest>
+  request: ccfapp.Request<JwkToPemRequest>,
 ): ccfapp.Response {
   const req = request.body.json();
   const res = ccfcrypto.pubJwkToPem(req.jwk);
@@ -270,7 +270,7 @@ export function pubJwkToPem(
 }
 
 export function jwkToPem(
-  request: ccfapp.Request<JwkToPemRequest>
+  request: ccfapp.Request<JwkToPemRequest>,
 ): ccfapp.Response {
   const req = request.body.json();
   const res = ccfcrypto.jwkToPem(req.jwk);
@@ -278,7 +278,7 @@ export function jwkToPem(
 }
 
 export function pubRsaJwkToPem(
-  request: ccfapp.Request<JwkToPemRequest>
+  request: ccfapp.Request<JwkToPemRequest>,
 ): ccfapp.Response {
   const req = request.body.json();
   const res = ccfcrypto.pubRsaJwkToPem(req.jwk);
@@ -286,7 +286,7 @@ export function pubRsaJwkToPem(
 }
 
 export function rsaJwkToPem(
-  request: ccfapp.Request<JwkToPemRequest>
+  request: ccfapp.Request<JwkToPemRequest>,
 ): ccfapp.Response {
   const req = request.body.json();
   const res = ccfcrypto.rsaJwkToPem(req.jwk);
@@ -294,7 +294,7 @@ export function rsaJwkToPem(
 }
 
 export function pubEddsaJwkToPem(
-  request: ccfapp.Request<JwkToPemRequest>
+  request: ccfapp.Request<JwkToPemRequest>,
 ): ccfapp.Response {
   const req = request.body.json();
   const res = ccfcrypto.pubEddsaJwkToPem(req.jwk);
@@ -302,7 +302,7 @@ export function pubEddsaJwkToPem(
 }
 
 export function eddsaJwkToPem(
-  request: ccfapp.Request<JwkToPemRequest>
+  request: ccfapp.Request<JwkToPemRequest>,
 ): ccfapp.Response {
   const req = request.body.json();
   const res = ccfcrypto.eddsaJwkToPem(req.jwk);

--- a/tests/npm-app/src/endpoints/jwt.ts
+++ b/tests/npm-app/src/endpoints/jwt.ts
@@ -24,7 +24,7 @@ interface BodyClaims {
 // this is an unauthenticated endpoint which extracts, parses, and validates
 // the JWT itself directly in TS.
 export function jwt(
-  request: ccfapp.Request
+  request: ccfapp.Request,
 ): ccfapp.Response<JwtResponse | ErrorResponse> {
   const authHeader = request.headers["authorization"];
   if (!authHeader) {
@@ -53,7 +53,7 @@ export function jwt(
   const keysMap = ccfapp.typedKv(
     "public:ccf.gov.jwt.public_signing_keys",
     ccfapp.string,
-    ccfapp.typedArray(Uint8Array)
+    ccfapp.typedArray(Uint8Array),
   );
   const publicKeyDer = keysMap.get(signingKeyId);
   if (publicKeyDer === undefined) {
@@ -76,7 +76,7 @@ export function jwt(
       // No trusted time, disable time validation.
       verifyAt: Date.parse("2020-01-01T00:00:00") / 1000,
       gracePeriod: 10 * 365 * 24 * 60 * 60,
-    }
+    },
   );
   if (!valid) {
     return unauthorized("jwt validation failed");

--- a/tests/npm-app/src/endpoints/log.ts
+++ b/tests/npm-app/src/endpoints/log.ts
@@ -29,7 +29,7 @@ export function setLogItem(request: ccfapp.Request<LogItem>): ccfapp.Response {
 }
 
 export function getAllLogItems(
-  request: ccfapp.Request
+  request: ccfapp.Request,
 ): ccfapp.Response<Array<LogEntry>> {
   let items: Array<LogEntry> = [];
   logMap.forEach(function (item, id) {

--- a/tests/npm-app/src/endpoints/oe.ts
+++ b/tests/npm-app/src/endpoints/oe.ts
@@ -21,7 +21,7 @@ interface ErrorResponse {
 }
 
 export function verifyOpenEnclaveEvidence(
-  request: ccfapp.Request<Evidence>
+  request: ccfapp.Request<Evidence>,
 ): ccfapp.Response<Claims | ErrorResponse> {
   const body = request.body.json();
   const evidence = ccfapp

--- a/tests/npm-app/src/endpoints/partition.ts
+++ b/tests/npm-app/src/endpoints/partition.ts
@@ -6,7 +6,7 @@ type PartitionRequest = any[];
 type PartitionResponse = [any[], any[]];
 
 export function partition(
-  request: ccfapp.Request<PartitionRequest>
+  request: ccfapp.Request<PartitionRequest>,
 ): ccfapp.Response<PartitionResponse> {
   // Example from https://lodash.com.
   let arr = request.body.json();

--- a/tests/npm-app/src/endpoints/proto.ts
+++ b/tests/npm-app/src/endpoints/proto.ts
@@ -10,7 +10,7 @@ export function proto(request: ccfapp.Request): ccfapp.Response<ProtoResponse> {
   let Type = protobuf.Type;
   let Field = protobuf.Field;
   let AwesomeMessage = new Type("AwesomeMessage").add(
-    new Field("awesomeField", 1, "string")
+    new Field("awesomeField", 1, "string"),
   );
 
   let message = AwesomeMessage.create({ awesomeField: request.body.text() });

--- a/tests/npm-app/src/endpoints/rpc.ts
+++ b/tests/npm-app/src/endpoints/rpc.ts
@@ -4,7 +4,7 @@ export function postApplyWrites(request: ccfapp.Request): ccfapp.Response {
   const kv = ccfapp.typedKv(
     "public:apply_writes",
     ccfapp.string,
-    ccfapp.string
+    ccfapp.string,
   );
   const params = request.body.json();
   kv.set("foo", params.val);
@@ -20,7 +20,7 @@ export function getApplyWrites(request: ccfapp.Request): ccfapp.Response {
   const kv = ccfapp.typedKv(
     "public:apply_writes",
     ccfapp.string,
-    ccfapp.string
+    ccfapp.string,
   );
   const v = kv.get("foo");
   return {


### PR DESCRIPTION
A new release of Prettier (3.0.0) was [just released](https://github.com/prettier/prettier/releases/tag/3.0.0), which includes a [breaking change](https://prettier.io/blog/2023/07/05/3.0.0.html#change-the-default-value-for-trailingcomma-to-all-11479httpsgithubcomprettierprettierpull11479-by-fiskerhttpsgithubcomfisker-13143httpsgithubcomprettierprettierpull13143-by-sosukesuzukihttpsgithubcomsosukesuzuki), causing [all of our format checks](https://github.com/microsoft/CCF/actions/runs/5454382106/jobs/9952254132#step:5:65) to fail.

Specifically, it wants to add trailing commas to a lot of our `.js` and `.ts` files.

We could add a Prettier config file enforcing the old behaviour, but trying that it appears the Typescript files are still touched. The simpler option I think is to accept this proposed reformatting.