### PR TITLE
Update Bencher github-script versions, remove github-actions attempt

### DIFF
--- a/.github/workflows/bencher_process.yml
+++ b/.github/workflows/bencher_process.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Download Benchmark Results
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             async function downloadArtifact(artifactName) {
@@ -50,7 +50,7 @@ jobs:
 
       - name: Export PR Event Data
         id: export
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             let fs = require('fs');
@@ -83,7 +83,6 @@ jobs:
             --testbed gha-virtual-ccf-sub \
             --adapter json \
             --err \
-            --github-actions '${{ secrets.GITHUB_TOKEN }}' \
             --ci-number '${{ env.PR_NUMBER }}' \
             --hash '${{ env.PR_HEAD_SHA }}' \
             --file "$BENCHMARK_RESULTS_FILE";

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ and performant applications that focus on multi-party compute and data.
 
 ## Get Started with CCF
 
+TODO: Don't merge me
+
 - Read the [CCF overview](https://ccf.microsoft.com/) and get familiar with [CCF's core concepts](https://microsoft.github.io/CCF/main/overview/what_is_ccf.html)
 - [Install](https://microsoft.github.io/CCF/main/build_apps/install_bin.html) CCF on Linux
 - Get familiar with CCF core developer API with the [template CCF app](https://github.com/microsoft/ccf-app-template)

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ and performant applications that focus on multi-party compute and data.
 
 ## Get Started with CCF
 
-TODO: Don't merge me
-
 - Read the [CCF overview](https://ccf.microsoft.com/) and get familiar with [CCF's core concepts](https://microsoft.github.io/CCF/main/overview/what_is_ccf.html)
 - [Install](https://microsoft.github.io/CCF/main/build_apps/install_bin.html) CCF on Linux
 - Get familiar with CCF core developer API with the [template CCF app](https://github.com/microsoft/ccf-app-template)


### PR DESCRIPTION
Seeing how the current Bencher config handles fork PRs (NB: Forked from a commit where bencher tests ran on main).

Unsure _why_ its unable to post comments, but it is, so removing that for now.