### PR TITLE
Update minimum required version for jsrasign to 11.0.0

### DIFF
--- a/tests/npm-app/package.json
+++ b/tests/npm-app/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@microsoft/ccf-app": "file:../../js/ccf-app",
     "js-base64": "^3.5.2",
-    "jsrsasign": "^10.0.4",
+    "jsrsasign": "^11.0.0",
     "jsrsasign-util": "^1.0.2",
     "jwt-decode": "^3.0.0",
     "lodash-es": "^4.17.15",
@@ -22,7 +22,7 @@
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@rollup/plugin-typescript": "^8.2.0",
-    "@types/jsrsasign": "^8.0.7",
+    "@types/jsrsasign": "^10.5.12",
     "@types/lodash-es": "^4.17.3",
     "del-cli": "^5.1.0",
     "http-server": "^0.13.0",


### PR DESCRIPTION
Pin updated to pick up security update.