### PR TITLE
Fix recv_propose_request_vote in trace validation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,23 +9,23 @@
     "ms-azure-devops.azure-pipelines",
     "ms-python.black-formatter",
     "ms-python.python",
-    "ms-vscode.cpptools",
+    "ms-vscode.cpptools"
   ],
   "settings": {
     "python.defaultInterpreterPath": "python3",
     "[python]": {
-      "editor.defaultFormatter": "ms-python.black-formatter",
+      "editor.defaultFormatter": "ms-python.black-formatter"
     },
     "python.formatting.provider": "none",
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll": true,
-    },
+      "source.fixAll": true
+    }
   },
   "features": {
     "ghcr.io/devcontainers/features/docker-from-docker:1": {
-      "version": "latest",
-    },
-  },
+      "version": "latest"
+    }
+  }
 }

--- a/.devcontainer/tlaplus/devcontainer.json
+++ b/.devcontainer/tlaplus/devcontainer.json
@@ -4,7 +4,7 @@
     "alygin.vscode-tlaplus-nightly",
     "joaompinto.vscode-graphviz",
     "EFanZh.graphviz-preview",
-    "cssho.vscode-svgviewer",
+    "cssho.vscode-svgviewer"
   ],
   "settings": {
     "tlaplus.tlc.statisticsSharing": "share",
@@ -12,9 +12,9 @@
     "tlaplus.java.home": "/home/codespace/java/current/",
     "[tlaplus]": {
       "editor.codeActionsOnSave": {
-        "source": true,
-      },
-    },
+        "source": true
+      }
+    }
   },
-  "postCreateCommand": "(cd tla/ && python install_deps.py)",
+  "postCreateCommand": "(cd tla/ && python install_deps.py)"
 }

--- a/js/ccf-app/test/tsconfig.json
+++ b/js/ccf-app/test/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "..",
+    "rootDir": ".."
   },
-  "include": ["./**/*"],
+  "include": ["./**/*"]
 }

--- a/js/ccf-app/tsconfig.json
+++ b/js/ccf-app/tsconfig.json
@@ -10,8 +10,8 @@
     "declaration": true,
     "strict": true,
     "rootDir": "src",
-    "outDir": ".",
+    "outDir": "."
   },
   "include": ["src"],
-  "exclude": [],
+  "exclude": []
 }

--- a/tests/js-interpreter-reuse/tsconfig.json
+++ b/tests/js-interpreter-reuse/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-  },
+    "emitDecoratorMetadata": true
+  }
 }

--- a/tests/npm-app/tsconfig.json
+++ b/tests/npm-app/tsconfig.json
@@ -8,7 +8,7 @@
     "noImplicitAny": false,
     "removeComments": true,
     "preserveConstEnums": true,
-    "sourceMap": false,
+    "sourceMap": false
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*"]
 }

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -330,16 +330,12 @@ IsCheckQuorum ==
 
 IsRcvProposeVoteRequest ==
     /\ IsEvent("recv_propose_request_vote")
-    /\ leadershipState[logline.msg.state.node_id] = Leader
     /\ LET i == logline.msg.state.node_id
-           j == logline.msg.to_node_id
-       IN /\ \E m \in Network!Messages':
+           j == logline.msg.from_node_id
+       IN /\ \E m \in Network!Messages(i, j):
                 /\ m.type = ProposeVoteRequest
-                /\ RcvProposeVoteRequest(i, j)
-                /\ m.type = RaftMsgType[logline.msg.packet.msg]
                 /\ m.term = logline.msg.packet.term
-                \* There is now one more message of this type.
-                /\ Network!OneMoreMessage(m)
+                /\ UNCHANGED vars
     /\ Range(logline.msg.state.committable_indices) \subseteq CommittableIndices(logline.msg.state.node_id)
 
 TraceNext ==

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -332,7 +332,7 @@ IsRcvProposeVoteRequest ==
     /\ IsEvent("recv_propose_request_vote")
     /\ LET i == logline.msg.state.node_id
            j == logline.msg.from_node_id
-       IN /\ \E m \in Network!Messages(i, j):
+       IN \E m \in Network!Messages(i, j):
                 /\ m.type = ProposeVoteRequest
                 /\ m.term = logline.msg.packet.term
                 /\ UNCHANGED vars

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -332,7 +332,7 @@ IsRcvProposeVoteRequest ==
     /\ IsEvent("recv_propose_request_vote")
     /\ LET i == logline.msg.state.node_id
            j == logline.msg.from_node_id
-       IN \E m \in Network!Messages(i, j):
+       IN \E m \in Network!MessagesTo(i, j):
                 /\ m.type = ProposeVoteRequest
                 /\ m.term = logline.msg.packet.term
                 /\ UNCHANGED vars


### PR DESCRIPTION
This was quite wrong, and/because not exercised until now. We don't actually need to do anything when this is matched, because Timeout is one of the next possible actions and gets matched automatically.

Also noticed during #5973.