### PR TITLE
Raft Spec: Fix IsRetiredCommittedLog to use log argument

### DIFF
--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -513,8 +513,8 @@ RetirementIndex(i) ==
 
 IsRetiredCommittedLog(log_i, commit_index_i, i) ==
     \E idx \in 1..commit_index_i:
-        /\ log[i][idx].contentType = TypeRetired
-        /\ i \in log[i][idx].retired
+        /\ log_i[idx].contentType = TypeRetired
+        /\ i \in log_i[idx].retired
 
 IsRetiredCommitted(i) ==
     IsRetiredCommittedLog(log[i],commitIndex[i],i)


### PR DESCRIPTION
Found while making changes in #5973, when `IsRetiredCommittedLog` is used on `log'/commitIdx'`, for example through `CalcMembershipState`, this can produce out of bounds access (`commitIdx'` used to index into `log[i]`, as opposed to `log'[i]`).