### PR TITLE
Add get_create_tx_claims_digest to the research API

### DIFF
--- a/include/ccf/research/create_tx_claims_digest.h
+++ b/include/ccf/research/create_tx_claims_digest.h
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include <kv/kv_types.h>
+#include <optional>
+
+namespace ccfapp
+{
+  /** Can be optionally implemented by the application to set the claims digest
+   * for the initial network create transaction.
+   *
+   * @return an optional claims digest
+   */
+  std::optional<ccf::ClaimsDigest::Digest> get_create_tx_claims_digest(
+    kv::ReadOnlyTx& tx)
+}

--- a/samples/apps/logging/CMakeLists.txt
+++ b/samples/apps/logging/CMakeLists.txt
@@ -16,7 +16,7 @@ if(NOT TARGET "ccf")
   find_package(${CCF_PROJECT} REQUIRED)
 endif()
 
-add_ccf_app(logging SRCS logging.cpp)
+add_ccf_app(logging SRCS logging.cpp create_tx_claims_digest.cpp)
 
 # Generate an ephemeral signing key
 add_custom_command(

--- a/samples/apps/logging/create_tx_claims_digest.cpp
+++ b/samples/apps/logging/create_tx_claims_digest.cpp
@@ -1,15 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the Apache 2.0 License.
-#include <optional>
-#include <ccf/tx.h>
 #include <ccf/receipt.h>
 #include <ccf/service/tables/constitution.h>
+#include <ccf/tx.h>
+#include <optional>
 
 namespace ccfapp
 {
-  std::optional<ccf::ClaimsDigest::Digest> get_create_tx_claims_digest(kv::ReadOnlyTx& tx)
+  std::optional<ccf::ClaimsDigest::Digest> get_create_tx_claims_digest(
+    kv::ReadOnlyTx& tx)
   {
-    auto constitution = tx.ro<ccf::Constitution>(ccf::Tables::CONSTITUTION)->get();
+    auto constitution =
+      tx.ro<ccf::Constitution>(ccf::Tables::CONSTITUTION)->get();
     if (!constitution.has_value())
     {
       throw std::logic_error("Constitution is missing");

--- a/samples/apps/logging/create_tx_claims_digest.cpp
+++ b/samples/apps/logging/create_tx_claims_digest.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#include <optional>
+#include <ccf/tx.h>
+#include <ccf/receipt.h>
+#include <ccf/service/tables/constitution.h>
+
+namespace ccfapp
+{
+  std::optional<ccf::ClaimsDigest::Digest> get_create_tx_claims_digest(kv::ReadOnlyTx& tx)
+  {
+    auto constitution = tx.ro<ccf::Constitution>(ccf::Tables::CONSTITUTION)->get();
+    if (!constitution.has_value())
+    {
+      throw std::logic_error("Constitution is missing");
+    }
+    return ccf::ClaimsDigest::Digest(constitution.value());
+  }
+}

--- a/src/node/rpc/no_create_tx_claims_digest.cpp
+++ b/src/node/rpc/no_create_tx_claims_digest.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+
+#include <optional>
+
+namespace ccfapp
+{
+  std::optional<ccf::ClaimsDigest::Digest> __attribute__((weak))
+  get_create_tx_claims_digest(kv::ReadOnlyTx& tx)
+  {
+    return std::nullopt;
+  }
+}

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -19,6 +19,7 @@
 #include "js/wrap.h"
 #include "node/network_state.h"
 #include "node/rpc/jwt_management.h"
+#include "node/rpc/no_create_tx_claims_digest.cpp"
 #include "node/rpc/serialization.h"
 #include "node/session_metrics.h"
 #include "node_interface.h"
@@ -1587,6 +1588,14 @@ namespace ccf
             ctx.tx, host_data, in.snp_security_policy);
           InternalTablesAccess::trust_node_uvm_endorsements(
             ctx.tx, in.snp_uvm_endorsements);
+        }
+
+        std::optional<ccf::ClaimsDigest::Digest> digest =
+          ccfapp::get_create_tx_claims_digest(ctx.tx);
+        if (digest.has_value())
+        {
+          auto digest_value = digest.value();
+          ctx.rpc_ctx->set_claims_digest(std::move(digest_value));
         }
 
         LOG_INFO_FMT("Created service");

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -909,7 +909,10 @@ def test_genesis_receipt(network, args):
         # Only the logging app sets a claim on the genesis
         assert claims_digest == sha256(constitution.encode()).hexdigest()
     else:
-        assert claims_digest == "0000000000000000000000000000000000000000000000000000000000000000"
+        assert (
+            claims_digest
+            == "0000000000000000000000000000000000000000000000000000000000000000"
+        )
 
     return network
 


### PR DESCRIPTION
Add a research API allowing applications to define a claims digest on the _create transaction_ of a network. As a sample, the following call is added to the logging app, to capture the digest of the constitution in the receipt of the _create transaction_.

```
namespace ccfapp
{
  std::optional<ccf::ClaimsDigest::Digest> get_create_tx_claims_digest(kv::ReadOnlyTx& tx)
  {
    auto constitution = tx.ro<ccf::Constitution>(ccf::Tables::CONSTITUTION)->get();
    if (!constitution.has_value())
    {
      throw std::logic_error("Constitution is missing");
    }
    return ccf::ClaimsDigest::Digest(constitution.value());
  }
}
```

Note that this is a research API, and is subject to change without prior notice.

Closes #6055.