### PR TITLE
Trace state and configuration after action

### DIFF
--- a/src/consensus/aft/impl/state.h
+++ b/src/consensus/aft/impl/state.h
@@ -10,6 +10,7 @@
 #include "consensus/aft/raft_types.h"
 #include "kv/kv_types.h"
 
+#include <deque>
 #include <map>
 #include <set>
 
@@ -160,6 +161,9 @@ namespace aft
     ViewHistory view_history;
     kv::Version new_view_idx = 0;
 
+    // Indices that are eligible for global commit, from a Node's perspective
+    std::deque<Index> committable_indices;
+
     // Replicas start in leadership state Follower. Apart from a single forced
     // transition from Follower to Leader on the initial node at startup,
     // the state machine is made up of the following transitions:
@@ -184,5 +188,6 @@ namespace aft
     commit_idx,
     new_view_idx,
     leadership_state,
-    membership_state);
+    membership_state,
+    committable_indices);
 }

--- a/src/consensus/aft/trace.h
+++ b/src/consensus/aft/trace.h
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ccf/ds/logger.h"
+#include "impl/state.h"
+#include "kv/kv_types.h"
+
+#define RAFT_TRACE_JSON_OUT(json_object) \
+  CCF_LOG_OUT(DEBUG, "raft_trace") << json_object
+
+namespace aft
+{
+  namespace trace
+  {
+    struct Line
+    {
+      nlohmann::json j;
+      std::shared_ptr<aft::State> state;
+      const std::list<kv::Configuration>* configurations = nullptr;
+
+      Line(
+        const std::string& function_,
+        const std::shared_ptr<aft::State>& state_) :
+        state(state_)
+      {
+        j["function"] = function_;
+        j["state"] = *state;
+      }
+
+      Line(
+        const std::string& function_,
+        const std::shared_ptr<aft::State>& state_,
+        const std::list<kv::Configuration>& configurations_) :
+        state(state_),
+        configurations(&configurations_)
+      {
+        j["function"] = function_;
+        j["state"] = *state;
+        j["configurations"] = *configurations;
+      }
+
+      ~Line()
+      {
+        j["state_after"] = *state;
+        if (configurations != nullptr)
+        {
+          j["configurations_after"] = *configurations;
+        }
+        RAFT_TRACE_JSON_OUT(j);
+      }
+    };
+  }
+}

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -156,13 +156,13 @@ IsTimeout ==
     /\ IsEvent("become_candidate")
     /\ logline.msg.state.leadership_state = "Candidate"
     /\ Timeout(logline.msg.state.node_id)
-    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.committable_indices)
+    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.state.committable_indices)
 
 IsBecomeLeader ==
     /\ IsEvent("become_leader")
     /\ logline.msg.state.leadership_state = "Leader"
     /\ BecomeLeader(logline.msg.state.node_id)
-    /\ committableIndices'[logline.msg.state.node_id] = Range(logline.msg.committable_indices)
+    /\ committableIndices'[logline.msg.state.node_id] = Range(logline.msg.state.committable_indices)
     
 IsClientRequest ==
     /\ IsEvent("replicate")
@@ -170,7 +170,7 @@ IsClientRequest ==
     /\ ClientRequest(logline.msg.state.node_id)
     \* TODO Consider creating a mapping from clientRequests to actual values in the system trace.
     \* TODO Alternatively, extract the written values from the system trace and redefine clientRequests at startup.
-    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.committable_indices)
+    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.state.committable_indices)
 
 IsSendAppendEntries ==
     /\ IsEvent("send_append_entries")
@@ -187,7 +187,7 @@ IsSendAppendEntries ==
                 /\ Network!OneMoreMessage(msg)
           /\ logline.msg.sent_idx + 1 = nextIndex[i][j]
           /\ logline.msg.match_idx = matchIndex[i][j]
-    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.committable_indices)
+    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.state.committable_indices)
 
 IsRcvAppendEntriesRequest ==
     /\ IsEvent("recv_append_entries")
@@ -205,14 +205,14 @@ IsSendAppendEntriesResponse ==
     \* Skip saer because ccfraft!HandleAppendEntriesRequest atomcially handles the request and sends the response.
        \* Find a similar pattern in Traceccfraft!IsRcvRequestVoteRequest below.
     /\ IsEvent("send_append_entries_response")
-    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.committable_indices)
+    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.state.committable_indices)
     /\ UNCHANGED vars
  
 IsAddConfiguration ==
     /\ IsEvent("add_configuration")
     /\ state[logline.msg.state.node_id] = Follower
     /\ UNCHANGED vars
-    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.committable_indices)
+    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.state.committable_indices)
 
 IsSignCommittableMessages ==
     /\ IsEvent("replicate")
@@ -224,7 +224,7 @@ IsSignCommittableMessages ==
      \* which is not the case if the logs ends after this "replicate" line.  If it does not end,
      \* the subsequent send_append_entries will assert the effect of SignCommittableMessages anyway.
      \* Also see IsExecuteAppendEntries below.
-    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.committable_indices)
+    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.state.committable_indices)
 
 IsAdvanceCommitIndex ==
     \* This is enabled *after* a SignCommittableMessages because ACI looks for a 
@@ -234,7 +234,7 @@ IsAdvanceCommitIndex ==
        /\ LET i == logline.msg.state.node_id
           IN /\ AdvanceCommitIndex(i)
              /\ commitIndex'[i] = logline.msg.state.commit_idx
-             /\ committableIndices'[i] = Range(logline.msg.committable_indices)
+             /\ committableIndices'[i] = Range(logline.msg.state.committable_indices)
     \/ /\ IsEvent("commit")
        /\ logline.msg.state.leadership_state = "Follower"
        /\ UNCHANGED vars
@@ -245,7 +245,7 @@ IsChangeConfiguration ==
     /\ LET i == logline.msg.state.node_id
            newConfiguration == DOMAIN logline.msg.new_configuration.nodes
        IN ChangeConfigurationInt(i, newConfiguration)
-    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.committable_indices)
+    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.state.committable_indices)
 
 IsRcvAppendEntriesResponse ==
     /\ IsEvent("recv_append_entries_response")
@@ -259,7 +259,7 @@ IsRcvAppendEntriesResponse ==
                   \/ UpdateTerm(i, j, m) \cdot HandleAppendEntriesResponse(i, j, m)
                   \/ UpdateTerm(i, j, m) \cdot DropResponseWhenNotInState(i, j, m)
                   \/ DropResponseWhenNotInState(i, j, m)
-    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.committable_indices)
+    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.state.committable_indices)
 
 IsSendRequestVote ==
     /\ IsEvent("send_request_vote")
@@ -274,7 +274,7 @@ IsSendRequestVote ==
                 /\ m.lastCommittableTerm = logline.msg.packet.term_of_last_committable_idx
                 \* There is now one more message of this type.
                 /\ Network!OneMoreMessage(m)
-    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.committable_indices)
+    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.state.committable_indices)
 
 IsRcvRequestVoteRequest ==
     \/ /\ IsEvent("recv_request_vote")
@@ -292,7 +292,7 @@ IsRcvRequestVoteRequest ==
                   \* a (ccfraft!UpdateTerm \cdot ccfraft!HandleRequestVoteRequest) step.
                   \* (see https://github.com/microsoft/CCF/issues/5057#issuecomment-1487279316)
                   \/ UpdateTerm(i, j, m) \cdot HandleRequestVoteRequest(i, j, m)
-    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.committable_indices)
+    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.state.committable_indices)
 
 IsExecuteAppendEntries ==
     \* Skip append because ccfraft!HandleRequestVoteRequest atomcially handles the request, sends the response,
@@ -318,20 +318,20 @@ IsRcvRequestVoteResponse ==
                \/ UpdateTerm(i, j, m) \cdot HandleRequestVoteResponse(i, j, m)
                \/ UpdateTerm(i, j, m) \cdot DropResponseWhenNotInState(i, j, m)
                \/ DropResponseWhenNotInState(i, j, m)
-    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.committable_indices)
+    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.state.committable_indices)
 
 IsBecomeFollower ==
     /\ IsEvent("become_follower")
     /\ state[logline.msg.state.node_id] \in {Follower}
     /\ configurations[logline.msg.state.node_id] = ToConfigurations(logline.msg.configurations)
     /\ UNCHANGED vars \* UNCHANGED implies that it doesn't matter if we prime the previous variables.
-    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.committable_indices)
+    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.state.committable_indices)
 
 IsCheckQuorum ==
     /\ IsEvent("become_follower")
     /\ state[logline.msg.state.node_id] = Leader
     /\ CheckQuorum(logline.msg.state.node_id)
-    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.committable_indices)
+    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.state.committable_indices)
 
 IsRcvProposeVoteRequest ==
     /\ IsEvent("recv_propose_request_vote")
@@ -344,7 +344,7 @@ IsRcvProposeVoteRequest ==
                 /\ m.term = logline.msg.packet.term
                 \* There is now one more message of this type.
                 /\ Network!OneMoreMessage(m)
-    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.committable_indices)
+    /\ committableIndices[logline.msg.state.node_id] = Range(logline.msg.state.committable_indices)
 
 TraceNext ==
     \/ IsTimeout


### PR DESCRIPTION
I am putting this up as a draft, based on #5795, this is what I discussed in #5794, but no longer think it's a good idea after doing it.

That's because to get a (meaningful) `state_after` or `configuration_after`, we virtually always have to wait until some other actions have been emitted, and so we get a log line that's out of order.

I suspect a better solution would be to split the functions in two ("add_configuration_enter", "add_configuration_exit"), but the trace spec would need significant adjustment.

For now I think we're better off doing ad-hoc logging of post-values on a need basis (I think only committable is missing at the moment).