### PR TITLE
[TLC Repro] Stack overflow likely caused by large state variable

### DIFF
--- a/tests/tvc.py
+++ b/tests/tvc.py
@@ -35,7 +35,7 @@ VALUE = "value"
 class Log:
     """
     A simple way to defer logging until the end of transaction cycle,
-    and to prepend actions if necessary, such as TruncateLedgerAction
+    and to prepend actions if necessary
     """
 
     def __init__(self):
@@ -116,7 +116,7 @@ def run(targets, cacert):
                                 )
                                 new_view, _ = tx_id(txid)
                                 if new_view > view:
-                                    log.prepend(action="TruncateLedgerAction")
+                                    # log.prepend(action="TruncateLedgerAction")
                                     view = new_view
                                 final = True
                                 break

--- a/tests/tvc.py
+++ b/tests/tvc.py
@@ -85,10 +85,13 @@ def run(targets, cacert):
             if response.status_code == 204:
                 log(action=f"{txtype}TxRequestAction", type=f"{txtype}TxRequest", tx=tx)
                 txid = response.headers["x-ms-ccf-transaction-id"]
+                # In principle, the spec doesn't observe the transaction id until RwTxResponseAction
+                # but in practice, it is needed for trace validation, to bound the number of AppendOtherTxnActions.
+                # We would otherwise risk inserting in the "wrong" place, and never get the correct RwTxResponseAction.
                 log(
                     action="RwTxExecuteAction",
                     type="RwTxExecute",
-                    view=tx_id(txid)[0],
+                    tx_id=tx_id(txid),
                     tx=tx,
                 )
                 log(

--- a/tla/consistency/ExternalHistory.tla
+++ b/tla/consistency/ExternalHistory.tla
@@ -21,6 +21,10 @@ TxStatuses == {
     InvalidStatus
     }
 
+\* Although views start at 1, this constant allows increasing the first branch
+\* that can be appended to, to enable trace validation against CCF, where view starts at 2
+CONSTANT FirstBranch
+
 \* Views start at 1, 0 is used a null value
 Views == Nat
 

--- a/tla/consistency/MCMultiNode.cfg
+++ b/tla/consistency/MCMultiNode.cfg
@@ -1,6 +1,7 @@
 SPECIFICATION MCSpecMultiNode
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 6
     ViewLimit = 3
 

--- a/tla/consistency/MCMultiNodeCommitReachability.cfg
+++ b/tla/consistency/MCMultiNodeCommitReachability.cfg
@@ -2,6 +2,7 @@ SPECIFICATION MCSpecMultiNodeReads
 
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 6
     ViewLimit = 1
 

--- a/tla/consistency/MCMultiNodeInvalidReachability.cfg
+++ b/tla/consistency/MCMultiNodeInvalidReachability.cfg
@@ -2,6 +2,7 @@ SPECIFICATION MCSpecMultiNodeReads
 
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 7
     ViewLimit = 2
 

--- a/tla/consistency/MCMultiNodeReads.cfg
+++ b/tla/consistency/MCMultiNodeReads.cfg
@@ -1,6 +1,7 @@
 SPECIFICATION MCSpecMultiNodeReads
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 6
     ViewLimit = 3
 

--- a/tla/consistency/MCMultiNodeReadsAlt.cfg
+++ b/tla/consistency/MCMultiNodeReadsAlt.cfg
@@ -1,6 +1,7 @@
 SPECIFICATION MCSpecMultiNodeReadsAlt
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 11
     ViewLimit = 3
 

--- a/tla/consistency/MCMultiNodeReadsNotLinearizable.cfg
+++ b/tla/consistency/MCMultiNodeReadsNotLinearizable.cfg
@@ -2,6 +2,7 @@ SPECIFICATION MCSpecMultiNodeReads
 
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 8
     ViewLimit = 2
 

--- a/tla/consistency/MCSingleNode.cfg
+++ b/tla/consistency/MCSingleNode.cfg
@@ -1,6 +1,7 @@
 SPECIFICATION MCSpecSingleNode
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 7
 
     RwTxRequest = RwTxRequest

--- a/tla/consistency/MCSingleNodeCommitReachability.cfg
+++ b/tla/consistency/MCSingleNodeCommitReachability.cfg
@@ -2,6 +2,7 @@ SPECIFICATION MCSpecSingleNode
 
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 3
 
     RwTxRequest = RwTxRequest

--- a/tla/consistency/MCSingleNodeReads.cfg
+++ b/tla/consistency/MCSingleNodeReads.cfg
@@ -1,6 +1,7 @@
 SPECIFICATION MCSpecSingleNodeReads
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 7
 
     RwTxRequest = RwTxRequest

--- a/tla/consistency/MultiNodeReads.cfg
+++ b/tla/consistency/MultiNodeReads.cfg
@@ -1,6 +1,8 @@
 SPECIFICATION SpecMultiNodeReads
 
 CONSTANTS
+    FirstBranch = 1
+    
     RwTxRequest = RwTxRequest
     RwTxResponse = RwTxResponse
     RoTxRequest = RoTxRequest

--- a/tla/consistency/SingleNode.tla
+++ b/tla/consistency/SingleNode.tla
@@ -33,7 +33,7 @@ TypeOK ==
 
 Init ==
     /\ history = <<>>
-    /\ ledgerBranches = [ x \in {1, 2} |-> <<>>]
+    /\ ledgerBranches = [ x \in 1..FirstBranch |-> <<>>]
 
 IndexOfLastRequested ==
     SelectLastInSeq(history, LAMBDA e : e.type \in {RwTxRequest, RoTxRequest})
@@ -61,7 +61,7 @@ RwTxExecuteAction ==
                 => history[i].tx /= ledgerBranches[view][seqnum].tx
         \* Note that a transaction can be added to any ledger, simulating the fact
         \* that it can be picked up by the current leader or any former leader
-        /\ \E view \in 2..Len(ledgerBranches):
+        /\ \E view \in FirstBranch..Len(ledgerBranches):
                 ledgerBranches' = [ledgerBranches EXCEPT ![view] = 
                     Append(@,[view |-> view, tx |-> history[i].tx])]
         /\ UNCHANGED history
@@ -79,7 +79,7 @@ RwTxResponseAction ==
             /\ j > i 
             /\ history[j].type = RwTxResponse
             /\ history[j].tx = history[i].tx} = {}
-        /\ \E view \in 2..Len(ledgerBranches):
+        /\ \E view \in FirstBranch..Len(ledgerBranches):
             /\ \E seqnum \in DOMAIN ledgerBranches[view]: 
                 /\ "tx" \in DOMAIN ledgerBranches[view][seqnum]
                 /\ history[i].tx = ledgerBranches[view][seqnum].tx
@@ -109,7 +109,7 @@ StatusCommittedResponseAction ==
 
 \* Append a transaction to the ledger which does not impact the state we are considering
 AppendOtherTxnAction ==
-    /\ \E view \in 2..Len(ledgerBranches):
+    /\ \E view \in FirstBranch..Len(ledgerBranches):
         ledgerBranches' = [ledgerBranches EXCEPT ![view] = 
                     Append(@,[view |-> view])]
     /\ UNCHANGED history

--- a/tla/consistency/SingleNode.tla
+++ b/tla/consistency/SingleNode.tla
@@ -79,7 +79,7 @@ RwTxResponseAction ==
             /\ j > i 
             /\ history[j].type = RwTxResponse
             /\ history[j].tx = history[i].tx} = {}
-        /\ \E view \in DOMAIN ledgerBranches:
+        /\ \E view \in 2..Len(ledgerBranches):
             /\ \E seqnum \in DOMAIN ledgerBranches[view]: 
                 /\ "tx" \in DOMAIN ledgerBranches[view][seqnum]
                 /\ history[i].tx = ledgerBranches[view][seqnum].tx

--- a/tla/consistency/SingleNode.tla
+++ b/tla/consistency/SingleNode.tla
@@ -33,7 +33,7 @@ TypeOK ==
 
 Init ==
     /\ history = <<>>
-    /\ ledgerBranches = [ x \in {1} |-> <<>>]
+    /\ ledgerBranches = [ x \in {1, 2} |-> <<>>]
 
 IndexOfLastRequested ==
     SelectLastInSeq(history, LAMBDA e : e.type \in {RwTxRequest, RoTxRequest})
@@ -61,7 +61,7 @@ RwTxExecuteAction ==
                 => history[i].tx /= ledgerBranches[view][seqnum].tx
         \* Note that a transaction can be added to any ledger, simulating the fact
         \* that it can be picked up by the current leader or any former leader
-        /\ \E view \in DOMAIN ledgerBranches:
+        /\ \E view \in 2..Len(ledgerBranches):
                 ledgerBranches' = [ledgerBranches EXCEPT ![view] = 
                     Append(@,[view |-> view, tx |-> history[i].tx])]
         /\ UNCHANGED history
@@ -109,7 +109,7 @@ StatusCommittedResponseAction ==
 
 \* Append a transaction to the ledger which does not impact the state we are considering
 AppendOtherTxnAction ==
-    /\ \E view \in DOMAIN ledgerBranches:
+    /\ \E view \in 2..Len(ledgerBranches):
         ledgerBranches' = [ledgerBranches EXCEPT ![view] = 
                     Append(@,[view |-> view])]
     /\ UNCHANGED history

--- a/tla/consistency/SingleNode.tla
+++ b/tla/consistency/SingleNode.tla
@@ -6,6 +6,8 @@
 
 EXTENDS ExternalHistoryInvars, TLC
 
+MaxOr(S) ==
+    Max(S \cup {0})
 
 \* Abstract ledgers that contains only client transactions (no signatures)
 \* Indexed by view, each ledger is the ledger associated with leader of that view 
@@ -63,11 +65,11 @@ RwTxExecuteAction ==
         \* that it can be picked up by the current leader or any former leader
         /\ \E view \in FirstBranch..Len(ledgerBranches):
                 ledgerBranches' = [ledgerBranches EXCEPT ![view] = 
-                    Append(@,[view |-> view, tx |-> history[i].tx])]
+                    @ @@ (MaxOr(DOMAIN ledgerBranches[view])+1) :> [view |-> view, tx |-> history[i].tx]]
         /\ UNCHANGED history
 
 LedgerBranchTxOnly(branch) ==
-    LET SubBranch == SelectSeq(branch, LAMBDA e : "tx" \in DOMAIN e)
+    LET SubBranch == [ i \in {j \in DOMAIN branch : "tx" \in DOMAIN branch[j] } |-> branch[i] ] 
     IN [i \in DOMAIN SubBranch |-> SubBranch[i].tx]
 
 \* Response to a read-write transaction
@@ -87,7 +89,7 @@ RwTxResponseAction ==
                     history,[
                         type |-> RwTxResponse, 
                         tx |-> history[i].tx, 
-                        observed |-> LedgerBranchTxOnly(SubSeq(ledgerBranches[view],1,seqnum)),
+                        observed |-> LedgerBranchTxOnly([j \in DOMAIN ledgerBranches[view] \cap 1..seqnum |-> ledgerBranches[view][j]]),
                         tx_id |-> <<ledgerBranches[view][seqnum].view, seqnum>>] )
     /\ UNCHANGED ledgerBranches
 
@@ -96,7 +98,7 @@ RwTxResponseAction ==
 StatusCommittedResponseAction ==
     /\ \E i \in DOMAIN history :
         /\ history[i].type = RwTxResponse
-        /\ Len(ledgerBranches[Len(ledgerBranches)]) >= history[i].tx_id[2]
+        /\ Max(DOMAIN ledgerBranches[Len(ledgerBranches)]) >= history[i].tx_id[2]
         /\ ledgerBranches[Len(ledgerBranches)][history[i].tx_id[2]].view = history[i].tx_id[1]
         \* Reply
         /\ history' = Append(
@@ -110,8 +112,7 @@ StatusCommittedResponseAction ==
 \* Append a transaction to the ledger which does not impact the state we are considering
 AppendOtherTxnAction ==
     /\ \E view \in FirstBranch..Len(ledgerBranches):
-        ledgerBranches' = [ledgerBranches EXCEPT ![view] = 
-                    Append(@,[view |-> view])]
+        ledgerBranches' = [ledgerBranches EXCEPT ![view] = @ @@ (MaxOr(DOMAIN ledgerBranches[view])+1) :> [view |-> view] ]
     /\ UNCHANGED history
 
 \* A CCF service with a single node will never have a view change

--- a/tla/consistency/SingleNodeReads.tla
+++ b/tla/consistency/SingleNodeReads.tla
@@ -22,7 +22,7 @@ RoTxResponseAction ==
             /\ j > i 
             /\ history[j].type = RoTxResponse
             /\ history[j].tx = history[i].tx} = {}
-        /\ \E view \in 2..Len(ledgerBranches):
+        /\ \E view \in FirstBranch..Len(ledgerBranches):
             /\ Len(ledgerBranches[view]) > 0
             /\ history' = Append(
                 history,[

--- a/tla/consistency/SingleNodeReads.tla
+++ b/tla/consistency/SingleNodeReads.tla
@@ -22,7 +22,7 @@ RoTxResponseAction ==
             /\ j > i 
             /\ history[j].type = RoTxResponse
             /\ history[j].tx = history[i].tx} = {}
-        /\ \E view \in DOMAIN ledgerBranches:
+        /\ \E view \in 2..Len(ledgerBranches):
             /\ Len(ledgerBranches[view]) > 0
             /\ history' = Append(
                 history,[

--- a/tla/consistency/SingleNodeReads.tla
+++ b/tla/consistency/SingleNodeReads.tla
@@ -23,13 +23,13 @@ RoTxResponseAction ==
             /\ history[j].type = RoTxResponse
             /\ history[j].tx = history[i].tx} = {}
         /\ \E view \in FirstBranch..Len(ledgerBranches):
-            /\ Len(ledgerBranches[view]) > 0
+            /\ ledgerBranches[view] # <<>>
             /\ history' = Append(
                 history,[
                     type |-> RoTxResponse, 
                     tx |-> history[i].tx, 
                     observed |-> LedgerBranchTxOnly(ledgerBranches[view]),
-                    tx_id |-> <<ledgerBranches[view][Len(ledgerBranches[view])].view, Len(ledgerBranches[view])>>] )
+                    tx_id |-> <<ledgerBranches[view][Max(DOMAIN ledgerBranches[view])].view, Max(DOMAIN ledgerBranches[view])>>] )
     /\ UNCHANGED ledgerBranches
 
 NextSingleNodeReadsAction ==

--- a/tla/consistency/TraceMultiNodeReads.cfg
+++ b/tla/consistency/TraceMultiNodeReads.cfg
@@ -46,3 +46,6 @@ CONSTANTS
 
     CommittedStatus = CommittedStatus
     InvalidStatus = InvalidStatus
+
+    \* View starts at 2 in CCF
+    FirstBranch = 2

--- a/tla/consistency/TraceMultiNodeReads.cfg
+++ b/tla/consistency/TraceMultiNodeReads.cfg
@@ -16,14 +16,14 @@ POSTCONDITION
 \* The real property to check is that TraceSpec contains a trace that refines ccfraft and
 \* matches the full log.  However, TLA cannot check this property directly because it
 \* is a hyperproperty.
-PROPERTIES
-    MNRSpec
+\* PROPERTIES
+\*     MNRSpec
 
-\* TLA has only limited support for hyperproperties.  The following property is a poorman's
-\* hyperproperty that asserts that TLC generated *at least one* trace that fully matches the
-\* log file. 
-PROPERTIES
-    TraceMatched
+\* \* TLA has only limited support for hyperproperties.  The following property is a poorman's
+\* \* hyperproperty that asserts that TLC generated *at least one* trace that fully matches the
+\* \* log file. 
+\* PROPERTIES
+\*     TraceMatched
 
 \* Checking for deadlocks during trace validation is disabled, as it may lead to false
 \* counterexamples. A trace specification defines a set of traces, where at least one

--- a/tla/consistency/TraceMultiNodeReads.tla
+++ b/tla/consistency/TraceMultiNodeReads.tla
@@ -57,14 +57,16 @@ IsRwTxExecuteAction ==
     /\ IsEvent("RwTxExecuteAction")
     /\ RwTxExecuteAction
     /\ Last(history').tx = logline.tx
-    /\ Len(ledgerBranches') = logline.view
+    \* RwTxExecuteAction can only take place if a branch exists for the view
+    /\ Len(ledgerBranches) >= logline.tx_id[1]
+    \* and it contains just the right amount of transactions (seqno - 1)
+    /\ Len(ledgerBranches[logline.tx_id[1]]) = logline.tx_id[2] - 1
 
 IsRwTxResponseAction ==
     /\ IsEvent("RwTxResponseAction")
     /\ RwTxResponseAction
     /\ Last(history').type = ToTxType[logline.type]
     /\ Last(history').tx = logline.tx
-    /\ Last(history').status = ToStatus[logline.status]
     /\ Last(history').tx_id = logline.tx_id
 
 IsStatusCommittedResponseAction ==
@@ -104,8 +106,6 @@ InsertTruncateLedgerAction ==
 
 InsertOtherTxnAction ==
     /\ IsNotEvent
-    /\ "tx_id" \in DOMAIN logline
-    /\ logline.tx_id[2] > Len(Last(ledgerBranches))
     /\ AppendOtherTxnAction
 
 TraceNext ==

--- a/tla/consistency/TraceMultiNodeReads.tla
+++ b/tla/consistency/TraceMultiNodeReads.tla
@@ -117,7 +117,7 @@ TraceNext ==
     \/ IsRoTxRequestAction
     \/ IsRoTxResponseAction
     \/ IsStatusInvalidResponseAction
-    \/ InsertTruncateLedgerAction
+    \* \/ InsertTruncateLedgerAction
     \/ InsertOtherTxnAction
 
 TraceSpec ==

--- a/tla/consistency/TraceMultiNodeReads.tla
+++ b/tla/consistency/TraceMultiNodeReads.tla
@@ -59,8 +59,8 @@ IsRwTxExecuteAction ==
     /\ Last(history').tx = logline.tx
     \* RwTxExecuteAction can only take place if a branch exists for the view
     /\ Len(ledgerBranches) >= logline.tx_id[1]
-    \* and that branch contains just the right amount of transactions (seqno - 1)
-    /\ Len(ledgerBranches[logline.tx_id[1]]) = logline.tx_id[2] - 1
+    \* and that branch contains just the right amount of transactions.
+    /\ Max(DOMAIN ledgerBranches[logline.tx_id[1]] \cup {0}) = logline.tx_id[2]
 
 IsRwTxResponseAction ==
     /\ IsEvent("RwTxResponseAction")

--- a/tla/consistency/TraceMultiNodeReads.tla
+++ b/tla/consistency/TraceMultiNodeReads.tla
@@ -59,7 +59,7 @@ IsRwTxExecuteAction ==
     /\ Last(history').tx = logline.tx
     \* RwTxExecuteAction can only take place if a branch exists for the view
     /\ Len(ledgerBranches) >= logline.tx_id[1]
-    \* and it contains just the right amount of transactions (seqno - 1)
+    \* and that branch contains just the right amount of transactions (seqno - 1)
     /\ Len(ledgerBranches[logline.tx_id[1]]) = logline.tx_id[2] - 1
 
 IsRwTxResponseAction ==

--- a/tla/consistency/TraceMultiNodeReads.tla
+++ b/tla/consistency/TraceMultiNodeReads.tla
@@ -86,6 +86,7 @@ IsRoTxResponseAction ==
     /\ RoTxResponseAction
     /\ Last(history').type = ToTxType[logline.type]
     /\ Last(history').tx = logline.tx
+    /\ Last(history').tx_id = logline.tx_id
 
 IsStatusInvalidResponseAction ==
     /\ IsEvent("StatusInvalidResponseAction")

--- a/tla/traces/consistency/trace.ndjson
+++ b/tla/traces/consistency/trace.ndjson
@@ -1,0 +1,20 @@
+{"action": "RwTxRequestAction", "type": "RwTxRequest", "tx": 0}
+{"action": "RwTxExecuteAction", "type": "RwTxExecute", "tx_id": [2, 29], "tx": 0}
+{"action": "RwTxResponseAction", "type": "RwTxResponse", "tx": 0, "tx_id": [2, 29]}
+{"action": "StatusCommittedResponseAction", "type": "TxStatusReceived", "tx_id": [2, 29], "status": "CommittedStatus"}
+{"action": "RoTxRequestAction", "type": "RoTxRequest", "tx": 1}
+{"action": "RoTxResponseAction", "type": "RoTxResponse", "tx": 1, "tx_id": [2, 30]}
+{"action": "RoTxRequestAction", "type": "RoTxRequest", "tx": 2}
+{"action": "RoTxResponseAction", "type": "RoTxResponse", "tx": 2, "tx_id": [2, 30]}
+{"action": "RwTxRequestAction", "type": "RwTxRequest", "tx": 3}
+{"action": "RwTxExecuteAction", "type": "RwTxExecute", "tx_id": [2, 31], "tx": 3}
+{"action": "RwTxResponseAction", "type": "RwTxResponse", "tx": 3, "tx_id": [2, 31]}
+{"action": "StatusCommittedResponseAction", "type": "TxStatusReceived", "tx_id": [2, 31], "status": "CommittedStatus"}
+{"action": "RwTxRequestAction", "type": "RwTxRequest", "tx": 4}
+{"action": "RwTxExecuteAction", "type": "RwTxExecute", "tx_id": [2, 34], "tx": 4}
+{"action": "RwTxResponseAction", "type": "RwTxResponse", "tx": 4, "tx_id": [2, 34]}
+{"action": "StatusInvalidResponseAction", "type": "TxStatusReceived", "tx_id": [2, 34], "status": "InvalidStatus"}
+{"action": "RwTxRequestAction", "type": "RwTxRequest", "tx": 5}
+{"action": "RwTxExecuteAction", "type": "RwTxExecute", "tx_id": [4, 36], "tx": 5}
+{"action": "RwTxResponseAction", "type": "RwTxResponse", "tx": 5, "tx_id": [4, 36]}
+


### PR DESCRIPTION
Steps:

```
cd tla
JSON=traces/consistency/trace.ndjson ./tlc.sh consistency/TraceMultiNodeReads.tla  > out
```

out then contains:

```
Error: This was a Java StackOverflowError. It was probably the result
of an incorrect recursive function definition that caused TLC to enter
an infinite loop when trying to compute the function or its application
to an element in its putative domain.
Error: The behavior up to this point is:
```

Warning: out gets large (30Mb+)