### PR TITLE
Support modeling different network guarantees.

### DIFF
--- a/tla/Network.tla
+++ b/tla/Network.tla
@@ -1,0 +1,86 @@
+-------------------------------- MODULE Network -------------------------------
+EXTENDS ccfraft, Sequences
+
+----------------------------------------------------------------------------------
+\* Reordering and duplication of messages:
+
+ReorderDupInitMessageVar ==
+    messages = <<>>
+    
+ReorderDupWithMessage(m, msgs) == 
+    IF m \notin (DOMAIN msgs) THEN
+        msgs @@ (m :> 1)
+    ELSE
+        [ msgs EXCEPT ![m] = @ + 1 ]
+
+ReorderDupWithoutMessage(m, msgs) == 
+    IF msgs[m] = 1 THEN
+        [ msg \in ((DOMAIN msgs) \ {m}) |-> msgs[msg] ]
+    ELSE
+        [ msgs EXCEPT ![m] = @ - 1 ]
+
+ReorderDupMessages ==
+    DOMAIN messages
+
+ReorderDupMessagesTo(dest) ==
+    { m \in Messages : m.dest = dest }
+
+----------------------------------------------------------------------------------
+\* Reordering and deduplication of messages (iff the spec removes message m from
+\* msgs after receiving m, i.e., ReorderNoDupWithoutMessage.)
+
+ReorderNoDupInitMessageVar ==
+    messages = {}
+
+ReorderNoDupWithMessage(m, msgs) == 
+    msgs \union {m}
+
+ReorderNoDupWithoutMessage(m, msgs) == 
+    msgs \ {m}
+
+ReorderNoDupMessages ==
+    messages
+
+ReorderNoDupMessagesTo(dest) ==
+    { m \in Messages : m.dest = dest }
+
+----------------------------------------------------------------------------------
+\* Ordering and duplication of messages:
+
+OrderInitMessageVar ==
+    messages = [ s \in Servers |-> <<>>]
+
+OrderWithMessage(m, msgs) ==
+    [ messages EXCEPT ![m.dest] = Append(@, m) ]
+
+OrderWithoutMessage(m, msgs) ==
+    [ messages EXCEPT ![m.dest] = SelectSeq(@, LAMBDA e: m # e) ]
+
+OrderMessages ==
+    UNION { Range(messages[s]) : s \in Servers }
+
+OrderMessagesTo(dest) ==
+    IF messages[dest] # <<>> THEN {messages[dest][1]} ELSE {}
+
+----------------------------------------------------------------------------------
+\* Ordering and deduplication of messages:
+
+OrderNoDupInitMessageVar ==
+    OrderInitMessageVar
+
+OrderNoDupWithMessage(m, msgs) ==
+    IF \E i \in 1..Len(msgs[m.dest]) : msgs[m.dest][i] = m THEN
+        msgs
+    ELSE
+        OrderWithMessage(m, msgs)
+
+OrderNoDupWithoutMessage(m, msgs) ==
+    OrderWithoutMessage(m, msgs)
+
+OrderNoDupMessages ==
+    OrderMessages
+
+OrderNoDupMessagesTo(dest) ==
+    OrderMessagesTo(dest)
+
+==================================================================================

--- a/tla/Traceccfraft.cfg
+++ b/tla/Traceccfraft.cfg
@@ -45,10 +45,11 @@ CONSTANTS
     AppendEntriesBatchsize <- TraceAppendEntriesBatchsize
 
     \* Redefine the value of variable messages to be a multi-set instead of an ordinary set.
-    WithMessage <- TraceWithMessage
-    WithoutMessage <- TraceWithoutMessage
-    Messages <- TraceMessages
-    InitMessagesVars <- TraceInitMessagesVars
+    WithMessage <- ReorderDupWithMessage
+    WithoutMessage <- ReorderDupWithoutMessage
+    Messages <- ReorderDupMessages
+    InitMessageVar <- ReorderDupInitMessageVar
+    
     InitReconfigurationVars <- TraceInitReconfigurationVars
 
     Nil = Nil

--- a/tla/Traceccfraft.tla
+++ b/tla/Traceccfraft.tla
@@ -1,5 +1,5 @@
 -------------------------------- MODULE Traceccfraft -------------------------------
-EXTENDS ccfraft, Json, IOUtils, Sequences
+EXTENDS ccfraft, Json, IOUtils, Sequences, Network
 
 \* raft_types.h enum RaftMsgType
 RaftMsgType ==
@@ -85,10 +85,6 @@ TraceAppendEntriesBatchsize(i, j) ==
     \* -1) .. to explicitly model heartbeats, i.e. a message with zero entries.
     (nextIndex[i][j] - 1) .. Len(log[i])
 
-TraceInitMessagesVars ==
-    /\ messages = <<>>
-    /\ commitsNotified = [i \in Servers |-> <<0,0>>] \* i.e., <<index, times of notification>>
-
 TraceInitReconfigurationVars ==
     /\ reconfigurationCount = 0
     /\ removedFromConfiguration = {}
@@ -97,21 +93,6 @@ TraceInitReconfigurationVars ==
     /\ configurations = [ s \in Servers |-> IF s = TraceLog[1].msg.state.node_id 
                                             THEN ToConfigurations(<<TraceLog[1].msg.new_configuration>>)
                                             ELSE [ j \in {0} |-> {} ] ]
-    
-TraceWithMessage(m, msgs) == 
-    IF m \notin (DOMAIN msgs) THEN
-        msgs @@ (m :> 1)
-    ELSE
-        [ msgs EXCEPT ![m] = @ + 1 ]
-
-TraceWithoutMessage(m, msgs) == 
-    IF msgs[m] = 1 THEN
-        [ msg \in ((DOMAIN msgs) \ {m}) |-> msgs[msg] ]
-    ELSE
-        [ msgs EXCEPT ![m] = @ - 1 ]
-
-TraceMessages ==
-    DOMAIN messages
 
 OneMoreMessage(msg) ==
     \/ msg \notin Messages /\ msg \in Messages'


### PR DESCRIPTION
    Distinct 7 959
    WithMessage <- OrderNoDupWithMessage
    WithoutMessage <- OrderNoDupWithoutMessage
    Messages <- OrderNoDupMessages
    MessagesOf <- OrderNoDupMessagesOf
    InitMessageVar <- OrderNoDupInitMessageVar

    Distinct 287 675
    WithMessage <- OrderWithMessage
    WithoutMessage <- OrderWithoutMessage
    Messages <- OrderMessages
    MessagesOf <- OrderMessagesOf
    InitMessageVar <- OrderInitMessageVar

    Distinct 1 399 231
    WithMessage <- ReorderDupWithMessage
    WithoutMessage <- ReorderDupWithoutMessage
    Messages <- ReorderDupMessages
    MessagesOf <- ReorderDupMessagesOf
    InitMessageVar <- ReorderDupInitMessageVar

    default: 153 453

Numbers collected from checking MCccfraft.cfg with TLCGet("level") < 22 as state constraint and Send <- MCSend commented.