### PR TITLE
Clean up nodes in reconfiguration test

### DIFF
--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -391,6 +391,7 @@ def test_add_node_from_snapshot(network, args, copy_ledger=True, from_backup=Fal
 
     primary, _ = network.find_primary()
     network.retire_node(primary, new_node)
+    new_node.stop()
     return network
 
 
@@ -420,6 +421,7 @@ def test_add_as_many_pending_nodes(network, args):
     # Cleanup killed pending nodes
     for new_node in new_nodes:
         network.retire_node(primary, new_node)
+        new_node.stop()
 
     wait_for_reconfiguration_to_complete(network)
 
@@ -446,6 +448,7 @@ def test_retire_primary(network, args):
 
     primary, backup = network.find_primary_and_any_backup()
     network.retire_node(primary, primary, timeout=15)
+    primary.stop()
     # Query this backup to find the new primary. If we ask any other
     # node, then this backup may not know the new primary by the
     # time we call check_can_progress.
@@ -889,15 +892,6 @@ def run_join_old_snapshot(args):
                 raise RuntimeError(
                     f"Node {new_node.local_node_id} started without snapshot unexpectedly joined the service successfully"
                 )
-
-
-def get_current_nodes_table(network):
-    tables, _ = network.get_latest_ledger_public_state()
-    tn = "public:ccf.gov.nodes.info"
-    r = {}
-    for nid, info in tables[tn].items():
-        r[nid.decode()] = json.loads(info)
-    return r
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stop nodes after they are no longer needed, and remove a bit of dead code.

Spun off from #5973.