### PR TITLE
Remove use of `METRICS_MONGO_CONNECTION`, disable cimetrics

### DIFF
--- a/.azure-pipelines-templates/common.yml
+++ b/.azure-pipelines-templates/common.yml
@@ -57,8 +57,9 @@ jobs:
       - ${{ if eq(parameters.suffix, 'ScanBuild') }}:
           - template: scan_build.yml
 
-      - ${{ if eq(parameters.suffix, 'Perf') }}:
-          - template: push_perf_data.yml
+      # Temporarily disabled, until cimetrics supports auth other than connection-string
+      # - ${{ if eq(parameters.suffix, 'Perf') }}:
+      #     - template: push_perf_data.yml
 
       - ${{ if eq(parameters.suffix, 'Release') }}:
           - template: install_deb.yml

--- a/.azure-pipelines-templates/matrix.yml
+++ b/.azure-pipelines-templates/matrix.yml
@@ -158,17 +158,18 @@ jobs:
           depends_on:
             - configure
 
-  - ${{ if eq(parameters.perf_tests, 'run') }}:
-      - template: cimetrics.yml
-        parameters:
-          target: Virtual
-          env: ${{ parameters.env.Virtual }}
-          suffix: "Perf"
-          installExtendedTestingTools: false
-          depends_on:
-            - configure
-            - SGX_Perf
-            - Virtual_Perf
-            - Virtual_Perf_MultiThreaded
-            - SGX_Perf_MultiThreaded
-            - Simulation
+  # Temporarily disabled, until cimetrics supports auth other than connection-string
+  # - ${{ if eq(parameters.perf_tests, 'run') }}:
+  #     - template: cimetrics.yml
+  #       parameters:
+  #         target: Virtual
+  #         env: ${{ parameters.env.Virtual }}
+  #         suffix: "Perf"
+  #         installExtendedTestingTools: false
+  #         depends_on:
+  #           - configure
+  #           - SGX_Perf
+  #           - Virtual_Perf
+  #           - Virtual_Perf_MultiThreaded
+  #           - SGX_Perf_MultiThreaded
+  #           - Simulation

--- a/.azure-pipelines-templates/metrics.yml
+++ b/.azure-pipelines-templates/metrics.yml
@@ -1,13 +1,9 @@
 steps:
   - script: ./cimetrics_env.sh python -m cimetrics.upload_complete
-    env:
-      METRICS_MONGO_CONNECTION: $(METRICS_MONGO_CONNECTION)
     workingDirectory: tests
     displayName: "Mark metrics upload as complete"
 
   - script: ./cimetrics_env.sh python -m cimetrics.plot
-    env:
-      METRICS_MONGO_CONNECTION: $(METRICS_MONGO_CONNECTION)
     workingDirectory: tests
     displayName: "Plot cimetrics"
 

--- a/.azure-pipelines-templates/push_perf_data.yml
+++ b/.azure-pipelines-templates/push_perf_data.yml
@@ -1,6 +1,4 @@
 steps:
   - script: ./cimetrics_env.sh python upload_pico_metrics.py
-    env:
-      METRICS_MONGO_CONNECTION: $(METRICS_MONGO_CONNECTION)
     workingDirectory: build
     displayName: "Upload picobench metrics"

--- a/.azure-pipelines-templates/simulation.yml
+++ b/.azure-pipelines-templates/simulation.yml
@@ -26,14 +26,13 @@ jobs:
         workingDirectory: tla
         displayName: Simulation
 
-      - ${{ if eq(parameters.metrics, true) }}:
-          - script: |
-              set -ex
-              ./cimetrics_env.sh python upload_tlc_stats.py sim ../tla/SIMccfraft_stats.json
-            env:
-              METRICS_MONGO_CONNECTION: $(METRICS_MONGO_CONNECTION)
-            workingDirectory: tests
-            displayName: Uploading TLC stats to cimetrics
+      # Temporarily disabled, until cimetrics supports auth other than connection-string
+      # - ${{ if eq(parameters.metrics, true) }}:
+      #     - script: |
+      #         set -ex
+      #         ./cimetrics_env.sh python upload_tlc_stats.py sim ../tla/SIMccfraft_stats.json
+      #       workingDirectory: tests
+      #       displayName: Uploading TLC stats to cimetrics
 
       - task: PublishPipelineArtifact@1
         inputs:


### PR DESCRIPTION
`METRICS_MONGO_CONNECTION` contains a secret, so we are removing it. This currently means we must also disable cimetrics.

We should separately explore if there's a cheap way to add an alternative auth mechanism to cimetrics.