### PR TITLE
Use Timestamp Parquet type for recording Piccolo's timestamps

### DIFF
--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -432,7 +432,7 @@ def cli_args():
     parser.add_argument(
         "--client-timeout-s",
         help="Number of seconds after which unresponsive clients are shut down",
-        default=180,
+        default=90,
         type=float,
     )
     parser.add_argument(

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -298,6 +298,7 @@ def run(args, append_messages):
                     agg_path = os.path.join(
                         network.common_dir, "aggregated_basicperf_output.parquet"
                     )
+
                     with open(agg_path, "wb") as f:
                         agg.write_parquet(f)
                     print(f"Aggregated results written to {agg_path}")

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -298,7 +298,6 @@ def run(args, append_messages):
                     agg_path = os.path.join(
                         network.common_dir, "aggregated_basicperf_output.parquet"
                     )
-
                     with open(agg_path, "wb") as f:
                         agg.write_parquet(f)
                     print(f"Aggregated results written to {agg_path}")

--- a/tests/infra/piccolo/analyzer.py
+++ b/tests/infra/piccolo/analyzer.py
@@ -70,7 +70,9 @@ class Analyze:
 
     def total_time_in_sec(self, df_sends: pd.DataFrame, df_responses: pd.DataFrame):
         # time_spent is: last timestamp of responses - first timestamp of sends
-        return df_responses.iloc[-1]["receiveTime"] - df_sends.iloc[0]["sendTime"]
+        return (
+            df_responses.iloc[-1]["receiveTime"] - df_sends.iloc[0]["sendTime"]
+        ).total_seconds()
 
     def sec_to_ms(self, time_in_sec: float) -> float:
         return time_in_sec / SEC_MS

--- a/tests/perf-system/submitter/parquet_data.h
+++ b/tests/perf-system/submitter/parquet_data.h
@@ -14,6 +14,6 @@ public:
   std::vector<std::string> ids;
   std::vector<std::vector<uint8_t>> request;
   std::vector<std::vector<uint8_t>> raw_response;
-  std::vector<double> send_time;
-  std::vector<double> response_time;
+  std::vector<int64_t> send_time;
+  std::vector<int64_t> response_time;
 };

--- a/tests/perf-system/submitter/submit.cpp
+++ b/tests/perf-system/submitter/submit.cpp
@@ -179,19 +179,22 @@ void store_parquet_results(ArgumentParser args, ParquetData data_handler)
 {
   LOG_INFO_FMT("Start storing results");
 
+  auto ms_timestamp_type = arrow::timestamp(arrow::TimeUnit::MILLI);
+
   // Write Send Parquet
   {
     arrow::StringBuilder message_id_builder;
     PARQUET_THROW_NOT_OK(message_id_builder.AppendValues(data_handler.ids));
 
-    arrow::NumericBuilder<arrow::DoubleType> send_time_builder;
+    arrow::TimestampBuilder send_time_builder(
+      ms_timestamp_type, arrow::default_memory_pool());
     PARQUET_THROW_NOT_OK(
       send_time_builder.AppendValues(data_handler.send_time));
 
     auto table = arrow::Table::Make(
       arrow::schema(
         {arrow::field("messageID", arrow::utf8()),
-         arrow::field("sendTime", arrow::float64())}),
+         arrow::field("sendTime", ms_timestamp_type)}),
       {message_id_builder.Finish().ValueOrDie(),
        send_time_builder.Finish().ValueOrDie()});
 
@@ -207,7 +210,8 @@ void store_parquet_results(ArgumentParser args, ParquetData data_handler)
     arrow::StringBuilder message_id_builder;
     PARQUET_THROW_NOT_OK(message_id_builder.AppendValues(data_handler.ids));
 
-    arrow::NumericBuilder<arrow::DoubleType> receive_time_builder;
+    arrow::TimestampBuilder receive_time_builder(
+      ms_timestamp_type, arrow::default_memory_pool());
     PARQUET_THROW_NOT_OK(
       receive_time_builder.AppendValues(data_handler.response_time));
 
@@ -221,7 +225,7 @@ void store_parquet_results(ArgumentParser args, ParquetData data_handler)
     auto table = arrow::Table::Make(
       arrow::schema({
         arrow::field("messageID", arrow::utf8()),
-        arrow::field("receiveTime", arrow::float64()),
+        arrow::field("receiveTime", ms_timestamp_type),
         arrow::field("rawResponse", arrow::binary()),
       }),
       {message_id_builder.Finish().ValueOrDie(),
@@ -340,8 +344,8 @@ int main(int argc, char** argv)
   for (size_t req = 0; req < requests_size; req++)
   {
     data_handler.raw_response.push_back(resp_text[req]);
-    double send_time = start[req].tv_sec + start[req].tv_usec / 1000000.0;
-    double response_time = end[req].tv_sec + end[req].tv_usec / 1000000.0;
+    size_t send_time = start[req].tv_sec * 1000 + start[req].tv_usec / 1000;
+    size_t response_time = end[req].tv_sec * 1000 + end[req].tv_usec / 1000;
     data_handler.send_time.push_back(send_time);
     data_handler.response_time.push_back(response_time);
   }


### PR DESCRIPTION
These were previously floats, resulting in hard-to-read tables and unlabelled latency units:

<img width="377" alt="image" src="https://github.com/microsoft/CCF/assets/6000239/6937831d-7a13-4c67-8db1-275888d4ed98">

By using the Parquet Timestamp type (storing milliseconds since the Linux epoch), we get nice rendering in the output table (and a smattering of type safety)

<img width="448" alt="image" src="https://github.com/microsoft/CCF/assets/6000239/b604d1ab-3f04-4258-885b-fcff5ac2bfc2">

This lets us compare when the clients were running at a glance, and recognise if one was running significantly before/after the others.

This PR includes removing a few sorts and replacing them with `min()`/`max()` where possible.