### PR TITLE
Run CodeQL on custom pool

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -65,15 +65,18 @@ jobs:
           sudo apt update
           sudo apt install -y ansible software-properties-common bsdmainutils dnsutils
           sudo ansible-playbook ccf-dev.yml --extra-vars "platform=virtual" --extra-vars "require_open_enclave=false"
+        name: Install dependencies
 
       - run: |
           mkdir build
           cd build
           cmake -DCOMPILE_TARGET=virtual -DREQUIRE_OPENENCLAVE=OFF -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=OFF -DLVI_MITIGATIONS=OFF -DCMAKE_C_COMPILER=`which clang-11` -DCMAKE_CXX_COMPILER=`which clang++-11` ..
+        name: Run CMake
 
       - run: |
           cd build
           make
+        name: Run Make
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,8 @@ permissions: read-all
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    # Insufficient space to run on public runner, so use custom pool
+    runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     permissions:
       security-events: write
 


### PR DESCRIPTION
CodeQL action has started failing, because it's running out of disk space. The public runners only give us [14GB](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories). Testing if this will work on our existing custom pool.