### PR TITLE
Fix `raft_test`: check size of view histories before accessing

### DIFF
--- a/src/consensus/aft/test/committable_suffix.cpp
+++ b/src/consensus/aft/test/committable_suffix.cpp
@@ -731,8 +731,11 @@ DOCTEST_TEST_CASE_TEMPLATE("Multi-term divergence", T, WorstCase, RandomCase)
       const auto history_on_B = rB.get_view_history(common_last_idx);
       DOCTEST_REQUIRE(history_on_A != history_on_B);
 
-      // In fact they diverge almost immediately
-      DOCTEST_REQUIRE(history_on_A[1] != history_on_B[1]);
+      // In fact they diverge almost immediately (if they are long enough)
+      if (history_on_A.size() > 1 && history_on_B.size() > 1)
+      {
+        DOCTEST_REQUIRE(history_on_A[1] != history_on_B[1]);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #6075.

This is an unlikely situation, but deterministically reproducible from a given seed.

We're attempting to produce ledgers which conflict across multiple terms, randomly, but in rare instances we'll actually produce view histories like this:

```
history_on_A = 1
history_on_B = 1, 5, 5, 5, 6, 6, 6, 6, 6
```

In this situation all of our later asserts (and reconciliation) will pass, but our sanity check here that one is not a prefix of the other needs to be softened.

### How rare is this failure?
Based on these 2 random choices:
```
const auto num_terms = rand() % 30 + 5;
for (size_t i = 0; i < num_terms; ++i)
{
  create_term_on(rand() % 2 == 0, term_length);
}
```
We'll hit this case when every call to `create_term_on` has the same first argument (eg - all `false`, or all `true`). My napkin-math says that's something like:

![image](https://github.com/microsoft/CCF/assets/6000239/29da51cd-2042-42b0-8594-974bcd172381)

![image](https://github.com/microsoft/CCF/assets/6000239/781bd0ca-58f2-4010-84c2-f10975e91c0b)

(via WolframAlpha)

Does it fail about 0.4% of the time? Almost exactly, according to ADO Analytics for the Daily pipeline:

<img width="395" alt="image" src="https://github.com/microsoft/CCF/assets/6000239/00599571-8cb7-4788-a1c6-c65da82e1205">

Hell yeah stats.