### PR TITLE
Run model checker in 1ES GHA pool

### DIFF
--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -13,6 +13,8 @@ jobs:
   model-checking:
     name: Model Checking
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
+    container:
+      image: ccfmsrc.azurecr.io/ccf/ci:05-09-2023-virtual-clang15
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - run: python ./tla/install_deps.py
+      - run: python3 ./tla/install_deps.py
 
       - name: MCccfraft.cfg
         run: |

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -26,19 +26,21 @@ jobs:
       - name: MCccfraft.cfg
         run: |
           cd tla/
-          ./tlc.sh -workers auto MCccfraft.tla
+          ./tlc.sh -workers auto MCccfraft.tla -dumpFormat MCccfraft.trace -dumpFormat MCccfraft.json
 
       - name: MCccfraftWithReconfig.cfg
         run: |
           cd tla/
-          ./tlc.sh -workers auto -config MCccfraftWithReconfig.cfg MCccfraft.tla
+          ./tlc.sh -workers auto -config MCccfraftWithReconfig.cfg MCccfraft.tla -dumpFormat MCccfraftWithReconfig.trace -dumpFormat MCccfraftWithReconfig.json
 
       - name: Upload TLC's out file as an artifact. Can be imported into the TLA+ Toolbox.
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: tlc
-          path: tla/*.out
+          path: |
+            tla/*.trace
+            tla/*.json
 
   simulation:
     name: Simulation

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -33,7 +33,7 @@ jobs:
           cd tla/
           ./tlc.sh -workers auto -config MCccfraftWithReconfig.cfg MCccfraft.tla -dumpTrace tla MCccfraftWithReconfig.trace -dumpTrace json MCccfraftWithReconfig.json
 
-      - name: Upload TLC's out file as an artifact. Can be imported into the TLA+ Toolbox.
+      - name: Upload traces in TLA and JSON format
         uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
@@ -55,7 +55,7 @@ jobs:
           cd tla/
           ./tlc.sh -workers auto -simulate -depth 500 SIMccfraft.tla -dumpTrace tla SIMccfraft.trace -dumpTrace json SIMccfraft.json
 
-      - name: Upload TLC's out file as an artifact. Can be imported into the TLA+ Toolbox.
+      - name: Upload traces in TLA and JSON format
         uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -26,12 +26,12 @@ jobs:
       - name: MCccfraft.cfg
         run: |
           cd tla/
-          ./tlc.sh -workers auto MCccfraft.tla -dumpFormat tla MCccfraft.trace -dumpFormat json MCccfraft.json
+          ./tlc.sh -workers auto MCccfraft.tla -dumpTrace tla MCccfraft.trace -dumpTrace json MCccfraft.json
 
       - name: MCccfraftWithReconfig.cfg
         run: |
           cd tla/
-          ./tlc.sh -workers auto -config MCccfraftWithReconfig.cfg MCccfraft.tla -dumpFormat tla MCccfraftWithReconfig.trace -dumpFormat json MCccfraftWithReconfig.json
+          ./tlc.sh -workers auto -config MCccfraftWithReconfig.cfg MCccfraft.tla -dumpTrace tla MCccfraftWithReconfig.trace -dumpTrace json MCccfraftWithReconfig.json
 
       - name: Upload TLC's out file as an artifact. Can be imported into the TLA+ Toolbox.
         uses: actions/upload-artifact@v3
@@ -53,7 +53,7 @@ jobs:
       - name: SIMccfraft.tla
         run: |
           cd tla/
-          ./tlc.sh -workers auto -simulate -depth 500 SIMccfraft.tla -dumpFormat tla SIMccfraft.trace -dumpFormat json SIMccfraft.json
+          ./tlc.sh -workers auto -simulate -depth 500 SIMccfraft.tla -dumpTrace tla SIMccfraft.trace -dumpTrace json SIMccfraft.json
 
       - name: Upload TLC's out file as an artifact. Can be imported into the TLA+ Toolbox.
         uses: actions/upload-artifact@v3

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -22,15 +22,13 @@ jobs:
 
       - name: MCccfraft.cfg
         run: |
-          set -exo pipefail
           cd tla/
-          ./tlc.sh -workers auto MCccfraft.tla 2>&1 | tee MCccfraft.out
+          ./tlc.sh -workers auto MCccfraft.tla
 
       - name: MCccfraftWithReconfig.cfg
         run: |
-          set -exo pipefail
           cd tla/
-          ./tlc.sh -workers auto -config MCccfraftWithReconfig.cfg MCccfraft.tla 2>&1 | tee MCccfraftWithReconfig.out
+          ./tlc.sh -workers auto -config MCccfraftWithReconfig.cfg MCccfraft.tla
 
       - name: Upload TLC's out file as an artifact. Can be imported into the TLA+ Toolbox.
         uses: actions/upload-artifact@v2

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   model-checking:
     name: Model Checking
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -26,12 +26,12 @@ jobs:
       - name: MCccfraft.cfg
         run: |
           cd tla/
-          ./tlc.sh -workers auto MCccfraft.tla -dumpTrace tla MCccfraft.trace -dumpTrace json MCccfraft.json
+          ./tlc.sh -workers auto MCccfraft.tla -dumpTrace tla MCccfraft.trace.tla -dumpTrace json MCccfraft.json
 
       - name: MCccfraftWithReconfig.cfg
         run: |
           cd tla/
-          ./tlc.sh -workers auto -config MCccfraftWithReconfig.cfg MCccfraft.tla -dumpTrace tla MCccfraftWithReconfig.trace -dumpTrace json MCccfraftWithReconfig.json
+          ./tlc.sh -workers auto -config MCccfraftWithReconfig.cfg MCccfraft.tla -dumpTrace tla MCccfraftWithReconfig.trace.tla -dumpTrace json MCccfraftWithReconfig.json
 
       - name: Upload traces in TLA and JSON format
         uses: actions/upload-artifact@v3
@@ -39,7 +39,7 @@ jobs:
         with:
           name: tlc
           path: |
-            tla/*.trace
+            tla/*.trace.tla
             tla/*.json
 
   simulation:
@@ -53,7 +53,7 @@ jobs:
       - name: SIMccfraft.tla
         run: |
           cd tla/
-          ./tlc.sh -workers auto -simulate -depth 500 SIMccfraft.tla -dumpTrace tla SIMccfraft.trace -dumpTrace json SIMccfraft.json
+          ./tlc.sh -workers auto -simulate -depth 500 SIMccfraft.tla -dumpTrace tla SIMccfraft.trace.tla -dumpTrace json SIMccfraft.json
 
       - name: Upload traces in TLA and JSON format
         uses: actions/upload-artifact@v3
@@ -61,5 +61,5 @@ jobs:
         with:
           name: tlc
           path: |
-            tla/*.trace
+            tla/*.trace.tla
             tla/*.json

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -18,7 +18,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - run: python3 ./tla/install_deps.py
+      - run: |
+          sudo apt update
+          sudo apt install -y default-jre
+          python3 ./tla/install_deps.py
 
       - name: MCccfraft.cfg
         run: |

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -26,12 +26,12 @@ jobs:
       - name: MCccfraft.cfg
         run: |
           cd tla/
-          ./tlc.sh -workers auto MCccfraft.tla -dumpFormat MCccfraft.trace -dumpFormat MCccfraft.json
+          ./tlc.sh -workers auto MCccfraft.tla -dumpFormat tla MCccfraft.trace -dumpFormat json MCccfraft.json
 
       - name: MCccfraftWithReconfig.cfg
         run: |
           cd tla/
-          ./tlc.sh -workers auto -config MCccfraftWithReconfig.cfg MCccfraft.tla -dumpFormat MCccfraftWithReconfig.trace -dumpFormat MCccfraftWithReconfig.json
+          ./tlc.sh -workers auto -config MCccfraftWithReconfig.cfg MCccfraft.tla -dumpFormat tla MCccfraftWithReconfig.trace -dumpFormat json MCccfraftWithReconfig.json
 
       - name: Upload TLC's out file as an artifact. Can be imported into the TLA+ Toolbox.
         uses: actions/upload-artifact@v3
@@ -48,17 +48,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - run: python ./tla/install_deps.py
+      - run: python3 ./tla/install_deps.py
 
       - name: SIMccfraft.tla
         run: |
-          set -exo pipefail
           cd tla/
-          ./tlc.sh -workers auto -simulate -depth 500 SIMccfraft.tla 2>&1 | tee SIMccfraft.out
+          ./tlc.sh -workers auto -simulate -depth 500 SIMccfraft.tla -dumpFormat tla SIMccfraft.trace -dumpFormat json SIMccfraft.json
 
       - name: Upload TLC's out file as an artifact. Can be imported into the TLA+ Toolbox.
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: tlc
-          path: tla/*.out
+          path: |
+            tla/*.trace
+            tla/*.json

--- a/js/ccf-app/package.json
+++ b/js/ccf-app/package.json
@@ -30,6 +30,6 @@
     "ts-node": "^10.4.0",
     "typedoc": "^0.25.0",
     "typescript": "^5.0.2",
-    "get-func-name": "2.0.0"
+    "get-func-name": "3.0.0"
   }
 }

--- a/tla/install_deps.py
+++ b/tla/install_deps.py
@@ -111,6 +111,7 @@ def install_deps(args: argparse.Namespace):
         )
 
     if args.apt_packages:
+        subprocess.Popen(["sudo", "apt-get", "update"]).wait()
         subprocess.Popen(
             "sudo apt-get install -y --no-install-recommends".split()
             + [

--- a/tla/install_deps.py
+++ b/tla/install_deps.py
@@ -9,27 +9,24 @@ import subprocess
 import tarfile
 
 TLA_DIR = os.path.dirname(os.path.realpath(__file__))
-HOME_DIR = os.path.expanduser('~')
+HOME_DIR = os.path.expanduser("~")
 
 
 def append_bashrc(line: str):
-
     bashrc_path = f"{HOME_DIR}/.bashrc"
-    with open(bashrc_path, "r+", encoding="utf-8") as bashrc_file:
+    with open(bashrc_path, "a+", encoding="utf-8") as bashrc_file:
+        bashrc_file.seek(0)
         bashrc_lines = bashrc_file.readlines()
         if line not in bashrc_lines:
-            if not bashrc_lines[-1].endswith("\n"):
-                bashrc_file.write("\n")
+            bashrc_file.write("\n")
             bashrc_file.writelines(line)
 
 
 def set_alias(key: str, value: str):
-
     append_bashrc(f"alias {key}='{value}'\n")
 
 
 def fetch_latest(url: str, dest: str = "."):
-
     subprocess.Popen(f"wget -N {url} -P /tmp".split()).wait()
     file_name = url.split("/")[-1]
     file_path = f"/tmp/{file_name}"
@@ -45,7 +42,8 @@ def fetch_latest(url: str, dest: str = "."):
         with tarfile.open(f"/tmp/{file_name}") as tar:
             tar.extractall(dest)
             rel_bin_path = next(
-                member.name for member in tar.getmembers() if "bin" in member.name)
+                member.name for member in tar.getmembers() if "bin" in member.name
+            )
             bin_path = os.path.join(dest, rel_bin_path)
 
     elif file_name.endswith(".jar"):
@@ -56,7 +54,6 @@ def fetch_latest(url: str, dest: str = "."):
 
 
 def _parse_args() -> argparse.Namespace:
-
     parser = argparse.ArgumentParser(
         description="Install CCF TLA+ dependencies",
     )
@@ -74,17 +71,13 @@ def _parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--skip-apt-packages",
-        action="store_false",
-        default=True,
-        dest="apt_packages"
+        "--skip-apt-packages", action="store_false", default=True, dest="apt_packages"
     )
 
     return parser.parse_args()
 
 
 def install_tlc():
-
     java = "java"
     tlaplus_path = "~/.vscode-remote/extensions/alygin.vscode-tlaplus-nightly-*/tools/tla2tools.jar"
     copy_tlaplus = f"-cp {tlaplus_path} tlc2.TLC"
@@ -94,9 +87,9 @@ def install_tlc():
 
 
 def install_deps(args: argparse.Namespace):
-
     # Setup tools directory
     tools_dir = os.path.join(TLA_DIR, "tools")
+
     def create_tools_dir():
         if not os.path.exists(tools_dir):
             os.mkdir(tools_dir)
@@ -119,7 +112,8 @@ def install_deps(args: argparse.Namespace):
 
     if args.apt_packages:
         subprocess.Popen(
-            "sudo apt-get install -y --no-install-recommends".split() + [
+            "sudo apt-get install -y --no-install-recommends".split()
+            + [
                 "wget",
                 "graphviz",
                 "htop",

--- a/tla/install_deps.py
+++ b/tla/install_deps.py
@@ -111,7 +111,6 @@ def install_deps(args: argparse.Namespace):
         )
 
     if args.apt_packages:
-        subprocess.Popen(["sudo", "apt-get", "update"]).wait()
         subprocess.Popen(
             "sudo apt-get install -y --no-install-recommends".split()
             + [


### PR DESCRIPTION
Resolves #5703 by moving the MC run a 1ES GHA pool with bigger nodes than the default GH pool.

This involved somewhat more changes than expected, but reduces runtime substantially. I've deliberately left the simulation where it is now, since it's single threaded and probably wouldn't benefit much while hogging the machines in the pool for quite some time.

With change:

![image](https://github.com/microsoft/CCF/assets/4016369/71768d02-9573-4c3c-a708-4146bff16d2a)

Without:

![image](https://github.com/microsoft/CCF/assets/4016369/99b95570-5ce0-4895-ab20-89d7978b4bf5)
