### PR TITLE
Add support for failover server to the submitter

### DIFF
--- a/src/apps/js_generic/oe_sign.conf
+++ b/src/apps/js_generic/oe_sign.conf
@@ -1,7 +1,7 @@
 # Enclave settings:
 NumHeapPages=524288
 NumStackPages=1024
-NumTCS=8
+NumTCS=14
 ProductID=1
 SecurityVersion=1
 # The Debug setting is automatically inserted by sign_app_library in CMake, to build both debuggable and non-debuggable variants

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -298,8 +298,17 @@ def run(args):
                         raise TimeoutError(
                             f"Client still running after {args.client_timeout_s}s"
                         )
+                    if (
+                        args.stop_primary_after_s
+                        and time.time() > start_time + args.stop_primary_after_s
+                        and not primary.is_stopped()
+                    ):
+                        LOG.info(
+                            f"Stopping primary after {args.stop_primary_after_s} seconds"
+                        )
+                        primary.stop()
 
-                    time.sleep(5)
+                    time.sleep(1)
 
                 for remote_client in clients:
                     remote_client.stop()

--- a/tests/perf-system/submitter/handle_arguments.h
+++ b/tests/perf-system/submitter/handle_arguments.h
@@ -17,7 +17,8 @@ public:
   std::string cert;
   std::string key;
   std::string rootCa;
-  std::string server_address = "127.0.0.1:8000";
+  std::string server_address;
+  std::string failover_server_address = "";
   std::string send_filepath;
   std::string response_filepath;
   std::string generator_filepath;
@@ -54,26 +55,32 @@ public:
         "-a,--server-address",
         server_address,
         "Specify the address to submit requests.")
+      ->required(true);
+    app
+      .add_option(
+        "--failover-server-address",
+        failover_server_address,
+        "Specify failover address, in case connection to the main server address is lost.")
       ->capture_default_str();
     app
       .add_option(
         "-s,--send-filepath",
         send_filepath,
         "Path to parquet file to store the submitted requests.")
-      ->required();
+      ->required(true);
     app
       .add_option(
         "-r,--response-filepath",
         response_filepath,
         "Path to parquet file to store the responses from the submitted "
         "requests.")
-      ->required();
+      ->required(true);
     app
       .add_option(
         "-g,--generator-filepath",
         generator_filepath,
         "Path to parquet file with the generated requests to be submitted.")
-      ->required();
+      ->required(true);
     app
       .add_option(
         "-m,--max-writes-ahead",


### PR DESCRIPTION
This adds a new flag `--stop-primary-after-s 5`, which when passed does the following things:

1. Set `--failover-server-address` to the first backup for all nodes otherwise pointing to the primary
2. Set the election timeout for all nodes but the first backup to 15 seconds, so as to ensure its election
3. After the configured number of seconds, shut down the primary

It's worth noting that the throughput diagram does not currently show the gap we would expect, owing to the immediate reconnection followed by a series of 4xx return codes, which we should not be counting as successful writes.

There are typically two reconnections:

```
2023-08-03T14:53:24.906610Z        100 [fail ] perf-system/submitter/submit.cpp:322 | Sending interrupted: unknown error, attempting reconnection to 127.0.0.2:35765
2023-08-03T14:53:25.336125Z        100 [info ] perf-system/submitter/submit.cpp:307 | Sent 180000 requests
2023-08-03T14:53:25.917959Z        100 [info ] perf-system/submitter/submit.cpp:307 | Sent 200000 requests
2023-08-03T14:53:26.500395Z        100 [info ] perf-system/submitter/submit.cpp:307 | Sent 220000 requests
2023-08-03T14:53:27.080966Z        100 [info ] perf-system/submitter/submit.cpp:307 | Sent 240000 requests
2023-08-03T14:53:27.663230Z        100 [info ] perf-system/submitter/submit.cpp:307 | Sent 260000 requests
2023-08-03T14:53:28.243593Z        100 [info ] perf-system/submitter/submit.cpp:307 | Sent 280000 requests
2023-08-03T14:53:28.266256Z        100 [fail ] perf-system/submitter/submit.cpp:322 | Sending interrupted: Underlying transport closed, attempting reconnection to 127.0.0.2:35765
2023-08-03T14:53:28.280154Z        100 [info ] perf-system/submitter/submit.cpp:307 | Sent 280000 requests
2023-08-03T14:53:28.850228Z        100 [info ] perf-system/submitter/submit.cpp:307 | Sent 300000 requests
2023-08-03T14:53:29.432626Z        100 [info ] perf-system/submitter/submit.cpp:307 | Sent 320000 requests
```

One when the primary shuts down, and another one when the election takes place and we reset the connection for session consistency reasons.