### PR TITLE
Get a shared boot time for offsetting submit times

### DIFF
--- a/tests/perf-system/submitter/handle_arguments.h
+++ b/tests/perf-system/submitter/handle_arguments.h
@@ -25,6 +25,8 @@ public:
   int max_inflight_requests = 0;
   std::string pid_file_path = "submit.pid";
 
+  size_t boot_time_us = 0u;
+
   ArgumentParser(const std::string& default_label, CLI::App& app) :
     label(default_label)
   {
@@ -60,7 +62,8 @@ public:
       .add_option(
         "--failover-server-address",
         failover_server_address,
-        "Specify failover address, in case connection to the main server address is lost.")
+        "Specify failover address, in case connection to the main server "
+        "address is lost.")
       ->capture_default_str();
     app
       .add_option(
@@ -99,5 +102,10 @@ public:
         pid_file_path,
         "Path to file where the pid of the submitter will be stored.")
       ->capture_default_str();
+    app.add_option(
+      "--boot-time",
+      boot_time_us,
+      "System boot time, as microseconds since Linux epoch, used to offset "
+      "CLOCK_MONOTONIC measurements");
   }
 };

--- a/tests/perf-system/submitter/submit.cpp
+++ b/tests/perf-system/submitter/submit.cpp
@@ -18,9 +18,9 @@
 #include <arrow/table.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
+#include <signal.h>
 #include <sys/sysinfo.h>
 #include <time.h>
-#include <signal.h>
 
 using namespace std;
 using namespace client;
@@ -355,12 +355,6 @@ int main(int argc, char** argv)
 
   LOG_INFO_FMT("Finished Request Submission");
 
-  // Calculate boot time
-  struct sysinfo info;
-  sysinfo(&info);
-  const auto boot_time = time(NULL) - info.uptime;
-  const auto boot_time_us = boot_time * 1'000'000;
-
   for (size_t req = 0; req < requests_size; req++)
   {
     auto& response = responses[req];
@@ -377,10 +371,10 @@ int main(int argc, char** argv)
     data_handler.response_headers.push_back(concat_headers);
     data_handler.response_body.push_back(std::move(response.body));
 
-    size_t send_time_us =
-      boot_time_us + start[req].tv_sec * 1'000'000 + start[req].tv_nsec / 1000;
+    size_t send_time_us = args.boot_time_us + start[req].tv_sec * 1'000'000 +
+      start[req].tv_nsec / 1000;
     size_t response_time_us =
-      boot_time_us + end[req].tv_sec * 1'000'000 + end[req].tv_nsec / 1000;
+      args.boot_time_us + end[req].tv_sec * 1'000'000 + end[req].tv_nsec / 1000;
     data_handler.send_time.push_back(send_time_us);
     data_handler.response_time.push_back(response_time_us);
   }


### PR DESCRIPTION
#5503 attempted to convert `CLOCK_MONOTONIC` times to wall-clock time, so that they can be compared with timestamps on other machines. However, since this was done in each client, it could produce visible skew between times from clients running on the same machine.

This PR attempts to calculate the system boot time once, and pass that to each client, so they get should produce times which are at least consistent with other times measured on the same machine, and passed the same boot time.