### PR TITLE
[release/4.x] Cherry pick: Fix HTTP handling errors reporting (#5680)

### DIFF
--- a/src/enclave/rpc_sessions.h
+++ b/src/enclave/rpc_sessions.h
@@ -122,21 +122,17 @@ namespace ccf
       return id;
     }
 
-    ListenInterface& get_interface_from_session_id(tls::ConnID id)
+    ListenInterface& get_interface_from_interface_id(
+      const ccf::ListenInterfaceID& id)
     {
-      // Lock must be first acquired and held while accessing returned interface
-      auto search = sessions.find(id);
-      if (search != sessions.end())
+      auto it = listening_interfaces.find(id);
+      if (it != listening_interfaces.end())
       {
-        auto it = listening_interfaces.find(search->second.first);
-        if (it != listening_interfaces.end())
-        {
-          return it->second;
-        }
+        return it->second;
       }
 
       throw std::logic_error(
-        fmt::format("No RPC interface for session ID {}", id));
+        fmt::format("No RPC interface for interface ID {}", id));
     }
 
     std::shared_ptr<ccf::Session> make_server_session(
@@ -181,22 +177,24 @@ namespace ccf
       to_host = writer_factory.create_writer_to_outside();
     }
 
-    void report_parsing_error(tls::ConnID id) override
+    void report_parsing_error(const ccf::ListenInterfaceID& id) override
     {
       std::lock_guard<ccf::pal::Mutex> guard(lock);
-      get_interface_from_session_id(id).errors.parsing++;
+      get_interface_from_interface_id(id).errors.parsing++;
     }
 
-    void report_request_payload_too_large_error(tls::ConnID id) override
+    void report_request_payload_too_large_error(
+      const ccf::ListenInterfaceID& id) override
     {
       std::lock_guard<ccf::pal::Mutex> guard(lock);
-      get_interface_from_session_id(id).errors.request_payload_too_large++;
+      get_interface_from_interface_id(id).errors.request_payload_too_large++;
     }
 
-    void report_request_header_too_large_error(tls::ConnID id) override
+    void report_request_header_too_large_error(
+      const ccf::ListenInterfaceID& id) override
     {
       std::lock_guard<ccf::pal::Mutex> guard(lock);
-      get_interface_from_session_id(id).errors.request_header_too_large++;
+      get_interface_from_interface_id(id).errors.request_header_too_large++;
     }
 
     void update_listening_interface_options(

--- a/src/http/error_reporter.h
+++ b/src/http/error_reporter.h
@@ -10,8 +10,10 @@ namespace http
   {
   public:
     virtual ~ErrorReporter() {}
-    virtual void report_parsing_error(tls::ConnID) = 0;
-    virtual void report_request_payload_too_large_error(tls::ConnID) = 0;
-    virtual void report_request_header_too_large_error(tls::ConnID) = 0;
+    virtual void report_parsing_error(const ccf::ListenInterfaceID&) = 0;
+    virtual void report_request_payload_too_large_error(
+      const ccf::ListenInterfaceID&) = 0;
+    virtual void report_request_header_too_large_error(
+      const ccf::ListenInterfaceID&) = 0;
   };
 }

--- a/src/http/http2_session.h
+++ b/src/http/http2_session.h
@@ -350,7 +350,7 @@ namespace http
       {
         if (error_reporter)
         {
-          error_reporter->report_request_payload_too_large_error(session_id);
+          error_reporter->report_request_payload_too_large_error(interface_id);
         }
 
         LOG_DEBUG_FMT("Request is too large: {}", e.what());
@@ -368,7 +368,7 @@ namespace http
       {
         if (error_reporter)
         {
-          error_reporter->report_request_header_too_large_error(session_id);
+          error_reporter->report_request_header_too_large_error(interface_id);
         }
 
         LOG_DEBUG_FMT("Request header is too large: {}", e.what());
@@ -386,7 +386,7 @@ namespace http
       {
         if (error_reporter)
         {
-          error_reporter->report_parsing_error(session_id);
+          error_reporter->report_parsing_error(interface_id);
         }
 
         LOG_DEBUG_FMT("Error parsing HTTP request: {}", e.what());

--- a/src/http/http_session.h
+++ b/src/http/http_session.h
@@ -124,7 +124,7 @@ namespace http
       {
         if (error_reporter)
         {
-          error_reporter->report_request_payload_too_large_error(session_id);
+          error_reporter->report_request_payload_too_large_error(interface_id);
         }
 
         LOG_DEBUG_FMT("Request is too large: {}", e.what());
@@ -140,7 +140,7 @@ namespace http
       {
         if (error_reporter)
         {
-          error_reporter->report_request_header_too_large_error(session_id);
+          error_reporter->report_request_header_too_large_error(interface_id);
         }
 
         LOG_DEBUG_FMT("Request header is too large: {}", e.what());
@@ -156,7 +156,7 @@ namespace http
       {
         if (error_reporter)
         {
-          error_reporter->report_parsing_error(session_id);
+          error_reporter->report_parsing_error(interface_id);
         }
         LOG_DEBUG_FMT("Error parsing HTTP request: {}", e.what());
 
@@ -340,10 +340,6 @@ namespace http
       }
       catch (const std::exception& e)
       {
-        if (error_reporter)
-        {
-          error_reporter->report_parsing_error(session_id);
-        }
         LOG_FAIL_FMT("Error parsing HTTP response on session {}", session_id);
         LOG_DEBUG_FMT("Error parsing HTTP response: {}", e.what());
         LOG_DEBUG_FMT(


### PR DESCRIPTION
Backports the following commits to `release/4.x`:
 - [Fix HTTP handling errors reporting (#5680)](https://github.com/microsoft/CCF/pull/5680)