### PR TITLE
[release/3.x] Cherry pick: Update CI image from 11-08 to 14-08 (#5544)

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -11,7 +11,7 @@ jobs:
     variables:
       Codeql.SkipTaskAutoInjection: true
       skipComponentGovernanceDetection: true
-    container: ccfmsrc.azurecr.io/ccf/ci:11-08-2023-virtual-clang15
+    container: ccfmsrc.azurecr.io/ccf/ci:14-08-2023-virtual-clang15
     pool:
       vmImage: ubuntu-20.04
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -29,15 +29,15 @@ schedules:
 resources:
   containers:
     - container: virtual
-      image: ccfmsrc.azurecr.io/ccf/ci:11-08-2023-virtual-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:14-08-2023-virtual-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: snp
-      image: ccfmsrc.azurecr.io/ccf/ci:11-08-2023-snp-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:14-08-2023-snp-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci:11-08-2023-sgx
+      image: ccfmsrc.azurecr.io/ccf/ci:14-08-2023-sgx
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /lib/modules:/lib/modules:ro
 
 variables:

--- a/.daily.yml
+++ b/.daily.yml
@@ -25,15 +25,15 @@ schedules:
 resources:
   containers:
     - container: virtual
-      image: ccfmsrc.azurecr.io/ccf/ci:11-08-2023-virtual-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:14-08-2023-virtual-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE
 
     - container: snp
-      image: ccfmsrc.azurecr.io/ccf/ci:11-08-2023-snp-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:14-08-2023-snp-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci:11-08-2023-sgx
+      image: ccfmsrc.azurecr.io/ccf/ci:14-08-2023-sgx
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx
 
 jobs:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "CCF Development Environment",
-  "image": "ccfmsrc.azurecr.io/ccf/ci:11-08-2023-virtual-clang15",
+  "image": "ccfmsrc.azurecr.io/ccf/ci:14-08-2023-virtual-clang15",
   "runArgs": [],
   "extensions": ["ms-vscode.cpptools", "ms-python.python"]
 }

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: ccfmsrc.azurecr.io/ccf/ci:11-08-2023-virtual-clang15
+    container: ccfmsrc.azurecr.io/ccf/ci:14-08-2023-virtual-clang15
 
     steps:
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -16,7 +16,7 @@ pr:
 resources:
   containers:
     - container: virtual
-      image: ccfmsrc.azurecr.io/ccf/ci:11-08-2023-virtual-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:14-08-2023-virtual-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
 jobs:

--- a/.stress.yml
+++ b/.stress.yml
@@ -20,7 +20,7 @@ schedules:
 resources:
   containers:
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci:11-08-2023-sgx
+      image: ccfmsrc.azurecr.io/ccf/ci:14-08-2023-sgx
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx
 
 jobs:


### PR DESCRIPTION
Backports the following commits to `release/3.x`:
 - [Update CI image from 11-08 to 14-08 (#5544)](https://github.com/microsoft/CCF/pull/5544)