### PR TITLE
ccfraft: Use `m.prevLogTerm` in `RejectAppendEntriesRequest` when finding highest match

### DIFF
--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -941,7 +941,7 @@ RejectAppendEntriesRequest(i, j, m, logOk) ==
                              dest           |-> j],
                              m)
                    \/ /\ prevTerm # 0
-                      /\ LET lli == FindHighestPossibleMatch(log[i], m.prevLogIndex, m.term)
+                      /\ LET lli == FindHighestPossibleMatch(log[i], m.prevLogIndex, m.prevLogTerm)
                          IN Reply([type        |-> AppendEntriesResponse,
                                 success        |-> FALSE,
                                 term           |-> IF lli = 0 THEN StartTerm ELSE log[i][lli].term,


### PR DESCRIPTION
Extracting spec fix from here into standalone PR for clarity:

https://github.com/microsoft/CCF/pull/6009#discussion_r1494481306