### PR TITLE
Follow up to #5895 

### DIFF
--- a/tla/consensus/MCccfraftAtomicReconfig.cfg
+++ b/tla/consensus/MCccfraftAtomicReconfig.cfg
@@ -77,6 +77,5 @@ INVARIANTS
     MonoLogInv
     LogConfigurationConsistentInv
     NoLeaderBeforeInitialTerm
-    MatchIndexLowerBoundNextIndexInv
     CommitCommittableIndices
     CommittableIndicesAreKnownSignaturesInv


### PR DESCRIPTION
A minor change I forgot to push in #5895. removing `MatchIndexLowerBoundNextIndexInv` from atomic reconfig configuration file