### PR TITLE
Fix HTTP handling errors reporting

### DIFF
--- a/src/enclave/rpc_sessions.h
+++ b/src/enclave/rpc_sessions.h
@@ -126,21 +126,17 @@ namespace ccf
       return id;
     }
 
-    ListenInterface& get_interface_from_session_id(tls::ConnID id)
+    ListenInterface& get_interface_from_interface_id(
+      const ccf::ListenInterfaceID& id)
     {
-      // Lock must be first acquired and held while accessing returned interface
-      auto search = sessions.find(id);
-      if (search != sessions.end())
+      auto it = listening_interfaces.find(id);
+      if (it != listening_interfaces.end())
       {
-        auto it = listening_interfaces.find(search->second.first);
-        if (it != listening_interfaces.end())
-        {
-          return it->second;
-        }
+        return it->second;
       }
 
       throw std::logic_error(
-        fmt::format("No RPC interface for session ID {}", id));
+        fmt::format("No RPC interface for interface ID {}", id));
     }
 
     std::shared_ptr<ccf::Session> make_server_session(
@@ -203,22 +199,24 @@ namespace ccf
       custom_protocol_subsystem = cpss;
     }
 
-    void report_parsing_error(tls::ConnID id) override
+    void report_parsing_error(const ccf::ListenInterfaceID& id) override
     {
       std::lock_guard<ccf::pal::Mutex> guard(lock);
-      get_interface_from_session_id(id).errors.parsing++;
+      get_interface_from_interface_id(id).errors.parsing++;
     }
 
-    void report_request_payload_too_large_error(tls::ConnID id) override
+    void report_request_payload_too_large_error(
+      const ccf::ListenInterfaceID& id) override
     {
       std::lock_guard<ccf::pal::Mutex> guard(lock);
-      get_interface_from_session_id(id).errors.request_payload_too_large++;
+      get_interface_from_interface_id(id).errors.request_payload_too_large++;
     }
 
-    void report_request_header_too_large_error(tls::ConnID id) override
+    void report_request_header_too_large_error(
+      const ccf::ListenInterfaceID& id) override
     {
       std::lock_guard<ccf::pal::Mutex> guard(lock);
-      get_interface_from_session_id(id).errors.request_header_too_large++;
+      get_interface_from_interface_id(id).errors.request_header_too_large++;
     }
 
     void update_listening_interface_options(

--- a/src/http/error_reporter.h
+++ b/src/http/error_reporter.h
@@ -10,8 +10,10 @@ namespace http
   {
   public:
     virtual ~ErrorReporter() {}
-    virtual void report_parsing_error(tls::ConnID) = 0;
-    virtual void report_request_payload_too_large_error(tls::ConnID) = 0;
-    virtual void report_request_header_too_large_error(tls::ConnID) = 0;
+    virtual void report_parsing_error(const ccf::ListenInterfaceID&) = 0;
+    virtual void report_request_payload_too_large_error(
+      const ccf::ListenInterfaceID&) = 0;
+    virtual void report_request_header_too_large_error(
+      const ccf::ListenInterfaceID&) = 0;
   };
 }

--- a/src/http/http2_session.h
+++ b/src/http/http2_session.h
@@ -350,7 +350,7 @@ namespace http
       {
         if (error_reporter)
         {
-          error_reporter->report_request_payload_too_large_error(session_id);
+          error_reporter->report_request_payload_too_large_error(interface_id);
         }
 
         LOG_DEBUG_FMT("Request is too large: {}", e.what());
@@ -368,7 +368,7 @@ namespace http
       {
         if (error_reporter)
         {
-          error_reporter->report_request_header_too_large_error(session_id);
+          error_reporter->report_request_header_too_large_error(interface_id);
         }
 
         LOG_DEBUG_FMT("Request header is too large: {}", e.what());
@@ -386,7 +386,7 @@ namespace http
       {
         if (error_reporter)
         {
-          error_reporter->report_parsing_error(session_id);
+          error_reporter->report_parsing_error(interface_id);
         }
 
         LOG_DEBUG_FMT("Error parsing HTTP request: {}", e.what());

--- a/src/http/http_session.h
+++ b/src/http/http_session.h
@@ -124,7 +124,7 @@ namespace http
       {
         if (error_reporter)
         {
-          error_reporter->report_request_payload_too_large_error(session_id);
+          error_reporter->report_request_payload_too_large_error(interface_id);
         }
 
         LOG_DEBUG_FMT("Request is too large: {}", e.what());
@@ -140,7 +140,7 @@ namespace http
       {
         if (error_reporter)
         {
-          error_reporter->report_request_header_too_large_error(session_id);
+          error_reporter->report_request_header_too_large_error(interface_id);
         }
 
         LOG_DEBUG_FMT("Request header is too large: {}", e.what());
@@ -156,7 +156,7 @@ namespace http
       {
         if (error_reporter)
         {
-          error_reporter->report_parsing_error(session_id);
+          error_reporter->report_parsing_error(interface_id);
         }
         LOG_DEBUG_FMT("Error parsing HTTP request: {}", e.what());
 
@@ -340,10 +340,6 @@ namespace http
       }
       catch (const std::exception& e)
       {
-        if (error_reporter)
-        {
-          error_reporter->report_parsing_error(session_id);
-        }
         LOG_FAIL_FMT("Error parsing HTTP response on session {}", session_id);
         LOG_DEBUG_FMT("Error parsing HTTP response: {}", e.what());
         LOG_DEBUG_FMT(

--- a/tests/infra/jwt_issuer.py
+++ b/tests/infra/jwt_issuer.py
@@ -45,8 +45,14 @@ class MyHTTPRequestHandler(BaseHTTPRequestHandler):
         body = json.dumps(body).encode()
         self.send_response(HTTPStatus.OK)
         self.send_header("Content-Length", str(len(body)))
+        if self.openid_server.inject_oversized_header:
+            default_max_header_size = 16 * 1024
+            self.send_header(
+                "X-OpenID-Provider-Header", "x" * default_max_header_size * 2
+            )
         self.end_headers()
         self.wfile.write(body)
+        self.openid_server.request_count += 1
 
     def log_message(self, fmt, *args):
         LOG.trace(f"OpenIDProviderServer: {fmt % args}")
@@ -61,6 +67,8 @@ class OpenIDProviderServer(AbstractContextManager):
         self.tls_cert_pem = tls_cert_pem
         self.bind_port = None
         self.start(self.port)
+        self.inject_oversized_header = False
+        self.request_count = 0
 
     def start(self, port):
         def handler(*args):

--- a/tla/ccfraft.tla
+++ b/tla/ccfraft.tla
@@ -1246,8 +1246,7 @@ LeaderCompletenessInv ==
 \* In CCF, only signature messages should ever be committed
 SignatureInv ==
     \A i \in Servers :
-        \/ commitIndex[i] = 0
-        \/ log[i][commitIndex[i]].contentType = TypeSignature
+        commitIndex[i] > 0 => log[i][commitIndex[i]].contentType = TypeSignature
 
 \* Each server's term should be equal to or greater than the terms of messages it has sent
 MonoTermInv ==
@@ -1256,10 +1255,9 @@ MonoTermInv ==
 \* Terms in logs should be monotonically increasing
 MonoLogInv ==
     \A i \in Servers :
-        \/ Len(log[i]) = 0
-        \/ /\ log[i][Len(log[i])].term <= currentTerm[i]
-           /\ \/ Len(log[i]) = 1
-              \/ \A k \in 1..Len(log[i])-1 :
+       log[i] # <<>> => 
+           /\ Last(log[i]).term <= currentTerm[i]
+           /\ \A k \in 1..Len(log[i])-1 :
                 \* Terms in logs should only increase after a signature
                 \/ log[i][k].term = log[i][k+1].term
                 \/ /\ log[i][k].term < log[i][k+1].term


### PR DESCRIPTION
Resolves #5511 

This contains two changes:

1. Do not try to look up a Listening Interface from a _client_ Connection ID. That look up will not complete. The consequence of that is that if an HTTP handling error takes places in an HTTPClientSession, we throw, causing #5511.
2. In server contexts, use the stable Listening Interface ID, rather than do a reverse lookup from Connection ID. If a race has caused the connection to close, reporting still works correctly, rather than throw.