### PR TITLE
[release/4.x] Cherry pick: Update CI images to 26-10-2023 (#5784)

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -11,7 +11,7 @@ jobs:
     variables:
       Codeql.SkipTaskAutoInjection: true
       skipComponentGovernanceDetection: true
-    container: ccfmsrc.azurecr.io/ccf/ci:05-09-2023-virtual-clang15
+    container: ccfmsrc.azurecr.io/ccf/ci:26-10-2023-virtual-clang15
     pool:
       vmImage: ubuntu-20.04
 

--- a/.azure-pipelines-templates/deploy_aci.yml
+++ b/.azure-pipelines-templates/deploy_aci.yml
@@ -59,7 +59,7 @@ jobs:
           ACR_TOKEN_NAME: ci-push-token
           ACR_CI_PUSH_TOKEN_PASSWORD: $(ACR_CI_PUSH_TOKEN_PASSWORD)
           ACR_REGISTRY: ccfmsrc.azurecr.io
-          BASE_IMAGE: ccfmsrc.azurecr.io/ccf/ci:05-09-2023-snp-clang15
+          BASE_IMAGE: ccfmsrc.azurecr.io/ccf/ci:26-10-2023-snp-clang15
 
       - script: |
           set -ex

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -29,15 +29,15 @@ schedules:
 resources:
   containers:
     - container: virtual
-      image: ccfmsrc.azurecr.io/ccf/ci:05-09-2023-virtual-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:26-10-2023-virtual-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: snp
-      image: ccfmsrc.azurecr.io/ccf/ci:05-09-2023-snp-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:26-10-2023-snp-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci:05-09-2023-sgx
+      image: ccfmsrc.azurecr.io/ccf/ci:26-10-2023-sgx
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /lib/modules:/lib/modules:ro
 
 variables:

--- a/.azure_pipelines_snp.yml
+++ b/.azure_pipelines_snp.yml
@@ -31,7 +31,7 @@ schedules:
 resources:
   containers:
     - container: virtual
-      image: ccfmsrc.azurecr.io/ccf/ci:05-09-2023-virtual-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:26-10-2023-virtual-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
 jobs:

--- a/.daily.yml
+++ b/.daily.yml
@@ -25,15 +25,15 @@ schedules:
 resources:
   containers:
     - container: virtual
-      image: ccfmsrc.azurecr.io/ccf/ci:05-09-2023-virtual-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:26-10-2023-virtual-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE
 
     - container: snp
-      image: ccfmsrc.azurecr.io/ccf/ci:05-09-2023-snp-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:26-10-2023-snp-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci:05-09-2023-sgx
+      image: ccfmsrc.azurecr.io/ccf/ci:26-10-2023-sgx
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx
 
 jobs:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "CCF Development Environment",
-  "image": "ccfmsrc.azurecr.io/ccf/ci:05-09-2023-virtual-clang15",
+  "image": "ccfmsrc.azurecr.io/ccf/ci:26-10-2023-virtual-clang15",
   "runArgs": [],
   "extensions": [
     "eamodio.gitlens",

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: ccfmsrc.azurecr.io/ccf/ci:05-09-2023-virtual-clang15
+    container: ccfmsrc.azurecr.io/ccf/ci:26-10-2023-virtual-clang15
 
     steps:
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -10,13 +10,91 @@ on:
   workflow_dispatch:
 
 jobs:
-  model-checking:
-    name: Model Checking
+  model-checking-consensus:
+    name: Model Checking - Consensus
+    runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
+    container:
+      image: ccfmsrc.azurecr.io/ccf/ci:26-10-2023-virtual-clang15
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          sudo apt update
+          sudo apt install -y default-jre
+          python3 ./tla/install_deps.py
+
+      - name: MCccfraft.cfg
+        run: |
+          cd tla/
+          ./tlc.sh -workers auto consensus/MCccfraft.tla -dumpTrace tla MCccfraft.trace.tla -dumpTrace json MCccfraft.json
+
+      - name: MCccfraftWithReconfig.cfg
+        run: |
+          cd tla/
+          ./tlc.sh -workers auto -config consensus/MCccfraftWithReconfig.cfg consensus/MCccfraft.tla -dumpTrace tla MCccfraftWithReconfig.trace.tla -dumpTrace json MCccfraftWithReconfig.json
+
+      - name: Upload traces in TLA and JSON format
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: tlc
+          path: |
+            tla/consensus/*_TTrace_*.tla
+            tla/consensus/*_TTrace_*.bin
+            tla/*.trace.tla
+            tla/*.json
+
+  simulation-consensus:
+    name: Simulation - Consensus
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
-      - run: python ./tla/install_deps.py
+      - run: python3 ./tla/install_deps.py
+
+      - name: SIMccfraft.tla
+        run: |
+          cd tla/
+          ./tlc.sh -workers auto -simulate -depth 500 consensus/SIMccfraft.tla -dumpTrace tla SIMccfraft.trace.tla -dumpTrace json SIMccfraft.json
+
+      - name: Upload traces in TLA and JSON format
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: tlc
+          path: |
+            tla/consensus/*_TTrace_*.tla
+            tla/consensus/*_TTrace_*.bin
+            tla/*.trace.tla
+            tla/*.json
+
+  model-checking-consistency:
+    name: Model Checking - Consistency
+    runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
+    container:
+      image: ccfmsrc.azurecr.io/ccf/ci:26-10-2023-virtual-clang15
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          sudo apt update
+          sudo apt install -y default-jre
+          python3 ./tla/install_deps.py
+
+      - name: consistency/MCSingleNode.cfg
+        run: |
+          cd tla/
+          ./tlc.sh -workers auto consistency/MCSingleNode.tla -dumpTrace json MCSingleNode.json
+
+      - name: consistency/MCSingleNodeReads.cfg
+        run: |
+          cd tla/
+          ./tlc.sh -workers auto consistency/MCSingleNodeReads.tla -dumpTrace json MCSingleNodeReads.json
+
+      - name: consistency/MCMultiNode.cfg
+        run: |
+          cd tla/
+          ./tlc.sh -workers auto consistency/MCMultiNode.tla -dumpTrace json MCMultiNode.json
 
       - name: MCccfraft.tla
         run: |

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -16,7 +16,7 @@ pr:
 resources:
   containers:
     - container: virtual
-      image: ccfmsrc.azurecr.io/ccf/ci:05-09-2023-virtual-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:26-10-2023-virtual-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
 jobs:

--- a/.stress.yml
+++ b/.stress.yml
@@ -20,7 +20,7 @@ schedules:
 resources:
   containers:
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci:05-09-2023-sgx
+      image: ccfmsrc.azurecr.io/ccf/ci:26-10-2023-sgx
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx
 
 jobs:

--- a/docker/ccf_ci_built
+++ b/docker/ccf_ci_built
@@ -4,7 +4,7 @@
 
 # Latest image as of this change
 ARG platform=sgx
-ARG base=ccfmsrc.azurecr.io/ccf/ci:05-09-2023-snp-clang-15
+ARG base=ccfmsrc.azurecr.io/ccf/ci:26-10-2023-snp-clang-15
 FROM ${base}
 
 # SSH. Note that this could (should) be done in the base ccf_ci image instead

--- a/scripts/azure_deployment/arm_aci.py
+++ b/scripts/azure_deployment/arm_aci.py
@@ -132,7 +132,7 @@ def parse_aci_args(parser: ArgumentParser) -> Namespace:
         "--aci-image",
         help="The name of the image to deploy in the ACI",
         type=str,
-        default="ccfmsrc.azurecr.io/ccf/ci:05-09-2023-snp",
+        default="ccfmsrc.azurecr.io/ccf/ci:26-10-2023-snp",
     )
     parser.add_argument(
         "--aci-type",


### PR DESCRIPTION
Backports the following commits to `release/4.x`:
 - [Update CI images to 26-10-2023 (#5784)](https://github.com/microsoft/CCF/pull/5784)