### PR TITLE
[WIP] Add a `reelection` scenario

### DIFF
--- a/tests/raft_scenarios/reelection
+++ b/tests/raft_scenarios/reelection
@@ -1,0 +1,41 @@
+# Test what happens when a node is re-elected, and receives messages from previous terms
+start_node,0
+emit_signature,2
+
+assert_is_primary,0
+assert_commit_idx,0,2
+
+trust_nodes,2,1,2
+emit_signature,2
+
+dispatch_all
+periodic_all,10
+dispatch_all
+assert_commit_idx,0,4
+assert_is_primary,0
+assert_is_backup,1
+assert_is_backup,2
+
+# Start from a steady state
+periodic_all,10
+dispatch_all
+assert_state_sync
+
+# Produce more entries
+emit_signature,2
+emit_signature,2
+
+# Send AEs, but don't get responses yet
+periodic_one,0,10
+dispatch_one,0
+
+# Time out, call a new election
+periodic_one,0,100
+assert_is_backup,0
+periodic_one,0,100
+assert_is_candidate,0
+
+# Receive vote responses and AEs
+dispatch_all
+
+state_all


### PR DESCRIPTION
Trying to debug an issue with trace validation, and adding this simple scenario which demonstrates the problem.

When a node becomes primary again, it should process (and discard) AER ACKs from previous terms. In this case, it doesn't, and I believe that's because it has unnecessarily dropped pending messages, since messages are ordered only by dest and not by src.

```
State 76: <Action line 385, col 22 to line 385, col 91 of module Traceccfraft>

/\ messages = ( "0" :>
      << [ type |-> AppendEntriesResponse,
           dest |-> "0",
           source |-> "2",
           term |-> 2,
           success |-> TRUE,
           lastLogIndex |-> 6 ],
         [ type |-> AppendEntriesResponse,
           dest |-> "0",
           source |-> "1",
           term |-> 2,
           success |-> TRUE,
           lastLogIndex |-> 6 ],
         [ type |-> AppendEntriesResponse,
           dest |-> "0",
           source |-> "2",
           term |-> 2,
           success |-> TRUE,
           lastLogIndex |-> 6 ],
         [ type |-> AppendEntriesResponse,
           dest |-> "0",
           source |-> "1",
           term |-> 2,
           success |-> TRUE,
           lastLogIndex |-> 6 ],
         [ type |-> RequestVoteResponse,
           dest |-> "0",
           source |-> "2",
           term |-> 3,
           voteGranted |-> TRUE ],
         [ type |-> RequestVoteResponse,
           dest |-> "0",
           source |-> "1",
           term |-> 3,
           voteGranted |-> TRUE ] >> @@
  "1" :> <<>> @@
  "2" :> <<>> )
/\ leadershipState = ("0" :> Candidate @@ "1" :> Follower @@ "2" :> Follower)

State 77: <Action line 385, col 22 to line 385, col 91 of module Traceccfraft>
/\ messages = ( "0" :>
      << [ type |-> RequestVoteResponse,
           dest |-> "0",
           source |-> "2",
           term |-> 3,
           voteGranted |-> TRUE ] >> @@
  "1" :> <<>> @@
  "2" :> <<>> )
/\ leadershipState = ("0" :> Candidate @@ "1" :> Follower @@ "2" :> Follower)
```

To process this RVR from 2 to 0 we have dropped several messages, including some from 1 to 0. The latter should not have been touched.