### PR TITLE
Don't log JS exception details by default

### DIFF
--- a/src/js/core/runtime.h
+++ b/src/js/core/runtime.h
@@ -28,8 +28,8 @@ namespace ccf::js::core
     static constexpr size_t default_stack_size = 1024 * 1024;
     static constexpr size_t default_heap_size = 100 * 1024 * 1024;
 
-    bool log_exception_details = true;
-    bool return_exception_details = true;
+    bool log_exception_details = false;
+    bool return_exception_details = false;
 
     Runtime();
     ~Runtime();


### PR DESCRIPTION
Restoring intended initial values for these 2 bools, which were accidentally updated to verbose-by-default in a recent refactor.