### PR TITLE
Improvements to secret sharing following review

### DIFF
--- a/include/ccf/crypto/entropy.h
+++ b/include/ccf/crypto/entropy.h
@@ -303,6 +303,5 @@ namespace crypto
   using EntropyPtr = std::shared_ptr<Entropy>;
   static EntropyPtr intel_drng_ptr;
 
-  /** Create a default Entropy object */
-  EntropyPtr create_entropy();
+  EntropyPtr get_entropy();
 }

--- a/include/ccf/crypto/symmetric_key.h
+++ b/include/ccf/crypto/symmetric_key.h
@@ -44,7 +44,7 @@ namespace crypto
       return GCM_SIZE_TAG + IV_SIZE;
     }
 
-    void set_random_iv(EntropyPtr entropy = crypto::create_entropy())
+    void set_random_iv(EntropyPtr entropy = crypto::get_entropy())
     {
       iv = entropy->random(IV_SIZE);
     }

--- a/src/crypto/entropy.cpp
+++ b/src/crypto/entropy.cpp
@@ -7,7 +7,7 @@
 
 namespace crypto
 {
-  EntropyPtr create_entropy()
+  EntropyPtr get_entropy()
   {
     if (use_drng)
     {

--- a/src/crypto/sharing.cpp
+++ b/src/crypto/sharing.cpp
@@ -8,177 +8,205 @@
 
 namespace crypto
 {
-  /* PRIME FIELD
-
-     For simplicity, we use a finite field F[prime] where all operations
-     are defined in plain uint64_t arithmetic, and we reduce after every
-     operation. This is not meant to be efficient. Compared to e.g. GF(2^n), the
-     main drawback is that we need to hash the "raw secret" to obtain a
-     uniformly-distributed secret.
-  */
-
-  using element = uint64_t;
-  constexpr element prime = (1ul << 31) - 1ul; // a notorious Mersenne prime
-
-  static element reduce(uint64_t x)
+  namespace sharing
   {
-    return (x % prime);
-  }
+    /* PRIME FIELD
 
-  static element mul(element x, element y)
-  {
-    return ((x * y) % prime);
-  }
+      For simplicity, we use a finite field F[prime] where all operations
+      are defined in plain uint64_t arithmetic, and we reduce after every
+      operation. This is not meant to be efficient. Compared to e.g. GF(2^n),
+      the main drawback is that we need to hash the "raw secret" to obtain a
+      uniformly-distributed secret.
+    */
 
-  static element add(element x, element y)
-  {
-    return ((x + y) % prime);
-  }
-
-  static element sub(element x, element y)
-  {
-    return ((prime + x - y)) % prime;
-  }
-
-  // naive algorithm, used only to compute coefficients, not for use on secrets!
-  static element exp(element x, size_t n)
-  {
-    element y = 1;
-    while (n > 0)
-    {
-      if (n & 1)
-        y = mul(y, x);
-      x = mul(x, x);
-      n >>= 1;
-    }
-    return y;
-  }
-
-  static element inv(element x)
-  {
-    if (x == 0)
-    {
-      throw std::invalid_argument("division by zero");
-    }
-    return exp(x, prime - 2);
-  }
-
-  // This function is specific to prime=2^31-1.
-  // We assume the lower 31 bits are uniformly distributed,
-  // and retry if they are all set to get uniformity in F[prime].
-
-  static element sample(const crypto::EntropyPtr& entropy)
-  {
-    uint64_t res = prime;
-    while (res == prime)
-    {
-      res = entropy->random64() & prime;
-    }
-    return res;
-  }
-
-  /* POLYNOMIAL SHARING AND INTERPOLATION */
-
-  static void sample_polynomial(
-    element p[], size_t degree, const crypto::EntropyPtr& entropy)
-  {
-    for (size_t i = 0; i <= degree; i++)
-    {
-      p[i] = sample(entropy);
-    }
-  }
-
-  static element eval(element p[], size_t degree, element x)
-  {
-    element y = 0, x_i = 1;
-    for (size_t i = 0; i <= degree; i++)
-    {
-      // x_i == x^i
-      y = add(y, mul(p[i], x_i));
-      x_i = mul(x, x_i);
-    }
-    return y;
-  }
-
-  void sample_secret_and_shares(
-    Share& raw_secret, const std::span<Share>& shares, size_t threshold)
-  {
-    if (shares.size() < 1)
-    {
-      throw std::invalid_argument("insufficient number of shares");
-    }
-
-    if (threshold < 1 || threshold > shares.size())
-    {
-      throw std::invalid_argument("invalid threshold");
-    }
-
-    size_t degree = threshold - 1;
-
-    raw_secret.x = 0;
-    for (size_t s = 0; s < shares.size(); s++)
-    {
-      shares[s].x = s + 1;
-    }
-
-    auto entropy = crypto::create_entropy();
-
-    for (size_t limb = 0; limb < LIMBS; limb++)
-    {
-      element p[degree + 1]; /*SECRET*/
-      sample_polynomial(p, degree, entropy);
-      raw_secret.y[limb] = p[0];
-      for (size_t s = 0; s < shares.size(); s++)
+    using element = uint64_t;
+    constexpr element prime = (1ul << 31) - 1ul; // a notorious Mersenne prime
+    /*
+    Constant time version of:
+      static element reduce(element x)
       {
-        shares[s].y[limb] = eval(p, degree, shares[s].x);
+        return (x % prime);
       }
-    }
-  }
-
-  void recover_unauthenticated_secret(
-    Share& raw_secret, const std::span<Share const>& shares, size_t threshold)
-  {
-    if (shares.size() < threshold)
+    Instructions checked against list published by Intel at:
+    https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/resources/data-operand-independent-timing-instructions.html
+    Note that IA32_UARCH_MISC_CTL[DOITM] must be set for this to be guaranteed,
+    as per:
+    https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/best-practices/data-operand-independent-timing-isa-guidance.html
+    This is always the case in SGX, but may not be true elsewhere.
+    */
+    element ct_reduce(element x)
     {
-      throw std::invalid_argument("insufficient input shares");
+      // initially, x < 2^64
+      // we compute under-approximations  x/(2^31) of x/prime
+      uint64_t d;
+      d = x >> 31;
+      x -= d * prime;
+      // after this first reduction, x <= 5*prime + 3
+      d = x >> 31;
+      x -= d * prime;
+      // after this second reduction, x <= prime + 3
+      d = (x + 1) >> 31;
+      x -= d * prime;
+      // d is correct for every x in this range
+      return x;
     }
-    // We systematically reduce the input shares instead of checking they are
-    // well-formed.
 
-    size_t degree = threshold - 1;
-
-    // Precomputes Lagrange coefficients for interpolating p(0). No secrets
-    // involved.
-    element lagrange[degree + 1];
-    for (size_t i = 0; i <= degree; i++)
+    static element mul(element x, element y)
     {
-      element numerator = 1, denominator = 1;
-      for (size_t j = 0; j <= degree; j++)
+      return ct_reduce(x * y);
+    }
+
+    static element add(element x, element y)
+    {
+      return ct_reduce(x + y);
+    }
+
+    static element sub(element x, element y)
+    {
+      return ct_reduce(prime + x - y);
+    }
+
+    // naive algorithm, used only to compute coefficients, not for use on
+    // secrets!
+    static element exp(element x, size_t n)
+    {
+      element y = 1;
+      while (n > 0)
       {
-        if (i != j)
-        {
-          numerator = mul(numerator, reduce(shares[j].x));
-          denominator =
-            mul(denominator, sub(reduce(shares[j].x), reduce(shares[i].x)));
-        }
+        if (n & 1)
+          y = mul(y, x);
+        x = mul(x, x);
+        n >>= 1;
       }
-      if (denominator == 0)
-      {
-        throw std::invalid_argument("duplicate input share");
-      }
-      lagrange[i] = mul(numerator, inv(denominator));
+      return y;
     }
 
-    // Interpolate every limb of the secret. Constant-time on y values.
-    raw_secret.x = 0;
-    for (size_t limb = 0; limb < LIMBS; limb++)
+    static element inv(element x)
     {
-      element y = 0;
+      if (x == 0)
+      {
+        throw std::invalid_argument("division by zero");
+      }
+      return exp(x, prime - 2);
+    }
+
+    // This function is specific to prime=2^31-1.
+    // We assume the lower 31 bits are uniformly distributed,
+    // and retry if they are all set to get uniformity in F[prime].
+
+    static element sample(const crypto::EntropyPtr& entropy)
+    {
+      uint64_t res = prime;
+      while (res == prime)
+      {
+        res = entropy->random64() & prime;
+      }
+      return res;
+    }
+
+    /* POLYNOMIAL SHARING AND INTERPOLATION */
+
+    static void sample_polynomial(
+      element p[], size_t degree, const crypto::EntropyPtr& entropy)
+    {
       for (size_t i = 0; i <= degree; i++)
       {
-        y = add(y, mul(lagrange[i], reduce(shares[i].y[limb])));
+        p[i] = sample(entropy);
       }
-      raw_secret.y[limb] = y;
+    }
+
+    static element eval(element p[], size_t degree, element x)
+    {
+      element y = 0, x_i = 1;
+      for (size_t i = 0; i <= degree; i++)
+      {
+        // x_i == x^i
+        y = add(y, mul(p[i], x_i));
+        x_i = mul(x, x_i);
+      }
+      return y;
+    }
+
+    void sample_secret_and_shares(
+      Share& raw_secret, const std::span<Share>& shares, size_t threshold)
+    {
+      if (shares.size() < 1)
+      {
+        throw std::invalid_argument("insufficient number of shares");
+      }
+
+      if (threshold < 1 || threshold > shares.size())
+      {
+        throw std::invalid_argument("invalid threshold");
+      }
+
+      size_t degree = threshold - 1;
+
+      raw_secret.x = 0;
+      for (size_t s = 0; s < shares.size(); s++)
+      {
+        shares[s].x = s + 1;
+      }
+
+      auto entropy = crypto::create_entropy();
+
+      for (size_t limb = 0; limb < LIMBS; limb++)
+      {
+        element p[degree + 1]; /*SECRET*/
+        sample_polynomial(p, degree, entropy);
+        raw_secret.y[limb] = p[0];
+        for (size_t s = 0; s < shares.size(); s++)
+        {
+          shares[s].y[limb] = eval(p, degree, shares[s].x);
+        }
+      }
+    }
+
+    void recover_unauthenticated_secret(
+      Share& raw_secret, const std::span<Share const>& shares, size_t threshold)
+    {
+      if (shares.size() < threshold)
+      {
+        throw std::invalid_argument("insufficient input shares");
+      }
+      // We systematically reduce the input shares instead of checking they are
+      // well-formed.
+
+      size_t degree = threshold - 1;
+
+      // Precomputes Lagrange coefficients for interpolating p(0). No secrets
+      // involved.
+      element lagrange[degree + 1];
+      for (size_t i = 0; i <= degree; i++)
+      {
+        element numerator = 1, denominator = 1;
+        for (size_t j = 0; j <= degree; j++)
+        {
+          if (i != j)
+          {
+            numerator = mul(numerator, ct_reduce(shares[j].x));
+            denominator = mul(
+              denominator, sub(ct_reduce(shares[j].x), ct_reduce(shares[i].x)));
+          }
+        }
+        if (denominator == 0)
+        {
+          throw std::invalid_argument("duplicate input share");
+        }
+        lagrange[i] = mul(numerator, inv(denominator));
+      }
+
+      // Interpolate every limb of the secret. Constant-time on y values.
+      raw_secret.x = 0;
+      for (size_t limb = 0; limb < LIMBS; limb++)
+      {
+        element y = 0;
+        for (size_t i = 0; i <= degree; i++)
+        {
+          y = add(y, mul(lagrange[i], ct_reduce(shares[i].y[limb])));
+        }
+        raw_secret.y[limb] = y;
+      }
     }
   }
 }

--- a/src/crypto/sharing.cpp
+++ b/src/crypto/sharing.cpp
@@ -148,7 +148,7 @@ namespace crypto
         shares[s].x = s + 1;
       }
 
-      auto entropy = crypto::create_entropy();
+      auto entropy = crypto::get_entropy();
 
       for (size_t limb = 0; limb < LIMBS; limb++)
       {

--- a/src/crypto/sharing.h
+++ b/src/crypto/sharing.h
@@ -114,7 +114,8 @@ namespace crypto
      * @param[in] shares Shares of raw_secret.
      * @param threshold Number of shares necessary to recover the secret.
      *
-     * Note that shares passed in excess of the threshold are ignored.
+     * Note that shares passed in excess of the threshold are ignored,
+     * and that recovery does not authenticate the shares or the threshold.
      *
      * @throws std::invalid_argument if the number of shares is insufficient,
      * or if two shares have the same x coordinate.

--- a/src/crypto/sharing.h
+++ b/src/crypto/sharing.h
@@ -16,102 +16,112 @@
 
 namespace crypto
 {
-  // We get (almost) 31 bits of entropy per limb, hence to get 256 bits of
-  // entropy of derived key material, with 80 bits of safety margin,
-  // ((256+80)/31) = 10 limbs.
-  static constexpr size_t LIMBS = 10;
-  static constexpr const char* key_label = "CCF Wrapping Key v1";
-
-  struct Share
+  namespace sharing
   {
-    // Index in a re-share, 0 is a full key, and 1+ is a partial share
-    uint32_t x = 0;
-    uint32_t y[LIMBS];
-    constexpr static size_t serialised_size =
-      sizeof(uint32_t) + sizeof(uint32_t) * LIMBS;
+    // We get (almost) 31 bits of entropy per limb, hence to get 256 bits of
+    // entropy of derived key material, with 80 bits of safety margin,
+    // ((256+80)/31) = 10 limbs.
+    static constexpr size_t LIMBS = 10;
+    static constexpr const char* key_label = "CCF Wrapping Key v1";
 
-    Share() = default;
-    bool operator==(const Share& other) const = default;
-
-    ~Share()
+    struct Share
     {
-      OPENSSL_cleanse(y, sizeof(y));
+      // Index in a re-share, 0 is a full key, and 1+ is a partial share
+      uint32_t x = 0;
+      uint32_t y[LIMBS];
+      constexpr static size_t serialised_size =
+        sizeof(uint32_t) + sizeof(uint32_t) * LIMBS;
+
+      Share() = default;
+      bool operator==(const Share& other) const = default;
+
+      ~Share()
+      {
+        OPENSSL_cleanse(y, sizeof(y));
+      };
+
+      HashBytes key(size_t key_size) const
+      {
+        if (x != 0)
+        {
+          throw std::invalid_argument(
+            "Cannot derive a key from a partial share");
+        }
+        const std::span<const uint8_t> ikm(
+          reinterpret_cast<const uint8_t*>(y), sizeof(y));
+        const std::span<const uint8_t> label(
+          reinterpret_cast<const uint8_t*>(y), sizeof(y));
+        auto k = crypto::hkdf(crypto::MDType::SHA256, key_size, ikm, {}, label);
+        return k;
+      }
+
+      std::vector<uint8_t> serialise() const
+      {
+        auto size = serialised_size;
+        std::vector<uint8_t> serialised(size);
+        auto data = serialised.data();
+        serialized::write(data, size, x);
+        for (size_t i = 0; i < LIMBS; ++i)
+        {
+          serialized::write(data, size, y[i]);
+        }
+        return serialised;
+      }
+
+      Share(const std::span<uint8_t const>& serialised)
+      {
+        if (serialised.size() != serialised_size)
+        {
+          throw std::invalid_argument("Invalid serialised share size");
+        }
+        auto data = serialised.data();
+        auto size = serialised.size();
+        x = serialized::read<uint32_t>(data, size);
+        for (size_t i = 0; i < LIMBS; ++i)
+        {
+          y[i] = serialized::read<uint32_t>(data, size);
+        }
+      }
+
+      std::string to_str() const
+      {
+        return fmt::format("x: {} y: {}", x, fmt::join(y, ", "));
+      }
     };
 
-    HashBytes key(size_t key_size) const
-    {
-      if (x != 0)
-      {
-        throw std::invalid_argument("Cannot derive a key from a partial share");
-      }
-      const std::span<const uint8_t> ikm(
-        reinterpret_cast<const uint8_t*>(y), sizeof(y));
-      const std::span<const uint8_t> label(
-        reinterpret_cast<const uint8_t*>(y), sizeof(y));
-      auto k = crypto::hkdf(crypto::MDType::SHA256, key_size, ikm, {}, label);
-      return k;
-    }
+    // Exposed for testing only
+    using element = uint64_t;
+    element ct_reduce(element x);
 
-    std::vector<uint8_t> serialise() const
-    {
-      auto size = serialised_size;
-      std::vector<uint8_t> serialised(size);
-      auto data = serialised.data();
-      serialized::write(data, size, x);
-      for (size_t i = 0; i < LIMBS; ++i)
-      {
-        serialized::write(data, size, y[i]);
-      }
-      return serialised;
-    }
+    /** Sample a secret into @p raw_secret, and split it into @p shares.
+     * Enforces 1 < @p threshold <= number of shares.
+     *
+     * @param[out] raw_secret Sampled secret value.
+     * @param[out] shares Shares of raw_secret. Note that the size of the span
+     * determines the number of shares.
+     * @param[in] threshold Number of shares necessary to recover the secret.
+     *
+     * The secret is guaranteed to contain at least 256 bits of entropy.
+     * Note that is it not safe to use the secret as a key directly,
+     * and that a round of key derivation is necessary (Share::key()).
+     */
+    void sample_secret_and_shares(
+      Share& raw_secret, const std::span<Share>& shares, size_t threshold);
 
-    Share(const std::span<uint8_t const>& serialised)
-    {
-      if (serialised.size() != serialised_size)
-      {
-        throw std::invalid_argument("Invalid serialised share size");
-      }
-      auto data = serialised.data();
-      auto size = serialised.size();
-      x = serialized::read<uint32_t>(data, size);
-      for (size_t i = 0; i < LIMBS; ++i)
-      {
-        y[i] = serialized::read<uint32_t>(data, size);
-      }
-    }
-
-    std::string to_str() const
-    {
-      return fmt::format("x: {} y: {}", x, fmt::join(y, ", "));
-    }
-  };
-
-  /** Sample a secret into @p raw_secret, and split it into @p shares.
-   * Enforces 1 < @p threshold <= number of shares.
-   *
-   * @param[out] raw_secret Sampled secret value.
-   * @param[out] shares Shares of raw_secret. Note that the size of the span
-   * determines the number of shares.
-   * @param[in] threshold Number of shares necessary to recover the secret.
-   *
-   * The secret is guaranteed to contain at least 256 bits of entropy.
-   * Note that is it not safe to use the secret as a key directly,
-   * and that a round of key derivation is necessary (Share::key()).
-   */
-  void sample_secret_and_shares(
-    Share& raw_secret, const std::span<Share>& shares, size_t threshold);
-
-  /** Using @p shares, recover @p secret, without authentication.
-   *
-   * @param[out] raw_secret Recovered secret value.
-   * @param[in] shares Shares of raw_secret.
-   * @param threshold Number of shares necessary to recover the secret.
-   *
-   * Note that shares passed in excess of the threshold are ignored.
-   *
-   * @throws std::invalid_argument if the number of shares is insufficient,
-   * or if two shares have the same x coordinate.
-   */
-  void recover_unauthenticated_secret(
-    Share& raw_secret, const std::span<Share const>& shares, size_t threshold);
+    /** Using @p shares, recover @p secret, without authentication.
+     *
+     * @param[out] raw_secret Recovered secret value.
+     * @param[in] shares Shares of raw_secret.
+     * @param threshold Number of shares necessary to recover the secret.
+     *
+     * Note that shares passed in excess of the threshold are ignored.
+     *
+     * @throws std::invalid_argument if the number of shares is insufficient,
+     * or if two shares have the same x coordinate.
+     */
+    void recover_unauthenticated_secret(
+      Share& raw_secret,
+      const std::span<Share const>& shares,
+      size_t threshold);
+  }
 }

--- a/src/crypto/test/bench.cpp
+++ b/src/crypto/test/bench.cpp
@@ -97,8 +97,7 @@ template <MDType M, size_t NContents>
 static void benchmark_hmac(picobench::state& s)
 {
   const auto contents = make_contents<NContents>();
-  const auto key =
-    crypto::create_entropy()->random(crypto::GCM_DEFAULT_KEY_SIZE);
+  const auto key = crypto::get_entropy()->random(crypto::GCM_DEFAULT_KEY_SIZE);
 
   s.start_timer();
   for (auto _ : s)

--- a/src/crypto/test/bench.cpp
+++ b/src/crypto/test/bench.cpp
@@ -474,7 +474,7 @@ namespace HMAC_bench
   PICOBENCH(openssl_hmac_sha256_64).PICO_HASH_SUFFIX();
 }
 
-std::vector<crypto::Share> shares;
+std::vector<crypto::sharing::Share> shares;
 
 PICOBENCH_SUITE("share");
 namespace SHARE_bench
@@ -488,8 +488,8 @@ namespace SHARE_bench
     for (auto _ : s)
     {
       (void)_;
-      crypto::Share secret;
-      crypto::sample_secret_and_shares(secret, shares, threshold);
+      crypto::sharing::Share secret;
+      crypto::sharing::sample_secret_and_shares(secret, shares, threshold);
       do_not_optimize(secret);
       clobber_memory();
     }
@@ -521,9 +521,10 @@ namespace SHARE_bench
     for (auto _ : s)
     {
       (void)_;
-      crypto::Share secret;
-      crypto::sample_secret_and_shares(secret, shares, threshold);
-      crypto::recover_unauthenticated_secret(secret, shares, threshold);
+      crypto::sharing::Share secret;
+      crypto::sharing::sample_secret_and_shares(secret, shares, threshold);
+      crypto::sharing::recover_unauthenticated_secret(
+        secret, shares, threshold);
       do_not_optimize(secret);
       clobber_memory();
     }

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -373,7 +373,7 @@ TEST_CASE("base64url")
 TEST_CASE("Wrap, unwrap with RSAKeyPair")
 {
   size_t input_len = 64;
-  std::vector<uint8_t> input = create_entropy()->random(input_len);
+  std::vector<uint8_t> input = get_entropy()->random(input_len);
 
   INFO("Cannot make RSA key from EC key");
   {
@@ -612,7 +612,7 @@ TEST_CASE("AES Key wrap with padding")
   auto key = get_raw_key();
   std::vector<uint8_t> aad(123, 'y');
 
-  std::vector<uint8_t> key_to_wrap = create_entropy()->random(997);
+  std::vector<uint8_t> key_to_wrap = get_entropy()->random(997);
 
   auto ossl = std::make_unique<KeyAesGcm_OpenSSL>(key);
 
@@ -644,7 +644,7 @@ TEST_CASE("CKM_RSA_PKCS_OAEP")
 
 TEST_CASE("CKM_RSA_AES_KEY_WRAP")
 {
-  std::vector<uint8_t> key_to_wrap = create_entropy()->random(256);
+  std::vector<uint8_t> key_to_wrap = get_entropy()->random(256);
 
   auto rsa_kp = make_rsa_key_pair();
   auto rsa_pk = make_rsa_public_key(rsa_kp->public_key_pem());
@@ -658,7 +658,7 @@ TEST_CASE("CKM_RSA_AES_KEY_WRAP")
 
 TEST_CASE("AES-GCM convenience functions")
 {
-  EntropyPtr entropy = create_entropy();
+  EntropyPtr entropy = get_entropy();
   std::vector<uint8_t> key = entropy->random(GCM_DEFAULT_KEY_SIZE);
   auto encrypted = aes_gcm_encrypt(key, contents);
   auto decrypted = aes_gcm_decrypt(key, encrypted);

--- a/src/crypto/test/secret_sharing.cpp
+++ b/src/crypto/test/secret_sharing.cpp
@@ -12,12 +12,27 @@
 
 using namespace crypto::sharing;
 
+void check_share_is_not_trivially_wrong(const Share& share)
+{
+  REQUIRE(share.x != 0);
+  for (size_t i = 0; i < LIMBS; ++i)
+  {
+    REQUIRE(share.y[i] != 0);
+    REQUIRE(share.y[i] != 0xFFFFFFFF);
+  }
+}
+
 void share_and_recover(size_t num_shares, size_t threshold, size_t recoveries)
 {
   std::vector<Share> shares(num_shares);
 
   Share secret;
   sample_secret_and_shares(secret, shares, threshold);
+
+  for (const auto& share : shares)
+  {
+    check_share_is_not_trivially_wrong(share);
+  }
 
   std::mt19937 rng{std::random_device{}()};
 

--- a/src/indexing/enclave_lfs_access.h
+++ b/src/indexing/enclave_lfs_access.h
@@ -123,7 +123,7 @@ namespace ccf::indexing
   public:
     EnclaveLFSAccess(const ringbuffer::WriterPtr& writer) :
       to_host(writer),
-      entropy_src(crypto::create_entropy())
+      entropy_src(crypto::get_entropy())
     {
       // Generate a fresh random key. Only this specific instance, in this
       // enclave, can read these files!

--- a/src/js/crypto.cpp
+++ b/src/js/crypto.cpp
@@ -35,7 +35,7 @@ namespace ccf::js
 
     try
     {
-      std::vector<uint8_t> key = crypto::create_entropy()->random(key_size / 8);
+      std::vector<uint8_t> key = crypto::get_entropy()->random(key_size / 8);
       return JS_NewArrayBufferCopy(ctx, key.data(), key.size());
     }
     catch (const std::exception& exc)

--- a/src/js/wrap.cpp
+++ b/src/js/wrap.cpp
@@ -2169,7 +2169,7 @@ namespace ccf::js
   static JSValue js_random_impl(
     JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv)
   {
-    crypto::EntropyPtr entropy = crypto::create_entropy();
+    crypto::EntropyPtr entropy = crypto::get_entropy();
 
     // Generate a random 64 bit unsigned int, and transform that to a double
     // between 0 and 1. Note this is non-uniform, and not cryptographically

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -832,7 +832,7 @@ namespace ccf
       peer_cert = {};
       peer_cv.reset();
 
-      auto e = crypto::create_entropy();
+      auto e = crypto::get_entropy();
       hkdf_salt = e->random(salt_len);
 
       // As a future simplification, we would like this to always be true
@@ -855,7 +855,7 @@ namespace ccf
       peer_cert = {};
       peer_cv.reset();
 
-      auto e = crypto::create_entropy();
+      auto e = crypto::get_entropy();
       hkdf_salt = e->random(salt_len);
     }
 
@@ -973,7 +973,7 @@ namespace ccf
       status(fmt::format("Channel to {}", peer_id_), INACTIVE),
       message_limit(message_limit_)
     {
-      auto e = crypto::create_entropy();
+      auto e = crypto::get_entropy();
       hkdf_salt = e->random(salt_len);
     }
 

--- a/src/node/ledger_secret.h
+++ b/src/node/ledger_secret.h
@@ -76,7 +76,7 @@ namespace ccf
   inline LedgerSecretPtr make_ledger_secret()
   {
     return std::make_shared<LedgerSecret>(
-      crypto::create_entropy()->random(crypto::GCM_DEFAULT_KEY_SIZE));
+      crypto::get_entropy()->random(crypto::GCM_DEFAULT_KEY_SIZE));
   }
 
   inline std::vector<uint8_t> decrypt_previous_ledger_secret_raw(

--- a/src/node/secret_share.h
+++ b/src/node/secret_share.h
@@ -17,7 +17,7 @@ extern "C"
   /// SSS assumes that there is a function of this prototype
   int randombytes(void* buf, size_t n)
   {
-    crypto::EntropyPtr entropy = crypto::create_entropy();
+    crypto::EntropyPtr entropy = crypto::get_entropy();
     entropy->random((unsigned char*)buf, n);
     return 0;
   }

--- a/src/node/test/secret_share.cpp
+++ b/src/node/test/secret_share.cpp
@@ -15,8 +15,8 @@ TEST_CASE("Simple test")
 
   INFO("Data to split must be have fixed length");
   {
-    auto random = crypto::create_entropy()->random(
-      ccf::SecretSharing::SECRET_TO_SPLIT_LENGTH);
+    auto random =
+      crypto::get_entropy()->random(ccf::SecretSharing::SECRET_TO_SPLIT_LENGTH);
     std::copy_n(
       random.begin(),
       ccf::SecretSharing::SECRET_TO_SPLIT_LENGTH,


### PR DESCRIPTION
Ensure that operations applied to the secret or to the shares are constant time, without relying on compiler optimisation, minor renaming and test improvements.

This is not particularly performance sensitive, but for the record:

Before:
```
commit c557d9c4642517fb12338a22b2742aa793800c5c (HEAD -> main)
cmake -GNinja -DCOMPILE_TARGET=virtual ..

share:
===============================================================================
   Name (baseline is *)   |   Dim   |  Total ms |  ns/op  |Baseline| Ops/second
===============================================================================
           share_10s_d1 * |      10 |     0.175 |   17515 |      - |    57091.6
            share_100s_d1 |      10 |     0.210 |   20988 |  1.198 |    47646.3
           share_1000s_d1 |      10 |     0.560 |   56005 |  3.197 |    17855.5
             share_10s_d5 |      10 |     0.682 |   68176 |  3.892 |    14667.8
            share_100s_d5 |      10 |     1.093 |  109267 |  6.238 |     9151.9
           share_1000s_d5 |      10 |     3.293 |  329292 | 18.800 |     3036.8
   share_n_recover_10s_d1 |      10 |     0.178 |   17756 |  1.014 |    56318.0
  share_n_recover_100s_d1 |      10 |     0.213 |   21251 |  1.213 |    47055.1
 share_n_recover_1000s_d1 |      10 |     0.561 |   56115 |  3.204 |    17820.5
   share_n_recover_10s_d5 |      10 |     0.884 |   88377 |  5.046 |    11315.1
  share_n_recover_100s_d5 |      10 |     1.104 |  110449 |  6.306 |     9053.9
 share_n_recover_1000s_d5 |      10 |     3.306 |  330566 | 18.873 |     3025.1
===============================================================================
```

After:

```
commit e42b1d5b5bd4ff08405d3e1756d2acca20fdce56 (HEAD -> secret_sharing_review_feedback, origin/secret_sharing_review_feedback)
cmake -GNinja -DCOMPILE_TARGET=virtual ..

share:
===============================================================================
   Name (baseline is *)   |   Dim   |  Total ms |  ns/op  |Baseline| Ops/second
===============================================================================
           share_10s_d1 * |      10 |     0.176 |   17636 |      - |    56699.6
            share_100s_d1 |      10 |     0.186 |   18606 |  1.055 |    53745.8
           share_1000s_d1 |      10 |     0.706 |   70605 |  4.003 |    14163.2
             share_10s_d5 |      10 |     0.877 |   87712 |  4.973 |    11400.9
            share_100s_d5 |      10 |     0.974 |   97373 |  5.521 |    10269.7
           share_1000s_d5 |      10 |     3.778 |  377773 | 21.420 |     2647.1
   share_n_recover_10s_d1 |      10 |     0.179 |   17867 |  1.013 |    55967.9
  share_n_recover_100s_d1 |      10 |     0.227 |   22668 |  1.285 |    44114.1
 share_n_recover_1000s_d1 |      10 |     0.708 |   70829 |  4.016 |    14118.4
   share_n_recover_10s_d5 |      10 |     0.893 |   89263 |  5.061 |    11202.8
  share_n_recover_100s_d5 |      10 |     1.175 |  117471 |  6.661 |     8512.7
 share_n_recover_1000s_d5 |      10 |     3.897 |  389687 | 22.095 |     2566.2
===============================================================================
```