### PR TITLE
Minor Raft QoL: Make message construction more readable

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1535,7 +1535,7 @@ namespace aft
       RequestVote rv;
       rv.term = state->current_view;
       rv.last_committable_idx = last_committable_idx;
-      rv.term_of_last_committable_idx = last_committable_idx;
+      rv.term_of_last_committable_idx = get_term_internal(last_committable_idx);
 
 #ifdef CCF_RAFT_TRACING
       nlohmann::json j = {};

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -960,13 +960,17 @@ namespace aft
         end_idx,
         state->commit_idx);
 
-      AppendEntries ae;
-      ae.idx = end_idx;
-      ae.prev_idx = prev_idx;
-      ae.term = state->current_view;
-      ae.prev_term = prev_term;
-      ae.leader_commit_idx = state->commit_idx;
-      ae.term_of_idx = term_of_idx;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc99-designator"
+      AppendEntries ae{
+        {},
+        {.idx = end_idx, .prev_idx = prev_idx},
+        .term = state->current_view,
+        .prev_term = prev_term,
+        .leader_commit_idx = state->commit_idx,
+        .term_of_idx = term_of_idx,
+      };
+#pragma clang diagnostic pop
 
       auto& node = all_other_nodes.at(to);
 
@@ -1376,10 +1380,11 @@ namespace aft
         response_idx,
         answer);
 
-      AppendEntriesResponse response;
-      response.term = response_term;
-      response.last_log_idx = response_idx;
-      response.success = answer;
+      AppendEntriesResponse response{
+        .term = response_term,
+        .last_log_idx = response_idx,
+        .success = answer,
+      };
 
 #ifdef CCF_RAFT_TRACING
       nlohmann::json j = {};
@@ -1532,10 +1537,11 @@ namespace aft
         last_committable_idx);
       CCF_ASSERT(last_committable_idx >= state->commit_idx, "lci < ci");
 
-      RequestVote rv;
-      rv.term = state->current_view;
-      rv.last_committable_idx = last_committable_idx;
-      rv.term_of_last_committable_idx = get_term_internal(last_committable_idx);
+      RequestVote rv{
+        .term = state->current_view,
+        .last_committable_idx = last_committable_idx,
+        .term_of_last_committable_idx = get_term_internal(last_committable_idx),
+      };
 
 #ifdef CCF_RAFT_TRACING
       nlohmann::json j = {};
@@ -1658,9 +1664,8 @@ namespace aft
         to,
         answer);
 
-      RequestVoteResponse response;
-      response.term = state->current_view;
-      response.vote_granted = answer;
+      RequestVoteResponse response{
+        .term = state->current_view, .vote_granted = answer};
 
       channels->send_authenticated(
         to, ccf::NodeMsgType::consensus_msg, response);
@@ -1978,8 +1983,7 @@ namespace aft
       {
         leader_id.reset();
         state->leadership_state = kv::LeadershipState::None;
-        ProposeRequestVote prv;
-        prv.term = state->current_view;
+        ProposeRequestVote prv{.term = state->current_view};
 
         std::optional<ccf::NodeId> successor = std::nullopt;
         Index max_match_idx = 0;

--- a/src/consensus/aft/raft_types.h
+++ b/src/consensus/aft/raft_types.h
@@ -115,14 +115,16 @@ namespace aft
     });
 
 #pragma pack(push, 1)
+  template <RaftMsgType M>
   struct RaftHeader
   {
-    RaftMsgType msg;
+    RaftMsgType msg = M;
   };
-  DECLARE_JSON_TYPE(RaftHeader);
-  DECLARE_JSON_REQUIRED_FIELDS(RaftHeader, msg);
 
-  struct AppendEntries : RaftHeader, consensus::AppendEntriesIndex
+  DECLARE_JSON_TYPE(RaftHeader<raft_append_entries>)
+  DECLARE_JSON_REQUIRED_FIELDS(RaftHeader<raft_append_entries>, msg)
+  struct AppendEntries : RaftHeader<raft_append_entries>,
+                         consensus::AppendEntriesIndex
   {
     Term term;
     Term prev_term;
@@ -134,10 +136,12 @@ namespace aft
     Term term_of_idx;
     // This is unused by the current implementation, but is kept to preserve
     // wire compatibility with previous versions of the code.
-    bool contains_new_view;
+    bool contains_new_view = false;
   };
   DECLARE_JSON_TYPE_WITH_2BASES(
-    AppendEntries, RaftHeader, consensus::AppendEntriesIndex);
+    AppendEntries,
+    RaftHeader<raft_append_entries>,
+    consensus::AppendEntriesIndex);
   DECLARE_JSON_REQUIRED_FIELDS(
     AppendEntries,
     term,
@@ -156,7 +160,9 @@ namespace aft
     {{AppendEntriesResponseType::OK, "OK"},
      {AppendEntriesResponseType::FAIL, "FAIL"}});
 
-  struct AppendEntriesResponse : RaftHeader
+  DECLARE_JSON_TYPE(RaftHeader<raft_append_entries_response>)
+  DECLARE_JSON_REQUIRED_FIELDS(RaftHeader<raft_append_entries_response>, msg)
+  struct AppendEntriesResponse : RaftHeader<raft_append_entries_response>
   {
     // This term and idx usually refer to the tail of the sender's log. The
     // exception is in a rejection because of a mismatching suffix, in which
@@ -170,35 +176,44 @@ namespace aft
     Index last_log_idx;
     AppendEntriesResponseType success;
   };
-  DECLARE_JSON_TYPE_WITH_BASE(AppendEntriesResponse, RaftHeader);
+  DECLARE_JSON_TYPE_WITH_BASE(
+    AppendEntriesResponse, RaftHeader<raft_append_entries_response>);
   DECLARE_JSON_REQUIRED_FIELDS(
     AppendEntriesResponse, term, last_log_idx, success);
 
-  struct RequestVote : RaftHeader
+  DECLARE_JSON_TYPE(RaftHeader<raft_request_vote>)
+  DECLARE_JSON_REQUIRED_FIELDS(RaftHeader<raft_request_vote>, msg)
+  struct RequestVote : RaftHeader<raft_request_vote>
   {
     Term term;
     Index last_committable_idx;
     Term term_of_last_committable_idx;
   };
-  DECLARE_JSON_TYPE_WITH_BASE(RequestVote, RaftHeader);
+  DECLARE_JSON_TYPE_WITH_BASE(RequestVote, RaftHeader<raft_request_vote>);
   DECLARE_JSON_REQUIRED_FIELDS(
     RequestVote, term, last_committable_idx, term_of_last_committable_idx);
 
-  struct RequestVoteResponse : RaftHeader
+  DECLARE_JSON_TYPE(RaftHeader<raft_request_vote_response>)
+  DECLARE_JSON_REQUIRED_FIELDS(RaftHeader<raft_request_vote_response>, msg)
+  struct RequestVoteResponse : RaftHeader<raft_request_vote_response>
   {
     Term term;
     bool vote_granted;
   };
-  DECLARE_JSON_TYPE_WITH_BASE(RequestVoteResponse, RaftHeader);
+  DECLARE_JSON_TYPE_WITH_BASE(
+    RequestVoteResponse, RaftHeader<raft_request_vote_response>);
   DECLARE_JSON_REQUIRED_FIELDS(RequestVoteResponse, term, vote_granted);
 
-  struct ProposeRequestVote : RaftHeader
+  DECLARE_JSON_TYPE(RaftHeader<raft_propose_request_vote>)
+  DECLARE_JSON_REQUIRED_FIELDS(RaftHeader<raft_propose_request_vote>, msg)
+  struct ProposeRequestVote : RaftHeader<raft_propose_request_vote>
   {
     // A node sends this to nudge another node to begin an election, for
     // instance because the sender is a retiring primary
     Term term;
   };
-  DECLARE_JSON_TYPE_WITH_BASE(ProposeRequestVote, RaftHeader);
+  DECLARE_JSON_TYPE_WITH_BASE(
+    ProposeRequestVote, RaftHeader<raft_propose_request_vote>);
   DECLARE_JSON_REQUIRED_FIELDS(ProposeRequestVote, term);
 
 #pragma pack(pop)


### PR DESCRIPTION
This is just a style change, and should no impact on behaviour.

I just noticed that the way we construct Raft messages gives me the heebie jeebies:

```
      AppendEntries ae = {
        {raft_append_entries},
        {end_idx, prev_idx},
        state->current_view,
        prev_term,
        state->commit_idx,
        term_of_idx,
        contains_new_view};
```

1. Why are we repeating `AppendEntries` and `raft_append_entries`?
2. What are all these fields?

This PR tries to resolve both, by setting the `msg` field (basically a discriminator for a tagged union struct) from a templated type, and assigning to each field by name.

```
      AppendEntries ae;
      ae.idx = end_idx;
      ae.prev_idx = prev_idx;
      ae.term = state->current_view;
      ae.prev_term = prev_term;
      ae.leader_commit_idx = state->commit_idx;
      ae.term_of_idx = term_of_idx;
```

This is only an extremely incremental change because:
1. You could still _re_ assign the `ae.msg` field to something else if you wanted to cause chaos (because we can't make it const, because of our JSON serialisation machinery).
2. The field names are still brief and confusing.

But I think this is a worthwhile improvement regardless.