### PR TITLE
Get `kv_bench` running again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1197,15 +1197,13 @@ if(BUILD_TESTS)
       LINK_LIBS ccf_kv.host
     )
 
-    if(LONG_TESTS)
-      add_picobench(
-        kv_bench
-        SRCS src/kv/test/kv_bench.cpp src/enclave/thread_local.cpp
-        LINK_LIBS ccf_kv.host
-      )
-      add_picobench(merkle_bench SRCS src/node/test/merkle_bench.cpp)
-      add_picobench(hash_bench SRCS src/ds/test/hash_bench.cpp)
-    endif()
+    add_picobench(
+      kv_bench
+      SRCS src/kv/test/kv_bench.cpp src/enclave/thread_local.cpp
+      LINK_LIBS ccf_kv.host
+    )
+    add_picobench(merkle_bench SRCS src/node/test/merkle_bench.cpp)
+    add_picobench(hash_bench SRCS src/ds/test/hash_bench.cpp)
 
     set(CONSTITUTION_ARGS
         --constitution

--- a/src/kv/test/kv_bench.cpp
+++ b/src/kv/test/kv_bench.cpp
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
-#define PICOBENCH_IMPLEMENT_WITH_MAIN
+#define PICOBENCH_IMPLEMENT
 
+#include "crypto/openssl/hash.h"
 #include "kv/store.h"
 #include "kv/test/stub_consensus.h"
 #include "node/encryptor.h"
@@ -280,3 +281,12 @@ PICOBENCH(des_snap<100>)
   .samples(snapshot_sample_size)
   .baseline();
 PICOBENCH(des_snap<1000>).iterations(map_count).samples(snapshot_sample_size);
+
+int main(int argc, char** argv)
+{
+  crypto::openssl_sha256_init();
+
+  picobench::runner runner;
+  runner.parse_cmd_line(argc, argv);
+  return runner.run();
+}


### PR DESCRIPTION
Noticed completely by accident on another PR. The combination of builds/tests we currently run never includes both CMake's `LONG_TESTS=ON` and the `benchmark` label to CTest, resulting in several picobenchmarks being skipped. One of those (`kv_bench`) was crashing on startup due to a missing initialization step.

I think these are all fast enough that they shouldn't be gated? Maybe they should be blocked in Debug runs or similar.