### PR TITLE
[release/4.x] Cherry-pick: Update CI image from 2024-04-03 to 2024-03-15 (#6105)

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -11,7 +11,7 @@ jobs:
     variables:
       Codeql.SkipTaskAutoInjection: true
       skipComponentGovernanceDetection: true
-    container: ccfmsrc.azurecr.io/ccf/ci:2024-03-21-virtual-clang15
+    container: ccfmsrc.azurecr.io/ccf/ci:2024-04-03-virtual-clang15
     pool:
       vmImage: ubuntu-20.04
 

--- a/.azure-pipelines-templates/deploy_aci.yml
+++ b/.azure-pipelines-templates/deploy_aci.yml
@@ -50,7 +50,7 @@ jobs:
       - script: |
           set -ex
           docker login -u $ACR_TOKEN_NAME -p $ACR_CI_PUSH_TOKEN_PASSWORD $ACR_REGISTRY
-          docker pull $ACR_REGISTRY/ccf/ci:2024-03-21-snp-clang15
+          docker pull $ACR_REGISTRY/ccf/ci:2024-04-03-snp-clang15
           docker build -f docker/ccf_ci_built . --build-arg="base=$BASE_IMAGE" --build-arg="platform=snp" -t $ACR_REGISTRY/ccf/ci:pr-`git rev-parse HEAD`
           docker push $ACR_REGISTRY/ccf/ci:pr-`git rev-parse HEAD`
         name: build_ci_image
@@ -59,7 +59,7 @@ jobs:
           ACR_TOKEN_NAME: ci-push-token
           ACR_CI_PUSH_TOKEN_PASSWORD: $(ACR_CI_PUSH_TOKEN_PASSWORD)
           ACR_REGISTRY: ccfmsrc.azurecr.io
-          BASE_IMAGE: ccfmsrc.azurecr.io/ccf/ci:2024-03-21-snp-clang15
+          BASE_IMAGE: ccfmsrc.azurecr.io/ccf/ci:2024-04-03-snp-clang15
 
       - script: |
           set -ex

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -29,15 +29,15 @@ schedules:
 resources:
   containers:
     - container: virtual
-      image: ccfmsrc.azurecr.io/ccf/ci:2024-03-21-virtual-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:2024-04-03-virtual-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: snp
-      image: ccfmsrc.azurecr.io/ccf/ci:2024-03-21-snp-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:2024-04-03-snp-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci:2024-03-21-sgx
+      image: ccfmsrc.azurecr.io/ccf/ci:2024-04-03-sgx
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /lib/modules:/lib/modules:ro
 
 variables:

--- a/.azure_pipelines_snp.yml
+++ b/.azure_pipelines_snp.yml
@@ -31,7 +31,7 @@ schedules:
 resources:
   containers:
     - container: virtual
-      image: ccfmsrc.azurecr.io/ccf/ci:2024-03-21-virtual-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:2024-04-03-virtual-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
 jobs:

--- a/.daily.yml
+++ b/.daily.yml
@@ -25,15 +25,15 @@ schedules:
 resources:
   containers:
     - container: virtual
-      image: ccfmsrc.azurecr.io/ccf/ci:2024-03-21-virtual-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:2024-04-03-virtual-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE
 
     - container: snp
-      image: ccfmsrc.azurecr.io/ccf/ci:2024-03-21-snp-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:2024-04-03-snp-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci:2024-03-21-sgx
+      image: ccfmsrc.azurecr.io/ccf/ci:2024-04-03-sgx
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx
 
 jobs:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "CCF Development Environment",
-  "image": "ccfmsrc.azurecr.io/ccf/ci:2024-03-21-virtual-clang15",
+  "image": "ccfmsrc.azurecr.io/ccf/ci:2024-04-03-virtual-clang15",
   "runArgs": [],
   "extensions": [
     "eamodio.gitlens",

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    container: ccfmsrc.azurecr.io/ccf/ci:2024-03-21-virtual-clang15
+    container: ccfmsrc.azurecr.io/ccf/ci:2024-04-03-virtual-clang15
 
     steps:
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -14,7 +14,7 @@ jobs:
     name: Model Checking - Consensus
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
-      image: ccfmsrc.azurecr.io/ccf/ci:2024-03-21-virtual-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:2024-04-03-virtual-clang15
 
     steps:
       - uses: actions/checkout@v3

--- a/.multi-thread.yml
+++ b/.multi-thread.yml
@@ -16,7 +16,7 @@ pr:
 resources:
   containers:
     - container: virtual
-      image: ccfmsrc.azurecr.io/ccf/ci:2024-03-21-virtual-clang15
+      image: ccfmsrc.azurecr.io/ccf/ci:2024-04-03-virtual-clang15
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
 jobs:

--- a/.stress.yml
+++ b/.stress.yml
@@ -20,7 +20,7 @@ schedules:
 resources:
   containers:
     - container: sgx
-      image: ccfmsrc.azurecr.io/ccf/ci:2024-03-21-sgx
+      image: ccfmsrc.azurecr.io/ccf/ci:2024-04-03-sgx
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx
 
 jobs:

--- a/docker/ccf_ci_built
+++ b/docker/ccf_ci_built
@@ -4,7 +4,7 @@
 
 # Latest image as of this change
 ARG platform=sgx
-ARG base=ccfmsrc.azurecr.io/ccf/ci:2024-03-21-snp-clang-15
+ARG base=ccfmsrc.azurecr.io/ccf/ci:2024-04-03-snp-clang-15
 FROM ${base}
 
 # SSH. Note that this could (should) be done in the base ccf_ci image instead

--- a/scripts/azure_deployment/arm_aci.py
+++ b/scripts/azure_deployment/arm_aci.py
@@ -132,7 +132,7 @@ def parse_aci_args(parser: ArgumentParser) -> Namespace:
         "--aci-image",
         help="The name of the image to deploy in the ACI",
         type=str,
-        default="ccfmsrc.azurecr.io/ccf/ci:2024-03-21-snp",
+        default="ccfmsrc.azurecr.io/ccf/ci:2024-04-03-snp",
     )
     parser.add_argument(
         "--aci-type",


### PR DESCRIPTION
Backports the following commits to release/4.x:
- #6105