### PR TITLE
Update PlausibleSucessorNodes logic and remove the global removedFromConfiguration

### DIFF
--- a/tla/consensus/MCAliases.tla
+++ b/tla/consensus/MCAliases.tla
@@ -64,7 +64,6 @@ DebugAliasAggregates ==
 
 DebugAliasVars ==
     [
-        removedFromConfiguration |-> removedFromConfiguration,
         configurations |-> configurations,
         messages |-> messages,
         currentTerm |-> currentTerm,
@@ -97,7 +96,6 @@ DebugActingServerAlias ==
         \* Comment this format in VSCode because it breaks its parser. :-()
         _format |-> B[srv] \o "/\\[0m %1$s = %2$s\n",
         srv |-> srv,
-        removedFromConfiguration |-> removedFromConfiguration,
         configurations |-> configurations[srv],
         currentTerm |-> currentTerm[srv],
         votedFor |-> votedFor[srv],

--- a/tla/consensus/Traceccfraft.tla
+++ b/tla/consensus/Traceccfraft.tla
@@ -109,7 +109,6 @@ TraceAppendEntriesBatchsize(i, j) ==
     sentIndex[i][j] .. Len(log[i])
 
 TraceInitReconfigurationVars ==
-    /\ removedFromConfiguration = {}
     /\ InitLogConfigServerVars({TraceLog[1].msg.state.node_id}, StartLog)
 
 -------------------------------------------------------------------------------------
@@ -529,8 +528,7 @@ TraceDifferentialInv ==
      \* 1) Toggle comments of TRUE and the LET/IN below
     TRUE
     \* LET t == INSTANCE trace d == t!Trace[l]
-    \* IN /\ d.removedFromConfiguration = removedFromConfiguration
-    \*    /\ d.configurations = configurations
+    \* IN /\ d.configurations = configurations
     \*    /\ d.messages = messages
     \*    /\ d.currentTerm = currentTerm
     \*    /\ d.state = leadershipState

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -548,9 +548,12 @@ AppendEntriesBatchsize(i, j) ==
 
 PlausibleSucessorNodes(i) ==
     \* Find plausible successor nodes for i
+    \* See raft.h::become_retired:2062
+    \* The node looks across nodes in all known configurations and finds the subset with the highest match index.
+    \* That set is further filtered to the nodes in the highest configuration.
     LET
-        activeServers == Servers \ removedFromConfiguration
-        highestMatchServers == {n \in activeServers : \A m \in activeServers : matchIndex[i][n] >= matchIndex[i][m]}
+        all_other_nodes == GetServerSet(i) \ {i}
+        highestMatchServers == {n \in all_other_nodes : \A m \in all_other_nodes : matchIndex[i][n] >= matchIndex[i][m]}
     IN {n \in highestMatchServers : \A m \in highestMatchServers: HighestConfigurationWithNode(i, n) >= HighestConfigurationWithNode(i, m)} \ {i}
 
 StartLog(startNode, _ignored) ==


### PR DESCRIPTION
With #6044, allows the global removedFromConfiguration to go away. #5973 will need to add a node-scope equivalent to its modified all_other_nodes (GetServerSet(i) + nodes that have been removed from that but are not RetiredCommitted).