### PR TITLE
Add swap_node to driver to enable new scenarios

### DIFF
--- a/src/consensus/aft/test/driver.cpp
+++ b/src/consensus/aft/test/driver.cpp
@@ -96,6 +96,10 @@ int main(int argc, char** argv)
         driver->trust_nodes(
           items[0], {std::next(items.begin()), items.end()}, lineno);
         break;
+      case shash("swap_node"):
+        assert(items.size() == 4);
+        driver->swap_node(items[1], items[2], items[3], lineno);
+        break;
       case shash("nodes"):
         assert(items.size() >= 2);
         items.erase(items.begin());

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -193,9 +193,10 @@ private:
 public:
   RaftDriver() = default;
 
+  // Note: deprecated, to be removed when the last scenario using it is removed
   void create_new_nodes(std::vector<std::string> node_ids)
   {
-    // Opinionated way to create network. Initial configuration is automatically
+    // Unrealistic way to create network. Initial configuration is automatically
     // added to all nodes.
     kv::Configuration::Nodes configuration;
     for (auto const& n : node_ids)
@@ -210,6 +211,7 @@ public:
     }
   }
 
+  // Note: deprecated, to be removed when the last scenario using it is removed
   void create_new_node(std::string node_id_s)
   {
     ccf::NodeId node_id(node_id_s);
@@ -219,6 +221,7 @@ public:
                     << std::endl;
   }
 
+  // Note: deprecated, to be removed when the last scenario using it is removed
   void create_start_node(const std::string& start_node_id, const size_t lineno)
   {
     if (!_nodes.empty())
@@ -246,7 +249,7 @@ public:
     {
       add_node(node_id);
       RAFT_DRIVER_OUT << fmt::format(
-                           "  Note over {}: Node {} created", node_id, node_id)
+                           "  Note over {}: Node {} trusted", node_id, node_id)
                       << std::endl;
     }
     kv::Configuration::Nodes configuration;
@@ -267,6 +270,38 @@ public:
     _replicate(term, {}, lineno, false, configuration);
   }
 
+  void swap_node(
+    const std::string& term,
+    const std::string& node_out,
+    const std::string& node_in,
+    const size_t lineno)
+  {
+    add_node(node_in);
+    RAFT_DRIVER_OUT << fmt::format(
+                         "  Note over {}: Node {} trusted", node_in, node_in)
+                    << std::endl;
+    RAFT_DRIVER_OUT << fmt::format(
+                         "  Note over {}: Node {} retired", node_out, node_out)
+                    << std::endl;
+    kv::Configuration::Nodes configuration;
+    for (const auto& [id, node] : _nodes)
+    {
+      if (id != node_out)
+      {
+        configuration.try_emplace(id);
+      }
+    }
+    for (const auto& [id, node] : _nodes)
+    {
+      if (id != node_in)
+      {
+        connect(id, node_in);
+      }
+    }
+    _replicate(term, {}, lineno, false, configuration);
+  }
+
+  // Note: deprecated, to be removed when the last scenario using it is removed
   void replicate_new_configuration(
     const std::string& term_s,
     std::vector<std::string> node_ids,


### PR DESCRIPTION
Ideally we'd have a swap_nodes, but:

1. it's not necessary to reproduce the issues spotted in #5919 and #5951
2. it's a bit awkward to do with the current $method_name(,\d+)+

I guess we'll do something like `swap_nodes,2,out,1,2,in,3,4` once we're done with the current issues.