### PR TITLE
Offset send and receive times by (approximate) boot time

### DIFF
--- a/tests/perf-system/submitter/submit.cpp
+++ b/tests/perf-system/submitter/submit.cpp
@@ -18,6 +18,7 @@
 #include <arrow/table.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
+#include <sys/sysinfo.h>
 #include <time.h>
 
 using namespace std;
@@ -320,7 +321,9 @@ int main(int argc, char** argv)
     catch (std::logic_error& e)
     {
       LOG_FAIL_FMT(
-        "Sending interrupted: {}, attempting reconnection to {}", e.what(), failover_server_address);
+        "Sending interrupted: {}, attempting reconnection to {}",
+        e.what(),
+        failover_server_address);
       connection = create_connection(certificates, failover_server_address);
       connection->set_tcp_nodelay(true);
       retry_count++;
@@ -329,13 +332,21 @@ int main(int argc, char** argv)
 
   LOG_INFO_FMT("Finished Request Submission");
 
+  // Calculate boot time
+  struct sysinfo info;
+  sysinfo(&info);
+  const auto boot_time = time(NULL) - info.uptime;
+  const auto boot_time_us = boot_time * 1'000'000;
+
   for (size_t req = 0; req < requests_size; req++)
   {
     data_handler.raw_response.push_back(resp_text[req]);
-    size_t send_time = start[req].tv_sec * 1'000'000 + start[req].tv_nsec / 1000;
-    size_t response_time = end[req].tv_sec * 1'000'000 + end[req].tv_nsec / 1000;
-    data_handler.send_time.push_back(send_time);
-    data_handler.response_time.push_back(response_time);
+    size_t send_time_us =
+      boot_time_us + start[req].tv_sec * 1'000'000 + start[req].tv_nsec / 1000;
+    size_t response_time_us =
+      boot_time_us + end[req].tv_sec * 1'000'000 + end[req].tv_nsec / 1000;
+    data_handler.send_time.push_back(send_time_us);
+    data_handler.response_time.push_back(response_time_us);
   }
 
   store_parquet_results(args, data_handler);


### PR DESCRIPTION
#5499 had a fun side effect:

![97d64f89-7f68-4065-8ba9-b625f595aabc](https://github.com/microsoft/CCF/assets/6000239/4f73f49c-2b55-403d-816c-f37985cdaf4f)

Because `CLOCK_MONOTONIC` is time since "an arbitrary epoch" (boot time on Linux), but we store it as though it were a Linux-1970-epoch timestamp, we display confusing send and receive times.

This attempts to corrects that by offsetting the written times by the system's boot time. We can only approximate that, and that's only an approximate match for the start of `CLOCK_MONOTONIC`. But it gets us timestamps that are "correct" within a few seconds, and correctly ordered amongst themselves.

![image](https://github.com/microsoft/CCF/assets/6000239/b92716d9-d61e-4148-b717-3072eb096f4f)
