### PR TITLE
Resolve stability issues with usage of stop-primary in basicperf

### DIFF
--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -313,24 +313,24 @@ def run(args):
                 for remote_client in clients:
                     remote_client.stop()
 
-                primary, _ = network.find_primary()
                 additional_metrics = {}
-                with primary.client() as nc:
-                    r = nc.get("/node/memory")
-                    assert r.status_code == http.HTTPStatus.OK.value
+                if not args.stop_primary_after_s:
+                    primary, _ = network.find_primary()
+                    with primary.client() as nc:
+                        r = nc.get("/node/memory")
+                        assert r.status_code == http.HTTPStatus.OK.value
 
-                    results = r.body.json()
-                    peak_value = results["peak_allocated_heap_size"]
+                        results = r.body.json()
+                        peak_value = results["peak_allocated_heap_size"]
 
-                    # Do not upload empty metrics (virtual doesn't report memory use)
-                    if peak_value != 0:
-                        # Construct name for heap metric, removing ^ suffix if present
-                        heap_peak_metric = args.label
-                        if heap_peak_metric.endswith("^"):
-                            heap_peak_metric = heap_peak_metric[:-1]
-                        heap_peak_metric += "_mem"
-
-                        additional_metrics[heap_peak_metric] = peak_value
+                        # Do not upload empty metrics (virtual doesn't report memory use)
+                        if peak_value != 0:
+                            # Construct name for heap metric, removing ^ suffix if present
+                            heap_peak_metric = args.label
+                            if heap_peak_metric.endswith("^"):
+                                heap_peak_metric = heap_peak_metric[:-1]
+                            heap_peak_metric += "_mem"
+                            additional_metrics[heap_peak_metric] = peak_value
 
                 network.stop_all_nodes()
 

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -357,6 +357,13 @@ def run(args):
                             requestSize=pl.col("request").apply(len),
                             responseSize=pl.col("rawResponse").apply(len),
                         )
+                        # 50x are expected when we stop the primary, 500 when we drop the session
+                        # to maintain consistency, and 504 when we try to write to the future primary
+                        # before their election. Since these requests effectively do nothing, they
+                        # should not count towards latency statistics.
+                        if args.stop_primary_after_s:
+                            overall = overall.filter(pl.col("responseStatus") < 500)
+
                         overall = overall.with_columns(
                             pl.col("receiveTime").alias("latency") - pl.col("sendTime")
                         )

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -984,7 +984,11 @@ class Network:
         return self.consortium.members
 
     def get_joined_nodes(self):
-        return [node for node in self.nodes if node.is_joined() and not node.suspended]
+        return [
+            node
+            for node in self.nodes
+            if node.is_joined() and not (node.is_stopped() or node.suspended)
+        ]
 
     def get_stopped_nodes(self):
         return [node for node in self.nodes if node.is_stopped()]


### PR DESCRIPTION
1. Piccolo now ignores SIGPIPE, since it will sometimes try to write to a socket after the primary has shut down unexpectedly
2. It is not possible to guarantee a primary will be elected in time, depending on the test duration, and so trying to snap the memory usage from the primary is now skipped
3. Filter out error responses produced as a result of the election