### PR TITLE
Ensure `DynamicJSEndpointRegistry` can control its own runtime options

### DIFF
--- a/include/ccf/js/core/context.h
+++ b/include/ccf/js/core/context.h
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <quickjs/quickjs-exports.h>
 #include <quickjs/quickjs.h>
+#include <span>
 
 // Forward declarations
 namespace ccf
@@ -161,7 +162,7 @@ namespace ccf::js::core
     JSWrappedValue call_with_rt_options(
       const JSWrappedValue& f,
       const std::vector<JSWrappedValue>& argv,
-      kv::Tx* tx,
+      const std::optional<ccf::JSRuntimeOptions>& options,
       RuntimeLimitsPolicy policy);
 
     // Call a JS function _without_ any stack, heap or execution time limits.

--- a/include/ccf/js/core/runtime.h
+++ b/include/ccf/js/core/runtime.h
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
-#include "ccf/tx.h"
+#include "ccf/service/tables/jsengine.h"
 
 #include <chrono>
 #include <quickjs/quickjs.h>
@@ -19,17 +19,16 @@ namespace ccf::js::core
   {
     JSRuntime* rt = nullptr;
 
-    std::chrono::milliseconds max_exec_time = default_max_execution_time;
+    std::chrono::milliseconds max_exec_time{
+      ccf::JSRuntimeOptions::Defaults::max_execution_time_ms};
 
     void add_ccf_classdefs();
 
   public:
-    static constexpr std::chrono::milliseconds default_max_execution_time{1000};
-    static constexpr size_t default_stack_size = 1024 * 1024;
-    static constexpr size_t default_heap_size = 100 * 1024 * 1024;
-
-    bool log_exception_details = false;
-    bool return_exception_details = false;
+    bool log_exception_details =
+      ccf::JSRuntimeOptions::Defaults::log_exception_details;
+    bool return_exception_details =
+      ccf::JSRuntimeOptions::Defaults::return_exception_details;
 
     Runtime();
     ~Runtime();
@@ -40,7 +39,9 @@ namespace ccf::js::core
     }
 
     void reset_runtime_options();
-    void set_runtime_options(kv::Tx* tx, RuntimeLimitsPolicy policy);
+    void set_runtime_options(
+      const std::optional<ccf::JSRuntimeOptions>& options_opt,
+      RuntimeLimitsPolicy policy);
 
     std::chrono::milliseconds get_max_exec_time() const
     {

--- a/include/ccf/js/registry.h
+++ b/include/ccf/js/registry.h
@@ -49,6 +49,7 @@ namespace ccf::js
     std::string interpreter_flush_map;
     std::string modules_quickjs_version_map;
     std::string modules_quickjs_bytecode_map;
+    std::string runtime_options_map;
 
     using PreExecutionHook = std::function<void(ccf::js::core::Context&)>;
 

--- a/include/ccf/service/tables/jsengine.h
+++ b/include/ccf/service/tables/jsengine.h
@@ -2,29 +2,40 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ccf/ds/json.h"
 #include "ccf/service/map.h"
 
 namespace ccf
 {
   struct JSRuntimeOptions
   {
+    struct Defaults
+    {
+      static constexpr size_t max_heap_bytes = 100 * 1024 * 1024;
+      static constexpr size_t max_stack_bytes = 1024 * 1024;
+      static constexpr uint64_t max_execution_time_ms = 1000;
+      static constexpr bool log_exception_details = false;
+      static constexpr bool return_exception_details = false;
+      static constexpr size_t max_cached_interpreters = 10;
+    };
+
     /// @brief heap size for QuickJS runtime
-    size_t max_heap_bytes;
+    size_t max_heap_bytes = Defaults::max_heap_bytes;
     /// @brief stack size for QuickJS runtime
-    size_t max_stack_bytes;
+    size_t max_stack_bytes = Defaults::max_stack_bytes;
     /// @brief max execution time for QuickJS
-    uint64_t max_execution_time_ms;
+    uint64_t max_execution_time_ms = Defaults::max_execution_time_ms;
     /// @brief emit exception details to the log
     /// NOTE: this is a security risk as it may leak sensitive information
     ///       to anyone with access to the application log, which is
     ///       unprotected.
-    bool log_exception_details = false;
+    bool log_exception_details = Defaults::log_exception_details;
     /// @brief return exception details in the response
     /// NOTE: this is a security risk as it may leak sensitive information,
     ///       albeit to the caller only.
-    bool return_exception_details = false;
+    bool return_exception_details = Defaults::return_exception_details;
     /// @brief how many interpreters may be cached in-memory for future reuse
-    size_t max_cached_interpreters = 10;
+    size_t max_cached_interpreters = Defaults::max_cached_interpreters;
   };
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(JSRuntimeOptions)

--- a/src/apps/js_generic/js_generic_base.cpp
+++ b/src/apps/js_generic/js_generic_base.cpp
@@ -213,10 +213,14 @@ namespace ccfapp
       auto request = request_extension->create_request_obj(
         ctx, endpoint->full_uri_path, endpoint_ctx, this);
 
+      auto options = endpoint_ctx.tx.ro<ccf::JSEngine>(ccf::Tables::JSENGINE)
+                       ->get()
+                       .value_or(ccf::JSRuntimeOptions());
+
       auto val = ctx.call_with_rt_options(
         export_func,
         {request},
-        endpoint_ctx.tx.ro<ccf::JSEngine>(ccf::Tables::JSENGINE)->get(),
+        options,
         ccf::js::core::RuntimeLimitsPolicy::NONE);
 
       for (auto extension : local_extensions)
@@ -239,12 +243,12 @@ namespace ccfapp
 
         auto [reason, trace] = ctx.error_message();
 
-        if (rt.log_exception_details)
+        if (options.log_exception_details)
         {
           CCF_APP_FAIL("{}: {}", reason, trace.value_or("<no trace>"));
         }
 
-        if (rt.return_exception_details)
+        if (options.return_exception_details)
         {
           std::vector<nlohmann::json> details = {
             ODataJSExceptionDetails{ccf::errors::JSException, reason, trace}};
@@ -326,7 +330,7 @@ namespace ccfapp
               {
                 auto [reason, trace] = ctx.error_message();
 
-                if (rt.log_exception_details)
+                if (options.log_exception_details)
                 {
                   CCF_APP_FAIL(
                     "Failed to convert return value to JSON:{} {}",
@@ -334,7 +338,7 @@ namespace ccfapp
                     trace.value_or("<no trace>"));
                 }
 
-                if (rt.return_exception_details)
+                if (options.return_exception_details)
                 {
                   std::vector<nlohmann::json> details = {
                     ODataJSExceptionDetails{
@@ -363,7 +367,7 @@ namespace ccfapp
             {
               auto [reason, trace] = ctx.error_message();
 
-              if (rt.log_exception_details)
+              if (options.log_exception_details)
               {
                 CCF_APP_FAIL(
                   "Failed to convert return value to JSON:{} {}",
@@ -371,7 +375,7 @@ namespace ccfapp
                   trace.value_or("<no trace>"));
               }
 
-              if (rt.return_exception_details)
+              if (options.return_exception_details)
               {
                 std::vector<nlohmann::json> details = {ODataJSExceptionDetails{
                   ccf::errors::JSException, reason, trace}};

--- a/src/apps/js_generic/js_generic_base.cpp
+++ b/src/apps/js_generic/js_generic_base.cpp
@@ -216,7 +216,7 @@ namespace ccfapp
       auto val = ctx.call_with_rt_options(
         export_func,
         {request},
-        &endpoint_ctx.tx,
+        endpoint_ctx.tx.ro<ccf::JSEngine>(ccf::Tables::JSENGINE)->get(),
         ccf::js::core::RuntimeLimitsPolicy::NONE);
 
       for (auto extension : local_extensions)

--- a/src/js/core/context.cpp
+++ b/src/js/core/context.cpp
@@ -445,10 +445,10 @@ namespace ccf::js::core
   JSWrappedValue Context::call_with_rt_options(
     const JSWrappedValue& f,
     const std::vector<JSWrappedValue>& argv,
-    kv::Tx* tx,
+    const std::optional<ccf::JSRuntimeOptions>& options,
     RuntimeLimitsPolicy policy)
   {
-    rt.set_runtime_options(tx, policy);
+    rt.set_runtime_options(options, policy);
     const auto curr_time = ccf::get_enclave_time();
     interrupt_data.start_time = curr_time;
     interrupt_data.max_execution_time = rt.get_max_exec_time();
@@ -456,6 +456,7 @@ namespace ccf::js::core
 
     auto rv = inner_call(f, argv);
 
+    JS_SetInterruptHandler(rt, NULL, NULL);
     rt.reset_runtime_options();
 
     return rv;

--- a/src/js/core/runtime.cpp
+++ b/src/js/core/runtime.cpp
@@ -51,9 +51,6 @@ namespace ccf::js::core
 
     this->max_exec_time =
       std::chrono::milliseconds{Defaults::max_execution_time_ms};
-
-    this->log_exception_details = Defaults::log_exception_details;
-    this->return_exception_details = Defaults::return_exception_details;
   }
 
   void Runtime::set_runtime_options(

--- a/src/js/extensions/ccf/gov_effects.cpp
+++ b/src/js/extensions/ccf/gov_effects.cpp
@@ -43,8 +43,10 @@ namespace ccf::js::extensions
       auto& tx = *tx_ptr;
 
       js::core::Context ctx2(js::TxAccess::APP_RW);
+      const auto options_handle = tx.ro<ccf::JSEngine>(ccf::Tables::JSENGINE);
       ctx2.runtime().set_runtime_options(
-        tx_ptr, js::core::RuntimeLimitsPolicy::NO_LOWER_THAN_DEFAULTS);
+        options_handle->get(),
+        js::core::RuntimeLimitsPolicy::NO_LOWER_THAN_DEFAULTS);
 
       auto quickjs_version =
         tx.wo<ccf::ModulesQuickJsVersion>(ccf::Tables::MODULES_QUICKJS_VERSION);

--- a/src/js/registry.cpp
+++ b/src/js/registry.cpp
@@ -146,10 +146,14 @@ namespace ccf::js
     auto request = request_extension->create_request_obj(
       ctx, endpoint->full_uri_path, endpoint_ctx, this);
 
+    auto options = endpoint_ctx.tx.ro<ccf::JSEngine>(runtime_options_map)
+                     ->get()
+                     .value_or(ccf::JSRuntimeOptions());
+
     auto val = ctx.call_with_rt_options(
       export_func,
       {request},
-      endpoint_ctx.tx.ro<ccf::JSEngine>(runtime_options_map)->get(),
+      options,
       ccf::js::core::RuntimeLimitsPolicy::NONE);
 
     for (auto extension : local_extensions)
@@ -170,12 +174,12 @@ namespace ccf::js
 
       auto [reason, trace] = ctx.error_message();
 
-      if (rt.log_exception_details)
+      if (options.log_exception_details)
       {
         CCF_APP_FAIL("{}: {}", reason, trace.value_or("<no trace>"));
       }
 
-      if (rt.return_exception_details)
+      if (options.return_exception_details)
       {
         std::vector<nlohmann::json> details = {ccf::ODataJSExceptionDetails{
           ccf::errors::JSException, reason, trace}};
@@ -257,7 +261,7 @@ namespace ccf::js
             {
               auto [reason, trace] = ctx.error_message();
 
-              if (rt.log_exception_details)
+              if (options.log_exception_details)
               {
                 CCF_APP_FAIL(
                   "Failed to convert return value to JSON:{} {}",
@@ -265,7 +269,7 @@ namespace ccf::js
                   trace.value_or("<no trace>"));
               }
 
-              if (rt.return_exception_details)
+              if (options.return_exception_details)
               {
                 std::vector<nlohmann::json> details = {
                   ccf::ODataJSExceptionDetails{
@@ -294,7 +298,7 @@ namespace ccf::js
           {
             auto [reason, trace] = ctx.error_message();
 
-            if (rt.log_exception_details)
+            if (options.log_exception_details)
             {
               CCF_APP_FAIL(
                 "Failed to convert return value to JSON:{} {}",
@@ -302,7 +306,7 @@ namespace ccf::js
                 trace.value_or("<no trace>"));
             }
 
-            if (rt.return_exception_details)
+            if (options.return_exception_details)
             {
               std::vector<nlohmann::json> details = {
                 ccf::ODataJSExceptionDetails{

--- a/src/js/registry.cpp
+++ b/src/js/registry.cpp
@@ -149,7 +149,7 @@ namespace ccf::js
     auto val = ctx.call_with_rt_options(
       export_func,
       {request},
-      &endpoint_ctx.tx,
+      endpoint_ctx.tx.ro<ccf::JSEngine>(runtime_options_map)->get(),
       ccf::js::core::RuntimeLimitsPolicy::NONE);
 
     for (auto extension : local_extensions)
@@ -408,7 +408,8 @@ namespace ccf::js
     modules_quickjs_version_map(
       fmt::format("{}.modules_quickjs_version", kv_prefix)),
     modules_quickjs_bytecode_map(
-      fmt::format("{}.modules_quickjs_bytecode", kv_prefix))
+      fmt::format("{}.modules_quickjs_bytecode", kv_prefix)),
+    runtime_options_map(fmt::format("{}.runtime_options", kv_prefix))
   {
     interpreter_cache =
       context.get_subsystem<ccf::js::AbstractInterpreterCache>();
@@ -491,7 +492,8 @@ namespace ccf::js
     // Refresh app bytecode
     ccf::js::core::Context jsctx(ccf::js::TxAccess::APP_RW);
     jsctx.runtime().set_runtime_options(
-      &ctx.tx, ccf::js::core::RuntimeLimitsPolicy::NO_LOWER_THAN_DEFAULTS);
+      ctx.tx.ro<ccf::JSEngine>(runtime_options_map)->get(),
+      ccf::js::core::RuntimeLimitsPolicy::NO_LOWER_THAN_DEFAULTS);
 
     auto quickjs_version =
       ctx.tx.wo<ccf::ModulesQuickJsVersion>(modules_quickjs_version_map);

--- a/src/node/gov/handlers/proposals.h
+++ b/src/node/gov/handlers/proposals.h
@@ -169,7 +169,7 @@ namespace ccf::gov::endpoints
         auto val = js_context.call_with_rt_options(
           ballot_func,
           argv,
-          &tx,
+          tx.ro<ccf::JSEngine>(ccf::Tables::JSENGINE)->get(),
           js::core::RuntimeLimitsPolicy::NO_LOWER_THAN_DEFAULTS);
 
         if (!val.is_exception())
@@ -231,7 +231,7 @@ namespace ccf::gov::endpoints
           auto val = js_context.call_with_rt_options(
             resolve_func,
             argv,
-            &tx,
+            tx.ro<ccf::JSEngine>(ccf::Tables::JSENGINE)->get(),
             js::core::RuntimeLimitsPolicy::NO_LOWER_THAN_DEFAULTS);
 
           if (val.is_exception())
@@ -320,7 +320,7 @@ namespace ccf::gov::endpoints
             auto val = js_context.call_with_rt_options(
               apply_func,
               argv,
-              &tx,
+              tx.ro<ccf::JSEngine>(ccf::Tables::JSENGINE)->get(),
               js::core::RuntimeLimitsPolicy::NO_LOWER_THAN_DEFAULTS);
 
             if (val.is_exception())
@@ -456,7 +456,7 @@ namespace ccf::gov::endpoints
             auto validate_result = context.call_with_rt_options(
               validate_func,
               {proposal_arg},
-              &ctx.tx,
+              ctx.tx.template ro<ccf::JSEngine>(ccf::Tables::JSENGINE)->get(),
               js::core::RuntimeLimitsPolicy::NO_LOWER_THAN_DEFAULTS);
 
             // Handle error cases of validation

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -175,7 +175,7 @@ namespace ccf
         auto val = context.call_with_rt_options(
           ballot_func,
           argv,
-          &tx,
+          tx.ro<ccf::JSEngine>(ccf::Tables::JSENGINE)->get(),
           js::core::RuntimeLimitsPolicy::NO_LOWER_THAN_DEFAULTS);
 
         if (!val.is_exception())
@@ -231,7 +231,7 @@ namespace ccf
         auto val = js_context.call_with_rt_options(
           resolve_func,
           argv,
-          &tx,
+          tx.ro<ccf::JSEngine>(ccf::Tables::JSENGINE)->get(),
           js::core::RuntimeLimitsPolicy::NO_LOWER_THAN_DEFAULTS);
 
         std::optional<jsgov::Failure> failure = std::nullopt;
@@ -330,7 +330,7 @@ namespace ccf
             auto apply_val = apply_js_context.call_with_rt_options(
               apply_func,
               apply_argv,
-              &tx,
+              tx.ro<ccf::JSEngine>(ccf::Tables::JSENGINE)->get(),
               js::core::RuntimeLimitsPolicy::NO_LOWER_THAN_DEFAULTS);
 
             if (apply_val.is_exception())
@@ -1189,7 +1189,7 @@ namespace ccf
         auto val = context.call_with_rt_options(
           validate_func,
           {proposal},
-          &ctx.tx,
+          ctx.tx.ro<ccf::JSEngine>(ccf::Tables::JSENGINE)->get(),
           js::core::RuntimeLimitsPolicy::NO_LOWER_THAN_DEFAULTS);
 
         if (val.is_exception())
@@ -1698,8 +1698,11 @@ namespace ccf
 
         {
           js::core::Context context(js::TxAccess::GOV_RO);
+          const auto options_handle =
+            ctx.tx.ro<ccf::JSEngine>(ccf::Tables::JSENGINE);
           context.runtime().set_runtime_options(
-            &ctx.tx, js::core::RuntimeLimitsPolicy::NO_LOWER_THAN_DEFAULTS);
+            options_handle->get(),
+            js::core::RuntimeLimitsPolicy::NO_LOWER_THAN_DEFAULTS);
           auto ballot_func = context.get_exported_function(
             params["ballot"], "vote", "body[\"ballot\"]");
         }

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -1431,19 +1431,11 @@ namespace ccf
         m.bytecode_used =
           version_val->get() == std::string(ccf::quickjs_version);
 
-        auto js_engine_options = js_engine_map->get();
-        m.max_stack_size = js::core::Runtime::default_stack_size;
-        m.max_heap_size = js::core::Runtime::default_heap_size;
-        m.max_execution_time =
-          js::core::Runtime::default_max_execution_time.count();
-        if (js_engine_options.has_value())
-        {
-          auto& options = js_engine_options.value();
-          m.max_stack_size = options.max_stack_bytes;
-          m.max_heap_size = options.max_heap_bytes;
-          m.max_execution_time = options.max_execution_time_ms;
-          m.max_cached_interpreters = options.max_cached_interpreters;
-        }
+        auto options = js_engine_map->get().value_or(ccf::JSRuntimeOptions{});
+        m.max_stack_size = options.max_stack_bytes;
+        m.max_heap_size = options.max_heap_bytes;
+        m.max_execution_time = options.max_execution_time_ms;
+        m.max_cached_interpreters = options.max_cached_interpreters;
 
         return m;
       };


### PR DESCRIPTION
This was previously using the hard-coded, governance controlled JSEngine table. We now avoid reading directly from the KV deep in the execution flow, and instead pass in the runtime options at the call-point. For the `DynamicJSEndpointRegistry`, that's expected to be stored in another prefix-named table.

Eagle-eyed viewers will note we currently have no way to _populate_ that table. That's coming shortly, in another PR, with a broader expansion of the methods exposed by `DynamicJSEndpointRegistry`.