### PR TITLE
Move up version detection in LTS test

### DIFF
--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -844,7 +844,7 @@ class CCFRemote(object):
                     enclave_log_level,
                 ]
 
-        if v is None or v >= Version("4.0.10"):
+        if v is None or v >= Version("4.0.11"):
             cmd += [
                 "--enclave-file",
                 self.enclave_file,


### PR DESCRIPTION
4.0.10 was cut without the new CLI flags, and so the LTS test needs adjusting.