### PR TITLE
Restore use of `-lvi-cfg` variants of OE libs

### DIFF
--- a/cmake/open_enclave.cmake
+++ b/cmake/open_enclave.cmake
@@ -38,6 +38,11 @@ if(REQUIRE_OPENENCLAVE)
     )
 
     option(LVI_MITIGATIONS "Enable LVI mitigations" ON)
+    if(LVI_MITIGATIONS)
+      string(APPEND OE_TARGET_LIBC -lvi-cfg)
+      list(TRANSFORM OE_TARGET_ENCLAVE_AND_STD APPEND -lvi-cfg)
+      list(TRANSFORM OE_TARGET_ENCLAVE_CORE_LIBS APPEND -lvi-cfg)
+    endif()
 
     function(add_lvi_mitigations name)
       if(LVI_MITIGATIONS)


### PR DESCRIPTION
In the upgrade to OE 0.19, we moved to building with Clang 11 so the LVI mitigation solution changed - `-mlvi-cfi` rather than a custom toolchain. In the process, we began linking against the unmitigated OE libs.