### PR TITLE
Do not run TLAi on forks

### DIFF
--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -113,7 +113,6 @@ jobs:
             tla/*.json
 
   tlai-linter:
-
     runs-on: ubuntu-latest
     if: github.repository == 'microsoft/CCF'
 

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -113,7 +113,9 @@ jobs:
             tla/*.json
 
   tlai-linter:
+
     runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/CCF'
 
     env:
       ## https://microsoft.github.io/genaiscript/reference/token/


### PR DESCRIPTION
Won't work because they haven't got access to tokens, this just results in a predictable red CI status.