### PR TITLE
[release/3.x] Cherry pick: Switch to a backup pool (#5512)

### DIFF
--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -5,7 +5,7 @@ parameters:
       pool: ado-virtual-ccf-sub
     SGX:
       container: sgx
-      pool: ado-sgx-ccf-sub
+      pool: ado-sgx-ccf-sub-backup
 
   build:
     common:

--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -11,7 +11,7 @@ parameters:
       pool: ado-virtual-ccf-sub
     SGX:
       container: sgx
-      pool: ado-sgx-ccf-sub
+      pool: ado-sgx-ccf-sub-backup
     SNPCC:
       container: snp
       pool: ado-virtual-ccf-sub

--- a/.azure-pipelines-templates/stress-matrix.yml
+++ b/.azure-pipelines-templates/stress-matrix.yml
@@ -4,7 +4,7 @@ jobs:
       target: SGX
       env:
         container: sgx
-        pool: ado-sgx-ccf-sub
+        pool: ado-sgx-ccf-sub-backup
       cmake_args: "-DCOMPILE_TARGET=sgx"
       suffix: "StressTest"
       artifact_name: "StressTest"


### PR DESCRIPTION
Backports the following commits to `release/3.x`:
 - [Switch to a backup pool (#5512)](https://github.com/microsoft/CCF/pull/5512)