### PR TITLE
Adding `is_new_follower` to consensus spec

### DIFF
--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -946,7 +946,6 @@ AppendEntriesAlreadyDone(i, j, index, m) ==
 
 ConflictAppendEntriesRequest(i, index, m) ==
     /\ Len(log[i]) >= index
-    /\ log[i][index].term /= m.entries[1].term
     /\ isNewFollower[i] = TRUE
     /\ LET new_log == [index2 \in 1..m.prevLogIndex |-> log[i][index2]] \* Truncate log
        IN /\ log' = [log EXCEPT ![i] = new_log]

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -541,6 +541,9 @@ InitLogConfigServerVars(startNodes, logPrefix(_,_)) ==
         /\ leadershipState = [i \in Servers |-> IF i = sn THEN Leader ELSE IF i \in startNodes THEN Follower ELSE None]
         /\ membershipState = [i \in Servers |-> Active]
         /\ commitIndex = [i \in Servers |-> IF i \in startNodes THEN Len(logPrefix({sn}, startNodes)) ELSE 0]
+        /\ sentIndex  = [i \in Servers |-> IF i = sn 
+            THEN [j \in Servers |-> Len(logPrefix({sn}, startNodes))] 
+            ELSE [j \in Servers |-> 0]]
     /\ configurations = [i \in Servers |-> IF i \in startNodes  THEN (Len(log[i])-1 :> startNodes) ELSE << >>]
     
 ------------------------------------------------------------------------------
@@ -560,7 +563,6 @@ InitCandidateVars ==
 \* leader does not send itself messages. It's still easier to include these
 \* in the functions.
 InitLeaderVars ==
-    /\ sentIndex  = [i \in Servers |-> [j \in Servers |-> 0]]
     /\ matchIndex = [i \in Servers |-> [j \in Servers |-> 0]]
 
 Init ==

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -945,7 +945,6 @@ AppendEntriesAlreadyDone(i, j, index, m) ==
     /\ UNCHANGED <<removedFromConfiguration, currentTerm, leadershipState, votedFor, log>>
 
 ConflictAppendEntriesRequest(i, index, m) ==
-    /\ m.entries /= << >>
     /\ Len(log[i]) >= index
     /\ log[i][index].term /= m.entries[1].term
     /\ isNewFollower[i] = TRUE

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -1089,18 +1089,6 @@ DropIgnoredMessage(i,j,m) ==
     /\ Discard(m)
     /\ UNCHANGED <<reconfigurationVars, serverVars, candidateVars, leaderVars, logVars>>
 
-\* Retired leaders send notify commit messages to update all nodes about the commit level
-UpdateCommitIndex(i,j,m) ==
-    /\ m.commitIndex > commitIndex[i]
-    /\ LET
-        new_config_index == LastConfigurationToIndex(i,m.commitIndex)
-        new_configurations == RestrictDomain(configurations[i], LAMBDA c : c >= new_config_index)
-        IN
-        /\ commitIndex' = [commitIndex EXCEPT ![i] = m.commitIndex]
-        /\ configurations' = [configurations EXCEPT ![i] = new_configurations]
-    /\ UNCHANGED <<messages, currentTerm,
-        votedFor, candidateVars, leaderVars, log, membershipState>>
-
 \* Receive a message.
 
 RcvDropIgnoredMessage(i, j) ==

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -1017,9 +1017,10 @@ AcceptAppendEntriesRequest(i, j, logOk, m) ==
     /\ logOk
     /\ LET index == m.prevLogIndex + 1
        IN \/ AppendEntriesAlreadyDone(i, j, index, m)
-          \/ ConflictAppendEntriesRequest(i, index, m)
           \/ NoConflictAppendEntriesRequest(i, j, m)
-
+          \/ ConflictAppendEntriesRequest(i, index, m) \cdot AppendEntriesAlreadyDone(i, j, index, m)
+          \/ ConflictAppendEntriesRequest(i, index, m) \cdot NoConflictAppendEntriesRequest(i, j, m)
+          
 \* Server i receives an AppendEntries request from server j with
 \* m.term <= currentTerm[i].
 HandleAppendEntriesRequest(i, j, m) ==


### PR DESCRIPTION
Add `is_new_follower` to the consensus spec to unblock https://github.com/microsoft/CCF/pull/5925. This PR also:
- allows the follower to rollback when it receives an AE even if there are no conflicting entries (or no entries at all in the AE). 
- sets the initial send_idx to the length of the leader's log
- prevents the `ConflictAppendEntriesRequest` action from being taken without also taking `AppendEntriesAlreadyDone` or `NoConflictAppendEntriesRequest`