### PR TITLE
Retired committed hook receives whole config

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -309,13 +309,13 @@ namespace aft
           CCF_ASSERT(
             state->retirement_phase == kv::RetirementPhase::Completed,
             "Node is not retired, cannot become retired committed");
-          state->retirement_phase = kv::RetirementPhase::RetiredCommitted;
           CCF_ASSERT_FMT(
             state->retired_committed_idx == state->commit_idx,
             "Retired "
             "committed index {} does not match current commit index {}",
             state->retired_committed_idx.value_or(0),
             state->commit_idx);
+          state->retirement_phase = kv::RetirementPhase::RetiredCommitted;
           state->retired_committed_idx = seqno;
         }
       }

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -296,7 +296,8 @@ namespace aft
       return state->membership_state == kv::MembershipState::Retired;
     }
 
-    void set_retired_committed(ccf::SeqNo seqno) override
+    void set_retired_committed(
+      ccf::SeqNo seqno, const std::vector<kv::NodeId>& node_ids) override
     {
       state->retirement_phase = kv::RetirementPhase::RetiredCommitted;
       CCF_ASSERT_FMT(

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -299,14 +299,26 @@ namespace aft
     void set_retired_committed(
       ccf::SeqNo seqno, const std::vector<kv::NodeId>& node_ids) override
     {
-      state->retirement_phase = kv::RetirementPhase::RetiredCommitted;
-      CCF_ASSERT_FMT(
-        state->retired_committed_idx == state->commit_idx,
-        "Retired "
-        "committed index {} does not match current commit index {}",
-        state->retired_committed_idx.value_or(0),
-        state->commit_idx);
-      state->retired_committed_idx = seqno;
+      for (auto& node_id : node_ids)
+      {
+        if (id() == node_id)
+        {
+          CCF_ASSERT(
+            state->membership_state == kv::MembershipState::Retired,
+            "Node is not retired, cannot become retired committed");
+          CCF_ASSERT(
+            state->retirement_phase == kv::RetirementPhase::Completed,
+            "Node is not retired, cannot become retired committed");
+          state->retirement_phase = kv::RetirementPhase::RetiredCommitted;
+          CCF_ASSERT_FMT(
+            state->retired_committed_idx == state->commit_idx,
+            "Retired "
+            "committed index {} does not match current commit index {}",
+            state->retired_committed_idx.value_or(0),
+            state->commit_idx);
+          state->retired_committed_idx = seqno;
+        }
+      }
     }
 
     Index last_committable_index() const

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -198,7 +198,7 @@ private:
       std::make_shared<aft::State>(node_id),
       nullptr);
     kv->set_set_retired_committed_hook(
-      [&raft](aft::Index idx, const std::vector<kv::NodeId>& node_ids) {
+      [raft](aft::Index idx, const std::vector<kv::NodeId>& node_ids) {
         raft->set_retired_committed(idx, node_ids);
       });
     raft->start_ticking();

--- a/src/consensus/aft/test/driver.h
+++ b/src/consensus/aft/test/driver.h
@@ -198,7 +198,9 @@ private:
       std::make_shared<aft::State>(node_id),
       nullptr);
     kv->set_set_retired_committed_hook(
-      [&raft](aft::Index idx) { raft->set_retired_committed(idx); });
+      [&raft](aft::Index idx, const std::vector<kv::NodeId>& node_ids) {
+        raft->set_retired_committed(idx, node_ids);
+      });
     raft->start_ticking();
 
     if (_nodes.find(node_id) != _nodes.end())

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -476,7 +476,9 @@ namespace kv
 
     virtual void enable_all_domains() {}
 
-    virtual void set_retired_committed(ccf::SeqNo){};
+    virtual void set_retired_committed(
+      ccf::SeqNo, const std::vector<NodeId>& node_ids)
+    {}
   };
 
   struct PendingTxInfo

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -2148,23 +2148,16 @@ namespace ccf
         network.nodes.get_name(),
         network.nodes.wrap_commit_hook(
           [this](kv::Version hook_version, const Nodes::Write& w) {
+            std::vector<NodeId> retired_committed_nodes;
             for (const auto& [node_id, node_info] : w)
             {
-              if (node_id != self)
+              if (node_info.has_value() && node_info->retired_committed)
               {
-                // Only update our own state
-                continue;
-              }
-
-              if (node_info.has_value())
-              {
-                if (node_info->retired_committed)
-                {
-                  consensus->set_retired_committed(hook_version);
-                }
-                return;
+                retired_committed_nodes.push_back(node_id);
               }
             }
+            consensus->set_retired_committed(
+              hook_version, retired_committed_nodes);
           }));
 
       // Service-endorsed certificate is passed to history as early as _local_


### PR DESCRIPTION
No impact change extracted from #5973, expanding #5962 to provide raft with enough information to know when it can stop tracking nodes.

```
set_retired_committed(ccf::SeqNo seqno)
```

becomes

```
set_retired_committed(const std::vector<kv::NodeId>& node_ids)
```