### PR TITLE
Run Bencher on PRs, upload results from workflow trigger

### DIFF
--- a/.github/workflows/bencher_process.yml
+++ b/.github/workflows/bencher_process.yml
@@ -1,0 +1,75 @@
+name: "Bencher: Process Benchmarks"
+
+on:
+  workflow_run:
+    workflows: ["Bencher: Run Benchmarks"]
+    types: [completed]
+
+jobs:
+  process_benchmarks:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    env:
+      BENCHMARK_RESULTS: benchmark_results.json
+      PR_EVENT: event.json
+
+    steps:
+      - name: Download Benchmark Results
+        uses: actions/github-script@v6
+        with:
+          script: |
+            async function downloadArtifact(artifactName) {
+              let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.payload.workflow_run.id,
+              });
+              let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+                return artifact.name == artifactName
+              })[0];
+              if (!matchArtifact) {
+                core.setFailed(`Failed to find artifact: ${artifactName}`);
+              }
+              let download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: matchArtifact.id,
+                archive_format: 'zip',
+              });
+              let fs = require('fs');
+              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${artifactName}.zip`, Buffer.from(download.data));
+            }
+            await downloadArtifact(process.env.BENCHMARK_RESULTS);
+            await downloadArtifact(process.env.PR_EVENT);
+
+      - name: Unzip Benchmark Results
+        run: |
+          unzip $BENCHMARK_RESULTS.zip
+          unzip $PR_EVENT.zip
+
+      - name: Export PR Event Data
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let fs = require('fs');
+            let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
+            core.exportVariable("PR_HEAD", `${prEvent.number}/merge`);
+            core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
+            core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
+            core.exportVariable("PR_NUMBER", prEvent.number);
+      - uses: bencherdev/bencher@main
+
+      - name: Track Benchmarks with Bencher
+        run: |
+          bencher run \
+          --project ccf \
+          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --branch '${{ env.PR_HEAD }}' \
+          --branch-start-point '${{ env.PR_BASE }}' \
+          --branch-start-point-hash '${{ env.PR_BASE_SHA }}' \
+          --testbed gha-virtual-ccf-sub \
+          --adapter json \
+          --err \
+          --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+          --ci-number '${{ env.PR_NUMBER }}' \
+          --file "$BENCHMARK_RESULTS"

--- a/.github/workflows/bencher_process.yml
+++ b/.github/workflows/bencher_process.yml
@@ -57,6 +57,7 @@ jobs:
             core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
             core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
             core.exportVariable("PR_NUMBER", prEvent.number);
+
       - uses: bencherdev/bencher@main
 
       - name: Track Benchmarks with Bencher

--- a/.github/workflows/bencher_run.yml
+++ b/.github/workflows/bencher_run.yml
@@ -1,11 +1,13 @@
-name: "Continous Benchmarking"
+name: "Bencher: Run Benchmarks"
 
 on:
   push:
     branches: main
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
 
 jobs:
-  benchmark_base_branch:
+  run_benchmarks:
     name: Continuous Benchmarking with Bencher
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
@@ -39,3 +41,15 @@ jobs:
           --adapter json \
           --err \
           --file build/bencher.json
+
+      - name: Upload Benchmark Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark_results.json
+          path: ./build/bencher.json
+
+      - name: Upload GitHub Pull Request Event
+        uses: actions/upload-artifact@v4
+        with:
+          name: event.json
+          path: ${{ github.event_path }}

--- a/.github/workflows/bencher_run.yml
+++ b/.github/workflows/bencher_run.yml
@@ -30,18 +30,6 @@ jobs:
           ./tests.sh -VV -R historical_query
           ./tests.sh -VV -R commit_latency
 
-      - uses: bencherdev/bencher@main
-      - name: Track base branch benchmarks with Bencher
-        run: |
-          bencher run \
-          --project ccf \
-          --token '${{ secrets.BENCHER_API_TOKEN }}' \
-          --branch main \
-          --testbed gha-virtual-ccf-sub \
-          --adapter json \
-          --err \
-          --file build/bencher.json
-
       - name: Upload Benchmark Results
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Based on Bencher's [example](https://github.com/bencherdev/example/blob/main/.github/workflows/track_fork_pr_benchmarks.yml), we split the yaml in 2:
- `bencher_run.yml` runs on our runner, on PRs from our forks, and gathers benchmark results, uploading them as workflow artifacts
- `bencher_process.yml` runs based on the version in `main`, with access to secrets, downloads the prior artifacts and uploads them to bencher

Note that I differ from the pure sample here, and try to do this process for pushes to `main` as well as PRs. I'd like to minimise the number of workflows if possible, but will revert and have a standalone main CB workflow if necessary.