### PR TITLE
Add setters and getter for JS runtime options, and sample HTTP APIs

### DIFF
--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -349,11 +349,6 @@
             "$ref": "#/components/schemas/boolean"
           }
         },
-        "required": [
-          "max_heap_bytes",
-          "max_stack_bytes",
-          "max_execution_time_ms"
-        ],
         "type": "object"
       },
       "JwtIssuerKeyFilter": {
@@ -1335,7 +1330,7 @@
   "info": {
     "description": "This API is used to submit and query proposals which affect CCF's public governance tables.",
     "title": "CCF Governance API",
-    "version": "4.1.6"
+    "version": "4.1.7"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/include/ccf/js/registry.h
+++ b/include/ccf/js/registry.h
@@ -79,6 +79,21 @@ namespace ccf::js
     void install_custom_endpoints(
       ccf::endpoints::EndpointContext& ctx, const ccf::js::Bundle& bundle);
 
+    /**
+     * Set options to control JS execution. Note that some hard limits may be
+     * applied to bound any values specified here.
+     */
+    ccf::ApiResult set_js_runtime_options_v1(
+      kv::Tx& tx, const ccf::JSRuntimeOptions& options);
+
+    /**
+     * Get the options which currently control JS execution. Note that if no
+     * value has been populated in the KV, this will return NotFound, but some
+     * default runtime limits may still be used.
+     */
+    ccf::ApiResult get_js_runtime_options_v1(
+      ccf::JSRuntimeOptions& options, kv::ReadOnlyTx& tx);
+
     /// \defgroup Overrides for base EndpointRegistry functions, looking up JS
     /// endpoints before delegating to base implementation.
     ///@{

--- a/include/ccf/js/registry.h
+++ b/include/ccf/js/registry.h
@@ -80,16 +80,16 @@ namespace ccf::js
       ccf::endpoints::EndpointContext& ctx, const ccf::js::Bundle& bundle);
 
     /**
-     * Set options to control JS execution. Note that some hard limits may be
-     * applied to bound any values specified here.
+     * Set options to control JS execution. Some hard limits may be applied to
+     * bound any values specified here.
      */
     ccf::ApiResult set_js_runtime_options_v1(
       kv::Tx& tx, const ccf::JSRuntimeOptions& options);
 
     /**
-     * Get the options which currently control JS execution. Note that if no
-     * value has been populated in the KV, this will return NotFound, but some
-     * default runtime limits may still be used.
+     * Get the options which currently control JS execution. If no value has
+     * been populated in the KV, this will return the default runtime options
+     * which will be applied instead.
      */
     ccf::ApiResult get_js_runtime_options_v1(
       ccf::JSRuntimeOptions& options, kv::ReadOnlyTx& tx);

--- a/include/ccf/service/tables/jsengine.h
+++ b/include/ccf/service/tables/jsengine.h
@@ -38,14 +38,82 @@ namespace ccf
     size_t max_cached_interpreters = Defaults::max_cached_interpreters;
   };
 
-  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(JSRuntimeOptions)
-  DECLARE_JSON_REQUIRED_FIELDS(
-    JSRuntimeOptions, max_heap_bytes, max_stack_bytes, max_execution_time_ms)
-  DECLARE_JSON_OPTIONAL_FIELDS(
-    JSRuntimeOptions,
-    log_exception_details,
-    return_exception_details,
-    max_cached_interpreters);
+  // Manually implemented to_json and from_json, so that we are maximally
+  // permissive in deserialisation (use defaults), but maximally verbose in
+  // serialisation (describe all fields)
+  inline void to_json(nlohmann::json& j, const JSRuntimeOptions& options)
+  {
+    j = nlohmann::json::object();
+    j["max_heap_bytes"] = options.max_heap_bytes;
+    j["max_stack_bytes"] = options.max_stack_bytes;
+    j["max_execution_time_ms"] = options.max_execution_time_ms;
+    j["log_exception_details"] = options.log_exception_details;
+    j["return_exception_details"] = options.return_exception_details;
+    j["max_cached_interpreters"] = options.max_cached_interpreters;
+  }
+
+  inline void from_json(const nlohmann::json& j, JSRuntimeOptions& options)
+  {
+    {
+      const auto it = j.find("max_heap_bytes");
+      if (it != j.end())
+      {
+        options.max_heap_bytes =
+          it->get<decltype(JSRuntimeOptions::max_heap_bytes)>();
+      }
+    }
+
+    {
+      const auto it = j.find("max_stack_bytes");
+      if (it != j.end())
+      {
+        options.max_stack_bytes =
+          it->get<decltype(JSRuntimeOptions::max_stack_bytes)>();
+      }
+    }
+    {
+      const auto it = j.find("max_execution_time_ms");
+      if (it != j.end())
+      {
+        options.max_execution_time_ms =
+          it->get<decltype(JSRuntimeOptions::max_execution_time_ms)>();
+      }
+    }
+    {
+      const auto it = j.find("log_exception_details");
+      if (it != j.end())
+      {
+        options.log_exception_details =
+          it->get<decltype(JSRuntimeOptions::log_exception_details)>();
+      }
+    }
+    {
+      const auto it = j.find("return_exception_details");
+      if (it != j.end())
+      {
+        options.return_exception_details =
+          it->get<decltype(JSRuntimeOptions::return_exception_details)>();
+      }
+    }
+    {
+      const auto it = j.find("max_cached_interpreters");
+      if (it != j.end())
+      {
+        options.max_cached_interpreters =
+          it->get<decltype(JSRuntimeOptions::max_cached_interpreters)>();
+      }
+    }
+  }
+
+  inline std::string schema_name(const JSRuntimeOptions*)
+  {
+    return "JSRuntimeOptions";
+  }
+
+  inline void fill_json_schema(nlohmann::json& schema, const JSRuntimeOptions*)
+  {
+    // TODO
+  }
 
   using JSEngine = ServiceValue<JSRuntimeOptions>;
 

--- a/samples/apps/basic/basic.cpp
+++ b/samples/apps/basic/basic.cpp
@@ -168,64 +168,83 @@ namespace basicapp
         .set_auto_schema<ccf::js::Bundle, void>()
         .install();
 
-      auto put_runtime_options = [this](ccf::endpoints::EndpointContext& ctx) {
-        const auto& caller_identity =
-          ctx.template get_caller<ccf::UserCOSESign1AuthnIdentity>();
+      auto patch_runtime_options =
+        [this](ccf::endpoints::EndpointContext& ctx) {
+          const auto& caller_identity =
+            ctx.template get_caller<ccf::UserCOSESign1AuthnIdentity>();
 
-        // Authorization Check
-        nlohmann::json user_data = nullptr;
-        auto result =
-          get_user_data_v1(ctx.tx, caller_identity.user_id, user_data);
-        if (result == ccf::ApiResult::InternalError)
-        {
-          ctx.rpc_ctx->set_error(
-            HTTP_STATUS_INTERNAL_SERVER_ERROR,
-            ccf::errors::InternalError,
-            fmt::format(
-              "Failed to get user data for user {}: {}",
-              caller_identity.user_id,
-              ccf::api_result_to_str(result)));
-          return;
-        }
-        const auto is_admin_it = user_data.find("isAdmin");
+          // Authorization Check
+          nlohmann::json user_data = nullptr;
+          auto result =
+            get_user_data_v1(ctx.tx, caller_identity.user_id, user_data);
+          if (result == ccf::ApiResult::InternalError)
+          {
+            ctx.rpc_ctx->set_error(
+              HTTP_STATUS_INTERNAL_SERVER_ERROR,
+              ccf::errors::InternalError,
+              fmt::format(
+                "Failed to get user data for user {}: {}",
+                caller_identity.user_id,
+                ccf::api_result_to_str(result)));
+            return;
+          }
+          const auto is_admin_it = user_data.find("isAdmin");
 
-        // Not every user gets to define custom endpoints, only users with
-        // isAdmin
-        if (
-          !user_data.is_object() || is_admin_it == user_data.end() ||
-          !is_admin_it.value().get<bool>())
-        {
-          ctx.rpc_ctx->set_error(
-            HTTP_STATUS_FORBIDDEN,
-            ccf::errors::AuthorizationFailed,
-            "Only admins may access this endpoint.");
-          return;
-        }
-        // End of Authorization Check
+          // Not every user gets to define custom endpoints, only users with
+          // isAdmin
+          if (
+            !user_data.is_object() || is_admin_it == user_data.end() ||
+            !is_admin_it.value().get<bool>())
+          {
+            ctx.rpc_ctx->set_error(
+              HTTP_STATUS_FORBIDDEN,
+              ccf::errors::AuthorizationFailed,
+              "Only admins may access this endpoint.");
+            return;
+          }
+          // End of Authorization Check
 
-        const auto j = nlohmann::json::parse(
-          caller_identity.content.begin(), caller_identity.content.end());
-        const auto options = j.get<ccf::JSRuntimeOptions>();
+          // Implement patch semantics.
+          // - Fetch current options
+          ccf::JSRuntimeOptions options;
+          get_js_runtime_options_v1(options, ctx.tx);
 
-        result = set_js_runtime_options_v1(ctx.tx, options);
-        if (result != ccf::ApiResult::OK)
-        {
-          ctx.rpc_ctx->set_error(
-            HTTP_STATUS_INTERNAL_SERVER_ERROR,
-            ccf::errors::InternalError,
-            fmt::format(
-              "Failed to set options: {}", ccf::api_result_to_str(result)));
-          return;
-        }
+          // - Convert current options to JSON
+          auto j_options = nlohmann::json(options);
 
-        ctx.rpc_ctx->set_response_status(HTTP_STATUS_NO_CONTENT);
-      };
+          // - Parse argument as JSON body
+          const auto arg_body = nlohmann::json::parse(
+            caller_identity.content.begin(), caller_identity.content.end());
+
+          // - Merge, to overwrite current options with anything from body. Note
+          // that nulls mean deletions, which results in resetting to a default
+          // value
+          j_options.merge_patch(arg_body);
+
+          // - Parse patched options from JSON
+          options = j_options.get<ccf::JSRuntimeOptions>();
+
+          result = set_js_runtime_options_v1(ctx.tx, options);
+          if (result != ccf::ApiResult::OK)
+          {
+            ctx.rpc_ctx->set_error(
+              HTTP_STATUS_INTERNAL_SERVER_ERROR,
+              ccf::errors::InternalError,
+              fmt::format(
+                "Failed to set options: {}", ccf::api_result_to_str(result)));
+            return;
+          }
+
+          ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+          ctx.rpc_ctx->set_response_header(
+            http::headers::CONTENT_TYPE, http::headervalues::contenttype::JSON);
+          ctx.rpc_ctx->set_response_body(nlohmann::json(options).dump(2));
+        };
       make_endpoint(
         "/custom_endpoints/runtime_options",
-        HTTP_PUT,
-        put_runtime_options,
+        HTTP_PATCH,
+        patch_runtime_options,
         {ccf::user_cose_sign1_auth_policy})
-        .set_auto_schema<ccf::JSRuntimeOptions, void>()
         .install();
 
       auto get_runtime_options = [this](ccf::endpoints::EndpointContext& ctx) {

--- a/src/js/registry.cpp
+++ b/src/js/registry.cpp
@@ -644,8 +644,6 @@ namespace ccf::js
   {
     try
     {
-      // TODO: Any validation to add here? Exec time shouldn't exceed consensus
-      // election time?
       tx.wo<ccf::JSEngine>(runtime_options_map)->put(options);
       return ccf::ApiResult::OK;
     }

--- a/src/js/registry.cpp
+++ b/src/js/registry.cpp
@@ -541,13 +541,10 @@ namespace ccf::js
   {
     try
     {
-      auto options_opt = tx.ro<ccf::JSEngine>(runtime_options_map)->get();
-      if (!options_opt.has_value())
-      {
-        return ccf::ApiResult::NotFound;
-      }
+      options = tx.ro<ccf::JSEngine>(runtime_options_map)
+                  ->get()
+                  .value_or(ccf::JSRuntimeOptions());
 
-      options = options_opt.value();
       return ccf::ApiResult::OK;
     }
     catch (const std::exception& e)

--- a/src/js/registry.cpp
+++ b/src/js/registry.cpp
@@ -520,6 +520,42 @@ namespace ccf::js
     });
   }
 
+  ccf::ApiResult DynamicJSEndpointRegistry::set_js_runtime_options_v1(
+    kv::Tx& tx, const ccf::JSRuntimeOptions& options)
+  {
+    try
+    {
+      // TODO: Any validation to add here? Exec time shouldn't exceed consensus
+      // election time?
+      tx.wo<ccf::JSEngine>(runtime_options_map)->put(options);
+      return ccf::ApiResult::OK;
+    }
+    catch (const std::exception& e)
+    {
+      return ccf::ApiResult::InternalError;
+    }
+  }
+
+  ccf::ApiResult DynamicJSEndpointRegistry::get_js_runtime_options_v1(
+    ccf::JSRuntimeOptions& options, kv::ReadOnlyTx& tx)
+  {
+    try
+    {
+      auto options_opt = tx.ro<ccf::JSEngine>(runtime_options_map)->get();
+      if (!options_opt.has_value())
+      {
+        return ccf::ApiResult::NotFound;
+      }
+
+      options = options_opt.value();
+      return ccf::ApiResult::OK;
+    }
+    catch (const std::exception& e)
+    {
+      return ccf::ApiResult::InternalError;
+    }
+  }
+
   ccf::endpoints::EndpointDefinitionPtr DynamicJSEndpointRegistry::
     find_endpoint(kv::Tx& tx, ccf::RpcContext& rpc_ctx)
   {

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -591,7 +591,7 @@ namespace ccf
       openapi_info.description =
         "This API is used to submit and query proposals which affect CCF's "
         "public governance tables.";
-      openapi_info.document_version = "4.1.6";
+      openapi_info.document_version = "4.1.7";
     }
 
     static std::optional<MemberId> get_caller_member_id(

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -1237,6 +1237,19 @@ class CCFClient:
         kwargs["http_verb"] = "OPTIONS"
         return self.call(*args, **kwargs)
 
+    def patch(self, *args, **kwargs) -> Response:
+        """
+        Issue ``PATCH`` request.
+        See :py:meth:`infra.clients.CCFClient.call`.
+
+        :return: :py:class:`infra.clients.Response`
+        """
+        if "http_verb" in kwargs:
+            raise ValueError('"http_verb" should not be specified')
+
+        kwargs["http_verb"] = "PATCH"
+        return self.call(*args, **kwargs)
+
     def wait_for_commit(
         self, response: Response, timeout: int = DEFAULT_COMMIT_TIMEOUT_SEC
     ):

--- a/tests/programmability.py
+++ b/tests/programmability.py
@@ -196,7 +196,7 @@ def test_custom_endpoints_js_options(network, args):
         defaults = r.body.json()
 
         same = test_options_patch(c)
-        assert same == defaults, f"Expected empty patch to retain default values"
+        assert same == defaults
 
         reduced_heap = test_options_patch(c, max_heap_bytes=42)
         assert reduced_heap == {**defaults, "max_heap_bytes": 42}

--- a/tests/programmability.py
+++ b/tests/programmability.py
@@ -116,6 +116,36 @@ def test_custom_endpoints(network, args):
     return network
 
 
+def test_custom_endpoints_js_options(network, args):
+    primary, _ = network.find_primary()
+
+    # Make user0 admin, so it can install custom endpoints
+    user = network.users[0]
+    network.consortium.set_user_data(
+        primary, user.service_id, user_data={"isAdmin": True}
+    )
+
+    with primary.client(None, None, user.local_id) as c:
+        r = c.call("/app/custom_endpoints/runtime_options", {}, http_verb="PATCH")
+        r = c.call(
+            "/app/custom_endpoints/runtime_options",
+            {"max_heap_bytes": 42},
+            http_verb="PATCH",
+        )
+        r = c.call(
+            "/app/custom_endpoints/runtime_options",
+            {"max_stack_bytes": 1},
+            http_verb="PATCH",
+        )
+        r = c.call(
+            "/app/custom_endpoints/runtime_options",
+            {"max_heap_bytes": None},
+            http_verb="PATCH",
+        )
+
+    return network
+
+
 def test_custom_role_definitions(network, args):
     primary, _ = network.find_primary()
     member = network.consortium.get_any_active_member()


### PR DESCRIPTION
Part of #6223.

Slightly different semantics than the governance equivalent (`set_js_runtime_options`), which I find slightly cumbersome. Instead the (sample) endpoint accepts a `PATCH` request, with `null` values permitted to reset any field to its default. To support that, we change the serialisation of this `JSRuntimeOptions` object to be more permissive on deserialisation (where previously it had a sharp distinction between the original fields and those added later), and verbose on serialisation.