### PR TITLE
[release/4.x] Cherry pick: Pass enclave path as CLI argument rather than in configuration (#5665)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.0.11]
+
+[4.0.11]: https://github.com/microsoft/CCF/releases/tag/ccf-4.0.11
+
+- Path to the enclave file should now be passed as `--enclave-file` CLI argument to `cchost`, rather than `enclave.file` entry within configuration file. This is to ensure the path to the application file is attested on Confidential Containers/SNP, even if the configuration itself is provided from un-attested storage. The configuration entry is deprecated, and will be removed in a future release.
+
 ## [4.0.10]
 
 [4.0.10]: https://github.com/microsoft/CCF/releases/tag/ccf-4.0.10

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -25,7 +25,7 @@
         }
       },
       "description": "This section includes configuration for the enclave application launched by this node",
-      "required": ["file"],
+      "required": [],
       "additionalProperties": false
     },
     "network": {
@@ -676,6 +676,6 @@
       "minimum": 0
     }
   },
-  "required": ["enclave", "network", "command"],
+  "required": ["network", "command"],
   "additionalProperties": false
 }

--- a/src/host/configuration.h
+++ b/src/host/configuration.h
@@ -64,6 +64,8 @@ namespace host
       std::string file;
       EnclaveType type;
       EnclavePlatform platform;
+
+      bool operator==(const Enclave&) const = default;
     };
     Enclave enclave = {};
 
@@ -165,8 +167,8 @@ namespace host
   };
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(CCHostConfig::Enclave);
-  DECLARE_JSON_REQUIRED_FIELDS(CCHostConfig::Enclave, type, file);
-  DECLARE_JSON_OPTIONAL_FIELDS(CCHostConfig::Enclave, platform);
+  DECLARE_JSON_REQUIRED_FIELDS(CCHostConfig::Enclave);
+  DECLARE_JSON_OPTIONAL_FIELDS(CCHostConfig::Enclave, file, type, platform);
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(CCHostConfig::OutputFiles);
   DECLARE_JSON_REQUIRED_FIELDS(CCHostConfig::OutputFiles);
@@ -221,9 +223,10 @@ namespace host
     CCHostConfig::Command, service_certificate_file, start, join, recover);
 
   DECLARE_JSON_TYPE_WITH_BASE_AND_OPTIONAL_FIELDS(CCHostConfig, CCFConfig);
-  DECLARE_JSON_REQUIRED_FIELDS(CCHostConfig, enclave, command);
+  DECLARE_JSON_REQUIRED_FIELDS(CCHostConfig, command);
   DECLARE_JSON_OPTIONAL_FIELDS(
     CCHostConfig,
+    enclave,
     tick_interval,
     slow_io_logging_threshold,
     node_client_interface,

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -78,7 +78,13 @@ int main(int argc, char** argv)
 {
   // ignore SIGPIPE
   signal(SIGPIPE, SIG_IGN);
-  CLI::App app{"ccf"};
+  CLI::App app{
+    "CCF Host launcher. Runs a single CCF node, based on the given "
+    "configuration file.\n"
+    "Some parameters are marked \"(security critical)\" - these must be passed "
+    "on the CLI rather than within a configuration file, so that (on relevant "
+    "platforms) their value is captured in an attestation even if the "
+    "configuration file itself is unattested.\n"};
 
   std::string config_file_path = "config.json";
   app.add_option(
@@ -109,8 +115,14 @@ int main(int argc, char** argv)
     .add_option(
       "--enclave-log-level",
       enclave_log_level,
-      "Logging level for the enclave code")
+      "Logging level for the enclave code (security critical)")
     ->transform(CLI::CheckedTransformer(log_level_options, CLI::ignore_case));
+
+  std::string enclave_file_path;
+  app.add_option(
+    "--enclave-file",
+    enclave_file_path,
+    "Path to enclave application (security critical)");
 
   try
   {
@@ -262,8 +274,26 @@ int main(int argc, char** argv)
     config.slow_io_logging_threshold;
 
   // create the enclave
+  if (!config.enclave.file.empty())
+  {
+    LOG_FAIL_FMT(
+      "DEPRECATED: Enclave path was specified in config file! This should be "
+      "removed from the config, and passed directly to the CLI instead");
+
+    if (enclave_file_path.empty())
+    {
+      enclave_file_path = config.enclave.file;
+    }
+  }
+
+  if (enclave_file_path.empty())
+  {
+    LOG_FATAL_FMT("No enclave file path specified");
+    return static_cast<int>(CLI::ExitCodes::ValidationError);
+  }
+
   host::Enclave enclave(
-    config.enclave.file, config.enclave.type, config.enclave.platform);
+    enclave_file_path, config.enclave.type, config.enclave.platform);
 
   // messaging ring buffers
   const auto buffer_size = config.memory.circuit_size;

--- a/tests/config.jinja
+++ b/tests/config.jinja
@@ -1,6 +1,5 @@
 {
   "enclave": {
-    "file": "{{ enclave_file }}",
     "type": "{{ enclave_type }}",
     "platform": "{{ enclave_platform }}"
   },

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -757,7 +757,7 @@ class CCFRemote(object):
             t = t_env.get_template(self.TEMPLATE_CONFIGURATION_FILE)
             output = t.render(
                 start_type=start_type.name.title(),
-                enclave_file=self.enclave_file,
+                enclave_file=self.enclave_file,  # Ignored by current jinja, but passed for LTS compat
                 enclave_type=enclave_type.title(),
                 enclave_platform=enclave_platform.title()
                 if enclave_platform == "virtual"
@@ -837,6 +837,12 @@ class CCFRemote(object):
                         "--enclave-log-level",
                         enclave_log_level,
                     ]
+                    
+            if v is None or v >= Version("4.0.11"):
+                cmd += [
+                    "--enclave-file",
+                    self.enclave_file,
+                ]
 
             if start_type == StartType.start:
                 members_info = kwargs.get("members_info")
@@ -884,6 +890,7 @@ class CCFRemote(object):
             sig_tx_interval = kwargs.get("sig_tx_interval")
 
             primary_rpc_interface = host.get_primary_interface()
+            
             cmd = [
                 bin_path,
                 f"--enclave-file={self.enclave_file}",


### PR DESCRIPTION
Backports the following commits to `release/4.x`:
- [Pass enclave path as CLI argument rather than in configuration (#5665)](https://github.com/microsoft/CCF/pull/5665)