### PR TITLE
Align the _logline in a TLA+ counterexample with its corresponding entry in the JSON log, from which the TLA+ state has been constructed.

### DIFF
--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -473,9 +473,7 @@ TraceDifferentialInv ==
 TraceAlias ==
     DebugAlias @@
     [
-        lvl |-> l,
-        ts |-> ts,
-        logline |-> logline.msg
+        _logline |-> TraceLog[l-1]
 
         \* Uncomment _ENABLED when debugging the enablement state of ccfraft's actions.
         \* ,_ENABLED |-> 


### PR DESCRIPTION
There's an issue in VScode's "TLA+ model checking" view. Expanding the _logline record fails when the current step is "add_configuration", as VScode struggles with "new_configurations: ...".