### PR TITLE
Adding `CommittableIndicesAreKnownSignaturesInv` to exhaustive model checking

### DIFF
--- a/tla/consensus/MCccfraft.cfg
+++ b/tla/consensus/MCccfraft.cfg
@@ -77,6 +77,7 @@ INVARIANTS
     NoLeaderInTermZeroInv
     MatchIndexLowerBoundNextIndexInv
     CommitCommittableIndices
+    CommittableIndicesAreKnownSignaturesInv
     \* DebugInvLeaderCannotStepDown
     \* DebugInvAnyCommitted
     \* DebugInvAllCommitted

--- a/tla/consensus/MCccfraftWithReconfig.cfg
+++ b/tla/consensus/MCccfraftWithReconfig.cfg
@@ -77,6 +77,7 @@ INVARIANTS
     NoLeaderInTermZeroInv
     MatchIndexLowerBoundNextIndexInv
     CommitCommittableIndices
+    CommittableIndicesAreKnownSignaturesInv
     \* DebugInvLeaderCannotStepDown
     \* DebugInvAnyCommitted
     \* DebugInvAllCommitted


### PR DESCRIPTION
`CommittableIndicesAreKnownSignaturesInv` was added in https://github.com/microsoft/CCF/pull/5764 but it is currently only checked by simulation. This PR adds it to the exhaustive mode checking.