### PR TITLE
Pin `sphinx-mdinclude` to 0.5.4

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -12,3 +12,6 @@ furo
 # docutils 0.17.0 causes "AttributeError: module 
 # 'docutils.nodes' has no attribute 'meta'" error when building doc
 docutils==0.18.*
+# Required-by: sphinxcontrib-openapi
+# cannot import name 'error_string' from 'docutils.io'
+sphinx-mdinclude==0.5.4


### PR DESCRIPTION
A new week, a new transitive-dependency-with-imprecise-version-constraints-causing-our-build-to-break. Our GitHub Pages action broke in the past few days:

```
Could not import extension sphinxcontrib.openapi (exception: cannot import name 'error_string' from 'docutils.io' (/data/src/2.CCF/env/lib/python3.8/site-packages/docutils/io.py))
```

Spelunking through packages named in the errors showed no recent releases, but a full code search showed `sphinx-mdinclude` (required by `sphinxcontrib.openapi`) using `docutils.io`, specifically:

```
from docutils.io import error_string as ErrorString
```

in v6.0, which was released a few days ago. Have pinned to previous version for now.