### PR TITLE
Expose node cert subject name in config correctly to test/sandbox infra

### DIFF
--- a/tests/config.jinja
+++ b/tests/config.jinja
@@ -12,7 +12,7 @@
   },
   "node_certificate":
   {
-    "subject_name": "CN=CCF Node",
+    "subject_name": "{{ subject_name }}",
     "subject_alt_names": {{ subject_alt_names|tojson }},
     "curve_id": "{{ curve_id }}",
     "initial_validity_days": {{ initial_node_cert_validity_days }}

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -217,8 +217,9 @@ def cli_args(
         default=True,
     )
     parser.add_argument(
-        "--sn",
+        "--subject-name",
         help="Subject Name in node certificate, eg. CN=CCF Node",
+        default="CN=CCF Node",
     )
     parser.add_argument(
         "--subject-alt-names",

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -198,6 +198,7 @@ class Network:
         "max_msg_size_bytes",
         "snp_security_policy_file",
         "snp_uvm_endorsements_file",
+        "subject_name",
     ]
 
     # Maximum delay (seconds) for updates to propagate from the primary to backups


### PR DESCRIPTION
Also renamed `--sn` to `--subject-name` for clarity. The option existed previously, but was not correctly forwarded and set in the config template.

Thank you @takuro-sato for spotting this.