### PR TITLE
Disable flaky tests on SNP

### DIFF
--- a/.azure-pipelines-templates/test_on_remote.yml
+++ b/.azure-pipelines-templates/test_on_remote.yml
@@ -45,7 +45,7 @@ jobs:
           set -ex
           cd /CCF/build
           npm config set cache /ccfci/workspace_$(Build.BuildNumber)/.npm
-          WORKSPACE=/ccfci/workspace_$(Build.BuildNumber) ELECTION_TIMEOUT_MS=10000 ./tests.sh -VV -T Test -LE "benchmark|perf|tlstest|vegeta|suite" -E "lts_compatibility"
+          WORKSPACE=/ccfci/workspace_$(Build.BuildNumber) ELECTION_TIMEOUT_MS=10000 ./tests.sh -VV -T Test -LE "benchmark|perf|tlstest|vegeta|suite|snp_flaky" -E "lts_compatibility"
           # Remove irrelevant and bulky data from workspace before uploading
           find /ccfci/workspace_$(Build.BuildNumber) -type f -name cchost -delete
           find /ccfci/workspace_$(Build.BuildNumber) -type f -name "*.so" -delete

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1388,7 +1388,9 @@ if(BUILD_TESTS)
     )
 
     add_e2e_test(
-      NAME jwt_test PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/jwt_test.py
+      NAME jwt_test
+      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/jwt_test.py
+      LABEL snp_flaky
     )
 
     add_e2e_test(
@@ -1485,6 +1487,7 @@ if(BUILD_TESTS)
     add_e2e_test(
       NAME consistency_trace_validation
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/consistency_trace_validation.py
+      LABEL snp_flaky
     )
 
     add_e2e_test(


### PR DESCRIPTION
We have a few tests that are flaky in the SNP CI. Don't currently have time to investigate why, so instead I'm adding a label to skip them on SNP. They're not testing anything platform specific so this isn't a huge loss, but still a gap in our coverage matrix.