### PR TITLE
MoreUpToDateCorrectInv is not an invariant, move to Debug

### DIFF
--- a/tla/consensus/MCccfraft.cfg
+++ b/tla/consensus/MCccfraft.cfg
@@ -71,7 +71,6 @@ INVARIANTS
     ElectionSafetyInv
     LogMatchingInv
     QuorumLogInv
-    MoreUpToDateCorrectInv
     LeaderCompletenessInv
     SignatureInv
     TypeInv

--- a/tla/consensus/MCccfraftAtomicReconfig.cfg
+++ b/tla/consensus/MCccfraftAtomicReconfig.cfg
@@ -71,7 +71,6 @@ INVARIANTS
     ElectionSafetyInv
     LogMatchingInv
     QuorumLogInv
-    MoreUpToDateCorrectInv
     LeaderCompletenessInv
     SignatureInv
     TypeInv

--- a/tla/consensus/MCccfraftWithReconfig.cfg
+++ b/tla/consensus/MCccfraftWithReconfig.cfg
@@ -71,7 +71,6 @@ INVARIANTS
     ElectionSafetyInv
     LogMatchingInv
     QuorumLogInv
-    MoreUpToDateCorrectInv
     LeaderCompletenessInv
     SignatureInv
     TypeInv

--- a/tla/consensus/SIMccfraft.cfg
+++ b/tla/consensus/SIMccfraft.cfg
@@ -73,7 +73,6 @@ INVARIANTS
     ElectionSafetyInv
     LogMatchingInv
     QuorumLogInv
-    MoreUpToDateCorrectInv
     LeaderCompletenessInv
     SignatureInv
 
@@ -102,3 +101,4 @@ INVARIANTS
     \* DebugInvAllMessagesProcessable
     \* DebugInvRetirementReachable
     \* DebugInvUpToDepth
+    \* DebugMoreUpToDateCorrectInv

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -1195,7 +1195,10 @@ UpToDateCheck(i, j) ==
 
 \* If a server i might request a vote from j, receives it and counts it then i 
 \* has all of j's committed entries
-MoreUpToDateCorrectInv ==
+\* This is not an invariant, it is possible for j to vote for i despite i not
+\* having all of j's committed entries. What isn't possible is for i to win
+\* an election without having all of j's committed entries.
+DebugMoreUpToDateCorrectInv ==
     \A i \in { s \in Servers : leadershipState[s] = Candidate } :
         \A j \in GetServerSet(i) :
             /\ i /= j 


### PR DESCRIPTION
After investigation of the failure raised in https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=80403&view=logs&j=ef8c4b80-2ff7-5042-ecea-fb36384f1d0d&t=c2a7e65a-2f43-5dbb-c6d6-70df1fdcc7fc, it has become clear that MoreUpToDateCorrectInv does not hold, and that valid traces can break it.

[SIMccfraft.json](https://github.com/microsoft/CCF/files/13975430/SIMccfraft.json)