### PR TITLE
Enable both Invalid and Commit on the future of the head branch

### DIFF
--- a/tla/consistency/MultiNode.tla
+++ b/tla/consistency/MultiNode.tla
@@ -30,6 +30,10 @@ StatusInvalidResponseAction ==
                /\ CommitSeqNum < history[i].tx_id[2]
                /\ ledgerBranches[Len(ledgerBranches)][CommitSeqNum].view > history[i].tx_id[1]
         \* or commit hasn't reached there,... but can never reach there
+        \* note that this effectively allows StatusInvalidResponseAction to "declare" future transactions
+        \* invalid, and requires a corresponding change in SingleNode::StatusCommittedResponseAction to
+        \* constrain future commits. This combined change is unnecessary for model checking, but greatly
+        \* simplifies trace validation. 
             \/ /\ history[i].tx_id[1] = Len(ledgerBranches)
                /\ history[i].tx_id[2] > CommitSeqNum
         \* Reply

--- a/tla/consistency/MultiNode.tla
+++ b/tla/consistency/MultiNode.tla
@@ -25,10 +25,13 @@ StatusInvalidResponseAction ==
         /\ \/ /\ CommitSeqNum >= history[i].tx_id[2]
               /\ Len(ledgerBranches[Len(ledgerBranches)]) >= history[i].tx_id[2]
               /\ ledgerBranches[Len(ledgerBranches)][history[i].tx_id[2]].view # history[i].tx_id[1]
-        \* or commit hasn't reached seqnum but never will as current seqnum is higher
+        \* or commit hasn't reached seqnum but never will as current view is higher
             \/ /\ CommitSeqNum > 0
                /\ CommitSeqNum < history[i].tx_id[2]
                /\ ledgerBranches[Len(ledgerBranches)][CommitSeqNum].view > history[i].tx_id[1]
+        \* or commit hasn't reached there,... but can never reach there
+            \/ /\ history[i].tx_id[1] = Len(ledgerBranches)
+               /\ history[i].tx_id[2] > CommitSeqNum
         \* Reply
         /\ history' = Append(
             history,[

--- a/tla/consistency/SingleNode.tla
+++ b/tla/consistency/SingleNode.tla
@@ -101,6 +101,10 @@ StatusCommittedResponseAction ==
            /\ Len(Last(ledgerBranches)) >= seqno
            /\ Last(ledgerBranches)[seqno].view = view
            \* There is no future InvalidStatus that's incompatible with this commit
+           \* This is to accomodate StatusInvalidResponseAction making future commits invalid,
+           \* and is an unnecessary complication for model checking. It does facilitate trace
+           \* validation though, by allowing immediate processing of Invalids without
+           \* needing to wait for the commit history knowledge to catch up.
            /\ \lnot \E j \in DOMAIN history:
                 /\ history[j].type = TxStatusReceived
                 /\ history[j].status = InvalidStatus


### PR DESCRIPTION
Following discussion with @eddyashton, attempt to modify the consistency spec, in a minimal way, to allow for constructive Invalid (i.e. allow both the StatusCommittedResponseAction and the StatusInvalidResponseAction to make decisions about the future commit history).

This should be a no-op from an MC perspective (to be confirmed by the full CI), but would facilitate trace validation by allowing Invalid to be matched even when the known commit history doesn't extend far enough.

Quite tentative.