### PR TITLE
Fix read backfill off-by-one

### DIFF
--- a/.azure-pipelines-templates/trace_validation.yml
+++ b/.azure-pipelines-templates/trace_validation.yml
@@ -23,7 +23,7 @@ steps:
           cd tla/
           mkdir -p traces/consistency
           mv ../build/consistency/trace.ndjson traces/consistency/
-          JSON=traces/consistency/trace.ndjson ./tlc.sh -dump dot,constrained,colorize,actionlabels traces/consistency/trace.dot -dumpTrace tla traces/consistency/trace.trace.tla -dumpTrace json traces/consistency/trace.trace.json consistency/TraceMultiNodeReads.tla
+          JVM_OPTIONS=-Dtlc2.tool.queue.IStateQueue=StateDeque JSON=traces/consistency/trace.ndjson ./tlc.sh -dump dot,constrained,colorize,actionlabels traces/consistency/trace.dot -dumpTrace tla traces/consistency/trace.trace.tla -dumpTrace json traces/consistency/trace.trace.json consistency/TraceMultiNodeReads.tla
           ls traces
         displayName: "Run Consistency Trace Validation"
 

--- a/tla/consistency/TraceMultiNodeReads.cfg
+++ b/tla/consistency/TraceMultiNodeReads.cfg
@@ -37,6 +37,9 @@ CHECK_DEADLOCK
 CONSTRAINT 
     Termination
 
+_PERIODIC
+    Stats
+
 CONSTANTS
     \* View starts at 2 in the implementation
     FirstBranch = 2

--- a/tla/consistency/TraceMultiNodeReads.tla
+++ b/tla/consistency/TraceMultiNodeReads.tla
@@ -60,16 +60,16 @@ IsRwTxRequestAction ==
 
 IsRwTxExecuteAction ==
     /\ IsEvent("RwTxExecuteAction")
-    \* Model action
-    /\ RwTxExecuteAction
-    \* Match message contents
-    /\ Last(history').tx = logline.tx
     \* RwTxExecuteAction can only take place if a branch exists for the view
     \* If there is no branch, BackfillLedgerBranches will create the right amount of branches
     /\ Len(ledgerBranches) >= logline.tx_id[1]
     \* That branch contains just the right amount of transactions (seqno - 1)
     \* If that's not the case, BackfillLedgerBranche will create the right amount of txs
     /\ Len(ledgerBranches[logline.tx_id[1]]) = logline.tx_id[2] - 1
+    \* Model action
+    /\ RwTxExecuteAction
+    \* Match message contents
+    /\ Last(history').tx = logline.tx
 
 IsRwTxResponseAction ==
     /\ IsEvent("RwTxResponseAction")
@@ -99,17 +99,17 @@ IsRoTxRequestAction ==
 
 IsRoTxResponseAction ==
     /\ IsEvent("RoTxResponseAction")
-    \* Model action
-    /\ RoTxResponseAction
-    \* Match message contents
-    /\ Last(history').type = ToTxType[logline.type]
-    /\ Last(history').tx = logline.tx
     \* RoTxResponseAction can only take place if a branch exists for the view
     \* If there is no branch, BackfillLedgerBranches will create the right amount of branches
     /\ Len(ledgerBranches) >= logline.tx_id[1]
     \* That branch contains just the right amount of transactions (seqno)
     \* If that's not the case, BackfillLedgerBranch will create the right amount of txs
     /\ Len(ledgerBranches[logline.tx_id[1]]) = logline.tx_id[2]
+    \* Model action
+    /\ RoTxResponseAction
+    \* Match message contents
+    /\ Last(history').type = ToTxType[logline.type]
+    /\ Last(history').tx = logline.tx
 
 IsStatusInvalidResponseAction ==
     /\ IsEvent("StatusInvalidResponseAction")

--- a/tla/consistency/TraceMultiNodeReads.tla
+++ b/tla/consistency/TraceMultiNodeReads.tla
@@ -1,6 +1,9 @@
 -------------------------------- MODULE TraceMultiNodeReads -------------------------------
 EXTENDS MultiNodeReads, Json, IOUtils, Sequences, SequencesExt
 
+Stats == 
+    PrintT(<<"VARIABLE l (TLCGet(0))", TLCGet(0)>>)
+
 \* Trace validation has been designed for TLC running in default model-checking
 \* mode, i.e., breadth-first search.
 \* The property TraceMatched will be violated if TLC runs with more than a single worker.

--- a/tla/consistency/TraceMultiNodeReads.tla
+++ b/tla/consistency/TraceMultiNodeReads.tla
@@ -39,7 +39,6 @@ ToStatus ==
     "CommittedStatus" :> CommittedStatus @@
     "InvalidStatus" :>  InvalidStatus
 
-Foo == l > 40
 
 IsEvent(e) ==
     \* Equals FALSE if we get past the end of the log, causing model checking to stop.


### PR DESCRIPTION
Stumbled across this error while investigating the timeout in https://dev.azure.com/MSRC-CCF/CCF/_build/results?buildId=84142&view=results

I incorrectly assumed the backfill logic was the same for Rw and Ro, but of course for Ro we need extend to the seqno itself, whereas for Rw it's to seqno - 1, since seqno is the write itself. Duh.

Does not have impact on the timeout.