### PR TITLE
Test that JS app code is correctly updated despite interpreter reuse

### DIFF
--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -522,9 +522,7 @@ class Consortium:
         proposal = self.get_any_active_member().propose(remote_node, proposal_body)
         return self.vote_using_majority(remote_node, proposal, careful_vote)
 
-    def set_js_app_from_dir(
-        self, remote_node, bundle_path, disable_bytecode_cache=False
-    ):
+    def read_bundle_from_dir(self, bundle_path):
         if os.path.isfile(bundle_path):
             tmp_dir = tempfile.TemporaryDirectory(prefix="ccf")
             shutil.unpack_archive(bundle_path, tmp_dir.name)
@@ -547,21 +545,18 @@ class Consortium:
                         f"{method} {url}: module '{module_path}' not found in bundle"
                     )
 
-        proposal_body, careful_vote = self.make_proposal(
-            "set_js_app",
-            bundle={"metadata": metadata, "modules": modules},
-            disable_bytecode_cache=disable_bytecode_cache,
-        )
-        proposal = self.get_any_active_member().propose(remote_node, proposal_body)
-        # Large apps take a long time to process - wait longer than normal for commit
-        return self.vote_using_majority(remote_node, proposal, careful_vote, timeout=30)
+        return {"metadata": metadata, "modules": modules}
 
-    def set_js_app_from_json(
-        self, remote_node, json_path, disable_bytecode_cache=False
+    def set_js_app_from_dir(
+        self, remote_node, bundle_path, disable_bytecode_cache=False
     ):
+        bundle = self.read_bundle_from_dir(bundle_path)
+        return self.set_js_app_from_bundle(remote_node, bundle)
+
+    def set_js_app_from_bundle(self, remote_node, bundle, disable_bytecode_cache=False):
         proposal_body, careful_vote = self.make_proposal(
             "set_js_app",
-            bundle=slurp_json(json_path),
+            bundle=bundle,
             disable_bytecode_cache=disable_bytecode_cache,
         )
 

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -551,7 +551,9 @@ class Consortium:
         self, remote_node, bundle_path, disable_bytecode_cache=False
     ):
         bundle = self.read_bundle_from_dir(bundle_path)
-        return self.set_js_app_from_bundle(remote_node, bundle)
+        return self.set_js_app_from_bundle(
+            remote_node, bundle, disable_bytecode_cache=disable_bytecode_cache
+        )
 
     def set_js_app_from_bundle(self, remote_node, bundle, disable_bytecode_cache=False):
         proposal_body, careful_vote = self.make_proposal(

--- a/tests/js-custom-authorization/custom_authorization.py
+++ b/tests/js-custom-authorization/custom_authorization.py
@@ -956,52 +956,50 @@ def run_interpreter_reuse(args):
     ) as network:
         network.start_and_open(args)
 
-        # TODO: Restore
-        # network = test_reused_interpreter_behaviour(network, args)  #
-        # network = test_caching_of_kv_handles(network, args)
+        network = test_reused_interpreter_behaviour(network, args)  #
+        network = test_caching_of_kv_handles(network, args)
         network = test_caching_of_app_code(network, args)
 
 
 if __name__ == "__main__":
     cr = ConcurrentRunner()
 
-    # TODO: Restore
-    # cr.add(
-    #     "authz",
-    #     run,
-    #     nodes=infra.e2e_args.nodes(cr.args, 1),
-    #     js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-custom-authorization"),
-    # )
+    cr.add(
+        "authz",
+        run,
+        nodes=infra.e2e_args.nodes(cr.args, 1),
+        js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-custom-authorization"),
+    )
 
-    # cr.add(
-    #     "limits",
-    #     run_limits,
-    #     nodes=infra.e2e_args.nodes(cr.args, 1),
-    #     js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-limits"),
-    # )
+    cr.add(
+        "limits",
+        run_limits,
+        nodes=infra.e2e_args.nodes(cr.args, 1),
+        js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-limits"),
+    )
 
-    # cr.add(
-    #     "authn",
-    #     run_authn,
-    #     nodes=infra.e2e_args.nodes(cr.args, 1),
-    #     js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-authentication"),
-    #     initial_user_count=4,
-    #     initial_member_count=2,
-    # )
+    cr.add(
+        "authn",
+        run_authn,
+        nodes=infra.e2e_args.nodes(cr.args, 1),
+        js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-authentication"),
+        initial_user_count=4,
+        initial_member_count=2,
+    )
 
-    # cr.add(
-    #     "content_types",
-    #     run_content_types,
-    #     nodes=infra.e2e_args.nodes(cr.args, 1),
-    #     js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-content-types"),
-    # )
+    cr.add(
+        "content_types",
+        run_content_types,
+        nodes=infra.e2e_args.nodes(cr.args, 1),
+        js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-content-types"),
+    )
 
-    # cr.add(
-    #     "api",
-    #     run_api,
-    #     nodes=infra.e2e_args.nodes(cr.args, 1),
-    #     js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-api"),
-    # )
+    cr.add(
+        "api",
+        run_api,
+        nodes=infra.e2e_args.nodes(cr.args, 1),
+        js_app_bundle=os.path.join(cr.args.js_app_bundle, "js-api"),
+    )
 
     cr.add(
         "interpreter_reuse",

--- a/tests/js-custom-authorization/custom_authorization.py
+++ b/tests/js-custom-authorization/custom_authorization.py
@@ -900,6 +900,8 @@ def test_reused_interpreter_behaviour(network, args):
         expect_much_smaller(repeat2, baseline)
         expect_much_smaller(repeat3, baseline)
 
+    return network
+
 
 def test_caching_of_kv_handles(network, args):
     primary, _ = network.find_nodes()
@@ -915,6 +917,8 @@ def test_caching_of_kv_handles(network, args):
         assert r.status_code == http.HTTPStatus.OK, r
         r = c.post("/app/increment")
         assert r.status_code == http.HTTPStatus.OK, r
+
+    return network
 
 
 def test_caching_of_app_code(network, args):

--- a/tests/js-interpreter-reuse/app.json
+++ b/tests/js-interpreter-reuse/app.json
@@ -74,6 +74,19 @@
           "key": "increment"
         }
       }
+    },
+    "/func_caching": {
+      "get": {
+        "js_module": "func_caching.js",
+        "js_function": "func_caching",
+        "forwarding_required": "never",
+        "authn_policies": ["no_auth"],
+        "mode": "readonly",
+        "openapi": {},
+        "interpreter_reuse": {
+          "key": "func_caching"
+        }
+      }
     }
   }
 }

--- a/tests/js-interpreter-reuse/src/func_caching.js
+++ b/tests/js-interpreter-reuse/src/func_caching.js
@@ -1,0 +1,6 @@
+export function func_caching(request) {
+  const s = "<func_caching_placeholder>";
+  console.log(`Executing with s: ${s}`);
+
+  return { body: s };
+}

--- a/tests/js-interpreter-reuse/src/rollup_entry.ts
+++ b/tests/js-interpreter-reuse/src/rollup_entry.ts
@@ -1,3 +1,4 @@
 export * from "./cache.js";
+export * from "./func_caching.js";
 export * from "./di_sample";
 export * from "./global_handle";

--- a/tests/js-modules/modules.py
+++ b/tests/js-modules/modules.py
@@ -483,7 +483,8 @@ def test_npm_app(network, args):
     bundle_path = os.path.join(
         app_dir, "dist", "bundle.json"
     )  # Produced by build step of test npm-app
-    network.consortium.set_js_app_from_json(primary, bundle_path)
+    bundle = infra.consortium.slurp_json(bundle_path)
+    network.consortium.set_js_app_from_bundle(primary, bundle)
 
     LOG.info("Calling npm app endpoints")
     with primary.client("user0") as c:
@@ -1211,7 +1212,8 @@ def test_js_execution_time(network, args):
     bundle_path = os.path.join(
         app_dir, "dist", "bundle.json"
     )  # Produced by build step of test npm-app in the previous test_npm_app
-    network.consortium.set_js_app_from_json(primary, bundle_path)
+    bundle = infra.consortium.slurp_json(bundle_path)
+    network.consortium.set_js_app_from_bundle(primary, bundle)
 
     LOG.info("Store JWT signing keys")
     jwt_key_priv_pem, _ = infra.crypto.generate_rsa_keypair(2048)


### PR DESCRIPTION
Just a regression test confirming current behaviour. Although the endpoint tries to reuse an interpreter, the interpreter cache is correctly flushed during app update. Note that this test will fail if the constitution is modified to _not_ flush interpreters in `set_js_app:apply`.