### PR TITLE
Use typed model values to prevent comparing things that shouldn't be compared.

### DIFF
--- a/tla/consistency/MCMultiNodeCommitReachability.cfg
+++ b/tla/consistency/MCMultiNodeCommitReachability.cfg
@@ -6,14 +6,14 @@ CONSTANTS
     HistoryLimit = 6
     ViewLimit = 1
 
-    RwTxRequest = RwTxRequest
-    RwTxResponse = RwTxResponse
-    RoTxRequest = RoTxRequest
-    RoTxResponse = RoTxResponse
-    TxStatusReceived = TxStatusReceived
+    RwTxRequest = T_RwTxRequest
+    RwTxResponse = T_RwTxResponse
+    RoTxRequest = T_RoTxRequest
+    RoTxResponse = T_RoTxResponse
+    TxStatusReceived = T_TxStatusReceived
 
-    CommittedStatus = CommittedStatus
-    InvalidStatus = InvalidStatus
+    CommittedStatus = S_CommittedStatus
+    InvalidStatus = S_InvalidStatus
 
 INVARIANTS
     MultiCommittedTxDebugInv

--- a/tla/consistency/MCMultiNodeReads.cfg
+++ b/tla/consistency/MCMultiNodeReads.cfg
@@ -5,14 +5,14 @@ CONSTANTS
     HistoryLimit = 6
     ViewLimit = 3
 
-    RwTxRequest = RwTxRequest
-    RwTxResponse = RwTxResponse
-    RoTxRequest = RoTxRequest
-    RoTxResponse = RoTxResponse
-    TxStatusReceived = TxStatusReceived
+    RwTxRequest = T_RwTxRequest
+    RwTxResponse = T_RwTxResponse
+    RoTxRequest = T_RoTxRequest
+    RoTxResponse = T_RoTxResponse
+    TxStatusReceived = T_TxStatusReceived
 
-    CommittedStatus = CommittedStatus
-    InvalidStatus = InvalidStatus
+    CommittedStatus = S_CommittedStatus
+    InvalidStatus = S_InvalidStatus
 
 INVARIANTS
     AllReceivedIsFirstSentInv

--- a/tla/consistency/MCMultiNodeReadsAlt.cfg
+++ b/tla/consistency/MCMultiNodeReadsAlt.cfg
@@ -5,14 +5,14 @@ CONSTANTS
     HistoryLimit = 11
     ViewLimit = 3
 
-    RwTxRequest = RwTxRequest
-    RwTxResponse = RwTxResponse
-    RoTxRequest = RoTxRequest
-    RoTxResponse = RoTxResponse
-    TxStatusReceived = TxStatusReceived
+    RwTxRequest = T_RwTxRequest
+    RwTxResponse = T_RwTxResponse
+    RoTxRequest = T_RoTxRequest
+    RoTxResponse = T_RoTxResponse
+    TxStatusReceived = T_TxStatusReceived
 
-    CommittedStatus = CommittedStatus
-    InvalidStatus = InvalidStatus
+    CommittedStatus = S_CommittedStatus
+    InvalidStatus = S_InvalidStatus
 
 INVARIANTS
     AllReceivedIsFirstSentInv

--- a/tla/consistency/MCSingleNode.cfg
+++ b/tla/consistency/MCSingleNode.cfg
@@ -4,14 +4,14 @@ CONSTANTS
     FirstBranch = 1
     HistoryLimit = 7
 
-    RwTxRequest = RwTxRequest
-    RwTxResponse = RwTxResponse
-    RoTxRequest = RoTxRequest
-    RoTxResponse = RoTxResponse
-    TxStatusReceived = TxStatusReceived
+    RwTxRequest = T_RwTxRequest
+    RwTxResponse = T_RwTxResponse
+    RoTxRequest = T_RoTxRequest
+    RoTxResponse = T_RoTxResponse
+    TxStatusReceived = T_TxStatusReceived
 
-    CommittedStatus = CommittedStatus
-    InvalidStatus = InvalidStatus
+    CommittedStatus = S_CommittedStatus
+    InvalidStatus = S_InvalidStatus
 
 INVARIANTS
     AllReceivedIsFirstSentInv

--- a/tla/consistency/MCSingleNodeReads.cfg
+++ b/tla/consistency/MCSingleNodeReads.cfg
@@ -4,14 +4,14 @@ CONSTANTS
     FirstBranch = 1
     HistoryLimit = 7
 
-    RwTxRequest = RwTxRequest
-    RwTxResponse = RwTxResponse
-    RoTxRequest = RoTxRequest
-    RoTxResponse = RoTxResponse
-    TxStatusReceived = TxStatusReceived
+    RwTxRequest = T_RwTxRequest
+    RwTxResponse = T_RwTxResponse
+    RoTxRequest = T_RoTxRequest
+    RoTxResponse = T_RoTxResponse
+    TxStatusReceived = T_TxStatusReceived
 
-    CommittedStatus = CommittedStatus
-    InvalidStatus = InvalidStatus
+    CommittedStatus = S_CommittedStatus
+    InvalidStatus = S_InvalidStatus
 
 INVARIANTS
     AllReceivedIsFirstSentInv

--- a/tla/consistency/MultiNodeReads.cfg
+++ b/tla/consistency/MultiNodeReads.cfg
@@ -3,14 +3,14 @@ SPECIFICATION SpecMultiNodeReads
 CONSTANTS
     FirstBranch = 1
 
-    RwTxRequest = RwTxRequest
-    RwTxResponse = RwTxResponse
-    RoTxRequest = RoTxRequest
-    RoTxResponse = RoTxResponse
-    TxStatusReceived = TxStatusReceived
+    RwTxRequest = T_RwTxRequest
+    RwTxResponse = T_RwTxResponse
+    RoTxRequest = T_RoTxRequest
+    RoTxResponse = T_RoTxResponse
+    TxStatusReceived = vTxStatusReceived
 
-    CommittedStatus = CommittedStatus
-    InvalidStatus = InvalidStatus
+    CommittedStatus = S_CommittedStatus
+    InvalidStatus = S_InvalidStatus
 
 INVARIANTS
     TypeOK

--- a/tla/consistency/TraceMultiNodeReads.cfg
+++ b/tla/consistency/TraceMultiNodeReads.cfg
@@ -47,11 +47,11 @@ CONSTANTS
     \* View starts at 2 in the implementation
     FirstBranch = 2
 
-    RwTxRequest = RwTxRequest
-    RwTxResponse = RwTxResponse
-    RoTxRequest = RoTxRequest
-    RoTxResponse = RoTxResponse
-    TxStatusReceived = TxStatusReceived
+    RwTxRequest = T_RwTxRequest
+    RwTxResponse = T_RwTxResponse
+    RoTxRequest = T_RoTxRequest
+    RoTxResponse = T_RoTxResponse
+    TxStatusReceived = T_TxStatusReceived
 
-    CommittedStatus = CommittedStatus
-    InvalidStatus = InvalidStatus
+    CommittedStatus = S_CommittedStatus
+    InvalidStatus = S_InvalidStatus


### PR DESCRIPTION
Low-risk change.

Squash any type-related discussions, and prevent future incantations of https://github.com/microsoft/CCF/pull/6164/commits/20d89bff161410663d14e0cd2ad0788fe6337409. ;-p

See section about *typed model values* in https://tla.msr-inria.inria.fr/tlatoolbox/doc/model/model-values.html