### PR TITLE
Allow driver to name the first node

### DIFF
--- a/src/consensus/aft/test/driver.cpp
+++ b/src/consensus/aft/test/driver.cpp
@@ -83,8 +83,8 @@ int main(int argc, char** argv)
     switch (shash(in))
     {
       case shash("start_node"):
-        assert(items.size() == 1);
-        driver->create_start_node(lineno);
+        assert(items.size() == 2);
+        driver->create_start_node(items[1], lineno);
         break;
       case shash("trust_node"):
         assert(items.size() == 3);

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -219,13 +219,12 @@ public:
                     << std::endl;
   }
 
-  void create_start_node(const size_t lineno)
+  void create_start_node(const std::string& start_node_id, const size_t lineno)
   {
     if (!_nodes.empty())
     {
       throw std::logic_error("Start node already exists");
     }
-    const std::string start_node_id = "0";
     kv::Configuration::Nodes configuration;
     add_node(start_node_id);
     configuration.try_emplace(start_node_id);
@@ -240,7 +239,7 @@ public:
 
   void trust_nodes(
     const std::string& term,
-    std::vector<std::string> node_ids,
+    const std::vector<std::string>& node_ids,
     const size_t lineno)
   {
     for (const auto& node_id : node_ids)

--- a/tests/raft_scenarios/append
+++ b/tests/raft_scenarios/append
@@ -1,6 +1,6 @@
 # Create a Start Node, commit initial transaction and signature
 # Append transaction to the node's log, observe that they are committed
-start_node
+start_node,0
 assert_is_primary,0
 emit_signature,2
 

--- a/tests/raft_scenarios/startup
+++ b/tests/raft_scenarios/startup
@@ -1,6 +1,6 @@
 # Create a Start Node, commit initial transaction and signature
 # https://microsoft.github.io/CCF/main/operations/start_network.html#starting-the-first-node
-start_node
+start_node,0
 assert_is_primary,0
 emit_signature,2
 


### PR DESCRIPTION
Useful for #5875, since the first node is usually known as "n1" in the spec, rather than "0" in the driver.