### PR TITLE
Add reelection scenario, and minimal change to Network.tla to trace validate

### DIFF
--- a/.azure-pipelines-templates/trace_validation.yml
+++ b/.azure-pipelines-templates/trace_validation.yml
@@ -9,5 +9,5 @@ steps:
   - script: |
       set -ex
       cd tla/
-      parallel 'JSON={} java -XX:+UseParallelGC -Dtlc2.tool.impl.Tool.cdot=true -Dtlc2.tool.queue.IStateQueue=StateDeque -cp tla2tools.jar:CommunityModules-deps.jar tlc2.TLC -lncheck final consensus/Traceccfraft.tla' ::: $(ls ../build/*.ndjson | grep -v _deprecated)
+      parallel 'JSON={} java -XX:+UseParallelGC -Dtlc2.tool.impl.Tool.cdot=true -Dtlc2.tool.queue.IStateQueue=StateDeque -cp tla2tools.jar:CommunityModules-deps.jar tlc2.TLC -lncheck final -checkpoint 0 consensus/Traceccfraft.tla' ::: $(ls ../build/*.ndjson | grep -v _deprecated)
     displayName: "Run trace validation"

--- a/.azure-pipelines-templates/trace_validation.yml
+++ b/.azure-pipelines-templates/trace_validation.yml
@@ -9,5 +9,5 @@ steps:
   - script: |
       set -ex
       cd tla/
-      parallel 'JSON={} ./tlc.sh consensus/Traceccfraft.tla' ::: $(ls ../build/*.ndjson | grep -v _deprecated)
+      parallel 'JSON={} java -XX:+UseParallelGC -Dtlc2.tool.impl.Tool.cdot=true -Dtlc2.tool.queue.IStateQueue=StateDeque -cp tla2tools.jar:CommunityModules-deps.jar tlc2.TLC -lncheck final consensus/Traceccfraft.tla' ::: $(ls ../build/*.ndjson | grep -v _deprecated)
     displayName: "Run trace validation"

--- a/tests/raft_scenarios/reelection
+++ b/tests/raft_scenarios/reelection
@@ -39,3 +39,4 @@ assert_is_candidate,0
 dispatch_all
 
 state_all
+assert_is_primary,0

--- a/tests/raft_scenarios/reelection
+++ b/tests/raft_scenarios/reelection
@@ -1,0 +1,41 @@
+# Test what happens when a node is re-elected, and receives messages from previous terms
+start_node,0
+emit_signature,2
+
+assert_is_primary,0
+assert_commit_idx,0,2
+
+trust_nodes,2,1,2
+emit_signature,2
+
+dispatch_all
+periodic_all,10
+dispatch_all
+assert_commit_idx,0,4
+assert_is_primary,0
+assert_is_backup,1
+assert_is_backup,2
+
+# Start from a steady state
+periodic_all,10
+dispatch_all
+assert_state_sync
+
+# Produce more entries
+emit_signature,2
+emit_signature,2
+
+# Send AEs, but don't get responses yet
+periodic_one,0,10
+dispatch_one,0
+
+# Time out, call a new election
+periodic_one,0,100
+assert_is_backup,0
+periodic_one,0,100
+assert_is_candidate,0
+
+# Receive vote responses and AEs
+dispatch_all
+
+state_all

--- a/tla/consensus/Network.tla
+++ b/tla/consensus/Network.tla
@@ -101,6 +101,17 @@ LOCAL OrderDropMessages(server) ==
     \E s \in AllSubSeqs(messages[server]):
         messages' = [ messages EXCEPT ![server] = s ]
 
+\* These alternatives of OrderDropMessages may be useful for debugging
+LOCAL OrderDropOlderMessages(server) ==
+   (* Always drop older messages first, i.e., an old message has to be handled or dropped before a new message can be handled or dropped. *)
+    \E s \in Suffixes(messages[server]):
+        messages' = [ messages EXCEPT ![server] = s ]
+
+LOCAL OrderDropConsecutiveMessages(server) ==
+   (* Drop messages regardless of "time", but only ever drop consecutive messages. *)
+    \E s \in SubSeqs(messages[server]):
+        messages' = [ messages EXCEPT ![server] = s ]
+
 ----------------------------------------------------------------------------------
 \* Point-to-Point Ordering and no duplication of messages:
 

--- a/tla/consensus/Network.tla
+++ b/tla/consensus/Network.tla
@@ -98,7 +98,7 @@ LOCAL OrderOneMoreMessage(m) ==
     \/ Len(SelectSeq(messages[m.dest], LAMBDA e: m = e)) < Len(SelectSeq(messages'[m.dest], LAMBDA e: m = e))
 
 LOCAL OrderDropMessages(server) ==
-    \E s \in Suffixes(messages[server]):  \* TODO - Change to SubSeqs if more sophisticated message loss is needed.
+    \E s \in AllSubSeqs(messages[server]):
         messages' = [ messages EXCEPT ![server] = s ]
 
 ----------------------------------------------------------------------------------

--- a/tla/consensus/Traceccfraft.cfg
+++ b/tla/consensus/Traceccfraft.cfg
@@ -72,7 +72,6 @@ CONSTANTS
     Reordered = Reordered
     \* Ordered instead of OrderedNoDup compared to ordinary model checking.
     Guarantee = Ordered
-    Receive <- DropAndReceive
 
     TypeEntry = TypeEntry
     TypeSignature = TypeSignature

--- a/tla/consensus/Traceccfraft.cfg
+++ b/tla/consensus/Traceccfraft.cfg
@@ -37,6 +37,9 @@ INVARIANT
 CHECK_DEADLOCK
     FALSE
 
+ACTION_CONSTRAINT 
+    Termination
+
 CONSTANTS
     Servers <- TraceServers
 

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -489,42 +489,25 @@ AppendEntriesResponses ==
 
 -------------------------------------------------------------------------------------
 
-RcvUpdateTermReqVote(i, j) ==
-    RcvUpdateTerm(i, j) \cdot RcvRequestVoteRequest(i, j)
-
-RcvUpdateTermRcvRequestVoteResponse(i, j) ==
-    RcvUpdateTerm(i, j) \cdot RcvRequestVoteResponse(i, j)
-
-RcvUpdateTermReqAppendEntries(i, j) ==
-    RcvUpdateTerm(i, j) \cdot RcvAppendEntriesRequest(i, j)
-
-RcvUpdateTermRcvAppendEntriesResponse(i, j) ==
-    RcvUpdateTerm(i, j) \cdot RcvAppendEntriesResponse(i, j)
-
-RcvAppendEntriesRequestRcvAppendEntriesRequest(i, j) ==
-    RcvAppendEntriesRequest(i, j) \cdot RcvAppendEntriesRequest(i, j)
-
 ComposedNext ==
     \* The implementation raft.h piggybacks UpdateTerm messages on the AppendEntries
      \* and Vote messages.  Thus, we need to compose the UpdateTerm action with the
      \* corresponding AppendEntries and RequestVote actions.  This is a reasonable
      \* code-level optimization that we do not want to model explicitly in TLA+.
     \E i, j \in Servers:
-        \/ RcvUpdateTermReqVote(i, j)
-        \/ RcvUpdateTermRcvRequestVoteResponse(i, j)
-        \/ RcvUpdateTermReqAppendEntries(i, j)
-        \/ RcvUpdateTermRcvAppendEntriesResponse(i, j)
+        \/ RcvUpdateTerm(i, j) \cdot
+            \/ RcvRequestVoteRequest(i, j)
+            \/ RcvRequestVoteResponse(i, j)
+            \/ RcvAppendEntriesRequest(i, j)
+            \/ RcvAppendEntriesResponse(i, j)
         \* The sub-action IsRcvAppendEntriesRequest requires a disjunct composing two 
         \* successive RcvAppendEntriesRequest to validate suffix_collision.1 and fancy_election.1.
         \* The trace validation fails with violations of property CCFSpec if we do not
         \* conjoin the composed action below. See the (marker) label RAERRAER above.
-        \/ RcvAppendEntriesRequestRcvAppendEntriesRequest(i, j)
+        \/ RcvAppendEntriesRequest(i, j) \cdot RcvAppendEntriesRequest(i, j)
 
 CCF == INSTANCE ccfraft
 
-DropAndReceive(i, j) ==
-    DropMessages \cdot CCF!Receive(i, j)
-
-CCFSpec == CCF!Init /\ [][CCF!Next \/ (DropMessages \cdot ComposedNext)]_CCF!vars
+CCFSpec == CCF!Init /\ [][DropMessages \cdot (CCF!Next \/ ComposedNext)]_CCF!vars
 
 ==================================================================================

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -254,6 +254,9 @@ IsRcvAppendEntriesResponse ==
                   \/ UpdateTerm(i, j, m) \cdot HandleAppendEntriesResponse(i, j, m)
                   \/ UpdateTerm(i, j, m) \cdot DropResponseWhenNotInState(i, j, m)
                   \/ DropResponseWhenNotInState(i, j, m)
+                  \* See comment on RcvAppendEntriesResponse in ccfraft
+                  \/ /\ m.success
+                     /\ DropStaleResponse(i, j, m)
                /\ IsAppendEntriesResponse(m, i, j, logline)
     /\ Range(logline.msg.state.committable_indices) \subseteq CommittableIndices(logline.msg.state.node_id)
 

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -368,19 +368,7 @@ TraceNext ==
     \/ IsRcvProposeVoteRequest
 
 TraceSpec ==
-    \* In an ideal world with extremely fast compute and a sophisticated TLC evaluator, we would simply compose  DropMessage and
-    \* TraceNext, i.e.,  DropMessage ⋅ TraceNext.  However, we are not in an ideal world, and, thus, we have to resort to the 
-    \* ~ENABLED TraceNext... workaround that mitigates state-space explosion by constraining the loss of messages to when a behavior
-    \* cannot be extended without losing/dropping messages. TLC handles the state-space explosion due to DropMessages at the level
-    \* of TraceSpec just fine. Instead, the bottleneck is rather checking refinement of ccfraft, which involves evaluating the big
-    \* formula  DropMessages ⋅ CCF!Next many times, which becomes prohibitively expensive with only modest state-space explosion.
-    \*
-    \* Other techniques, such as using an action constraint to ignore successors that unnecessarily discard messages, proved difficult
-    \* to express. Excluding the variable 'messages' in TraceView also proved ineffective. In the end, it seems as if it needs a new
-    \* mode in TLC that checks refinement only for the set of traces whose length equals Len(TraceLog). This means delaying the
-    \* refinement check until after the log has been matched. The class tlc2.tool.CheckImplFile might be a good starting point, although
-    \* its current implementation doesn't account for non-determinism arising from log gaps or missed messages.
-    TraceInit /\ [][(IF ~ENABLED TraceNext THEN DropMessages \cdot TraceNext ELSE TraceNext)]_<<l, ts, vars>>
+    TraceInit /\ [][IF ENABLED TraceNext THEN TraceNext ELSE DropMessages \cdot TraceNext]_<<l, ts, vars>>
 
 -------------------------------------------------------------------------------------
 

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -372,6 +372,9 @@ TraceSpec ==
 
 -------------------------------------------------------------------------------------
 
+Termination ==
+    l = Len(TraceLog) => TLCSet("exit", TRUE)
+
 TraceView ==
     \* A high-level state  s  can appear multiple times in a system trace.  Including the
      \* current level in TLC's view ensures that TLC will not stop model checking when  s


### PR DESCRIPTION
See https://github.com/microsoft/CCF/pull/5940. This achieves the same goal (allowing trace validation of scenarios like reelection) with a much smaller change - using AllSubSeqs (see https://github.com/microsoft/CCF/pull/5940#issuecomment-1901767392) in OrderDropMessages, and duplicating the ACK-dropping logic of https://github.com/microsoft/CCF/pull/5941 in the Trace spec.

Related https://github.com/tlaplus/tlaplus/pull/867, which softens the performance impact of this change on the TV.