### PR TITLE
Fix flaky scenario on 4.x branch

### DIFF
--- a/tests/raft_scenarios/bad_network
+++ b/tests/raft_scenarios/bad_network
@@ -111,6 +111,7 @@ dispatch_all_once
 
 # Node 1 is now primary, though it still doesn't know that 2 is committed
 state_all
+emit_signature,7
 
 # Now we allow the network to heal and return to normal
 periodic_all,10


### PR DESCRIPTION
Noticed that the `raft_scenario_test` is failing occasionally on 4.x. Unsure exactly where the non-determinism comes from (multiple nodes calling elections? Undefined dispatch order?), but it is resolved by ensuring the final primary emits a signature so that commit can be advanced to it.