### PR TITLE
Add retirement phase to state and retirement state to viz

### DIFF
--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -688,7 +688,6 @@
       },
       "RetirementPhase": {
         "enum": [
-          "Committed",
           "Ordered",
           "Signed",
           "Completed"
@@ -905,7 +904,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "4.8.0"
+    "version": "4.9.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/src/consensus/aft/impl/state.h
+++ b/src/consensus/aft/impl/state.h
@@ -151,6 +151,7 @@ namespace aft
   struct State
   {
     State(const ccf::NodeId& node_id_) : node_id(node_id_) {}
+    State() = default;
 
     ccf::pal::Mutex lock;
 
@@ -178,8 +179,10 @@ namespace aft
     // Candidate -> Follower, when receiving entries for a newer term
     kv::LeadershipState leadership_state = kv::LeadershipState::None;
     kv::MembershipState membership_state = kv::MembershipState::Active;
+
+    std::optional<kv::RetirementPhase> retirement_phase = std::nullopt;
   };
-  DECLARE_JSON_TYPE(State);
+  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(State);
   DECLARE_JSON_REQUIRED_FIELDS(
     State,
     node_id,
@@ -190,4 +193,5 @@ namespace aft
     leadership_state,
     membership_state,
     committable_indices);
+  DECLARE_JSON_OPTIONAL_FIELDS(State, retirement_phase);
 }

--- a/src/consensus/aft/impl/state.h
+++ b/src/consensus/aft/impl/state.h
@@ -181,6 +181,10 @@ namespace aft
     kv::MembershipState membership_state = kv::MembershipState::Active;
 
     std::optional<kv::RetirementPhase> retirement_phase = std::nullopt;
+    // Index at which this node observes its retirement
+    std::optional<ccf::SeqNo> retirement_idx = std::nullopt;
+    // Earliest index at which this node's retirement can be committed
+    std::optional<ccf::SeqNo> retirement_committable_idx = std::nullopt;
   };
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(State);
   DECLARE_JSON_REQUIRED_FIELDS(
@@ -193,5 +197,6 @@ namespace aft
     leadership_state,
     membership_state,
     committable_indices);
-  DECLARE_JSON_OPTIONAL_FIELDS(State, retirement_phase);
+  DECLARE_JSON_OPTIONAL_FIELDS(
+    State, retirement_phase, retirement_idx, retirement_committable_idx);
 }

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -156,11 +156,6 @@ namespace aft
     // Used to remove retired nodes from store
     std::unique_ptr<ccf::RetiredNodeCleanup> retired_node_cleanup;
 
-    // Index at which this node observes its retirement
-    std::optional<ccf::SeqNo> retirement_idx = std::nullopt;
-    // Earliest index at which this node's retirement can be committed
-    std::optional<ccf::SeqNo> retirement_committable_idx = std::nullopt;
-
     size_t entry_size_not_limited = 0;
     size_t entry_count = 0;
     Index entries_batch_size = 20;
@@ -572,13 +567,13 @@ namespace aft
         if (index != state->last_idx + 1)
           return false;
 
-        if (retirement_committable_idx.has_value())
+        if (state->retirement_committable_idx.has_value())
         {
           CCF_ASSERT_FMT(
-            index > retirement_committable_idx.value(),
+            index > state->retirement_committable_idx.value(),
             "Index {} unexpectedly lower than retirement_committable_idx {}",
             index,
-            retirement_committable_idx.value());
+            state->retirement_committable_idx.value());
           return false;
         }
 
@@ -872,7 +867,7 @@ namespace aft
     bool can_replicate_unsafe()
     {
       return state->leadership_state == kv::LeadershipState::Leader &&
-        !retirement_committable_idx.has_value();
+        !state->retirement_committable_idx.has_value();
     }
 
     Index get_commit_idx_unsafe()
@@ -1076,8 +1071,8 @@ namespace aft
         is_retired() &&
         state->retirement_phase >= kv::RetirementPhase::Completed)
       {
-        assert(retirement_committable_idx.has_value());
-        if (r.idx > retirement_committable_idx)
+        assert(state->retirement_committable_idx.has_value());
+        if (r.idx > state->retirement_committable_idx)
         {
           send_append_entries_response(from, AppendEntriesResponseType::FAIL);
           return;
@@ -1938,21 +1933,21 @@ namespace aft
       if (phase == kv::RetirementPhase::Ordered)
       {
         CCF_ASSERT_FMT(
-          !retirement_idx.has_value(),
+          !state->retirement_idx.has_value(),
           "retirement_idx already set to {}",
-          retirement_idx.value());
-        retirement_idx = idx;
+          state->retirement_idx.value());
+        state->retirement_idx = idx;
         RAFT_INFO_FMT("Node retiring at {}", idx);
       }
       else if (phase == kv::RetirementPhase::Signed)
       {
-        assert(retirement_idx.has_value());
+        assert(state->retirement_idx.has_value());
         CCF_ASSERT_FMT(
-          idx >= retirement_idx.value(),
+          idx >= state->retirement_idx.value(),
           "Index {} unexpectedly lower than retirement_idx {}",
           idx,
-          retirement_idx.value());
-        retirement_committable_idx = idx;
+          state->retirement_idx.value());
+        state->retirement_committable_idx = idx;
         RAFT_INFO_FMT("Node retirement committable at {}", idx);
       }
       else if (phase == kv::RetirementPhase::Completed)
@@ -2192,8 +2187,8 @@ namespace aft
       if (
         is_retired() &&
         state->retirement_phase == kv::RetirementPhase::Signed &&
-        retirement_committable_idx.has_value() &&
-        idx >= retirement_committable_idx.value())
+        state->retirement_committable_idx.has_value() &&
+        idx >= state->retirement_committable_idx.value())
       {
         become_retired(idx, kv::RetirementPhase::Completed);
       }
@@ -2303,10 +2298,10 @@ namespace aft
         state->membership_state == kv::MembershipState::Retired &&
         state->retirement_phase == kv::RetirementPhase::Signed)
       {
-        assert(retirement_committable_idx.has_value());
-        if (retirement_committable_idx.value() > idx)
+        assert(state->retirement_committable_idx.has_value());
+        if (state->retirement_committable_idx.value() > idx)
         {
-          retirement_committable_idx = std::nullopt;
+          state->retirement_committable_idx = std::nullopt;
           state->retirement_phase = kv::RetirementPhase::Ordered;
         }
       }
@@ -2315,10 +2310,10 @@ namespace aft
         state->membership_state == kv::MembershipState::Retired &&
         state->retirement_phase == kv::RetirementPhase::Ordered)
       {
-        assert(retirement_idx.has_value());
-        if (retirement_idx.value() > idx)
+        assert(state->retirement_idx.has_value());
+        if (state->retirement_idx.value() > idx)
         {
-          retirement_idx = std::nullopt;
+          state->retirement_idx = std::nullopt;
           state->retirement_phase = std::nullopt;
           state->membership_state = kv::MembershipState::Active;
           RAFT_DEBUG_FMT("Becoming Active after rollback");

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -161,7 +161,6 @@ namespace kv
 
   enum class RetirementPhase
   {
-    Committed = 0,
     Ordered = 1,
     Signed = 2,
     Completed = 3
@@ -169,8 +168,7 @@ namespace kv
 
   DECLARE_JSON_ENUM(
     RetirementPhase,
-    {{RetirementPhase::Committed, "Committed"},
-     {RetirementPhase::Ordered, "Ordered"},
+    {{RetirementPhase::Ordered, "Ordered"},
      {RetirementPhase::Signed, "Signed"},
      {RetirementPhase::Completed, "Completed"}});
 

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -383,7 +383,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
-      openapi_info.document_version = "4.8.0";
+      openapi_info.document_version = "4.9.0";
     }
 
     void init_handlers() override

--- a/tests/trace_viz.py
+++ b/tests/trace_viz.py
@@ -12,6 +12,10 @@ LEADERSHIP_STATUS = {
     "Candidate": ":person_raising_hand:",
 }
 
+MEMBERSHIP_STATUS = {"Active": "A", "Retired": "R"}
+
+RETIREMENT_PHASE = {"Ordered": "o", "Signed": "s", "Completed": "c", None: " "}
+
 FUNCTIONS = {
     "add_configuration": "Cfg",
     "replicate": "Rpl",
@@ -39,24 +43,37 @@ def digits(value):
     return len(str(value))
 
 
-def diffed_key(old, new, key, suffix, size):
+def diffed_key(old, new, key, suffix, size, sub=lambda x: x):
     if old is None or old[key] == new[key]:
-        return f"{new[key]:>{size}}{suffix}"
+        return f"{sub(new[key]):>{size}}{suffix}"
     color = "bright_white on red"
-    return f"[{color}]{new[key]:>{size}}{suffix}[/{color}]"
+    return f"[{color}]{sub(new[key]):>{size}}{suffix}[/{color}]"
+
+
+def diffed_opt_key(old, new, key, suffix, size, sub=lambda x: x):
+    if old is None or old.get(key) == new.get(key):
+        return f"{sub(new.get(key)):>{size}}{suffix}"
+    color = "bright_white on red"
+    return f"[{color}]{sub(new.get(key)):>{size}}{suffix}[/{color}]"
 
 
 def render_state(state, func, old_state, tag, cfg):
     if state is None:
         return " "
     ls = LEADERSHIP_STATUS[state["leadership_state"]]
+    ms = diffed_key(old_state, state, "membership_state", "", 1, MEMBERSHIP_STATUS.get)
+    rp = diffed_opt_key(
+        old_state, state, "retirement_phase", "", 1, RETIREMENT_PHASE.get
+    )
     nid = state["node_id"]
     v = diffed_key(old_state, state, "current_view", "", cfg.view)
     i = diffed_key(old_state, state, "last_idx", "", cfg.index)
     c = diffed_key(old_state, state, "commit_idx", "", cfg.commit)
     f = FUNCTIONS[func]
     opc = "bold bright_white on red" if func else "normal"
-    return f"[{opc}]{nid:>{cfg.nodes}}{ls}{f:<4} [/{opc}]{TAG[tag]} {v}.{i} {c}"
+    return (
+        f"[{opc}]{nid:>{cfg.nodes}}{ls}{f:<4} [/{opc}]{TAG[tag]} {ms}{rp} {v}.{i} {c}"
+    )
 
 
 class DigitsCfg:


### PR DESCRIPTION
- Remove `RetirementPhase::Committed`, it is unused.
- Move retirement phase and index and committable index to state, so they are included in the trace.
- Use retirement state and phase in trace viz.

I think we probably want to stop accessing the details of the retirement state directly from raft.h, and use a few well chosen conditions, like is_retirement_known_by_all_future_primaries(), or is_later_than_retirement(idx), but that may be debatable and is best done separately.

![image](https://github.com/microsoft/CCF/assets/4016369/6598e1f2-cc06-402c-8752-c9f33a1f621d)
