### PR TITLE
Restore running full CI on main, take 2

### DIFF
--- a/.azure-pipelines-templates/configure.yml
+++ b/.azure-pipelines-templates/configure.yml
@@ -16,7 +16,7 @@ jobs:
           echo "##vso[task.setvariable variable=docOnly;isOutput=true]false" #set variable docOnly to false
           if [ ${SYSTEM_PULLREQUEST_TARGETBRANCH} ]; then
             echo " - Running on PR, checking diff for non-doc changes"
-            if git diff --ignore-submodules=dirty --quiet "origin/${$SYSTEM_PULLREQUEST_TARGETBRANCH}" -- ':!doc' ':!*.md' ':!scripts/azure_deployment'; then
+            if git diff --ignore-submodules=dirty --quiet "origin/${SYSTEM_PULLREQUEST_TARGETBRANCH}" -- ':!doc' ':!*.md' ':!scripts/azure_deployment'; then
               echo " - Documentation change only"
               echo "##vso[task.setvariable variable=docOnly;isOutput=true]true" #set variable docOnly to true
             else

--- a/.azure-pipelines-templates/configure.yml
+++ b/.azure-pipelines-templates/configure.yml
@@ -12,12 +12,17 @@ jobs:
       - script: |
           set -ex
           echo "Determine if any code has changed."
-          if git diff --ignore-submodules=dirty --quiet origin/${SYSTEM_PULLREQUEST_TARGETBRANCH:-main} -- ':!doc' ':!*.md' ':!scripts/azure_deployment'; then
-            echo " - Documentation change only"
-            echo "##vso[task.setvariable variable=docOnly;isOutput=true]true" #set variable docOnly to true
-          else
-            echo " - Source has changed"
-            echo "##vso[task.setvariable variable=docOnly;isOutput=true]false" #set variable docOnly to false
+          echo "Assuming full build should be run."
+          echo "##vso[task.setvariable variable=docOnly;isOutput=true]false" #set variable docOnly to false
+          if [ ${SYSTEM_PULLREQUEST_TARGETBRANCH} ]; then
+            echo " - Running on PR, checking diff for non-doc changes"
+            if git diff --ignore-submodules=dirty --quiet origin/${$SYSTEM_PULLREQUEST_TARGETBRANCH} -- ':!doc' ':!*.md' ':!scripts/azure_deployment'; then
+              echo " - Documentation change only"
+              echo "##vso[task.setvariable variable=docOnly;isOutput=true]true" #set variable docOnly to true
+            else
+              echo " - Source has changed"
+            fi
           fi
+
         displayName: "Check for runtime changes"
         name: setVarStep

--- a/.azure-pipelines-templates/configure.yml
+++ b/.azure-pipelines-templates/configure.yml
@@ -16,7 +16,7 @@ jobs:
           echo "##vso[task.setvariable variable=docOnly;isOutput=true]false" #set variable docOnly to false
           if [ ${SYSTEM_PULLREQUEST_TARGETBRANCH} ]; then
             echo " - Running on PR, checking diff for non-doc changes"
-            if git diff --ignore-submodules=dirty --quiet origin/${$SYSTEM_PULLREQUEST_TARGETBRANCH} -- ':!doc' ':!*.md' ':!scripts/azure_deployment'; then
+            if git diff --ignore-submodules=dirty --quiet "origin/${$SYSTEM_PULLREQUEST_TARGETBRANCH}" -- ':!doc' ':!*.md' ':!scripts/azure_deployment'; then
               echo " - Documentation change only"
               echo "##vso[task.setvariable variable=docOnly;isOutput=true]true" #set variable docOnly to true
             else


### PR DESCRIPTION
#5773 was insufficient. It removed an error, but running a "does this contain any non-docs changes" on `main` runs obviously fails, yet we want to run the full CI there. This nests the check - we're _not_ docs-only by default, and only go docs-only if this is a PR run (env var is set) _and_ the diff reports docs-only changes.