### PR TITLE
Remove scheduled CI triggers for 3.x

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -15,17 +15,6 @@ pr:
     include:
       - "*"
 
-schedules:
-  - cron: "0 3 * * Mon-Fri"
-    displayName: Daily morning build
-    branches:
-      include:
-        - main
-        - "release/*"
-      exclude:
-        - "release/1.x"
-    always: true
-
 resources:
   containers:
     - container: virtual

--- a/.daily.yml
+++ b/.daily.yml
@@ -11,17 +11,6 @@ pr:
 
 trigger: none
 
-schedules:
-  - cron: "0 3 * * Mon-Fri"
-    displayName: Daily build
-    branches:
-      include:
-        - main
-        - "release/*"
-      exclude:
-        - "release/1.x"
-    always: true
-
 resources:
   containers:
     - container: virtual


### PR DESCRIPTION
These are still running daily, but failing because they reference unsupported images. Removing, as 3.x has been out of support for several months.