### PR TITLE
Add reconfiguration to basicperf

### DIFF
--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -278,7 +278,7 @@ def run(args):
                 # All clients talking to the primary are configured to fail over to the first backup,
                 # which is the only node whose election timeout has not been raised, to guarantee its
                 # election as the old primary becomes unavailable.
-                if args.stop_primary_after_s:
+                if args.stop_primary_after_s and target == "primary":
                     cmd.append(
                         f"--failover-server-address={backups[0].get_public_rpc_host()}:{backups[0].get_public_rpc_port()}"
                     )

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -345,7 +345,6 @@ def run(args):
                             os.path.join(committed_snapshots_dir, latest_snapshot),
                             latest_snapshot_dir,
                         )
-                        # TODO: delete all but the last snapshot to minimise copy time to new remote
                         LOG.info(
                             f"Stopping primary after {args.stop_primary_after_s} seconds"
                         )

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -307,6 +307,7 @@ def run(args):
 
             try:
                 start_time = time.time()
+                primary_has_stopped = False
                 while True:
                     stop_waiting = True
                     for i, remote_client in enumerate(clients):
@@ -325,7 +326,7 @@ def run(args):
                     if (
                         args.stop_primary_after_s
                         and time.time() > start_time + args.stop_primary_after_s
-                        and not primary.is_stopped()
+                        and not primary_has_stopped
                     ):
                         committed_snapshots_dir = network.get_committed_snapshots(
                             primary, force_txs=False
@@ -334,6 +335,7 @@ def run(args):
                             f"Stopping primary after {args.stop_primary_after_s} seconds"
                         )
                         primary.stop()
+                        primary_has_stopped = True
                         old_primary = primary
                         primary, _ = network.wait_for_new_primary(primary)
                         if args.add_new_node_after_primary_stops:

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -224,7 +224,11 @@ def run(args):
         requests_file_paths = []
         for client_def in args.client_def:
             count, gen, iterations, target = client_def.split(",")
-            rr_idx = 0
+            # The round robin index deliberately starts at 1, so that backups/any are
+            # loaded uniformly but the first instance slightly less so where possible. This
+            # is useful when running a failover test, to avoid the new primary being targeted
+            # by reads.
+            rr_idx = 1
             for _ in range(int(count)):
                 LOG.info(f"Generating {iterations} requests for client_{client_idx}")
                 msgs = generator.Messages()


### PR DESCRIPTION
Add a `--add-new-node-before-primary-stops <hostname>` that can be combined with `--stop-primary-after-s <duration>`, which configures in a new node after stopping, and retiring the primary.