### PR TITLE
Revert "Extend testing of JS runtime limits"

### DIFF
--- a/tests/js-limits/app.json
+++ b/tests/js-limits/app.json
@@ -5,7 +5,7 @@
         "js_module": "limits.js",
         "js_function": "recursive",
         "forwarding_required": "sometimes",
-        "authn_policies": ["no_auth"],
+        "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {}
       }
@@ -15,17 +15,7 @@
         "js_module": "limits.js",
         "js_function": "alloc",
         "forwarding_required": "sometimes",
-        "authn_policies": ["no_auth"],
-        "mode": "readonly",
-        "openapi": {}
-      }
-    },
-    "/sleep": {
-      "post": {
-        "js_module": "limits.js",
-        "js_function": "sleep",
-        "forwarding_required": "sometimes",
-        "authn_policies": ["no_auth"],
+        "authn_policies": ["user_cert"],
         "mode": "readonly",
         "openapi": {}
       }

--- a/tests/js-limits/src/limits.js
+++ b/tests/js-limits/src/limits.js
@@ -15,17 +15,3 @@ export function alloc(request) {
   new Uint8Array(size);
   return {};
 }
-
-export function sleep(request) {
-  const time = request.body.json()["time"];
-  ccf.enableUntrustedDateTime(true);
-  const start = new Date();
-  while (true) {
-    const now = new Date();
-    const diff = now - start;
-    if (diff > time) {
-      break;
-    }
-  }
-  return {};
-}

--- a/tests/js-modules/modules.py
+++ b/tests/js-modules/modules.py
@@ -991,6 +991,73 @@ def test_npm_app(network, args):
     return network
 
 
+@reqs.description("Test JS execution time out with npm app endpoint")
+def test_js_execution_time(network, args):
+    primary, _ = network.find_nodes()
+
+    LOG.info("Deploying npm app")
+    app_dir = os.path.join(PARENT_DIR, "npm-app")
+    bundle_path = os.path.join(
+        app_dir, "dist", "bundle.json"
+    )  # Produced by build step of test npm-app in the previous test_npm_app
+    network.consortium.set_js_app_from_json(primary, bundle_path)
+
+    LOG.info("Store JWT signing keys")
+    jwt_key_priv_pem, _ = infra.crypto.generate_rsa_keypair(2048)
+    jwt_cert_pem = infra.crypto.generate_cert(jwt_key_priv_pem)
+    jwt_kid = "my_other_key_id"
+    issuer = "https://example.issuer"
+    with tempfile.NamedTemporaryFile(prefix="ccf", mode="w+") as metadata_fp:
+        jwt_cert_der = infra.crypto.cert_pem_to_der(jwt_cert_pem)
+        der_b64 = base64.b64encode(jwt_cert_der).decode("ascii")
+        data = {
+            "issuer": issuer,
+            "jwks": {"keys": [{"kty": "RSA", "kid": jwt_kid, "x5c": [der_b64]}]},
+        }
+        json.dump(data, metadata_fp)
+        metadata_fp.flush()
+        network.consortium.set_jwt_issuer(primary, metadata_fp.name)
+
+    LOG.info("Calling jwt endpoint after storing keys")
+    with primary.client("user0") as c:
+        # fetch defaults from js_metrics endpoint
+        r = c.get("/node/js_metrics")
+        body = r.body.json()
+        default_max_heap_size = body["max_heap_size"]
+        default_max_stack_size = body["max_stack_size"]
+        default_max_execution_time = body["max_execution_time"]
+
+        # set JS execution time to a lower value which will timeout this
+        # endpoint execution
+        network.consortium.set_js_runtime_options(
+            primary,
+            max_heap_bytes=50 * 1024 * 1024,
+            max_stack_bytes=1024 * 512,
+            max_execution_time_ms=1,
+        )
+        user_id = "user0"
+        jwt = infra.crypto.create_jwt({"sub": user_id}, jwt_key_priv_pem, jwt_kid)
+
+        r = c.get("/app/jwt", headers={"authorization": "Bearer " + jwt})
+        assert r.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR, r.status_code
+        body = r.body.json()
+        assert body["error"]["message"] == "Operation took too long to complete."
+
+        # reset the execution time
+        network.consortium.set_js_runtime_options(
+            primary,
+            max_heap_bytes=default_max_heap_size,
+            max_stack_bytes=default_max_stack_size,
+            max_execution_time_ms=default_max_execution_time,
+        )
+        r = c.get("/app/jwt", headers={"authorization": "Bearer " + jwt})
+        assert r.status_code == http.HTTPStatus.OK, r.status_code
+        body = r.body.json()
+        assert body["userId"] == user_id, r.body
+
+    return network
+
+
 @reqs.description("Test JS exception output")
 def test_js_exception_output(network, args):
     primary, _ = network.find_nodes()
@@ -1098,6 +1165,7 @@ def run(args):
         network = test_dynamic_endpoints(network, args)
         network = test_set_js_runtime(network, args)
         network = test_npm_app(network, args)
+        network = test_js_execution_time(network, args)
         network = test_js_exception_output(network, args)
         network = test_user_cose_authentication(network, args)
 


### PR DESCRIPTION
Reverts microsoft/CCF#5594.

Intended to close this PR, not merge it - tweaking these numbers is dangerous, as the stack limits on each platform differ.