### PR TITLE
Add details of last matching line in TV CI

### DIFF
--- a/.azure-pipelines-templates/trace_validation.yml
+++ b/.azure-pipelines-templates/trace_validation.yml
@@ -12,7 +12,7 @@ steps:
       cd tla/
       mkdir traces
       cp ../build/*.ndjson traces/
-      parallel 'set -o pipefail && echo {} && JVM_OPTIONS=-Dtlc2.tool.queue.IStateQueue=StateDeque JSON={} ./tlc.sh -dump dot,constrained,colorize,actionlabels {}.dot -dumpTrace tla {}.trace.tla -dumpTrace json {}.trace.json consensus/Traceccfraft.tla | egrep "CounterExample written" | ./last_line.sh {}.trace.json' ::: $(ls traces/*.ndjson)
+      parallel 'set -o pipefail && echo {} && JVM_OPTIONS=-Dtlc2.tool.queue.IStateQueue=StateDeque JSON={} ./tlc.sh -dump dot,constrained,colorize,actionlabels {}.dot -dumpTrace tla {}.trace.tla -dumpTrace json {}.trace.json consensus/Traceccfraft.tla | ./last_line.sh {}.trace.json' ::: $(ls traces/*.ndjson)
     displayName: "Run trace validation"
 
   - task: PublishPipelineArtifact@1

--- a/.azure-pipelines-templates/trace_validation.yml
+++ b/.azure-pipelines-templates/trace_validation.yml
@@ -12,7 +12,7 @@ steps:
       cd tla/
       mkdir traces
       cp ../build/*.ndjson traces/
-      parallel 'set -o pipefail && echo {} && JVM_OPTIONS=-Dtlc2.tool.queue.IStateQueue=StateDeque JSON={} ./tlc.sh -dump dot,constrained,colorize,actionlabels {}.dot -dumpTrace tla {}.trace.tla -dumpTrace json {}.trace.json consensus/Traceccfraft.tla | egrep "(CounterExample written|Finished in)"' ::: $(ls traces/*.ndjson)
+      parallel 'set -o pipefail && echo {} && JVM_OPTIONS=-Dtlc2.tool.queue.IStateQueue=StateDeque JSON={} ./tlc.sh -dump dot,constrained,colorize,actionlabels {}.dot -dumpTrace tla {}.trace.tla -dumpTrace json {}.trace.json consensus/Traceccfraft.tla | egrep "CounterExample written" | ./last_line.sh {}.trace.json' ::: $(ls traces/*.ndjson)
     displayName: "Run trace validation"
 
   - task: PublishPipelineArtifact@1

--- a/tla/last_line.sh
+++ b/tla/last_line.sh
@@ -4,8 +4,13 @@
 
 # Extract a summary of the last line in a trace, useful when finding out where a scenario has mismatched
 
+RED="\033[31m"
+NORMAL="\033[0;39m"
+
 if [ -e "$1" ]; then
-    cat "$1" | jq '.action | last | .[2][1]._logline | "Last matched [" + .h_ts + "] " + .msg.function + " (" + .cmd + ")"'
+    echo -ne "$RED"
+    cat "$1" | jq '.action | last | .[2][1]._logline | "Last matched [" + .h_ts + "] " + .msg.function + " (" + .cmd + ")"' | xargs
+    echo -ne "$NORMAL"
     exit 1
 fi
 exit 0

--- a/tla/last_line.sh
+++ b/tla/last_line.sh
@@ -6,4 +6,6 @@
 
 if [ -e "$1" ]; then
     cat "$1" | jq '.action | last | .[2][1]._logline | "Last matched [" + .h_ts + "] " + .msg.function + " (" + .cmd + ")"'
+    exit 1
 fi
+exit 0

--- a/tla/last_line.sh
+++ b/tla/last_line.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+# Extract a summary of the last line in a trace, useful when finding out where a scenario has mismatched
+
+if [ -e "$1" ]; then
+    cat "$1" | jq '.action | last | .[2][1]._logline | "Last matched [" + .h_ts + "] " + .msg.function + " (" + .cmd + ")"'
+fi


### PR DESCRIPTION
Made possible by https://github.com/tlaplus/tlaplus/commit/f153944df690111878f521fc530ebc511a7e9892, sample output:

```
traces/append.ndjson
traces/election.ndjson
traces/reconnect.ndjson
traces/reconfiguration.ndjson
traces/multi_election.ndjson
traces/check_quorum.ndjson
traces/replicate.ndjson
traces/reelection.ndjson
traces/retire_one.ndjson
traces/startup.ndjson
traces/election_while_reconfiguration.ndjson
traces/startup_2nodes.ndjson
traces/soft_rollback.ndjson
traces/bad_network.ndjson
traces/swap_node_no_election.ndjson
"Last matched [181] send_append_entries (periodic_all,10)"
traces/suffix_collision.1.ndjson
traces/swap_node.ndjson
"Last matched [361] send_append_entries (periodic_all,10)"
traces/fancy_election.1.ndjson
traces/fancy_election.2.ndjson
```

We might want to add more context, but this at least lets us find quickly which scenario(s) failed, and where exactly.