### PR TITLE
Updating TLA+ README.md

### DIFF
--- a/tla/README.md
+++ b/tla/README.md
@@ -1,9 +1,7 @@
-# TLA+ specification
+# TLA+ specifications
 
-This directory contains a formal specification of CCF's variant of Raft in TLA+. For more information, please refer to the CCF documentation: https://microsoft.github.io/CCF/main/architecture/raft_tla.html.
+This directory contains some formal specifications of CCF. For more information, please refer to the CCF TLA+ documentation: https://microsoft.github.io/CCF/main/architecture/raft_tla.html.
 
-You can also interact with this specification using codespaces:
+You can also interact with these specifications using codespaces:
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=180112558&machine=xLargePremiumLinux&devcontainer_path=.devcontainer%2Ftlaplus%2Fdevcontainer.json&location=WestEurope)
-
-You can also manually run [install_deps.py](install_deps.py) to install or update the dependencies required to interact with the spec. Run with `--help` to see all available options


### PR DESCRIPTION
Addressing https://github.com/microsoft/CCF/pull/5751#issuecomment-1773058841

I think the docs are best of place for TLA+ related documentation so this readme just points to the docs page and includes a neat button to launch a TLA+ codespace (with the largest host for exhaustive model checking)