### PR TITLE
[release/4.x] Cherry pick: Pin JS dependency to resolve &#x60;npm test&#x60; failure (#5688)

### DIFF
--- a/js/ccf-app/package.json
+++ b/js/ccf-app/package.json
@@ -28,7 +28,13 @@
     "mocha": "^10.0.0",
     "node-forge": "^1.2.0",
     "ts-node": "^10.4.0",
+<<<<<<< HEAD
     "typedoc": "^0.24.1",
     "typescript": "^5.0.2"
+=======
+    "typedoc": "^0.25.0",
+    "typescript": "^5.0.2",
+    "get-func-name": "2.0.0"
+>>>>>>> 820d98d08... Pin JS dependency to resolve `npm test` failure (#5688)
   }
 }

--- a/js/ccf-app/package.json
+++ b/js/ccf-app/package.json
@@ -28,13 +28,8 @@
     "mocha": "^10.0.0",
     "node-forge": "^1.2.0",
     "ts-node": "^10.4.0",
-<<<<<<< HEAD
     "typedoc": "^0.24.1",
-    "typescript": "^5.0.2"
-=======
-    "typedoc": "^0.25.0",
     "typescript": "^5.0.2",
     "get-func-name": "2.0.0"
->>>>>>> 820d98d08... Pin JS dependency to resolve `npm test` failure (#5688)
   }
 }


### PR DESCRIPTION
Backports the following commits to `release/4.x`:
 - [Pin JS dependency to resolve &#x60;npm test&#x60; failure (#5688)](https://github.com/microsoft/CCF/pull/5688)