### PR TITLE
Python infra: Set `gov_api_version` from launch

### DIFF
--- a/tests/governance_history.py
+++ b/tests/governance_history.py
@@ -292,7 +292,7 @@ def run(args):
             ).withdraw(primary, new_member_proposal)
             infra.checker.Checker(c)(response)
         assert response.status_code == http.HTTPStatus.OK.value
-        assert response.body.json()["state"] == ProposalState.WITHDRAWN.value
+        assert response.body.json()["proposalState"] == ProposalState.WITHDRAWN.value
         member = network.consortium.get_member_by_local_id(
             new_member_proposal.proposer_id
         )

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -56,6 +56,7 @@ class Consortium:
         curve=None,
         public_state=None,
         authenticate_session="COSE",
+        gov_api_version=infra.member.MemberAPI.Preview_v1.API_VERSION,
     ):
         self.common_dir = common_dir
         self.members = []
@@ -64,7 +65,7 @@ class Consortium:
         self.consensus = consensus
         self.recovery_threshold = None
         self.authenticate_session = authenticate_session
-        self.gov_api_impl = infra.member.MemberAPI.Classic
+        self.set_gov_api_version(gov_api_version)
         # If a list of member IDs is passed in, generate fresh member identities.
         # Otherwise, recover the state of the consortium from the common directory
         # and the state of the service

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -581,12 +581,11 @@ class Network:
             args.consensus,
             initial_members_info,
             args.participants_curve,
+            gov_api_version=args.gov_api_version,
         )
         set_authenticate_session = kwargs.pop("set_authenticate_session", None)
         if set_authenticate_session is not None:
             self.consortium.set_authenticate_session(set_authenticate_session)
-
-        self.consortium.set_gov_api_version(args.gov_api_version)
 
         primary = self._start_all_nodes(args, **kwargs)
         self.wait_for_all_nodes_to_commit(primary=primary)
@@ -681,12 +680,11 @@ class Network:
                 self.share_script,
                 args.consensus,
                 public_state=public_state,
+                gov_api_version=args.gov_api_version,
             )
 
         if set_authenticate_session is not None:
             self.consortium.set_authenticate_session(set_authenticate_session)
-
-        self.consortium.set_gov_api_version(args.gov_api_version)
 
         for node in self.get_joined_nodes():
             self.wait_for_state(


### PR DESCRIPTION
Previously had weird early period where members who were created too early used classic API, regardless of intended settings.