### PR TITLE
Do not run CI on older branches

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -11,6 +11,8 @@ pr:
     include:
       - main
       - "release/*"
+    exclude:
+      - "release/[0-3].x"
   paths:
     include:
       - "*"
@@ -23,7 +25,7 @@ schedules:
         - main
         - "release/*"
       exclude:
-        - "release/[0-2].x"
+        - "release/[0-3].x"
     always: true
 
 resources:

--- a/.azure_pipelines_snp.yml
+++ b/.azure_pipelines_snp.yml
@@ -2,6 +2,8 @@ pr:
   branches:
     include:
       - main
+    exclude:
+      - "release/[0-3].x"
   paths:
     include:
       - scripts/azure_deployment/*
@@ -17,7 +19,7 @@ trigger:
       - main
       - "release/*"
     exclude:
-      - "release/[1-2].x"
+      - "release/[0-3].x"
 
 schedules:
   - cron: "0 9-18/3 * * Mon-Fri"

--- a/.daily.yml
+++ b/.daily.yml
@@ -3,6 +3,8 @@ pr:
     include:
       - main
       - "release/*"
+    exclude:
+      - "release/[0-3].x"
   paths:
     include:
       - .daily.yml
@@ -19,7 +21,7 @@ schedules:
         - main
         - "release/*"
       exclude:
-        - "release/[1-2].x"
+        - "release/[0-3].x"
     always: true
 
 resources:

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -3,11 +3,15 @@ trigger:
   branches:
     include:
       - main
+    exclude:
+      - "release/[0-3].x"
 
 pr:
   branches:
     include:
       - main
+    exclude:
+      - "release/[0-3].x"
   paths:
     include:
       - .multi-thread.yml

--- a/.stress.yml
+++ b/.stress.yml
@@ -2,6 +2,8 @@ pr:
   branches:
     include:
       - main
+    exclude:
+      - "release/[0-3].x"
   paths:
     include:
       - .stress.yml
@@ -15,6 +17,8 @@ schedules:
     branches:
       include:
         - main
+      exclude:
+        - "release/[0-3].x"
     always: true
 
 resources:


### PR DESCRIPTION
There was some gating, but it was incomplete. release/0.x is currently used to test package signing.