### PR TITLE
[{release/4.x}] Cherry pick: {Update `llhttp` from `6.0.9` to `9.0.1` (#5607)}

### DIFF
--- a/3rdparty/exported/llhttp/api.c
+++ b/3rdparty/exported/llhttp/api.c
@@ -60,11 +60,24 @@ const llhttp_settings_t wasm_settings = {
   wasm_on_message_begin,
   wasm_on_url,
   wasm_on_status,
+  NULL,
+  NULL,
   wasm_on_header_field,
   wasm_on_header_value,
+  NULL,
+  NULL,
   wasm_on_headers_complete_wrap,
   wasm_on_body,
   wasm_on_message_complete,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   NULL,
   NULL,
 };
@@ -79,6 +92,8 @@ llhttp_t* llhttp_alloc(llhttp_type_t type) {
 void llhttp_free(llhttp_t* parser) {
   free(parser);
 }
+
+#endif  // defined(__wasm__)
 
 /* Some getters required to get stuff from the parser */
 
@@ -105,8 +120,6 @@ int llhttp_get_status_code(llhttp_t* parser) {
 uint8_t llhttp_get_upgrade(llhttp_t* parser) {
   return parser->upgrade;
 }
-
-#endif  // defined(__wasm__)
 
 
 void llhttp_reset(llhttp_t* parser) {
@@ -226,6 +239,15 @@ const char* llhttp_method_name(llhttp_method_t method) {
 #undef HTTP_METHOD_GEN
 }
 
+const char* llhttp_status_name(llhttp_status_t status) {
+#define HTTP_STATUS_GEN(NUM, NAME, STRING) case HTTP_STATUS_##NAME: return #STRING;
+  switch (status) {
+    HTTP_STATUS_MAP(HTTP_STATUS_GEN)
+    default: abort();
+  }
+#undef HTTP_STATUS_GEN
+}
+
 
 void llhttp_set_lenient_headers(llhttp_t* parser, int enabled) {
   if (enabled) {
@@ -258,6 +280,38 @@ void llhttp_set_lenient_transfer_encoding(llhttp_t* parser, int enabled) {
     parser->lenient_flags |= LENIENT_TRANSFER_ENCODING;
   } else {
     parser->lenient_flags &= ~LENIENT_TRANSFER_ENCODING;
+  }
+}
+
+void llhttp_set_lenient_version(llhttp_t* parser, int enabled) {
+  if (enabled) {
+    parser->lenient_flags |= LENIENT_VERSION;
+  } else {
+    parser->lenient_flags &= ~LENIENT_VERSION;
+  }
+}
+
+void llhttp_set_lenient_data_after_close(llhttp_t* parser, int enabled) {
+  if (enabled) {
+    parser->lenient_flags |= LENIENT_DATA_AFTER_CLOSE;
+  } else {
+    parser->lenient_flags &= ~LENIENT_DATA_AFTER_CLOSE;
+  }
+}
+
+void llhttp_set_lenient_optional_lf_after_cr(llhttp_t* parser, int enabled) {
+  if (enabled) {
+    parser->lenient_flags |= LENIENT_OPTIONAL_LF_AFTER_CR;
+  } else {
+    parser->lenient_flags &= ~LENIENT_OPTIONAL_LF_AFTER_CR;
+  }
+}
+
+void llhttp_set_lenient_optional_crlf_after_chunk(llhttp_t* parser, int enabled) {
+  if (enabled) {
+    parser->lenient_flags |= LENIENT_OPTIONAL_CRLF_AFTER_CHUNK;
+  } else {
+    parser->lenient_flags &= ~LENIENT_OPTIONAL_CRLF_AFTER_CHUNK;
   }
 }
 
@@ -295,6 +349,34 @@ int llhttp__on_status(llhttp_t* s, const char* p, const char* endp) {
 int llhttp__on_status_complete(llhttp_t* s, const char* p, const char* endp) {
   int err;
   CALLBACK_MAYBE(s, on_status_complete);
+  return err;
+}
+
+
+int llhttp__on_method(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  SPAN_CALLBACK_MAYBE(s, on_method, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_method_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_method_complete);
+  return err;
+}
+
+
+int llhttp__on_version(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  SPAN_CALLBACK_MAYBE(s, on_version, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_version_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_version_complete);
   return err;
 }
 
@@ -355,9 +437,44 @@ int llhttp__on_chunk_header(llhttp_t* s, const char* p, const char* endp) {
 }
 
 
+int llhttp__on_chunk_extension_name(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  SPAN_CALLBACK_MAYBE(s, on_chunk_extension_name, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_chunk_extension_name_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_chunk_extension_name_complete);
+  return err;
+}
+
+
+int llhttp__on_chunk_extension_value(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  SPAN_CALLBACK_MAYBE(s, on_chunk_extension_value, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_chunk_extension_value_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_chunk_extension_value_complete);
+  return err;
+}
+
+
 int llhttp__on_chunk_complete(llhttp_t* s, const char* p, const char* endp) {
   int err;
   CALLBACK_MAYBE(s, on_chunk_complete);
+  return err;
+}
+
+
+int llhttp__on_reset(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_reset);
   return err;
 }
 

--- a/3rdparty/exported/llhttp/llhttp.c
+++ b/3rdparty/exported/llhttp/llhttp.c
@@ -1,5 +1,3 @@
-#if LLHTTP_STRICT_MODE
-
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
@@ -332,26 +330,40 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_closed,
   s_n_llhttp__internal__n_invoke_llhttp__after_message_complete,
   s_n_llhttp__internal__n_pause_1,
-  s_n_llhttp__internal__n_invoke_is_equal_upgrade,
-  s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2,
   s_n_llhttp__internal__n_chunk_data_almost_done,
   s_n_llhttp__internal__n_consume_content_length,
   s_n_llhttp__internal__n_span_start_llhttp__on_body,
   s_n_llhttp__internal__n_invoke_is_equal_content_length,
   s_n_llhttp__internal__n_chunk_size_almost_done,
-  s_n_llhttp__internal__n_chunk_parameters,
+  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete,
+  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_1,
+  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete,
+  s_n_llhttp__internal__n_chunk_extension_quoted_value_done,
+  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1,
+  s_n_llhttp__internal__n_error_21,
+  s_n_llhttp__internal__n_chunk_extension_quoted_value,
+  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2,
+  s_n_llhttp__internal__n_error_23,
+  s_n_llhttp__internal__n_chunk_extension_value,
+  s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_value,
+  s_n_llhttp__internal__n_error_24,
+  s_n_llhttp__internal__n_chunk_extension_name,
+  s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_name,
+  s_n_llhttp__internal__n_chunk_extensions,
   s_n_llhttp__internal__n_chunk_size_otherwise,
   s_n_llhttp__internal__n_chunk_size,
   s_n_llhttp__internal__n_chunk_size_digit,
-  s_n_llhttp__internal__n_invoke_update_content_length,
+  s_n_llhttp__internal__n_invoke_update_content_length_1,
+  s_n_llhttp__internal__n_invoke_is_equal_upgrade,
+  s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2,
   s_n_llhttp__internal__n_consume_content_length_1,
   s_n_llhttp__internal__n_span_start_llhttp__on_body_1,
   s_n_llhttp__internal__n_eof,
   s_n_llhttp__internal__n_span_start_llhttp__on_body_2,
   s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete,
+  s_n_llhttp__internal__n_error_5,
   s_n_llhttp__internal__n_headers_almost_done,
   s_n_llhttp__internal__n_header_field_colon_discard_ws,
-  s_n_llhttp__internal__n_error_19,
   s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete,
   s_n_llhttp__internal__n_span_start_llhttp__on_header_value,
   s_n_llhttp__internal__n_header_value_discard_lws,
@@ -359,8 +371,7 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_header_value_lws,
   s_n_llhttp__internal__n_header_value_almost_done,
   s_n_llhttp__internal__n_header_value_lenient,
-  s_n_llhttp__internal__n_error_23,
-  s_n_llhttp__internal__n_header_value_lenient_failed,
+  s_n_llhttp__internal__n_error_41,
   s_n_llhttp__internal__n_header_value_otherwise,
   s_n_llhttp__internal__n_header_value_connection_token,
   s_n_llhttp__internal__n_header_value_connection_ws,
@@ -368,12 +379,12 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_header_value_connection_2,
   s_n_llhttp__internal__n_header_value_connection_3,
   s_n_llhttp__internal__n_header_value_connection,
-  s_n_llhttp__internal__n_error_26,
-  s_n_llhttp__internal__n_error_27,
+  s_n_llhttp__internal__n_error_43,
+  s_n_llhttp__internal__n_error_44,
   s_n_llhttp__internal__n_header_value_content_length_ws,
   s_n_llhttp__internal__n_header_value_content_length,
-  s_n_llhttp__internal__n_error_29,
-  s_n_llhttp__internal__n_error_28,
+  s_n_llhttp__internal__n_error_46,
+  s_n_llhttp__internal__n_error_45,
   s_n_llhttp__internal__n_header_value_te_token_ows,
   s_n_llhttp__internal__n_header_value,
   s_n_llhttp__internal__n_header_value_te_token,
@@ -395,16 +406,24 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_header_field,
   s_n_llhttp__internal__n_span_start_llhttp__on_header_field,
   s_n_llhttp__internal__n_header_field_start,
+  s_n_llhttp__internal__n_headers_start,
   s_n_llhttp__internal__n_url_to_http_09,
   s_n_llhttp__internal__n_url_skip_to_http09,
   s_n_llhttp__internal__n_url_skip_lf_to_http09_1,
   s_n_llhttp__internal__n_url_skip_lf_to_http09,
   s_n_llhttp__internal__n_req_pri_upgrade,
-  s_n_llhttp__internal__n_req_http_complete_1,
+  s_n_llhttp__internal__n_req_http_complete_crlf,
   s_n_llhttp__internal__n_req_http_complete,
+  s_n_llhttp__internal__n_invoke_load_method_1,
+  s_n_llhttp__internal__n_invoke_llhttp__on_version_complete,
+  s_n_llhttp__internal__n_error_51,
+  s_n_llhttp__internal__n_error_57,
   s_n_llhttp__internal__n_req_http_minor,
+  s_n_llhttp__internal__n_error_58,
   s_n_llhttp__internal__n_req_http_dot,
+  s_n_llhttp__internal__n_error_59,
   s_n_llhttp__internal__n_req_http_major,
+  s_n_llhttp__internal__n_span_start_llhttp__on_version,
   s_n_llhttp__internal__n_req_http_start_1,
   s_n_llhttp__internal__n_req_http_start_2,
   s_n_llhttp__internal__n_req_http_start_3,
@@ -432,99 +451,120 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_url_entry_connect,
   s_n_llhttp__internal__n_req_spaces_before_url,
   s_n_llhttp__internal__n_req_first_space_before_url,
-  s_n_llhttp__internal__n_start_req_2,
-  s_n_llhttp__internal__n_start_req_3,
-  s_n_llhttp__internal__n_start_req_1,
-  s_n_llhttp__internal__n_start_req_4,
-  s_n_llhttp__internal__n_start_req_6,
-  s_n_llhttp__internal__n_start_req_8,
-  s_n_llhttp__internal__n_start_req_9,
-  s_n_llhttp__internal__n_start_req_7,
-  s_n_llhttp__internal__n_start_req_5,
-  s_n_llhttp__internal__n_start_req_12,
-  s_n_llhttp__internal__n_start_req_13,
-  s_n_llhttp__internal__n_start_req_11,
-  s_n_llhttp__internal__n_start_req_10,
-  s_n_llhttp__internal__n_start_req_14,
-  s_n_llhttp__internal__n_start_req_17,
-  s_n_llhttp__internal__n_start_req_16,
-  s_n_llhttp__internal__n_start_req_15,
-  s_n_llhttp__internal__n_start_req_18,
-  s_n_llhttp__internal__n_start_req_20,
-  s_n_llhttp__internal__n_start_req_21,
-  s_n_llhttp__internal__n_start_req_19,
-  s_n_llhttp__internal__n_start_req_23,
-  s_n_llhttp__internal__n_start_req_24,
-  s_n_llhttp__internal__n_start_req_26,
-  s_n_llhttp__internal__n_start_req_28,
-  s_n_llhttp__internal__n_start_req_29,
-  s_n_llhttp__internal__n_start_req_27,
-  s_n_llhttp__internal__n_start_req_25,
-  s_n_llhttp__internal__n_start_req_30,
-  s_n_llhttp__internal__n_start_req_22,
-  s_n_llhttp__internal__n_start_req_31,
-  s_n_llhttp__internal__n_start_req_32,
-  s_n_llhttp__internal__n_start_req_35,
-  s_n_llhttp__internal__n_start_req_36,
-  s_n_llhttp__internal__n_start_req_34,
-  s_n_llhttp__internal__n_start_req_37,
-  s_n_llhttp__internal__n_start_req_38,
-  s_n_llhttp__internal__n_start_req_42,
-  s_n_llhttp__internal__n_start_req_43,
-  s_n_llhttp__internal__n_start_req_41,
-  s_n_llhttp__internal__n_start_req_40,
-  s_n_llhttp__internal__n_start_req_39,
-  s_n_llhttp__internal__n_start_req_45,
-  s_n_llhttp__internal__n_start_req_44,
-  s_n_llhttp__internal__n_start_req_33,
-  s_n_llhttp__internal__n_start_req_48,
-  s_n_llhttp__internal__n_start_req_49,
-  s_n_llhttp__internal__n_start_req_50,
-  s_n_llhttp__internal__n_start_req_51,
-  s_n_llhttp__internal__n_start_req_47,
-  s_n_llhttp__internal__n_start_req_46,
-  s_n_llhttp__internal__n_start_req_54,
-  s_n_llhttp__internal__n_start_req_56,
-  s_n_llhttp__internal__n_start_req_57,
-  s_n_llhttp__internal__n_start_req_55,
-  s_n_llhttp__internal__n_start_req_53,
-  s_n_llhttp__internal__n_start_req_58,
-  s_n_llhttp__internal__n_start_req_59,
-  s_n_llhttp__internal__n_start_req_52,
-  s_n_llhttp__internal__n_start_req_61,
-  s_n_llhttp__internal__n_start_req_62,
-  s_n_llhttp__internal__n_start_req_60,
-  s_n_llhttp__internal__n_start_req_65,
-  s_n_llhttp__internal__n_start_req_67,
-  s_n_llhttp__internal__n_start_req_68,
-  s_n_llhttp__internal__n_start_req_66,
-  s_n_llhttp__internal__n_start_req_69,
-  s_n_llhttp__internal__n_start_req_64,
-  s_n_llhttp__internal__n_start_req_63,
-  s_n_llhttp__internal__n_start_req,
-  s_n_llhttp__internal__n_invoke_llhttp__on_status_complete,
+  s_n_llhttp__internal__n_invoke_llhttp__on_method_complete_1,
+  s_n_llhttp__internal__n_after_start_req_2,
+  s_n_llhttp__internal__n_after_start_req_3,
+  s_n_llhttp__internal__n_after_start_req_1,
+  s_n_llhttp__internal__n_after_start_req_4,
+  s_n_llhttp__internal__n_after_start_req_6,
+  s_n_llhttp__internal__n_after_start_req_8,
+  s_n_llhttp__internal__n_after_start_req_9,
+  s_n_llhttp__internal__n_after_start_req_7,
+  s_n_llhttp__internal__n_after_start_req_5,
+  s_n_llhttp__internal__n_after_start_req_12,
+  s_n_llhttp__internal__n_after_start_req_13,
+  s_n_llhttp__internal__n_after_start_req_11,
+  s_n_llhttp__internal__n_after_start_req_10,
+  s_n_llhttp__internal__n_after_start_req_14,
+  s_n_llhttp__internal__n_after_start_req_17,
+  s_n_llhttp__internal__n_after_start_req_16,
+  s_n_llhttp__internal__n_after_start_req_15,
+  s_n_llhttp__internal__n_after_start_req_18,
+  s_n_llhttp__internal__n_after_start_req_20,
+  s_n_llhttp__internal__n_after_start_req_21,
+  s_n_llhttp__internal__n_after_start_req_19,
+  s_n_llhttp__internal__n_after_start_req_23,
+  s_n_llhttp__internal__n_after_start_req_24,
+  s_n_llhttp__internal__n_after_start_req_26,
+  s_n_llhttp__internal__n_after_start_req_28,
+  s_n_llhttp__internal__n_after_start_req_29,
+  s_n_llhttp__internal__n_after_start_req_27,
+  s_n_llhttp__internal__n_after_start_req_25,
+  s_n_llhttp__internal__n_after_start_req_30,
+  s_n_llhttp__internal__n_after_start_req_22,
+  s_n_llhttp__internal__n_after_start_req_31,
+  s_n_llhttp__internal__n_after_start_req_32,
+  s_n_llhttp__internal__n_after_start_req_35,
+  s_n_llhttp__internal__n_after_start_req_36,
+  s_n_llhttp__internal__n_after_start_req_34,
+  s_n_llhttp__internal__n_after_start_req_37,
+  s_n_llhttp__internal__n_after_start_req_38,
+  s_n_llhttp__internal__n_after_start_req_42,
+  s_n_llhttp__internal__n_after_start_req_43,
+  s_n_llhttp__internal__n_after_start_req_41,
+  s_n_llhttp__internal__n_after_start_req_40,
+  s_n_llhttp__internal__n_after_start_req_39,
+  s_n_llhttp__internal__n_after_start_req_45,
+  s_n_llhttp__internal__n_after_start_req_44,
+  s_n_llhttp__internal__n_after_start_req_33,
+  s_n_llhttp__internal__n_after_start_req_48,
+  s_n_llhttp__internal__n_after_start_req_49,
+  s_n_llhttp__internal__n_after_start_req_50,
+  s_n_llhttp__internal__n_after_start_req_51,
+  s_n_llhttp__internal__n_after_start_req_47,
+  s_n_llhttp__internal__n_after_start_req_46,
+  s_n_llhttp__internal__n_after_start_req_54,
+  s_n_llhttp__internal__n_after_start_req_56,
+  s_n_llhttp__internal__n_after_start_req_57,
+  s_n_llhttp__internal__n_after_start_req_55,
+  s_n_llhttp__internal__n_after_start_req_53,
+  s_n_llhttp__internal__n_after_start_req_58,
+  s_n_llhttp__internal__n_after_start_req_59,
+  s_n_llhttp__internal__n_after_start_req_52,
+  s_n_llhttp__internal__n_after_start_req_61,
+  s_n_llhttp__internal__n_after_start_req_62,
+  s_n_llhttp__internal__n_after_start_req_60,
+  s_n_llhttp__internal__n_after_start_req_65,
+  s_n_llhttp__internal__n_after_start_req_67,
+  s_n_llhttp__internal__n_after_start_req_68,
+  s_n_llhttp__internal__n_after_start_req_66,
+  s_n_llhttp__internal__n_after_start_req_69,
+  s_n_llhttp__internal__n_after_start_req_64,
+  s_n_llhttp__internal__n_after_start_req_63,
+  s_n_llhttp__internal__n_after_start_req,
+  s_n_llhttp__internal__n_span_start_llhttp__on_method_1,
   s_n_llhttp__internal__n_res_line_almost_done,
   s_n_llhttp__internal__n_res_status,
   s_n_llhttp__internal__n_span_start_llhttp__on_status,
   s_n_llhttp__internal__n_res_status_start,
   s_n_llhttp__internal__n_res_status_code_otherwise,
-  s_n_llhttp__internal__n_res_status_code,
-  s_n_llhttp__internal__n_res_http_end,
+  s_n_llhttp__internal__n_res_status_code_digit_3,
+  s_n_llhttp__internal__n_res_status_code_digit_2,
+  s_n_llhttp__internal__n_res_status_code_digit_1,
+  s_n_llhttp__internal__n_res_after_version,
+  s_n_llhttp__internal__n_invoke_llhttp__on_version_complete_1,
+  s_n_llhttp__internal__n_error_73,
+  s_n_llhttp__internal__n_error_85,
   s_n_llhttp__internal__n_res_http_minor,
+  s_n_llhttp__internal__n_error_86,
   s_n_llhttp__internal__n_res_http_dot,
+  s_n_llhttp__internal__n_error_87,
   s_n_llhttp__internal__n_res_http_major,
+  s_n_llhttp__internal__n_span_start_llhttp__on_version_1,
   s_n_llhttp__internal__n_start_res,
+  s_n_llhttp__internal__n_invoke_llhttp__on_method_complete,
   s_n_llhttp__internal__n_req_or_res_method_2,
+  s_n_llhttp__internal__n_invoke_update_type_1,
   s_n_llhttp__internal__n_req_or_res_method_3,
   s_n_llhttp__internal__n_req_or_res_method_1,
   s_n_llhttp__internal__n_req_or_res_method,
+  s_n_llhttp__internal__n_span_start_llhttp__on_method,
   s_n_llhttp__internal__n_start_req_or_res,
   s_n_llhttp__internal__n_invoke_load_type,
+  s_n_llhttp__internal__n_invoke_update_finish,
   s_n_llhttp__internal__n_start,
 };
 typedef enum llparse_state_e llparse_state_t;
 
+int llhttp__on_method(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
 int llhttp__on_url(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__on_version(
     llhttp__internal_t* s, const unsigned char* p,
     const unsigned char* endp);
 
@@ -540,7 +580,26 @@ int llhttp__on_body(
     llhttp__internal_t* s, const unsigned char* p,
     const unsigned char* endp);
 
+int llhttp__on_chunk_extension_name(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__on_chunk_extension_value(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
 int llhttp__on_status(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__internal__c_load_initial_message_completed(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return state->initial_message_completed;
+}
+
+int llhttp__on_reset(
     llhttp__internal_t* s, const unsigned char* p,
     const unsigned char* endp);
 
@@ -572,6 +631,10 @@ int llhttp__internal__c_store_method(
   return 0;
 }
 
+int llhttp__on_method_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
 int llhttp__internal__c_is_equal_method(
     llhttp__internal_t* state,
     const unsigned char* p,
@@ -599,14 +662,14 @@ int llhttp__on_url_complete(
     llhttp__internal_t* s, const unsigned char* p,
     const unsigned char* endp);
 
-int llhttp__internal__c_test_flags(
+int llhttp__internal__c_test_lenient_flags(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
-  return (state->flags & 128) == 128;
+  return (state->lenient_flags & 1) == 1;
 }
 
-int llhttp__on_chunk_complete(
+int llhttp__after_headers_complete(
     llhttp__internal_t* s, const unsigned char* p,
     const unsigned char* endp);
 
@@ -614,55 +677,7 @@ int llhttp__on_message_complete(
     llhttp__internal_t* s, const unsigned char* p,
     const unsigned char* endp);
 
-int llhttp__internal__c_is_equal_upgrade(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->upgrade == 1;
-}
-
 int llhttp__after_message_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_update_finish_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->finish = 0;
-  return 0;
-}
-
-int llhttp__internal__c_test_lenient_flags(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->lenient_flags & 4) == 4;
-}
-
-int llhttp__internal__c_test_flags_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->flags & 544) == 544;
-}
-
-int llhttp__internal__c_test_lenient_flags_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->lenient_flags & 2) == 2;
-}
-
-int llhttp__before_headers_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_headers_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__after_headers_complete(
     llhttp__internal_t* s, const unsigned char* p,
     const unsigned char* endp);
 
@@ -672,6 +687,36 @@ int llhttp__internal__c_update_content_length(
     const unsigned char* endp) {
   state->content_length = 0;
   return 0;
+}
+
+int llhttp__internal__c_update_initial_message_completed(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->initial_message_completed = 1;
+  return 0;
+}
+
+int llhttp__internal__c_update_finish_1(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->finish = 0;
+  return 0;
+}
+
+int llhttp__internal__c_test_lenient_flags_2(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 4) == 4;
+}
+
+int llhttp__internal__c_test_lenient_flags_3(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 32) == 32;
 }
 
 int llhttp__internal__c_mul_add_content_length(
@@ -711,12 +756,45 @@ int llhttp__internal__c_is_equal_content_length(
   return state->content_length == 0;
 }
 
+int llhttp__on_chunk_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__internal__c_test_lenient_flags_4(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 128) == 128;
+}
+
 int llhttp__internal__c_or_flags(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
   state->flags |= 128;
   return 0;
+}
+
+int llhttp__internal__c_test_lenient_flags_5(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 64) == 64;
+}
+
+int llhttp__on_chunk_extension_name_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__on_chunk_extension_value_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__internal__c_is_equal_upgrade(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return state->upgrade == 1;
 }
 
 int llhttp__internal__c_update_finish_3(
@@ -726,6 +804,35 @@ int llhttp__internal__c_update_finish_3(
   state->finish = 1;
   return 0;
 }
+
+int llhttp__internal__c_test_flags(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->flags & 128) == 128;
+}
+
+int llhttp__internal__c_test_flags_1(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->flags & 544) == 544;
+}
+
+int llhttp__internal__c_test_lenient_flags_6(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 2) == 2;
+}
+
+int llhttp__before_headers_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__on_headers_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
 
 int llhttp__internal__c_or_flags_1(
     llhttp__internal_t* state,
@@ -750,13 +857,6 @@ int llhttp__internal__c_store_header_state(
     int match) {
   state->header_state = match;
   return 0;
-}
-
-int llhttp__internal__c_test_lenient_flags_2(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->lenient_flags & 1) == 1;
 }
 
 int llhttp__on_header_field_complete(
@@ -814,7 +914,7 @@ int llhttp__internal__c_or_flags_6(
   return 0;
 }
 
-int llhttp__internal__c_update_header_state_2(
+int llhttp__internal__c_update_header_state_3(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -822,7 +922,7 @@ int llhttp__internal__c_update_header_state_2(
   return 0;
 }
 
-int llhttp__internal__c_update_header_state_4(
+int llhttp__internal__c_update_header_state_1(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -830,7 +930,7 @@ int llhttp__internal__c_update_header_state_4(
   return 0;
 }
 
-int llhttp__internal__c_update_header_state_5(
+int llhttp__internal__c_update_header_state_6(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -838,7 +938,7 @@ int llhttp__internal__c_update_header_state_5(
   return 0;
 }
 
-int llhttp__internal__c_update_header_state_6(
+int llhttp__internal__c_update_header_state_7(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -894,7 +994,7 @@ int llhttp__internal__c_test_flags_3(
   return (state->flags & 8) == 8;
 }
 
-int llhttp__internal__c_test_lenient_flags_4(
+int llhttp__internal__c_test_lenient_flags_13(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -917,7 +1017,7 @@ int llhttp__internal__c_and_flags(
   return 0;
 }
 
-int llhttp__internal__c_update_header_state_7(
+int llhttp__internal__c_update_header_state_8(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -958,12 +1058,16 @@ int llhttp__internal__c_store_http_minor(
   return 0;
 }
 
-int llhttp__internal__c_test_lenient_flags_6(
+int llhttp__internal__c_test_lenient_flags_15(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
   return (state->lenient_flags & 16) == 16;
 }
+
+int llhttp__on_version_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
 
 int llhttp__internal__c_load_http_major(
     llhttp__internal_t* state,
@@ -1010,11 +1114,6 @@ int llhttp__internal__c_mul_add_status_code(
     }
   }
   state->status_code += match;
-  
-  /* Enforce maximum */
-  if (state->status_code > 999) {
-    return 1;
-  }
   return 0;
 }
 
@@ -1066,7 +1165,7 @@ static llparse_state_t llhttp__internal__run(
         }
         default: {
           p++;
-          goto s_n_llhttp__internal__n_error_4;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_3;
         }
       }
       /* UNREACHABLE */;
@@ -1076,7 +1175,7 @@ static llparse_state_t llhttp__internal__run(
     s_n_llhttp__internal__n_invoke_llhttp__after_message_complete: {
       switch (llhttp__after_message_complete(state, p, endp)) {
         case 1:
-          goto s_n_llhttp__internal__n_invoke_update_finish_2;
+          goto s_n_llhttp__internal__n_invoke_update_content_length;
         default:
           goto s_n_llhttp__internal__n_invoke_update_finish_1;
       }
@@ -1090,30 +1189,6 @@ static llparse_state_t llhttp__internal__run(
       state->error_pos = (const char*) p;
       state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
       return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_is_equal_upgrade:
-    s_n_llhttp__internal__n_invoke_is_equal_upgrade: {
-      switch (llhttp__internal__c_is_equal_upgrade(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
-        default:
-          goto s_n_llhttp__internal__n_pause_1;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2:
-    s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2: {
-      switch (llhttp__on_message_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_invoke_is_equal_upgrade;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_5;
-        default:
-          goto s_n_llhttp__internal__n_error_14;
-      }
       /* UNREACHABLE */;
       abort();
     }
@@ -1135,7 +1210,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_chunk_data_almost_done;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_8;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_4;
         }
       }
       /* UNREACHABLE */;
@@ -1192,23 +1267,106 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_header;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_9;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_5;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_chunk_parameters:
-    s_n_llhttp__internal__n_chunk_parameters: {
+    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete:
+    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete: {
+      switch (llhttp__on_chunk_extension_name_complete(state, p, endp)) {
+        case 0:
+          goto s_n_llhttp__internal__n_chunk_size_almost_done;
+        case 21:
+          goto s_n_llhttp__internal__n_pause_5;
+        default:
+          goto s_n_llhttp__internal__n_error_15;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_1:
+    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_1: {
+      switch (llhttp__on_chunk_extension_name_complete(state, p, endp)) {
+        case 0:
+          goto s_n_llhttp__internal__n_chunk_extensions;
+        case 21:
+          goto s_n_llhttp__internal__n_pause_6;
+        default:
+          goto s_n_llhttp__internal__n_error_16;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete:
+    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete: {
+      switch (llhttp__on_chunk_extension_value_complete(state, p, endp)) {
+        case 0:
+          goto s_n_llhttp__internal__n_chunk_size_almost_done;
+        case 21:
+          goto s_n_llhttp__internal__n_pause_7;
+        default:
+          goto s_n_llhttp__internal__n_error_18;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_chunk_extension_quoted_value_done:
+    s_n_llhttp__internal__n_chunk_extension_quoted_value_done: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_chunk_extension_quoted_value_done;
+      }
+      switch (*p) {
+        case 13: {
+          p++;
+          goto s_n_llhttp__internal__n_chunk_size_almost_done;
+        }
+        case ';': {
+          p++;
+          goto s_n_llhttp__internal__n_chunk_extensions;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_20;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1:
+    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1: {
+      switch (llhttp__on_chunk_extension_value_complete(state, p, endp)) {
+        case 0:
+          goto s_n_llhttp__internal__n_chunk_extension_quoted_value_done;
+        case 21:
+          goto s_n_llhttp__internal__n_pause_8;
+        default:
+          goto s_n_llhttp__internal__n_error_19;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_error_21:
+    s_n_llhttp__internal__n_error_21: {
+      state->error = 0x2;
+      state->reason = "Invalid character in chunk extensions quoted value";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_error;
+      return s_error;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_chunk_extension_quoted_value:
+    s_n_llhttp__internal__n_chunk_extension_quoted_value: {
       static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -1219,19 +1377,184 @@ static llparse_state_t llhttp__internal__run(
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
       };
       if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_parameters;
+        return s_n_llhttp__internal__n_chunk_extension_quoted_value;
       }
       switch (lookup_table[(uint8_t) *p]) {
         case 1: {
           p++;
-          goto s_n_llhttp__internal__n_chunk_parameters;
+          goto s_n_llhttp__internal__n_chunk_extension_quoted_value;
         }
         case 2: {
           p++;
-          goto s_n_llhttp__internal__n_chunk_size_almost_done;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_10;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_2;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2:
+    s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2: {
+      switch (llhttp__on_chunk_extension_value_complete(state, p, endp)) {
+        case 0:
+          goto s_n_llhttp__internal__n_chunk_size_otherwise;
+        case 21:
+          goto s_n_llhttp__internal__n_pause_9;
+        default:
+          goto s_n_llhttp__internal__n_error_22;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_error_23:
+    s_n_llhttp__internal__n_error_23: {
+      state->error = 0x2;
+      state->reason = "Invalid character in chunk extensions value";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_error;
+      return s_error;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_chunk_extension_value:
+    s_n_llhttp__internal__n_chunk_extension_value: {
+      static uint8_t lookup_table[] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 2, 3, 2, 2, 2, 2, 2, 0, 0, 2, 2, 0, 2, 2, 0,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 4, 0, 0, 0, 0,
+        0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 2, 0, 2, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+      };
+      if (p == endp) {
+        return s_n_llhttp__internal__n_chunk_extension_value;
+      }
+      switch (lookup_table[(uint8_t) *p]) {
+        case 1: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value;
+        }
+        case 2: {
+          p++;
+          goto s_n_llhttp__internal__n_chunk_extension_value;
+        }
+        case 3: {
+          p++;
+          goto s_n_llhttp__internal__n_chunk_extension_quoted_value;
+        }
+        case 4: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_3;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_4;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_value:
+    s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_value: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_value;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_chunk_extension_value;
+      goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_2;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_error_24:
+    s_n_llhttp__internal__n_error_24: {
+      state->error = 0x2;
+      state->reason = "Invalid character in chunk extensions name";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_error;
+      return s_error;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_chunk_extension_name:
+    s_n_llhttp__internal__n_chunk_extension_name: {
+      static uint8_t lookup_table[] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 2, 0, 2, 2, 2, 2, 2, 0, 0, 2, 2, 0, 2, 2, 0,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 3, 0, 4, 0, 0,
+        0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 2, 0, 2, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+      };
+      if (p == endp) {
+        return s_n_llhttp__internal__n_chunk_extension_name;
+      }
+      switch (lookup_table[(uint8_t) *p]) {
+        case 1: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name;
+        }
+        case 2: {
+          p++;
+          goto s_n_llhttp__internal__n_chunk_extension_name;
+        }
+        case 3: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_1;
+        }
+        case 4: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_2;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_3;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_name:
+    s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_name: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_name;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_chunk_extension_name;
+      goto s_n_llhttp__internal__n_chunk_extension_name;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_chunk_extensions:
+    s_n_llhttp__internal__n_chunk_extensions: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_chunk_extensions;
+      }
+      switch (*p) {
+        case 13: {
+          p++;
+          goto s_n_llhttp__internal__n_error_13;
+        }
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_error_14;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_name;
         }
       }
       /* UNREACHABLE */;
@@ -1247,16 +1570,12 @@ static llparse_state_t llhttp__internal__run(
           p++;
           goto s_n_llhttp__internal__n_chunk_size_almost_done;
         }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_parameters;
-        }
         case ';': {
           p++;
-          goto s_n_llhttp__internal__n_chunk_parameters;
+          goto s_n_llhttp__internal__n_chunk_extensions;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_11;
+          goto s_n_llhttp__internal__n_error_25;
         }
       }
       /* UNREACHABLE */;
@@ -1502,17 +1821,41 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_13;
+          goto s_n_llhttp__internal__n_error_27;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_invoke_update_content_length:
-    s_n_llhttp__internal__n_invoke_update_content_length: {
+    case s_n_llhttp__internal__n_invoke_update_content_length_1:
+    s_n_llhttp__internal__n_invoke_update_content_length_1: {
       switch (llhttp__internal__c_update_content_length(state, p, endp)) {
         default:
           goto s_n_llhttp__internal__n_chunk_size_digit;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_is_equal_upgrade:
+    s_n_llhttp__internal__n_invoke_is_equal_upgrade: {
+      switch (llhttp__internal__c_is_equal_upgrade(state, p, endp)) {
+        case 0:
+          goto s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
+        default:
+          goto s_n_llhttp__internal__n_pause_1;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2:
+    s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2: {
+      switch (llhttp__on_message_complete(state, p, endp)) {
+        case 0:
+          goto s_n_llhttp__internal__n_invoke_is_equal_upgrade;
+        case 21:
+          goto s_n_llhttp__internal__n_pause_11;
+        default:
+          goto s_n_llhttp__internal__n_error_28;
       }
       /* UNREACHABLE */;
       abort();
@@ -1573,16 +1916,26 @@ static llparse_state_t llhttp__internal__run(
         case 1:
           goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_1;
         case 2:
-          goto s_n_llhttp__internal__n_invoke_update_content_length;
+          goto s_n_llhttp__internal__n_invoke_update_content_length_1;
         case 3:
           goto s_n_llhttp__internal__n_span_start_llhttp__on_body_1;
         case 4:
           goto s_n_llhttp__internal__n_invoke_update_finish_3;
         case 5:
-          goto s_n_llhttp__internal__n_error_15;
+          goto s_n_llhttp__internal__n_error_29;
         default:
           goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete;
       }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_error_5:
+    s_n_llhttp__internal__n_error_5: {
+      state->error = 0xa;
+      state->reason = "Invalid header field char";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_error;
+      return s_error;
       /* UNREACHABLE */;
       abort();
     }
@@ -1597,7 +1950,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_test_flags;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_18;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_7;
         }
       }
       /* UNREACHABLE */;
@@ -1620,21 +1973,15 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_19:
-    s_n_llhttp__internal__n_error_19: {
-      state->error = 0xa;
-      state->reason = "Invalid header field char";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
     case s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete:
     s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete: {
       switch (llhttp__on_header_value_complete(state, p, endp)) {
-        default:
+        case 0:
           goto s_n_llhttp__internal__n_header_field_start;
+        case 21:
+          goto s_n_llhttp__internal__n_pause_14;
+        default:
+          goto s_n_llhttp__internal__n_error_37;
       }
       /* UNREACHABLE */;
       abort();
@@ -1658,11 +2005,11 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 9: {
           p++;
-          goto s_n_llhttp__internal__n_header_value_discard_ws;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_10;
         }
         case ' ': {
           p++;
-          goto s_n_llhttp__internal__n_header_value_discard_ws;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_10;
         }
         default: {
           goto s_n_llhttp__internal__n_invoke_load_header_state;
@@ -1682,7 +2029,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_header_value_discard_lws;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_21;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_11;
         }
       }
       /* UNREACHABLE */;
@@ -1695,13 +2042,13 @@ static llparse_state_t llhttp__internal__run(
       }
       switch (*p) {
         case 9: {
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
         }
         case ' ': {
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
         }
         default: {
-          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
+          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
         }
       }
       /* UNREACHABLE */;
@@ -1718,7 +2065,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_header_value_lws;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_22;
+          goto s_n_llhttp__internal__n_error_40;
         }
       }
       /* UNREACHABLE */;
@@ -1744,29 +2091,13 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_23:
-    s_n_llhttp__internal__n_error_23: {
-      state->error = 0x19;
-      state->reason = "Missing expected CR after header value";
+    case s_n_llhttp__internal__n_error_41:
+    s_n_llhttp__internal__n_error_41: {
+      state->error = 0xa;
+      state->reason = "Invalid header value char";
       state->error_pos = (const char*) p;
       state->_current = (void*) (intptr_t) s_error;
       return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_lenient_failed:
-    s_n_llhttp__internal__n_header_value_lenient_failed: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_lenient_failed;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_24;
-        }
-      }
       /* UNREACHABLE */;
       abort();
     }
@@ -1780,7 +2111,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_3;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_12;
         }
       }
       /* UNREACHABLE */;
@@ -1843,10 +2174,10 @@ static llparse_state_t llhttp__internal__run(
         }
         case ',': {
           p++;
-          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
+          goto s_n_llhttp__internal__n_invoke_load_header_state_5;
         }
         default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_4;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_5;
         }
       }
       /* UNREACHABLE */;
@@ -1864,7 +2195,7 @@ static llparse_state_t llhttp__internal__run(
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          goto s_n_llhttp__internal__n_invoke_update_header_state_2;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_3;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_header_value_connection_1;
@@ -1888,7 +2219,7 @@ static llparse_state_t llhttp__internal__run(
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          goto s_n_llhttp__internal__n_invoke_update_header_state_5;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_6;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_header_value_connection_2;
@@ -1912,7 +2243,7 @@ static llparse_state_t llhttp__internal__run(
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          goto s_n_llhttp__internal__n_invoke_update_header_state_6;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_header_value_connection_3;
@@ -1957,8 +2288,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_26:
-    s_n_llhttp__internal__n_error_26: {
+    case s_n_llhttp__internal__n_error_43:
+    s_n_llhttp__internal__n_error_43: {
       state->error = 0xb;
       state->reason = "Content-Length overflow";
       state->error_pos = (const char*) p;
@@ -1967,8 +2298,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_27:
-    s_n_llhttp__internal__n_error_27: {
+    case s_n_llhttp__internal__n_error_44:
+    s_n_llhttp__internal__n_error_44: {
       state->error = 0xb;
       state->reason = "Invalid character in Content-Length";
       state->error_pos = (const char*) p;
@@ -2063,8 +2394,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_29:
-    s_n_llhttp__internal__n_error_29: {
+    case s_n_llhttp__internal__n_error_46:
+    s_n_llhttp__internal__n_error_46: {
       state->error = 0xf;
       state->reason = "Invalid `Transfer-Encoding` header value";
       state->error_pos = (const char*) p;
@@ -2073,8 +2404,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_28:
-    s_n_llhttp__internal__n_error_28: {
+    case s_n_llhttp__internal__n_error_45:
+    s_n_llhttp__internal__n_error_45: {
       state->error = 0xf;
       state->reason = "Invalid `Transfer-Encoding` header value";
       state->error_pos = (const char*) p;
@@ -2196,7 +2527,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_header_value_te_token_ows;
         }
         default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_8;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_9;
         }
       }
       /* UNREACHABLE */;
@@ -2209,10 +2540,10 @@ static llparse_state_t llhttp__internal__run(
       }
       switch (*p) {
         case 10: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_8;
         }
         case 13: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_8;
         }
         case ' ': {
           p++;
@@ -2275,7 +2606,7 @@ static llparse_state_t llhttp__internal__run(
         }
         case 10: {
           p++;
-          goto s_n_llhttp__internal__n_header_value_discard_lws;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_9;
         }
         case 13: {
           p++;
@@ -2295,8 +2626,12 @@ static llparse_state_t llhttp__internal__run(
     case s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete:
     s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete: {
       switch (llhttp__on_header_field_complete(state, p, endp)) {
-        default:
+        case 0:
           goto s_n_llhttp__internal__n_header_value_discard_ws;
+        case 21:
+          goto s_n_llhttp__internal__n_pause_15;
+        default:
+          goto s_n_llhttp__internal__n_error_34;
       }
       /* UNREACHABLE */;
       abort();
@@ -2311,7 +2646,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_2;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_30;
+          goto s_n_llhttp__internal__n_error_47;
         }
       }
       /* UNREACHABLE */;
@@ -2395,13 +2730,13 @@ static llparse_state_t llhttp__internal__run(
       }
       switch (*p) {
         case ' ': {
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_2;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_8;
         }
         case ':': {
           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_9;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
         }
       }
       /* UNREACHABLE */;
@@ -2426,7 +2761,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_header_field_3;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
         }
       }
       /* UNREACHABLE */;
@@ -2451,7 +2786,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_header_field_4;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
         }
       }
       /* UNREACHABLE */;
@@ -2472,7 +2807,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_header_field_4;
         }
         default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
         }
       }
       /* UNREACHABLE */;
@@ -2496,7 +2831,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_header_field_1;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
         }
       }
       /* UNREACHABLE */;
@@ -2521,7 +2856,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_header_field_5;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
         }
       }
       /* UNREACHABLE */;
@@ -2546,7 +2881,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_header_field_6;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
         }
       }
       /* UNREACHABLE */;
@@ -2571,7 +2906,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_header_field_7;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
         }
       }
       /* UNREACHABLE */;
@@ -2600,7 +2935,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_header_field_7;
         }
         default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
         }
       }
       /* UNREACHABLE */;
@@ -2624,7 +2959,8 @@ static llparse_state_t llhttp__internal__run(
       }
       switch (*p) {
         case 10: {
-          goto s_n_llhttp__internal__n_headers_almost_done;
+          p++;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_1;
         }
         case 13: {
           p++;
@@ -2632,6 +2968,23 @@ static llparse_state_t llhttp__internal__run(
         }
         default: {
           goto s_n_llhttp__internal__n_span_start_llhttp__on_header_field;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_headers_start:
+    s_n_llhttp__internal__n_headers_start: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_headers_start;
+      }
+      switch (*p) {
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_header_field_start;
         }
       }
       /* UNREACHABLE */;
@@ -2645,11 +2998,11 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 9: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 12: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         default: {
           goto s_n_llhttp__internal__n_invoke_update_http_major;
@@ -2666,11 +3019,11 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 9: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 12: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         default: {
           p++;
@@ -2691,7 +3044,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_to_http_09;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_31;
+          goto s_n_llhttp__internal__n_error_48;
         }
       }
       /* UNREACHABLE */;
@@ -2705,18 +3058,18 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 9: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 12: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 13: {
           p++;
           goto s_n_llhttp__internal__n_url_skip_lf_to_http09_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_31;
+          goto s_n_llhttp__internal__n_error_48;
         }
       }
       /* UNREACHABLE */;
@@ -2734,30 +3087,30 @@ static llparse_state_t llhttp__internal__run(
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          goto s_n_llhttp__internal__n_error_36;
+          goto s_n_llhttp__internal__n_error_55;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_req_pri_upgrade;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_37;
+          goto s_n_llhttp__internal__n_error_56;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_req_http_complete_1:
-    s_n_llhttp__internal__n_req_http_complete_1: {
+    case s_n_llhttp__internal__n_req_http_complete_crlf:
+    s_n_llhttp__internal__n_req_http_complete_crlf: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_complete_1;
+        return s_n_llhttp__internal__n_req_http_complete_crlf;
       }
       switch (*p) {
         case 10: {
           p++;
-          goto s_n_llhttp__internal__n_header_field_start;
+          goto s_n_llhttp__internal__n_headers_start;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_35;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_16;
         }
       }
       /* UNREACHABLE */;
@@ -2769,18 +3122,58 @@ static llparse_state_t llhttp__internal__run(
         return s_n_llhttp__internal__n_req_http_complete;
       }
       switch (*p) {
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_start;
-        }
         case 13: {
           p++;
-          goto s_n_llhttp__internal__n_req_http_complete_1;
+          goto s_n_llhttp__internal__n_req_http_complete_crlf;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_35;
+          goto s_n_llhttp__internal__n_error_54;
         }
       }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_load_method_1:
+    s_n_llhttp__internal__n_invoke_load_method_1: {
+      switch (llhttp__internal__c_load_method(state, p, endp)) {
+        case 34:
+          goto s_n_llhttp__internal__n_req_pri_upgrade;
+        default:
+          goto s_n_llhttp__internal__n_req_http_complete;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_version_complete:
+    s_n_llhttp__internal__n_invoke_llhttp__on_version_complete: {
+      switch (llhttp__on_version_complete(state, p, endp)) {
+        case 0:
+          goto s_n_llhttp__internal__n_invoke_load_method_1;
+        case 21:
+          goto s_n_llhttp__internal__n_pause_17;
+        default:
+          goto s_n_llhttp__internal__n_error_52;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_error_51:
+    s_n_llhttp__internal__n_error_51: {
+      state->error = 0x9;
+      state->reason = "Invalid HTTP version";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_error;
+      return s_error;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_error_57:
+    s_n_llhttp__internal__n_error_57: {
+      state->error = 0x9;
+      state->reason = "Invalid minor version";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_error;
+      return s_error;
       /* UNREACHABLE */;
       abort();
     }
@@ -2841,9 +3234,19 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_minor;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_40;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_version_2;
         }
       }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_error_58:
+    s_n_llhttp__internal__n_error_58: {
+      state->error = 0x9;
+      state->reason = "Expected dot";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_error;
+      return s_error;
       /* UNREACHABLE */;
       abort();
     }
@@ -2858,9 +3261,19 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_http_minor;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_41;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_version_3;
         }
       }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_error_59:
+    s_n_llhttp__internal__n_error_59: {
+      state->error = 0x9;
+      state->reason = "Invalid major version";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_error;
+      return s_error;
       /* UNREACHABLE */;
       abort();
     }
@@ -2921,9 +3334,20 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_major;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_42;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_version_4;
         }
       }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_version:
+    s_n_llhttp__internal__n_span_start_llhttp__on_version: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_version;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_version;
+      goto s_n_llhttp__internal__n_req_http_major;
       /* UNREACHABLE */;
       abort();
     }
@@ -2945,7 +3369,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_http_start_1;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_45;
+          goto s_n_llhttp__internal__n_error_62;
         }
       }
       /* UNREACHABLE */;
@@ -2969,7 +3393,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_http_start_2;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_45;
+          goto s_n_llhttp__internal__n_error_62;
         }
       }
       /* UNREACHABLE */;
@@ -2993,7 +3417,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_http_start_3;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_45;
+          goto s_n_llhttp__internal__n_error_62;
         }
       }
       /* UNREACHABLE */;
@@ -3022,7 +3446,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_http_start_3;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_45;
+          goto s_n_llhttp__internal__n_error_62;
         }
       }
       /* UNREACHABLE */;
@@ -3036,11 +3460,11 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 9: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 12: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         default: {
           goto s_n_llhttp__internal__n_invoke_llhttp__on_url_complete_1;
@@ -3057,11 +3481,11 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 9: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 12: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         default: {
           p++;
@@ -3097,7 +3521,7 @@ static llparse_state_t llhttp__internal__run(
       switch (lookup_table[(uint8_t) *p]) {
         case 1: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 2: {
           goto s_n_llhttp__internal__n_span_end_llhttp__on_url_6;
@@ -3113,7 +3537,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_fragment;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_46;
+          goto s_n_llhttp__internal__n_error_63;
         }
       }
       /* UNREACHABLE */;
@@ -3155,7 +3579,7 @@ static llparse_state_t llhttp__internal__run(
       switch (lookup_table[(uint8_t) *p]) {
         case 1: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 2: {
           goto s_n_llhttp__internal__n_span_end_llhttp__on_url_9;
@@ -3174,7 +3598,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_stub_query_3;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_47;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -3188,14 +3612,14 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 9: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 10: {
           goto s_n_llhttp__internal__n_span_end_llhttp__on_url_3;
         }
         case 12: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 13: {
           goto s_n_llhttp__internal__n_span_end_llhttp__on_url_4;
@@ -3212,7 +3636,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_query;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_48;
+          goto s_n_llhttp__internal__n_error_65;
         }
       }
       /* UNREACHABLE */;
@@ -3244,7 +3668,7 @@ static llparse_state_t llhttp__internal__run(
       switch (lookup_table[(uint8_t) *p]) {
         case 1: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 2: {
           p++;
@@ -3313,7 +3737,7 @@ static llparse_state_t llhttp__internal__run(
       switch (lookup_table[(uint8_t) *p]) {
         case 1: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 2: {
           goto s_n_llhttp__internal__n_span_end_llhttp__on_url_12;
@@ -3337,10 +3761,10 @@ static llparse_state_t llhttp__internal__run(
         }
         case 8: {
           p++;
-          goto s_n_llhttp__internal__n_error_49;
+          goto s_n_llhttp__internal__n_error_66;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_50;
+          goto s_n_llhttp__internal__n_error_67;
         }
       }
       /* UNREACHABLE */;
@@ -3372,7 +3796,7 @@ static llparse_state_t llhttp__internal__run(
       switch (lookup_table[(uint8_t) *p]) {
         case 1: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 2: {
           goto s_n_llhttp__internal__n_span_end_llhttp__on_url;
@@ -3399,7 +3823,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_server_with_at;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_68;
         }
       }
       /* UNREACHABLE */;
@@ -3416,7 +3840,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_server;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_53;
+          goto s_n_llhttp__internal__n_error_69;
         }
       }
       /* UNREACHABLE */;
@@ -3430,30 +3854,30 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 9: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 10: {
           p++;
-          goto s_n_llhttp__internal__n_error_52;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 12: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 13: {
           p++;
-          goto s_n_llhttp__internal__n_error_52;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case ' ': {
           p++;
-          goto s_n_llhttp__internal__n_error_52;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case '/': {
           p++;
           goto s_n_llhttp__internal__n_url_schema_delim_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_53;
+          goto s_n_llhttp__internal__n_error_69;
         }
       }
       /* UNREACHABLE */;
@@ -3472,14 +3896,14 @@ static llparse_state_t llhttp__internal__run(
     case s_n_llhttp__internal__n_url_schema:
     s_n_llhttp__internal__n_url_schema: {
       static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 2, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0,
-        0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0,
-        0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0,
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0,
+        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
+        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3495,21 +3919,17 @@ static llparse_state_t llhttp__internal__run(
       switch (lookup_table[(uint8_t) *p]) {
         case 1: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_error_52;
-        }
-        case 3: {
           goto s_n_llhttp__internal__n_span_end_stub_schema;
         }
-        case 4: {
+        case 3: {
           p++;
           goto s_n_llhttp__internal__n_url_schema;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_54;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -3518,14 +3938,14 @@ static llparse_state_t llhttp__internal__run(
     case s_n_llhttp__internal__n_url_start:
     s_n_llhttp__internal__n_url_start: {
       static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 2, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 3,
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0,
-        0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0,
+        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
+        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3541,20 +3961,16 @@ static llparse_state_t llhttp__internal__run(
       switch (lookup_table[(uint8_t) *p]) {
         case 1: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_error_52;
-        }
-        case 3: {
           goto s_n_llhttp__internal__n_span_start_stub_path_2;
         }
-        case 4: {
+        case 3: {
           goto s_n_llhttp__internal__n_url_schema;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_55;
+          goto s_n_llhttp__internal__n_error_71;
         }
       }
       /* UNREACHABLE */;
@@ -3579,11 +3995,11 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 9: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 12: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         default: {
           goto s_n_llhttp__internal__n_span_start_llhttp__on_url_1;
@@ -3611,11 +4027,11 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 9: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         case 12: {
           p++;
-          goto s_n_llhttp__internal__n_error_1;
+          goto s_n_llhttp__internal__n_error_2;
         }
         default: {
           goto s_n_llhttp__internal__n_span_start_llhttp__on_url;
@@ -3652,16 +4068,29 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_spaces_before_url;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_56;
+          goto s_n_llhttp__internal__n_error_72;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_2:
-    s_n_llhttp__internal__n_start_req_2: {
+    case s_n_llhttp__internal__n_invoke_llhttp__on_method_complete_1:
+    s_n_llhttp__internal__n_invoke_llhttp__on_method_complete_1: {
+      switch (llhttp__on_method_complete(state, p, endp)) {
+        case 0:
+          goto s_n_llhttp__internal__n_req_first_space_before_url;
+        case 21:
+          goto s_n_llhttp__internal__n_pause_22;
+        default:
+          goto s_n_llhttp__internal__n_error_89;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_after_start_req_2:
+    s_n_llhttp__internal__n_after_start_req_2: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_2;
+        return s_n_llhttp__internal__n_after_start_req_2;
       }
       switch (*p) {
         case 'L': {
@@ -3670,18 +4099,18 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_3:
-    s_n_llhttp__internal__n_start_req_3: {
+    case s_n_llhttp__internal__n_after_start_req_3:
+    s_n_llhttp__internal__n_after_start_req_3: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_3;
+        return s_n_llhttp__internal__n_after_start_req_3;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob18, 6);
       p = match_seq.current;
@@ -3692,42 +4121,42 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_3;
+          return s_n_llhttp__internal__n_after_start_req_3;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_1:
-    s_n_llhttp__internal__n_start_req_1: {
+    case s_n_llhttp__internal__n_after_start_req_1:
+    s_n_llhttp__internal__n_after_start_req_1: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_1;
+        return s_n_llhttp__internal__n_after_start_req_1;
       }
       switch (*p) {
         case 'C': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_2;
+          goto s_n_llhttp__internal__n_after_start_req_2;
         }
         case 'N': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_3;
+          goto s_n_llhttp__internal__n_after_start_req_3;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_4:
-    s_n_llhttp__internal__n_start_req_4: {
+    case s_n_llhttp__internal__n_after_start_req_4:
+    s_n_llhttp__internal__n_after_start_req_4: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_4;
+        return s_n_llhttp__internal__n_after_start_req_4;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob19, 3);
       p = match_seq.current;
@@ -3738,21 +4167,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_4;
+          return s_n_llhttp__internal__n_after_start_req_4;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_6:
-    s_n_llhttp__internal__n_start_req_6: {
+    case s_n_llhttp__internal__n_after_start_req_6:
+    s_n_llhttp__internal__n_after_start_req_6: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_6;
+        return s_n_llhttp__internal__n_after_start_req_6;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob20, 6);
       p = match_seq.current;
@@ -3763,21 +4192,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_6;
+          return s_n_llhttp__internal__n_after_start_req_6;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_8:
-    s_n_llhttp__internal__n_start_req_8: {
+    case s_n_llhttp__internal__n_after_start_req_8:
+    s_n_llhttp__internal__n_after_start_req_8: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_8;
+        return s_n_llhttp__internal__n_after_start_req_8;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob21, 4);
       p = match_seq.current;
@@ -3788,19 +4217,19 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_8;
+          return s_n_llhttp__internal__n_after_start_req_8;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_9:
-    s_n_llhttp__internal__n_start_req_9: {
+    case s_n_llhttp__internal__n_after_start_req_9:
+    s_n_llhttp__internal__n_after_start_req_9: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_9;
+        return s_n_llhttp__internal__n_after_start_req_9;
       }
       switch (*p) {
         case 'Y': {
@@ -3809,60 +4238,60 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_7:
-    s_n_llhttp__internal__n_start_req_7: {
+    case s_n_llhttp__internal__n_after_start_req_7:
+    s_n_llhttp__internal__n_after_start_req_7: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_7;
+        return s_n_llhttp__internal__n_after_start_req_7;
       }
       switch (*p) {
         case 'N': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_8;
+          goto s_n_llhttp__internal__n_after_start_req_8;
         }
         case 'P': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_9;
+          goto s_n_llhttp__internal__n_after_start_req_9;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_5:
-    s_n_llhttp__internal__n_start_req_5: {
+    case s_n_llhttp__internal__n_after_start_req_5:
+    s_n_llhttp__internal__n_after_start_req_5: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_5;
+        return s_n_llhttp__internal__n_after_start_req_5;
       }
       switch (*p) {
         case 'H': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_6;
+          goto s_n_llhttp__internal__n_after_start_req_6;
         }
         case 'O': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_7;
+          goto s_n_llhttp__internal__n_after_start_req_7;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_12:
-    s_n_llhttp__internal__n_start_req_12: {
+    case s_n_llhttp__internal__n_after_start_req_12:
+    s_n_llhttp__internal__n_after_start_req_12: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_12;
+        return s_n_llhttp__internal__n_after_start_req_12;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob22, 3);
       p = match_seq.current;
@@ -3873,21 +4302,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_12;
+          return s_n_llhttp__internal__n_after_start_req_12;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_13:
-    s_n_llhttp__internal__n_start_req_13: {
+    case s_n_llhttp__internal__n_after_start_req_13:
+    s_n_llhttp__internal__n_after_start_req_13: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_13;
+        return s_n_llhttp__internal__n_after_start_req_13;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob23, 5);
       p = match_seq.current;
@@ -3898,59 +4327,59 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_13;
+          return s_n_llhttp__internal__n_after_start_req_13;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_11:
-    s_n_llhttp__internal__n_start_req_11: {
+    case s_n_llhttp__internal__n_after_start_req_11:
+    s_n_llhttp__internal__n_after_start_req_11: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_11;
+        return s_n_llhttp__internal__n_after_start_req_11;
       }
       switch (*p) {
         case 'L': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_12;
+          goto s_n_llhttp__internal__n_after_start_req_12;
         }
         case 'S': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_13;
+          goto s_n_llhttp__internal__n_after_start_req_13;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_10:
-    s_n_llhttp__internal__n_start_req_10: {
+    case s_n_llhttp__internal__n_after_start_req_10:
+    s_n_llhttp__internal__n_after_start_req_10: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_10;
+        return s_n_llhttp__internal__n_after_start_req_10;
       }
       switch (*p) {
         case 'E': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_11;
+          goto s_n_llhttp__internal__n_after_start_req_11;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_14:
-    s_n_llhttp__internal__n_start_req_14: {
+    case s_n_llhttp__internal__n_after_start_req_14:
+    s_n_llhttp__internal__n_after_start_req_14: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_14;
+        return s_n_llhttp__internal__n_after_start_req_14;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob24, 4);
       p = match_seq.current;
@@ -3961,21 +4390,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_14;
+          return s_n_llhttp__internal__n_after_start_req_14;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_17:
-    s_n_llhttp__internal__n_start_req_17: {
+    case s_n_llhttp__internal__n_after_start_req_17:
+    s_n_llhttp__internal__n_after_start_req_17: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_17;
+        return s_n_llhttp__internal__n_after_start_req_17;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob26, 9);
       p = match_seq.current;
@@ -3986,24 +4415,24 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_17;
+          return s_n_llhttp__internal__n_after_start_req_17;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_16:
-    s_n_llhttp__internal__n_start_req_16: {
+    case s_n_llhttp__internal__n_after_start_req_16:
+    s_n_llhttp__internal__n_after_start_req_16: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_16;
+        return s_n_llhttp__internal__n_after_start_req_16;
       }
       switch (*p) {
         case '_': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_17;
+          goto s_n_llhttp__internal__n_after_start_req_17;
         }
         default: {
           match = 1;
@@ -4013,36 +4442,36 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_15:
-    s_n_llhttp__internal__n_start_req_15: {
+    case s_n_llhttp__internal__n_after_start_req_15:
+    s_n_llhttp__internal__n_after_start_req_15: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_15;
+        return s_n_llhttp__internal__n_after_start_req_15;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob25, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          goto s_n_llhttp__internal__n_start_req_16;
+          goto s_n_llhttp__internal__n_after_start_req_16;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_15;
+          return s_n_llhttp__internal__n_after_start_req_15;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_18:
-    s_n_llhttp__internal__n_start_req_18: {
+    case s_n_llhttp__internal__n_after_start_req_18:
+    s_n_llhttp__internal__n_after_start_req_18: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_18;
+        return s_n_llhttp__internal__n_after_start_req_18;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob27, 3);
       p = match_seq.current;
@@ -4053,21 +4482,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_18;
+          return s_n_llhttp__internal__n_after_start_req_18;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_20:
-    s_n_llhttp__internal__n_start_req_20: {
+    case s_n_llhttp__internal__n_after_start_req_20:
+    s_n_llhttp__internal__n_after_start_req_20: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_20;
+        return s_n_llhttp__internal__n_after_start_req_20;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob28, 2);
       p = match_seq.current;
@@ -4078,21 +4507,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_20;
+          return s_n_llhttp__internal__n_after_start_req_20;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_21:
-    s_n_llhttp__internal__n_start_req_21: {
+    case s_n_llhttp__internal__n_after_start_req_21:
+    s_n_llhttp__internal__n_after_start_req_21: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_21;
+        return s_n_llhttp__internal__n_after_start_req_21;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob29, 2);
       p = match_seq.current;
@@ -4103,42 +4532,42 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_21;
+          return s_n_llhttp__internal__n_after_start_req_21;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_19:
-    s_n_llhttp__internal__n_start_req_19: {
+    case s_n_llhttp__internal__n_after_start_req_19:
+    s_n_llhttp__internal__n_after_start_req_19: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_19;
+        return s_n_llhttp__internal__n_after_start_req_19;
       }
       switch (*p) {
         case 'I': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_20;
+          goto s_n_llhttp__internal__n_after_start_req_20;
         }
         case 'O': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_21;
+          goto s_n_llhttp__internal__n_after_start_req_21;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_23:
-    s_n_llhttp__internal__n_start_req_23: {
+    case s_n_llhttp__internal__n_after_start_req_23:
+    s_n_llhttp__internal__n_after_start_req_23: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_23;
+        return s_n_llhttp__internal__n_after_start_req_23;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob30, 6);
       p = match_seq.current;
@@ -4149,21 +4578,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_23;
+          return s_n_llhttp__internal__n_after_start_req_23;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_24:
-    s_n_llhttp__internal__n_start_req_24: {
+    case s_n_llhttp__internal__n_after_start_req_24:
+    s_n_llhttp__internal__n_after_start_req_24: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_24;
+        return s_n_llhttp__internal__n_after_start_req_24;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob31, 3);
       p = match_seq.current;
@@ -4174,21 +4603,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_24;
+          return s_n_llhttp__internal__n_after_start_req_24;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_26:
-    s_n_llhttp__internal__n_start_req_26: {
+    case s_n_llhttp__internal__n_after_start_req_26:
+    s_n_llhttp__internal__n_after_start_req_26: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_26;
+        return s_n_llhttp__internal__n_after_start_req_26;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob32, 7);
       p = match_seq.current;
@@ -4199,21 +4628,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_26;
+          return s_n_llhttp__internal__n_after_start_req_26;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_28:
-    s_n_llhttp__internal__n_start_req_28: {
+    case s_n_llhttp__internal__n_after_start_req_28:
+    s_n_llhttp__internal__n_after_start_req_28: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_28;
+        return s_n_llhttp__internal__n_after_start_req_28;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob33, 6);
       p = match_seq.current;
@@ -4224,19 +4653,19 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_28;
+          return s_n_llhttp__internal__n_after_start_req_28;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_29:
-    s_n_llhttp__internal__n_start_req_29: {
+    case s_n_llhttp__internal__n_after_start_req_29:
+    s_n_llhttp__internal__n_after_start_req_29: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_29;
+        return s_n_llhttp__internal__n_after_start_req_29;
       }
       switch (*p) {
         case 'L': {
@@ -4245,60 +4674,60 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_27:
-    s_n_llhttp__internal__n_start_req_27: {
+    case s_n_llhttp__internal__n_after_start_req_27:
+    s_n_llhttp__internal__n_after_start_req_27: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_27;
+        return s_n_llhttp__internal__n_after_start_req_27;
       }
       switch (*p) {
         case 'A': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_28;
+          goto s_n_llhttp__internal__n_after_start_req_28;
         }
         case 'O': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_29;
+          goto s_n_llhttp__internal__n_after_start_req_29;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_25:
-    s_n_llhttp__internal__n_start_req_25: {
+    case s_n_llhttp__internal__n_after_start_req_25:
+    s_n_llhttp__internal__n_after_start_req_25: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_25;
+        return s_n_llhttp__internal__n_after_start_req_25;
       }
       switch (*p) {
         case 'A': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_26;
+          goto s_n_llhttp__internal__n_after_start_req_26;
         }
         case 'C': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_27;
+          goto s_n_llhttp__internal__n_after_start_req_27;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_30:
-    s_n_llhttp__internal__n_start_req_30: {
+    case s_n_llhttp__internal__n_after_start_req_30:
+    s_n_llhttp__internal__n_after_start_req_30: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_30;
+        return s_n_llhttp__internal__n_after_start_req_30;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob34, 2);
       p = match_seq.current;
@@ -4309,50 +4738,50 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_30;
+          return s_n_llhttp__internal__n_after_start_req_30;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_22:
-    s_n_llhttp__internal__n_start_req_22: {
+    case s_n_llhttp__internal__n_after_start_req_22:
+    s_n_llhttp__internal__n_after_start_req_22: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_22;
+        return s_n_llhttp__internal__n_after_start_req_22;
       }
       switch (*p) {
         case '-': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_23;
+          goto s_n_llhttp__internal__n_after_start_req_23;
         }
         case 'E': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_24;
+          goto s_n_llhttp__internal__n_after_start_req_24;
         }
         case 'K': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_25;
+          goto s_n_llhttp__internal__n_after_start_req_25;
         }
         case 'O': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_30;
+          goto s_n_llhttp__internal__n_after_start_req_30;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_31:
-    s_n_llhttp__internal__n_start_req_31: {
+    case s_n_llhttp__internal__n_after_start_req_31:
+    s_n_llhttp__internal__n_after_start_req_31: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_31;
+        return s_n_llhttp__internal__n_after_start_req_31;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob35, 5);
       p = match_seq.current;
@@ -4363,21 +4792,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_31;
+          return s_n_llhttp__internal__n_after_start_req_31;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_32:
-    s_n_llhttp__internal__n_start_req_32: {
+    case s_n_llhttp__internal__n_after_start_req_32:
+    s_n_llhttp__internal__n_after_start_req_32: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_32;
+        return s_n_llhttp__internal__n_after_start_req_32;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob36, 6);
       p = match_seq.current;
@@ -4388,21 +4817,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_32;
+          return s_n_llhttp__internal__n_after_start_req_32;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_35:
-    s_n_llhttp__internal__n_start_req_35: {
+    case s_n_llhttp__internal__n_after_start_req_35:
+    s_n_llhttp__internal__n_after_start_req_35: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_35;
+        return s_n_llhttp__internal__n_after_start_req_35;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob37, 2);
       p = match_seq.current;
@@ -4413,21 +4842,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_35;
+          return s_n_llhttp__internal__n_after_start_req_35;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_36:
-    s_n_llhttp__internal__n_start_req_36: {
+    case s_n_llhttp__internal__n_after_start_req_36:
+    s_n_llhttp__internal__n_after_start_req_36: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_36;
+        return s_n_llhttp__internal__n_after_start_req_36;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob38, 2);
       p = match_seq.current;
@@ -4438,42 +4867,42 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_36;
+          return s_n_llhttp__internal__n_after_start_req_36;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_34:
-    s_n_llhttp__internal__n_start_req_34: {
+    case s_n_llhttp__internal__n_after_start_req_34:
+    s_n_llhttp__internal__n_after_start_req_34: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_34;
+        return s_n_llhttp__internal__n_after_start_req_34;
       }
       switch (*p) {
         case 'T': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_35;
+          goto s_n_llhttp__internal__n_after_start_req_35;
         }
         case 'U': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_36;
+          goto s_n_llhttp__internal__n_after_start_req_36;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_37:
-    s_n_llhttp__internal__n_start_req_37: {
+    case s_n_llhttp__internal__n_after_start_req_37:
+    s_n_llhttp__internal__n_after_start_req_37: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_37;
+        return s_n_llhttp__internal__n_after_start_req_37;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob39, 2);
       p = match_seq.current;
@@ -4484,21 +4913,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_37;
+          return s_n_llhttp__internal__n_after_start_req_37;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_38:
-    s_n_llhttp__internal__n_start_req_38: {
+    case s_n_llhttp__internal__n_after_start_req_38:
+    s_n_llhttp__internal__n_after_start_req_38: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_38;
+        return s_n_llhttp__internal__n_after_start_req_38;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob40, 2);
       p = match_seq.current;
@@ -4509,21 +4938,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_38;
+          return s_n_llhttp__internal__n_after_start_req_38;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_42:
-    s_n_llhttp__internal__n_start_req_42: {
+    case s_n_llhttp__internal__n_after_start_req_42:
+    s_n_llhttp__internal__n_after_start_req_42: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_42;
+        return s_n_llhttp__internal__n_after_start_req_42;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob41, 3);
       p = match_seq.current;
@@ -4534,21 +4963,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_42;
+          return s_n_llhttp__internal__n_after_start_req_42;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_43:
-    s_n_llhttp__internal__n_start_req_43: {
+    case s_n_llhttp__internal__n_after_start_req_43:
+    s_n_llhttp__internal__n_after_start_req_43: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_43;
+        return s_n_llhttp__internal__n_after_start_req_43;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob42, 4);
       p = match_seq.current;
@@ -4559,57 +4988,57 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_43;
+          return s_n_llhttp__internal__n_after_start_req_43;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_41:
-    s_n_llhttp__internal__n_start_req_41: {
+    case s_n_llhttp__internal__n_after_start_req_41:
+    s_n_llhttp__internal__n_after_start_req_41: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_41;
+        return s_n_llhttp__internal__n_after_start_req_41;
       }
       switch (*p) {
         case 'F': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_42;
+          goto s_n_llhttp__internal__n_after_start_req_42;
         }
         case 'P': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_43;
+          goto s_n_llhttp__internal__n_after_start_req_43;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_40:
-    s_n_llhttp__internal__n_start_req_40: {
+    case s_n_llhttp__internal__n_after_start_req_40:
+    s_n_llhttp__internal__n_after_start_req_40: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_40;
+        return s_n_llhttp__internal__n_after_start_req_40;
       }
       switch (*p) {
         case 'P': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_41;
+          goto s_n_llhttp__internal__n_after_start_req_41;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_39:
-    s_n_llhttp__internal__n_start_req_39: {
+    case s_n_llhttp__internal__n_after_start_req_39:
+    s_n_llhttp__internal__n_after_start_req_39: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_39;
+        return s_n_llhttp__internal__n_after_start_req_39;
       }
       switch (*p) {
         case 'I': {
@@ -4619,21 +5048,21 @@ static llparse_state_t llhttp__internal__run(
         }
         case 'O': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_40;
+          goto s_n_llhttp__internal__n_after_start_req_40;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_45:
-    s_n_llhttp__internal__n_start_req_45: {
+    case s_n_llhttp__internal__n_after_start_req_45:
+    s_n_llhttp__internal__n_after_start_req_45: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_45;
+        return s_n_llhttp__internal__n_after_start_req_45;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob43, 2);
       p = match_seq.current;
@@ -4644,24 +5073,24 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_45;
+          return s_n_llhttp__internal__n_after_start_req_45;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_44:
-    s_n_llhttp__internal__n_start_req_44: {
+    case s_n_llhttp__internal__n_after_start_req_44:
+    s_n_llhttp__internal__n_after_start_req_44: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_44;
+        return s_n_llhttp__internal__n_after_start_req_44;
       }
       switch (*p) {
         case 'R': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_45;
+          goto s_n_llhttp__internal__n_after_start_req_45;
         }
         case 'T': {
           p++;
@@ -4669,51 +5098,51 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_33:
-    s_n_llhttp__internal__n_start_req_33: {
+    case s_n_llhttp__internal__n_after_start_req_33:
+    s_n_llhttp__internal__n_after_start_req_33: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_33;
+        return s_n_llhttp__internal__n_after_start_req_33;
       }
       switch (*p) {
         case 'A': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_34;
+          goto s_n_llhttp__internal__n_after_start_req_34;
         }
         case 'L': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_37;
+          goto s_n_llhttp__internal__n_after_start_req_37;
         }
         case 'O': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_38;
+          goto s_n_llhttp__internal__n_after_start_req_38;
         }
         case 'R': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_39;
+          goto s_n_llhttp__internal__n_after_start_req_39;
         }
         case 'U': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_44;
+          goto s_n_llhttp__internal__n_after_start_req_44;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_48:
-    s_n_llhttp__internal__n_start_req_48: {
+    case s_n_llhttp__internal__n_after_start_req_48:
+    s_n_llhttp__internal__n_after_start_req_48: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_48;
+        return s_n_llhttp__internal__n_after_start_req_48;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob44, 3);
       p = match_seq.current;
@@ -4724,21 +5153,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_48;
+          return s_n_llhttp__internal__n_after_start_req_48;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_49:
-    s_n_llhttp__internal__n_start_req_49: {
+    case s_n_llhttp__internal__n_after_start_req_49:
+    s_n_llhttp__internal__n_after_start_req_49: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_49;
+        return s_n_llhttp__internal__n_after_start_req_49;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob45, 3);
       p = match_seq.current;
@@ -4749,21 +5178,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_49;
+          return s_n_llhttp__internal__n_after_start_req_49;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_50:
-    s_n_llhttp__internal__n_start_req_50: {
+    case s_n_llhttp__internal__n_after_start_req_50:
+    s_n_llhttp__internal__n_after_start_req_50: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_50;
+        return s_n_llhttp__internal__n_after_start_req_50;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob46, 5);
       p = match_seq.current;
@@ -4774,21 +5203,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_50;
+          return s_n_llhttp__internal__n_after_start_req_50;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_51:
-    s_n_llhttp__internal__n_start_req_51: {
+    case s_n_llhttp__internal__n_after_start_req_51:
+    s_n_llhttp__internal__n_after_start_req_51: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_51;
+        return s_n_llhttp__internal__n_after_start_req_51;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob47, 3);
       p = match_seq.current;
@@ -4799,67 +5228,67 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_51;
+          return s_n_llhttp__internal__n_after_start_req_51;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_47:
-    s_n_llhttp__internal__n_start_req_47: {
+    case s_n_llhttp__internal__n_after_start_req_47:
+    s_n_llhttp__internal__n_after_start_req_47: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_47;
+        return s_n_llhttp__internal__n_after_start_req_47;
       }
       switch (*p) {
         case 'B': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_48;
+          goto s_n_llhttp__internal__n_after_start_req_48;
         }
         case 'C': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_49;
+          goto s_n_llhttp__internal__n_after_start_req_49;
         }
         case 'D': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_50;
+          goto s_n_llhttp__internal__n_after_start_req_50;
         }
         case 'P': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_51;
+          goto s_n_llhttp__internal__n_after_start_req_51;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_46:
-    s_n_llhttp__internal__n_start_req_46: {
+    case s_n_llhttp__internal__n_after_start_req_46:
+    s_n_llhttp__internal__n_after_start_req_46: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_46;
+        return s_n_llhttp__internal__n_after_start_req_46;
       }
       switch (*p) {
         case 'E': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_47;
+          goto s_n_llhttp__internal__n_after_start_req_47;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_54:
-    s_n_llhttp__internal__n_start_req_54: {
+    case s_n_llhttp__internal__n_after_start_req_54:
+    s_n_llhttp__internal__n_after_start_req_54: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_54;
+        return s_n_llhttp__internal__n_after_start_req_54;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob48, 3);
       p = match_seq.current;
@@ -4870,19 +5299,19 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_54;
+          return s_n_llhttp__internal__n_after_start_req_54;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_56:
-    s_n_llhttp__internal__n_start_req_56: {
+    case s_n_llhttp__internal__n_after_start_req_56:
+    s_n_llhttp__internal__n_after_start_req_56: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_56;
+        return s_n_llhttp__internal__n_after_start_req_56;
       }
       switch (*p) {
         case 'P': {
@@ -4891,18 +5320,18 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_57:
-    s_n_llhttp__internal__n_start_req_57: {
+    case s_n_llhttp__internal__n_after_start_req_57:
+    s_n_llhttp__internal__n_after_start_req_57: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_57;
+        return s_n_llhttp__internal__n_after_start_req_57;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob49, 9);
       p = match_seq.current;
@@ -4913,63 +5342,63 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_57;
+          return s_n_llhttp__internal__n_after_start_req_57;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_55:
-    s_n_llhttp__internal__n_start_req_55: {
+    case s_n_llhttp__internal__n_after_start_req_55:
+    s_n_llhttp__internal__n_after_start_req_55: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_55;
+        return s_n_llhttp__internal__n_after_start_req_55;
       }
       switch (*p) {
         case 'U': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_56;
+          goto s_n_llhttp__internal__n_after_start_req_56;
         }
         case '_': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_57;
+          goto s_n_llhttp__internal__n_after_start_req_57;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_53:
-    s_n_llhttp__internal__n_start_req_53: {
+    case s_n_llhttp__internal__n_after_start_req_53:
+    s_n_llhttp__internal__n_after_start_req_53: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_53;
+        return s_n_llhttp__internal__n_after_start_req_53;
       }
       switch (*p) {
         case 'A': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_54;
+          goto s_n_llhttp__internal__n_after_start_req_54;
         }
         case 'T': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_55;
+          goto s_n_llhttp__internal__n_after_start_req_55;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_58:
-    s_n_llhttp__internal__n_start_req_58: {
+    case s_n_llhttp__internal__n_after_start_req_58:
+    s_n_llhttp__internal__n_after_start_req_58: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_58;
+        return s_n_llhttp__internal__n_after_start_req_58;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob50, 4);
       p = match_seq.current;
@@ -4980,21 +5409,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_58;
+          return s_n_llhttp__internal__n_after_start_req_58;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_59:
-    s_n_llhttp__internal__n_start_req_59: {
+    case s_n_llhttp__internal__n_after_start_req_59:
+    s_n_llhttp__internal__n_after_start_req_59: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_59;
+        return s_n_llhttp__internal__n_after_start_req_59;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob51, 7);
       p = match_seq.current;
@@ -5005,46 +5434,46 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_59;
+          return s_n_llhttp__internal__n_after_start_req_59;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_52:
-    s_n_llhttp__internal__n_start_req_52: {
+    case s_n_llhttp__internal__n_after_start_req_52:
+    s_n_llhttp__internal__n_after_start_req_52: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_52;
+        return s_n_llhttp__internal__n_after_start_req_52;
       }
       switch (*p) {
         case 'E': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_53;
+          goto s_n_llhttp__internal__n_after_start_req_53;
         }
         case 'O': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_58;
+          goto s_n_llhttp__internal__n_after_start_req_58;
         }
         case 'U': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_59;
+          goto s_n_llhttp__internal__n_after_start_req_59;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_61:
-    s_n_llhttp__internal__n_start_req_61: {
+    case s_n_llhttp__internal__n_after_start_req_61:
+    s_n_llhttp__internal__n_after_start_req_61: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_61;
+        return s_n_llhttp__internal__n_after_start_req_61;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob52, 6);
       p = match_seq.current;
@@ -5055,21 +5484,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_61;
+          return s_n_llhttp__internal__n_after_start_req_61;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_62:
-    s_n_llhttp__internal__n_start_req_62: {
+    case s_n_llhttp__internal__n_after_start_req_62:
+    s_n_llhttp__internal__n_after_start_req_62: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_62;
+        return s_n_llhttp__internal__n_after_start_req_62;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob53, 3);
       p = match_seq.current;
@@ -5080,42 +5509,42 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_62;
+          return s_n_llhttp__internal__n_after_start_req_62;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_60:
-    s_n_llhttp__internal__n_start_req_60: {
+    case s_n_llhttp__internal__n_after_start_req_60:
+    s_n_llhttp__internal__n_after_start_req_60: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_60;
+        return s_n_llhttp__internal__n_after_start_req_60;
       }
       switch (*p) {
         case 'E': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_61;
+          goto s_n_llhttp__internal__n_after_start_req_61;
         }
         case 'R': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_62;
+          goto s_n_llhttp__internal__n_after_start_req_62;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_65:
-    s_n_llhttp__internal__n_start_req_65: {
+    case s_n_llhttp__internal__n_after_start_req_65:
+    s_n_llhttp__internal__n_after_start_req_65: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_65;
+        return s_n_llhttp__internal__n_after_start_req_65;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob54, 3);
       p = match_seq.current;
@@ -5126,21 +5555,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_65;
+          return s_n_llhttp__internal__n_after_start_req_65;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_67:
-    s_n_llhttp__internal__n_start_req_67: {
+    case s_n_llhttp__internal__n_after_start_req_67:
+    s_n_llhttp__internal__n_after_start_req_67: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_67;
+        return s_n_llhttp__internal__n_after_start_req_67;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob55, 2);
       p = match_seq.current;
@@ -5151,21 +5580,21 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_67;
+          return s_n_llhttp__internal__n_after_start_req_67;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_68:
-    s_n_llhttp__internal__n_start_req_68: {
+    case s_n_llhttp__internal__n_after_start_req_68:
+    s_n_llhttp__internal__n_after_start_req_68: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_68;
+        return s_n_llhttp__internal__n_after_start_req_68;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob56, 2);
       p = match_seq.current;
@@ -5176,42 +5605,42 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_68;
+          return s_n_llhttp__internal__n_after_start_req_68;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_66:
-    s_n_llhttp__internal__n_start_req_66: {
+    case s_n_llhttp__internal__n_after_start_req_66:
+    s_n_llhttp__internal__n_after_start_req_66: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_66;
+        return s_n_llhttp__internal__n_after_start_req_66;
       }
       switch (*p) {
         case 'I': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_67;
+          goto s_n_llhttp__internal__n_after_start_req_67;
         }
         case 'O': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_68;
+          goto s_n_llhttp__internal__n_after_start_req_68;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_69:
-    s_n_llhttp__internal__n_start_req_69: {
+    case s_n_llhttp__internal__n_after_start_req_69:
+    s_n_llhttp__internal__n_after_start_req_69: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_69;
+        return s_n_llhttp__internal__n_after_start_req_69;
       }
       match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob57, 8);
       p = match_seq.current;
@@ -5222,140 +5651,142 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_69;
+          return s_n_llhttp__internal__n_after_start_req_69;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_64:
-    s_n_llhttp__internal__n_start_req_64: {
+    case s_n_llhttp__internal__n_after_start_req_64:
+    s_n_llhttp__internal__n_after_start_req_64: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_64;
+        return s_n_llhttp__internal__n_after_start_req_64;
       }
       switch (*p) {
         case 'B': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_65;
+          goto s_n_llhttp__internal__n_after_start_req_65;
         }
         case 'L': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_66;
+          goto s_n_llhttp__internal__n_after_start_req_66;
         }
         case 'S': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_69;
+          goto s_n_llhttp__internal__n_after_start_req_69;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_63:
-    s_n_llhttp__internal__n_start_req_63: {
+    case s_n_llhttp__internal__n_after_start_req_63:
+    s_n_llhttp__internal__n_after_start_req_63: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_63;
+        return s_n_llhttp__internal__n_after_start_req_63;
       }
       switch (*p) {
         case 'N': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_64;
+          goto s_n_llhttp__internal__n_after_start_req_64;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req:
-    s_n_llhttp__internal__n_start_req: {
+    case s_n_llhttp__internal__n_after_start_req:
+    s_n_llhttp__internal__n_after_start_req: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req;
+        return s_n_llhttp__internal__n_after_start_req;
       }
       switch (*p) {
         case 'A': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_1;
+          goto s_n_llhttp__internal__n_after_start_req_1;
         }
         case 'B': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_4;
+          goto s_n_llhttp__internal__n_after_start_req_4;
         }
         case 'C': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_5;
+          goto s_n_llhttp__internal__n_after_start_req_5;
         }
         case 'D': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_10;
+          goto s_n_llhttp__internal__n_after_start_req_10;
         }
         case 'F': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_14;
+          goto s_n_llhttp__internal__n_after_start_req_14;
         }
         case 'G': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_15;
+          goto s_n_llhttp__internal__n_after_start_req_15;
         }
         case 'H': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_18;
+          goto s_n_llhttp__internal__n_after_start_req_18;
         }
         case 'L': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_19;
+          goto s_n_llhttp__internal__n_after_start_req_19;
         }
         case 'M': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_22;
+          goto s_n_llhttp__internal__n_after_start_req_22;
         }
         case 'N': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_31;
+          goto s_n_llhttp__internal__n_after_start_req_31;
         }
         case 'O': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_32;
+          goto s_n_llhttp__internal__n_after_start_req_32;
         }
         case 'P': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_33;
+          goto s_n_llhttp__internal__n_after_start_req_33;
         }
         case 'R': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_46;
+          goto s_n_llhttp__internal__n_after_start_req_46;
         }
         case 'S': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_52;
+          goto s_n_llhttp__internal__n_after_start_req_52;
         }
         case 'T': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_60;
+          goto s_n_llhttp__internal__n_after_start_req_60;
         }
         case 'U': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_63;
+          goto s_n_llhttp__internal__n_after_start_req_63;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_69;
+          goto s_n_llhttp__internal__n_error_90;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_status_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__on_status_complete: {
-      switch (llhttp__on_status_complete(state, p, endp)) {
-        default:
-          goto s_n_llhttp__internal__n_header_field_start;
+    case s_n_llhttp__internal__n_span_start_llhttp__on_method_1:
+    s_n_llhttp__internal__n_span_start_llhttp__on_method_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_method_1;
       }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_method;
+      goto s_n_llhttp__internal__n_after_start_req;
       /* UNREACHABLE */;
       abort();
     }
@@ -5369,8 +5800,12 @@ static llparse_state_t llhttp__internal__run(
           p++;
           goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
         }
+        case 13: {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
+        }
         default: {
-          goto s_n_llhttp__internal__n_error_60;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_18;
         }
       }
       /* UNREACHABLE */;
@@ -5445,16 +5880,142 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_res_status_start;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_61;
+          goto s_n_llhttp__internal__n_error_77;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_res_status_code:
-    s_n_llhttp__internal__n_res_status_code: {
+    case s_n_llhttp__internal__n_res_status_code_digit_3:
+    s_n_llhttp__internal__n_res_status_code_digit_3: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_res_status_code;
+        return s_n_llhttp__internal__n_res_status_code_digit_3;
+      }
+      switch (*p) {
+        case '0': {
+          p++;
+          match = 0;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '1': {
+          p++;
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '2': {
+          p++;
+          match = 2;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '3': {
+          p++;
+          match = 3;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '4': {
+          p++;
+          match = 4;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '5': {
+          p++;
+          match = 5;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '6': {
+          p++;
+          match = 6;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '7': {
+          p++;
+          match = 7;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '8': {
+          p++;
+          match = 8;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        case '9': {
+          p++;
+          match = 9;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_2;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_79;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_res_status_code_digit_2:
+    s_n_llhttp__internal__n_res_status_code_digit_2: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_res_status_code_digit_2;
+      }
+      switch (*p) {
+        case '0': {
+          p++;
+          match = 0;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '1': {
+          p++;
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '2': {
+          p++;
+          match = 2;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '3': {
+          p++;
+          match = 3;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '4': {
+          p++;
+          match = 4;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '5': {
+          p++;
+          match = 5;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '6': {
+          p++;
+          match = 6;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '7': {
+          p++;
+          match = 7;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '8': {
+          p++;
+          match = 8;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        case '9': {
+          p++;
+          match = 9;
+          goto s_n_llhttp__internal__n_invoke_mul_add_status_code_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_81;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_res_status_code_digit_1:
+    s_n_llhttp__internal__n_res_status_code_digit_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_res_status_code_digit_1;
       }
       switch (*p) {
         case '0': {
@@ -5508,16 +6069,16 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
         }
         default: {
-          goto s_n_llhttp__internal__n_res_status_code_otherwise;
+          goto s_n_llhttp__internal__n_error_83;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_res_http_end:
-    s_n_llhttp__internal__n_res_http_end: {
+    case s_n_llhttp__internal__n_res_after_version:
+    s_n_llhttp__internal__n_res_after_version: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_res_http_end;
+        return s_n_llhttp__internal__n_res_after_version;
       }
       switch (*p) {
         case ' ': {
@@ -5525,9 +6086,42 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_update_status_code;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_62;
+          goto s_n_llhttp__internal__n_error_84;
         }
       }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_version_complete_1:
+    s_n_llhttp__internal__n_invoke_llhttp__on_version_complete_1: {
+      switch (llhttp__on_version_complete(state, p, endp)) {
+        case 0:
+          goto s_n_llhttp__internal__n_res_after_version;
+        case 21:
+          goto s_n_llhttp__internal__n_pause_21;
+        default:
+          goto s_n_llhttp__internal__n_error_74;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_error_73:
+    s_n_llhttp__internal__n_error_73: {
+      state->error = 0x9;
+      state->reason = "Invalid HTTP version";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_error;
+      return s_error;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_error_85:
+    s_n_llhttp__internal__n_error_85: {
+      state->error = 0x9;
+      state->reason = "Invalid minor version";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_error;
+      return s_error;
       /* UNREACHABLE */;
       abort();
     }
@@ -5588,9 +6182,19 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_65;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_version_7;
         }
       }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_error_86:
+    s_n_llhttp__internal__n_error_86: {
+      state->error = 0x9;
+      state->reason = "Expected dot";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_error;
+      return s_error;
       /* UNREACHABLE */;
       abort();
     }
@@ -5605,9 +6209,19 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_res_http_minor;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_66;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_version_8;
         }
       }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_error_87:
+    s_n_llhttp__internal__n_error_87: {
+      state->error = 0x9;
+      state->reason = "Invalid major version";
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_error;
+      return s_error;
       /* UNREACHABLE */;
       abort();
     }
@@ -5668,9 +6282,20 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_major_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_67;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_version_9;
         }
       }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_version_1:
+    s_n_llhttp__internal__n_span_start_llhttp__on_version_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_version_1;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_version;
+      goto s_n_llhttp__internal__n_res_http_major;
       /* UNREACHABLE */;
       abort();
     }
@@ -5686,14 +6311,27 @@ static llparse_state_t llhttp__internal__run(
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          goto s_n_llhttp__internal__n_res_http_major;
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_version_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_res;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_70;
+          goto s_n_llhttp__internal__n_error_91;
         }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_method_complete:
+    s_n_llhttp__internal__n_invoke_llhttp__on_method_complete: {
+      switch (llhttp__on_method_complete(state, p, endp)) {
+        case 0:
+          goto s_n_llhttp__internal__n_req_first_space_before_url;
+        case 21:
+          goto s_n_llhttp__internal__n_pause_19;
+        default:
+          goto s_n_llhttp__internal__n_error_1;
       }
       /* UNREACHABLE */;
       abort();
@@ -5717,8 +6355,17 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_or_res_method_2;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_68;
+          goto s_n_llhttp__internal__n_error_88;
         }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_update_type_1:
+    s_n_llhttp__internal__n_invoke_update_type_1: {
+      switch (llhttp__internal__c_update_type_1(state, p, endp)) {
+        default:
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_version_1;
       }
       /* UNREACHABLE */;
       abort();
@@ -5735,13 +6382,13 @@ static llparse_state_t llhttp__internal__run(
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          goto s_n_llhttp__internal__n_invoke_update_type_1;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_req_or_res_method_3;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_68;
+          goto s_n_llhttp__internal__n_error_88;
         }
       }
       /* UNREACHABLE */;
@@ -5762,7 +6409,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_or_res_method_3;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_68;
+          goto s_n_llhttp__internal__n_error_88;
         }
       }
       /* UNREACHABLE */;
@@ -5779,9 +6426,20 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_or_res_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_68;
+          goto s_n_llhttp__internal__n_error_88;
         }
       }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_method:
+    s_n_llhttp__internal__n_span_start_llhttp__on_method: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_method;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_method;
+      goto s_n_llhttp__internal__n_req_or_res_method;
       /* UNREACHABLE */;
       abort();
     }
@@ -5792,7 +6450,7 @@ static llparse_state_t llhttp__internal__run(
       }
       switch (*p) {
         case 'H': {
-          goto s_n_llhttp__internal__n_req_or_res_method;
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_method;
         }
         default: {
           goto s_n_llhttp__internal__n_invoke_update_type_2;
@@ -5805,11 +6463,20 @@ static llparse_state_t llhttp__internal__run(
     s_n_llhttp__internal__n_invoke_load_type: {
       switch (llhttp__internal__c_load_type(state, p, endp)) {
         case 1:
-          goto s_n_llhttp__internal__n_start_req;
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_method_1;
         case 2:
           goto s_n_llhttp__internal__n_start_res;
         default:
           goto s_n_llhttp__internal__n_start_req_or_res;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_update_finish:
+    s_n_llhttp__internal__n_invoke_update_finish: {
+      switch (llhttp__internal__c_update_finish(state, p, endp)) {
+        default:
+          goto s_n_llhttp__internal__n_invoke_llhttp__on_message_begin;
       }
       /* UNREACHABLE */;
       abort();
@@ -5829,7 +6496,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start;
         }
         default: {
-          goto s_n_llhttp__internal__n_invoke_update_finish;
+          goto s_n_llhttp__internal__n_invoke_load_initial_message_completed;
         }
       }
       /* UNREACHABLE */;
@@ -5839,16 +6506,7 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */
       abort();
   }
-  s_n_llhttp__internal__n_error_1: {
-    state->error = 0x7;
-    state->reason = "Invalid characters in url (strict mode)";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_52: {
+  s_n_llhttp__internal__n_error_2: {
     state->error = 0x7;
     state->reason = "Invalid characters in url";
     state->error_pos = (const char*) p;
@@ -5865,7 +6523,23 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_4: {
+  s_n_llhttp__internal__n_invoke_update_initial_message_completed: {
+    switch (llhttp__internal__c_update_initial_message_completed(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_finish_2;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_content_length: {
+    switch (llhttp__internal__c_update_content_length(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_initial_message_completed;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_7: {
     state->error = 0x5;
     state->reason = "Data after `Connection: close`";
     state->error_pos = (const char*) p;
@@ -5874,10 +6548,20 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags: {
-    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_3: {
+    switch (llhttp__internal__c_test_lenient_flags_3(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_invoke_update_finish_2;
+        goto s_n_llhttp__internal__n_closed;
+      default:
+        goto s_n_llhttp__internal__n_error_7;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_2: {
+    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_update_initial_message_completed;
       default:
         goto s_n_llhttp__internal__n_closed;
     }
@@ -5887,65 +6571,8 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_update_finish_1: {
     switch (llhttp__internal__c_update_finish_1(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_2;
     }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_5: {
-    state->error = 0x15;
-    state->reason = "on_message_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_is_equal_upgrade;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_14: {
-    state->error = 0x12;
-    state->reason = "`on_message_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_7: {
-    state->error = 0x15;
-    state->reason = "on_chunk_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_17: {
-    state->error = 0x14;
-    state->reason = "`on_chunk_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete_1: {
-    switch (llhttp__on_chunk_complete(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_7;
-      default:
-        goto s_n_llhttp__internal__n_error_17;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_16: {
-    state->error = 0x4;
-    state->reason = "Content-Length can't be present with Transfer-Encoding";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
     /* UNREACHABLE */;
     abort();
   }
@@ -5958,7 +6585,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_5: {
+  s_n_llhttp__internal__n_error_8: {
     state->error = 0x12;
     state->reason = "`on_message_complete` callback error";
     state->error_pos = (const char*) p;
@@ -5974,12 +6601,12 @@ static llparse_state_t llhttp__internal__run(
       case 21:
         goto s_n_llhttp__internal__n_pause_2;
       default:
-        goto s_n_llhttp__internal__n_error_5;
+        goto s_n_llhttp__internal__n_error_8;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_12: {
+  s_n_llhttp__internal__n_error_26: {
     state->error = 0xc;
     state->reason = "Chunk size overflow";
     state->error_pos = (const char*) p;
@@ -5992,12 +6619,12 @@ static llparse_state_t llhttp__internal__run(
     state->error = 0x15;
     state->reason = "on_chunk_complete pause";
     state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_update_content_length;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_update_content_length_1;
     return s_error;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_7: {
+  s_n_llhttp__internal__n_error_10: {
     state->error = 0x14;
     state->reason = "`on_chunk_complete` callback error";
     state->error_pos = (const char*) p;
@@ -6009,21 +6636,31 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete: {
     switch (llhttp__on_chunk_complete(state, p, endp)) {
       case 0:
-        goto s_n_llhttp__internal__n_invoke_update_content_length;
+        goto s_n_llhttp__internal__n_invoke_update_content_length_1;
       case 21:
         goto s_n_llhttp__internal__n_pause_3;
       default:
-        goto s_n_llhttp__internal__n_error_7;
+        goto s_n_llhttp__internal__n_error_10;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_8: {
+  s_n_llhttp__internal__n_error_11: {
     state->error = 0x2;
-    state->reason = "Expected CRLF after chunk";
+    state->reason = "Expected LF after chunk data";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_4: {
+    switch (llhttp__internal__c_test_lenient_flags_4(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete;
+      default:
+        goto s_n_llhttp__internal__n_error_11;
+    }
     /* UNREACHABLE */;
     abort();
   }
@@ -6061,7 +6698,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_6: {
+  s_n_llhttp__internal__n_error_9: {
     state->error = 0x13;
     state->reason = "`on_chunk_header` callback error";
     state->error_pos = (const char*) p;
@@ -6077,12 +6714,12 @@ static llparse_state_t llhttp__internal__run(
       case 21:
         goto s_n_llhttp__internal__n_pause_4;
       default:
-        goto s_n_llhttp__internal__n_error_6;
+        goto s_n_llhttp__internal__n_error_9;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_9: {
+  s_n_llhttp__internal__n_error_12: {
     state->error = 0x2;
     state->reason = "Expected LF after chunk size";
     state->error_pos = (const char*) p;
@@ -6091,16 +6728,325 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_10: {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_5: {
+    switch (llhttp__internal__c_test_lenient_flags_5(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_header;
+      default:
+        goto s_n_llhttp__internal__n_error_12;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_13: {
     state->error = 0x2;
-    state->reason = "Invalid character in chunk parameters";
+    state->reason = "Invalid character in chunk extensions";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_11: {
+  s_n_llhttp__internal__n_error_14: {
+    state->error = 0x2;
+    state->reason = "Invalid character in chunk extensions";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_5: {
+    state->error = 0x15;
+    state->reason = "on_chunk_extension_name pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_size_almost_done;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_15: {
+    state->error = 0x22;
+    state->reason = "`on_chunk_extension_name` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_chunk_extension_name(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_6: {
+    state->error = 0x15;
+    state->reason = "on_chunk_extension_name pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_extensions;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_16: {
+    state->error = 0x22;
+    state->reason = "`on_chunk_extension_name` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_1: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_chunk_extension_name(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_1;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_1;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_7: {
+    state->error = 0x15;
+    state->reason = "on_chunk_extension_value pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_size_almost_done;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_18: {
+    state->error = 0x23;
+    state->reason = "`on_chunk_extension_value` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_chunk_extension_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_20: {
+    state->error = 0x2;
+    state->reason = "Invalid character in chunk extensions quote value";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_8: {
+    state->error = 0x15;
+    state->reason = "on_chunk_extension_value pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_extension_quoted_value_done;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_19: {
+    state->error = 0x23;
+    state->reason = "`on_chunk_extension_value` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_1: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_chunk_extension_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_1;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_2: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_chunk_extension_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_21;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_error_21;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_9: {
+    state->error = 0x15;
+    state->reason = "on_chunk_extension_value pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_size_otherwise;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_22: {
+    state->error = 0x23;
+    state->reason = "`on_chunk_extension_value` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_3: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_chunk_extension_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_value_complete_2;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_value_4: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_chunk_extension_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_23;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_error_23;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_10: {
+    state->error = 0x15;
+    state->reason = "on_chunk_extension_name pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_extension_value;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_17: {
+    state->error = 0x22;
+    state->reason = "`on_chunk_extension_name` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_extension_name_complete_2: {
+    switch (llhttp__on_chunk_extension_name_complete(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_chunk_extension_value;
+      case 21:
+        goto s_n_llhttp__internal__n_pause_10;
+      default:
+        goto s_n_llhttp__internal__n_error_17;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_2: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_chunk_extension_name(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_value;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_span_start_llhttp__on_chunk_extension_value;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_extension_name_3: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_chunk_extension_name(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_24;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_error_24;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_25: {
     state->error = 0xc;
     state->reason = "Invalid character in chunk size";
     state->error_pos = (const char*) p;
@@ -6112,16 +7058,34 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_mul_add_content_length: {
     switch (llhttp__internal__c_mul_add_content_length(state, p, endp, match)) {
       case 1:
-        goto s_n_llhttp__internal__n_error_12;
+        goto s_n_llhttp__internal__n_error_26;
       default:
         goto s_n_llhttp__internal__n_chunk_size;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_13: {
+  s_n_llhttp__internal__n_error_27: {
     state->error = 0xc;
     state->reason = "Invalid character in chunk size";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_11: {
+    state->error = 0x15;
+    state->reason = "on_message_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_is_equal_upgrade;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_28: {
+    state->error = 0x12;
+    state->reason = "`on_message_complete` callback error";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
@@ -6153,7 +7117,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_15: {
+  s_n_llhttp__internal__n_error_29: {
     state->error = 0xf;
     state->reason = "Request has invalid `Transfer-Encoding`";
     state->error_pos = (const char*) p;
@@ -6171,7 +7135,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_3: {
+  s_n_llhttp__internal__n_error_6: {
     state->error = 0x12;
     state->reason = "`on_message_complete` callback error";
     state->error_pos = (const char*) p;
@@ -6187,8 +7151,57 @@ static llparse_state_t llhttp__internal__run(
       case 21:
         goto s_n_llhttp__internal__n_pause;
       default:
-        goto s_n_llhttp__internal__n_error_3;
+        goto s_n_llhttp__internal__n_error_6;
     }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_1: {
+    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
+      default:
+        goto s_n_llhttp__internal__n_error_5;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_13: {
+    state->error = 0x15;
+    state->reason = "on_chunk_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_32: {
+    state->error = 0x14;
+    state->reason = "`on_chunk_complete` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete_1: {
+    switch (llhttp__on_chunk_complete(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
+      case 21:
+        goto s_n_llhttp__internal__n_pause_13;
+      default:
+        goto s_n_llhttp__internal__n_error_32;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_31: {
+    state->error = 0x4;
+    state->reason = "Content-Length can't be present with Transfer-Encoding";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
     /* UNREACHABLE */;
     abort();
   }
@@ -6216,7 +7229,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_6: {
+  s_n_llhttp__internal__n_pause_12: {
     state->error = 0x15;
     state->reason = "Paused by on_headers_complete";
     state->error_pos = (const char*) p;
@@ -6225,7 +7238,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_2: {
+  s_n_llhttp__internal__n_error_30: {
     state->error = 0x11;
     state->reason = "User callback error";
     state->error_pos = (const char*) p;
@@ -6243,9 +7256,9 @@ static llparse_state_t llhttp__internal__run(
       case 2:
         goto s_n_llhttp__internal__n_invoke_update_upgrade;
       case 21:
-        goto s_n_llhttp__internal__n_pause_6;
+        goto s_n_llhttp__internal__n_pause_12;
       default:
-        goto s_n_llhttp__internal__n_error_2;
+        goto s_n_llhttp__internal__n_error_30;
     }
     /* UNREACHABLE */;
     abort();
@@ -6258,10 +7271,10 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_1: {
-    switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_6: {
+    switch (llhttp__internal__c_test_lenient_flags_6(state, p, endp)) {
       case 0:
-        goto s_n_llhttp__internal__n_error_16;
+        goto s_n_llhttp__internal__n_error_31;
       default:
         goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
     }
@@ -6271,7 +7284,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_test_flags_1: {
     switch (llhttp__internal__c_test_flags_1(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_1;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_6;
       default:
         goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
     }
@@ -6288,12 +7301,22 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_18: {
+  s_n_llhttp__internal__n_error_33: {
     state->error = 0x2;
     state->reason = "Expected LF after headers";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_7: {
+    switch (llhttp__internal__c_test_lenient_flags_5(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_test_flags;
+      default:
+        goto s_n_llhttp__internal__n_error_33;
+    }
     /* UNREACHABLE */;
     abort();
   }
@@ -6307,16 +7330,16 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_19;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_5;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_error_19;
+    goto s_n_llhttp__internal__n_error_5;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_2: {
-    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_8: {
+    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_header_field_colon_discard_ws;
       default:
@@ -6325,9 +7348,46 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_20: {
+  s_n_llhttp__internal__n_error_36: {
+    state->error = 0xa;
+    state->reason = "Invalid header value char";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_10: {
+    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_header_value_discard_ws;
+      default:
+        goto s_n_llhttp__internal__n_error_36;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_38: {
     state->error = 0xb;
     state->reason = "Empty Content-Length";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_14: {
+    state->error = 0x15;
+    state->reason = "on_header_value_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_field_start;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_37: {
+    state->error = 0x1d;
+    state->reason = "`on_header_value_complete` callback error";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
@@ -6410,14 +7470,33 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_load_header_state: {
     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
       case 2:
-        goto s_n_llhttp__internal__n_error_20;
+        goto s_n_llhttp__internal__n_error_38;
       default:
         goto s_n_llhttp__internal__n_invoke_load_header_state_1;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_21: {
+  s_n_llhttp__internal__n_error_35: {
+    state->error = 0xa;
+    state->reason = "Invalid header value char";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_9: {
+    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_header_value_discard_lws;
+      default:
+        goto s_n_llhttp__internal__n_error_35;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_39: {
     state->error = 0x2;
     state->reason = "Expected LF after CR";
     state->error_pos = (const char*) p;
@@ -6426,7 +7505,35 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_11: {
+    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_header_value_discard_lws;
+      default:
+        goto s_n_llhttp__internal__n_error_39;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
   s_n_llhttp__internal__n_invoke_update_header_state_1: {
+    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_header_state_3: {
+    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+      case 8:
+        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+      default:
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_header_state_2: {
     switch (llhttp__internal__c_update_header_state(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
@@ -6437,7 +7544,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_or_flags_7: {
     switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
     }
     /* UNREACHABLE */;
     abort();
@@ -6445,7 +7552,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_or_flags_8: {
     switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
     }
     /* UNREACHABLE */;
     abort();
@@ -6453,7 +7560,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_or_flags_9: {
     switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
     }
     /* UNREACHABLE */;
     abort();
@@ -6466,7 +7573,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_load_header_state_3: {
+  s_n_llhttp__internal__n_invoke_load_header_state_4: {
     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
       case 5:
         goto s_n_llhttp__internal__n_invoke_or_flags_7;
@@ -6482,7 +7589,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_22: {
+  s_n_llhttp__internal__n_error_40: {
     state->error = 0x3;
     state->reason = "Missing expected LF after header value";
     state->error_pos = (const char*) p;
@@ -6553,35 +7660,25 @@ static llparse_state_t llhttp__internal__run(
     err = llhttp__on_header_value(state, start, p);
     if (err != 0) {
       state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_23;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_41;
       return s_error;
     }
-    p++;
-    goto s_n_llhttp__internal__n_error_23;
+    goto s_n_llhttp__internal__n_error_41;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_24: {
-    state->error = 0xa;
-    state->reason = "Invalid header value char";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_3: {
-    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_12: {
+    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_header_value_lenient;
       default:
-        goto s_n_llhttp__internal__n_header_value_lenient_failed;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_update_header_state_3: {
+  s_n_llhttp__internal__n_invoke_update_header_state_4: {
     switch (llhttp__internal__c_update_header_state(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_header_value_connection;
@@ -6592,7 +7689,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_or_flags_11: {
     switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
     }
     /* UNREACHABLE */;
     abort();
@@ -6600,7 +7697,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_or_flags_12: {
     switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
     }
     /* UNREACHABLE */;
     abort();
@@ -6608,7 +7705,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_or_flags_13: {
     switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
     }
     /* UNREACHABLE */;
     abort();
@@ -6621,7 +7718,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_load_header_state_4: {
+  s_n_llhttp__internal__n_invoke_load_header_state_5: {
     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
       case 5:
         goto s_n_llhttp__internal__n_invoke_or_flags_11;
@@ -6637,24 +7734,16 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_update_header_state_4: {
-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_update_header_state_5: {
+    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_header_value_connection_token;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_update_header_state_2: {
-    switch (llhttp__internal__c_update_header_state_2(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_connection_ws;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_5: {
-    switch (llhttp__internal__c_update_header_state_5(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_update_header_state_3: {
+    switch (llhttp__internal__c_update_header_state_3(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_header_value_connection_ws;
     }
@@ -6663,6 +7752,14 @@ static llparse_state_t llhttp__internal__run(
   }
   s_n_llhttp__internal__n_invoke_update_header_state_6: {
     switch (llhttp__internal__c_update_header_state_6(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_value_connection_ws;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_header_state_7: {
+    switch (llhttp__internal__c_update_header_state_7(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_header_value_connection_ws;
     }
@@ -6679,10 +7776,10 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_26;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_43;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_26;
+    goto s_n_llhttp__internal__n_error_43;
     /* UNREACHABLE */;
     abort();
   }
@@ -6714,14 +7811,14 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_27;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_44;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_27;
+    goto s_n_llhttp__internal__n_error_44;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_25: {
+  s_n_llhttp__internal__n_error_42: {
     state->error = 0x4;
     state->reason = "Duplicate Content-Length";
     state->error_pos = (const char*) p;
@@ -6735,7 +7832,7 @@ static llparse_state_t llhttp__internal__run(
       case 0:
         goto s_n_llhttp__internal__n_header_value_content_length;
       default:
-        goto s_n_llhttp__internal__n_error_25;
+        goto s_n_llhttp__internal__n_error_42;
     }
     /* UNREACHABLE */;
     abort();
@@ -6750,16 +7847,16 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_29;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_46;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_error_29;
+    goto s_n_llhttp__internal__n_error_46;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_update_header_state_7: {
-    switch (llhttp__internal__c_update_header_state_7(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_update_header_state_8: {
+    switch (llhttp__internal__c_update_header_state_8(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_header_value_otherwise;
     }
@@ -6776,16 +7873,16 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_28;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_45;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_error_28;
+    goto s_n_llhttp__internal__n_error_45;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_4: {
-    switch (llhttp__internal__c_test_lenient_flags_4(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_13: {
+    switch (llhttp__internal__c_test_lenient_flags_13(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7;
       default:
@@ -6797,15 +7894,15 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_load_type_1: {
     switch (llhttp__internal__c_load_type(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_4;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_13;
       default:
         goto s_n_llhttp__internal__n_header_value_te_chunked;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_update_header_state_8: {
-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_update_header_state_9: {
+    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_header_value;
     }
@@ -6828,8 +7925,8 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_5: {
-    switch (llhttp__internal__c_test_lenient_flags_4(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_14: {
+    switch (llhttp__internal__c_test_lenient_flags_13(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8;
       default:
@@ -6841,7 +7938,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_load_type_2: {
     switch (llhttp__internal__c_load_type(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_5;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_14;
       default:
         goto s_n_llhttp__internal__n_invoke_or_flags_17;
     }
@@ -6869,7 +7966,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_or_flags_18: {
     switch (llhttp__internal__c_or_flags_18(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_8;
+        goto s_n_llhttp__internal__n_invoke_update_header_state_9;
     }
     /* UNREACHABLE */;
     abort();
@@ -6887,6 +7984,24 @@ static llparse_state_t llhttp__internal__run(
       default:
         goto s_n_llhttp__internal__n_header_value;
     }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_15: {
+    state->error = 0x15;
+    state->reason = "on_header_field_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_discard_ws;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_34: {
+    state->error = 0x1c;
+    state->reason = "`on_header_field_complete` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
     /* UNREACHABLE */;
     abort();
   }
@@ -6926,7 +8041,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_30: {
+  s_n_llhttp__internal__n_error_47: {
     state->error = 0xa;
     state->reason = "Invalid header token";
     state->error_pos = (const char*) p;
@@ -6935,8 +8050,8 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_update_header_state_9: {
-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_update_header_state_10: {
+    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_header_field_general;
     }
@@ -6951,18 +8066,59 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_update_header_state_10: {
-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_update_header_state_11: {
+    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_header_field_general;
     }
     /* UNREACHABLE */;
     abort();
   }
+  s_n_llhttp__internal__n_error_4: {
+    state->error = 0x1e;
+    state->reason = "Unexpected space after start line";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags: {
+    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_header_field_start;
+      default:
+        goto s_n_llhttp__internal__n_error_4;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_16: {
+    state->error = 0x15;
+    state->reason = "on_url_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_headers_start;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_3: {
+    state->error = 0x1a;
+    state->reason = "`on_url_complete` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
   s_n_llhttp__internal__n_invoke_llhttp__on_url_complete: {
     switch (llhttp__on_url_complete(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_headers_start;
+      case 21:
+        goto s_n_llhttp__internal__n_pause_16;
       default:
-        goto s_n_llhttp__internal__n_header_field_start;
+        goto s_n_llhttp__internal__n_error_3;
     }
     /* UNREACHABLE */;
     abort();
@@ -7000,7 +8156,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_31: {
+  s_n_llhttp__internal__n_error_48: {
     state->error = 0x7;
     state->reason = "Expected CRLF";
     state->error_pos = (const char*) p;
@@ -7026,7 +8182,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_36: {
+  s_n_llhttp__internal__n_error_55: {
     state->error = 0x17;
     state->reason = "Pause on PRI/Upgrade";
     state->error_pos = (const char*) p;
@@ -7035,7 +8191,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_37: {
+  s_n_llhttp__internal__n_error_56: {
     state->error = 0x9;
     state->reason = "Expected HTTP/2 Connection Preface";
     state->error_pos = (const char*) p;
@@ -7044,7 +8200,26 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_35: {
+  s_n_llhttp__internal__n_error_53: {
+    state->error = 0x2;
+    state->reason = "Expected CRLF after version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_16: {
+    switch (llhttp__internal__c_test_lenient_flags_5(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_headers_start;
+      default:
+        goto s_n_llhttp__internal__n_error_53;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_54: {
     state->error = 0x9;
     state->reason = "Expected CRLF after version";
     state->error_pos = (const char*) p;
@@ -7053,81 +8228,87 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_load_method_1: {
-    switch (llhttp__internal__c_load_method(state, p, endp)) {
-      case 34:
-        goto s_n_llhttp__internal__n_req_pri_upgrade;
-      default:
-        goto s_n_llhttp__internal__n_req_http_complete;
-    }
+  s_n_llhttp__internal__n_pause_17: {
+    state->error = 0x15;
+    state->reason = "on_version_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_load_method_1;
+    return s_error;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_34: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
+  s_n_llhttp__internal__n_error_52: {
+    state->error = 0x21;
+    state->reason = "`on_version_complete` callback error";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_version_1: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_version(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_version_complete;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_version_complete;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_version: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_version(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_51;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_error_51;
     /* UNREACHABLE */;
     abort();
   }
   s_n_llhttp__internal__n_invoke_load_http_minor: {
     switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
       case 9:
-        goto s_n_llhttp__internal__n_invoke_load_method_1;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_1;
       default:
-        goto s_n_llhttp__internal__n_error_34;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version;
     }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_38: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
     /* UNREACHABLE */;
     abort();
   }
   s_n_llhttp__internal__n_invoke_load_http_minor_1: {
     switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
       case 0:
-        goto s_n_llhttp__internal__n_invoke_load_method_1;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_1;
       case 1:
-        goto s_n_llhttp__internal__n_invoke_load_method_1;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_1;
       default:
-        goto s_n_llhttp__internal__n_error_38;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version;
     }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_39: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
     /* UNREACHABLE */;
     abort();
   }
   s_n_llhttp__internal__n_invoke_load_http_minor_2: {
     switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
       case 0:
-        goto s_n_llhttp__internal__n_invoke_load_method_1;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_1;
       default:
-        goto s_n_llhttp__internal__n_error_39;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version;
     }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_33: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
     /* UNREACHABLE */;
     abort();
   }
@@ -7140,15 +8321,15 @@ static llparse_state_t llhttp__internal__run(
       case 2:
         goto s_n_llhttp__internal__n_invoke_load_http_minor_2;
       default:
-        goto s_n_llhttp__internal__n_error_33;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_6: {
-    switch (llhttp__internal__c_test_lenient_flags_6(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_15: {
+    switch (llhttp__internal__c_test_lenient_flags_15(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_invoke_load_method_1;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_1;
       default:
         goto s_n_llhttp__internal__n_invoke_load_http_major;
     }
@@ -7158,26 +8339,42 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_store_http_minor: {
     switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
       default:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_6;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_15;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_40: {
-    state->error = 0x9;
-    state->reason = "Invalid minor version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
+  s_n_llhttp__internal__n_span_end_llhttp__on_version_2: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_version(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_57;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_error_57;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_41: {
-    state->error = 0x9;
-    state->reason = "Expected dot";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
+  s_n_llhttp__internal__n_span_end_llhttp__on_version_3: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_version(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_58;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_error_58;
     /* UNREACHABLE */;
     abort();
   }
@@ -7189,16 +8386,24 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_42: {
-    state->error = 0x9;
-    state->reason = "Invalid major version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
+  s_n_llhttp__internal__n_span_end_llhttp__on_version_4: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_version(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_59;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_error_59;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_32: {
+  s_n_llhttp__internal__n_error_50: {
     state->error = 0x8;
     state->reason = "Invalid method for HTTP/x.x request";
     state->error_pos = (const char*) p;
@@ -7210,82 +8415,82 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_load_method: {
     switch (llhttp__internal__c_load_method(state, p, endp)) {
       case 0:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 1:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 2:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 3:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 4:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 5:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 6:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 7:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 8:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 9:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 10:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 11:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 12:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 13:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 14:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 15:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 16:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 17:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 18:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 19:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 20:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 21:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 22:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 23:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 24:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 25:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 26:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 27:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 28:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 29:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 30:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 31:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 32:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 33:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 34:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       default:
-        goto s_n_llhttp__internal__n_error_32;
+        goto s_n_llhttp__internal__n_error_50;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_45: {
+  s_n_llhttp__internal__n_error_62: {
     state->error = 0x8;
     state->reason = "Expected HTTP/";
     state->error_pos = (const char*) p;
@@ -7294,7 +8499,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_43: {
+  s_n_llhttp__internal__n_error_60: {
     state->error = 0x8;
     state->reason = "Expected SOURCE method for ICE/x.x request";
     state->error_pos = (const char*) p;
@@ -7306,14 +8511,14 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_load_method_2: {
     switch (llhttp__internal__c_load_method(state, p, endp)) {
       case 33:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       default:
-        goto s_n_llhttp__internal__n_error_43;
+        goto s_n_llhttp__internal__n_error_60;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_44: {
+  s_n_llhttp__internal__n_error_61: {
     state->error = 0x8;
     state->reason = "Invalid method for RTSP/x.x request";
     state->error_pos = (const char*) p;
@@ -7325,43 +8530,65 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_load_method_3: {
     switch (llhttp__internal__c_load_method(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 3:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 6:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 35:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 36:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 37:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 38:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 39:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 40:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 41:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 42:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 43:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 44:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       case 45:
-        goto s_n_llhttp__internal__n_req_http_major;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_version;
       default:
-        goto s_n_llhttp__internal__n_error_44;
+        goto s_n_llhttp__internal__n_error_61;
     }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_18: {
+    state->error = 0x15;
+    state->reason = "on_url_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_req_http_start;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_49: {
+    state->error = 0x1a;
+    state->reason = "`on_url_complete` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
     /* UNREACHABLE */;
     abort();
   }
   s_n_llhttp__internal__n_invoke_llhttp__on_url_complete_1: {
     switch (llhttp__on_url_complete(state, p, endp)) {
-      default:
+      case 0:
         goto s_n_llhttp__internal__n_req_http_start;
+      case 21:
+        goto s_n_llhttp__internal__n_pause_18;
+      default:
+        goto s_n_llhttp__internal__n_error_49;
     }
     /* UNREACHABLE */;
     abort();
@@ -7434,7 +8661,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_46: {
+  s_n_llhttp__internal__n_error_63: {
     state->error = 0x7;
     state->reason = "Invalid char in url fragment start";
     state->error_pos = (const char*) p;
@@ -7494,7 +8721,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_47: {
+  s_n_llhttp__internal__n_error_64: {
     state->error = 0x7;
     state->reason = "Invalid char in url query";
     state->error_pos = (const char*) p;
@@ -7503,7 +8730,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_48: {
+  s_n_llhttp__internal__n_error_65: {
     state->error = 0x7;
     state->reason = "Invalid char in url path";
     state->error_pos = (const char*) p;
@@ -7614,7 +8841,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_49: {
+  s_n_llhttp__internal__n_error_66: {
     state->error = 0x7;
     state->reason = "Double @ in url";
     state->error_pos = (const char*) p;
@@ -7623,7 +8850,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_50: {
+  s_n_llhttp__internal__n_error_67: {
     state->error = 0x7;
     state->reason = "Unexpected char in url server";
     state->error_pos = (const char*) p;
@@ -7632,7 +8859,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_51: {
+  s_n_llhttp__internal__n_error_68: {
     state->error = 0x7;
     state->reason = "Unexpected char in url server";
     state->error_pos = (const char*) p;
@@ -7641,7 +8868,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_53: {
+  s_n_llhttp__internal__n_error_69: {
     state->error = 0x7;
     state->reason = "Unexpected char in url schema";
     state->error_pos = (const char*) p;
@@ -7650,7 +8877,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_54: {
+  s_n_llhttp__internal__n_error_70: {
     state->error = 0x7;
     state->reason = "Unexpected char in url schema";
     state->error_pos = (const char*) p;
@@ -7659,7 +8886,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_55: {
+  s_n_llhttp__internal__n_error_71: {
     state->error = 0x7;
     state->reason = "Unexpected start char in url";
     state->error_pos = (const char*) p;
@@ -7678,7 +8905,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_56: {
+  s_n_llhttp__internal__n_error_72: {
     state->error = 0x6;
     state->reason = "Expected space after method";
     state->error_pos = (const char*) p;
@@ -7687,15 +8914,50 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
+  s_n_llhttp__internal__n_pause_22: {
+    state->error = 0x15;
+    state->reason = "on_method_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_req_first_space_before_url;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_89: {
+    state->error = 0x20;
+    state->reason = "`on_method_complete` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_method_2: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_method(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_method_complete_1;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_method_complete_1;
+    /* UNREACHABLE */;
+    abort();
+  }
   s_n_llhttp__internal__n_invoke_store_method_1: {
     switch (llhttp__internal__c_store_method(state, p, endp, match)) {
       default:
-        goto s_n_llhttp__internal__n_req_first_space_before_url;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_method_2;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_69: {
+  s_n_llhttp__internal__n_error_90: {
     state->error = 0x6;
     state->reason = "Invalid method encountered";
     state->error_pos = (const char*) p;
@@ -7704,26 +8966,64 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_59: {
+  s_n_llhttp__internal__n_error_82: {
     state->error = 0xd;
-    state->reason = "Response overflow";
+    state->reason = "Invalid status code";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_mul_add_status_code: {
-    switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
-      case 1:
-        goto s_n_llhttp__internal__n_error_59;
+  s_n_llhttp__internal__n_error_80: {
+    state->error = 0xd;
+    state->reason = "Invalid status code";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_78: {
+    state->error = 0xd;
+    state->reason = "Invalid status code";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_pause_20: {
+    state->error = 0x15;
+    state->reason = "on_status_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_headers_start;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_75: {
+    state->error = 0x1b;
+    state->reason = "`on_status_complete` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__on_status_complete: {
+    switch (llhttp__on_status_complete(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_headers_start;
+      case 21:
+        goto s_n_llhttp__internal__n_pause_20;
       default:
-        goto s_n_llhttp__internal__n_res_status_code;
+        goto s_n_llhttp__internal__n_error_75;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_60: {
+  s_n_llhttp__internal__n_error_76: {
     state->error = 0x2;
     state->reason = "Expected LF after CR";
     state->error_pos = (const char*) p;
@@ -7732,6 +9032,16 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_18: {
+    switch (llhttp__internal__c_test_lenient_flags_5(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
+      default:
+        goto s_n_llhttp__internal__n_error_76;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
   s_n_llhttp__internal__n_span_end_llhttp__on_status: {
     const unsigned char* start;
     int err;
@@ -7742,11 +9052,11 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_res_line_almost_done;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
+    goto s_n_llhttp__internal__n_res_line_almost_done;
     /* UNREACHABLE */;
     abort();
   }
@@ -7768,7 +9078,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_61: {
+  s_n_llhttp__internal__n_error_77: {
     state->error = 0xd;
     state->reason = "Invalid response status";
     state->error_pos = (const char*) p;
@@ -7777,7749 +9087,38 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_update_status_code: {
-    switch (llhttp__internal__c_update_status_code(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_res_status_code;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_62: {
-    state->error = 0x9;
-    state->reason = "Expected space after version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_58: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_minor_3: {
-    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
-      case 9:
-        goto s_n_llhttp__internal__n_res_http_end;
-      default:
-        goto s_n_llhttp__internal__n_error_58;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_63: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_minor_4: {
-    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_res_http_end;
+  s_n_llhttp__internal__n_invoke_mul_add_status_code_2: {
+    switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
       case 1:
-        goto s_n_llhttp__internal__n_res_http_end;
+        goto s_n_llhttp__internal__n_error_78;
       default:
-        goto s_n_llhttp__internal__n_error_63;
+        goto s_n_llhttp__internal__n_res_status_code_otherwise;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_64: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_minor_5: {
-    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_res_http_end;
-      default:
-        goto s_n_llhttp__internal__n_error_64;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_57: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_major_1: {
-    switch (llhttp__internal__c_load_http_major(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_load_http_minor_3;
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_load_http_minor_4;
-      case 2:
-        goto s_n_llhttp__internal__n_invoke_load_http_minor_5;
-      default:
-        goto s_n_llhttp__internal__n_error_57;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_7: {
-    switch (llhttp__internal__c_test_lenient_flags_6(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_res_http_end;
-      default:
-        goto s_n_llhttp__internal__n_invoke_load_http_major_1;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_store_http_minor_1: {
-    switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_7;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_65: {
-    state->error = 0x9;
-    state->reason = "Invalid minor version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_66: {
-    state->error = 0x9;
-    state->reason = "Expected dot";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_store_http_major_1: {
-    switch (llhttp__internal__c_store_http_major(state, p, endp, match)) {
-      default:
-        goto s_n_llhttp__internal__n_res_http_dot;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_67: {
-    state->error = 0x9;
-    state->reason = "Invalid major version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_70: {
-    state->error = 0x8;
-    state->reason = "Expected HTTP/";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_type: {
-    switch (llhttp__internal__c_update_type(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_req_first_space_before_url;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_store_method: {
-    switch (llhttp__internal__c_store_method(state, p, endp, match)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_type;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_68: {
-    state->error = 0x8;
-    state->reason = "Invalid word encountered";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_type_1: {
-    switch (llhttp__internal__c_update_type_1(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_res_http_major;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_type_2: {
-    switch (llhttp__internal__c_update_type(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_start_req;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_8: {
-    state->error = 0x15;
-    state->reason = "on_message_begin pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_load_type;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error: {
-    state->error = 0x10;
-    state->reason = "`on_message_begin` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_message_begin: {
-    switch (llhttp__on_message_begin(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_load_type;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_8;
-      default:
-        goto s_n_llhttp__internal__n_error;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_finish: {
-    switch (llhttp__internal__c_update_finish(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_message_begin;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-}
-
-int llhttp__internal_execute(llhttp__internal_t* state, const char* p, const char* endp) {
-  llparse_state_t next;
-
-  /* check lingering errors */
-  if (state->error != 0) {
-    return state->error;
-  }
-
-  /* restart spans */
-  if (state->_span_pos0 != NULL) {
-    state->_span_pos0 = (void*) p;
-  }
-  
-  next = llhttp__internal__run(state, (const unsigned char*) p, (const unsigned char*) endp);
-  if (next == s_error) {
-    return state->error;
-  }
-  state->_current = (void*) (intptr_t) next;
-
-  /* execute spans */
-  if (state->_span_pos0 != NULL) {
-    int error;
-  
-    error = ((llhttp__internal__span_cb) state->_span_cb0)(state, state->_span_pos0, (const char*) endp);
-    if (error != 0) {
-      state->error = error;
-      state->error_pos = endp;
-      return error;
-    }
-  }
-  
-  return 0;
-}
-
-#else  /* !LLHTTP_STRICT_MODE */
-
-#include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
-
-#ifdef __SSE4_2__
- #ifdef _MSC_VER
-  #include <nmmintrin.h>
- #else  /* !_MSC_VER */
-  #include <x86intrin.h>
- #endif  /* _MSC_VER */
-#endif  /* __SSE4_2__ */
-
-#ifdef _MSC_VER
- #define ALIGN(n) _declspec(align(n))
-#else  /* !_MSC_VER */
- #define ALIGN(n) __attribute__((aligned(n)))
-#endif  /* _MSC_VER */
-
-#include "llhttp.h"
-
-typedef int (*llhttp__internal__span_cb)(
-             llhttp__internal_t*, const char*, const char*);
-
-#ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob0[] = {
-  0x9, 0x9, 0xc, 0xc, '!', '"', '$', '>', '@', '~', 0x80,
-  0xff, 0x0, 0x0, 0x0, 0x0
-};
-#endif  /* __SSE4_2__ */
-static const unsigned char llparse_blob1[] = {
-  'o', 'n'
-};
-static const unsigned char llparse_blob2[] = {
-  'e', 'c', 't', 'i', 'o', 'n'
-};
-static const unsigned char llparse_blob3[] = {
-  'l', 'o', 's', 'e'
-};
-static const unsigned char llparse_blob4[] = {
-  'e', 'e', 'p', '-', 'a', 'l', 'i', 'v', 'e'
-};
-static const unsigned char llparse_blob5[] = {
-  'p', 'g', 'r', 'a', 'd', 'e'
-};
-static const unsigned char llparse_blob6[] = {
-  'c', 'h', 'u', 'n', 'k', 'e', 'd'
-};
-#ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob7[] = {
-  0x9, 0x9, ' ', '~', 0x80, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0,
-  0x0, 0x0, 0x0, 0x0, 0x0
-};
-#endif  /* __SSE4_2__ */
-#ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob8[] = {
-  ' ', '!', '#', '\'', '*', '+', '-', '.', '0', '9', 'A',
-  'Z', '^', 'z', '|', '|'
-};
-#endif  /* __SSE4_2__ */
-#ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob9[] = {
-  '~', '~', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-  0x0, 0x0, 0x0, 0x0, 0x0
-};
-#endif  /* __SSE4_2__ */
-static const unsigned char llparse_blob10[] = {
-  'e', 'n', 't', '-', 'l', 'e', 'n', 'g', 't', 'h'
-};
-static const unsigned char llparse_blob11[] = {
-  'r', 'o', 'x', 'y', '-', 'c', 'o', 'n', 'n', 'e', 'c',
-  't', 'i', 'o', 'n'
-};
-static const unsigned char llparse_blob12[] = {
-  'r', 'a', 'n', 's', 'f', 'e', 'r', '-', 'e', 'n', 'c',
-  'o', 'd', 'i', 'n', 'g'
-};
-static const unsigned char llparse_blob13[] = {
-  'p', 'g', 'r', 'a', 'd', 'e'
-};
-static const unsigned char llparse_blob14[] = {
-  0xd, 0xa
-};
-static const unsigned char llparse_blob15[] = {
-  'T', 'T', 'P', '/'
-};
-static const unsigned char llparse_blob16[] = {
-  0xd, 0xa, 0xd, 0xa, 'S', 'M', 0xd, 0xa, 0xd, 0xa
-};
-static const unsigned char llparse_blob17[] = {
-  'C', 'E', '/'
-};
-static const unsigned char llparse_blob18[] = {
-  'T', 'S', 'P', '/'
-};
-static const unsigned char llparse_blob19[] = {
-  'N', 'O', 'U', 'N', 'C', 'E'
-};
-static const unsigned char llparse_blob20[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob21[] = {
-  'E', 'C', 'K', 'O', 'U', 'T'
-};
-static const unsigned char llparse_blob22[] = {
-  'N', 'E', 'C', 'T'
-};
-static const unsigned char llparse_blob23[] = {
-  'E', 'T', 'E'
-};
-static const unsigned char llparse_blob24[] = {
-  'C', 'R', 'I', 'B', 'E'
-};
-static const unsigned char llparse_blob25[] = {
-  'L', 'U', 'S', 'H'
-};
-static const unsigned char llparse_blob26[] = {
-  'E', 'T'
-};
-static const unsigned char llparse_blob27[] = {
-  'P', 'A', 'R', 'A', 'M', 'E', 'T', 'E', 'R'
-};
-static const unsigned char llparse_blob28[] = {
-  'E', 'A', 'D'
-};
-static const unsigned char llparse_blob29[] = {
-  'N', 'K'
-};
-static const unsigned char llparse_blob30[] = {
-  'C', 'K'
-};
-static const unsigned char llparse_blob31[] = {
-  'S', 'E', 'A', 'R', 'C', 'H'
-};
-static const unsigned char llparse_blob32[] = {
-  'R', 'G', 'E'
-};
-static const unsigned char llparse_blob33[] = {
-  'C', 'T', 'I', 'V', 'I', 'T', 'Y'
-};
-static const unsigned char llparse_blob34[] = {
-  'L', 'E', 'N', 'D', 'A', 'R'
-};
-static const unsigned char llparse_blob35[] = {
-  'V', 'E'
-};
-static const unsigned char llparse_blob36[] = {
-  'O', 'T', 'I', 'F', 'Y'
-};
-static const unsigned char llparse_blob37[] = {
-  'P', 'T', 'I', 'O', 'N', 'S'
-};
-static const unsigned char llparse_blob38[] = {
-  'C', 'H'
-};
-static const unsigned char llparse_blob39[] = {
-  'S', 'E'
-};
-static const unsigned char llparse_blob40[] = {
-  'A', 'Y'
-};
-static const unsigned char llparse_blob41[] = {
-  'S', 'T'
-};
-static const unsigned char llparse_blob42[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob43[] = {
-  'A', 'T', 'C', 'H'
-};
-static const unsigned char llparse_blob44[] = {
-  'G', 'E'
-};
-static const unsigned char llparse_blob45[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob46[] = {
-  'O', 'R', 'D'
-};
-static const unsigned char llparse_blob47[] = {
-  'I', 'R', 'E', 'C', 'T'
-};
-static const unsigned char llparse_blob48[] = {
-  'O', 'R', 'T'
-};
-static const unsigned char llparse_blob49[] = {
-  'R', 'C', 'H'
-};
-static const unsigned char llparse_blob50[] = {
-  'P', 'A', 'R', 'A', 'M', 'E', 'T', 'E', 'R'
-};
-static const unsigned char llparse_blob51[] = {
-  'U', 'R', 'C', 'E'
-};
-static const unsigned char llparse_blob52[] = {
-  'B', 'S', 'C', 'R', 'I', 'B', 'E'
-};
-static const unsigned char llparse_blob53[] = {
-  'A', 'R', 'D', 'O', 'W', 'N'
-};
-static const unsigned char llparse_blob54[] = {
-  'A', 'C', 'E'
-};
-static const unsigned char llparse_blob55[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob56[] = {
-  'N', 'K'
-};
-static const unsigned char llparse_blob57[] = {
-  'C', 'K'
-};
-static const unsigned char llparse_blob58[] = {
-  'U', 'B', 'S', 'C', 'R', 'I', 'B', 'E'
-};
-static const unsigned char llparse_blob59[] = {
-  'H', 'T', 'T', 'P', '/'
-};
-static const unsigned char llparse_blob60[] = {
-  'A', 'D'
-};
-static const unsigned char llparse_blob61[] = {
-  'T', 'P', '/'
-};
-
-enum llparse_match_status_e {
-  kMatchComplete,
-  kMatchPause,
-  kMatchMismatch
-};
-typedef enum llparse_match_status_e llparse_match_status_t;
-
-struct llparse_match_s {
-  llparse_match_status_t status;
-  const unsigned char* current;
-};
-typedef struct llparse_match_s llparse_match_t;
-
-static llparse_match_t llparse__match_sequence_to_lower(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp,
-    const unsigned char* seq, uint32_t seq_len) {
-  uint32_t index;
-  llparse_match_t res;
-
-  index = s->_index;
-  for (; p != endp; p++) {
-    unsigned char current;
-
-    current = ((*p) >= 'A' && (*p) <= 'Z' ? (*p | 0x20) : (*p));
-    if (current == seq[index]) {
-      if (++index == seq_len) {
-        res.status = kMatchComplete;
-        goto reset;
-      }
-    } else {
-      res.status = kMatchMismatch;
-      goto reset;
-    }
-  }
-  s->_index = index;
-  res.status = kMatchPause;
-  res.current = p;
-  return res;
-reset:
-  s->_index = 0;
-  res.current = p;
-  return res;
-}
-
-static llparse_match_t llparse__match_sequence_to_lower_unsafe(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp,
-    const unsigned char* seq, uint32_t seq_len) {
-  uint32_t index;
-  llparse_match_t res;
-
-  index = s->_index;
-  for (; p != endp; p++) {
-    unsigned char current;
-
-    current = ((*p) | 0x20);
-    if (current == seq[index]) {
-      if (++index == seq_len) {
-        res.status = kMatchComplete;
-        goto reset;
-      }
-    } else {
-      res.status = kMatchMismatch;
-      goto reset;
-    }
-  }
-  s->_index = index;
-  res.status = kMatchPause;
-  res.current = p;
-  return res;
-reset:
-  s->_index = 0;
-  res.current = p;
-  return res;
-}
-
-static llparse_match_t llparse__match_sequence_id(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp,
-    const unsigned char* seq, uint32_t seq_len) {
-  uint32_t index;
-  llparse_match_t res;
-
-  index = s->_index;
-  for (; p != endp; p++) {
-    unsigned char current;
-
-    current = *p;
-    if (current == seq[index]) {
-      if (++index == seq_len) {
-        res.status = kMatchComplete;
-        goto reset;
-      }
-    } else {
-      res.status = kMatchMismatch;
-      goto reset;
-    }
-  }
-  s->_index = index;
-  res.status = kMatchPause;
-  res.current = p;
-  return res;
-reset:
-  s->_index = 0;
-  res.current = p;
-  return res;
-}
-
-enum llparse_state_e {
-  s_error,
-  s_n_llhttp__internal__n_closed,
-  s_n_llhttp__internal__n_invoke_llhttp__after_message_complete,
-  s_n_llhttp__internal__n_pause_1,
-  s_n_llhttp__internal__n_invoke_is_equal_upgrade,
-  s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2,
-  s_n_llhttp__internal__n_chunk_data_almost_done_skip,
-  s_n_llhttp__internal__n_chunk_data_almost_done,
-  s_n_llhttp__internal__n_consume_content_length,
-  s_n_llhttp__internal__n_span_start_llhttp__on_body,
-  s_n_llhttp__internal__n_invoke_is_equal_content_length,
-  s_n_llhttp__internal__n_chunk_size_almost_done,
-  s_n_llhttp__internal__n_chunk_parameters,
-  s_n_llhttp__internal__n_chunk_size_otherwise,
-  s_n_llhttp__internal__n_chunk_size,
-  s_n_llhttp__internal__n_chunk_size_digit,
-  s_n_llhttp__internal__n_invoke_update_content_length,
-  s_n_llhttp__internal__n_consume_content_length_1,
-  s_n_llhttp__internal__n_span_start_llhttp__on_body_1,
-  s_n_llhttp__internal__n_eof,
-  s_n_llhttp__internal__n_span_start_llhttp__on_body_2,
-  s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete,
-  s_n_llhttp__internal__n_headers_almost_done,
-  s_n_llhttp__internal__n_header_field_colon_discard_ws,
-  s_n_llhttp__internal__n_error_14,
-  s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete,
-  s_n_llhttp__internal__n_span_start_llhttp__on_header_value,
-  s_n_llhttp__internal__n_header_value_discard_lws,
-  s_n_llhttp__internal__n_header_value_discard_ws_almost_done,
-  s_n_llhttp__internal__n_header_value_lws,
-  s_n_llhttp__internal__n_header_value_almost_done,
-  s_n_llhttp__internal__n_header_value_lenient,
-  s_n_llhttp__internal__n_error_17,
-  s_n_llhttp__internal__n_header_value_lenient_failed,
-  s_n_llhttp__internal__n_header_value_otherwise,
-  s_n_llhttp__internal__n_header_value_connection_token,
-  s_n_llhttp__internal__n_header_value_connection_ws,
-  s_n_llhttp__internal__n_header_value_connection_1,
-  s_n_llhttp__internal__n_header_value_connection_2,
-  s_n_llhttp__internal__n_header_value_connection_3,
-  s_n_llhttp__internal__n_header_value_connection,
-  s_n_llhttp__internal__n_error_20,
-  s_n_llhttp__internal__n_error_21,
-  s_n_llhttp__internal__n_header_value_content_length_ws,
-  s_n_llhttp__internal__n_header_value_content_length,
-  s_n_llhttp__internal__n_error_23,
-  s_n_llhttp__internal__n_error_22,
-  s_n_llhttp__internal__n_header_value_te_token_ows,
-  s_n_llhttp__internal__n_header_value,
-  s_n_llhttp__internal__n_header_value_te_token,
-  s_n_llhttp__internal__n_header_value_te_chunked_last,
-  s_n_llhttp__internal__n_header_value_te_chunked,
-  s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1,
-  s_n_llhttp__internal__n_header_value_discard_ws,
-  s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete,
-  s_n_llhttp__internal__n_header_field_general_otherwise,
-  s_n_llhttp__internal__n_header_field_general,
-  s_n_llhttp__internal__n_header_field_colon,
-  s_n_llhttp__internal__n_header_field_3,
-  s_n_llhttp__internal__n_header_field_4,
-  s_n_llhttp__internal__n_header_field_2,
-  s_n_llhttp__internal__n_header_field_1,
-  s_n_llhttp__internal__n_header_field_5,
-  s_n_llhttp__internal__n_header_field_6,
-  s_n_llhttp__internal__n_header_field_7,
-  s_n_llhttp__internal__n_header_field,
-  s_n_llhttp__internal__n_span_start_llhttp__on_header_field,
-  s_n_llhttp__internal__n_header_field_start,
-  s_n_llhttp__internal__n_url_skip_to_http09,
-  s_n_llhttp__internal__n_url_skip_lf_to_http09,
-  s_n_llhttp__internal__n_req_pri_upgrade,
-  s_n_llhttp__internal__n_req_http_complete_1,
-  s_n_llhttp__internal__n_req_http_complete,
-  s_n_llhttp__internal__n_req_http_minor,
-  s_n_llhttp__internal__n_req_http_dot,
-  s_n_llhttp__internal__n_req_http_major,
-  s_n_llhttp__internal__n_req_http_start_1,
-  s_n_llhttp__internal__n_req_http_start_2,
-  s_n_llhttp__internal__n_req_http_start_3,
-  s_n_llhttp__internal__n_req_http_start,
-  s_n_llhttp__internal__n_url_skip_to_http,
-  s_n_llhttp__internal__n_url_fragment,
-  s_n_llhttp__internal__n_span_end_stub_query_3,
-  s_n_llhttp__internal__n_url_query,
-  s_n_llhttp__internal__n_url_query_or_fragment,
-  s_n_llhttp__internal__n_url_path,
-  s_n_llhttp__internal__n_span_start_stub_path_2,
-  s_n_llhttp__internal__n_span_start_stub_path,
-  s_n_llhttp__internal__n_span_start_stub_path_1,
-  s_n_llhttp__internal__n_url_server_with_at,
-  s_n_llhttp__internal__n_url_server,
-  s_n_llhttp__internal__n_url_schema_delim_1,
-  s_n_llhttp__internal__n_url_schema_delim,
-  s_n_llhttp__internal__n_span_end_stub_schema,
-  s_n_llhttp__internal__n_url_schema,
-  s_n_llhttp__internal__n_url_start,
-  s_n_llhttp__internal__n_span_start_llhttp__on_url_1,
-  s_n_llhttp__internal__n_span_start_llhttp__on_url,
-  s_n_llhttp__internal__n_req_spaces_before_url,
-  s_n_llhttp__internal__n_req_first_space_before_url,
-  s_n_llhttp__internal__n_start_req_2,
-  s_n_llhttp__internal__n_start_req_3,
-  s_n_llhttp__internal__n_start_req_1,
-  s_n_llhttp__internal__n_start_req_4,
-  s_n_llhttp__internal__n_start_req_6,
-  s_n_llhttp__internal__n_start_req_8,
-  s_n_llhttp__internal__n_start_req_9,
-  s_n_llhttp__internal__n_start_req_7,
-  s_n_llhttp__internal__n_start_req_5,
-  s_n_llhttp__internal__n_start_req_12,
-  s_n_llhttp__internal__n_start_req_13,
-  s_n_llhttp__internal__n_start_req_11,
-  s_n_llhttp__internal__n_start_req_10,
-  s_n_llhttp__internal__n_start_req_14,
-  s_n_llhttp__internal__n_start_req_17,
-  s_n_llhttp__internal__n_start_req_16,
-  s_n_llhttp__internal__n_start_req_15,
-  s_n_llhttp__internal__n_start_req_18,
-  s_n_llhttp__internal__n_start_req_20,
-  s_n_llhttp__internal__n_start_req_21,
-  s_n_llhttp__internal__n_start_req_19,
-  s_n_llhttp__internal__n_start_req_23,
-  s_n_llhttp__internal__n_start_req_24,
-  s_n_llhttp__internal__n_start_req_26,
-  s_n_llhttp__internal__n_start_req_28,
-  s_n_llhttp__internal__n_start_req_29,
-  s_n_llhttp__internal__n_start_req_27,
-  s_n_llhttp__internal__n_start_req_25,
-  s_n_llhttp__internal__n_start_req_30,
-  s_n_llhttp__internal__n_start_req_22,
-  s_n_llhttp__internal__n_start_req_31,
-  s_n_llhttp__internal__n_start_req_32,
-  s_n_llhttp__internal__n_start_req_35,
-  s_n_llhttp__internal__n_start_req_36,
-  s_n_llhttp__internal__n_start_req_34,
-  s_n_llhttp__internal__n_start_req_37,
-  s_n_llhttp__internal__n_start_req_38,
-  s_n_llhttp__internal__n_start_req_42,
-  s_n_llhttp__internal__n_start_req_43,
-  s_n_llhttp__internal__n_start_req_41,
-  s_n_llhttp__internal__n_start_req_40,
-  s_n_llhttp__internal__n_start_req_39,
-  s_n_llhttp__internal__n_start_req_45,
-  s_n_llhttp__internal__n_start_req_44,
-  s_n_llhttp__internal__n_start_req_33,
-  s_n_llhttp__internal__n_start_req_48,
-  s_n_llhttp__internal__n_start_req_49,
-  s_n_llhttp__internal__n_start_req_50,
-  s_n_llhttp__internal__n_start_req_51,
-  s_n_llhttp__internal__n_start_req_47,
-  s_n_llhttp__internal__n_start_req_46,
-  s_n_llhttp__internal__n_start_req_54,
-  s_n_llhttp__internal__n_start_req_56,
-  s_n_llhttp__internal__n_start_req_57,
-  s_n_llhttp__internal__n_start_req_55,
-  s_n_llhttp__internal__n_start_req_53,
-  s_n_llhttp__internal__n_start_req_58,
-  s_n_llhttp__internal__n_start_req_59,
-  s_n_llhttp__internal__n_start_req_52,
-  s_n_llhttp__internal__n_start_req_61,
-  s_n_llhttp__internal__n_start_req_62,
-  s_n_llhttp__internal__n_start_req_60,
-  s_n_llhttp__internal__n_start_req_65,
-  s_n_llhttp__internal__n_start_req_67,
-  s_n_llhttp__internal__n_start_req_68,
-  s_n_llhttp__internal__n_start_req_66,
-  s_n_llhttp__internal__n_start_req_69,
-  s_n_llhttp__internal__n_start_req_64,
-  s_n_llhttp__internal__n_start_req_63,
-  s_n_llhttp__internal__n_start_req,
-  s_n_llhttp__internal__n_invoke_llhttp__on_status_complete,
-  s_n_llhttp__internal__n_res_line_almost_done,
-  s_n_llhttp__internal__n_res_status,
-  s_n_llhttp__internal__n_span_start_llhttp__on_status,
-  s_n_llhttp__internal__n_res_status_start,
-  s_n_llhttp__internal__n_res_status_code_otherwise,
-  s_n_llhttp__internal__n_res_status_code,
-  s_n_llhttp__internal__n_res_http_end,
-  s_n_llhttp__internal__n_res_http_minor,
-  s_n_llhttp__internal__n_res_http_dot,
-  s_n_llhttp__internal__n_res_http_major,
-  s_n_llhttp__internal__n_start_res,
-  s_n_llhttp__internal__n_req_or_res_method_2,
-  s_n_llhttp__internal__n_req_or_res_method_3,
-  s_n_llhttp__internal__n_req_or_res_method_1,
-  s_n_llhttp__internal__n_req_or_res_method,
-  s_n_llhttp__internal__n_start_req_or_res,
-  s_n_llhttp__internal__n_invoke_load_type,
-  s_n_llhttp__internal__n_start,
-};
-typedef enum llparse_state_e llparse_state_t;
-
-int llhttp__on_url(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_header_field(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_header_value(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_body(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_status(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_update_finish(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->finish = 2;
-  return 0;
-}
-
-int llhttp__on_message_begin(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_load_type(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->type;
-}
-
-int llhttp__internal__c_store_method(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp,
-    int match) {
-  state->method = match;
-  return 0;
-}
-
-int llhttp__internal__c_is_equal_method(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->method == 5;
-}
-
-int llhttp__internal__c_update_http_major(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->http_major = 0;
-  return 0;
-}
-
-int llhttp__internal__c_update_http_minor(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->http_minor = 9;
-  return 0;
-}
-
-int llhttp__on_url_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_test_flags(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->flags & 128) == 128;
-}
-
-int llhttp__on_chunk_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_message_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_is_equal_upgrade(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->upgrade == 1;
-}
-
-int llhttp__after_message_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_update_finish_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->finish = 0;
-  return 0;
-}
-
-int llhttp__internal__c_test_lenient_flags(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->lenient_flags & 4) == 4;
-}
-
-int llhttp__internal__c_test_flags_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->flags & 544) == 544;
-}
-
-int llhttp__internal__c_test_lenient_flags_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->lenient_flags & 2) == 2;
-}
-
-int llhttp__before_headers_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__on_headers_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__after_headers_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_update_content_length(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->content_length = 0;
-  return 0;
-}
-
-int llhttp__internal__c_mul_add_content_length(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp,
-    int match) {
-  /* Multiplication overflow */
-  if (state->content_length > 0xffffffffffffffffULL / 16) {
-    return 1;
-  }
-  
-  state->content_length *= 16;
-  
-  /* Addition overflow */
-  if (match >= 0) {
-    if (state->content_length > 0xffffffffffffffffULL - match) {
-      return 1;
-    }
-  } else {
-    if (state->content_length < 0ULL - match) {
-      return 1;
-    }
-  }
-  state->content_length += match;
-  return 0;
-}
-
-int llhttp__on_chunk_header(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_is_equal_content_length(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->content_length == 0;
-}
-
-int llhttp__internal__c_or_flags(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 128;
-  return 0;
-}
-
-int llhttp__internal__c_update_finish_3(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->finish = 1;
-  return 0;
-}
-
-int llhttp__internal__c_or_flags_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 64;
-  return 0;
-}
-
-int llhttp__internal__c_update_upgrade(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->upgrade = 1;
-  return 0;
-}
-
-int llhttp__internal__c_store_header_state(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp,
-    int match) {
-  state->header_state = match;
-  return 0;
-}
-
-int llhttp__internal__c_test_lenient_flags_2(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->lenient_flags & 1) == 1;
-}
-
-int llhttp__on_header_field_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_load_header_state(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->header_state;
-}
-
-int llhttp__internal__c_or_flags_3(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 1;
-  return 0;
-}
-
-int llhttp__internal__c_update_header_state(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->header_state = 1;
-  return 0;
-}
-
-int llhttp__on_header_value_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_or_flags_4(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 2;
-  return 0;
-}
-
-int llhttp__internal__c_or_flags_5(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 4;
-  return 0;
-}
-
-int llhttp__internal__c_or_flags_6(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 8;
-  return 0;
-}
-
-int llhttp__internal__c_update_header_state_2(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->header_state = 6;
-  return 0;
-}
-
-int llhttp__internal__c_update_header_state_4(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->header_state = 0;
-  return 0;
-}
-
-int llhttp__internal__c_update_header_state_5(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->header_state = 5;
-  return 0;
-}
-
-int llhttp__internal__c_update_header_state_6(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->header_state = 7;
-  return 0;
-}
-
-int llhttp__internal__c_test_flags_2(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->flags & 32) == 32;
-}
-
-int llhttp__internal__c_mul_add_content_length_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp,
-    int match) {
-  /* Multiplication overflow */
-  if (state->content_length > 0xffffffffffffffffULL / 10) {
-    return 1;
-  }
-  
-  state->content_length *= 10;
-  
-  /* Addition overflow */
-  if (match >= 0) {
-    if (state->content_length > 0xffffffffffffffffULL - match) {
-      return 1;
-    }
-  } else {
-    if (state->content_length < 0ULL - match) {
-      return 1;
-    }
-  }
-  state->content_length += match;
-  return 0;
-}
-
-int llhttp__internal__c_or_flags_15(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 32;
-  return 0;
-}
-
-int llhttp__internal__c_test_flags_3(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->flags & 8) == 8;
-}
-
-int llhttp__internal__c_test_lenient_flags_4(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->lenient_flags & 8) == 8;
-}
-
-int llhttp__internal__c_or_flags_16(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 512;
-  return 0;
-}
-
-int llhttp__internal__c_and_flags(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags &= -9;
-  return 0;
-}
-
-int llhttp__internal__c_update_header_state_7(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->header_state = 8;
-  return 0;
-}
-
-int llhttp__internal__c_or_flags_18(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->flags |= 16;
-  return 0;
-}
-
-int llhttp__internal__c_load_method(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->method;
-}
-
-int llhttp__internal__c_store_http_major(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp,
-    int match) {
-  state->http_major = match;
-  return 0;
-}
-
-int llhttp__internal__c_store_http_minor(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp,
-    int match) {
-  state->http_minor = match;
-  return 0;
-}
-
-int llhttp__internal__c_test_lenient_flags_6(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->lenient_flags & 16) == 16;
-}
-
-int llhttp__internal__c_load_http_major(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->http_major;
-}
-
-int llhttp__internal__c_load_http_minor(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return state->http_minor;
-}
-
-int llhttp__internal__c_update_status_code(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->status_code = 0;
-  return 0;
-}
-
-int llhttp__internal__c_mul_add_status_code(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp,
-    int match) {
-  /* Multiplication overflow */
-  if (state->status_code > 0xffff / 10) {
-    return 1;
-  }
-  
-  state->status_code *= 10;
-  
-  /* Addition overflow */
-  if (match >= 0) {
-    if (state->status_code > 0xffff - match) {
-      return 1;
-    }
-  } else {
-    if (state->status_code < 0 - match) {
-      return 1;
-    }
-  }
-  state->status_code += match;
-  
-  /* Enforce maximum */
-  if (state->status_code > 999) {
-    return 1;
-  }
-  return 0;
-}
-
-int llhttp__on_status_complete(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp);
-
-int llhttp__internal__c_update_type(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->type = 1;
-  return 0;
-}
-
-int llhttp__internal__c_update_type_1(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  state->type = 2;
-  return 0;
-}
-
-int llhttp__internal_init(llhttp__internal_t* state) {
-  memset(state, 0, sizeof(*state));
-  state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_start;
-  return 0;
-}
-
-static llparse_state_t llhttp__internal__run(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  int match;
-  switch ((llparse_state_t) (intptr_t) state->_current) {
-    case s_n_llhttp__internal__n_closed:
-    s_n_llhttp__internal__n_closed: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_closed;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_closed;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__after_message_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__after_message_complete: {
-      switch (llhttp__after_message_complete(state, p, endp)) {
-        case 1:
-          goto s_n_llhttp__internal__n_invoke_update_finish_2;
-        default:
-          goto s_n_llhttp__internal__n_invoke_update_finish_1;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_pause_1:
-    s_n_llhttp__internal__n_pause_1: {
-      state->error = 0x16;
-      state->reason = "Pause on CONNECT/Upgrade";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_is_equal_upgrade:
-    s_n_llhttp__internal__n_invoke_is_equal_upgrade: {
-      switch (llhttp__internal__c_is_equal_upgrade(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
-        default:
-          goto s_n_llhttp__internal__n_pause_1;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2:
-    s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2: {
-      switch (llhttp__on_message_complete(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_invoke_is_equal_upgrade;
-        case 21:
-          goto s_n_llhttp__internal__n_pause_5;
-        default:
-          goto s_n_llhttp__internal__n_error_10;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_data_almost_done_skip:
-    s_n_llhttp__internal__n_chunk_data_almost_done_skip: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_data_almost_done_skip;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_data_almost_done:
-    s_n_llhttp__internal__n_chunk_data_almost_done: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_data_almost_done;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_chunk_data_almost_done_skip;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_consume_content_length:
-    s_n_llhttp__internal__n_consume_content_length: {
-      size_t avail;
-      uint64_t need;
-      
-      avail = endp - p;
-      need = state->content_length;
-      if (avail >= need) {
-        p += need;
-        state->content_length = 0;
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_body;
-      }
-      
-      state->content_length -= avail;
-      return s_n_llhttp__internal__n_consume_content_length;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_body:
-    s_n_llhttp__internal__n_span_start_llhttp__on_body: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_body;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_body;
-      goto s_n_llhttp__internal__n_consume_content_length;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_is_equal_content_length:
-    s_n_llhttp__internal__n_invoke_is_equal_content_length: {
-      switch (llhttp__internal__c_is_equal_content_length(state, p, endp)) {
-        case 0:
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_body;
-        default:
-          goto s_n_llhttp__internal__n_invoke_or_flags;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_size_almost_done:
-    s_n_llhttp__internal__n_chunk_size_almost_done: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_size_almost_done;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_header;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_parameters:
-    s_n_llhttp__internal__n_chunk_parameters: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_parameters;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_parameters;
-        }
-        case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_size_almost_done;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_6;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_size_otherwise:
-    s_n_llhttp__internal__n_chunk_size_otherwise: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_size_otherwise;
-      }
-      switch (*p) {
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_size_almost_done;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_parameters;
-        }
-        case ';': {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_parameters;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_7;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_size:
-    s_n_llhttp__internal__n_chunk_size: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_size;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'A': {
-          p++;
-          match = 10;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'B': {
-          p++;
-          match = 11;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'C': {
-          p++;
-          match = 12;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'D': {
-          p++;
-          match = 13;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'E': {
-          p++;
-          match = 14;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'F': {
-          p++;
-          match = 15;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'a': {
-          p++;
-          match = 10;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'b': {
-          p++;
-          match = 11;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'c': {
-          p++;
-          match = 12;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'd': {
-          p++;
-          match = 13;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'e': {
-          p++;
-          match = 14;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'f': {
-          p++;
-          match = 15;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_chunk_size_otherwise;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_chunk_size_digit:
-    s_n_llhttp__internal__n_chunk_size_digit: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_chunk_size_digit;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'A': {
-          p++;
-          match = 10;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'B': {
-          p++;
-          match = 11;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'C': {
-          p++;
-          match = 12;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'D': {
-          p++;
-          match = 13;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'E': {
-          p++;
-          match = 14;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'F': {
-          p++;
-          match = 15;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'a': {
-          p++;
-          match = 10;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'b': {
-          p++;
-          match = 11;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'c': {
-          p++;
-          match = 12;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'd': {
-          p++;
-          match = 13;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'e': {
-          p++;
-          match = 14;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        case 'f': {
-          p++;
-          match = 15;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_9;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_update_content_length:
-    s_n_llhttp__internal__n_invoke_update_content_length: {
-      switch (llhttp__internal__c_update_content_length(state, p, endp)) {
-        default:
-          goto s_n_llhttp__internal__n_chunk_size_digit;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_consume_content_length_1:
-    s_n_llhttp__internal__n_consume_content_length_1: {
-      size_t avail;
-      uint64_t need;
-      
-      avail = endp - p;
-      need = state->content_length;
-      if (avail >= need) {
-        p += need;
-        state->content_length = 0;
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_body_1;
-      }
-      
-      state->content_length -= avail;
-      return s_n_llhttp__internal__n_consume_content_length_1;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_body_1:
-    s_n_llhttp__internal__n_span_start_llhttp__on_body_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_body_1;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_body;
-      goto s_n_llhttp__internal__n_consume_content_length_1;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_eof:
-    s_n_llhttp__internal__n_eof: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_eof;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_eof;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_body_2:
-    s_n_llhttp__internal__n_span_start_llhttp__on_body_2: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_body_2;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_body;
-      goto s_n_llhttp__internal__n_eof;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete: {
-      switch (llhttp__after_headers_complete(state, p, endp)) {
-        case 1:
-          goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_1;
-        case 2:
-          goto s_n_llhttp__internal__n_invoke_update_content_length;
-        case 3:
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_body_1;
-        case 4:
-          goto s_n_llhttp__internal__n_invoke_update_finish_3;
-        case 5:
-          goto s_n_llhttp__internal__n_error_11;
-        default:
-          goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_headers_almost_done:
-    s_n_llhttp__internal__n_headers_almost_done: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_headers_almost_done;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_invoke_test_flags;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_colon_discard_ws:
-    s_n_llhttp__internal__n_header_field_colon_discard_ws: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_colon_discard_ws;
-      }
-      switch (*p) {
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_colon_discard_ws;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_field_colon;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_14:
-    s_n_llhttp__internal__n_error_14: {
-      state->error = 0xa;
-      state->reason = "Invalid header field char";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete: {
-      switch (llhttp__on_header_value_complete(state, p, endp)) {
-        default:
-          goto s_n_llhttp__internal__n_header_field_start;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_header_value:
-    s_n_llhttp__internal__n_span_start_llhttp__on_header_value: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_header_value;
-      goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_discard_lws:
-    s_n_llhttp__internal__n_header_value_discard_lws: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_discard_lws;
-      }
-      switch (*p) {
-        case 9: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_discard_ws;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_discard_ws;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_load_header_state;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_discard_ws_almost_done:
-    s_n_llhttp__internal__n_header_value_discard_ws_almost_done: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_discard_ws_almost_done;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_header_value_discard_lws;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_lws:
-    s_n_llhttp__internal__n_header_value_lws: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_lws;
-      }
-      switch (*p) {
-        case 9: {
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
-        }
-        case ' ': {
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_almost_done:
-    s_n_llhttp__internal__n_header_value_almost_done: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_almost_done;
-      }
-      switch (*p) {
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_lws;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_16;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_lenient:
-    s_n_llhttp__internal__n_header_value_lenient: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_lenient;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3;
-        }
-        case 13: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4;
-        }
-        default: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_lenient;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_17:
-    s_n_llhttp__internal__n_error_17: {
-      state->error = 0x19;
-      state->reason = "Missing expected CR after header value";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_lenient_failed:
-    s_n_llhttp__internal__n_header_value_lenient_failed: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_lenient_failed;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_18;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_otherwise:
-    s_n_llhttp__internal__n_header_value_otherwise: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_otherwise;
-      }
-      switch (*p) {
-        case 13: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_3;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_connection_token:
-    s_n_llhttp__internal__n_header_value_connection_token: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_connection_token;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection_token;
-        }
-        case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_value_otherwise;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_connection_ws:
-    s_n_llhttp__internal__n_header_value_connection_ws: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_connection_ws;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_header_value_otherwise;
-        }
-        case 13: {
-          goto s_n_llhttp__internal__n_header_value_otherwise;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection_ws;
-        }
-        case ',': {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_4;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_connection_1:
-    s_n_llhttp__internal__n_header_value_connection_1: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_connection_1;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob3, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_update_header_state_2;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_value_connection_1;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_header_value_connection_token;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_connection_2:
-    s_n_llhttp__internal__n_header_value_connection_2: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_connection_2;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob4, 9);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_update_header_state_5;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_value_connection_2;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_header_value_connection_token;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_connection_3:
-    s_n_llhttp__internal__n_header_value_connection_3: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_connection_3;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob5, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_update_header_state_6;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_value_connection_3;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_header_value_connection_token;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_connection:
-    s_n_llhttp__internal__n_header_value_connection: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_connection;
-      }
-      switch (((*p) >= 'A' && (*p) <= 'Z' ? (*p | 0x20) : (*p))) {
-        case 9: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection;
-        }
-        case 'c': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection_1;
-        }
-        case 'k': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection_2;
-        }
-        case 'u': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_connection_3;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_value_connection_token;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_20:
-    s_n_llhttp__internal__n_error_20: {
-      state->error = 0xb;
-      state->reason = "Content-Length overflow";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_21:
-    s_n_llhttp__internal__n_error_21: {
-      state->error = 0xb;
-      state->reason = "Invalid character in Content-Length";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_content_length_ws:
-    s_n_llhttp__internal__n_header_value_content_length_ws: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_content_length_ws;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_invoke_or_flags_15;
-        }
-        case 13: {
-          goto s_n_llhttp__internal__n_invoke_or_flags_15;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_content_length_ws;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_6;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_content_length:
-    s_n_llhttp__internal__n_header_value_content_length: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_content_length;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_mul_add_content_length_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_value_content_length_ws;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_23:
-    s_n_llhttp__internal__n_error_23: {
-      state->error = 0xf;
-      state->reason = "Invalid `Transfer-Encoding` header value";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_error_22:
-    s_n_llhttp__internal__n_error_22: {
-      state->error = 0xf;
-      state->reason = "Invalid `Transfer-Encoding` header value";
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_error;
-      return s_error;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_te_token_ows:
-    s_n_llhttp__internal__n_header_value_te_token_ows: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_te_token_ows;
-      }
-      switch (*p) {
-        case 9: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_te_token_ows;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_te_token_ows;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_value_te_chunked;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value:
-    s_n_llhttp__internal__n_header_value: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value;
-      }
-      #ifdef __SSE4_2__
-      if (endp - p >= 16) {
-        __m128i ranges;
-        __m128i input;
-        int avail;
-        int match_len;
-      
-        /* Load input */
-        input = _mm_loadu_si128((__m128i const*) p);
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob7);
-      
-        /* Find first character that does not match `ranges` */
-        match_len = _mm_cmpestri(ranges, 6,
-            input, 16,
-            _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES |
-              _SIDD_NEGATIVE_POLARITY);
-      
-        if (match_len != 0) {
-          p += match_len;
-          goto s_n_llhttp__internal__n_header_value;
-        }
-        goto s_n_llhttp__internal__n_header_value_otherwise;
-      }
-      #endif  /* __SSE4_2__ */
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_value_otherwise;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_te_token:
-    s_n_llhttp__internal__n_header_value_te_token: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_te_token;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_te_token;
-        }
-        case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_te_token_ows;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_8;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_te_chunked_last:
-    s_n_llhttp__internal__n_header_value_te_chunked_last: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_te_chunked_last;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
-        }
-        case 13: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_te_chunked_last;
-        }
-        case ',': {
-          goto s_n_llhttp__internal__n_invoke_load_type_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_value_te_token;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_te_chunked:
-    s_n_llhttp__internal__n_header_value_te_chunked: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_te_chunked;
-      }
-      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob6, 7);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_te_chunked_last;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_value_te_chunked;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_header_value_te_token;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1:
-    s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_header_value;
-      goto s_n_llhttp__internal__n_invoke_load_header_state_2;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_value_discard_ws:
-    s_n_llhttp__internal__n_header_value_discard_ws: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_discard_ws;
-      }
-      switch (*p) {
-        case 9: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_discard_ws;
-        }
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_discard_lws;
-        }
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_discard_ws_almost_done;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_header_value_discard_ws;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete: {
-      switch (llhttp__on_header_field_complete(state, p, endp)) {
-        default:
-          goto s_n_llhttp__internal__n_header_value_discard_ws;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_general_otherwise:
-    s_n_llhttp__internal__n_header_field_general_otherwise: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_general_otherwise;
-      }
-      switch (*p) {
-        case ':': {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_2;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_24;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_general:
-    s_n_llhttp__internal__n_header_field_general: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 1, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0,
-        0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_general;
-      }
-      #ifdef __SSE4_2__
-      if (endp - p >= 16) {
-        __m128i ranges;
-        __m128i input;
-        int avail;
-        int match_len;
-      
-        /* Load input */
-        input = _mm_loadu_si128((__m128i const*) p);
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob8);
-      
-        /* Find first character that does not match `ranges` */
-        match_len = _mm_cmpestri(ranges, 16,
-            input, 16,
-            _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES |
-              _SIDD_NEGATIVE_POLARITY);
-      
-        if (match_len != 0) {
-          p += match_len;
-          goto s_n_llhttp__internal__n_header_field_general;
-        }
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob9);
-      
-        /* Find first character that does not match `ranges` */
-        match_len = _mm_cmpestri(ranges, 2,
-            input, 16,
-            _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES |
-              _SIDD_NEGATIVE_POLARITY);
-      
-        if (match_len != 0) {
-          p += match_len;
-          goto s_n_llhttp__internal__n_header_field_general;
-        }
-        goto s_n_llhttp__internal__n_header_field_general_otherwise;
-      }
-      #endif  /* __SSE4_2__ */
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_general;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_header_field_general_otherwise;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_colon:
-    s_n_llhttp__internal__n_header_field_colon: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_colon;
-      }
-      switch (*p) {
-        case ' ': {
-          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_2;
-        }
-        case ':': {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_9;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_3:
-    s_n_llhttp__internal__n_header_field_3: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_3;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob2, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_store_header_state;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_field_3;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_4:
-    s_n_llhttp__internal__n_header_field_4: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_4;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob10, 10);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_header_state;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_field_4;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_2:
-    s_n_llhttp__internal__n_header_field_2: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_2;
-      }
-      switch (((*p) >= 'A' && (*p) <= 'Z' ? (*p | 0x20) : (*p))) {
-        case 'n': {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_3;
-        }
-        case 't': {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_4;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_1:
-    s_n_llhttp__internal__n_header_field_1: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_1;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob1, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_2;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_field_1;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_5:
-    s_n_llhttp__internal__n_header_field_5: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_5;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob11, 15);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_store_header_state;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_field_5;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_6:
-    s_n_llhttp__internal__n_header_field_6: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_6;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob12, 16);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_store_header_state;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_field_6;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_7:
-    s_n_llhttp__internal__n_header_field_7: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_7;
-      }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob13, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_store_header_state;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_field_7;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field:
-    s_n_llhttp__internal__n_header_field: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field;
-      }
-      switch (((*p) >= 'A' && (*p) <= 'Z' ? (*p | 0x20) : (*p))) {
-        case 'c': {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_1;
-        }
-        case 'p': {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_5;
-        }
-        case 't': {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_6;
-        }
-        case 'u': {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_7;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_header_field:
-    s_n_llhttp__internal__n_span_start_llhttp__on_header_field: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_header_field;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_header_field;
-      goto s_n_llhttp__internal__n_header_field;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_header_field_start:
-    s_n_llhttp__internal__n_header_field_start: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_header_field_start;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_headers_almost_done;
-        }
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_headers_almost_done;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_field;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_skip_to_http09:
-    s_n_llhttp__internal__n_url_skip_to_http09: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_skip_to_http09;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_invoke_update_http_major;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_skip_lf_to_http09:
-    s_n_llhttp__internal__n_url_skip_lf_to_http09: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_skip_lf_to_http09;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob14, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_update_http_major;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_url_skip_lf_to_http09;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_25;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_pri_upgrade:
-    s_n_llhttp__internal__n_req_pri_upgrade: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_pri_upgrade;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob16, 10);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_error_30;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_req_pri_upgrade;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_31;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_complete_1:
-    s_n_llhttp__internal__n_req_http_complete_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_complete_1;
-      }
-      switch (*p) {
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_start;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_29;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_complete:
-    s_n_llhttp__internal__n_req_http_complete: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_complete;
-      }
-      switch (*p) {
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_header_field_start;
-        }
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_req_http_complete_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_29;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_minor:
-    s_n_llhttp__internal__n_req_http_minor: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_minor;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_34;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_dot:
-    s_n_llhttp__internal__n_req_http_dot: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_dot;
-      }
-      switch (*p) {
-        case '.': {
-          p++;
-          goto s_n_llhttp__internal__n_req_http_minor;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_35;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_major:
-    s_n_llhttp__internal__n_req_http_major: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_major;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_store_http_major;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_36;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_start_1:
-    s_n_llhttp__internal__n_req_http_start_1: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_start_1;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob15, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_load_method;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_req_http_start_1;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_39;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_start_2:
-    s_n_llhttp__internal__n_req_http_start_2: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_start_2;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob17, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_load_method_2;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_req_http_start_2;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_39;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_start_3:
-    s_n_llhttp__internal__n_req_http_start_3: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_start_3;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob18, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_load_method_3;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_req_http_start_3;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_39;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_http_start:
-    s_n_llhttp__internal__n_req_http_start: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_start;
-      }
-      switch (*p) {
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_req_http_start;
-        }
-        case 'H': {
-          p++;
-          goto s_n_llhttp__internal__n_req_http_start_1;
-        }
-        case 'I': {
-          p++;
-          goto s_n_llhttp__internal__n_req_http_start_2;
-        }
-        case 'R': {
-          p++;
-          goto s_n_llhttp__internal__n_req_http_start_3;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_39;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_skip_to_http:
-    s_n_llhttp__internal__n_url_skip_to_http: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_skip_to_http;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_invoke_llhttp__on_url_complete_1;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_fragment:
-    s_n_llhttp__internal__n_url_fragment: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 3, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_fragment;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_url_fragment;
-        }
-        case 2: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_6;
-        }
-        case 3: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_7;
-        }
-        case 4: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_8;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_40;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_end_stub_query_3:
-    s_n_llhttp__internal__n_span_end_stub_query_3: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_end_stub_query_3;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_url_fragment;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_query:
-    s_n_llhttp__internal__n_url_query: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 3, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        4, 1, 1, 5, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_query;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_url_query;
-        }
-        case 2: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_9;
-        }
-        case 3: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_10;
-        }
-        case 4: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_11;
-        }
-        case 5: {
-          goto s_n_llhttp__internal__n_span_end_stub_query_3;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_41;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_query_or_fragment:
-    s_n_llhttp__internal__n_url_query_or_fragment: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_query_or_fragment;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_3;
-        }
-        case 13: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_4;
-        }
-        case ' ': {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_5;
-        }
-        case '#': {
-          p++;
-          goto s_n_llhttp__internal__n_url_fragment;
-        }
-        case '?': {
-          p++;
-          goto s_n_llhttp__internal__n_url_query;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_42;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_path:
-    s_n_llhttp__internal__n_url_path: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_path;
-      }
-      #ifdef __SSE4_2__
-      if (endp - p >= 16) {
-        __m128i ranges;
-        __m128i input;
-        int avail;
-        int match_len;
-      
-        /* Load input */
-        input = _mm_loadu_si128((__m128i const*) p);
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob0);
-      
-        /* Find first character that does not match `ranges` */
-        match_len = _mm_cmpestri(ranges, 12,
-            input, 16,
-            _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES |
-              _SIDD_NEGATIVE_POLARITY);
-      
-        if (match_len != 0) {
-          p += match_len;
-          goto s_n_llhttp__internal__n_url_path;
-        }
-        goto s_n_llhttp__internal__n_url_query_or_fragment;
-      }
-      #endif  /* __SSE4_2__ */
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_url_path;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_url_query_or_fragment;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_stub_path_2:
-    s_n_llhttp__internal__n_span_start_stub_path_2: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_stub_path_2;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_url_path;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_stub_path:
-    s_n_llhttp__internal__n_span_start_stub_path: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_stub_path;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_url_path;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_stub_path_1:
-    s_n_llhttp__internal__n_span_start_stub_path_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_stub_path_1;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_url_path;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_server_with_at:
-    s_n_llhttp__internal__n_url_server_with_at: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        3, 4, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 0, 6,
-        7, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 0, 4,
-        0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 4, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_server_with_at;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_12;
-        }
-        case 2: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_13;
-        }
-        case 3: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_14;
-        }
-        case 4: {
-          p++;
-          goto s_n_llhttp__internal__n_url_server;
-        }
-        case 5: {
-          goto s_n_llhttp__internal__n_span_start_stub_path_1;
-        }
-        case 6: {
-          p++;
-          goto s_n_llhttp__internal__n_url_query;
-        }
-        case 7: {
-          p++;
-          goto s_n_llhttp__internal__n_error_43;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_44;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_server:
-    s_n_llhttp__internal__n_url_server: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        3, 4, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 0, 6,
-        7, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 0, 4,
-        0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 4, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_server;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url;
-        }
-        case 2: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_1;
-        }
-        case 3: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_url_2;
-        }
-        case 4: {
-          p++;
-          goto s_n_llhttp__internal__n_url_server;
-        }
-        case 5: {
-          goto s_n_llhttp__internal__n_span_start_stub_path;
-        }
-        case 6: {
-          p++;
-          goto s_n_llhttp__internal__n_url_query;
-        }
-        case 7: {
-          p++;
-          goto s_n_llhttp__internal__n_url_server_with_at;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_45;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_schema_delim_1:
-    s_n_llhttp__internal__n_url_schema_delim_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_schema_delim_1;
-      }
-      switch (*p) {
-        case '/': {
-          p++;
-          goto s_n_llhttp__internal__n_url_server;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_47;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_schema_delim:
-    s_n_llhttp__internal__n_url_schema_delim: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_schema_delim;
-      }
-      switch (*p) {
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_error_46;
-        }
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_error_46;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_error_46;
-        }
-        case '/': {
-          p++;
-          goto s_n_llhttp__internal__n_url_schema_delim_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_47;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_end_stub_schema:
-    s_n_llhttp__internal__n_span_end_stub_schema: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_end_stub_schema;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_url_schema_delim;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_schema:
-    s_n_llhttp__internal__n_url_schema: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0,
-        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
-        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_schema;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_error_46;
-        }
-        case 2: {
-          goto s_n_llhttp__internal__n_span_end_stub_schema;
-        }
-        case 3: {
-          p++;
-          goto s_n_llhttp__internal__n_url_schema;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_48;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_url_start:
-    s_n_llhttp__internal__n_url_start: {
-      static uint8_t lookup_table[] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
-        0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-      };
-      if (p == endp) {
-        return s_n_llhttp__internal__n_url_start;
-      }
-      switch (lookup_table[(uint8_t) *p]) {
-        case 1: {
-          p++;
-          goto s_n_llhttp__internal__n_error_46;
-        }
-        case 2: {
-          goto s_n_llhttp__internal__n_span_start_stub_path_2;
-        }
-        case 3: {
-          goto s_n_llhttp__internal__n_url_schema;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_49;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_url_1:
-    s_n_llhttp__internal__n_span_start_llhttp__on_url_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_url_1;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_url;
-      goto s_n_llhttp__internal__n_url_start;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_url:
-    s_n_llhttp__internal__n_span_start_llhttp__on_url: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_url;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_url;
-      goto s_n_llhttp__internal__n_url_server;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_spaces_before_url:
-    s_n_llhttp__internal__n_req_spaces_before_url: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_spaces_before_url;
-      }
-      switch (*p) {
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_req_spaces_before_url;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_is_equal_method;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_first_space_before_url:
-    s_n_llhttp__internal__n_req_first_space_before_url: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_first_space_before_url;
-      }
-      switch (*p) {
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_req_spaces_before_url;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_50;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_2:
-    s_n_llhttp__internal__n_start_req_2: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_2;
-      }
-      switch (*p) {
-        case 'L': {
-          p++;
-          match = 19;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_3:
-    s_n_llhttp__internal__n_start_req_3: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_3;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob19, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 36;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_3;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_1:
-    s_n_llhttp__internal__n_start_req_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_1;
-      }
-      switch (*p) {
-        case 'C': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_2;
-        }
-        case 'N': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_3;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_4:
-    s_n_llhttp__internal__n_start_req_4: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_4;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob20, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 16;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_4;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_6:
-    s_n_llhttp__internal__n_start_req_6: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_6;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob21, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 22;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_6;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_8:
-    s_n_llhttp__internal__n_start_req_8: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_8;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob22, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_8;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_9:
-    s_n_llhttp__internal__n_start_req_9: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_9;
-      }
-      switch (*p) {
-        case 'Y': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_7:
-    s_n_llhttp__internal__n_start_req_7: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_7;
-      }
-      switch (*p) {
-        case 'N': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_8;
-        }
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_9;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_5:
-    s_n_llhttp__internal__n_start_req_5: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_5;
-      }
-      switch (*p) {
-        case 'H': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_6;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_7;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_12:
-    s_n_llhttp__internal__n_start_req_12: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_12;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob23, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_12;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_13:
-    s_n_llhttp__internal__n_start_req_13: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_13;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob24, 5);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 35;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_13;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_11:
-    s_n_llhttp__internal__n_start_req_11: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_11;
-      }
-      switch (*p) {
-        case 'L': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_12;
-        }
-        case 'S': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_13;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_10:
-    s_n_llhttp__internal__n_start_req_10: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_10;
-      }
-      switch (*p) {
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_11;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_14:
-    s_n_llhttp__internal__n_start_req_14: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_14;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob25, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 45;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_14;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_17:
-    s_n_llhttp__internal__n_start_req_17: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_17;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob27, 9);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 41;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_17;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_16:
-    s_n_llhttp__internal__n_start_req_16: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_16;
-      }
-      switch (*p) {
-        case '_': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_17;
-        }
-        default: {
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_15:
-    s_n_llhttp__internal__n_start_req_15: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_15;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob26, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_16;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_15;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_18:
-    s_n_llhttp__internal__n_start_req_18: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_18;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob28, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_18;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_20:
-    s_n_llhttp__internal__n_start_req_20: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_20;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob29, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 31;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_20;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_21:
-    s_n_llhttp__internal__n_start_req_21: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_21;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob30, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_21;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_19:
-    s_n_llhttp__internal__n_start_req_19: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_19;
-      }
-      switch (*p) {
-        case 'I': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_20;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_21;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_23:
-    s_n_llhttp__internal__n_start_req_23: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_23;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob31, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 24;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_23;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_24:
-    s_n_llhttp__internal__n_start_req_24: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_24;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob32, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 23;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_24;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_26:
-    s_n_llhttp__internal__n_start_req_26: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_26;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob33, 7);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 21;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_26;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_28:
-    s_n_llhttp__internal__n_start_req_28: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_28;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob34, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 30;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_28;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_29:
-    s_n_llhttp__internal__n_start_req_29: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_29;
-      }
-      switch (*p) {
-        case 'L': {
-          p++;
-          match = 10;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_27:
-    s_n_llhttp__internal__n_start_req_27: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_27;
-      }
-      switch (*p) {
-        case 'A': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_28;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_29;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_25:
-    s_n_llhttp__internal__n_start_req_25: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_25;
-      }
-      switch (*p) {
-        case 'A': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_26;
-        }
-        case 'C': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_27;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_30:
-    s_n_llhttp__internal__n_start_req_30: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_30;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob35, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 11;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_30;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_22:
-    s_n_llhttp__internal__n_start_req_22: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_22;
-      }
-      switch (*p) {
-        case '-': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_23;
-        }
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_24;
-        }
-        case 'K': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_25;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_30;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_31:
-    s_n_llhttp__internal__n_start_req_31: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_31;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob36, 5);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 25;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_31;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_32:
-    s_n_llhttp__internal__n_start_req_32: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_32;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob37, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_32;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_35:
-    s_n_llhttp__internal__n_start_req_35: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_35;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob38, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 28;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_35;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_36:
-    s_n_llhttp__internal__n_start_req_36: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_36;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob39, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 39;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_36;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_34:
-    s_n_llhttp__internal__n_start_req_34: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_34;
-      }
-      switch (*p) {
-        case 'T': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_35;
-        }
-        case 'U': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_36;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_37:
-    s_n_llhttp__internal__n_start_req_37: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_37;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob40, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 38;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_37;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_38:
-    s_n_llhttp__internal__n_start_req_38: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_38;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob41, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_38;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_42:
-    s_n_llhttp__internal__n_start_req_42: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_42;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob42, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 12;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_42;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_43:
-    s_n_llhttp__internal__n_start_req_43: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_43;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob43, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 13;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_43;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_41:
-    s_n_llhttp__internal__n_start_req_41: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_41;
-      }
-      switch (*p) {
-        case 'F': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_42;
-        }
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_43;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_40:
-    s_n_llhttp__internal__n_start_req_40: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_40;
-      }
-      switch (*p) {
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_41;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_39:
-    s_n_llhttp__internal__n_start_req_39: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_39;
-      }
-      switch (*p) {
-        case 'I': {
-          p++;
-          match = 34;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_40;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_45:
-    s_n_llhttp__internal__n_start_req_45: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_45;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob44, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 29;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_45;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_44:
-    s_n_llhttp__internal__n_start_req_44: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_44;
-      }
-      switch (*p) {
-        case 'R': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_45;
-        }
-        case 'T': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_33:
-    s_n_llhttp__internal__n_start_req_33: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_33;
-      }
-      switch (*p) {
-        case 'A': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_34;
-        }
-        case 'L': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_37;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_38;
-        }
-        case 'R': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_39;
-        }
-        case 'U': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_44;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_48:
-    s_n_llhttp__internal__n_start_req_48: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_48;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob45, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 17;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_48;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_49:
-    s_n_llhttp__internal__n_start_req_49: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_49;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob46, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 44;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_49;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_50:
-    s_n_llhttp__internal__n_start_req_50: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_50;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob47, 5);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 43;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_50;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_51:
-    s_n_llhttp__internal__n_start_req_51: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_51;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob48, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 20;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_51;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_47:
-    s_n_llhttp__internal__n_start_req_47: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_47;
-      }
-      switch (*p) {
-        case 'B': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_48;
-        }
-        case 'C': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_49;
-        }
-        case 'D': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_50;
-        }
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_51;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_46:
-    s_n_llhttp__internal__n_start_req_46: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_46;
-      }
-      switch (*p) {
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_47;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_54:
-    s_n_llhttp__internal__n_start_req_54: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_54;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob49, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 14;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_54;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_56:
-    s_n_llhttp__internal__n_start_req_56: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_56;
-      }
-      switch (*p) {
-        case 'P': {
-          p++;
-          match = 37;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_57:
-    s_n_llhttp__internal__n_start_req_57: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_57;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob50, 9);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 42;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_57;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_55:
-    s_n_llhttp__internal__n_start_req_55: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_55;
-      }
-      switch (*p) {
-        case 'U': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_56;
-        }
-        case '_': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_57;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_53:
-    s_n_llhttp__internal__n_start_req_53: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_53;
-      }
-      switch (*p) {
-        case 'A': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_54;
-        }
-        case 'T': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_55;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_58:
-    s_n_llhttp__internal__n_start_req_58: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_58;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob51, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 33;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_58;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_59:
-    s_n_llhttp__internal__n_start_req_59: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_59;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob52, 7);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 26;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_59;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_52:
-    s_n_llhttp__internal__n_start_req_52: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_52;
-      }
-      switch (*p) {
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_53;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_58;
-        }
-        case 'U': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_59;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_61:
-    s_n_llhttp__internal__n_start_req_61: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_61;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob53, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 40;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_61;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_62:
-    s_n_llhttp__internal__n_start_req_62: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_62;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob54, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_62;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_60:
-    s_n_llhttp__internal__n_start_req_60: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_60;
-      }
-      switch (*p) {
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_61;
-        }
-        case 'R': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_62;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_65:
-    s_n_llhttp__internal__n_start_req_65: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_65;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob55, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 18;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_65;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_67:
-    s_n_llhttp__internal__n_start_req_67: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_67;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob56, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 32;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_67;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_68:
-    s_n_llhttp__internal__n_start_req_68: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_68;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob57, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 15;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_68;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_66:
-    s_n_llhttp__internal__n_start_req_66: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_66;
-      }
-      switch (*p) {
-        case 'I': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_67;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_68;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_69:
-    s_n_llhttp__internal__n_start_req_69: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_69;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob58, 8);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 27;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_69;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_64:
-    s_n_llhttp__internal__n_start_req_64: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_64;
-      }
-      switch (*p) {
-        case 'B': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_65;
-        }
-        case 'L': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_66;
-        }
-        case 'S': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_69;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_63:
-    s_n_llhttp__internal__n_start_req_63: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_63;
-      }
-      switch (*p) {
-        case 'N': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_64;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req:
-    s_n_llhttp__internal__n_start_req: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req;
-      }
-      switch (*p) {
-        case 'A': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_1;
-        }
-        case 'B': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_4;
-        }
-        case 'C': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_5;
-        }
-        case 'D': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_10;
-        }
-        case 'F': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_14;
-        }
-        case 'G': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_15;
-        }
-        case 'H': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_18;
-        }
-        case 'L': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_19;
-        }
-        case 'M': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_22;
-        }
-        case 'N': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_31;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_32;
-        }
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_33;
-        }
-        case 'R': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_46;
-        }
-        case 'S': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_52;
-        }
-        case 'T': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_60;
-        }
-        case 'U': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_63;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_62;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_llhttp__on_status_complete:
-    s_n_llhttp__internal__n_invoke_llhttp__on_status_complete: {
-      switch (llhttp__on_status_complete(state, p, endp)) {
-        default:
-          goto s_n_llhttp__internal__n_header_field_start;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_line_almost_done:
-    s_n_llhttp__internal__n_res_line_almost_done: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_line_almost_done;
-      }
-      p++;
-      goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_status:
-    s_n_llhttp__internal__n_res_status: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_status;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_status;
-        }
-        case 13: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_status_1;
-        }
-        default: {
-          p++;
-          goto s_n_llhttp__internal__n_res_status;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_span_start_llhttp__on_status:
-    s_n_llhttp__internal__n_span_start_llhttp__on_status: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_span_start_llhttp__on_status;
-      }
-      state->_span_pos0 = (void*) p;
-      state->_span_cb0 = llhttp__on_status;
-      goto s_n_llhttp__internal__n_res_status;
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_status_start:
-    s_n_llhttp__internal__n_res_status_start: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_status_start;
-      }
-      switch (*p) {
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
-        }
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_res_line_almost_done;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_status;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_status_code_otherwise:
-    s_n_llhttp__internal__n_res_status_code_otherwise: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_status_code_otherwise;
-      }
-      switch (*p) {
-        case 10: {
-          goto s_n_llhttp__internal__n_res_status_start;
-        }
-        case 13: {
-          goto s_n_llhttp__internal__n_res_status_start;
-        }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_res_status_start;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_54;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_status_code:
-    s_n_llhttp__internal__n_res_status_code: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_status_code;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_mul_add_status_code;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_res_status_code_otherwise;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_http_end:
-    s_n_llhttp__internal__n_res_http_end: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_http_end;
-      }
-      switch (*p) {
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_update_status_code;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_55;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_http_minor:
-    s_n_llhttp__internal__n_res_http_minor: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_http_minor;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_http_dot:
-    s_n_llhttp__internal__n_res_http_dot: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_http_dot;
-      }
-      switch (*p) {
-        case '.': {
-          p++;
-          goto s_n_llhttp__internal__n_res_http_minor;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_59;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_res_http_major:
-    s_n_llhttp__internal__n_res_http_major: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_res_http_major;
-      }
-      switch (*p) {
-        case '0': {
-          p++;
-          match = 0;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '1': {
-          p++;
-          match = 1;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '2': {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '3': {
-          p++;
-          match = 3;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '4': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '5': {
-          p++;
-          match = 5;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '6': {
-          p++;
-          match = 6;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '7': {
-          p++;
-          match = 7;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '8': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        case '9': {
-          p++;
-          match = 9;
-          goto s_n_llhttp__internal__n_invoke_store_http_major_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_60;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_res:
-    s_n_llhttp__internal__n_start_res: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_res;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob59, 5);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_res_http_major;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_res;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_63;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_or_res_method_2:
-    s_n_llhttp__internal__n_req_or_res_method_2: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_or_res_method_2;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob60, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_method;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_req_or_res_method_2;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_61;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_or_res_method_3:
-    s_n_llhttp__internal__n_req_or_res_method_3: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_or_res_method_3;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob61, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          goto s_n_llhttp__internal__n_invoke_update_type_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_req_or_res_method_3;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_61;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_or_res_method_1:
-    s_n_llhttp__internal__n_req_or_res_method_1: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_or_res_method_1;
-      }
-      switch (*p) {
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_req_or_res_method_2;
-        }
-        case 'T': {
-          p++;
-          goto s_n_llhttp__internal__n_req_or_res_method_3;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_61;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_req_or_res_method:
-    s_n_llhttp__internal__n_req_or_res_method: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_req_or_res_method;
-      }
-      switch (*p) {
-        case 'H': {
-          p++;
-          goto s_n_llhttp__internal__n_req_or_res_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_61;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_or_res:
-    s_n_llhttp__internal__n_start_req_or_res: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_or_res;
-      }
-      switch (*p) {
-        case 'H': {
-          goto s_n_llhttp__internal__n_req_or_res_method;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_update_type_2;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_invoke_load_type:
-    s_n_llhttp__internal__n_invoke_load_type: {
-      switch (llhttp__internal__c_load_type(state, p, endp)) {
-        case 1:
-          goto s_n_llhttp__internal__n_start_req;
-        case 2:
-          goto s_n_llhttp__internal__n_start_res;
-        default:
-          goto s_n_llhttp__internal__n_start_req_or_res;
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start:
-    s_n_llhttp__internal__n_start: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start;
-      }
-      switch (*p) {
-        case 10: {
-          p++;
-          goto s_n_llhttp__internal__n_start;
-        }
-        case 13: {
-          p++;
-          goto s_n_llhttp__internal__n_start;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_update_finish;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    default:
-      /* UNREACHABLE */
-      abort();
-  }
-  s_n_llhttp__internal__n_error_46: {
-    state->error = 0x7;
-    state->reason = "Invalid characters in url";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_finish_2: {
-    switch (llhttp__internal__c_update_finish_1(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_start;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags: {
-    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_update_finish_2;
-      default:
-        goto s_n_llhttp__internal__n_closed;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_finish_1: {
-    switch (llhttp__internal__c_update_finish_1(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_5: {
-    state->error = 0x15;
-    state->reason = "on_message_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_is_equal_upgrade;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_10: {
-    state->error = 0x12;
-    state->reason = "`on_message_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_7: {
-    state->error = 0x15;
-    state->reason = "on_chunk_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_13: {
-    state->error = 0x14;
-    state->reason = "`on_chunk_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete_1: {
-    switch (llhttp__on_chunk_complete(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_7;
-      default:
-        goto s_n_llhttp__internal__n_error_13;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_12: {
-    state->error = 0x4;
-    state->reason = "Content-Length can't be present with Transfer-Encoding";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_2: {
-    state->error = 0x15;
-    state->reason = "on_message_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_pause_1;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_3: {
-    state->error = 0x12;
-    state->reason = "`on_message_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_1: {
-    switch (llhttp__on_message_complete(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_pause_1;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_2;
-      default:
-        goto s_n_llhttp__internal__n_error_3;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_8: {
-    state->error = 0xc;
-    state->reason = "Chunk size overflow";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_3: {
-    state->error = 0x15;
-    state->reason = "on_chunk_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_update_content_length;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_5: {
-    state->error = 0x14;
-    state->reason = "`on_chunk_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete: {
-    switch (llhttp__on_chunk_complete(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_update_content_length;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_3;
-      default:
-        goto s_n_llhttp__internal__n_error_5;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_body: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_body(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_data_almost_done;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_chunk_data_almost_done;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags: {
-    switch (llhttp__internal__c_or_flags(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_field_start;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_4: {
-    state->error = 0x15;
-    state->reason = "on_chunk_header pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_is_equal_content_length;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_4: {
-    state->error = 0x13;
-    state->reason = "`on_chunk_header` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_chunk_header: {
-    switch (llhttp__on_chunk_header(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_is_equal_content_length;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_4;
-      default:
-        goto s_n_llhttp__internal__n_error_4;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_6: {
-    state->error = 0x2;
-    state->reason = "Invalid character in chunk parameters";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_7: {
-    state->error = 0xc;
-    state->reason = "Invalid character in chunk size";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_mul_add_content_length: {
-    switch (llhttp__internal__c_mul_add_content_length(state, p, endp, match)) {
-      case 1:
-        goto s_n_llhttp__internal__n_error_8;
-      default:
-        goto s_n_llhttp__internal__n_chunk_size;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_9: {
-    state->error = 0xc;
-    state->reason = "Invalid character in chunk size";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_body_1: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_body(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_finish_3: {
-    switch (llhttp__internal__c_update_finish_3(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_body_2;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_11: {
-    state->error = 0xf;
-    state->reason = "Request has invalid `Transfer-Encoding`";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause: {
-    state->error = 0x15;
-    state->reason = "on_message_complete pause";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_2: {
-    state->error = 0x12;
-    state->reason = "`on_message_complete` callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_message_complete: {
-    switch (llhttp__on_message_complete(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
-      case 21:
-        goto s_n_llhttp__internal__n_pause;
-      default:
-        goto s_n_llhttp__internal__n_error_2;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_1: {
-    switch (llhttp__internal__c_or_flags_1(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_2: {
-    switch (llhttp__internal__c_or_flags_1(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_upgrade: {
-    switch (llhttp__internal__c_update_upgrade(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_or_flags_2;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_pause_6: {
-    state->error = 0x15;
-    state->reason = "Paused by on_headers_complete";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_1: {
-    state->error = 0x11;
-    state->reason = "User callback error";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_headers_complete: {
-    switch (llhttp__on_headers_complete(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_or_flags_1;
-      case 2:
-        goto s_n_llhttp__internal__n_invoke_update_upgrade;
-      case 21:
-        goto s_n_llhttp__internal__n_pause_6;
-      default:
-        goto s_n_llhttp__internal__n_error_1;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete: {
-    switch (llhttp__before_headers_complete(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_headers_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_1: {
-    switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_error_12;
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_flags_1: {
-    switch (llhttp__internal__c_test_flags_1(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_1;
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_flags: {
-    switch (llhttp__internal__c_test_flags(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_chunk_complete_1;
-      default:
-        goto s_n_llhttp__internal__n_invoke_test_flags_1;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_field: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_field(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_14;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_error_14;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_2: {
-    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_header_field_colon_discard_ws;
-      default:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_15: {
-    state->error = 0xb;
-    state->reason = "Empty Content-Length";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state: {
-    switch (llhttp__internal__c_update_header_state(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_3: {
-    switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_4: {
-    switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_5: {
-    switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_6: {
-    switch (llhttp__internal__c_or_flags_6(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_header_state_1: {
-    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
-      case 5:
-        goto s_n_llhttp__internal__n_invoke_or_flags_3;
-      case 6:
-        goto s_n_llhttp__internal__n_invoke_or_flags_4;
-      case 7:
-        goto s_n_llhttp__internal__n_invoke_or_flags_5;
-      case 8:
-        goto s_n_llhttp__internal__n_invoke_or_flags_6;
-      default:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_header_state: {
-    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
-      case 2:
-        goto s_n_llhttp__internal__n_error_15;
-      default:
-        goto s_n_llhttp__internal__n_invoke_load_header_state_1;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_1: {
-    switch (llhttp__internal__c_update_header_state(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_7: {
-    switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_8: {
-    switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_9: {
-    switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_10: {
-    switch (llhttp__internal__c_or_flags_6(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_header_state_3: {
-    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
-      case 5:
-        goto s_n_llhttp__internal__n_invoke_or_flags_7;
-      case 6:
-        goto s_n_llhttp__internal__n_invoke_or_flags_8;
-      case 7:
-        goto s_n_llhttp__internal__n_invoke_or_flags_9;
-      case 8:
-        goto s_n_llhttp__internal__n_invoke_or_flags_10;
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_16: {
-    state->error = 0x3;
-    state->reason = "Missing expected LF after header value";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_header_value_almost_done;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_header_value_almost_done;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_header_value_almost_done;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_17;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_error_17;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_18: {
-    state->error = 0xa;
-    state->reason = "Invalid header value char";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_3: {
-    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_header_value_lenient;
-      default:
-        goto s_n_llhttp__internal__n_header_value_lenient_failed;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_3: {
-    switch (llhttp__internal__c_update_header_state(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_connection;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_11: {
-    switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_12: {
-    switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_13: {
-    switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_14: {
-    switch (llhttp__internal__c_or_flags_6(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_connection;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_header_state_4: {
-    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
-      case 5:
-        goto s_n_llhttp__internal__n_invoke_or_flags_11;
-      case 6:
-        goto s_n_llhttp__internal__n_invoke_or_flags_12;
-      case 7:
-        goto s_n_llhttp__internal__n_invoke_or_flags_13;
-      case 8:
-        goto s_n_llhttp__internal__n_invoke_or_flags_14;
-      default:
-        goto s_n_llhttp__internal__n_header_value_connection;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_4: {
-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_connection_token;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_2: {
-    switch (llhttp__internal__c_update_header_state_2(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_connection_ws;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_5: {
-    switch (llhttp__internal__c_update_header_state_5(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_connection_ws;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_6: {
-    switch (llhttp__internal__c_update_header_state_6(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_connection_ws;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_20;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_error_20;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_mul_add_content_length_1: {
-    switch (llhttp__internal__c_mul_add_content_length_1(state, p, endp, match)) {
-      case 1:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5;
-      default:
-        goto s_n_llhttp__internal__n_header_value_content_length;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_15: {
-    switch (llhttp__internal__c_or_flags_15(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_otherwise;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_6: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_21;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_error_21;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_19: {
-    state->error = 0x4;
-    state->reason = "Duplicate Content-Length";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_flags_2: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_header_value_content_length;
-      default:
-        goto s_n_llhttp__internal__n_error_19;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_23;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_error_23;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_7: {
-    switch (llhttp__internal__c_update_header_state_7(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_otherwise;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_value(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_22;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_error_22;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_4: {
-    switch (llhttp__internal__c_test_lenient_flags_4(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7;
-      default:
-        goto s_n_llhttp__internal__n_header_value_te_chunked;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_type_1: {
-    switch (llhttp__internal__c_load_type(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_4;
-      default:
-        goto s_n_llhttp__internal__n_header_value_te_chunked;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_8: {
-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_and_flags: {
-    switch (llhttp__internal__c_and_flags(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_value_te_chunked;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_17: {
-    switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_and_flags;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_5: {
-    switch (llhttp__internal__c_test_lenient_flags_4(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8;
-      default:
-        goto s_n_llhttp__internal__n_invoke_or_flags_17;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_type_2: {
-    switch (llhttp__internal__c_load_type(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_5;
-      default:
-        goto s_n_llhttp__internal__n_invoke_or_flags_17;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_16: {
-    switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_and_flags;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_flags_3: {
-    switch (llhttp__internal__c_test_flags_3(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_load_type_2;
-      default:
-        goto s_n_llhttp__internal__n_invoke_or_flags_16;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_or_flags_18: {
-    switch (llhttp__internal__c_or_flags_18(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_header_state_8;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_header_state_2: {
-    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_header_value_connection;
-      case 2:
-        goto s_n_llhttp__internal__n_invoke_test_flags_2;
-      case 3:
-        goto s_n_llhttp__internal__n_invoke_test_flags_3;
-      case 4:
-        goto s_n_llhttp__internal__n_invoke_or_flags_18;
-      default:
-        goto s_n_llhttp__internal__n_header_value;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_field_1: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_field(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_field_2: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_header_field(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_24: {
-    state->error = 0xa;
-    state->reason = "Invalid header token";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_9: {
-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_field_general;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_store_header_state: {
-    switch (llhttp__internal__c_store_header_state(state, p, endp, match)) {
-      default:
-        goto s_n_llhttp__internal__n_header_field_colon;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_header_state_10: {
-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_field_general;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_url_complete: {
-    switch (llhttp__on_url_complete(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_header_field_start;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_http_minor: {
-    switch (llhttp__internal__c_update_http_minor(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_url_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_update_http_major: {
-    switch (llhttp__internal__c_update_http_major(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_update_http_minor;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_3: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_25: {
-    state->error = 0x7;
-    state->reason = "Expected CRLF";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_4: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_lf_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_lf_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_30: {
-    state->error = 0x17;
-    state->reason = "Pause on PRI/Upgrade";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_31: {
-    state->error = 0x9;
-    state->reason = "Expected HTTP/2 Connection Preface";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_29: {
-    state->error = 0x9;
-    state->reason = "Expected CRLF after version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_method_1: {
-    switch (llhttp__internal__c_load_method(state, p, endp)) {
-      case 34:
-        goto s_n_llhttp__internal__n_req_pri_upgrade;
-      default:
-        goto s_n_llhttp__internal__n_req_http_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_28: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_minor: {
-    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
-      case 9:
-        goto s_n_llhttp__internal__n_invoke_load_method_1;
-      default:
-        goto s_n_llhttp__internal__n_error_28;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_32: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_minor_1: {
-    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_load_method_1;
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_load_method_1;
-      default:
-        goto s_n_llhttp__internal__n_error_32;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_33: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_minor_2: {
-    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_load_method_1;
-      default:
-        goto s_n_llhttp__internal__n_error_33;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_27: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_http_major: {
-    switch (llhttp__internal__c_load_http_major(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_invoke_load_http_minor;
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_load_http_minor_1;
-      case 2:
-        goto s_n_llhttp__internal__n_invoke_load_http_minor_2;
-      default:
-        goto s_n_llhttp__internal__n_error_27;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_6: {
-    switch (llhttp__internal__c_test_lenient_flags_6(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_load_method_1;
-      default:
-        goto s_n_llhttp__internal__n_invoke_load_http_major;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_store_http_minor: {
-    switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
-      default:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_6;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_34: {
-    state->error = 0x9;
-    state->reason = "Invalid minor version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_35: {
-    state->error = 0x9;
-    state->reason = "Expected dot";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_store_http_major: {
-    switch (llhttp__internal__c_store_http_major(state, p, endp, match)) {
-      default:
-        goto s_n_llhttp__internal__n_req_http_dot;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_36: {
-    state->error = 0x9;
-    state->reason = "Invalid major version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_26: {
-    state->error = 0x8;
-    state->reason = "Invalid method for HTTP/x.x request";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_method: {
-    switch (llhttp__internal__c_load_method(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 1:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 2:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 3:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 4:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 5:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 6:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 7:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 8:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 9:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 10:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 11:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 12:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 13:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 14:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 15:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 16:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 17:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 18:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 19:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 20:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 21:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 22:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 23:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 24:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 25:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 26:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 27:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 28:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 29:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 30:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 31:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 32:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 33:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 34:
-        goto s_n_llhttp__internal__n_req_http_major;
-      default:
-        goto s_n_llhttp__internal__n_error_26;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_39: {
-    state->error = 0x8;
-    state->reason = "Expected HTTP/";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_37: {
-    state->error = 0x8;
-    state->reason = "Expected SOURCE method for ICE/x.x request";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_method_2: {
-    switch (llhttp__internal__c_load_method(state, p, endp)) {
-      case 33:
-        goto s_n_llhttp__internal__n_req_http_major;
-      default:
-        goto s_n_llhttp__internal__n_error_37;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_38: {
-    state->error = 0x8;
-    state->reason = "Invalid method for RTSP/x.x request";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_load_method_3: {
-    switch (llhttp__internal__c_load_method(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 3:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 6:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 35:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 36:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 37:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 38:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 39:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 40:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 41:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 42:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 43:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 44:
-        goto s_n_llhttp__internal__n_req_http_major;
-      case 45:
-        goto s_n_llhttp__internal__n_req_http_major;
-      default:
-        goto s_n_llhttp__internal__n_error_38;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_llhttp__on_url_complete_1: {
-    switch (llhttp__on_url_complete(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_req_http_start;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_5: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_6: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_7: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_lf_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_lf_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_8: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_40: {
-    state->error = 0x7;
-    state->reason = "Invalid char in url fragment start";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_9: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_10: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_lf_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_lf_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_11: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_41: {
-    state->error = 0x7;
-    state->reason = "Invalid char in url query";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_42: {
-    state->error = 0x7;
-    state->reason = "Invalid char in url path";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_1: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_lf_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_lf_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_2: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_12: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_13: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_lf_to_http09;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_lf_to_http09;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_url_14: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_url(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_url_skip_to_http;
-      return s_error;
-    }
-    goto s_n_llhttp__internal__n_url_skip_to_http;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_43: {
-    state->error = 0x7;
-    state->reason = "Double @ in url";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_44: {
-    state->error = 0x7;
-    state->reason = "Unexpected char in url server";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_45: {
-    state->error = 0x7;
-    state->reason = "Unexpected char in url server";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_47: {
-    state->error = 0x7;
-    state->reason = "Unexpected char in url schema";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_48: {
-    state->error = 0x7;
-    state->reason = "Unexpected char in url schema";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_49: {
-    state->error = 0x7;
-    state->reason = "Unexpected start char in url";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_is_equal_method: {
-    switch (llhttp__internal__c_is_equal_method(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_url_1;
-      default:
-        goto s_n_llhttp__internal__n_span_start_llhttp__on_url;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_50: {
-    state->error = 0x6;
-    state->reason = "Expected space after method";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_store_method_1: {
-    switch (llhttp__internal__c_store_method(state, p, endp, match)) {
-      default:
-        goto s_n_llhttp__internal__n_req_first_space_before_url;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_62: {
-    state->error = 0x6;
-    state->reason = "Invalid method encountered";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_53: {
+  s_n_llhttp__internal__n_error_79: {
     state->error = 0xd;
-    state->reason = "Response overflow";
+    state->reason = "Invalid status code";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_mul_add_status_code_1: {
+    switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
+      case 1:
+        goto s_n_llhttp__internal__n_error_80;
+      default:
+        goto s_n_llhttp__internal__n_res_status_code_digit_3;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_81: {
+    state->error = 0xd;
+    state->reason = "Invalid status code";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
@@ -15529,52 +9128,16 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_mul_add_status_code: {
     switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
       case 1:
-        goto s_n_llhttp__internal__n_error_53;
+        goto s_n_llhttp__internal__n_error_82;
       default:
-        goto s_n_llhttp__internal__n_res_status_code;
+        goto s_n_llhttp__internal__n_res_status_code_digit_2;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_span_end_llhttp__on_status: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_status(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_span_end_llhttp__on_status_1: {
-    const unsigned char* start;
-    int err;
-    
-    start = state->_span_pos0;
-    state->_span_pos0 = NULL;
-    err = llhttp__on_status(state, start, p);
-    if (err != 0) {
-      state->error = err;
-      state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_res_line_almost_done;
-      return s_error;
-    }
-    p++;
-    goto s_n_llhttp__internal__n_res_line_almost_done;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_54: {
+  s_n_llhttp__internal__n_error_83: {
     state->error = 0xd;
-    state->reason = "Invalid response status";
+    state->reason = "Invalid status code";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
@@ -15584,12 +9147,12 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_update_status_code: {
     switch (llhttp__internal__c_update_status_code(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_res_status_code;
+        goto s_n_llhttp__internal__n_res_status_code_digit_1;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_55: {
+  s_n_llhttp__internal__n_error_84: {
     state->error = 0x9;
     state->reason = "Expected space after version";
     state->error_pos = (const char*) p;
@@ -15598,71 +9161,87 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_52: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
+  s_n_llhttp__internal__n_pause_21: {
+    state->error = 0x15;
+    state->reason = "on_version_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_res_after_version;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_74: {
+    state->error = 0x21;
+    state->reason = "`on_version_complete` callback error";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_version_6: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_version(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_version_complete_1;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_version_complete_1;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_version_5: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_version(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_73;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_error_73;
     /* UNREACHABLE */;
     abort();
   }
   s_n_llhttp__internal__n_invoke_load_http_minor_3: {
     switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
       case 9:
-        goto s_n_llhttp__internal__n_res_http_end;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_6;
       default:
-        goto s_n_llhttp__internal__n_error_52;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_5;
     }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_56: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
     /* UNREACHABLE */;
     abort();
   }
   s_n_llhttp__internal__n_invoke_load_http_minor_4: {
     switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
       case 0:
-        goto s_n_llhttp__internal__n_res_http_end;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_6;
       case 1:
-        goto s_n_llhttp__internal__n_res_http_end;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_6;
       default:
-        goto s_n_llhttp__internal__n_error_56;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_5;
     }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_57: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
     /* UNREACHABLE */;
     abort();
   }
   s_n_llhttp__internal__n_invoke_load_http_minor_5: {
     switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
       case 0:
-        goto s_n_llhttp__internal__n_res_http_end;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_6;
       default:
-        goto s_n_llhttp__internal__n_error_57;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_5;
     }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_51: {
-    state->error = 0x9;
-    state->reason = "Invalid HTTP version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
     /* UNREACHABLE */;
     abort();
   }
@@ -15675,15 +9254,15 @@ static llparse_state_t llhttp__internal__run(
       case 2:
         goto s_n_llhttp__internal__n_invoke_load_http_minor_5;
       default:
-        goto s_n_llhttp__internal__n_error_51;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_5;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_lenient_flags_7: {
-    switch (llhttp__internal__c_test_lenient_flags_6(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_17: {
+    switch (llhttp__internal__c_test_lenient_flags_15(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_res_http_end;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_version_6;
       default:
         goto s_n_llhttp__internal__n_invoke_load_http_major_1;
     }
@@ -15693,26 +9272,42 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_store_http_minor_1: {
     switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
       default:
-        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_7;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_17;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_58: {
-    state->error = 0x9;
-    state->reason = "Invalid minor version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
+  s_n_llhttp__internal__n_span_end_llhttp__on_version_7: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_version(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_85;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_error_85;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_59: {
-    state->error = 0x9;
-    state->reason = "Expected dot";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
+  s_n_llhttp__internal__n_span_end_llhttp__on_version_8: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_version(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_86;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_error_86;
     /* UNREACHABLE */;
     abort();
   }
@@ -15724,16 +9319,24 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_60: {
-    state->error = 0x9;
-    state->reason = "Invalid major version";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
+  s_n_llhttp__internal__n_span_end_llhttp__on_version_9: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_version(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_87;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_error_87;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_63: {
+  s_n_llhttp__internal__n_error_91: {
     state->error = 0x8;
     state->reason = "Expected HTTP/";
     state->error_pos = (const char*) p;
@@ -15742,10 +9345,45 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
+  s_n_llhttp__internal__n_pause_19: {
+    state->error = 0x15;
+    state->reason = "on_method_complete pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_req_first_space_before_url;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_1: {
+    state->error = 0x20;
+    state->reason = "`on_method_complete` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_method: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_method(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_method_complete;
+      return s_error;
+    }
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_method_complete;
+    /* UNREACHABLE */;
+    abort();
+  }
   s_n_llhttp__internal__n_invoke_update_type: {
     switch (llhttp__internal__c_update_type(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_req_first_space_before_url;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_method;
     }
     /* UNREACHABLE */;
     abort();
@@ -15758,7 +9396,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_61: {
+  s_n_llhttp__internal__n_error_88: {
     state->error = 0x8;
     state->reason = "Invalid word encountered";
     state->error_pos = (const char*) p;
@@ -15767,23 +9405,32 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_update_type_1: {
-    switch (llhttp__internal__c_update_type_1(state, p, endp)) {
-      default:
-        goto s_n_llhttp__internal__n_res_http_major;
+  s_n_llhttp__internal__n_span_end_llhttp__on_method_1: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_method(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) p;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_update_type_1;
+      return s_error;
     }
+    goto s_n_llhttp__internal__n_invoke_update_type_1;
     /* UNREACHABLE */;
     abort();
   }
   s_n_llhttp__internal__n_invoke_update_type_2: {
     switch (llhttp__internal__c_update_type(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_start_req;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_method_1;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_pause_8: {
+  s_n_llhttp__internal__n_pause_23: {
     state->error = 0x15;
     state->reason = "on_message_begin pause";
     state->error_pos = (const char*) p;
@@ -15806,17 +9453,49 @@ static llparse_state_t llhttp__internal__run(
       case 0:
         goto s_n_llhttp__internal__n_invoke_load_type;
       case 21:
-        goto s_n_llhttp__internal__n_pause_8;
+        goto s_n_llhttp__internal__n_pause_23;
       default:
         goto s_n_llhttp__internal__n_error;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_update_finish: {
-    switch (llhttp__internal__c_update_finish(state, p, endp)) {
+  s_n_llhttp__internal__n_pause_24: {
+    state->error = 0x15;
+    state->reason = "on_reset pause";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_update_finish;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_92: {
+    state->error = 0x1f;
+    state->reason = "`on_reset` callback error";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__on_reset: {
+    switch (llhttp__on_reset(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_update_finish;
+      case 21:
+        goto s_n_llhttp__internal__n_pause_24;
       default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__on_message_begin;
+        goto s_n_llhttp__internal__n_error_92;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_initial_message_completed: {
+    switch (llhttp__internal__c_load_initial_message_completed(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_reset;
+      default:
+        goto s_n_llhttp__internal__n_invoke_update_finish;
     }
     /* UNREACHABLE */;
     abort();
@@ -15856,5 +9535,3 @@ int llhttp__internal_execute(llhttp__internal_t* state, const char* p, const cha
   
   return 0;
 }
-
-#endif  /* LLHTTP_STRICT_MODE */

--- a/3rdparty/exported/llhttp/llhttp.h
+++ b/3rdparty/exported/llhttp/llhttp.h
@@ -1,13 +1,10 @@
+
 #ifndef INCLUDE_LLHTTP_H_
 #define INCLUDE_LLHTTP_H_
 
-#define LLHTTP_VERSION_MAJOR 6
+#define LLHTTP_VERSION_MAJOR 9
 #define LLHTTP_VERSION_MINOR 0
-#define LLHTTP_VERSION_PATCH 9
-
-#ifndef LLHTTP_STRICT_MODE
-# define LLHTTP_STRICT_MODE 0
-#endif
+#define LLHTTP_VERSION_PATCH 1
 
 #ifndef INCLUDE_LLHTTP_ITSELF_H_
 #define INCLUDE_LLHTTP_ITSELF_H_
@@ -38,6 +35,7 @@ struct llhttp__internal_s {
   uint8_t finish;
   uint16_t flags;
   uint16_t status_code;
+  uint8_t initial_message_completed;
   void* settings;
 };
 
@@ -48,6 +46,7 @@ int llhttp__internal_execute(llhttp__internal_t* s, const char* p, const char* e
 }  /* extern "C" */
 #endif
 #endif  /* INCLUDE_LLHTTP_ITSELF_H_ */
+
 
 #ifndef LLLLHTTP_C_HEADERS_
 #define LLLLHTTP_C_HEADERS_
@@ -62,6 +61,7 @@ enum llhttp_errno {
   HPE_CR_EXPECTED = 25,
   HPE_LF_EXPECTED = 3,
   HPE_UNEXPECTED_CONTENT_LENGTH = 4,
+  HPE_UNEXPECTED_SPACE = 30,
   HPE_CLOSED_CONNECTION = 5,
   HPE_INVALID_METHOD = 6,
   HPE_INVALID_URL = 7,
@@ -81,7 +81,16 @@ enum llhttp_errno {
   HPE_PAUSED = 21,
   HPE_PAUSED_UPGRADE = 22,
   HPE_PAUSED_H2_UPGRADE = 23,
-  HPE_USER = 24
+  HPE_USER = 24,
+  HPE_CB_URL_COMPLETE = 26,
+  HPE_CB_STATUS_COMPLETE = 27,
+  HPE_CB_METHOD_COMPLETE = 32,
+  HPE_CB_VERSION_COMPLETE = 33,
+  HPE_CB_HEADER_FIELD_COMPLETE = 28,
+  HPE_CB_HEADER_VALUE_COMPLETE = 29,
+  HPE_CB_CHUNK_EXTENSION_NAME_COMPLETE = 34,
+  HPE_CB_CHUNK_EXTENSION_VALUE_COMPLETE = 35,
+  HPE_CB_RESET = 31
 };
 typedef enum llhttp_errno llhttp_errno_t;
 
@@ -103,7 +112,10 @@ enum llhttp_lenient_flags {
   LENIENT_CHUNKED_LENGTH = 0x2,
   LENIENT_KEEP_ALIVE = 0x4,
   LENIENT_TRANSFER_ENCODING = 0x8,
-  LENIENT_VERSION = 0x10
+  LENIENT_VERSION = 0x10,
+  LENIENT_DATA_AFTER_CLOSE = 0x20,
+  LENIENT_OPTIONAL_LF_AFTER_CR = 0x40,
+  LENIENT_OPTIONAL_CRLF_AFTER_CHUNK = 0x80
 };
 typedef enum llhttp_lenient_flags llhttp_lenient_flags_t;
 
@@ -171,6 +183,109 @@ enum llhttp_method {
 };
 typedef enum llhttp_method llhttp_method_t;
 
+enum llhttp_status {
+  HTTP_STATUS_CONTINUE = 100,
+  HTTP_STATUS_SWITCHING_PROTOCOLS = 101,
+  HTTP_STATUS_PROCESSING = 102,
+  HTTP_STATUS_EARLY_HINTS = 103,
+  HTTP_STATUS_RESPONSE_IS_STALE = 110,
+  HTTP_STATUS_REVALIDATION_FAILED = 111,
+  HTTP_STATUS_DISCONNECTED_OPERATION = 112,
+  HTTP_STATUS_HEURISTIC_EXPIRATION = 113,
+  HTTP_STATUS_MISCELLANEOUS_WARNING = 199,
+  HTTP_STATUS_OK = 200,
+  HTTP_STATUS_CREATED = 201,
+  HTTP_STATUS_ACCEPTED = 202,
+  HTTP_STATUS_NON_AUTHORITATIVE_INFORMATION = 203,
+  HTTP_STATUS_NO_CONTENT = 204,
+  HTTP_STATUS_RESET_CONTENT = 205,
+  HTTP_STATUS_PARTIAL_CONTENT = 206,
+  HTTP_STATUS_MULTI_STATUS = 207,
+  HTTP_STATUS_ALREADY_REPORTED = 208,
+  HTTP_STATUS_TRANSFORMATION_APPLIED = 214,
+  HTTP_STATUS_IM_USED = 226,
+  HTTP_STATUS_MISCELLANEOUS_PERSISTENT_WARNING = 299,
+  HTTP_STATUS_MULTIPLE_CHOICES = 300,
+  HTTP_STATUS_MOVED_PERMANENTLY = 301,
+  HTTP_STATUS_FOUND = 302,
+  HTTP_STATUS_SEE_OTHER = 303,
+  HTTP_STATUS_NOT_MODIFIED = 304,
+  HTTP_STATUS_USE_PROXY = 305,
+  HTTP_STATUS_SWITCH_PROXY = 306,
+  HTTP_STATUS_TEMPORARY_REDIRECT = 307,
+  HTTP_STATUS_PERMANENT_REDIRECT = 308,
+  HTTP_STATUS_BAD_REQUEST = 400,
+  HTTP_STATUS_UNAUTHORIZED = 401,
+  HTTP_STATUS_PAYMENT_REQUIRED = 402,
+  HTTP_STATUS_FORBIDDEN = 403,
+  HTTP_STATUS_NOT_FOUND = 404,
+  HTTP_STATUS_METHOD_NOT_ALLOWED = 405,
+  HTTP_STATUS_NOT_ACCEPTABLE = 406,
+  HTTP_STATUS_PROXY_AUTHENTICATION_REQUIRED = 407,
+  HTTP_STATUS_REQUEST_TIMEOUT = 408,
+  HTTP_STATUS_CONFLICT = 409,
+  HTTP_STATUS_GONE = 410,
+  HTTP_STATUS_LENGTH_REQUIRED = 411,
+  HTTP_STATUS_PRECONDITION_FAILED = 412,
+  HTTP_STATUS_PAYLOAD_TOO_LARGE = 413,
+  HTTP_STATUS_URI_TOO_LONG = 414,
+  HTTP_STATUS_UNSUPPORTED_MEDIA_TYPE = 415,
+  HTTP_STATUS_RANGE_NOT_SATISFIABLE = 416,
+  HTTP_STATUS_EXPECTATION_FAILED = 417,
+  HTTP_STATUS_IM_A_TEAPOT = 418,
+  HTTP_STATUS_PAGE_EXPIRED = 419,
+  HTTP_STATUS_ENHANCE_YOUR_CALM = 420,
+  HTTP_STATUS_MISDIRECTED_REQUEST = 421,
+  HTTP_STATUS_UNPROCESSABLE_ENTITY = 422,
+  HTTP_STATUS_LOCKED = 423,
+  HTTP_STATUS_FAILED_DEPENDENCY = 424,
+  HTTP_STATUS_TOO_EARLY = 425,
+  HTTP_STATUS_UPGRADE_REQUIRED = 426,
+  HTTP_STATUS_PRECONDITION_REQUIRED = 428,
+  HTTP_STATUS_TOO_MANY_REQUESTS = 429,
+  HTTP_STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE_UNOFFICIAL = 430,
+  HTTP_STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE = 431,
+  HTTP_STATUS_LOGIN_TIMEOUT = 440,
+  HTTP_STATUS_NO_RESPONSE = 444,
+  HTTP_STATUS_RETRY_WITH = 449,
+  HTTP_STATUS_BLOCKED_BY_PARENTAL_CONTROL = 450,
+  HTTP_STATUS_UNAVAILABLE_FOR_LEGAL_REASONS = 451,
+  HTTP_STATUS_CLIENT_CLOSED_LOAD_BALANCED_REQUEST = 460,
+  HTTP_STATUS_INVALID_X_FORWARDED_FOR = 463,
+  HTTP_STATUS_REQUEST_HEADER_TOO_LARGE = 494,
+  HTTP_STATUS_SSL_CERTIFICATE_ERROR = 495,
+  HTTP_STATUS_SSL_CERTIFICATE_REQUIRED = 496,
+  HTTP_STATUS_HTTP_REQUEST_SENT_TO_HTTPS_PORT = 497,
+  HTTP_STATUS_INVALID_TOKEN = 498,
+  HTTP_STATUS_CLIENT_CLOSED_REQUEST = 499,
+  HTTP_STATUS_INTERNAL_SERVER_ERROR = 500,
+  HTTP_STATUS_NOT_IMPLEMENTED = 501,
+  HTTP_STATUS_BAD_GATEWAY = 502,
+  HTTP_STATUS_SERVICE_UNAVAILABLE = 503,
+  HTTP_STATUS_GATEWAY_TIMEOUT = 504,
+  HTTP_STATUS_HTTP_VERSION_NOT_SUPPORTED = 505,
+  HTTP_STATUS_VARIANT_ALSO_NEGOTIATES = 506,
+  HTTP_STATUS_INSUFFICIENT_STORAGE = 507,
+  HTTP_STATUS_LOOP_DETECTED = 508,
+  HTTP_STATUS_BANDWIDTH_LIMIT_EXCEEDED = 509,
+  HTTP_STATUS_NOT_EXTENDED = 510,
+  HTTP_STATUS_NETWORK_AUTHENTICATION_REQUIRED = 511,
+  HTTP_STATUS_WEB_SERVER_UNKNOWN_ERROR = 520,
+  HTTP_STATUS_WEB_SERVER_IS_DOWN = 521,
+  HTTP_STATUS_CONNECTION_TIMEOUT = 522,
+  HTTP_STATUS_ORIGIN_IS_UNREACHABLE = 523,
+  HTTP_STATUS_TIMEOUT_OCCURED = 524,
+  HTTP_STATUS_SSL_HANDSHAKE_FAILED = 525,
+  HTTP_STATUS_INVALID_SSL_CERTIFICATE = 526,
+  HTTP_STATUS_RAILGUN_ERROR = 527,
+  HTTP_STATUS_SITE_IS_OVERLOADED = 529,
+  HTTP_STATUS_SITE_IS_FROZEN = 530,
+  HTTP_STATUS_IDENTITY_PROVIDER_AUTHENTICATION_ERROR = 561,
+  HTTP_STATUS_NETWORK_READ_TIMEOUT = 598,
+  HTTP_STATUS_NETWORK_CONNECT_TIMEOUT = 599
+};
+typedef enum llhttp_status llhttp_status_t;
+
 #define HTTP_ERRNO_MAP(XX) \
   XX(0, OK, OK) \
   XX(1, INTERNAL, INTERNAL) \
@@ -178,6 +293,7 @@ typedef enum llhttp_method llhttp_method_t;
   XX(25, CR_EXPECTED, CR_EXPECTED) \
   XX(3, LF_EXPECTED, LF_EXPECTED) \
   XX(4, UNEXPECTED_CONTENT_LENGTH, UNEXPECTED_CONTENT_LENGTH) \
+  XX(30, UNEXPECTED_SPACE, UNEXPECTED_SPACE) \
   XX(5, CLOSED_CONNECTION, CLOSED_CONNECTION) \
   XX(6, INVALID_METHOD, INVALID_METHOD) \
   XX(7, INVALID_URL, INVALID_URL) \
@@ -198,6 +314,15 @@ typedef enum llhttp_method llhttp_method_t;
   XX(22, PAUSED_UPGRADE, PAUSED_UPGRADE) \
   XX(23, PAUSED_H2_UPGRADE, PAUSED_H2_UPGRADE) \
   XX(24, USER, USER) \
+  XX(26, CB_URL_COMPLETE, CB_URL_COMPLETE) \
+  XX(27, CB_STATUS_COMPLETE, CB_STATUS_COMPLETE) \
+  XX(32, CB_METHOD_COMPLETE, CB_METHOD_COMPLETE) \
+  XX(33, CB_VERSION_COMPLETE, CB_VERSION_COMPLETE) \
+  XX(28, CB_HEADER_FIELD_COMPLETE, CB_HEADER_FIELD_COMPLETE) \
+  XX(29, CB_HEADER_VALUE_COMPLETE, CB_HEADER_VALUE_COMPLETE) \
+  XX(34, CB_CHUNK_EXTENSION_NAME_COMPLETE, CB_CHUNK_EXTENSION_NAME_COMPLETE) \
+  XX(35, CB_CHUNK_EXTENSION_VALUE_COMPLETE, CB_CHUNK_EXTENSION_VALUE_COMPLETE) \
+  XX(31, CB_RESET, CB_RESET) \
 
 
 #define HTTP_METHOD_MAP(XX) \
@@ -303,10 +428,113 @@ typedef enum llhttp_method llhttp_method_t;
   XX(45, FLUSH, FLUSH) \
 
 
+#define HTTP_STATUS_MAP(XX) \
+  XX(100, CONTINUE, CONTINUE) \
+  XX(101, SWITCHING_PROTOCOLS, SWITCHING_PROTOCOLS) \
+  XX(102, PROCESSING, PROCESSING) \
+  XX(103, EARLY_HINTS, EARLY_HINTS) \
+  XX(110, RESPONSE_IS_STALE, RESPONSE_IS_STALE) \
+  XX(111, REVALIDATION_FAILED, REVALIDATION_FAILED) \
+  XX(112, DISCONNECTED_OPERATION, DISCONNECTED_OPERATION) \
+  XX(113, HEURISTIC_EXPIRATION, HEURISTIC_EXPIRATION) \
+  XX(199, MISCELLANEOUS_WARNING, MISCELLANEOUS_WARNING) \
+  XX(200, OK, OK) \
+  XX(201, CREATED, CREATED) \
+  XX(202, ACCEPTED, ACCEPTED) \
+  XX(203, NON_AUTHORITATIVE_INFORMATION, NON_AUTHORITATIVE_INFORMATION) \
+  XX(204, NO_CONTENT, NO_CONTENT) \
+  XX(205, RESET_CONTENT, RESET_CONTENT) \
+  XX(206, PARTIAL_CONTENT, PARTIAL_CONTENT) \
+  XX(207, MULTI_STATUS, MULTI_STATUS) \
+  XX(208, ALREADY_REPORTED, ALREADY_REPORTED) \
+  XX(214, TRANSFORMATION_APPLIED, TRANSFORMATION_APPLIED) \
+  XX(226, IM_USED, IM_USED) \
+  XX(299, MISCELLANEOUS_PERSISTENT_WARNING, MISCELLANEOUS_PERSISTENT_WARNING) \
+  XX(300, MULTIPLE_CHOICES, MULTIPLE_CHOICES) \
+  XX(301, MOVED_PERMANENTLY, MOVED_PERMANENTLY) \
+  XX(302, FOUND, FOUND) \
+  XX(303, SEE_OTHER, SEE_OTHER) \
+  XX(304, NOT_MODIFIED, NOT_MODIFIED) \
+  XX(305, USE_PROXY, USE_PROXY) \
+  XX(306, SWITCH_PROXY, SWITCH_PROXY) \
+  XX(307, TEMPORARY_REDIRECT, TEMPORARY_REDIRECT) \
+  XX(308, PERMANENT_REDIRECT, PERMANENT_REDIRECT) \
+  XX(400, BAD_REQUEST, BAD_REQUEST) \
+  XX(401, UNAUTHORIZED, UNAUTHORIZED) \
+  XX(402, PAYMENT_REQUIRED, PAYMENT_REQUIRED) \
+  XX(403, FORBIDDEN, FORBIDDEN) \
+  XX(404, NOT_FOUND, NOT_FOUND) \
+  XX(405, METHOD_NOT_ALLOWED, METHOD_NOT_ALLOWED) \
+  XX(406, NOT_ACCEPTABLE, NOT_ACCEPTABLE) \
+  XX(407, PROXY_AUTHENTICATION_REQUIRED, PROXY_AUTHENTICATION_REQUIRED) \
+  XX(408, REQUEST_TIMEOUT, REQUEST_TIMEOUT) \
+  XX(409, CONFLICT, CONFLICT) \
+  XX(410, GONE, GONE) \
+  XX(411, LENGTH_REQUIRED, LENGTH_REQUIRED) \
+  XX(412, PRECONDITION_FAILED, PRECONDITION_FAILED) \
+  XX(413, PAYLOAD_TOO_LARGE, PAYLOAD_TOO_LARGE) \
+  XX(414, URI_TOO_LONG, URI_TOO_LONG) \
+  XX(415, UNSUPPORTED_MEDIA_TYPE, UNSUPPORTED_MEDIA_TYPE) \
+  XX(416, RANGE_NOT_SATISFIABLE, RANGE_NOT_SATISFIABLE) \
+  XX(417, EXPECTATION_FAILED, EXPECTATION_FAILED) \
+  XX(418, IM_A_TEAPOT, IM_A_TEAPOT) \
+  XX(419, PAGE_EXPIRED, PAGE_EXPIRED) \
+  XX(420, ENHANCE_YOUR_CALM, ENHANCE_YOUR_CALM) \
+  XX(421, MISDIRECTED_REQUEST, MISDIRECTED_REQUEST) \
+  XX(422, UNPROCESSABLE_ENTITY, UNPROCESSABLE_ENTITY) \
+  XX(423, LOCKED, LOCKED) \
+  XX(424, FAILED_DEPENDENCY, FAILED_DEPENDENCY) \
+  XX(425, TOO_EARLY, TOO_EARLY) \
+  XX(426, UPGRADE_REQUIRED, UPGRADE_REQUIRED) \
+  XX(428, PRECONDITION_REQUIRED, PRECONDITION_REQUIRED) \
+  XX(429, TOO_MANY_REQUESTS, TOO_MANY_REQUESTS) \
+  XX(430, REQUEST_HEADER_FIELDS_TOO_LARGE_UNOFFICIAL, REQUEST_HEADER_FIELDS_TOO_LARGE_UNOFFICIAL) \
+  XX(431, REQUEST_HEADER_FIELDS_TOO_LARGE, REQUEST_HEADER_FIELDS_TOO_LARGE) \
+  XX(440, LOGIN_TIMEOUT, LOGIN_TIMEOUT) \
+  XX(444, NO_RESPONSE, NO_RESPONSE) \
+  XX(449, RETRY_WITH, RETRY_WITH) \
+  XX(450, BLOCKED_BY_PARENTAL_CONTROL, BLOCKED_BY_PARENTAL_CONTROL) \
+  XX(451, UNAVAILABLE_FOR_LEGAL_REASONS, UNAVAILABLE_FOR_LEGAL_REASONS) \
+  XX(460, CLIENT_CLOSED_LOAD_BALANCED_REQUEST, CLIENT_CLOSED_LOAD_BALANCED_REQUEST) \
+  XX(463, INVALID_X_FORWARDED_FOR, INVALID_X_FORWARDED_FOR) \
+  XX(494, REQUEST_HEADER_TOO_LARGE, REQUEST_HEADER_TOO_LARGE) \
+  XX(495, SSL_CERTIFICATE_ERROR, SSL_CERTIFICATE_ERROR) \
+  XX(496, SSL_CERTIFICATE_REQUIRED, SSL_CERTIFICATE_REQUIRED) \
+  XX(497, HTTP_REQUEST_SENT_TO_HTTPS_PORT, HTTP_REQUEST_SENT_TO_HTTPS_PORT) \
+  XX(498, INVALID_TOKEN, INVALID_TOKEN) \
+  XX(499, CLIENT_CLOSED_REQUEST, CLIENT_CLOSED_REQUEST) \
+  XX(500, INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR) \
+  XX(501, NOT_IMPLEMENTED, NOT_IMPLEMENTED) \
+  XX(502, BAD_GATEWAY, BAD_GATEWAY) \
+  XX(503, SERVICE_UNAVAILABLE, SERVICE_UNAVAILABLE) \
+  XX(504, GATEWAY_TIMEOUT, GATEWAY_TIMEOUT) \
+  XX(505, HTTP_VERSION_NOT_SUPPORTED, HTTP_VERSION_NOT_SUPPORTED) \
+  XX(506, VARIANT_ALSO_NEGOTIATES, VARIANT_ALSO_NEGOTIATES) \
+  XX(507, INSUFFICIENT_STORAGE, INSUFFICIENT_STORAGE) \
+  XX(508, LOOP_DETECTED, LOOP_DETECTED) \
+  XX(509, BANDWIDTH_LIMIT_EXCEEDED, BANDWIDTH_LIMIT_EXCEEDED) \
+  XX(510, NOT_EXTENDED, NOT_EXTENDED) \
+  XX(511, NETWORK_AUTHENTICATION_REQUIRED, NETWORK_AUTHENTICATION_REQUIRED) \
+  XX(520, WEB_SERVER_UNKNOWN_ERROR, WEB_SERVER_UNKNOWN_ERROR) \
+  XX(521, WEB_SERVER_IS_DOWN, WEB_SERVER_IS_DOWN) \
+  XX(522, CONNECTION_TIMEOUT, CONNECTION_TIMEOUT) \
+  XX(523, ORIGIN_IS_UNREACHABLE, ORIGIN_IS_UNREACHABLE) \
+  XX(524, TIMEOUT_OCCURED, TIMEOUT_OCCURED) \
+  XX(525, SSL_HANDSHAKE_FAILED, SSL_HANDSHAKE_FAILED) \
+  XX(526, INVALID_SSL_CERTIFICATE, INVALID_SSL_CERTIFICATE) \
+  XX(527, RAILGUN_ERROR, RAILGUN_ERROR) \
+  XX(529, SITE_IS_OVERLOADED, SITE_IS_OVERLOADED) \
+  XX(530, SITE_IS_FROZEN, SITE_IS_FROZEN) \
+  XX(561, IDENTITY_PROVIDER_AUTHENTICATION_ERROR, IDENTITY_PROVIDER_AUTHENTICATION_ERROR) \
+  XX(598, NETWORK_READ_TIMEOUT, NETWORK_READ_TIMEOUT) \
+  XX(599, NETWORK_CONNECT_TIMEOUT, NETWORK_CONNECT_TIMEOUT) \
+
+
 #ifdef __cplusplus
 }  /* extern "C" */
 #endif
 #endif  /* LLLLHTTP_C_HEADERS_ */
+
 
 #ifndef INCLUDE_LLHTTP_API_H_
 #define INCLUDE_LLHTTP_API_H_
@@ -334,8 +562,12 @@ struct llhttp_settings_s {
   /* Possible return values 0, -1, HPE_USER */
   llhttp_data_cb on_url;
   llhttp_data_cb on_status;
+  llhttp_data_cb on_method;
+  llhttp_data_cb on_version;
   llhttp_data_cb on_header_field;
   llhttp_data_cb on_header_value;
+  llhttp_data_cb      on_chunk_extension_name;
+  llhttp_data_cb      on_chunk_extension_value;
 
   /* Possible return values:
    * 0  - Proceed normally
@@ -353,6 +585,14 @@ struct llhttp_settings_s {
 
   /* Possible return values 0, -1, `HPE_PAUSED` */
   llhttp_cb      on_message_complete;
+  llhttp_cb      on_url_complete;
+  llhttp_cb      on_status_complete;
+  llhttp_cb      on_method_complete;
+  llhttp_cb      on_version_complete;
+  llhttp_cb      on_header_field_complete;
+  llhttp_cb      on_header_value_complete;
+  llhttp_cb      on_chunk_extension_name_complete;
+  llhttp_cb      on_chunk_extension_value_complete;
 
   /* When on_chunk_header is called, the current chunk length is stored
    * in parser->content_length.
@@ -360,12 +600,7 @@ struct llhttp_settings_s {
    */
   llhttp_cb      on_chunk_header;
   llhttp_cb      on_chunk_complete;
-
-  /* Information-only callbacks, return value is ignored */
-  llhttp_cb      on_url_complete;
-  llhttp_cb      on_status_complete;
-  llhttp_cb      on_header_field_complete;
-  llhttp_cb      on_header_value_complete;
+  llhttp_cb      on_reset;
 };
 
 /* Initialize the parser with specific type and user settings.
@@ -515,6 +750,9 @@ const char* llhttp_errno_name(llhttp_errno_t err);
 LLHTTP_EXPORT
 const char* llhttp_method_name(llhttp_method_t method);
 
+/* Returns textual name of HTTP status */
+LLHTTP_EXPORT
+const char* llhttp_status_name(llhttp_status_t status);
 
 /* Enables/disables lenient header value parsing (disabled by default).
  *
@@ -523,7 +761,8 @@ const char* llhttp_method_name(llhttp_method_t method);
  * `HPE_INVALID_HEADER_TOKEN` will be raised for incorrect header values when
  * lenient parsing is "on".
  *
- * **(USE AT YOUR OWN RISK)**
+ * **Enabling this flag can pose a security issue since you will be exposed to
+ * request smuggling attacks. USE WITH CAUTION!**
  */
 LLHTTP_EXPORT
 void llhttp_set_lenient_headers(llhttp_t* parser, int enabled);
@@ -537,7 +776,8 @@ void llhttp_set_lenient_headers(llhttp_t* parser, int enabled);
  * request smuggling, but may be less desirable for small number of cases
  * involving legacy servers.
  *
- * **(USE AT YOUR OWN RISK)**
+ * **Enabling this flag can pose a security issue since you will be exposed to
+ * request smuggling attacks. USE WITH CAUTION!**
  */
 LLHTTP_EXPORT
 void llhttp_set_lenient_chunked_length(llhttp_t* parser, int enabled);
@@ -552,8 +792,10 @@ void llhttp_set_lenient_chunked_length(llhttp_t* parser, int enabled);
  * but might interact badly with outdated and insecure clients. With this flag
  * the extra request/response will be parsed normally.
  *
- * **(USE AT YOUR OWN RISK)**
+ * **Enabling this flag can pose a security issue since you will be exposed to
+ * poisoning attacks. USE WITH CAUTION!**
  */
+LLHTTP_EXPORT
 void llhttp_set_lenient_keep_alive(llhttp_t* parser, int enabled);
 
 /* Enables/disables lenient handling of `Transfer-Encoding` header.
@@ -565,13 +807,65 @@ void llhttp_set_lenient_keep_alive(llhttp_t* parser, int enabled);
  * avoid request smuggling.
  * With this flag the extra value will be parsed normally.
  *
- * **(USE AT YOUR OWN RISK)**
+ * **Enabling this flag can pose a security issue since you will be exposed to 
+ * request smuggling attacks. USE WITH CAUTION!**
  */
+LLHTTP_EXPORT
 void llhttp_set_lenient_transfer_encoding(llhttp_t* parser, int enabled);
+
+/* Enables/disables lenient handling of HTTP version.
+ *
+ * Normally `llhttp` would error when the HTTP version in the request or status line
+ * is not `0.9`, `1.0`, `1.1` or `2.0`.
+ * With this flag the invalid value will be parsed normally.
+ *
+ * **Enabling this flag can pose a security issue since you will allow unsupported
+ * HTTP versions. USE WITH CAUTION!**
+ */
+LLHTTP_EXPORT
+void llhttp_set_lenient_version(llhttp_t* parser, int enabled);
+
+/* Enables/disables lenient handling of additional data received after a message ends
+ * and keep-alive is disabled.
+ *
+ * Normally `llhttp` would error when additional unexpected data is received if the message
+ * contains the `Connection` header with `close` value.
+ * With this flag the extra data will discarded without throwing an error.
+ *
+ * **Enabling this flag can pose a security issue since you will be exposed to
+ * poisoning attacks. USE WITH CAUTION!**
+ */
+LLHTTP_EXPORT
+void llhttp_set_lenient_data_after_close(llhttp_t* parser, int enabled);
+
+/* Enables/disables lenient handling of incomplete CRLF sequences.
+ *
+ * Normally `llhttp` would error when a CR is not followed by LF when terminating the
+ * request line, the status line, the headers or a chunk header.
+ * With this flag only a CR is required to terminate such sections.
+ *
+ * **Enabling this flag can pose a security issue since you will be exposed to
+ * request smuggling attacks. USE WITH CAUTION!**
+ */
+LLHTTP_EXPORT
+void llhttp_set_lenient_optional_lf_after_cr(llhttp_t* parser, int enabled);
+
+/* Enables/disables lenient handling of chunks not separated via CRLF.
+ *
+ * Normally `llhttp` would error when after a chunk data a CRLF is missing before
+ * starting a new chunk.
+ * With this flag the new chunk can start immediately after the previous one.
+ *
+ * **Enabling this flag can pose a security issue since you will be exposed to
+ * request smuggling attacks. USE WITH CAUTION!**
+ */
+LLHTTP_EXPORT
+void llhttp_set_lenient_optional_crlf_after_chunk(llhttp_t* parser, int enabled);
 
 #ifdef __cplusplus
 }  /* extern "C" */
 #endif
 #endif  /* INCLUDE_LLHTTP_API_H_ */
+
 
 #endif  /* INCLUDE_LLHTTP_H_ */

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [4.0.8]: https://github.com/microsoft/CCF/releases/tag/ccf-4.0.8
 
 - Add `/node/ready/app` and `/node/ready/gov` endpoints for the use of load balancers wanting to check if a node is ready to accept application or governance transactions. See [Operator RPC API](https://microsoft.github.io/CCF/main/operations/operator_rpc_api.html) for details.
+- Updated `llhttp` from `6.0.9` to `9.0.1`.
+- Updated `fmt` library from `9.1.0` to `10.1.1`.
 - Updated QCBOR from `1.1` to `1.2`.
-- Upgrade `nghttp2` from `1.51.0` to `1.55.1`.
+- Updated `nghttp2` from `1.51.0` to `1.55.1`.
 
 ## [4.0.7]
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -87,7 +87,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/nodejs/llhttp",
-          "commitHash": "6d954cbdc7f641f0a63a4427cf4d6be397f74ee8"
+          "commitHash": "f8aeb3587ad76def113396091a31baf28fdf6834"
         }
       }
     },

--- a/include/ccf/http_status.h
+++ b/include/ccf/http_status.h
@@ -2,86 +2,12 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
-/* Status Codes */
-#define HTTP_STATUS_MAP(XX) \
-  XX(100, CONTINUE, "Continue") \
-  XX(101, SWITCHING_PROTOCOLS, "Switching Protocols") \
-  XX(102, PROCESSING, "Processing") \
-  XX(200, OK, "OK") \
-  XX(201, CREATED, "Created") \
-  XX(202, ACCEPTED, "Accepted") \
-  XX(203, NON_AUTHORITATIVE_INFORMATION, "Non-Authoritative Information") \
-  XX(204, NO_CONTENT, "No Content") \
-  XX(205, RESET_CONTENT, "Reset Content") \
-  XX(206, PARTIAL_CONTENT, "Partial Content") \
-  XX(207, MULTI_STATUS, "Multi-Status") \
-  XX(208, ALREADY_REPORTED, "Already Reported") \
-  XX(226, IM_USED, "IM Used") \
-  XX(300, MULTIPLE_CHOICES, "Multiple Choices") \
-  XX(301, MOVED_PERMANENTLY, "Moved Permanently") \
-  XX(302, FOUND, "Found") \
-  XX(303, SEE_OTHER, "See Other") \
-  XX(304, NOT_MODIFIED, "Not Modified") \
-  XX(305, USE_PROXY, "Use Proxy") \
-  XX(307, TEMPORARY_REDIRECT, "Temporary Redirect") \
-  XX(308, PERMANENT_REDIRECT, "Permanent Redirect") \
-  XX(400, BAD_REQUEST, "Bad Request") \
-  XX(401, UNAUTHORIZED, "Unauthorized") \
-  XX(402, PAYMENT_REQUIRED, "Payment Required") \
-  XX(403, FORBIDDEN, "Forbidden") \
-  XX(404, NOT_FOUND, "Not Found") \
-  XX(405, METHOD_NOT_ALLOWED, "Method Not Allowed") \
-  XX(406, NOT_ACCEPTABLE, "Not Acceptable") \
-  XX(407, PROXY_AUTHENTICATION_REQUIRED, "Proxy Authentication Required") \
-  XX(408, REQUEST_TIMEOUT, "Request Timeout") \
-  XX(409, CONFLICT, "Conflict") \
-  XX(410, GONE, "Gone") \
-  XX(411, LENGTH_REQUIRED, "Length Required") \
-  XX(412, PRECONDITION_FAILED, "Precondition Failed") \
-  XX(413, PAYLOAD_TOO_LARGE, "Payload Too Large") \
-  XX(414, URI_TOO_LONG, "URI Too Long") \
-  XX(415, UNSUPPORTED_MEDIA_TYPE, "Unsupported Media Type") \
-  XX(416, RANGE_NOT_SATISFIABLE, "Range Not Satisfiable") \
-  XX(417, EXPECTATION_FAILED, "Expectation Failed") \
-  XX(421, MISDIRECTED_REQUEST, "Misdirected Request") \
-  XX(422, UNPROCESSABLE_ENTITY, "Unprocessable Entity") \
-  XX(423, LOCKED, "Locked") \
-  XX(424, FAILED_DEPENDENCY, "Failed Dependency") \
-  XX(426, UPGRADE_REQUIRED, "Upgrade Required") \
-  XX(428, PRECONDITION_REQUIRED, "Precondition Required") \
-  XX(429, TOO_MANY_REQUESTS, "Too Many Requests") \
-  XX(431, REQUEST_HEADER_FIELDS_TOO_LARGE, "Request Header Fields Too Large") \
-  XX(451, UNAVAILABLE_FOR_LEGAL_REASONS, "Unavailable For Legal Reasons") \
-  XX(500, INTERNAL_SERVER_ERROR, "Internal Server Error") \
-  XX(501, NOT_IMPLEMENTED, "Not Implemented") \
-  XX(502, BAD_GATEWAY, "Bad Gateway") \
-  XX(503, SERVICE_UNAVAILABLE, "Service Unavailable") \
-  XX(504, GATEWAY_TIMEOUT, "Gateway Timeout") \
-  XX(505, HTTP_VERSION_NOT_SUPPORTED, "HTTP Version Not Supported") \
-  XX(506, VARIANT_ALSO_NEGOTIATES, "Variant Also Negotiates") \
-  XX(507, INSUFFICIENT_STORAGE, "Insufficient Storage") \
-  XX(508, LOOP_DETECTED, "Loop Detected") \
-  XX(510, NOT_EXTENDED, "Not Extended") \
-  XX(511, NETWORK_AUTHENTICATION_REQUIRED, "Network Authentication Required")
+#include <llhttp/llhttp.h>
 
-enum http_status
-{
-#define XX(num, name, string) HTTP_STATUS_##name = num,
-  HTTP_STATUS_MAP(XX)
-#undef XX
-};
+using http_status = llhttp_status;
 
 /* Returns a string version of the HTTP status code. */
-static inline const char* http_status_str(enum http_status s)
+static inline const char* http_status_str(http_status s)
 {
-  switch (s)
-  {
-#define XX(num, name, string) \
-  case HTTP_STATUS_##name: \
-    return string;
-    HTTP_STATUS_MAP(XX)
-#undef XX
-    default:
-      return "<unknown>";
-  }
+  return llhttp_status_name(s);
 }

--- a/src/endpoints/grpc/grpc_status.h
+++ b/src/endpoints/grpc/grpc_status.h
@@ -53,7 +53,7 @@ static inline const char* grpc_status_str(enum grpc_status s)
 // automatically convert HTTP errors to gRPC statuses.
 // Inspired by
 // https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
-static grpc_status http_status_to_grpc(enum http_status s)
+static grpc_status http_status_to_grpc(http_status s)
 {
   // Note: GRPC_STATUS_CANCELLED, GRPC_STATUS_ABORTED and GRPC_STATUS_DATA_LOSS
   // are currently never returned


### PR DESCRIPTION
Backports the following commits to `{release/4.x}`:
{ - [Update `llhttp` from `6.0.9` to `9.0.1` (#5607)](https://github.com/microsoft/CCF/pull/5607)}