### PR TITLE
Add realistic reconfiguration commands for driver

### DIFF
--- a/src/consensus/aft/test/driver.cpp
+++ b/src/consensus/aft/test/driver.cpp
@@ -82,6 +82,20 @@ int main(int argc, char** argv)
     }
     switch (shash(in))
     {
+      case shash("start_node"):
+        assert(items.size() == 1);
+        driver->create_start_node(lineno);
+        break;
+      case shash("trust_node"):
+        assert(items.size() == 3);
+        driver->trust_nodes(items[1], {items[2]}, lineno);
+        break;
+      case shash("trust_nodes"):
+        assert(items.size() >= 3);
+        items.erase(items.begin());
+        driver->trust_nodes(
+          items[0], {std::next(items.begin()), items.end()}, lineno);
+        break;
       case shash("nodes"):
         assert(items.size() >= 2);
         items.erase(items.begin());

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -219,6 +219,55 @@ public:
                     << std::endl;
   }
 
+  void create_start_node(const size_t lineno)
+  {
+    if (!_nodes.empty())
+    {
+      throw std::logic_error("Start node already exists");
+    }
+    const std::string start_node_id = "0";
+    kv::Configuration::Nodes configuration;
+    add_node(start_node_id);
+    configuration.try_emplace(start_node_id);
+    _nodes[start_node_id].raft->force_become_primary();
+    _replicate("2", {}, lineno, false, configuration);
+    RAFT_DRIVER_OUT << fmt::format(
+                         "  Note over {}: Node {} created",
+                         start_node_id,
+                         start_node_id)
+                    << std::endl;
+  }
+
+  void trust_nodes(
+    const std::string& term,
+    std::vector<std::string> node_ids,
+    const size_t lineno)
+  {
+    for (const auto& node_id : node_ids)
+    {
+      add_node(node_id);
+      RAFT_DRIVER_OUT << fmt::format(
+                           "  Note over {}: Node {} created", node_id, node_id)
+                      << std::endl;
+    }
+    kv::Configuration::Nodes configuration;
+    for (const auto& [id, node] : _nodes)
+    {
+      configuration.try_emplace(id);
+    }
+    for (const auto& node_id : node_ids)
+    {
+      for (const auto& [id, node] : _nodes)
+      {
+        if (id != node_id)
+        {
+          connect(id, node_id);
+        }
+      }
+    }
+    _replicate(term, {}, lineno, false, configuration);
+  }
+
   void replicate_new_configuration(
     const std::string& term_s,
     std::vector<std::string> node_ids,

--- a/tests/raft_scenarios/append
+++ b/tests/raft_scenarios/append
@@ -1,0 +1,25 @@
+# Create a Start Node, commit initial transaction and signature
+# Append transaction to the node's log, observe that they are committed
+start_node
+assert_is_primary,0
+emit_signature,2
+
+assert_is_primary,0
+assert_commit_idx,0,2
+
+replicate,2,first transaction
+# Commit hasn't moved, the transaction is not part of a signed
+# suffix, and so is not committable
+assert_commit_idx,0,2
+emit_signature,2
+# The signature has been emitted, commit is immediate since
+# no other nodes need to be notified
+assert_commit_idx,0,4
+
+# Append more than one transaction in a signed batch
+replicate,2,second transaction
+replicate,2,third transaction
+replicate,2,fourth transaction
+assert_commit_idx,0,4
+emit_signature,2
+assert_commit_idx,0,8

--- a/tests/raft_scenarios/startup
+++ b/tests/raft_scenarios/startup
@@ -1,0 +1,8 @@
+# Create a Start Node, commit initial transaction and signature
+# https://microsoft.github.io/CCF/main/operations/start_network.html#starting-the-first-node
+start_node
+assert_is_primary,0
+emit_signature,2
+
+assert_is_primary,0
+assert_commit_idx,0,2


### PR DESCRIPTION
The driver was never updated after we switched to [network bootstrapping](https://microsoft.github.io/CCF/main/operations/start_network.html), which makes expressing impossible scenarios too easy, and realistic scenarios more tedious than necessary.

This is a small change in the direction of more realism in the driver. I have also changed the Start node to use force_become_leader(), as in the real system, which makes the initial tx id line up at 2.1.

Nodes are fully connected as soon as they are trusted, they can be disconnected manually where appropriate.

This is a chunk of #5769, enough to express realistic scenarios, but without converting the existing ones and requiring the cascading TLA+ changes just yet.