### PR TITLE
Tighten TODO check to all directories

### DIFF
--- a/scripts/check-todo.sh
+++ b/scripts/check-todo.sh
@@ -13,7 +13,7 @@ DENYLIST="TODO FIXME"
 STATUS=0
 
 for DENYTERM in $DENYLIST; do
-  FOUND=$(git ls-files "$@" | xargs grep -n "$DENYTERM")
+  FOUND=$(git ls-files ":!:3rdparty" ":!:.github/ISSUE_TEMPLATE" ":!:scripts/ci-checks.sh" ":!:scripts/check-todo.sh" ":!:Doxyfile" "$@" | xargs grep -n "$DENYTERM")
 
   if [ "$FOUND" == "" ]; then
     echo "No ${DENYTERM}s found"

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -36,8 +36,9 @@ group "Shell scripts"
 git ls-files | grep -e '\.sh$' | grep -E -v "^3rdparty" | xargs shellcheck -s bash -e SC2044,SC2002,SC1091,SC2181
 endgroup
 
+# No inline TODOs in the codebase, use tickets, with a pointer to the code if necessary.
 group "TODOs"
-"$SCRIPT_DIR"/check-todo.sh include src
+"$SCRIPT_DIR"/check-todo.sh .
 endgroup
 
 group "Public includes"


### PR DESCRIPTION
We have had the check-todo script for a while now, as part of our executable project policy and it's done a good job of keeping tasks in issues, where they can be detailed, discussed and planned. Some directories had not been added at first, as we focused on the code we shipped, but we're not far off doing this across the project.