### PR TITLE
Restrict triggers for signed release pipeline

### DIFF
--- a/.azure-pipelines-release.yml
+++ b/.azure-pipelines-release.yml
@@ -1,7 +1,7 @@
 trigger:
   tags:
     include:
-    - ccf-5.*
+      - ccf-5.*
 
 resources:
   containers:

--- a/.azure-pipelines-release.yml
+++ b/.azure-pipelines-release.yml
@@ -1,30 +1,7 @@
 trigger:
-  batch: true
-  branches:
+  tags:
     include:
-      - main
-      - "refs/tags/ccf-*"
-
-pr:
-  autoCancel: true
-  branches:
-    include:
-      - main
-      - "release/*"
-  paths:
-    include:
-      - "*"
-
-schedules:
-  - cron: "0 3 * * Mon-Fri"
-    displayName: Daily morning build
-    branches:
-      include:
-        - main
-        - "release/*"
-      exclude:
-        - "release/[0-2].x"
-    always: true
+    - ccf-5.*
 
 resources:
   containers:


### PR DESCRIPTION
The pipeline is being triggered in too many circumstances at the moment. Noticed when looking at artifact billing.