### PR TITLE
Modify `bad_network` scenario to be deterministic

### DIFF
--- a/tests/raft_scenarios/bad_network
+++ b/tests/raft_scenarios/bad_network
@@ -9,6 +9,7 @@ dispatch_all
 
 periodic_all,10
 dispatch_all
+assert_is_primary,0
 
 # An initial entry is written and successfully replicated
 replicate,1,helloworld
@@ -60,9 +61,11 @@ dispatch_all_once
 
 # Eventually Node 2 is partitioned for so long that it calls an election
 periodic_one,2,100
+assert_is_candidate,2
 
 # But this RequestVote is lost!
 periodic_all,10
+assert_is_backup,1
 drop_pending,1  #< The ACKs from 1 are constantly dropped
 drop_pending,2
 dispatch_all_once
@@ -82,12 +85,13 @@ drop_pending,2
 periodic_one,2,100
 drop_pending,2
 
-# TODO: Add more precise state assert? Currently 2 is @5.1, and is a Candidate
+assert_is_candidate,2
 
 # Eventually Node 1 stops hearing from Node 0, and calls an election
 state_all
 drop_pending,1
 periodic_one,1,100
+assert_is_candidate,1
 dispatch_all_once  #< Finally, everyone hears about this!
 
 drop_pending,0  #< Node 0's response (in favour is dropped)
@@ -111,6 +115,7 @@ dispatch_all_once
 
 # Node 1 is now primary, though it still doesn't know that 2 is committed
 state_all
+assert_is_primary,1
 
 # Now we allow the network to heal and return to normal
 periodic_all,10

--- a/tests/raft_scenarios/bad_network
+++ b/tests/raft_scenarios/bad_network
@@ -36,10 +36,6 @@ periodic_all,10
 drop_pending,0
 dispatch_all
 
-periodic_all,10
-drop_pending,0
-dispatch_all
-
 # Before either follower times out, the message eventually reaches Node 1 (though not Node 2)
 periodic_all,10
 drop_pending_to,0,2


### PR DESCRIPTION
Surprising failure of Trace Validation [here](https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=77693&view=logs&j=0c81e209-1101-513f-1f15-37e9c3575eb2&t=a05664f3-ab91-5eb2-6acd-14e2179ad708) is caused by `bad_network` having non-deterministic behaviour, occasionally producing a trace which failed validation. For now I'm restoring the intended determinism - I'll investigate why the trace validation failed separately, and see if there's a further fix required.

Since our scenarios do not attempt to lock the RNG with a seed, each node's Raft election timeout is randomised, triggering somewhere between 50 and 100 ms of (faked) idleness. We add `periodic_all,10` steps to trigger heartbeat messages, and `periodic_one,N,110` to trigger an election. This scenario had 5 consecutive `periodic_all,10` steps, during which one of the backup nodes wouldn't receive any message from the primary. This will trigger an election in ~1/50 runs, resulting in a completely different trace. I've removed one of the duplicated periodics, and added various state assertions so that future divergence is more obvious.