### PR TITLE
Speed up trace validation

### DIFF
--- a/tla/Network.tla
+++ b/tla/Network.tla
@@ -84,19 +84,13 @@ LOCAL OrderWithMessage(m, msgs) ==
     [ msgs EXCEPT ![m.dest] = Append(@, m) ]
 
 LOCAL OrderWithoutMessage(m, msgs) ==
-    IF \E i \in 1..Len(msgs[m.dest]) : msgs[m.dest][i] = m THEN
-        [ msgs EXCEPT ![m.dest] = RemoveAt(@, SelectInSeq(@, LAMBDA e: e = m)) ]
-    ELSE
-        msgs
+    [ msgs EXCEPT ![m.dest] = RemoveFirst(@, m) ]
 
 LOCAL OrderMessages ==
     UNION { Range(messages[s]) : s \in Servers }
 
 LOCAL OrderMessagesTo(dest, source) ==
-    IF \E i \in 1..Len(messages[dest]) : messages[dest][i].source = source THEN
-        {messages[dest][SelectInSeq(messages[dest], LAMBDA e: e.source = source)]}
-    ELSE
-        {}
+    FoldLeft(LAMBDA acc, e: IF acc = {} /\ e.source = source THEN acc \cup {e} ELSE acc, {}, messages[dest])
 
 LOCAL OrderOneMoreMessage(m) ==
     \/ /\ m \notin OrderMessages

--- a/tla/Traceccfraft.cfg
+++ b/tla/Traceccfraft.cfg
@@ -67,6 +67,7 @@ CONSTANTS
     Reordered = Reordered
     \* Ordered instead of OrderedNoDup compared to ordinary model checking.
     Guarantee = Ordered
+    Receive <- DropAndReceive
 
     TypeEntry = TypeEntry
     TypeSignature = TypeSignature

--- a/tla/Traceccfraft.tla
+++ b/tla/Traceccfraft.tla
@@ -534,6 +534,10 @@ ComposedNext ==
         \/ RcvAppendEntriesRequestRcvAppendEntriesRequest(i, j)
 
 CCF == INSTANCE ccfraft
-CCFSpec == CCF!Init /\ [][(DropMessages \cdot (CCF!Next \/ ComposedNext)) \/ RaftDriverQuirks]_CCF!vars
+
+DropAndReceive(i, j) ==
+    DropMessages \cdot CCF!Receive(i, j)
+
+CCFSpec == CCF!Init /\ [][CCF!Next \/ (DropMessages \cdot ComposedNext) \/ RaftDriverQuirks]_CCF!vars
 
 ==================================================================================


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/CCF/pull/5716.  `fancy_election.2` completes in 23 seconds:

```

Semantic processing of module Naturals
Semantic processing of module Sequences
Semantic processing of module FiniteSets
Semantic processing of module TLC
Semantic processing of module Folds
Semantic processing of module Functions
Semantic processing of module FiniteSetsExt
Semantic processing of module SequencesExt
Semantic processing of module Bags
Semantic processing of module Network
Semantic processing of module ccfraft
Semantic processing of module Json
Semantic processing of module Integers
Semantic processing of module IOUtils
Semantic processing of module TLCExt
Semantic processing of module _TLCTrace
Semantic processing of module Traceccfraft
Starting... (2023-10-14 03:46:08)
Implied-temporal checking--satisfiability problem has 1 branches.
<<"Trace:", "../build/fancy_election.2.ndjson", "Length:", 360>>
Computing initial states...
Finished computing initial states: 1 distinct state generated at 2023-10-14 03:46:10.
Progress(115) at 2023-10-14 03:46:13: 115 states generated (115 s/min), 115 distinct states found (115 ds/min), 0 states left on queue.
Progress(360) at 2023-10-14 03:46:28: 3,077 states generated, 2,952 distinct states found, 0 states left on queue.
Checking temporal properties for the complete state space with 2952 total distinct states at (2023-10-14 03:46:28)
Finished checking temporal properties in 00s at 2023-10-14 03:46:28
Model checking completed. No error has been found.
  Estimates of the probability that TLC did not check all reachable states
  because two distinct states had the same fingerprint:
  calculated (optimistic):  val = 2.0E-14
3077 states generated, 2952 distinct states found, 0 states left on queue.
The depth of the complete state graph search is 360.
The average outdegree of the complete state graph is 1 (minimum is 0, the maximum 6 and the 95th percentile is 1).
Finished in 23s at (2023-10-14 03:46:28)
```