### PR TITLE
Trace viz script

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -19,6 +19,7 @@ pyOpenSSL
 grpcio-tools == 1.44.0 # Pin to a working version for SNP platform
 JWCrypto
 pycose
+rich
 # Piccolo dependencies
 fastparquet==2023.*
 prettytable==3.*

--- a/tests/trace_viz.py
+++ b/tests/trace_viz.py
@@ -1,0 +1,71 @@
+import sys
+import json
+import rich
+
+# TODO
+# Calculate alignment based on max nodes, view, index, commit index
+# Only highlight individual state changes
+     
+LEADERSHIP_STATUS = {
+    "None": ":beginner:",
+    "Leader": ":crown:",
+    "Follower": ":guard:",
+    "Candidate": ":person_raising_hand:"
+}
+
+FUNCTIONS = {
+    "add_configuration": "Cfg",
+    "replicate": "Rpl",
+    "send_append_entries": "SAe",
+    "recv_append_entries": "RAe",
+    "execute_append_entries_sync": "EAe",
+    "send_append_entries_response": "SAeR",
+    "recv_append_entries_response": "RAeR",
+    "send_request_vote": "SRv",
+    "recv_request_vote": "RRv",
+    "recv_request_vote_response": "RRvR",
+    "recv_propose_request_vote": "RPRv",
+    "become_candidate": "BCan",
+    "become_leader": "BLea",
+    "become_follower": "BFol",
+    "commit": "Cmt",
+    None: ""
+}
+    
+def render_state(state, func, old_state):
+    if state is None:
+        return " "
+    ls = LEADERSHIP_STATUS[state["leadership_state"]]
+    nid = state["node_id"]
+    v = state["current_view"]
+    i = state["last_idx"]
+    c = state["commit_idx"]
+    f = FUNCTIONS[func]
+    opc = "bold bright_white on red" if func else "normal"
+    sc = "white on red" if func and (old_state != state) else "grey93"
+    return f"[{opc}]{nid:>2}{ls}{f:<4} [/{opc}][{sc}]{v:>2}v {i:>3}i {c:>3}c[/{sc}]"
+
+    
+def table(lines):
+    entries = [json.loads(line) for line in lines]
+    nodes = []
+    for entry in entries:
+        node_id = entry["msg"]["state"]["node_id"]
+        if node_id not in nodes:
+            nodes.append(node_id)
+    node_to_state = {}
+    rows = []
+    for entry in entries:
+        node_id = entry["msg"]["state"]["node_id"]
+        old_state = node_to_state.get(node_id)
+        node_to_state[node_id] = entry["msg"]["state"]
+        states = [(node_to_state.get(node),
+                   entry["msg"]["function"] if node == node_id else None,
+                   old_state if node == node_id else None)  for node in nodes]
+        rows.append("     ".join(render_state(*state) for state in states))
+    return rows
+    
+if __name__ == "__main__":
+    with open(sys.argv[1]) as tf:
+        for line in table(tf.readlines()):
+            rich.print(line)

--- a/tests/trace_viz.py
+++ b/tests/trace_viz.py
@@ -1,15 +1,21 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
 import sys
 import json
 import rich
 
-# TODO
-# Calculate alignment based on max nodes, view, index, commit index
-     
+"""
+TODO
+
+Add status on responses (votes and append entries)
+"""
+
 LEADERSHIP_STATUS = {
     "None": ":beginner:",
     "Leader": ":crown:",
     "Follower": ":guard:",
-    "Candidate": ":person_raising_hand:"
+    "Candidate": ":person_raising_hand:",
 }
 
 FUNCTIONS = {
@@ -28,48 +34,77 @@ FUNCTIONS = {
     "become_leader": "BLea",
     "become_follower": "BFol",
     "commit": "Cmt",
-    None: ""
+    None: "",
 }
+
+
+def digits(value):
+    return len(str(value))
+
 
 def diffed_key(old, new, key, suffix, size):
     if old is None or old[key] == new[key]:
         return f"{new[key]:>{size}}{suffix}"
     color = "bright_white on red"
     return f"[{color}]{new[key]:>{size}}{suffix}[/{color}]"
-    
-def render_state(state, func, old_state):
+
+
+def render_state(state, func, old_state, cfg):
     if state is None:
         return " "
     ls = LEADERSHIP_STATUS[state["leadership_state"]]
     nid = state["node_id"]
-    v = diffed_key(old_state, state, "current_view", "v", 2)
-    i = diffed_key(old_state, state, "last_idx", "i", 3)
-    c = diffed_key(old_state, state, "commit_idx", "c", 3)
+    v = diffed_key(old_state, state, "current_view", "v", cfg.view)
+    i = diffed_key(old_state, state, "last_idx", "i", cfg.index)
+    c = diffed_key(old_state, state, "commit_idx", "c", cfg.commit)
     f = FUNCTIONS[func]
     opc = "bold bright_white on red" if func else "normal"
-    sc = "white on red" if func and (old_state != state) else "grey93"
-    return f"[{opc}]{nid:>2}{ls}{f:<4} [/{opc}]{v} {i} {c}"
+    return f"[{opc}]{nid:>{cfg.nodes}}{ls}{f:<4} [/{opc}]{v} {i} {c}"
 
-    
+
+class DigitsCfg:
+    nodes = 0
+    view = 0
+    index = 0
+    commit = 0
+
+
 def table(lines):
     entries = [json.loads(line) for line in lines]
     nodes = []
+    max_view = 0
+    max_index = 0
+    max_commit = 0
     for entry in entries:
         node_id = entry["msg"]["state"]["node_id"]
         if node_id not in nodes:
             nodes.append(node_id)
+        max_view = max(max_view, entry["msg"]["state"]["current_view"])
+        max_index = max(max_index, entry["msg"]["state"]["last_idx"])
+        max_commit = max(max_commit, entry["msg"]["state"]["commit_idx"])
+    dcfg = DigitsCfg()
+    dcfg.nodes = max(nodes, key=len)
+    dcfg.view = digits(max_view)
+    dcfg.index = digits(max_index)
+    dcfg.commit = digits(max_commit)
     node_to_state = {}
     rows = []
     for entry in entries:
         node_id = entry["msg"]["state"]["node_id"]
         old_state = node_to_state.get(node_id)
         node_to_state[node_id] = entry["msg"]["state"]
-        states = [(node_to_state.get(node),
-                   entry["msg"]["function"] if node == node_id else None,
-                   old_state if node == node_id else None)  for node in nodes]
-        rows.append("     ".join(render_state(*state) for state in states))
+        states = [
+            (
+                node_to_state.get(node),
+                entry["msg"]["function"] if node == node_id else None,
+                old_state if node == node_id else None,
+            )
+            for node in nodes
+        ]
+        rows.append("     ".join(render_state(*state, dcfg) for state in states))
     return rows
-    
+
+
 if __name__ == "__main__":
     with open(sys.argv[1]) as tf:
         for line in table(tf.readlines()):

--- a/tests/trace_viz.py
+++ b/tests/trace_viz.py
@@ -4,7 +4,6 @@ import rich
 
 # TODO
 # Calculate alignment based on max nodes, view, index, commit index
-# Only highlight individual state changes
      
 LEADERSHIP_STATUS = {
     "None": ":beginner:",
@@ -31,19 +30,25 @@ FUNCTIONS = {
     "commit": "Cmt",
     None: ""
 }
+
+def diffed_key(old, new, key, suffix, size):
+    if old is None or old[key] == new[key]:
+        return f"{new[key]:>{size}}{suffix}"
+    color = "bright_white on red"
+    return f"[{color}]{new[key]:>{size}}{suffix}[/{color}]"
     
 def render_state(state, func, old_state):
     if state is None:
         return " "
     ls = LEADERSHIP_STATUS[state["leadership_state"]]
     nid = state["node_id"]
-    v = state["current_view"]
-    i = state["last_idx"]
-    c = state["commit_idx"]
+    v = diffed_key(old_state, state, "current_view", "v", 2)
+    i = diffed_key(old_state, state, "last_idx", "i", 3)
+    c = diffed_key(old_state, state, "commit_idx", "c", 3)
     f = FUNCTIONS[func]
     opc = "bold bright_white on red" if func else "normal"
     sc = "white on red" if func and (old_state != state) else "grey93"
-    return f"[{opc}]{nid:>2}{ls}{f:<4} [/{opc}][{sc}]{v:>2}v {i:>3}i {c:>3}c[/{sc}]"
+    return f"[{opc}]{nid:>2}{ls}{f:<4} [/{opc}]{v} {i} {c}"
 
     
 def table(lines):


### PR DESCRIPTION
The JSON traces are painful to read when working on validation, especially with lots of nodes, I would really like something more compact and readable. I'd like to get this working for the traces we get from TLC too, eventually.

This needs a venv with the test dependencies installed to work. If you've run `make_traces.sh` before, you'll have that, just `source build/env/bin/activate`. Or just `pip install rich` in whatever venv you use.

The output looks like this:

![image](https://github.com/microsoft/CCF/assets/4016369/1895545c-31c2-4193-a002-8ac98b7beb3f)

Suggestions and changes very welcome.