### PR TITLE
Fix `lts_compatibility`: Bump version check for `--enclave-file` arg

### DIFF
--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -842,7 +842,7 @@ class CCFRemote(object):
                     enclave_log_level,
                 ]
 
-        if v is None or v >= Version("4.0.9"):
+        if v is None or v >= Version("4.0.10"):
             cmd += [
                 "--enclave-file",
                 self.enclave_file,


### PR DESCRIPTION
This hasn't been backported yet, but 4.0.9 has released.

Have a plan for a better check, this is a quickfix.