### PR TITLE
Minor Raft QoL cleanup

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -170,6 +170,11 @@ namespace aft
     std::uniform_int_distribution<int> distrib;
     std::default_random_engine rand;
 
+    // AppendEntries messages are currently constrained to only contain entries
+    // from a single term, so that the receiver can know the term of each entry
+    // pre-deserialisation, without an additional header.
+    static constexpr size_t max_terms_per_append_entries = 1;
+
   public:
     static constexpr size_t append_entries_size_limit = 20000;
     std::unique_ptr<LedgerProxy> ledger;
@@ -902,6 +907,9 @@ namespace aft
         // Cap the end index in 2 ways:
         // - Must contain no more than entries_batch_size entries
         // - Must contain entries from a single term
+        static_assert(
+          max_terms_per_append_entries == 1,
+          "AppendEntries construction logic enforces single term");
         auto max_idx = state->last_idx;
         const auto term_of_ae = state->view_history.view_at(start);
         const auto index_at_end_of_term =
@@ -1287,6 +1295,10 @@ namespace aft
                 // NB: This is only safe as long as AppendEntries only contain a
                 // single term. If they cover multiple terms, then we need to
                 // know our previous signature locally.
+                static_assert(
+                  max_terms_per_append_entries == 1,
+                  "AppendEntries processing for term updates assumes single "
+                  "term");
                 state->view_history.update(r.prev_idx + 1, ds->get_term());
               }
               commit_if_possible(r.leader_commit_idx);

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1185,7 +1185,7 @@ namespace aft
         }
 
         kv::TxID expected{r.term_of_idx, i};
-        auto ds = store->apply(entry, public_only, expected);
+        auto ds = store->deserialize(entry, public_only, expected);
         if (ds == nullptr)
         {
           RAFT_FAIL_FMT(

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -36,7 +36,7 @@ namespace aft
     virtual void compact(Index v) = 0;
     virtual void rollback(const kv::TxID& tx_id, Term term_of_next_version) = 0;
     virtual void initialise_term(Term t) = 0;
-    virtual std::unique_ptr<kv::AbstractExecutionWrapper> apply(
+    virtual std::unique_ptr<kv::AbstractExecutionWrapper> deserialize(
       const std::vector<uint8_t> data,
       bool public_only = false,
       const std::optional<kv::TxID>& expected_txid = std::nullopt) = 0;
@@ -78,7 +78,7 @@ namespace aft
       }
     }
 
-    std::unique_ptr<kv::AbstractExecutionWrapper> apply(
+    std::unique_ptr<kv::AbstractExecutionWrapper> deserialize(
       const std::vector<uint8_t> data,
       bool public_only = false,
       const std::optional<kv::TxID>& expected_txid = std::nullopt) override


### PR DESCRIPTION
Pulling some non-functional changes out of #5991, so they can be merge separately:

- Rename the early `apply` (which _returns_ an ExecutionWrapper), to `deserialize`. This makes it more clearly distinct from the later `apply()` call (_on_ that ExecutionWrapper).
- Add `static_assert`s where we rely on AppendEntries containing a single term. This should cause build breaks if we change this assumption in future, or at least more clearly highlight where changes need to be made.