### PR TITLE
Ruff lint update: Use `isinstance`

### DIFF
--- a/tests/infra/piccolo/generator.py
+++ b/tests/infra/piccolo/generator.py
@@ -38,7 +38,7 @@ class Messages:
             headers["content-type"] = content_type
 
         # Convert body to bytes if we were given a string
-        if type(body) == str:
+        if isinstance(body, str):
             body = body.encode("utf-8")
 
         request_line = f"{verb.upper()} {path} {http_version}"


### PR DESCRIPTION
New version of `ruff` flags this, so format checks are currently failing.