### PR TITLE
Stop retired nodes in tests that resize network

### DIFF
--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -1247,6 +1247,7 @@ class Network:
         while node_count > target_count:
             primary, backup = self.find_primary_and_any_backup()
             self.retire_node(primary, backup)
+            backup.stop()
             node_count -= 1
         primary, _ = self.find_primary()
         self.wait_for_all_nodes_to_commit(primary)


### PR DESCRIPTION
With #5973, nodes that are retired committed, but not aware of it, can be disruptive to the network. There were a few cases in our tests that were updated in the PR, but this was missed and manifested itself in this CI run: https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=82762&view=logs&j=8f3dc89c-3708-5926-47e7-27120a268dab&t=3aae4c9d-f0dc-5b97-1b0e-f86312395af9

Longer term, the implementation of PreVote (#2577) will resolve this.