### PR TITLE
[release/4.x] Cherry pick: Include intermediate certs in TLS handshake (#5453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [4.0.5]: https://github.com/microsoft/CCF/releases/tag/ccf-4.0.5
 
 - Debug logging is now available in non-SGX builds by default, and controlled by a run-time CLI argument (`--enclave-log-level`). On SGX this remains a build-time decision (#5375).
+- Supporting intermediate cert chain included in TLS handshake, where previously only server leaf certificate was present (#5453).
 - Added `getVersionOfPreviousWrite` to TypeScript `TypedKvMap` interface (#5451).
 
 ## [4.0.4]

--- a/tests/acme_endorsement.py
+++ b/tests/acme_endorsement.py
@@ -48,7 +48,7 @@ def wait_for_port_to_listen(host, port, timeout=10):
 
 @reqs.description("Start network and wait for ACME certificates")
 def wait_for_certificates(
-    args, network_name, ca_certs, interface_name, challenge_interface, timeout=5 * 60
+    args, network_name, root_cert, interface_name, challenge_interface, timeout=5
 ):
     with infra.network.network(
         args.nodes, args.binary_dir, args.debug_nodes, args.perf_nodes, pdb=args.pdb
@@ -76,8 +76,7 @@ def wait_for_certificates(
                     context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
                     context.verify_mode = ssl.CERT_REQUIRED
                     context.check_hostname = True
-                    for crt in ca_certs:
-                        context.load_verify_locations(cadata=crt)
+                    context.load_verify_locations(cadata=root_cert)
 
                     s = socket.socket()
                     s.settimeout(1)
@@ -92,9 +91,12 @@ def wait_for_certificates(
                     assert network_public_key == cert_public_key
                     num_ok += 1
                 except Exception as ex:
-                    LOG.trace(f"Likely expected exception: {ex}")
+                    LOG.warning(f"Likely temporary exception: {ex}")
 
             if num_ok != len(args.nodes):
+                LOG.warning(
+                    f"{num_ok}/{len(args.nodes)} nodes presenting endorsed cert"
+                )
                 time.sleep(1)
 
         # We can't run test_unsecured_interfaces against the ACME-endorsed interface
@@ -195,12 +197,9 @@ def get_without_cert_check(url):
     return urllib.request.urlopen(url, context=ctx).read().decode("utf-8")
 
 
-def get_pebble_ca_certs(mgmt_address):
+def get_pebble_root_cert(mgmt_address):
     ca = get_without_cert_check("https://" + mgmt_address + "/roots/0")
-    intermediate = get_without_cert_check(
-        "https://" + mgmt_address + "/intermediates/0"
-    )
-    return ca, intermediate
+    return ca
 
 
 @reqs.description("Test that secure content is not available on an unsecured interface")
@@ -321,11 +320,11 @@ def run_pebble(args):
             )
 
             try:
-                ca_certs = get_pebble_ca_certs(mgmt_address)
+                root_cert = get_pebble_root_cert(mgmt_address)
                 wait_for_certificates(
                     args,
                     network_name,
-                    ca_certs,
+                    root_cert,
                     "acme_endorsed_interface",
                     "acme_challenge_server_if",
                 )


### PR DESCRIPTION
Backports the following commits to `release/4.x`:
 - [Include intermediate certs in TLS handshake (#5453)](https://github.com/microsoft/CCF/pull/5453)