### PR TITLE
Auto report constitution changes

### DIFF
--- a/.azure-pipelines-templates/release.yml
+++ b/.azure-pipelines-templates/release.yml
@@ -14,7 +14,7 @@ jobs:
 
       - script: |
           set -ex
-          python3.8 ./scripts/extract-release-notes.py --target-git-version --append-mcr-images | tee $(Build.BinariesDirectory)/rel-notes.md
+          python3.8 ./scripts/extract-release-notes.py --target-git-version --append-mcr-images --describe-path-changes "./samples/constitution" | tee $(Build.BinariesDirectory)/rel-notes.md
         displayName: Extract release notes
 
       - script: |

--- a/scripts/extract-release-notes.py
+++ b/scripts/extract-release-notes.py
@@ -145,7 +145,9 @@ def main():
                     if diff.returncode == 1:
                         # Insert a hyperlink to a GitHub compare page.
                         # This shows all changes between tags, not localised to the path, but seems to be the best we can do automatically.
-                        print(f"\n- **Note**: This release include changes to `{path}`, which may be viewed [here](https://github.com/Microsoft/CCF/compare/{prev_version}...{git_version}#files_bucket)")
+                        print(
+                            f"\n- **Note**: This release include changes to `{path}`, which may be viewed [here](https://github.com/Microsoft/CCF/compare/{prev_version}...{git_version}#files_bucket)"
+                        )
 
             if args.append_mcr_images:
                 print("\n**MCR Docker Images:** ", end="")

--- a/scripts/extract-release-notes.py
+++ b/scripts/extract-release-notes.py
@@ -47,6 +47,12 @@ def main():
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "--describe-path-changes",
+        help="If true, add a note whenever the given path has changes between releases.",
+        action="append",
+        default=[],
+    )
     args = parser.parse_args()
 
     if args.target_git_version:
@@ -115,6 +121,32 @@ def main():
                         print("\n" + "-" * 80 + "\n")
                     print(f"# {version}")
                 print("\n".join(release_notes[version]).strip())
+
+                for path in args.describe_path_changes:
+                    git_version = f"ccf-{version}"
+                    prev_version = subprocess.run(
+                        ["git", "describe", "--tags", f"{git_version}^", "--abbrev=0"],
+                        capture_output=True,
+                        universal_newlines=True,
+                    ).stdout.strip()
+                    diff = subprocess.run(
+                        [
+                            "git",
+                            "diff",
+                            "--exit-code",
+                            prev_version,
+                            git_version,
+                            "--",
+                            path,
+                        ],
+                        capture_output=True,
+                        universal_newlines=True,
+                    )
+                    if diff.returncode == 1:
+                        # Insert a hyperlink to a GitHub compare page.
+                        # This shows all changes between tags, not localised to the path, but seems to be the best we can do automatically.
+                        print(f" - Note: This release include changes to `{path}`, which may be viewed [here](https://github.com/Microsoft/CCF/compare/{prev_version}...{git_version}#files_bucket)")
+
             if args.append_mcr_images:
                 print("\n**MCR Docker Images:** ", end="")
                 print(
@@ -125,6 +157,7 @@ def main():
                         ]
                     )
                 )
+
         else:
             print("CHANGELOG is valid!")
 

--- a/scripts/extract-release-notes.py
+++ b/scripts/extract-release-notes.py
@@ -145,7 +145,7 @@ def main():
                     if diff.returncode == 1:
                         # Insert a hyperlink to a GitHub compare page.
                         # This shows all changes between tags, not localised to the path, but seems to be the best we can do automatically.
-                        print(f" - Note: This release include changes to `{path}`, which may be viewed [here](https://github.com/Microsoft/CCF/compare/{prev_version}...{git_version}#files_bucket)")
+                        print(f"\n- **Note**: This release include changes to `{path}`, which may be viewed [here](https://github.com/Microsoft/CCF/compare/{prev_version}...{git_version}#files_bucket)")
 
             if args.append_mcr_images:
                 print("\n**MCR Docker Images:** ", end="")


### PR DESCRIPTION
Sometimes we touch things and forget to mention them in the CHANGELOG. One place this is particularly dangerous is when we modify the constitution - the sample constitution is rarely touched, yet subtle changes to those actions can be critical for new features.

This adds support in our `extract-release-notes` script for automatically inserting a note whenever a path is touched, with a link (as close as I can get) to the corresponding diff, and uses this option to insert a note whenever the `samples/constitutions` folder changes. Note that most (especially major) changes should still be called out as a separate explicit entry in the release notes. This is designed to serve as a backstop to ensure such critical changes are always described in the release.