### PR TITLE
[release/4.x] Cherry pick: SEV-SNP: Make UVM endorsements SVN an arbitrary string (#5620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [4.0.8]: https://github.com/microsoft/CCF/releases/tag/ccf-4.0.8
 
+- Converted SNP attestation UVM endorsements from integer to arbitrary string.
+
 - Add `/node/ready/app` and `/node/ready/gov` endpoints for the use of load balancers wanting to check if a node is ready to accept application or governance transactions. See [Operator RPC API](https://microsoft.github.io/CCF/main/operations/operator_rpc_api.html) for details.
 - Updated QCBOR from `1.1` to `1.2`.
 - Upgrade `nghttp2` from `1.51.0` to `1.55.1`.

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -1143,7 +1143,7 @@
       "UVMEndorsementsData": {
         "properties": {
           "svn": {
-            "$ref": "#/components/schemas/uint64"
+            "$ref": "#/components/schemas/string"
           }
         },
         "required": [
@@ -1270,7 +1270,7 @@
   "info": {
     "description": "This API is used to submit and query proposals which affect CCF's public governance tables.",
     "title": "CCF Governance API",
-    "version": "4.1.0"
+    "version": "4.1.3"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/include/ccf/service/tables/uvm_endorsements.h
+++ b/include/ccf/service/tables/uvm_endorsements.h
@@ -10,7 +10,7 @@ namespace ccf
 {
   struct UVMEndorsementsData
   {
-    size_t svn;
+    std::string svn;
 
     bool operator==(const UVMEndorsementsData&) const = default;
   };

--- a/samples/constitutions/default/actions.js
+++ b/samples/constitutions/default/actions.js
@@ -993,8 +993,7 @@ const actions = new Map([
       function (args) {
         checkType(args.did, "string", "did");
         checkType(args.feed, "string", "feed");
-        checkType(args.svn, "integer", "svn");
-        checkBounds(args.svn, 0, null, "svn");
+        checkType(args.svn, "string", "svn");
       },
       function (args, proposalId) {
         let uvmEndorsementsForDID = ccf.kv[

--- a/src/node/quote.cpp
+++ b/src/node/quote.cpp
@@ -31,9 +31,7 @@ namespace ccf
       if (uvm_endorsements_data.did == did)
       {
         auto search = value.find(uvm_endorsements_data.feed);
-        if (
-          search != value.end() &&
-          uvm_endorsements_data.svn >= search->second.svn)
+        if (search != value.end())
         {
           match = true;
           return false;

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -606,7 +606,7 @@ namespace ccf
       openapi_info.description =
         "This API is used to submit and query proposals which affect CCF's "
         "public governance tables.";
-      openapi_info.document_version = "4.1.0";
+      openapi_info.document_version = "4.1.3";
     }
 
     static std::optional<MemberId> get_caller_member_id(

--- a/src/node/uvm_endorsements.h
+++ b/src/node/uvm_endorsements.h
@@ -22,7 +22,7 @@ namespace ccf
   {
     DID did;
     Feed feed;
-    size_t svn;
+    std::string svn;
 
     bool operator==(const UVMEndorsements&) const = default;
   };
@@ -311,6 +311,6 @@ namespace ccf
       phdr.feed,
       payload.sevsnpvm_guest_svn);
 
-    return {did, phdr.feed, std::stoul(payload.sevsnpvm_guest_svn)};
+    return {did, phdr.feed, payload.sevsnpvm_guest_svn};
   }
 }

--- a/tests/code_update.py
+++ b/tests/code_update.py
@@ -109,17 +109,17 @@ def test_snp_measurements_tables(network, args):
     assert len(value) == 2
     assert value[new_feed]["svn"] == svn
 
-    LOG.debug("Bump SVN for new feed")
-    bumped_svn = svn + 1
+    LOG.debug("Change SVN for new feed")
+    new_svn = f"{svn}_2"
     network.consortium.add_snp_uvm_endorsement(
-        primary, did=did, feed=new_feed, svn=bumped_svn
+        primary, did=did, feed=new_feed, svn=new_svn
     )
     uvm_endorsements = get_trusted_uvm_endorsements(primary)
     assert (
         len(uvm_endorsements) == 1
     ), f"Expected one UVM endorsement, {uvm_endorsements}"
     did, value = next(iter(uvm_endorsements.items()))
-    assert value[new_feed]["svn"] == bumped_svn
+    assert value[new_feed]["svn"] == new_svn
 
     LOG.debug("Add new DID")
     new_did = "did:x509:newdid"


### PR DESCRIPTION
Backports the following commits to `{release/4.x}`:
{ - [SEV-SNP: Make UVM endorsements SVN an arbitrary string (#5620)](https://github.com/microsoft/CCF/pull/5620)}