### PR TITLE
Remove node output from config timeout test appearing in e2e output

### DIFF
--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -394,8 +394,8 @@ def run_config_timeout_check(args):
         ],
         cwd=start_node_path,
         env={"ASAN_OPTIONS": "alloc_dealloc_mismatch=0"},
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stdout=open(os.path.join(start_node_path, "out"), "wb"),
+        stderr=open(os.path.join(start_node_path, "err"), "wb"),
     )
     time.sleep(2)
     LOG.info("Copy a partial config")

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -383,10 +383,19 @@ def run_config_timeout_check(args):
     LOG.info("No config at all")
     assert not os.path.exists(os.path.join(start_node_path, "0.config.json"))
     LOG.info(f"Attempt to start node without a config under {start_node_path}")
+    config_timeout = 10
     proc = subprocess.Popen(
-        ["./cchost", "--config", "0.config.json", "--config-timeout", "10s"],
+        [
+            "./cchost",
+            "--config",
+            "0.config.json",
+            "--config-timeout",
+            f"{config_timeout}s",
+        ],
         cwd=start_node_path,
         env={"ASAN_OPTIONS": "alloc_dealloc_mismatch=0"},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
     time.sleep(2)
     LOG.info("Copy a partial config")
@@ -399,8 +408,9 @@ def run_config_timeout_check(args):
         os.path.join(start_node_path, "0.config.json.bak"),
         os.path.join(start_node_path, "0.config.json"),
     )
-    time.sleep(10)
-    LOG.info("Wait out the rest of the timeout")
+    LOG.info(f"Wait out the rest of the {config_timeout}s timeout")
+    time.sleep(config_timeout)
+    LOG.info("Check node")
     assert proc.poll() is None, "Node process should still be running"
     assert os.path.exists(os.path.join(start_node_path, "service_cert.pem"))
     proc.terminate()


### PR DESCRIPTION
The recently added `run_config_timeout_check` starts a `cchost` instance by hand so that we directly control the config. This was not started with any `stdout` redirection, so the node output was interleaved with the Python output in every e2e run, [as here](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=72581&view=logs&j=8f3dc89c-3708-5926-47e7-27120a268dab&t=bb1a7e6d-8f5b-56e4-638c-b498b20b4b62&l=36327):

```
57: 2023-07-06 03:23:59.634 | INFO     | {operations} e2e_operations:run_config_timeout_check:397 - Move a full config back
57: 0        100 [info ] ../src/host/main.cpp:161             | CCF version: ccf-4.0.0-121-gbc8b04a75
57: 1        100 [info ] ../src/host/main.cpp:169             | Configuration file 0.config.json:
57: 
57: 2        100 [info ] ../src/host/main.cpp:178             | Environment: {
57:   "ASAN_OPTIONS": "alloc_dealloc_mismatch=0"
57: }
57: 
57: 3        100 [info ] ../src/host/main.cpp:209             | Recovery threshold unset. Defaulting to number of initial consortium members with a public encryption key (3).
57: 4        100 [debug] ../src/ds/messaging.h:106            | Setting handler for OversizedMessage::fragment (4236346845)
57: 5        100 [debug] ../src/ds/messaging.h:106            | Setting handler for AppMessage::launch_host_process (542245731)
57: 6        100 [debug] ../src/ds/messaging.h:106            | Setting handler for AdminMessage::work_stats (2854380612)
57: 7        100 [debug] ../src/ds/messaging.h:106            | Setting handler for AdminMessage::log_msg (1225314783)
...
57: 232        100 [debug] ../src/host/load_monitor.h:84        | {"end_time_ms":1688613849211,"ringbuffer_messages":{"AdminMessage::work_stats":{"bytes":23972,"count":461}},"start_time_ms":1688613848711}
57: 233        100 [debug] ../src/host/load_monitor.h:91        | {"end_time_ms":1688613849211,"ringbuffer_messages":{"AdminMessage::tick":{"bytes":0,"count":461}},"start_time_ms":1688613848711}
57: 2023-07-06 03:24:09.645 | INFO     | {operations} e2e_operations:run_config_timeout_check:403 - Wait out the rest of the timeout
57: 234        100 [info ] ../src/host/sig_term.h:39            | Terminated: Shutting down enclave gracefully...
57: 235 -0.002 0   [info ] ../src/enclave/enclave.h:473         | Enclave stopped successfully. Stopping host...
57: 236        100 [info ] ../src/host/handle_ring_buffer.h:100 | Host stopped successfully
57: 237        100 [info ] ../src/host/main.cpp:704             | Exited event loop
57: 238        100 [info ] ../src/host/main.cpp:722             | Ran an extra 1 cleanup iteration(s)
```

I think this makes the test output harder to read, so I've redirected the output of this process where it won't be interleaved with the e2e output.

```
61: 2023-07-06 13:37:50.815 | INFO     | {operations} e2e_operations:run_config_timeout_check:383 - No config at all
61: 2023-07-06 13:37:50.815 | INFO     | {operations} e2e_operations:run_config_timeout_check:385 - Attempt to start node without a config under /data/src/3.CCF/build.virtual/workspace/operations_schema_test_cft_0
61: 2023-07-06 13:37:52.821 | INFO     | {operations} e2e_operations:run_config_timeout_check:401 - Copy a partial config
61: 2023-07-06 13:37:54.824 | INFO     | {operations} e2e_operations:run_config_timeout_check:406 - Move a full config back
61: 2023-07-06 13:37:54.826 | INFO     | {operations} e2e_operations:run_config_timeout_check:411 - Wait out the rest of the 10s timeout
61: 2023-07-06 13:38:04.827 | INFO     | {operations} e2e_operations:run_config_timeout_check:413 - Check node
```