### PR TITLE
Update status casing in documentation to match REST API

### DIFF
--- a/doc/use_apps/verify_tx.rst
+++ b/doc/use_apps/verify_tx.rst
@@ -16,28 +16,28 @@ To guarantee that their request is successfully committed to the ledger, a user 
     content-type: application/json
     x-ms-ccf-transaction-id: 5.42
 
-    {"status":"COMMITTED"}
+    {"status":"Committed"}
 
 This example queries the status of :term:`Transaction ID` ``2.18`` (constructed from view ``2`` and sequence number ``18``). The response indicates this was successfully committed. The headers also show that the service has since made progress with other requests and changed view (``x-ms-ccf-transaction-id: 5.42``).
 
 The possible statuses returned by :http:GET:`/app/tx` are:
 
-- ``UNKNOWN`` - this node has not received a transaction with the given ID
-- ``PENDING`` - this node has received a transaction with the given ID, but does not yet know if the transaction has been committed
-- ``COMMITTED`` - this node knows that this transaction is committed, it is an irrevocable and durable part of the service's transaction history
-- ``INVALID`` - this node knows that the given transaction cannot be committed. This occurs when the view changes, and some pending transactions may be lost and must be resubmitted, but also applies to IDs which are known to be impossible given the current committed IDs
+- ``Unknown`` - this node has not received a transaction with the given ID
+- ``Pending`` - this node has received a transaction with the given ID, but does not yet know if the transaction has been committed
+- ``Committed`` - this node knows that this transaction is committed, it is an irrevocable and durable part of the service's transaction history
+- ``Invalid`` - this node knows that the given transaction cannot be committed. This occurs when the view changes, and some pending transactions may be lost and must be resubmitted, but also applies to IDs which are known to be impossible given the current committed IDs
 
 On a given node, the possible transitions between states are described in the following diagram:
 
 .. mermaid::
 
     stateDiagram
-        UNKNOWN --> PENDING
-        PENDING --> UNKNOWN
-        PENDING --> COMMITTED
-        PENDING --> INVALID
+        Unknown --> Pending
+        Pending --> Unknown
+        Pending --> Committed
+        Pending --> Invalid
 
-It is possible that intermediate states are not visible (e.g. a transition from ``UNKNOWN`` to ``COMMITTED`` may never publically show a ``PENDING`` result). Nodes may disagree on the current state due to communication delays, but will never disagree on transitions (in other words, they may believe a ``COMMITTED`` transaction is still ``UNKNOWN`` or ``PENDING``, but will never report it as ``INVALID``). A transition from ``PENDING`` to ``UNKNOWN`` can only occur immediately after an election, while the node is confirming where the new view starts, and will usually resolve to ``COMMITTED`` or ``PENDING`` quickly afterwards.
+It is possible that intermediate states are not visible (e.g. a transition from ``Unknown`` to ``Committed`` may never publically show a ``Pending`` result). Nodes may disagree on the current state due to communication delays, but will never disagree on transitions (in other words, they may believe a ``COMMITTED`` transaction is still ``Unknown`` or ``Pending``, but will never report it as ``Invalid``). A transition from ``Pending`` to ``Unknown`` can only occur immediately after an election, while the node is confirming where the new view starts, and will usually resolve to ``Committed`` or ``Pending`` quickly afterwards.
 
 Note that transaction IDs are uniquely assigned by the service - once a request has been assigned an ID, this ID will never be associated with a different write transaction. In normal operation, the next requests will be given versions 2.19, then 2.20, and so on, and after a short delay ``2.18`` will be committed. If requests are submitted in parallel, they will be applied in a consistent order indicated by their assigned versions.
 


### PR DESCRIPTION
Raised in #5981, although the internal C++ enums are still ALL_CAPS, we switched to CamelCase to meet Azure guidelines. It makes sense to follow that convention when describing values returned by the REST API.