### PR TITLE
Make main release pipeline safe for release experiments

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -23,7 +23,7 @@ schedules:
         - main
         - "release/*"
       exclude:
-        - "release/[1-2].x"
+        - "release/[0-2].x"
     always: true
 
 resources:


### PR DESCRIPTION
Will be using `release/0.x` separately for new release pipeline experiments.