### PR TITLE
Atomic replacement of shutdown node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1460,7 +1460,7 @@ if(BUILD_TESTS)
         PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/infra/basicperf.py
         CLIENT_BIN ./submit
         ADDITIONAL_ARGS --package "samples/apps/basic/libbasic" --client-def
-                        "${WORKER_THREADS},write,100000,any"
+                        "${WORKER_THREADS},write,100000,primary"
       )
     endif()
 

--- a/samples/apps/basic/basic.cpp
+++ b/samples/apps/basic/basic.cpp
@@ -51,6 +51,7 @@ namespace basicapp
       };
       make_endpoint(
         "/records/{key}", HTTP_PUT, put, {ccf::user_cert_auth_policy})
+        .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
         .install();
 
       auto get = [this](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
@@ -85,6 +86,7 @@ namespace basicapp
       };
       make_read_only_endpoint(
         "/records/{key}", HTTP_GET, get, {ccf::user_cert_auth_policy})
+        .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
         .install();
 
       auto post = [this](ccf::endpoints::EndpointContext& ctx) {

--- a/samples/apps/basic/js/app.json
+++ b/samples/apps/basic/js/app.json
@@ -4,7 +4,7 @@
       "get": {
         "js_module": "basic.js",
         "js_function": "get_record",
-        "forwarding_required": "sometimes",
+        "forwarding_required": "never",
         "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {}
@@ -12,7 +12,7 @@
       "put": {
         "js_module": "basic.js",
         "js_function": "put_record",
-        "forwarding_required": "always",
+        "forwarding_required": "never",
         "authn_policies": ["user_cert"],
         "mode": "readwrite",
         "openapi": {}

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -520,7 +520,7 @@ namespace aft
 
       if (state->leadership_state != kv::LeadershipState::Leader)
       {
-        RAFT_FAIL_FMT(
+        RAFT_DEBUG_FMT(
           "Failed to replicate {} items: not leader", entries.size());
         rollback(state->last_idx);
         return false;
@@ -528,7 +528,7 @@ namespace aft
 
       if (term != state->current_view)
       {
-        RAFT_FAIL_FMT(
+        RAFT_DEBUG_FMT(
           "Failed to replicate {} items at term {}, current term is {}",
           entries.size(),
           term,

--- a/src/host/node_connections.h
+++ b/src/host/node_connections.h
@@ -297,7 +297,7 @@ namespace asynchost
               const auto address_it = node_addresses.find(to);
               if (address_it == node_addresses.end())
               {
-                LOG_INFO_FMT("Ignoring node_outbound to unknown node {}", to);
+                LOG_TRACE_FMT("Ignoring node_outbound to unknown node {}", to);
                 return;
               }
 

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -420,7 +420,7 @@ def run(args):
                         # to maintain consistency, and 504 when we try to write to the future primary
                         # before their election. Since these requests effectively do nothing, they
                         # should not count towards latency statistics.
-                        #if args.stop_primary_after_s:
+                        # if args.stop_primary_after_s:
                         #    overall = overall.filter(pl.col("responseStatus") < 500)
 
                         overall = overall.with_columns(

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -278,7 +278,7 @@ def run(args):
                 # All clients talking to the primary are configured to fail over to the first backup,
                 # which is the only node whose election timeout has not been raised, to guarantee its
                 # election as the old primary becomes unavailable.
-                if args.stop_primary_after_s:
+                if args.stop_primary_after_s and target == "primary":
                     cmd.append(
                         f"--failover-server-address={backups[0].get_public_rpc_host()}:{backups[0].get_public_rpc_port()}"
                     )

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -345,7 +345,6 @@ def run(args):
                             os.path.join(committed_snapshots_dir, latest_snapshot),
                             latest_snapshot_dir,
                         )
-                        # TODO: delete all but the last snapshot to minimise copy time to new remote
                         LOG.info(
                             f"Stopping primary after {args.stop_primary_after_s} seconds"
                         )

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -307,6 +307,7 @@ def run(args):
 
             try:
                 start_time = time.time()
+                primary_has_stopped = False
                 while True:
                     stop_waiting = True
                     for i, remote_client in enumerate(clients):
@@ -325,7 +326,7 @@ def run(args):
                     if (
                         args.stop_primary_after_s
                         and time.time() > start_time + args.stop_primary_after_s
-                        and not primary.is_stopped()
+                        and not primary_has_stopped
                     ):
                         committed_snapshots_dir = network.get_committed_snapshots(
                             primary, force_txs=False
@@ -334,6 +335,7 @@ def run(args):
                             f"Stopping primary after {args.stop_primary_after_s} seconds"
                         )
                         primary.stop()
+                        primary_has_stopped = True
                         old_primary = primary
                         primary, _ = network.wait_for_new_primary(primary)
                         if args.add_new_node_after_primary_stops:

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -420,8 +420,8 @@ def run(args):
                         # to maintain consistency, and 504 when we try to write to the future primary
                         # before their election. Since these requests effectively do nothing, they
                         # should not count towards latency statistics.
-                        if args.stop_primary_after_s:
-                            overall = overall.filter(pl.col("responseStatus") < 500)
+                        #if args.stop_primary_after_s:
+                        #    overall = overall.filter(pl.col("responseStatus") < 500)
 
                         overall = overall.with_columns(
                             pl.col("receiveTime").alias("latency") - pl.col("sendTime")

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -192,7 +192,7 @@ def create_and_add_node(network, host, old_primary, snapshots_dir, statistics):
         snapshots_dir=snapshots_dir,
     )
     LOG.info(f"Replace node {old_primary.local_node_id} with {node.local_node_id}")
-    network.replace_stopped_node(old_primary, node, args)
+    network.replace_stopped_node(old_primary, node, args, statistics=statistics)
     LOG.info(f"Done replacing node: {host}")
 
 
@@ -356,7 +356,7 @@ def run(args):
                         old_primary = primary
                         primary, _ = network.wait_for_new_primary(primary)
                         statistics[
-                            "new_primary_election_time"
+                            "new_primary_detected_time"
                         ] = datetime.datetime.now().isoformat()
                         if args.add_new_node_after_primary_stops:
                             create_and_add_node(

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -207,6 +207,23 @@ def create_and_add_node(
     statistics["new_node_join_complete_time"] = datetime.datetime.now().isoformat()
     LOG.info(f"Done adding new node: {host}")
 
+def create_and_add_node(
+    network, host, old_primary, new_primary, snapshots_dir, statistics
+):
+    LOG.info(f"Add new node: {host}")
+    node = network.create_node(host)
+    statistics["new_node_join_start_time"] = datetime.datetime.now().isoformat()
+    network.join_node(
+        node,
+        args.package,
+        args,
+        timeout=10,
+        copy_ledger=False,
+        snapshots_dir=snapshots_dir,
+    )
+    LOG.info(f"Replace node {old_primary.local_node_id} with {node.local_node_id}")
+    network.replace_node(old_primary, node, args)
+    LOG.info(f"Done replacing node: {host}")
 
 def run(args):
     hosts = args.nodes or ["local://localhost"]

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -224,7 +224,11 @@ def run(args):
         requests_file_paths = []
         for client_def in args.client_def:
             count, gen, iterations, target = client_def.split(",")
-            rr_idx = 0
+            # The round robin index deliberately starts at 1, so that backups/any are
+            # loaded uniformly but the first instance slightly less so where possible. This
+            # is useful when running a failover test, to avoid the new primary being targeted
+            # by reads.
+            rr_idx = 1
             for _ in range(int(count)):
                 LOG.info(f"Generating {iterations} requests for client_{client_idx}")
                 msgs = generator.Messages()

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -361,6 +361,25 @@ class Consortium:
             **kwargs,
         )
 
+    def replace_node(self, remote_node, node_to_retire, node_to_add, valid_from, validity_period_days=None, **kwargs,):
+        proposal_body = {"actions": []}
+        trust_args = {"node_id": node_to_add.node_id, "valid_from": str(valid_from)}
+        if validity_period_days is not None:
+            trust_args["validity_period_days"] = validity_period_days
+        proposal_body["actions"].append(
+            {"name": "transition_node_to_trusted", "args": trust_args}
+        )
+        proposal_body["actions"].append(
+            {"name": "remove_node", "args": {"node_id": node_to_retire.node_id}}
+        )
+        proposal = self.get_any_active_member().propose(remote_node, proposal_body)
+        self.vote_using_majority(
+            remote_node,
+            proposal,
+            {"ballot": "export function vote (proposal, proposer_id) { return true }"},
+            **kwargs,
+        )
+
     def trust_node(self, remote_node, node_id, *args, **kwargs):
         return self.trust_nodes(remote_node, [node_id], *args, **kwargs)
 

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -361,7 +361,15 @@ class Consortium:
             **kwargs,
         )
 
-    def replace_node(self, remote_node, node_to_retire, node_to_add, valid_from, validity_period_days=None, **kwargs,):
+    def replace_node(
+        self,
+        remote_node,
+        node_to_retire,
+        node_to_add,
+        valid_from,
+        validity_period_days=None,
+        **kwargs,
+    ):
         proposal_body = {"actions": []}
         trust_args = {"node_id": node_to_add.node_id, "valid_from": str(valid_from)}
         if validity_period_days is not None:

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -955,7 +955,7 @@ class Network:
 
         self.nodes.remove(node_to_retire)
 
-    def replace_node(
+    def replace_stopped_node(
         self,
         node_to_retire,
         node_to_add,
@@ -963,7 +963,7 @@ class Network:
         valid_from=None,
         validity_period_days=None,
         no_wait=False,
-        timeout=None,
+        timeout=5,
     ):
         primary, _ = self.find_primary()
         try:
@@ -980,25 +980,15 @@ class Network:
                     validity_period_days=validity_period_days,
                     timeout=args.ledger_recovery_timeout,
                 )
-            if not no_wait:
-                # The main endorsed RPC interface is only open once the node
-                # has caught up and observed commit on the service open transaction.
-                node_to_add.wait_for_node_to_join(
-                    timeout=timeout or args.ledger_recovery_timeout
-                )
         except (ValueError, TimeoutError):
-            LOG.error(f"New trusted node {node_to_add.node_id} failed to join the network")
+            LOG.error(
+                f"NFailed to replace {node_to_retire.node_id} with {node_to_add.node_id}"
+            )
             node_to_add.stop()
             raise
 
         node_to_add.network_state = infra.node.NodeNetworkState.joined
-        node_to_add.set_certificate_validity_period(
-            valid_from,
-            validity_period_days or args.maximum_node_certificate_validity_days,
-        )
-        if not no_wait:
-            self.wait_for_all_nodes_to_commit(primary=primary)
-        end_time = time.time() + 5
+        end_time = time.time() + timeout
         r = None
         while time.time() < end_time:
             try:
@@ -1006,9 +996,7 @@ class Network:
                     r = c.get("/node/network/removable_nodes").body.json()
                     if node_to_retire.node_id in {n["node_id"] for n in r["nodes"]}:
                         check_commit = infra.checker.Checker(c)
-                        r = c.delete(
-                            f"/node/network/nodes/{node_to_retire.node_id}"
-                        )
+                        r = c.delete(f"/node/network/nodes/{node_to_retire.node_id}")
                         check_commit(r)
                         break
                     else:


### PR DESCRIPTION
Performs node replacement as an atomic transaction when using `--add-new-node-after-primary-stops`.