### PR TITLE
GHA permissions: Add security-events write permission for CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,8 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-20.04
+    permissions:
+      security-events: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Following #5949, this adds a further permission so that CodeQL can interact with code scanning alerts.