### PR TITLE
Restore running full CI on main, take 4

### DIFF
--- a/.azure-pipelines-templates/configure.yml
+++ b/.azure-pipelines-templates/configure.yml
@@ -10,7 +10,6 @@ jobs:
       - checkout: self
         clean: true
       - script: |
-          set -ex
           echo "Determine if any code has changed."
           echo "Assuming full build should be run."
           echo "##vso[task.setvariable variable=docOnly;isOutput=true]false"


### PR DESCRIPTION
See #5774 &c.

ADO is doing something we don't understand:

```
Started: Today at 15:13
Duration: 6m 11s
Evaluating: and(succeeded(), eq(dependencies['configure']['outputs']['setVarStep.docOnly'], 'false'))
Expanded: and(True, eq('false''', 'false'))
Result: False
```

This started when the `set -ex` was introduced, so maybe that's what blows up. Backing that out here as a final flail.