### PR TITLE
Remove extra quote-mark in documentation

### DIFF
--- a/doc/audit/read_write_restrictions.rst
+++ b/doc/audit/read_write_restrictions.rst
@@ -75,4 +75,4 @@ The possible access permissions are elaborated in the table below:
     | Application              | Read-only  | None       | Read-only  | None       | Writeable  | Writeable  |
     +--------------------------+------------+------------+------------+------------+------------+------------+
 
-Any violation of these restrictions (eg - calling ``set`` on a `Read-only`` table, or ``has`` on a `None` table) results in an exception being thrown.
+Any violation of these restrictions (eg - calling ``set`` on a `Read-only` table, or ``has`` on a `None` table) results in an exception being thrown.


### PR DESCRIPTION
Noticed a minor typo in the docs:

![image](https://github.com/microsoft/CCF/assets/6000239/2dfd79b0-160e-45c7-b2c8-95dd78d04104)

This change makes that say _`Read-only`_ rather than _``Read-only` ``_