### PR TITLE
Fix `lts_compatibility` in SGX Debug - don't pass unsafe `--enclave-log-level`

### DIFF
--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -834,10 +834,12 @@ class CCFRemote(object):
                 else None
             )
             if v is None or v >= Version("4.0.5"):
-                cmd += [
-                    "--enclave-log-level",
-                    enclave_log_level,
-                ]
+                # Avoid passing too-low level to debug SGX nodes
+                if not (enclave_type == "debug" and enclave_platform == "sgx"):
+                    cmd += [
+                        "--enclave-log-level",
+                        enclave_log_level,
+                    ]
 
             if start_type == StartType.start:
                 members_info = kwargs.get("members_info")


### PR DESCRIPTION
#5375 introduced a crash in the `lts_compatibility` test in SGX Debug builds that was missed until 4.0.5 was cut. It attempts to pass `--enclave-log-level Debug` to LTS nodes built with minimum logging level = INFO, and those nodes throw at CLI validation.

This is a quick-fix to stop passing the argument at all when it is potentially unsafe. It does mean the infra won't produce the verbose logs for SGX Debug, but we can resolve that with a more targeted fix when we have more time.