### PR TITLE
Fix bug in TLS context - allow incoming write buffer to be relocated

### DIFF
--- a/src/enclave/tls_session.h
+++ b/src/enclave/tls_session.h
@@ -417,7 +417,7 @@ namespace ccf
         else
         {
           LOG_TRACE_FMT(
-            "TLS {} on flush: {}", session_id, tls::error_string(r));
+            "TLS session {} error on flush: {}", session_id, -r);
           stop(error);
         }
       }

--- a/src/enclave/tls_session.h
+++ b/src/enclave/tls_session.h
@@ -416,8 +416,7 @@ namespace ccf
         }
         else
         {
-          LOG_TRACE_FMT(
-            "TLS session {} error on flush: {}", session_id, -r);
+          LOG_TRACE_FMT("TLS session {} error on flush: {}", session_id, -r);
           stop(error);
         }
       }

--- a/src/tls/context.h
+++ b/src/tls/context.h
@@ -60,6 +60,15 @@ namespace tls
       SSL_CTX_set1_curves_list(cfg, "P-521:P-384:P-256");
       SSL_set1_curves_list(ssl, "P-521:P-384:P-256");
 
+      // Allow buffer to be relocated between WANT_WRITE retries, and do partial
+      // writes if possible
+      SSL_CTX_set_mode(
+        cfg,
+        SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER | SSL_MODE_ENABLE_PARTIAL_WRITE);
+      SSL_set_mode(
+        ssl,
+        SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER | SSL_MODE_ENABLE_PARTIAL_WRITE);
+
       // Initialise connection
       if (client)
         SSL_set_connect_state(ssl);


### PR DESCRIPTION
Spotted some odd TLS errors during multi-threaded perf tests, where clients were being disconnected. Tracked it down to this. There were cases where we got a `WANTS_WRITE/WANTS_READ` response from an attempted write, which means a handshake is still in-progress or similar, and we need to retry the write later. The default semantics are very strict, and we must "retry the write" with exactly the same pointer and size. Our source for this is a `pending_writes` buffer, so if it got resized and reallocated, we'd pass a new pointer and this would blow up. There's a magic flag to make it less strict, which it seems we want. This is well explained in [this StackOverflow answer](https://stackoverflow.com/questions/2997218/why-am-i-getting-error1409f07fssl-routinesssl3-write-pending-bad-write-retr), once you've convinced OpenSSL to log its errors correctly.