### PR TITLE
Remove deprecated EnclaveAttestationProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.0.0-dev11]
+
+[5.0.0-dev11]: https://github.com/microsoft/CCF/releases/tag/ccf-5.0.0-dev11
+
+### Deprecated
+
+- `ccf::EnclaveAttestationProvider` has been removed. It is replaced by `ccf::AttestationProvider`
+
 ## [5.0.0-dev10]
 
 [5.0.0-dev10]: https://github.com/microsoft/CCF/releases/tag/ccf-5.0.0-dev10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [5.0.0-dev11]: https://github.com/microsoft/CCF/releases/tag/ccf-5.0.0-dev11
 
-### Deprecated
+### Removed
 
 - `ccf::EnclaveAttestationProvider` has been removed. It is replaced by `ccf::AttestationProvider`
 

--- a/include/ccf/node/quote.h
+++ b/include/ccf/node/quote.h
@@ -41,7 +41,4 @@ namespace ccf
       const std::vector<uint8_t>& expected_node_public_key_der,
       pal::PlatformAttestationMeasurement& measurement);
   };
-
-  using EnclaveAttestationProvider CCF_DEPRECATED("Will be removed in 4.x") =
-    AttestationProvider;
 }


### PR DESCRIPTION
Deprecated in 3.0.0, was due to be removed in 4.0.0.