### PR TITLE
Syntactic change to show sender and receive in action labels of TLC counterexamples.

### DIFF
--- a/tla/SIMccfraft.tla
+++ b/tla/SIMccfraft.tla
@@ -23,7 +23,7 @@ Forward ==
     \/ \E i, j \in Servers : NotifyCommit(i,j)
     \/ \E i \in Servers : AdvanceCommitIndex(i)
     \/ \E i, j \in Servers : AppendEntries(i, j)
-    \/ Receive
+    \/ \E i, j \in Servers : Receive(i, j)
 
 SIMNext ==
     \* To increase coverage, favor sub-actions during simulation that move the 


### PR DESCRIPTION
<img width="598" alt="image" src="https://github.com/microsoft/CCF/assets/88777/8c7f2c3f-2807-4fa9-8d90-8743f34f9d66">





Also enables more fine grained fairness constraints:

```tla
Spec == 
    /\ Init
    /\ [][Next]_vars
    /\ WF_vars(Next)
    /\ \A i, j \in Servers : WF_vars(Receive(i,j)
```