### PR TITLE
More trace validation scenarios

### DIFF
--- a/tests/raft_scenarios/bad_network
+++ b/tests/raft_scenarios/bad_network
@@ -1,19 +1,33 @@
-nodes,0,1,2
-connect,0,1
-connect,1,2
-connect,0,2
+start_node,0
+assert_is_primary,0
+emit_signature,2
 
-# Node 0 starts first, and wins the first election
-periodic_one,0,110
+assert_is_primary,0
+assert_commit_idx,0,2
+
+trust_node,2,1
+emit_signature,2
+
 dispatch_all
-
 periodic_all,10
 dispatch_all
+assert_commit_idx,0,4
+
+trust_node,2,2
+emit_signature,2
+
+dispatch_all
+periodic_all,10
+dispatch_all
+assert_commit_idx,0,6
+
 assert_is_primary,0
+assert_is_backup,1
+assert_is_backup,2
 
 # An initial entry is written and successfully replicated
-replicate,1,helloworld
-emit_signature,1
+replicate,2,helloworld
+emit_signature,2
 
 periodic_all,10
 dispatch_all
@@ -25,8 +39,8 @@ state_all
 assert_state_sync
 
 # An additional entry takes much longer to replicate, as it is lost on bad connection between nodes
-replicate,1,salutonmondo
-emit_signature,1
+replicate,2,salutonmondo
+emit_signature,2
 
 periodic_all,10
 drop_pending,0
@@ -53,7 +67,7 @@ dispatch_all_once
 drop_pending_to,1,0  #< This is dropped!
 dispatch_all_once
 
-# At this point, 1.2 is committed, but nobody knows that yet
+# At this point, 2.10 is committed, but nobody knows that yet
 
 # Eventually Node 2 is partitioned for so long that it calls an election
 periodic_one,2,100

--- a/tests/raft_scenarios/fancy_election.1
+++ b/tests/raft_scenarios/fancy_election.1
@@ -1,28 +1,47 @@
-nodes,0,1,2
+start_node,0
+assert_is_primary,0
+emit_signature,2
 
-# Node 2 is initially partitioned
-connect,0,1
+assert_is_primary,0
+assert_commit_idx,0,2
 
-# Node 0 starts first, and begins sending messages first
-periodic_one,0,110
+trust_node,2,1
+emit_signature,2
+
 dispatch_all
-
 periodic_all,10
 dispatch_all
+assert_commit_idx,0,4
 
-state_all
+trust_node,2,2
+emit_signature,2
 
-replicate,1,helloworld
-emit_signature,1
+# Node 2 is initially partitioned
+disconnect,0,2
+disconnect,1,2
+
+dispatch_all
+periodic_all,10
+dispatch_all
+periodic_all,10
+dispatch_all
+assert_commit_idx,0,6
+assert_commit_idx,1,6
+
+assert_is_primary,0
+assert_is_backup,1
+
+replicate,2,helloworld
+emit_signature,2
 periodic_all,10
 dispatch_all
 
 # Build an uncommitted suffix
-replicate,1,salutonmondo
-replicate,1,hallo
-replicate,1,hullo
-replicate,1,ahoyhoy
-emit_signature,1
+replicate,2,salutonmondo
+replicate,2,hallo
+replicate,2,hullo
+replicate,2,ahoyhoy
+emit_signature,2
 
 # Dispatch AppendEntries containing this suffix, which will be received by Node 1, making
 # it committed (known by a majority of nodes), though its commit status remains unknown
@@ -39,10 +58,10 @@ dispatch_one,1
 state_all
 
 # Build a further suffix which is _not_ shared in time
-replicate,1,z
-replicate,1,zz
-replicate,1,zzz
-emit_signature,1
+replicate,2,z
+replicate,2,zz
+replicate,2,zzz
+emit_signature,2
 
 state_all
 
@@ -65,8 +84,8 @@ dispatch_one,1
 dispatch_one,2
 
 # Node 1 appends a new committable entry to confirm its primaryship
-replicate,2,ConfirmCommit
-emit_signature,2
+replicate,3,ConfirmCommit
+emit_signature,3
 
 # Node 1 sends an initial AppendEntries probe
 periodic_one,1,10

--- a/tests/raft_scenarios/soft_rollback
+++ b/tests/raft_scenarios/soft_rollback
@@ -1,22 +1,33 @@
 # Fully-connected 3-node network
-nodes,0,1,2
-connect,0,1
-connect,1,2
-connect,0,2
+start_node,0
+assert_is_primary,0
+emit_signature,2
 
-# Node 0 starts first, calls and wins an election
-periodic_one,0,110
+assert_is_primary,0
+assert_commit_idx,0,2
+
+trust_node,2,1
+emit_signature,2
+
 dispatch_all
-
 periodic_all,10
 dispatch_all
+assert_commit_idx,0,4
 
-state_all
-assert_is_primary,0
+trust_node,2,2
+emit_signature,2
+
+dispatch_all
+periodic_all,10
+dispatch_all
+periodic_all,10
+dispatch_all
+assert_commit_idx,0,6
+assert_state_sync
 
 # Node 0 emits an entry, and signature
-replicate,1,hello world
-emit_signature,1
+replicate,2,hello world
+emit_signature,2
 periodic_all,10
 
 # But only succeeds in replicating this to node 1
@@ -36,8 +47,8 @@ periodic_one,1,110
 dispatch_all
 
 # Node 1 may do work in this term, but crucially doesn't get as far as emitting a signature
-replicate,2,saluton mondo
-replicate,2,ah well nevertheless
+replicate,3,saluton mondo
+replicate,3,ah well nevertheless
 state_all
 
 # Node 2 calls an election, advancing to term 3
@@ -73,8 +84,8 @@ assert_is_primary,1
 
 # Regardless of earlier disagreements, we can all agree now
 reconnect_node,2
-replicate,4,place trace checker
-emit_signature,4
+replicate,5,place trace checker
+emit_signature,5
 periodic_all,10
 dispatch_all
 periodic_all,10

--- a/tests/raft_scenarios/suffix_collision.1
+++ b/tests/raft_scenarios/suffix_collision.1
@@ -1,24 +1,40 @@
-nodes,0,1,2
-connect,0,1
-connect,1,2
-connect,0,2
+start_node,0
+assert_is_primary,0
+emit_signature,2
 
-# Node 0 starts first, and begins sending messages first
-periodic_one,0,110
+assert_is_primary,0
+assert_commit_idx,0,2
+
+trust_node,2,1
+emit_signature,2
+
 dispatch_all
+periodic_all,10
+dispatch_all
+assert_commit_idx,0,4
 
+trust_node,2,2
+emit_signature,2
+
+dispatch_all
+periodic_all,10
+dispatch_all
+periodic_all,10
+dispatch_all
+assert_commit_idx,0,6
+assert_state_sync
+
+assert_is_primary,0
+assert_is_backup,1
+assert_is_backup,2
+
+replicate,2,hello world
+emit_signature,2
 periodic_all,10
 dispatch_all
 
-state_all
-
-replicate,1,hello world
-emit_signature,1
-periodic_all,10
-dispatch_all
-
-replicate,1,saluton mondo
-emit_signature,1
+replicate,2,saluton mondo
+emit_signature,2
 periodic_all,10
 dispatch_all
 
@@ -31,8 +47,8 @@ state_all
 disconnect,0,1
 disconnect,0,2
 
-replicate,1,drop me 1
-emit_signature,1
+replicate,2,drop me 1
+emit_signature,2
 periodic_all,10
 dispatch_all
 
@@ -48,13 +64,13 @@ dispatch_all  #< This AppendEntries starts at a point that Node 1 would accept, 
 state_all
 
 # Node 1 replicates a new entry, resulting in the same seqno as Node 0
-replicate,2,keep me 1
-emit_signature,2
+replicate,3,keep me 1
+emit_signature,3
 periodic_all,10
 dispatch_all
 
-replicate,2,keep me 2
-emit_signature,2
+replicate,3,keep me 2
+emit_signature,3
 periodic_all,10
 dispatch_all
 

--- a/tests/raft_scenarios/suffix_collision.2
+++ b/tests/raft_scenarios/suffix_collision.2
@@ -1,27 +1,40 @@
-# 3 nodes
-nodes,0,1,2
+start_node,0
+assert_is_primary,0
+emit_signature,2
 
-# Fully connected
-connect,0,1
-connect,1,2
-connect,0,2
+assert_is_primary,0
+assert_commit_idx,0,2
 
-# Node 0 starts first, and begins sending messages first
-periodic_one,0,110
+trust_node,2,1
+emit_signature,2
+
 dispatch_all
+periodic_all,10
+dispatch_all
+assert_commit_idx,0,4
 
+trust_node,2,2
+emit_signature,2
+
+dispatch_all
+periodic_all,10
+dispatch_all
+periodic_all,10
+dispatch_all
+assert_commit_idx,0,6
+assert_state_sync
+
+assert_is_primary,0
+assert_is_backup,1
+assert_is_backup,2
+
+replicate,2,hello world
+emit_signature,2
 periodic_all,10
 dispatch_all
 
-state_all
-
-replicate,1,hello world
-emit_signature,1
-periodic_all,10
-dispatch_all
-
-replicate,1,saluton mondo
-emit_signature,1
+replicate,2,saluton mondo
+emit_signature,2
 periodic_all,10
 dispatch_all
 
@@ -36,10 +49,10 @@ assert_state_sync
 disconnect,0,1
 disconnect,0,2
 
-replicate,1,drop me 1
-replicate,1,drop me 2
-replicate,1,drop me 3
-emit_signature,1
+replicate,2,drop me 1
+replicate,2,drop me 2
+replicate,2,drop me 3
+emit_signature,2
 periodic_all,10
 dispatch_all
 
@@ -55,13 +68,13 @@ dispatch_all  #< This AppendEntries starts at a point that Node 1 would accept, 
 state_all
 
 # Node 1 replicates new entries
-replicate,2,keep me 1
-emit_signature,2
+replicate,3,keep me 1
+emit_signature,3
 periodic_all,10
 dispatch_all
 
-replicate,2,keep me 2
-emit_signature,2
+replicate,3,keep me 2
+emit_signature,3
 periodic_all,10
 dispatch_all
 
@@ -74,8 +87,8 @@ dispatch_all
 periodic_all,10
 dispatch_all
 
-replicate,3,keep me term 3
-emit_signature,3
+replicate,4,keep me term 4
+emit_signature,4
 
 periodic_all,10
 dispatch_all
@@ -86,8 +99,8 @@ dispatch_all
 periodic_all,10
 dispatch_all
 
-replicate,4,keep me term 4
-emit_signature,4
+replicate,5,keep me term 5
+emit_signature,5
 
 periodic_all,10
 dispatch_all

--- a/tests/raft_scenarios/suffix_collision.3
+++ b/tests/raft_scenarios/suffix_collision.3
@@ -1,34 +1,53 @@
 # 5 initial nodes
-nodes,0,1,2,3,4
+start_node,0
+assert_is_primary,0
+emit_signature,2
 
-# fully connected
-connect,0,1
-connect,0,2
-connect,0,3
-connect,0,4
-connect,1,2
-connect,1,3
-connect,1,4
-connect,2,3
-connect,2,4
-connect,3,4
+assert_is_primary,0
+assert_commit_idx,0,2
 
-# Node 0 starts first, and begins sending messages first
-periodic_one,0,110
+trust_node,2,1
+emit_signature,2
+
 dispatch_all
+periodic_all,10
+dispatch_all
+assert_commit_idx,0,4
 
+trust_node,2,2
+emit_signature,2
+
+dispatch_all
+periodic_all,10
+dispatch_all
+assert_commit_idx,0,6
+
+trust_node,2,3
+emit_signature,2
+
+dispatch_all
+periodic_all,10
+dispatch_all
+assert_commit_idx,0,8
+
+trust_node,2,4
+emit_signature,2
+
+dispatch_all
+periodic_all,10
+dispatch_all
+periodic_all,10
+dispatch_all
+assert_commit_idx,0,10
+assert_state_sync
+
+replicate,2,hello world
+emit_signature,2
 periodic_all,10
 dispatch_all
 
-state_all
-
-replicate,1,hello world
-emit_signature,1
-periodic_all,10
-dispatch_all
-
-replicate,1,saluton mondo
-emit_signature,1
+replicate,2,saluton mondo
+emit_signature,2
 periodic_all,10
 dispatch_all
 
@@ -55,27 +74,27 @@ periodic_all,10
 dispatch_all
 
 # Node 0 continues to produce a suffix in term 1
-replicate,1,branch a 0
-emit_signature,1
+replicate,2,branch a 0
+emit_signature,2
 
-replicate,1,branch a 1
-emit_signature,1
+replicate,2,branch a 1
+emit_signature,2
 
-replicate,1,branch a 2
-emit_signature,1
+replicate,2,branch a 2
+emit_signature,2
 
 # Node 2 continues to produce a suffix in term 2
-replicate,2,branch b 0
-emit_signature,2
+replicate,3,branch b 0
+emit_signature,3
 
-replicate,2,branch b 1
-emit_signature,2
+replicate,3,branch b 1
+emit_signature,3
 
-replicate,2,branch b 2
-emit_signature,2
+replicate,3,branch b 2
+emit_signature,3
 
-replicate,2,branch b 3
-emit_signature,2
+replicate,3,branch b 3
+emit_signature,3
 
 # AEs describing these suffices are produced, but lost in transit
 periodic_all,10
@@ -102,24 +121,24 @@ dispatch_all
 disconnect,2,4
 
 # Node 0 continues to produce a suffix in term 3
-replicate,3,branch a 10
-emit_signature,3
+replicate,4,branch a 10
+emit_signature,4
 
-replicate,3,branch a 11
-emit_signature,3
+replicate,4,branch a 11
+emit_signature,4
 
-replicate,3,branch a 12
-emit_signature,3
+replicate,4,branch a 12
+emit_signature,4
 
 # Node 2 continues to produce a suffix in term 4
-replicate,4,branch b 10
-emit_signature,4
+replicate,5,branch b 10
+emit_signature,5
 
-replicate,4,branch b 11
-emit_signature,4
+replicate,5,branch b 11
+emit_signature,5
 
-replicate,4,branch b 12
-emit_signature,4
+replicate,5,branch b 12
+emit_signature,5
 
 # AEs describing these suffices are produced, and delivered,
 # but due to partition they cannot be committed

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -38,10 +38,8 @@ IsAppendEntriesResponse(msg, dst, src, logline) ==
     /\ msg.type = AppendEntriesResponse
     /\ msg.type = RaftMsgType[logline.msg.packet.msg]
     /\ msg.dest   = dst
-    /\ msg.source = src
-    \* raft.h::send_append_entries_response:1348 RAeR FAIL set their term to the term of index
-    \* for the last entry in the backup's log, not the term of the current leader. 
-    \* /\ msg.term = logline.msg.packet.term
+    /\ msg.source = src 
+    /\ msg.term = logline.msg.packet.term
     \* raft_types.h enum AppendEntriesResponseType
     /\ msg.success = (logline.msg.packet.success = "OK")
     /\ msg.lastLogIndex = logline.msg.packet.last_log_idx

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -38,7 +38,7 @@ IsAppendEntriesResponse(msg, dst, src, logline) ==
     /\ msg.type = AppendEntriesResponse
     /\ msg.type = RaftMsgType[logline.msg.packet.msg]
     /\ msg.dest   = dst
-    /\ msg.source = src 
+    /\ msg.source = src
     /\ msg.term = logline.msg.packet.term
     \* raft_types.h enum AppendEntriesResponseType
     /\ msg.success = (logline.msg.packet.success = "OK")

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -39,7 +39,9 @@ IsAppendEntriesResponse(msg, dst, src, logline) ==
     /\ msg.type = RaftMsgType[logline.msg.packet.msg]
     /\ msg.dest   = dst
     /\ msg.source = src
-    /\ msg.term = logline.msg.packet.term
+    \* raft.h::send_append_entries_response:1348 RAeR FAIL set their term to the term of index
+    \* for the last entry in the batch, not the term of the current leader. 
+    \* /\ msg.term = logline.msg.packet.term
     \* raft_types.h enum AppendEntriesResponseType
     /\ msg.success = (logline.msg.packet.success = "OK")
     /\ msg.lastLogIndex = logline.msg.packet.last_log_idx

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -40,7 +40,7 @@ IsAppendEntriesResponse(msg, dst, src, logline) ==
     /\ msg.dest   = dst
     /\ msg.source = src
     \* raft.h::send_append_entries_response:1348 RAeR FAIL set their term to the term of index
-    \* for the last entry in the batch, not the term of the current leader. 
+    \* for the last entry in the backup's log, not the term of the current leader. 
     \* /\ msg.term = logline.msg.packet.term
     \* raft_types.h enum AppendEntriesResponseType
     /\ msg.success = (logline.msg.packet.success = "OK")

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -788,7 +788,7 @@ RejectAppendEntriesRequest(i, j, m, logOk) ==
        \/ /\ m.term >= currentTerm[i]
           /\ leadershipState[i] = Follower
           /\ ~logOk
-          \* raft.h::send_append_entries_response:1348 RAeR FAIL set their term to the term of index
+          \* raft.h::send_append_entries_response:1348 AppendEntriesResponse messages with answer == FAIL set their term to the term of index
           \* for the last entry in the backup's log, not the term of the current leader
           /\ LET prevTerm == IF m.prevLogIndex = 0 THEN 0
                              ELSE IF m.prevLogIndex > Len(log[i]) THEN 0 ELSE log[i][Len(log[i])].term

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -788,10 +788,12 @@ RejectAppendEntriesRequest(i, j, m, logOk) ==
        \/ /\ m.term >= currentTerm[i]
           /\ leadershipState[i] = Follower
           /\ ~logOk
-          /\ LET prevTerm == IF m.prevLogIndex = 0 THEN StartTerm
+          \* raft.h::send_append_entries_response:1348 RAeR FAIL set their term to the term of index
+          \* for the last entry in the backup's log, not the term of the current leader
+          /\ LET prevTerm == IF m.prevLogIndex = 0 THEN 0
                              ELSE IF m.prevLogIndex > Len(log[i]) THEN 0 ELSE log[i][Len(log[i])].term
              IN /\ m.prevLogTerm # prevTerm
-                /\ \/ /\ prevTerm = StartTerm
+                /\ \/ /\ prevTerm = 0
                       /\ Reply([type        |-> AppendEntriesResponse,
                              success        |-> FALSE,
                              term           |-> currentTerm[i],
@@ -799,7 +801,7 @@ RejectAppendEntriesRequest(i, j, m, logOk) ==
                              source         |-> i,
                              dest           |-> j],
                              m)
-                   \/ /\ prevTerm # StartTerm
+                   \/ /\ prevTerm # 0
                       /\ LET lli == FindHighestPossibleMatch(log[i], m.prevLogIndex, m.term)
                          IN Reply([type        |-> AppendEntriesResponse,
                                 success        |-> FALSE,


### PR DESCRIPTION
Add soft rollback, fancy election 1, suffix collisions 1,2,3 and bad network scenarios, as well as spec fix necessary to align receive append entries response to the one on the implementation.

It is worth nothing that the spec and implementation of CCF differ from Raft on the term value set on receive append entries responses when they fail. @heidihoward spotted this earlier when reviewing the implementation, now is a good time to discuss and resolve the discrepancy:

**Raft**: term of the current, as provided previously on the send append entries.

![image](https://github.com/microsoft/CCF/assets/4016369/59b105e2-ee40-4817-8dc6-98bec922214b)

From https://raft.github.io/raft.pdf (wouldn't it be nice if there was a way to link to a section in a paper?).

**CCF implementation**: [term of the last index in the backup's log](https://github.com/microsoft/CCF/blob/e5a7106a03686e5da881c1ec9f182d3a468159de/src/consensus/aft/raft.h#L1348), [same in the spec, with additional prevLogIndex fix in this PR](https://github.com/microsoft/CCF/blob/e5a7106a03686e5da881c1ec9f182d3a468159de/tla/consensus/ccfraft.tla#L778).