### PR TITLE
Add remaining performance tests to bencher

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -25,7 +25,10 @@ jobs:
           cd build
           cmake -GNinja -DCOMPILE_TARGET=virtual -DWORKER_THREADS=1 ..
           ninja
+          ./tests.sh -VV -L benchmark
           ./tests.sh -VV -L perf
+          source env/bin/activate
+          PYTHONPATH=../tests python upload_pico_metrics.py
 
       - uses: bencherdev/bencher@main
       - name: Track base branch benchmarks with Bencher

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -2,7 +2,9 @@ name: "Bencher: Run Benchmarks"
 
 on:
   push:
-    branches: main
+    branches:
+      - main
+      - more_perf_tests_on_bencher
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -29,6 +29,7 @@ jobs:
           ./tests.sh -VV -L perf
           source env/bin/activate
           PYTHONPATH=../tests python upload_pico_metrics.py
+        shell: bash
 
       - uses: bencherdev/bencher@main
       - name: Track base branch benchmarks with Bencher

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -21,13 +21,9 @@ jobs:
           git config --global --add safe.directory /__w/CCF/CCF
           mkdir build
           cd build
-          cmake -GNinja -DCOMPILE_TARGET=virtual ..
+          cmake -GNinja -DCOMPILE_TARGET=virtual -DWORKER_THREADS=1 ..
           ninja
-          # Limited list of benchmarks for now, but should be extended to
-          # everything under a single label eventually
-          ./tests.sh -VV -R pi_basic_
-          ./tests.sh -VV -R historical_query
-          ./tests.sh -VV -R commit_latency
+          ./tests.sh -VV -L perf
 
       - uses: bencherdev/bencher@main
       - name: Track base branch benchmarks with Bencher

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - more_perf_tests_on_bencher
   workflow_dispatch:
 
 jobs:
@@ -25,8 +24,11 @@ jobs:
           cd build
           cmake -GNinja -DCOMPILE_TARGET=virtual -DWORKER_THREADS=1 ..
           ninja
+          # Microbenchmarks
           ./tests.sh -VV -L benchmark
+          # End to end performance tests
           ./tests.sh -VV -L perf
+          # Convert microbenchmark output to bencher json
           source env/bin/activate
           PYTHONPATH=../tests python upload_pico_metrics.py
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1585,7 +1585,7 @@ if(BUILD_TESTS)
       )
     endif()
 
-    add_perf_test(
+    add_piccolo_test(
       NAME pi_ls
       PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/infra/piccolo_driver.py
       CLIENT_BIN ./submit
@@ -1619,7 +1619,7 @@ if(BUILD_TESTS)
       )
     endif()
 
-    add_perf_test(
+    add_piccolo_test(
       NAME pi_ls_jwt
       PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/infra/piccolo_driver.py
       CLIENT_BIN ./submit

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -252,11 +252,6 @@ function(add_perf_test)
   set_property(
     TEST ${TEST_NAME}
     APPEND
-    PROPERTY LABELS cft
-  )
-  set_property(
-    TEST ${TEST_NAME}
-    APPEND
     PROPERTY ENVIRONMENT
              "TSAN_OPTIONS=suppressions=${CCF_DIR}/tsan_env_suppressions"
   )
@@ -323,11 +318,6 @@ function(add_piccolo_test)
     TEST ${TEST_NAME}
     APPEND
     PROPERTY LABELS perf
-  )
-  set_property(
-    TEST ${TEST_NAME}
-    APPEND
-    PROPERTY LABELS cft
   )
   set_property(
     TEST ${TEST_NAME}

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -389,14 +389,14 @@ def run(args):
                         current_value = results["current_allocated_heap_size"]
                         peak_value = results["peak_allocated_heap_size"]
 
-                        # Do not upload empty metrics (virtual doesn't report memory use)
-                        if current_value != 0 and peak_value != 0:
-                            metrics.append(
-                                infra.bencher.Memory(
-                                    value=current_value,
-                                    high_value=peak_value,
-                                )
-                            )
+                        bf = infra.bencher.Bencher()
+                        bf.set(
+                            f"{args.label}_mem",
+                            infra.bencher.Memory(
+                                current_value,
+                                high_value=peak_value,
+                            ),
+                        )
 
                 network.stop_all_nodes()
 

--- a/tests/infra/piccolo_driver.py
+++ b/tests/infra/piccolo_driver.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 from piccolo import generator
 from piccolo import analyzer
+import infra.bencher
 
 
 def get_command_args(args, network, get_command):
@@ -216,21 +217,15 @@ def run(get_command, args):
                     with primary.client() as nc:
                         r = nc.get("/node/memory")
                         assert r.status_code == http.HTTPStatus.OK.value
-
                         results = r.body.json()
-
+                        current_value = results["current_allocated_heap_size"]
                         peak_value = results["peak_allocated_heap_size"]
 
-                        # Do not upload empty metrics (virtual doesn't report memory use)
-                        if peak_value != 0:
-                            # Construct name for heap metric, removing ^ suffix if present
-                            heap_peak_metric = args.label
-                            if heap_peak_metric.endswith("^"):
-                                heap_peak_metric = heap_peak_metric[:-1]
-                            heap_peak_metric += "_mem"
-
-                            # https://github.com/microsoft/CCF/issues/6126
-                            # metrics.put(heap_peak_metric, peak_value)
+                        bf = infra.bencher.Bencher()
+                        bf.set(
+                            f"{args.label}_mem",
+                            infra.bencher.Memory(current_value, high_value=peak_value),
+                        )
 
                     for remote_client in clients:
                         remote_client.stop()

--- a/tests/upload_pico_metrics.py
+++ b/tests/upload_pico_metrics.py
@@ -4,6 +4,7 @@ import collections
 import csv
 import os
 from loguru import logger as LOG
+import infra.bencher
 
 benchmark_specs = {
     "kv_bench.csv": [
@@ -94,12 +95,12 @@ if __name__ == "__main__":
                 f"Could not find file {filename}: skipping metrics publishing for this file"
             )
 
-    # https://github.com/microsoft/CCF/issues/6126
-    # if found_metrics:
-    #     with cimetrics.upload.metrics(complete=False) as metrics:
-    #         for name, results in found_metrics.items():
-    #             many_results = len(results) > 1
-    #             for i, result in enumerate(results):
-    #                 upload_name = f"{name}_{i}" if many_results else name
-    #                 LOG.debug(f"Uploading metric: {upload_name} = {result}")
-    #                 metrics.put(upload_name, result)
+    bf = infra.bencher.Bencher()
+    for name, results in found_metrics.items():
+        many_results = len(results) > 1
+        for i, result in enumerate(results):
+            upload_name = f"{name}_{i}" if many_results else name
+            bf.set(
+                upload_name,
+                infra.bencher.Throughput(result),
+            )

--- a/tests/upload_pico_metrics.py
+++ b/tests/upload_pico_metrics.py
@@ -8,25 +8,25 @@ from loguru import logger as LOG
 benchmark_specs = {
     "kv_bench.csv": [
         {
-            "_name": "KV ser (/s)^",
+            "_name": "KV ser (/s)",
             "Suite": "serialise",
             "Benchmark": "serialise<SD::PUBLIC>",
             "D": "10",
         },
         {
-            "_name": "KV deser (/s)^",
+            "_name": "KV deser (/s)",
             "Suite": "deserialise",
             "Benchmark": "deserialise<SD::PUBLIC>",
             "D": "10",
         },
         {
-            "_name": "KV snap ser (/s)^",
+            "_name": "KV snap ser (/s)",
             "Suite": "serialise_snapshot",
             "Benchmark": "ser_snap<1000>",
             "D": "100",
         },
         {
-            "_name": "KV snap deser (/s)^",
+            "_name": "KV snap deser (/s)",
             "Suite": "deserialise_snapshot",
             "Benchmark": "des_snap<1000>",
             "D": "100",
@@ -34,25 +34,25 @@ benchmark_specs = {
     ],
     "map_bench.csv": [
         {
-            "_name": "CHAMP put (/s)^",
+            "_name": "CHAMP put (/s)",
             "Suite": "put",
             "Benchmark": "bench_champ_map_put",
             "D": "2048",
         },
         {
-            "_name": "CHAMP get (/s)^",
+            "_name": "CHAMP get (/s)",
             "Suite": "get",
             "Benchmark": "bench_champ_map_get",
             "D": "2048",
         },
         {
-            "_name": "RB put (/s)^",
+            "_name": "RB put (/s)",
             "Suite": "put",
             "Benchmark": "bench_rb_map_put",
             "D": "2048",
         },
         {
-            "_name": "RB get (/s)^",
+            "_name": "RB get (/s)",
             "Suite": "get",
             "Benchmark": "bench_rb_map_get",
             "D": "2048",


### PR DESCRIPTION
Ticking off some items on #6126 by moving remaining tests, memory metrics and microbenchmarks to bencher.

Also get rid of the ^ business.