### PR TITLE
Add `workflow_dispatch` triggers to more GHA workflows

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions: read-all
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/codeql-analysis.yml"
+  workflow_dispatch:
 
 permissions: read-all
 

--- a/.github/workflows/daily-check.yml
+++ b/.github/workflows/daily-check.yml
@@ -1,6 +1,6 @@
 name: "Daily Build Status"
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 permissions: read-all
 


### PR DESCRIPTION
This adds buttons to trigger manual runs, that might be useful for these workflows. Prompted by a flaky CodeQL run.

![image](https://github.com/microsoft/CCF/assets/6000239/ddeacf18-0dee-4685-8748-1e1e3b559f34)
