### PR TITLE
Fix SNP `code_update_test` - `ccf.digest` is now `ccf.crypto.digest`

### DIFF
--- a/samples/constitutions/default/actions.js
+++ b/samples/constitutions/default/actions.js
@@ -1038,7 +1038,7 @@ const actions = new Map([
         // SHA-256 digest is the specified host data
         if (args.security_policy != "") {
           const securityPolicyDigest = ccf.bufToStr(
-            ccf.digest("SHA-256", ccf.strToBuf(args.security_policy)),
+            ccf.crypto.digest("SHA-256", ccf.strToBuf(args.security_policy)),
           );
           const hostData = ccf.bufToStr(hexStrToBuf(args.host_data));
           if (securityPolicyDigest != hostData) {


### PR DESCRIPTION
This was renamed in the JS API a while ago, but missed from the SNP path while that test was omitted.