### PR TITLE
Using max in remove from configurations

### DIFF
--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -649,7 +649,7 @@ ChangeConfigurationInt(i, newConfiguration) ==
         addedNodes == newConfiguration \ CurrentConfiguration(i)
         newSentIndex == [ k \in Servers |-> IF k \in addedNodes THEN Len(log[i]) ELSE sentIndex[i][k]]
        IN sentIndex' = [sentIndex EXCEPT ![i] = newSentIndex]
-    /\ removedFromConfiguration' = removedFromConfiguration \cup (CurrentConfiguration(i) \ newConfiguration)
+    /\ removedFromConfiguration' = removedFromConfiguration \cup (MaxConfiguration(i) \ newConfiguration)
     /\ log' = [log EXCEPT ![i] = Append(log[i], 
                                             [term |-> currentTerm[i],
                                              configuration |-> newConfiguration,


### PR DESCRIPTION
`removedFromConfigurations` currently uses `CurrentConfiguration` when deciding whether a `newConfiguration` removes any nodes. Unfortunately, when there are pending configurations and a new configuration removes a node that is added by a pending configuration, this does not get reflected in`removedFromConfigurations`.

Here's a possible fix but I'm open to suggestions

Follow on from https://github.com/microsoft/CCF/pull/5919#discussion_r1467440262