### PR TITLE
Parameterise consistency spec on FirstView

### DIFF
--- a/tla/consistency/ExternalHistory.tla
+++ b/tla/consistency/ExternalHistory.tla
@@ -21,6 +21,10 @@ TxStatuses == {
     InvalidStatus
     }
 
+\* Although views start at 1 in the consistency spec, this constant allows increasing the first branch
+\* that can be appended to, to enable trace validation against the implementation, where view starts at 2
+CONSTANT FirstBranch
+
 \* Views start at 1, 0 is used a null value
 Views == Nat
 

--- a/tla/consistency/MCMultiNode.cfg
+++ b/tla/consistency/MCMultiNode.cfg
@@ -1,6 +1,7 @@
 SPECIFICATION MCSpecMultiNode
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 6
     ViewLimit = 3
 

--- a/tla/consistency/MCMultiNodeCommitReachability.cfg
+++ b/tla/consistency/MCMultiNodeCommitReachability.cfg
@@ -2,6 +2,7 @@ SPECIFICATION MCSpecMultiNodeReads
 
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 6
     ViewLimit = 1
 

--- a/tla/consistency/MCMultiNodeInvalidReachability.cfg
+++ b/tla/consistency/MCMultiNodeInvalidReachability.cfg
@@ -2,6 +2,7 @@ SPECIFICATION MCSpecMultiNodeReads
 
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 7
     ViewLimit = 2
 

--- a/tla/consistency/MCMultiNodeReads.cfg
+++ b/tla/consistency/MCMultiNodeReads.cfg
@@ -1,6 +1,7 @@
 SPECIFICATION MCSpecMultiNodeReads
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 6
     ViewLimit = 3
 

--- a/tla/consistency/MCMultiNodeReadsAlt.cfg
+++ b/tla/consistency/MCMultiNodeReadsAlt.cfg
@@ -1,6 +1,7 @@
 SPECIFICATION MCSpecMultiNodeReadsAlt
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 11
     ViewLimit = 3
 

--- a/tla/consistency/MCMultiNodeReadsNotLinearizable.cfg
+++ b/tla/consistency/MCMultiNodeReadsNotLinearizable.cfg
@@ -2,6 +2,7 @@ SPECIFICATION MCSpecMultiNodeReads
 
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 8
     ViewLimit = 2
 

--- a/tla/consistency/MCSingleNode.cfg
+++ b/tla/consistency/MCSingleNode.cfg
@@ -1,6 +1,7 @@
 SPECIFICATION MCSpecSingleNode
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 7
 
     RwTxRequest = RwTxRequest

--- a/tla/consistency/MCSingleNodeCommitReachability.cfg
+++ b/tla/consistency/MCSingleNodeCommitReachability.cfg
@@ -2,6 +2,7 @@ SPECIFICATION MCSpecSingleNode
 
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 3
 
     RwTxRequest = RwTxRequest

--- a/tla/consistency/MCSingleNodeReads.cfg
+++ b/tla/consistency/MCSingleNodeReads.cfg
@@ -1,6 +1,7 @@
 SPECIFICATION MCSpecSingleNodeReads
 
 CONSTANTS
+    FirstBranch = 1
     HistoryLimit = 7
 
     RwTxRequest = RwTxRequest

--- a/tla/consistency/MultiNodeReads.cfg
+++ b/tla/consistency/MultiNodeReads.cfg
@@ -1,6 +1,8 @@
 SPECIFICATION SpecMultiNodeReads
 
 CONSTANTS
+    FirstBranch = 1
+
     RwTxRequest = RwTxRequest
     RwTxResponse = RwTxResponse
     RoTxRequest = RoTxRequest

--- a/tla/consistency/SingleNodeReads.tla
+++ b/tla/consistency/SingleNodeReads.tla
@@ -22,7 +22,7 @@ RoTxResponseAction ==
             /\ j > i 
             /\ history[j].type = RoTxResponse
             /\ history[j].tx = history[i].tx} = {}
-        /\ \E view \in DOMAIN ledgerBranches:
+        /\ \E view \in FirstBranch..Len(ledgerBranches):
             /\ Len(ledgerBranches[view]) > 0
             /\ history' = Append(
                 history,[

--- a/tla/consistency/TraceMultiNodeReads.cfg
+++ b/tla/consistency/TraceMultiNodeReads.cfg
@@ -38,6 +38,9 @@ CONSTRAINT
     Termination
 
 CONSTANTS
+    \* View starts at 2 in the implementation
+    FirstBranch = 2
+
     RwTxRequest = RwTxRequest
     RwTxResponse = RwTxResponse
     RoTxRequest = RoTxRequest


### PR DESCRIPTION
Split from #6136, this is useful when doing trace validation to be able to re-use `RwTxExecuteAction` without changes. We want to append to an arbitrary view (there could be an isolated primary), but definitely not to 1.