### PR TITLE
Revert #4700 - restore `pull_request` trigger for `build-ci-container.yml`

### DIFF
--- a/.github/workflows/build-ci-container.yml
+++ b/.github/workflows/build-ci-container.yml
@@ -2,7 +2,7 @@ name: "Build SNP CI Testing CCF Container"
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - release/3.x

--- a/.github/workflows/build-ci-container.yml
+++ b/.github/workflows/build-ci-container.yml
@@ -28,9 +28,6 @@ jobs:
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
 
       - name: Debug
         run: |

--- a/.github/workflows/build-ci-container.yml
+++ b/.github/workflows/build-ci-container.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     branches:
       - main
-      - release/3.x
     paths:
       - scripts/azure_deployment/*
       - .github/workflows/build-ci-container.yml
@@ -16,7 +15,6 @@ on:
   push:
     branches:
       - main
-      - release/3.x
   schedule:
     - cron: "0 9 * * Mon-Fri"
 


### PR DESCRIPTION
See #4700.

Switching to `pull_request_target` let us trigger this from forks, with access to secrets, but doesn't apply the same security restrictions as `pull_request`. We may replace this with an ADO pipeline in future. For now, we can trigger rebuilds of the SNP CI containers with PRs from `microsoft/` branches.