### PR TITLE
Add `contains_globally_committed` to `kv::Set`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [5.0.0-dev12]: https://github.com/microsoft/CCF/releases/tag/ccf-5.0.0-dev12
 
+### Added
+
+- There is now a `contains_globally_committed(k)` method on `kv::Set<K>`, with the same semantics as `get_globally_committed(k)` on `kv::Map<K, V>` (#5928).
+
 ### Changed
 
 - JS endpoints marked as `"mode": "readonly"` are prevented from writing to the KV. Attempting to call `map.set(k, v)`, `map.delete(k)`, or `map.clear()` on any KV table in such an endpoint will now result in an error being thrown (#5921).

--- a/include/ccf/kv/set_handle.h
+++ b/include/ccf/kv/set_handle.h
@@ -34,6 +34,21 @@ namespace kv
       return read_handle.has(KSerialiser::to_serialised(key));
     }
 
+    /** Test whether a key's presence is globally committed, meaning it has been
+     * replciated and acknowledged by consensus protocol.
+     *
+     * @see kv::ReadableMapHandle::get_globally_committed
+     *
+     * @param key Key to test
+     *
+     * @return Boolean true iff key exists in globally committed state
+     */
+    bool contains_globally_committed(const K& key)
+    {
+      return read_handle.has_globally_committed(
+        KSerialiser::to_serialised(key));
+    }
+
     /** Get version when this key was last added to the set.
      *
      * Returns nullopt if the key is not present.

--- a/include/ccf/kv/untyped_map_handle.h
+++ b/include/ccf/kv/untyped_map_handle.h
@@ -56,6 +56,8 @@ namespace kv::untyped
     std::optional<ValueType> get_globally_committed(const KeyType& key);
 
     bool has(const KeyType& key);
+    
+    bool has_globally_committed(const KeyType& key);
 
     void put(const KeyType& key, const ValueType& value);
 

--- a/include/ccf/kv/untyped_map_handle.h
+++ b/include/ccf/kv/untyped_map_handle.h
@@ -56,7 +56,7 @@ namespace kv::untyped
     std::optional<ValueType> get_globally_committed(const KeyType& key);
 
     bool has(const KeyType& key);
-    
+
     bool has_globally_committed(const KeyType& key);
 
     void put(const KeyType& key, const ValueType& value);

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -199,9 +199,15 @@ TEST_CASE("sets and values")
       REQUIRE(set_handle->contains(k2));
       REQUIRE(set_handle->size() == 2);
 
+      REQUIRE(!set_handle->contains_globally_committed(k1));
+      REQUIRE(!set_handle->contains_globally_committed(k2));
+
       set_handle->remove(k2);
       REQUIRE(!set_handle->contains(k2));
       REQUIRE(set_handle->size() == 1);
+
+      REQUIRE(!set_handle->contains_globally_committed(k1));
+      REQUIRE(!set_handle->contains_globally_committed(k2));
 
       REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
     }
@@ -212,6 +218,10 @@ TEST_CASE("sets and values")
       auto set_handle = tx.ro(set);
       REQUIRE(set_handle->contains(k1));
       REQUIRE(!set_handle->contains(k2));
+
+      REQUIRE(set_handle->contains_globally_committed(k1));
+      REQUIRE(!set_handle->contains_globally_committed(k2));
+
       REQUIRE(set_handle->size() == 1);
       std::set<std::string> std_set;
       set_handle->foreach([&std_set](const std::string& entry) {
@@ -239,6 +249,9 @@ TEST_CASE("sets and values")
       set_handle->remove(k1);
       REQUIRE(!set_handle->contains(k1));
       REQUIRE(set_handle->size() == 0);
+
+      REQUIRE(set_handle->contains_globally_committed(k1));
+      REQUIRE(!set_handle->contains_globally_committed(k2));
 
       REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
     }

--- a/src/kv/untyped_map_handle.cpp
+++ b/src/kv/untyped_map_handle.cpp
@@ -153,6 +153,12 @@ namespace kv::untyped
     return found;
   }
 
+  bool MapHandle::has_globally_committed(const MapHandle::KeyType& key)
+  {
+    auto raw = tx_changes.committed.getp(key);
+    return raw != nullptr;
+  }
+
   void MapHandle::put(
     const MapHandle::KeyType& key, const MapHandle::ValueType& value)
   {


### PR DESCRIPTION
Resolves #5926.