### PR TITLE
Ask `ruff` to autofix Python lint errors, where possible

### DIFF
--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -21,6 +21,8 @@ function group(){
     # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
     if [[ ${CI} ]]; then
       echo "::group::$1"
+    else
+      echo "-=[ $1 ]=-"
     fi
 }
 function endgroup() {

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -119,7 +119,11 @@ pip install -U -r python/requirements.txt 1>/dev/null
 endgroup
 
 group "Python lint"
-ruff check python/ tests/
+if [ $FIX -ne 0 ]; then
+  ruff check --fix python/ tests/
+else
+  ruff check python/ tests/
+fi
 endgroup
 
 group "Python types"


### PR DESCRIPTION
For some errors that ruff spots, such as unused includes, it will print an error along the lines of "I could have tried to fix this automatically, if you'd given me the `--fix` arg". It's odd-to-annoying ifthat appears when we _have_ passed the `-f[ix]` arg to our `ci-checks` wrapper!

So the wrapper's `fix` mode now enables ruff's `fix` mode, as it does with similar tools.

Also, because we have mixed verbosity of the tools called from this wrapper, I've modified it to always print group headings. There might be a reason this was disabled, that I've forgotten? But I think it makes the output far more readable.