### PR TITLE
Minor refactorings

### DIFF
--- a/tla/consensus/SIMccfraft.cfg
+++ b/tla/consensus/SIMccfraft.cfg
@@ -90,3 +90,4 @@ INVARIANTS
     \* DebugInvSuccessfulCommitAfterReconfig
     \* DebugInvAllMessagesProcessable
     \* DebugInvRetirementReachable
+    \* DebugInvUpToDepth

--- a/tla/consensus/SIMccfraft.tla
+++ b/tla/consensus/SIMccfraft.tla
@@ -48,6 +48,10 @@ StopAfter ==
     (* The smoke test has a time budget of 20 minutes. *)
     IN TLCSet("exit", TLCGet("duration") > timeout)
 
+DebugInvUpToDepth ==
+    \* The following invariant causes TLC to terminate with a counterexample of length
+    \* -depth after generating the first trace.
+    TLCGet("level") < TLCGet("config").depth
 =============================================================================
 
 ------------------------------- MODULE SIMPostCondition -------------------------------

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -644,15 +644,11 @@ ChangeConfigurationInt(i, newConfiguration) ==
     \* Keep track of running reconfigurations to limit state space
     /\ reconfigurationCount' = reconfigurationCount + 1
     /\ removedFromConfiguration' = removedFromConfiguration \cup (CurrentConfiguration(i) \ newConfiguration)
-    /\ LET
-        entry == [
-            term |-> currentTerm[i],
-            configuration |-> newConfiguration,
-            contentType |-> TypeReconfiguration]
-        newLog == Append(log[i], entry)
-        IN
-        /\ log' = [log EXCEPT ![i] = newLog]
-        /\ configurations' = [configurations EXCEPT ![i] = configurations[i] @@ Len(log'[i]) :> newConfiguration]
+    /\ log' = [log EXCEPT ![i] = Append(log[i], 
+                                            [term |-> currentTerm[i],
+                                             configuration |-> newConfiguration,
+                                             contentType |-> TypeReconfiguration])]
+    /\ configurations' = [configurations EXCEPT ![i] = configurations[i] @@ Len(log'[i]) :> newConfiguration]
     /\ UNCHANGED <<messageVars, serverVars, candidateVars,
                     leaderVars, commitIndex, committableIndices>>
 

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -635,10 +635,6 @@ SignCommittableMessages(i) ==
 ChangeConfigurationInt(i, newConfiguration) ==
     \* Only leader can propose changes
     /\ state[i] = Leader
-    \* Configuration is non empty
-    /\ newConfiguration /= {}
-    \* Configuration is a proper subset of the Servers
-    /\ newConfiguration \subseteq Servers
     \* Configuration is not equal to the previous configuration
     /\ newConfiguration /= MaxConfiguration(i)
     \* Keep track of running reconfigurations to limit state space
@@ -653,7 +649,8 @@ ChangeConfigurationInt(i, newConfiguration) ==
                     leaderVars, commitIndex, committableIndices>>
 
 ChangeConfiguration(i) ==
-    \E newConfiguration \in SUBSET(Servers \ removedFromConfiguration) :
+    \* Reconfigure to any *non-empty* subset of servers.
+    \E newConfiguration \in SUBSET(Servers \ removedFromConfiguration) \ {{}}:
         ChangeConfigurationInt(i, newConfiguration)
 
 \* Leader i advances its commitIndex to the next possible Index.

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -645,8 +645,7 @@ ChangeConfigurationInt(i, newConfiguration) ==
                                              configuration |-> newConfiguration,
                                              contentType |-> TypeReconfiguration])]
     /\ configurations' = [configurations EXCEPT ![i] = configurations[i] @@ Len(log'[i]) :> newConfiguration]
-    /\ UNCHANGED <<messageVars, serverVars, candidateVars,
-                    leaderVars, commitIndex, committableIndices>>
+    /\ UNCHANGED <<messageVars, serverVars, candidateVars, leaderVars, commitIndex, committableIndices>>
 
 ChangeConfiguration(i) ==
     \* Reconfigure to any *non-empty* subset of servers.


### PR DESCRIPTION
* Show value of newConfiguration parameter of ChangeConfigurationInt in traces
* Add DebugInvUpToDepth invariant to SIMccfraft to quickly generate a trace of length N by passing N to TLC's `-depth` cli.

Related to https://github.com/microsoft/CCF/pull/5875