### PR TITLE
Get intended reuse from `CommonContext`

### DIFF
--- a/include/ccf/js/common_context.h
+++ b/include/ccf/js/common_context.h
@@ -15,13 +15,13 @@ namespace ccf::js
 {
   // This is intended to extend a js::core::Context with various CCF-specific
   // extensions, expected to be accessible in every execution context (eg -
-  // ccf.bufToStr converters, ccf.crypto helpers, kv access). This is
+  // ccf.bufToStr converters, ccf.crypto helpers). This is
   // implemented as a CRTP mixin so that you could build your own hierarchy.
   template <typename Base>
   class WithCommonExtensions : public Base
   {
   public:
-    WithCommonExtensions(TxAccess acc, kv::Tx* tx) : Base(acc)
+    WithCommonExtensions(TxAccess acc) : Base(acc)
     {
       // override Math.random
       Base::add_extension(
@@ -39,6 +39,22 @@ namespace ccf::js
       Base::add_extension(
         std::make_shared<ccf::js::extensions::CryptoExtension>());
 
+      // add openenclave.*
+      Base::add_extension(
+        std::make_shared<ccf::js::extensions::OpenEnclaveExtension>());
+
+      // add snp_attestation.*
+      Base::add_extension(
+        std::make_shared<ccf::js::extensions::SnpAttestationExtension>());
+    }
+  };
+
+  template <typename Base>
+  class WithKVExtension : public Base
+  {
+  public:
+    WithKVExtension(TxAccess acc, kv::Tx* tx) : Base(acc)
+    {
       // add ccf.kv.*
       Base::add_extension(
         std::make_shared<ccf::js::extensions::KvExtension>(tx));
@@ -46,4 +62,5 @@ namespace ccf::js
   };
 
   using CommonContext = WithCommonExtensions<js::core::Context>;
+  using CommonContextWithLocalTx = WithKVExtension<CommonContext>;
 }

--- a/src/apps/js_generic/js_generic_base.cpp
+++ b/src/apps/js_generic/js_generic_base.cpp
@@ -5,20 +5,15 @@
 #include "ccf/crypto/rsa_key_pair.h"
 #include "ccf/endpoints/authentication/all_of_auth.h"
 #include "ccf/historical_queries_adapter.h"
+#include "ccf/js/common_context.h"
 #include "ccf/js/core/context.h"
 #include "ccf/js/core/wrapped_property_enum.h"
 #include "ccf/js/extensions/ccf/consensus.h"
-#include "ccf/js/extensions/ccf/converters.h"
-#include "ccf/js/extensions/ccf/crypto.h"
 #include "ccf/js/extensions/ccf/historical.h"
 #include "ccf/js/extensions/ccf/host.h"
 #include "ccf/js/extensions/ccf/kv.h"
 #include "ccf/js/extensions/ccf/request.h"
 #include "ccf/js/extensions/ccf/rpc.h"
-#include "ccf/js/extensions/console.h"
-#include "ccf/js/extensions/math/random.h"
-#include "ccf/js/extensions/openenclave.h"
-#include "ccf/js/extensions/snp_attestation.h"
 #include "ccf/js/interpreter_cache_interface.h"
 #include "ccf/js/modules/chained_module_loader.h"
 #include "ccf/js/modules/kv_bytecode_module_loader.h"
@@ -504,18 +499,7 @@ namespace ccfapp
       // Install dependency-less (ie reusable) extensions on interpreters _at
       // creation_, rather than on every run
       js::extensions::Extensions extensions;
-      // override Math.random
-      extensions.emplace_back(
-        std::make_shared<ccf::js::extensions::MathRandomExtension>());
-      // add console.[debug|log|...]
-      extensions.emplace_back(
-        std::make_shared<ccf::js::extensions::ConsoleExtension>());
-      // add ccf.[strToBuf|bufToStr|...]
-      extensions.emplace_back(
-        std::make_shared<ccf::js::extensions::ConvertersExtension>());
-      // add ccf.crypto.*
-      extensions.emplace_back(
-        std::make_shared<ccf::js::extensions::CryptoExtension>());
+
       // add ccf.consensus.*
       extensions.emplace_back(
         std::make_shared<ccf::js::extensions::ConsensusExtension>(this));
@@ -527,16 +511,11 @@ namespace ccfapp
       extensions.emplace_back(
         std::make_shared<ccf::js::extensions::HistoricalExtension>(
           &context.get_historical_state()));
-      // add openenclave.*
-      extensions.emplace_back(
-        std::make_shared<ccf::js::extensions::OpenEnclaveExtension>());
-      // add snp_attestation.*
-      extensions.emplace_back(
-        std::make_shared<ccf::js::extensions::SnpAttestationExtension>());
 
       interpreter_cache->set_interpreter_factory(
         [extensions](ccf::js::TxAccess access) {
-          auto interpreter = std::make_shared<js::core::Context>(access);
+          // CommonContext also adds many extensions
+          auto interpreter = std::make_shared<js::CommonContext>(access);
 
           for (auto extension : extensions)
           {

--- a/src/js/registry.cpp
+++ b/src/js/registry.cpp
@@ -20,20 +20,15 @@
 #include "ccf/endpoint.h"
 #include "ccf/endpoints/authentication/js.h"
 #include "ccf/js/bundle.h"
+#include "ccf/js/common_context.h"
 #include "ccf/js/core/context.h"
 #include "ccf/js/core/wrapped_property_enum.h"
 #include "ccf/js/extensions/ccf/consensus.h"
-#include "ccf/js/extensions/ccf/converters.h"
-#include "ccf/js/extensions/ccf/crypto.h"
 #include "ccf/js/extensions/ccf/historical.h"
 #include "ccf/js/extensions/ccf/host.h"
 #include "ccf/js/extensions/ccf/kv.h"
 #include "ccf/js/extensions/ccf/request.h"
 #include "ccf/js/extensions/ccf/rpc.h"
-#include "ccf/js/extensions/console.h"
-#include "ccf/js/extensions/math/random.h"
-#include "ccf/js/extensions/openenclave.h"
-#include "ccf/js/extensions/snp_attestation.h"
 #include "ccf/js/interpreter_cache_interface.h"
 #include "ccf/js/modules/chained_module_loader.h"
 #include "ccf/js/modules/kv_bytecode_module_loader.h"
@@ -428,18 +423,7 @@ namespace ccf::js
     // Install dependency-less (ie reusable) extensions on interpreters _at
     // creation_, rather than on every run
     ccf::js::extensions::Extensions extensions;
-    // override Math.random
-    extensions.emplace_back(
-      std::make_shared<ccf::js::extensions::MathRandomExtension>());
-    // add console.[debug|log|...]
-    extensions.emplace_back(
-      std::make_shared<ccf::js::extensions::ConsoleExtension>());
-    // add ccf.[strToBuf|bufToStr|...]
-    extensions.emplace_back(
-      std::make_shared<ccf::js::extensions::ConvertersExtension>());
-    // add ccf.crypto.*
-    extensions.emplace_back(
-      std::make_shared<ccf::js::extensions::CryptoExtension>());
+
     // add ccf.consensus.*
     extensions.emplace_back(
       std::make_shared<ccf::js::extensions::ConsensusExtension>(this));
@@ -451,16 +435,11 @@ namespace ccf::js
     extensions.emplace_back(
       std::make_shared<ccf::js::extensions::HistoricalExtension>(
         &context.get_historical_state()));
-    // add openenclave.*
-    extensions.emplace_back(
-      std::make_shared<ccf::js::extensions::OpenEnclaveExtension>());
-    // add snp_attestation.*
-    extensions.emplace_back(
-      std::make_shared<ccf::js::extensions::SnpAttestationExtension>());
 
     interpreter_cache->set_interpreter_factory(
       [extensions](ccf::js::TxAccess access) {
-        auto interpreter = std::make_shared<ccf::js::core::Context>(access);
+        // CommonContext also adds many extensions
+        auto interpreter = std::make_shared<ccf::js::CommonContext>(access);
 
         for (auto extension : extensions)
         {

--- a/src/node/gov/handlers/proposals.h
+++ b/src/node/gov/handlers/proposals.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #include "ccf/base_endpoint_registry.h"
+#include "ccf/js/common_context.h"
 #include "ccf/js/extensions/ccf/gov_effects.h"
-#include "js/common_context.h"
 #include "js/extensions/ccf/network.h"
 #include "js/extensions/ccf/node.h"
 #include "node/gov/api_version.h"
@@ -151,7 +151,7 @@ namespace ccf::gov::endpoints
       // Evaluate ballots
       for (const auto& [mid, mb] : proposal_info.ballots)
       {
-        js::CommonContext js_context(js::TxAccess::GOV_RO, &tx);
+        js::CommonContextWithLocalTx js_context(js::TxAccess::GOV_RO, &tx);
 
         auto ballot_func = js_context.get_exported_function(
           mb,
@@ -193,7 +193,7 @@ namespace ccf::gov::endpoints
       // votes, there is no change to the proposal stored in the KV.
       {
         {
-          js::CommonContext js_context(js::TxAccess::GOV_RO, &tx);
+          js::CommonContextWithLocalTx js_context(js::TxAccess::GOV_RO, &tx);
 
           auto resolve_func = js_context.get_exported_function(
             constitution,
@@ -297,7 +297,7 @@ namespace ccf::gov::endpoints
                 "Unexpected: Could not access GovEffects subsytem");
             }
 
-            js::CommonContext js_context(js::TxAccess::GOV_RW, &tx);
+            js::CommonContextWithLocalTx js_context(js::TxAccess::GOV_RW, &tx);
 
             js_context.add_extension(
               std::make_shared<ccf::js::extensions::NodeExtension>(
@@ -445,7 +445,7 @@ namespace ccf::gov::endpoints
               return;
             }
 
-            js::CommonContext context(js::TxAccess::GOV_RO, &ctx.tx);
+            js::CommonContextWithLocalTx context(js::TxAccess::GOV_RO, &ctx.tx);
 
             auto validate_func = context.get_exported_function(
               constitution.value(),

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -8,6 +8,7 @@
 #include "ccf/crypto/sha256.h"
 #include "ccf/ds/nonstd.h"
 #include "ccf/http_query.h"
+#include "ccf/js/common_context.h"
 #include "ccf/json_handler.h"
 #include "ccf/node/quote.h"
 #include "ccf/service/tables/gov.h"
@@ -15,7 +16,6 @@
 #include "ccf/service/tables/members.h"
 #include "ccf/service/tables/nodes.h"
 #include "frontend.h"
-#include "js/common_context.h"
 #include "js/extensions/ccf/network.h"
 #include "js/extensions/ccf/node.h"
 #include "node/gov/gov_endpoint_registry.h"
@@ -153,7 +153,7 @@ namespace ccf
       std::optional<ccf::jsgov::VoteFailures> vote_failures = std::nullopt;
       for (const auto& [mid, mb] : pi_->ballots)
       {
-        js::CommonContext context(js::TxAccess::GOV_RO, &tx);
+        js::CommonContextWithLocalTx context(js::TxAccess::GOV_RO, &tx);
 
         auto ballot_func = context.get_exported_function(
           mb,
@@ -200,7 +200,7 @@ namespace ccf
       }
 
       {
-        js::CommonContext js_context(js::TxAccess::GOV_RO, &tx);
+        js::CommonContextWithLocalTx js_context(js::TxAccess::GOV_RO, &tx);
 
         auto resolve_func = js_context.get_exported_function(
           constitution,
@@ -307,7 +307,8 @@ namespace ccf
                 "Unexpected: Could not access GovEffects subsytem");
             }
 
-            js::CommonContext apply_js_context(js::TxAccess::GOV_RW, &tx);
+            js::CommonContextWithLocalTx apply_js_context(
+              js::TxAccess::GOV_RW, &tx);
 
             apply_js_context.add_extension(
               std::make_shared<ccf::js::extensions::NodeExtension>(
@@ -1171,7 +1172,7 @@ namespace ccf
 
         auto validate_script = constitution.value();
 
-        js::CommonContext context(js::TxAccess::GOV_RO, &ctx.tx);
+        js::CommonContextWithLocalTx context(js::TxAccess::GOV_RO, &ctx.tx);
 
         auto validate_func = context.get_exported_function(
           validate_script,


### PR DESCRIPTION
I added this `CommonContext` so we wouldn't have to list the same basic extensions everywhere, but then didn't use it for the app interpreters (`js_generic` and `registry.cpp`). This rejigs things a little so its useable in those situations.