### PR TITLE
`NextIndex` is not updated on successful AE response

### DIFF
--- a/tests/raft_scenarios/replicate_deprecated
+++ b/tests/raft_scenarios/replicate_deprecated
@@ -13,6 +13,7 @@ dispatch_all
 state_all
 replicate,1,helloworld
 emit_signature,1
+emit_signature,1
 periodic_all,10
 dispatch_all
 periodic_all,1

--- a/tests/raft_scenarios/replicate_deprecated
+++ b/tests/raft_scenarios/replicate_deprecated
@@ -13,7 +13,6 @@ dispatch_all
 state_all
 replicate,1,helloworld
 emit_signature,1
-emit_signature,1
 periodic_all,10
 dispatch_all
 periodic_all,1

--- a/tla/consensus/MCccfraft.cfg
+++ b/tla/consensus/MCccfraft.cfg
@@ -77,6 +77,5 @@ INVARIANTS
     MonoLogInv
     NoLeaderBeforeInitialTerm
     LogConfigurationConsistentInv
-    MatchIndexLowerBoundNextIndexInv
     CommitCommittableIndices
     CommittableIndicesAreKnownSignaturesInv

--- a/tla/consensus/MCccfraftWithReconfig.cfg
+++ b/tla/consensus/MCccfraftWithReconfig.cfg
@@ -77,6 +77,5 @@ INVARIANTS
     MonoLogInv
     NoLeaderBeforeInitialTerm
     LogConfigurationConsistentInv
-    MatchIndexLowerBoundNextIndexInv
     CommitCommittableIndices
     CommittableIndicesAreKnownSignaturesInv

--- a/tla/consensus/SIMccfraft.cfg
+++ b/tla/consensus/SIMccfraft.cfg
@@ -77,8 +77,6 @@ INVARIANTS
     NoLeaderBeforeInitialTerm
     LogConfigurationConsistentInv
 
-    MatchIndexLowerBoundNextIndexInv
-
     CommitCommittableIndices
 
     CommittableIndicesAreKnownSignaturesInv

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -276,7 +276,7 @@ CandidateVarsTypeInv ==
 
 \* The next entry to send to each follower, called send_idx in raft.h
 \* In CCF, the leader updates nextIndex optimically when an AE message is dispatched
-\* In contrast, In Raft the leader only updates nextIndex when an AE response is received
+\* In contrast, in Raft the leader only updates nextIndex when an AE response is received
 VARIABLE nextIndex
 
 \* nextIndex cannot be zero as its the index of the first log

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -274,9 +274,9 @@ CandidateVarsTypeInv ==
 
 \* The following variables are used only on leaders:
 
-\* The next entry to send to each follower.
-\* nextIndex is called send_idx in raft.h
+\* The next entry to send to each follower, called send_idx in raft.h
 \* In CCF, the leader updates nextIndex optimically when an AE message is dispatched
+\* In contrast, In Raft the leader only updates nextIndex when an AE response is received
 VARIABLE nextIndex
 
 \* nextIndex cannot be zero as its the index of the first log

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -274,7 +274,7 @@ CandidateVarsTypeInv ==
 
 \* The following variables are used only on leaders:
 
-\* The next entry to send to each follower, called send_idx in raft.h
+\* The next entry to send to each follower, called sent_idx in raft.h
 \* In CCF, the leader updates nextIndex optimically when an AE message is dispatched
 \* In contrast, in Raft the leader only updates nextIndex when an AE response is received
 VARIABLE nextIndex

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -273,7 +273,10 @@ CandidateVarsTypeInv ==
     /\ VotesGrantedTypeInv
 
 \* The following variables are used only on leaders:
+
 \* The next entry to send to each follower.
+\* nextIndex is called send_idx in raft.h
+\* In CCF, the leader updates nextIndex optimically when an AE message is dispatched
 VARIABLE nextIndex
 
 \* nextIndex cannot be zero as its the index of the first log
@@ -921,6 +924,7 @@ HandleAppendEntriesResponse(i, j, m) ==
           /\ m.success \* successful
           \* max(...) because why would we ever want to go backwards on a success response?!
           /\ matchIndex' = [matchIndex EXCEPT ![i][j] = max(@, m.lastLogIndex)]
+          \* nextIndex is unchanged on successful AE response as it was already updated when the AE was dispatched
           /\ UNCHANGED nextIndex
        \/ /\ \lnot m.success \* not successful
           /\ LET tm == FindHighestPossibleMatch(log[i], m.lastLogIndex, m.term)

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -1247,6 +1247,9 @@ NoLeaderBeforeInitialTerm ==
     \A i \in Servers :
         currentTerm[i] < StartTerm => state[i] # Leader
 
+\* MatchIndexLowerBoundNextIndexInv is not currently an invariant but 
+\* we might wish to add it in the future. This could be achieved by updating 
+\* nextIndex to max of current nextIndex and matchIndex when an AE ACK is received.
 MatchIndexLowerBoundNextIndexInv ==
     \A i,j \in Servers :
         state[i] = Leader =>

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -921,7 +921,7 @@ HandleAppendEntriesResponse(i, j, m) ==
           /\ m.success \* successful
           \* max(...) because why would we ever want to go backwards on a success response?!
           /\ matchIndex' = [matchIndex EXCEPT ![i][j] = max(@, m.lastLogIndex)]
-          /\ nextIndex'  = [nextIndex  EXCEPT ![i][j] = max(@, m.lastLogIndex + 1)]
+          /\ UNCHANGED nextIndex
        \/ /\ \lnot m.success \* not successful
           /\ LET tm == FindHighestPossibleMatch(log[i], m.lastLogIndex, m.term)
              IN nextIndex' = [nextIndex EXCEPT ![i][j] = max(min(tm, nextIndex[i][j]-1), matchIndex[i][j]) + 1 ]


### PR DESCRIPTION
CCF's consensus optimistically updates the send_idx when an AE message is dispatched so it does not need to update it on a successful AE response