### PR TITLE
Towards easier debugging of trace validation.

### DIFF
--- a/.azure-pipelines-templates/trace_validation.yml
+++ b/.azure-pipelines-templates/trace_validation.yml
@@ -9,5 +9,5 @@ steps:
   - script: |
       set -ex
       cd tla/
-      parallel 'JSON={} java -XX:+UseParallelGC -Dtlc2.tool.impl.Tool.cdot=true -Dtlc2.tool.queue.IStateQueue=StateDeque -cp tla2tools.jar:CommunityModules-deps.jar tlc2.TLC -lncheck final -checkpoint 0 consensus/Traceccfraft.tla' ::: $(ls ../build/*.ndjson | grep -v _deprecated)
+      parallel 'JSON={} java -XX:+UseParallelGC -Dtlc2.tool.impl.Tool.cdot=true -Dtlc2.tool.queue.IStateQueue=StateDeque -cp tla2tools.jar:CommunityModules-deps.jar tlc2.TLC -lncheck final -checkpoint 0 -dump dot,constrained,colorize,actionlabels {}.dot consensus/Traceccfraft.tla' ::: $(ls ../build/*.ndjson | grep -v _deprecated)
     displayName: "Run trace validation"

--- a/tla/consensus/Traceccfraft.cfg
+++ b/tla/consensus/Traceccfraft.cfg
@@ -31,6 +31,9 @@ PROPERTIES
 INVARIANT 
     TraceDifferentialInv
 
+CONSTRAINT
+    TraceMatchesConstraints
+
 \* Checking for deadlocks during trace validation is disabled, as it may lead to false
 \* counterexamples. A trace specification defines a set of traces, where at least one
 \* trace is expected to match the log file in terms of variable values and length.

--- a/tla/consensus/Traceccfraft.cfg
+++ b/tla/consensus/Traceccfraft.cfg
@@ -10,6 +10,9 @@ SPECIFICATION
 VIEW
     TraceView
 
+POSTCONDITION 
+    TraceMatchedNonTrivially
+
 \* Some of the traces in TraceSpec may not refine the high-level specification ccfraft.
 \* Those traces will cause the trace validator to report a counterexample even if 
 \* TraceSpec contains a trace that refines ccfraft and fully matches the log file.

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -411,6 +411,27 @@ TraceMatchedNonTrivially ==
     \* If, e.g., the FALSE state constraint excludes all states, TraceMatched won't be violated.
     TLCGet("stats").diameter = Len(TraceLog)
 
+TraceMatchesConstraints ==
+    \* ccfraft's invariants become (state) constraints in Traceccfraft.  When validating traces,
+    \* the constraints exclude all states that do not satisfy the "invariants".  If no states
+    \* remain and the level  l  is less than the length of the trace log, i.e.,  Len(TraceLog),
+    \* TraceMatched  above will be violated and TLC will print a counterexample.
+    /\ LogInv
+    /\ MoreThanOneLeaderInv
+    /\ CandidateTermNotInLogInv
+    /\ ElectionSafetyInv
+    /\ LogMatchingInv
+    /\ QuorumLogInv
+    /\ LeaderCompletenessInv
+    /\ SignatureInv
+    /\ TypeInv
+    /\ MonoTermInv
+    /\ MonoLogInv
+    /\ NoLeaderBeforeInitialTerm
+    /\ LogConfigurationConsistentInv
+    /\ MembershipStateConsistentInv
+    /\ CommitCommittableIndices
+
 -------------------------------------------------------------------------------------
 
 TraceDifferentialInv ==

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -404,6 +404,10 @@ TraceMatched ==
     \* Note: Consider changing {1,2,3} to (Nat \ {0}) while validating traces with holes.
     [](l <= Len(TraceLog) => [](TLCGet("queue") \in Nat \ {0} \/ l > Len(TraceLog)))
 
+TraceMatchedNonTrivially ==
+    \* If, e.g., the FALSE state constraint excludes all states, TraceMatched won't be violated.
+    TLCGet("stats").diameter = Len(TraceLog)
+
 -------------------------------------------------------------------------------------
 
 TraceDifferentialInv ==

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -404,7 +404,7 @@ TraceMatched ==
     \* the variable messages. However, the loglines before h_ts 506 do not allow us to determine
     \* which request it is.
     \*
-    \* Note: Consider changing {1,2,3} to (Nat \ {0}) while validating traces with holes.
+    \* Note: Consider strengthening (Nat \ {0}) to {1} when validating traces with no nondeterminism.
     [](l <= Len(TraceLog) => [](TLCGet("queue") \in Nat \ {0} \/ l > Len(TraceLog)))
 
 TraceMatchedNonTrivially ==

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -367,8 +367,11 @@ TraceNext ==
 
     \/ IsRcvProposeVoteRequest
 
+DropAndNext ==
+    IF ENABLED TraceNext THEN TraceNext ELSE DropMessages \cdot TraceNext
+
 TraceSpec ==
-    TraceInit /\ [][IF ENABLED TraceNext THEN TraceNext ELSE DropMessages \cdot TraceNext]_<<l, ts, vars>>
+    TraceInit /\ [][DropAndNext]_<<l, ts, vars>>
 
 -------------------------------------------------------------------------------------
 


### PR DESCRIPTION
When TLC fails to validate a log, it prints a counterexample for the `TraceMatched` property that doesn't provide sufficient information to pinpoint the exact problem.  During trace validation, TLC generates a set of traces—finite prefixes of the possible behaviors as defined by the specification. Among these, the longest trace is considered the first candidate for detailed analysis (in the case of a breadth-first search, all traces are of equal length). Then, users are particularly interested in exploring the successor states to final state of this longest trace. Additionally, users would want to know which part of the next-state relation, or any state or action constraint, was evaluated as FALSE, leading to the exclusion of the successor states from the model.
However, the longest trace could be a red herring; especially with depth-first search, as shorter traces could be the one that has to be completed. Therefore, for an accurate diagnosis of the issue, TLC should display its entire graph of traces rather than just a single trace.

Note that in the special case that trace validation is completely deterministic, TLC will generate a single prefix.

Requested:
https://github.com/microsoft/CCF/pull/5933

Related:
https://github.com/tlaplus/tlaplus/pull/867
https://github.com/tlaplus/tlaplus/commit/f7b4c8ac2406bd90bcfc03fdd4651c318df9c604
https://github.com/tlaplus/tlaplus/commit/312518885c0f4688fceb1b30d27c2aed61a6628f
https://github.com/tlaplus/tlaplus/commit/c2713def38aa1d3255a6c2fe2aa037253e00e361