### PR TITLE
Restore test in the `Stress` pipeline

### DIFF
--- a/.azure-pipelines-templates/stress-matrix.yml
+++ b/.azure-pipelines-templates/stress-matrix.yml
@@ -5,7 +5,7 @@ jobs:
       env:
         container: sgx
         pool: ado-sgx-ccf-sub-backup
-      cmake_args: "-DCOMPILE_TARGET=sgx"
+      cmake_args: "-DCOMPILE_TARGET=sgx -DLONG_TESTS=ON"
       suffix: "StressTest"
       artifact_name: "StressTest"
       ctest_filter: '-L "vegeta" -C "long_stress"'

--- a/.azure-pipelines-templates/test.yml
+++ b/.azure-pipelines-templates/test.yml
@@ -17,7 +17,7 @@ steps:
     workingDirectory: build
 
   # Only run privileged tests in container environment
-  - ${{ if not( or( eq(parameters.suffix, 'Perf'), eq(parameters.suffix, 'Tracing'))) }}:
+  - ${{ if not( or( eq(parameters.suffix, 'Perf'), eq(parameters.suffix, 'Tracing'), eq(parameters.suffix, 'StressTest') ) ) }}:
       - script: |
           set -ex
           sudo bash -c "source env/bin/activate && ctest -VV --timeout ${{ parameters.ctest_timeout }} --no-compress-output -L partitions -C partitions"

--- a/.stress.yml
+++ b/.stress.yml
@@ -5,7 +5,7 @@ pr:
   paths:
     include:
       - .stress.yml
-      - .stress-matrix.yml
+      - .azure-pipelines-templates/stress-matrix.yml
 
 trigger: none
 


### PR DESCRIPTION
I noticed that the `CCF Github Stress` pipeline completed [suspiciously fast](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=76519&view=logs&j=b69c18ba-eebc-5249-7cb0-46eb355ef417&t=2cf99aca-b9fc-5fa9-d216-d926ddc3fbc3) (45s). This is because it doesn't actually test anything - the stress tests are gated behind `LONG_TESTS`, which wasn't present, and this `ctest` adds a `vegeta` filter. So no tests match.

This resolves that, and additionally skips the `CTest Partitions` test in this job.