### PR TITLE
RaftDriver: Check `commit_safety` after every step, as invariant

### DIFF
--- a/src/consensus/aft/test/driver.cpp
+++ b/src/consensus/aft/test/driver.cpp
@@ -88,7 +88,7 @@ int main(int argc, char** argv)
     }
 #endif
     // Steps which don't alter state don't need to recheck invariants
-    bool skip_invariants = false; 
+    bool skip_invariants = false;
 
     switch (shash(in))
     {

--- a/src/consensus/aft/test/driver.cpp
+++ b/src/consensus/aft/test/driver.cpp
@@ -254,10 +254,6 @@ int main(int argc, char** argv)
         skip_invariants = true;
         driver->assert_state_sync(lineno);
         break;
-      case shash("assert_commit_safety"):
-        assert(items.size() == 2);
-        driver->assert_commit_safety(items[1], lineno);
-        break;
       case shash("assert_is_backup"):
         assert(items.size() == 2);
         skip_invariants = true;

--- a/src/consensus/aft/test/driver.cpp
+++ b/src/consensus/aft/test/driver.cpp
@@ -87,6 +87,9 @@ int main(int argc, char** argv)
                 << std::endl;
     }
 #endif
+    // Steps which don't alter state don't need to recheck invariants
+    bool skip_invariants = false; 
+
     switch (shash(in))
     {
       case shash("start_node"):
@@ -170,18 +173,22 @@ int main(int argc, char** argv)
         break;
       case shash("state_one"):
         assert(items.size() == 2);
+        skip_invariants = true;
         driver->state_one(items[1]);
         break;
       case shash("state_all"):
         assert(items.size() == 1);
+        skip_invariants = true;
         driver->state_all();
         break;
       case shash("summarise_log"):
         assert(items.size() == 2);
+        skip_invariants = true;
         driver->summarise_log(items[1]);
         break;
       case shash("summarise_logs_all"):
         assert(items.size() == 1);
+        skip_invariants = true;
         driver->summarise_logs_all();
         break;
       case shash("shuffle_one"):
@@ -244,6 +251,7 @@ int main(int argc, char** argv)
         break;
       case shash("assert_state_sync"):
         assert(items.size() == 1);
+        skip_invariants = true;
         driver->assert_state_sync(lineno);
         break;
       case shash("assert_commit_safety"):
@@ -252,38 +260,47 @@ int main(int argc, char** argv)
         break;
       case shash("assert_is_backup"):
         assert(items.size() == 2);
+        skip_invariants = true;
         driver->assert_is_backup(items[1], lineno);
         break;
       case shash("assert_isnot_backup"):
         assert(items.size() == 2);
+        skip_invariants = true;
         driver->assert_isnot_backup(items[1], lineno);
         break;
       case shash("assert_is_primary"):
         assert(items.size() == 2);
+        skip_invariants = true;
         driver->assert_is_primary(items[1], lineno);
         break;
       case shash("assert_isnot_primary"):
         assert(items.size() == 2);
+        skip_invariants = true;
         driver->assert_isnot_primary(items[1], lineno);
         break;
       case shash("assert_is_candidate"):
         assert(items.size() == 2);
+        skip_invariants = true;
         driver->assert_is_candidate(items[1], lineno);
         break;
       case shash("assert_isnot_candidate"):
         assert(items.size() == 2);
+        skip_invariants = true;
         driver->assert_isnot_candidate(items[1], lineno);
         break;
       case shash("assert_is_retired"):
         assert(items.size() == 2);
+        skip_invariants = true;
         driver->assert_is_retired(items[1], lineno);
         break;
       case shash("assert_is_active"):
         assert(items.size() == 2);
+        skip_invariants = true;
         driver->assert_is_active(items[1], lineno);
         break;
       case shash("assert_commit_idx"):
         assert(items.size() == 3);
+        skip_invariants = true;
         driver->assert_commit_idx(items[1], items[2], lineno);
         break;
       case shash("replicate_new_configuration"):
@@ -298,11 +315,18 @@ int main(int argc, char** argv)
         break;
       case shash(""):
         // Ignore empty lines
+        skip_invariants = true;
         break;
       default:
         throw std::runtime_error(
           fmt::format("Unknown action '{}' at line {}", items[0], lineno));
     }
+
+    if (!skip_invariants)
+    {
+      driver->assert_invariants(lineno);
+    }
+
     ++lineno;
   }
 

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -1122,8 +1122,8 @@ public:
       if (configuration.idx <= committed_seqno)
       {
         const auto nodes = configuration.nodes;
-        const auto present_count =
-          std::count_if(nodes.begin(), nodes.end(), [&present_on](const auto& it) {
+        const auto present_count = std::count_if(
+          nodes.begin(), nodes.end(), [&present_on](const auto& it) {
             const auto& [id, _] = it;
             return present_on[id];
           });
@@ -1131,28 +1131,23 @@ public:
         const auto quorum = (nodes.size() / 2) + 1;
         if (present_count < quorum)
         {
-          RAFT_DRIVER_OUT
-            << fmt::format(
-                 "  Note over {}: Node has advanced commit to {}, "
-                 "yet this entry is only present on {}/{} nodes "
-                 "(need at least {} for safety in configuration {}, beginning "
-                 "at {})",
-                 node_id,
-                 committed_seqno,
-                 present_count,
-                 _nodes.size(),
-                 quorum,
-                 configuration.rid,
-                 configuration.idx)
-            << std::endl;
+          RAFT_DRIVER_PRINT(
+            "Note over {}: Node has advanced commit to {},  yet this entry is "
+            "only present on {}/{} nodes (need at least {} for safety in "
+            "configuration {}, beginning at {})",
+            node_id,
+            committed_seqno,
+            present_count,
+            _nodes.size(),
+            quorum,
+            configuration.rid,
+            configuration.idx);
           throw std::runtime_error(fmt::format(
             "Node ({}) at unsafe commit idx ({}) on line {}",
             node_id,
             committed_seqno,
             lineno));
         }
-        RAFT_DRIVER_OUT << "Note right of bob: Checked quorumloginv!"
-                        << std::endl;
       }
     }
   }

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -1199,6 +1199,20 @@ public:
       }
     }
   }
+
+  void assert_commit_safety_all(const size_t lineno)
+  {
+    for (const auto& [node_id, _] : _nodes)
+    {
+      assert_commit_safety(node_id, lineno);
+    }
+  }
+
+  void assert_invariants(const size_t lineno)
+  {
+    // Check invariants:
+    // Assert commit_index on all nodes is safe
+    assert_commit_safety_all(lineno);
   }
 
   void assert_commit_idx(

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -1132,8 +1132,6 @@ public:
     // majority of nodes (ledger matches exactly up to and including this
     // seqno).
     // Similar to the QuorumLogInv invariant from the TLA spec.
-    // NB: This currently assumes a single configuration, as it checks a quorum
-    // of all nodes rather than within each configuration
     const auto& raft = _nodes.at(node_id).raft;
     const auto committed_seqno = raft->get_committed_seqno();
 
@@ -1154,33 +1152,53 @@ public:
     };
     const auto committed_prefix = get_ledger_prefix(node_id, committed_seqno);
 
-    auto is_present = [&](const auto& it) {
-      const auto& [id, _] = it;
-      return get_ledger_prefix(id, committed_seqno) == committed_prefix;
-    };
-
-    const auto present_count =
-      std::count_if(_nodes.begin(), _nodes.end(), is_present);
-
-    const auto quorum = (_nodes.size() / 2) + 1;
-    if (present_count < quorum)
+    std::map<ccf::NodeId, bool> present_on;
+    for (const auto& [node_id, _] : _nodes)
     {
-      RAFT_DRIVER_OUT << fmt::format(
-                           "  Note over {}: Node has advanced commit to {}, "
-                           "yet this entry is only present on {}/{} nodes "
-                           "(need at least {} for safety)",
-                           node_id,
-                           committed_seqno,
-                           present_count,
-                           _nodes.size(),
-                           quorum)
-                      << std::endl;
-      throw std::runtime_error(fmt::format(
-        "Node ({}) at unsafe commit idx ({}) on line {}",
-        node_id,
-        committed_seqno,
-        lineno));
+      present_on[node_id] =
+        get_ledger_prefix(node_id, committed_seqno) == committed_prefix;
     }
+
+    const auto details = raft->get_details();
+    for (const auto& configuration : details.configs)
+    {
+      if (configuration.idx <= committed_seqno)
+      {
+        const auto nodes = configuration.nodes;
+        const auto present_count =
+          std::count_if(nodes.begin(), nodes.end(), [&present_on](const auto& it) {
+            const auto& [id, _] = it;
+            return present_on[id];
+          });
+
+        const auto quorum = (nodes.size() / 2) + 1;
+        if (present_count < quorum)
+        {
+          RAFT_DRIVER_OUT
+            << fmt::format(
+                 "  Note over {}: Node has advanced commit to {}, "
+                 "yet this entry is only present on {}/{} nodes "
+                 "(need at least {} for safety in configuration {}, beginning "
+                 "at {})",
+                 node_id,
+                 committed_seqno,
+                 present_count,
+                 _nodes.size(),
+                 quorum,
+                 configuration.rid,
+                 configuration.idx)
+            << std::endl;
+          throw std::runtime_error(fmt::format(
+            "Node ({}) at unsafe commit idx ({}) on line {}",
+            node_id,
+            committed_seqno,
+            lineno));
+        }
+        RAFT_DRIVER_OUT << "Note right of bob: Checked quorumloginv!"
+                        << std::endl;
+      }
+    }
+  }
   }
 
   void assert_commit_idx(

--- a/tests/raft_scenarios/soft_rollback
+++ b/tests/raft_scenarios/soft_rollback
@@ -37,7 +37,6 @@ dispatch_all
 # NB: This dispatch includes the response, so node 0 has advanced commit
 # This response could arrive much later, since 0 and 1 do not need to communicate further
 state_all
-assert_commit_safety,0
 
 # Disconnect node 0. Not strictly required, but simplifies work going forwards
 disconnect_node,0
@@ -59,7 +58,6 @@ dispatch_one,2
 
 # Node 1 should retain the committed state!
 state_all
-assert_commit_safety,0
 
 # Node 1 should not vote for node 2!
 dispatch_one,1
@@ -69,7 +67,6 @@ assert_isnot_primary,2
 periodic_all,10
 dispatch_all
 state_all
-assert_commit_safety,0
 
 # Now restore comms between 0 and 1, and disconnect 2
 reconnect_node,0

--- a/tests/raft_scenarios/suffix_collision.2
+++ b/tests/raft_scenarios/suffix_collision.2
@@ -118,9 +118,6 @@ connect,0,2
 periodic_all,10
 dispatch_all
 state_all
-assert_commit_safety,0
-assert_commit_safety,1
-assert_commit_safety,2
 
 # Node 1 tries to bring node 0 back in line
 # But we get unlucky with timing, and node 1 continually follows up with a heartbeat before hearing the response

--- a/tests/raft_scenarios/suffix_collision.3
+++ b/tests/raft_scenarios/suffix_collision.3
@@ -162,10 +162,9 @@ dispatch_one,2
 dispatch_one,0
 
 # Node 2 receives ACK from node 3
+# It must not advance commit based on the NACK index from node 0!
 dispatch_one,3
 
 # Debug print current state
 state_all
 
-# It must not advance commit based on the NACK index from node 0!
-assert_commit_safety,2


### PR DESCRIPTION
I realised that the coverage of our `assert_commit_safety` action is unnecessarily sparse. We insert it occasionally, but could be missing any number of safety violations elsewhere. It's cheap enough (with the current scale of scenarios) to assert this on every node, at every step. So we do!