### PR TITLE
Pin polars to 0.18.7, and shut down network and clients earlier

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -22,4 +22,4 @@ pycose
 # Piccolo dependencies
 fastparquet==2023.*
 prettytable==3.*
-polars
+polars==0.18.7


### PR DESCRIPTION
There is a very substantial perf regression in read_parquet between polars 0.18.7 and 0.18.11 (>5x). We are also slowing down the analysis unnecessarily by keeping the network up.