### PR TITLE
[release/4.x] Cherry pick: OpenSSL3: remove use of deprecated functions (#5481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [4.0.8]: https://github.com/microsoft/CCF/releases/tag/ccf-4.0.8
 
+- SGX builds now use OpenSSL 3.1.1 by default (#5481).
 - Converted SNP attestation UVM endorsements from integer to arbitrary string.
-
 - Add `/node/ready/app` and `/node/ready/gov` endpoints for the use of load balancers wanting to check if a node is ready to accept application or governance transactions. See [Operator RPC API](https://microsoft.github.io/CCF/main/operations/operator_rpc_api.html) for details.
 - Updated `llhttp` from `6.0.9` to `9.0.1`.
 - Updated `fmt` library from `9.1.0` to `10.1.1`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,9 +247,6 @@ set(CCF_ENDPOINTS_SOURCES
     ${CCF_DIR}/src/node/receipt.cpp
 )
 
-find_library(CRYPTO_LIBRARY crypto)
-find_library(TLS_LIBRARY ssl)
-
 include(${CCF_DIR}/cmake/crypto.cmake)
 include(${CCF_DIR}/cmake/quickjs.cmake)
 include(${CCF_DIR}/cmake/sss.cmake)

--- a/cmake/crypto.cmake
+++ b/cmake/crypto.cmake
@@ -54,10 +54,14 @@ elseif(COMPILE_TARGET STREQUAL "snp")
   )
 endif()
 
+find_library(CRYPTO_LIBRARY crypto)
+find_library(TLS_LIBRARY ssl)
+
 add_library(ccfcrypto.host STATIC ${CCFCRYPTO_SRC})
 add_san(ccfcrypto.host)
 target_compile_options(ccfcrypto.host PUBLIC ${COMPILE_LIBCXX})
 target_link_options(ccfcrypto.host PUBLIC ${LINK_LIBCXX})
+
 target_link_libraries(ccfcrypto.host PUBLIC qcbor.host)
 target_link_libraries(ccfcrypto.host PUBLIC t_cose.host)
 target_link_libraries(ccfcrypto.host PUBLIC crypto)

--- a/cmake/open_enclave.cmake
+++ b/cmake/open_enclave.cmake
@@ -23,7 +23,7 @@ if(COMPILE_TARGET STREQUAL "sgx")
   set(OE_TARGET_LIBC openenclave::oelibc)
   set(OE_TARGET_ENCLAVE_AND_STD
       openenclave::oeenclave openenclave::oelibcxx openenclave::oelibc
-      openenclave::oecryptoopenssl
+      ${OE_OPENSSL_LIBRARY}
   )
   # These oe libraries must be linked in specific order
   set(OE_TARGET_ENCLAVE_CORE_LIBS

--- a/cmake/open_enclave.cmake
+++ b/cmake/open_enclave.cmake
@@ -12,6 +12,13 @@ find_package(OpenEnclave 0.19.3 CONFIG REQUIRED)
 # standard naming patterns, for example use OE_INCLUDEDIR rather than
 # OpenEnclave_INCLUDE_DIRS
 
+option(USE_OPENSSL_3 "Use OpenSSL 3.x for Open Enclave builds" ON)
+if(USE_OPENSSL_3)
+  set(OE_OPENSSL_LIBRARY openenclave::oecryptoopenssl_3)
+else()
+  set(OE_OPENSSL_LIBRARY openenclave::oecryptoopenssl)
+endif()
+
 if(COMPILE_TARGET STREQUAL "sgx")
   set(OE_TARGET_LIBC openenclave::oelibc)
   set(OE_TARGET_ENCLAVE_AND_STD

--- a/cmake/t_cose.cmake
+++ b/cmake/t_cose.cmake
@@ -26,7 +26,7 @@ if(COMPILE_TARGET STREQUAL "sgx")
 
   target_link_libraries(t_cose.enclave PUBLIC qcbor.enclave)
   # This is needed to get the OpenSSL includes from Open Enclave
-  target_link_libraries(t_cose.enclave PRIVATE openenclave::oecryptoopenssl)
+  target_link_libraries(t_cose.enclave PRIVATE ${OE_OPENSSL_LIBRARY})
 
   install(
     TARGETS t_cose.enclave

--- a/src/crypto/key_wrap.cpp
+++ b/src/crypto/key_wrap.cpp
@@ -9,6 +9,7 @@
 #include "openssl/symmetric_key.h"
 
 #include <cstdint>
+#include <openssl/rand.h>
 #include <stdexcept>
 #include <vector>
 

--- a/src/crypto/openssl/cose_verifier.cpp
+++ b/src/crypto/openssl/cose_verifier.cpp
@@ -39,7 +39,11 @@ namespace crypto
 
     EVP_PKEY* pk = X509_get_pubkey(cert);
 
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    if (EVP_PKEY_get_base_id(pk) == EVP_PKEY_EC)
+#else
     if (EVP_PKEY_get0_EC_KEY(pk))
+#endif
     {
       public_key = std::make_shared<PublicKey_OpenSSL>(pk);
     }

--- a/src/crypto/openssl/public_key.cpp
+++ b/src/crypto/openssl/public_key.cpp
@@ -18,6 +18,11 @@
 #include <stdexcept>
 #include <string>
 
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+#  include <openssl/core_names.h>
+#  include <openssl/param_build.h>
+#endif
+
 namespace crypto
 {
   using namespace OpenSSL;
@@ -44,7 +49,7 @@ namespace crypto
     }
   }
 
-  Unique_EC_KEY PublicKey_OpenSSL::ec_key_public_from_jwk(
+  std::pair<Unique_BIGNUM, Unique_BIGNUM> get_components(
     const JsonWebKeyECPublic& jwk)
   {
     if (jwk.kty != JsonWebKeyType::EC)
@@ -52,24 +57,68 @@ namespace crypto
       throw std::logic_error("Cannot construct public key from non-EC JWK");
     }
 
-    auto nid = get_openssl_group_id(jwk_curve_to_curve_id(jwk.crv));
-
-    Unique_BIGNUM x, y;
+    std::pair<Unique_BIGNUM, Unique_BIGNUM> xy;
     auto x_raw = raw_from_b64url(jwk.x);
     auto y_raw = raw_from_b64url(jwk.y);
-    OpenSSL::CHECKNULL(BN_bin2bn(x_raw.data(), x_raw.size(), x));
-    OpenSSL::CHECKNULL(BN_bin2bn(y_raw.data(), y_raw.size(), y));
+    OpenSSL::CHECKNULL(BN_bin2bn(x_raw.data(), x_raw.size(), xy.first));
+    OpenSSL::CHECKNULL(BN_bin2bn(y_raw.data(), y_raw.size(), xy.second));
+
+    return xy;
+  }
+
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+  std::vector<uint8_t> PublicKey_OpenSSL::ec_point_public_from_jwk(
+    const JsonWebKeyECPublic& jwk)
+  {
+    auto nid = get_openssl_group_id(jwk_curve_to_curve_id(jwk.crv));
+    auto [x, y] = get_components(jwk);
+
+    Unique_BN_CTX bn_ctx;
+    Unique_EC_GROUP group(nid);
+    Unique_EC_POINT p(group);
+    CHECK1(EC_POINT_set_affine_coordinates(group, p, x, y, bn_ctx));
+    size_t buf_size = EC_POINT_point2oct(
+      group, p, POINT_CONVERSION_UNCOMPRESSED, nullptr, 0, bn_ctx);
+    std::vector<uint8_t> buf(buf_size);
+    CHECKPOSITIVE(EC_POINT_point2oct(
+      group, p, POINT_CONVERSION_UNCOMPRESSED, buf.data(), buf.size(), bn_ctx));
+    return buf;
+  }
+#else
+  Unique_EC_KEY PublicKey_OpenSSL::ec_key_public_from_jwk(
+    const JsonWebKeyECPublic& jwk)
+  {
+    auto nid = get_openssl_group_id(jwk_curve_to_curve_id(jwk.crv));
+    auto [x, y] = get_components(jwk);
 
     Unique_EC_KEY ec_key(nid);
     CHECK1(EC_KEY_set_public_key_affine_coordinates(ec_key, x, y));
     return ec_key;
   }
+#endif
 
   PublicKey_OpenSSL::PublicKey_OpenSSL(const JsonWebKeyECPublic& jwk)
   {
     key = EVP_PKEY_new();
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    auto nid = get_openssl_group_id(jwk_curve_to_curve_id(jwk.crv));
+    auto buf = ec_point_public_from_jwk(jwk);
+
+    OSSL_PARAM params[3];
+    params[0] = OSSL_PARAM_construct_utf8_string(
+      OSSL_PKEY_PARAM_GROUP_NAME, (char*)OSSL_EC_curve_nid2name(nid), 0);
+    params[1] = OSSL_PARAM_construct_octet_string(
+      OSSL_PKEY_PARAM_PUB_KEY, buf.data(), buf.size());
+    params[2] = OSSL_PARAM_construct_end();
+
+    Unique_EVP_PKEY_CTX pctx("EC");
+    CHECK1(EVP_PKEY_fromdata_init(pctx));
+    CHECK1(EVP_PKEY_fromdata(pctx, &key, EVP_PKEY_PUBLIC_KEY, params));
+#else
     CHECK1(EVP_PKEY_set1_EC_KEY(key, ec_key_public_from_jwk(jwk)));
+#endif
   }
+
   PublicKey_OpenSSL::PublicKey_OpenSSL(EVP_PKEY* key) : key(key) {}
 
   PublicKey_OpenSSL::~PublicKey_OpenSSL()
@@ -82,8 +131,7 @@ namespace crypto
 
   CurveID PublicKey_OpenSSL::get_curve_id() const
   {
-    int nid =
-      EC_GROUP_get_curve_name(EC_KEY_get0_group(EVP_PKEY_get0_EC_KEY(key)));
+    int nid = get_openssl_group_id();
     switch (nid)
     {
       case NID_secp384r1:
@@ -100,8 +148,33 @@ namespace crypto
 
   int PublicKey_OpenSSL::get_openssl_group_id() const
   {
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    size_t gname_len = 0;
+    CHECK1(EVP_PKEY_get_group_name(key, NULL, 0, &gname_len));
+    std::string gname(gname_len + 1, 0);
+    CHECK1(EVP_PKEY_get_group_name(
+      key, (char*)gname.data(), gname.size(), &gname_len));
+    gname.resize(gname_len);
+    if (gname == SN_secp384r1)
+    {
+      return NID_secp384r1;
+    }
+    else if (gname == SN_X9_62_prime256v1)
+    {
+      return NID_X9_62_prime256v1;
+    }
+    else if (gname == SN_secp256k1)
+    {
+      return NID_secp256k1;
+    }
+    else
+    {
+      throw std::runtime_error(fmt::format("Unknown OpenSSL group {}", gname));
+    }
+#else
     return EC_GROUP_get_curve_name(
       EC_KEY_get0_group(EVP_PKEY_get0_EC_KEY(key)));
+#endif
   }
 
   int PublicKey_OpenSSL::get_openssl_group_id(CurveID gid)
@@ -213,32 +286,63 @@ namespace crypto
 
   Unique_PKEY key_from_raw_ec_point(const std::vector<uint8_t>& raw, int nid)
   {
-    // To extract a raw encoding of the EC point, OpenSSL has i2d_PublicKey,
-    // but the converse in d2i_PublicKey is useless until we switch to 3.0
-    // (see also https://github.com/openssl/openssl/issues/16989).
-    // So, instead we reconstruct the key the long way round.
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    const unsigned char* pp = raw.data();
+    EVP_PKEY* pkey = NULL;
+    OSSL_PARAM params[2];
+    params[0] = OSSL_PARAM_construct_utf8_string(
+      OSSL_PKEY_PARAM_GROUP_NAME, (char*)OSSL_EC_curve_nid2name(nid), 0);
+    params[1] = OSSL_PARAM_construct_end();
 
+    Unique_EVP_PKEY_CTX pctx("EC");
+    EVP_PKEY_fromdata_init(pctx);
+    EVP_PKEY_fromdata(
+      pctx, &pkey, OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS, params);
+
+    pkey = d2i_PublicKey(EVP_PKEY_EC, &pkey, &pp, raw.size());
+    if (pkey == NULL)
+    {
+      EVP_PKEY_free(pkey);
+      throw std::logic_error("Error loading public key");
+    }
+
+    Unique_PKEY pk(pkey);
+    EVP_PKEY_up_ref(pk);
+    EVP_PKEY_free(pkey);
+    return pk;
+#else
     Unique_BN_CTX bn_ctx;
     Unique_EC_GROUP group(nid);
     Unique_EC_POINT p(group);
     CHECK1(EC_POINT_oct2point(group, p, raw.data(), raw.size(), bn_ctx));
     Unique_EC_KEY ec_key(nid);
-    CHECK1(EC_KEY_set_public_key(ec_key, p));
+
     Unique_PKEY pk;
+    CHECK1(EC_KEY_set_public_key(ec_key, p));
     CHECK1(EVP_PKEY_set1_EC_KEY(pk, ec_key));
     EVP_PKEY_up_ref(pk);
     return pk;
+#endif
   }
 
   PublicKey::Coordinates PublicKey_OpenSSL::coordinates() const
   {
+    Coordinates r;
+    Unique_BIGNUM x, y;
+    Unique_EC_GROUP group(get_openssl_group_id());
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    BIGNUM* bn_x = NULL;
+    BIGNUM* bn_y = NULL;
+    CHECK1(EVP_PKEY_get_bn_param(key, OSSL_PKEY_PARAM_EC_PUB_X, &bn_x));
+    x.reset(bn_x);
+    CHECK1(EVP_PKEY_get_bn_param(key, OSSL_PKEY_PARAM_EC_PUB_Y, &bn_y));
+    y.reset(bn_y);
+#else
     Unique_EC_KEY eckey(EVP_PKEY_get1_EC_KEY(key));
     const EC_POINT* p = EC_KEY_get0_public_key(eckey);
-    Unique_EC_GROUP group(get_openssl_group_id());
     Unique_BN_CTX bn_ctx;
-    Unique_BIGNUM x, y;
     CHECK1(EC_POINT_get_affine_coordinates(group, p, x, y, bn_ctx));
-    Coordinates r;
+#endif
     int sz = EC_GROUP_get_degree(group) / 8;
     r.x.resize(sz);
     r.y.resize(sz);

--- a/src/crypto/openssl/public_key.h
+++ b/src/crypto/openssl/public_key.h
@@ -18,8 +18,13 @@ namespace crypto
     EVP_PKEY* key = nullptr;
     PublicKey_OpenSSL();
 
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    std::vector<uint8_t> ec_point_public_from_jwk(
+      const JsonWebKeyECPublic& jwk);
+#else
     OpenSSL::Unique_EC_KEY ec_key_public_from_jwk(
       const JsonWebKeyECPublic& jwk);
+#endif
 
   public:
     PublicKey_OpenSSL(PublicKey_OpenSSL&& key) = default;

--- a/src/crypto/openssl/rsa_public_key.cpp
+++ b/src/crypto/openssl/rsa_public_key.cpp
@@ -5,13 +5,22 @@
 #include "crypto/openssl/rsa_key_pair.h"
 #include "openssl_wrappers.h"
 
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+#  include <openssl/core_names.h>
+#  include <openssl/encoder.h>
+#endif
+
 namespace crypto
 {
   using namespace OpenSSL;
 
   RSAPublicKey_OpenSSL::RSAPublicKey_OpenSSL(EVP_PKEY* c) : PublicKey_OpenSSL(c)
   {
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    if (EVP_PKEY_get_base_id(key) != EVP_PKEY_RSA)
+#else
     if (!EVP_PKEY_get0_RSA(key))
+#endif
     {
       throw std::logic_error("invalid RSA key");
     }
@@ -21,7 +30,11 @@ namespace crypto
   {
     Unique_BIO mem(pem);
     key = PEM_read_bio_PUBKEY(mem, NULL, NULL, NULL);
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    if (!key || EVP_PKEY_get_base_id(key) != EVP_PKEY_RSA)
+#else
     if (!key || !EVP_PKEY_get0_RSA(key))
+#endif
     {
       throw std::logic_error("invalid RSA key");
     }
@@ -30,37 +43,54 @@ namespace crypto
   RSAPublicKey_OpenSSL::RSAPublicKey_OpenSSL(const std::vector<uint8_t>& der)
   {
     const unsigned char* pp = der.data();
-    RSA* rsa = nullptr;
+    key = EVP_PKEY_new();
     if (
-      ((rsa = d2i_RSA_PUBKEY(NULL, &pp, der.size())) ==
+      ((key = d2i_PUBKEY(&key, &pp, der.size())) ==
        NULL) && // "SubjectPublicKeyInfo structure" format
-      ((rsa = d2i_RSAPublicKey(NULL, &pp, der.size())) ==
+      ((key = d2i_PublicKey(EVP_PKEY_RSA, &key, &pp, der.size())) ==
        NULL)) // PKCS#1 structure format
     {
       unsigned long ec = ERR_get_error();
       auto msg = OpenSSL::error_string(ec);
       throw std::runtime_error(fmt::format("OpenSSL error: {}", msg));
     }
-
-    key = EVP_PKEY_new();
-    OpenSSL::CHECK1(EVP_PKEY_set1_RSA(key, rsa));
-    RSA_free(rsa);
   }
 
-  OpenSSL::Unique_RSA RSAPublicKey_OpenSSL::rsa_public_from_jwk(
+  std::pair<Unique_BIGNUM, Unique_BIGNUM> get_modulus_and_exponent(
     const JsonWebKeyRSAPublic& jwk)
   {
     if (jwk.kty != JsonWebKeyType::RSA)
     {
-      throw std::logic_error(
-        "Cannot construct RSA public key from non-RSA JWK");
+      throw std::logic_error("Cannot construct public key from non-RSA JWK");
     }
 
-    Unique_BIGNUM e, n;
-    auto e_raw = raw_from_b64url(jwk.e);
+    std::pair<Unique_BIGNUM, Unique_BIGNUM> ne;
     auto n_raw = raw_from_b64url(jwk.n);
-    OpenSSL::CHECKNULL(BN_bin2bn(e_raw.data(), e_raw.size(), e));
-    OpenSSL::CHECKNULL(BN_bin2bn(n_raw.data(), n_raw.size(), n));
+    auto e_raw = raw_from_b64url(jwk.e);
+    OpenSSL::CHECKNULL(BN_bin2bn(n_raw.data(), n_raw.size(), ne.first));
+    OpenSSL::CHECKNULL(BN_bin2bn(e_raw.data(), e_raw.size(), ne.second));
+
+    return ne;
+  }
+
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+  std::pair<std::vector<uint8_t>, std::vector<uint8_t>> RSAPublicKey_OpenSSL::
+    rsa_public_raw_from_jwk(const JsonWebKeyRSAPublic& jwk)
+  {
+    auto [n, e] = get_modulus_and_exponent(jwk);
+    std::pair<std::vector<uint8_t>, std::vector<uint8_t>> r(
+      BN_num_bytes(n), BN_num_bytes(e));
+
+    CHECKPOSITIVE(BN_bn2nativepad(n, r.first.data(), r.first.size()));
+    CHECKPOSITIVE(BN_bn2nativepad(e, r.second.data(), r.second.size()));
+
+    return r;
+  }
+#else
+  OpenSSL::Unique_RSA RSAPublicKey_OpenSSL::rsa_public_from_jwk(
+    const JsonWebKeyRSAPublic& jwk)
+  {
+    auto [n, e] = get_modulus_and_exponent(jwk);
 
     Unique_RSA rsa;
     CHECK1(RSA_set0_key(rsa, n, e, nullptr));
@@ -69,11 +99,27 @@ namespace crypto
 
     return rsa;
   }
+#endif
 
   RSAPublicKey_OpenSSL::RSAPublicKey_OpenSSL(const JsonWebKeyRSAPublic& jwk)
   {
     key = EVP_PKEY_new();
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    auto [n_raw, e_raw] = rsa_public_raw_from_jwk(jwk);
+
+    OSSL_PARAM params[3];
+    params[0] = OSSL_PARAM_construct_BN(
+      OSSL_PKEY_PARAM_RSA_N, n_raw.data(), n_raw.size());
+    params[1] = OSSL_PARAM_construct_BN(
+      OSSL_PKEY_PARAM_RSA_E, e_raw.data(), e_raw.size());
+    params[2] = OSSL_PARAM_construct_end();
+
+    Unique_EVP_PKEY_CTX pctx("RSA");
+    CHECK1(EVP_PKEY_fromdata_init(pctx));
+    CHECK1(EVP_PKEY_fromdata(pctx, &key, EVP_PKEY_PUBLIC_KEY, params));
+#else
     CHECK1(EVP_PKEY_set1_RSA(key, rsa_public_from_jwk(jwk)));
+#endif
   }
 
   size_t RSAPublicKey_OpenSSL::key_size() const
@@ -166,17 +212,33 @@ namespace crypto
     return r;
   }
 
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+  Unique_BIGNUM RSAPublicKey_OpenSSL::get_bn_param(const char* key_name) const
+  {
+    Unique_BIGNUM r;
+    BIGNUM* bn = NULL;
+    CHECK1(EVP_PKEY_get_bn_param(key, key_name, &bn));
+    r.reset(bn);
+    return r;
+  }
+#endif
+
   RSAPublicKey::Components RSAPublicKey_OpenSSL::components() const
   {
-    RSA* rsa = EVP_PKEY_get0_RSA(key);
+    Components r;
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    r.n = bn_bytes(get_bn_param(OSSL_PKEY_PARAM_RSA_N));
+    r.e = bn_bytes(get_bn_param(OSSL_PKEY_PARAM_RSA_E));
+#else
+    const RSA* rsa = EVP_PKEY_get0_RSA(key);
     if (!rsa)
     {
       throw std::logic_error("invalid RSA key");
     }
 
-    Components r;
     r.n = bn_bytes(RSA_get0_n(rsa));
     r.e = bn_bytes(RSA_get0_e(rsa));
+#endif
     return r;
   }
 

--- a/src/crypto/openssl/rsa_public_key.h
+++ b/src/crypto/openssl/rsa_public_key.h
@@ -16,7 +16,12 @@ namespace crypto
   class RSAPublicKey_OpenSSL : public PublicKey_OpenSSL, public RSAPublicKey
   {
   protected:
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    std::pair<std::vector<uint8_t>, std::vector<uint8_t>>
+    rsa_public_raw_from_jwk(const JsonWebKeyRSAPublic& jwk);
+#else
     OpenSSL::Unique_RSA rsa_public_from_jwk(const JsonWebKeyRSAPublic& jwk);
+#endif
 
   public:
     RSAPublicKey_OpenSSL() = default;
@@ -52,6 +57,10 @@ namespace crypto
     virtual Components components() const override;
 
     static std::vector<uint8_t> bn_bytes(const BIGNUM* bn);
+
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    OpenSSL::Unique_BIGNUM get_bn_param(const char* key_name) const;
+#endif
 
     virtual JsonWebKeyRSAPublic public_key_jwk_rsa(
       const std::optional<std::string>& kid = std::nullopt) const override;

--- a/src/crypto/openssl/verifier.cpp
+++ b/src/crypto/openssl/verifier.cpp
@@ -56,6 +56,17 @@ namespace crypto
 
     EVP_PKEY* pk = X509_get_pubkey(cert);
 
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    auto base_id = EVP_PKEY_get_base_id(pk);
+    if (base_id == EVP_PKEY_EC)
+    {
+      public_key = std::make_unique<PublicKey_OpenSSL>(pk);
+    }
+    else if (base_id == EVP_PKEY_RSA)
+    {
+      public_key = std::make_unique<RSAPublicKey_OpenSSL>(pk);
+    }
+#else
     if (EVP_PKEY_get0_EC_KEY(pk))
     {
       public_key = std::make_unique<PublicKey_OpenSSL>(pk);
@@ -64,6 +75,7 @@ namespace crypto
     {
       public_key = std::make_unique<RSAPublicKey_OpenSSL>(pk);
     }
+#endif
     else
     {
       throw std::logic_error("unsupported public key type");

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -821,7 +821,14 @@ TEST_CASE("PEM to JWK and back")
   INFO("RSA");
   {
     auto kp = make_rsa_key_pair();
+
     auto pubk = make_rsa_public_key(kp->public_key_pem());
+
+    INFO("DER");
+    {
+      auto pubk_der = make_rsa_public_key(kp->public_key_der());
+      REQUIRE(pubk_der->public_key_pem() == kp->public_key_pem());
+    }
 
     INFO("Public");
     {
@@ -844,6 +851,7 @@ TEST_CASE("PEM to JWK and back")
 
       auto kp2 = make_rsa_key_pair(jwk);
       auto jwk2 = kp2->private_key_jwk_rsa(kid);
+
       REQUIRE(jwk == jwk2);
     }
   }

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -48,7 +48,9 @@ namespace ccf
     std::unique_ptr<ccf::NodeState> node;
     ringbuffer::WriterPtr to_host = nullptr;
     std::chrono::microseconds last_tick_time;
+#if !(defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3)
     ENGINE* rdrand_engine = nullptr;
+#endif
 
     StartType start_type;
 
@@ -94,6 +96,11 @@ namespace ccf
       ccf::pal::initialize_enclave();
       ccf::initialize_verifiers();
 
+      // https://github.com/microsoft/CCF/issues/5569
+      // Open Enclave with OpenSSL 3.x (default for SGX) is built with RDCPU
+      // (https://github.com/openenclave/openenclave/blob/master/docs/OpenSSLSupport.md#how-to-use-rand-apis)
+      // and so does not need to make use of the (deprecated) ENGINE_x API.
+#if !(defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3)
       // From
       // https://software.intel.com/content/www/us/en/develop/articles/how-to-use-the-rdrand-engine-in-openssl-for-random-number-generation.html
       if (
@@ -107,6 +114,7 @@ namespace ccf
         throw ccf::ccf_openssl_rdrand_init_error(
           "could not initialize RDRAND engine for OpenSSL");
       }
+#endif
 
       to_host = writer_factory->create_writer_to_outside();
 
@@ -182,12 +190,14 @@ namespace ccf
 
     ~Enclave()
     {
+#if !(defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3)
       if (rdrand_engine)
       {
         LOG_TRACE_FMT("Finishing RDRAND engine");
         ENGINE_finish(rdrand_engine);
         ENGINE_free(rdrand_engine);
       }
+#endif
       LOG_TRACE_FMT("Shutting down enclave");
       ccf::shutdown_verifiers();
       ccf::pal::shutdown_enclave();

--- a/src/enclave/tls_session.h
+++ b/src/enclave/tls_session.h
@@ -673,7 +673,15 @@ namespace ccf
       (void)argi;
       (void)argl;
 
-      if (ret && oper == (BIO_CB_READ | BIO_CB_RETURN))
+      if (ret == 1 && oper == (BIO_CB_CTRL | BIO_CB_RETURN))
+      {
+        // This callback may be fired at the end of large batches of TLS frames
+        // on OpenSSL 3.x. Note that processed == nullptr in this case, hence
+        // the early exit.
+        return 0;
+      }
+
+      if (ret && (oper == (BIO_CB_READ | BIO_CB_RETURN)))
       {
         // Pipe object
         void* ctx = (BIO_get_callback_arg(b));

--- a/src/node/snapshot_serdes.h
+++ b/src/node/snapshot_serdes.h
@@ -85,7 +85,8 @@ namespace ccf
           root.h.data(),
           root.h.size(),
           receipt->signature.data(),
-          receipt->signature.size()))
+          receipt->signature.size(),
+          crypto::MDType::SHA256))
     {
       throw std::logic_error(
         "Signature verification failed for snapshot receipt");


### PR DESCRIPTION
Backports the following commits to `release/4.x`:
 - [OpenSSL3: remove use of deprecated functions (#5481)](https://github.com/microsoft/CCF/pull/5481)