### PR TITLE
Swap Pools to mitigate region outage

### DIFF
--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -11,7 +11,7 @@ parameters:
       pool: ado-virtual-ccf-sub
     SGX:
       container: sgx
-      pool: ado-sgx-ccf-sub
+      pool: ado-sgx-ccf-sub-backup
     SNPCC:
       container: snp
       pool: ado-virtual-ccf-sub


### PR DESCRIPTION
Not necessary, there is a way to setup a pool to be the backup for another one in case of failure.