### PR TITLE
Remove `is_create_request` flag

### DIFF
--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1948,7 +1948,6 @@ namespace ccf
         InvalidSessionId, self_signed_node_cert.raw());
       auto ctx = make_rpc_context(node_session, packed);
 
-      ctx->is_create_request = true;
       std::shared_ptr<ccf::RpcHandler> search =
         http::fetch_rpc_handler(ctx, this->rpc_map);
 

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -642,8 +642,8 @@ namespace ccf
           }
           else
           {
-            bool is_primary = (consensus == nullptr) ||
-              consensus->can_replicate() || ctx->is_create_request;
+            bool is_primary =
+              (consensus == nullptr) || consensus->can_replicate();
             const bool forwardable = (consensus != nullptr);
 
             if (!is_primary && forwardable)

--- a/src/node/rpc/rpc_context_impl.h
+++ b/src/node/rpc/rpc_context_impl.h
@@ -127,7 +127,6 @@ namespace ccf
       set_response_trailer(grpc::make_message_trailer(msg));
     }
 
-    bool is_create_request = false;
     bool response_is_pending = false;
     bool terminate_session = false;
 


### PR DESCRIPTION
I believe this is no longer needed - the create request is correctly executed locally for other reasons.