### PR TITLE
Disable pr builds

### DIFF
--- a/.azure-pipelines-release.yml
+++ b/.azure-pipelines-release.yml
@@ -3,6 +3,8 @@ trigger:
     include:
       - ccf-5.*
 
+pr: none
+
 resources:
   containers:
     - container: virtual


### PR DESCRIPTION
I thought #5957 had done that, by removing the pr block, but the default is to run on pr it seems.