### PR TITLE
Pin JS dependency to resolve `npm test` failure

### DIFF
--- a/js/ccf-app/package.json
+++ b/js/ccf-app/package.json
@@ -29,6 +29,7 @@
     "node-forge": "^1.2.0",
     "ts-node": "^10.4.0",
     "typedoc": "^0.25.0",
-    "typescript": "^5.0.2"
+    "typescript": "^5.0.2",
+    "get-func-name": "2.0.0"
   }
 }


### PR DESCRIPTION
Breaking change in `get-func-name` 2.0.1, used by `chai` to test our JS package. Pinning to 2.0.0 for now.

https://github.com/chaijs/get-func-name/issues/42