### PR TITLE
Remove method support check in js batched stress test

### DIFF
--- a/tests/e2e_batched.py
+++ b/tests/e2e_batched.py
@@ -17,7 +17,6 @@ id_gen = itertools.count()
 
 
 @reqs.description("Running batch submission of new entries")
-@reqs.supports_methods("/app/batch/submit", "/app/batch/fetch")
 def test(network, args, batch_size=100, write_key_divisor=1, write_size_multiplier=1):
     LOG.info(f"Number of batched entries: {batch_size}")
     primary, _ = network.find_primary()


### PR DESCRIPTION
Change to address the following issue:

https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=79909&view=logs&j=f3457e4b-102d-5a4f-f801-dc119e4853a8&t=ae98f324-492e-5969-593b-258ede9c5463

```
48: 13:06:11.719 | INFO     | __main__:run_to_destruction:115 - Large write set caused an exception, as expected
48: 13:06:11.719 | INFO     | __main__:run_to_destruction:116 - Exception was: Could not check if test requirements were met: 
48: 13:06:11.719 | INFO     | __main__:run_to_destruction:117 - Polling for 120s for node to terminate
```

in https://github.com/microsoft/CCF/blob/d95a0cea350970b223b60465eaeab47b38111748/tests/e2e_batched.py#L104

Large writes can cause an election without a crash, in which case the attempt to find a primary to look up available endpoints (quite unnecessary in the context of the destruction loop) will time out, causing the exception above. The nodes are still healthy and do not eventually shut down, leading to the test failure.