### PR TITLE
Adding RetiredCommitted transaction to consensus spec

### DIFF
--- a/tla/consensus/MCccfraft.cfg
+++ b/tla/consensus/MCccfraft.cfg
@@ -43,6 +43,7 @@ CONSTANTS
     TypeEntry = Entry
     TypeSignature = Signature
     TypeReconfiguration = Reconfiguration
+    TypeRetiredCommitted = RetiredCommitted
 
     NodeOne = n1
     NodeTwo = n2

--- a/tla/consensus/MCccfraft.cfg
+++ b/tla/consensus/MCccfraft.cfg
@@ -84,3 +84,4 @@ INVARIANTS
     LogConfigurationConsistentInv
     MembershipStateConsistentInv
     CommitCommittableIndices
+    RetiredCommittedInv

--- a/tla/consensus/MCccfraftAtomicReconfig.cfg
+++ b/tla/consensus/MCccfraftAtomicReconfig.cfg
@@ -84,3 +84,4 @@ INVARIANTS
     MembershipStateConsistentInv
     NoLeaderBeforeInitialTerm
     CommitCommittableIndices
+    RetiredCommittedInv

--- a/tla/consensus/MCccfraftAtomicReconfig.cfg
+++ b/tla/consensus/MCccfraftAtomicReconfig.cfg
@@ -43,6 +43,7 @@ CONSTANTS
     TypeEntry = Entry
     TypeSignature = Signature
     TypeReconfiguration = Reconfiguration
+    TypeRetiredCommitted = RetiredCommitted
 
     NodeOne = n1
     NodeTwo = n2

--- a/tla/consensus/MCccfraftWithReconfig.cfg
+++ b/tla/consensus/MCccfraftWithReconfig.cfg
@@ -43,6 +43,7 @@ CONSTANTS
     TypeEntry = Entry
     TypeSignature = Signature
     TypeReconfiguration = Reconfiguration
+    TypeRetiredCommitted = RetiredCommitted
 
     NodeOne = n1
     NodeTwo = n2

--- a/tla/consensus/MCccfraftWithReconfig.cfg
+++ b/tla/consensus/MCccfraftWithReconfig.cfg
@@ -84,3 +84,4 @@ INVARIANTS
     LogConfigurationConsistentInv
     MembershipStateConsistentInv
     CommitCommittableIndices
+    RetiredCommittedInv

--- a/tla/consensus/SIMCoverageccfraft.cfg
+++ b/tla/consensus/SIMCoverageccfraft.cfg
@@ -30,6 +30,7 @@ CONSTANTS
     TypeEntry = Entry
     TypeSignature = Signature
     TypeReconfiguration = Reconfiguration
+    TypeRetiredCommitted = RetiredCommitted
 
     NodeOne = n1
     NodeTwo = n2

--- a/tla/consensus/SIMccfraft.cfg
+++ b/tla/consensus/SIMccfraft.cfg
@@ -30,6 +30,7 @@ CONSTANTS
     TypeEntry = Entry
     TypeSignature = Signature
     TypeReconfiguration = Reconfiguration
+    TypeRetiredCommitted = RetiredCommitted
 
     NodeOne = n1
     NodeTwo = n2

--- a/tla/consensus/SIMccfraft.cfg
+++ b/tla/consensus/SIMccfraft.cfg
@@ -97,6 +97,8 @@ INVARIANTS
 
     CommitCommittableIndices
 
+    RetiredCommittedInv
+
     \* DebugInvLeaderCannotStepDown
     \* DebugInvAnyCommitted
     \* DebugInvAllCommitted

--- a/tla/consensus/Traceccfraft.cfg
+++ b/tla/consensus/Traceccfraft.cfg
@@ -74,6 +74,7 @@ CONSTANTS
     TypeEntry = TypeEntry
     TypeSignature = TypeSignature
     TypeReconfiguration = TypeReconfiguration
+    TypeRetiredCommitted = RetiredCommitted
 
     \* state.h my_node_id is a string.
     NodeOne = "0"

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -74,8 +74,7 @@ CONSTANTS
 MembershipStates == {
     Active,
     RetirementOrdered,
-    RetirementSigned,
-    RetirementCompleted
+    RetirementSigned
     }
 
 \* Message types:
@@ -91,7 +90,8 @@ CONSTANTS
 CONSTANTS
     TypeEntry,
     TypeSignature,
-    TypeReconfiguration
+    TypeReconfiguration,
+    TypeRetiredCommitted
 
 \* Set of nodes for this model
 CONSTANTS Servers
@@ -163,7 +163,7 @@ EntryTypeOK(entry) ==
     /\ \/ /\ entry.contentType = TypeEntry
           /\ entry.request \in Nat \ {0}
        \/ entry.contentType = TypeSignature
-       \/ /\ entry.contentType = TypeReconfiguration
+       \/ /\ entry.contentType \in {TypeReconfiguration, TypeRetiredCommitted}
           /\ entry.configuration \subseteq Servers
 
 AppendEntriesRequestTypeOK(m) ==
@@ -685,6 +685,7 @@ BecomeLeader(i) ==
     \* been rolled back as it was unsigned
     /\ membershipState' = [membershipState EXCEPT ![i] = 
         IF @ = RetirementOrdered THEN Active ELSE @]
+    \* TODO: Check if any node's retirement has been committed and add retired_committed if so
     /\ UNCHANGED <<removedFromConfiguration, messageVars, currentTerm, votedFor, isNewFollower, candidateVars, commitIndex>>
 
 \* Leader i receives a client request to add 42 to the log.
@@ -825,6 +826,7 @@ AdvanceCommitIndex(i) ==
                     /\ UNCHANGED <<currentTerm, votedFor, isNewFollower>>
                  \* Otherwise, states remain unchanged
                  ELSE UNCHANGED <<messages, serverVars>>
+              \* TODO: Check if any node's retirement has been committed and add retired_committed if so
            \* Otherwise, Configuration and states remain unchanged
            ELSE UNCHANGED <<messages, serverVars, reconfigurationVars, leadershipState>>
     /\ UNCHANGED <<candidateVars, leaderVars, log, removedFromConfiguration>>

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -518,7 +518,7 @@ CalcMembershipState(log_i, commit_index_i, i) ==
 
 \* Set of nodes with retired committed transactions in a given log
 AllRetiredCommittedTxns(log_i) ==
-    UNION {entry.retired: entry \in {k \in log_i: k.contentType = TypeRetiredCommitted}}
+    UNION {log_i[idx].retired: idx \in {k \in DOMAIN log_i: log_i[k].contentType = TypeRetiredCommitted}}
 
 \* Set of retired nodes in a given log
 AllRetired(log_i) ==

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -74,7 +74,8 @@ CONSTANTS
 MembershipStates == {
     Active,
     RetirementOrdered,
-    RetirementSigned
+    RetirementSigned,
+    RetirementCompleted
     }
 
 \* Message types:

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -1442,6 +1442,17 @@ CommitCommittableIndices ==
             /\ CommittableIndices(i) = {}
         \/ commitIndex[i] \in CommittableIndices(i)
 
+
+\* Check that retired committed transactions are added only when retirement committed has been observed
+RetiredCommittedInv ==
+    \A i \in Servers :
+        \A k \in DOMAIN log[i] : 
+            log[i][k].contentType = TypeRetiredCommitted
+            => \A j \in log[i][k].retired : 
+                /\ RetirementIndexLog(log[i],j) # 0 
+                /\ RetirementIndexLog(log[i],j) <= k
+                /\ RetirementIndexLog(log[i],j) <= commitIndex[i]
+
 ------------------------------------------------------------------------------
 \* Properties
 

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -856,8 +856,8 @@ AdvanceCommitIndex(i) ==
                  \* Otherwise, states remain unchanged
                  ELSE UNCHANGED <<messages, serverVars>>
            \* Otherwise, Configuration and states remain unchanged
-           ELSE UNCHANGED <<messages, serverVars, reconfigurationVars, log, leadershipState>>
-    /\ UNCHANGED <<candidateVars, leaderVars, removedFromConfiguration>>
+           ELSE UNCHANGED <<messages, serverVars, reconfigurationVars, leadershipState>>
+    /\ UNCHANGED <<candidateVars, leaderVars, removedFromConfiguration, log>>
 
 \* CCF supports checkQuorum which enables a leader to choose to abdicate leadership.
 CheckQuorum(i) ==


### PR DESCRIPTION
This PR adds the RetiredCommitted transaction to the consensus specification. 

This PR just allows leaders to add `RetiredCommitted` transactions but they will not be used for anything (yet!)