### PR TITLE
Implement `build_api` in `DynamicJSEndpointRegistry`

### DIFF
--- a/include/ccf/js/registry.h
+++ b/include/ccf/js/registry.h
@@ -132,6 +132,8 @@ namespace ccf::js
       ccf::endpoints::EndpointDefinitionPtr e,
       ccf::endpoints::CommandEndpointContext& endpoint_ctx,
       const ccf::TxID& tx_id) override;
+
+    void build_api(nlohmann::json& document, kv::ReadOnlyTx& tx) override;
     ///@}
   };
 }

--- a/src/js/registry.cpp
+++ b/src/js/registry.cpp
@@ -793,4 +793,42 @@ namespace ccf::js
     ccf::endpoints::EndpointRegistry::execute_endpoint_locally_committed(
       e, endpoint_ctx, tx_id);
   }
+
+  // Since we do our own dispatch (overriding find_endpoint), make sure we
+  // describe those operations in the auto-generated OpenAPI
+  void DynamicJSEndpointRegistry::build_api(
+    nlohmann::json& document, kv::ReadOnlyTx& tx)
+  {
+    ccf::UserEndpointRegistry::build_api(document, tx);
+
+    auto endpoints = tx.ro<ccf::endpoints::EndpointsMap>(metadata_map);
+
+    endpoints->foreach([&document](const auto& key, const auto& properties) {
+      const auto http_verb = key.verb.get_http_method();
+      if (!http_verb.has_value())
+      {
+        return true;
+      }
+
+      if (!properties.openapi_hidden)
+      {
+        auto& path_op = ds::openapi::path_operation(
+          ds::openapi::path(
+            document,
+            fmt::format(
+              "/{}{}",
+              ccf::get_actor_prefix(ccf::ActorsType::users),
+              key.uri_path)),
+          http_verb.value(),
+          false);
+        if (!properties.openapi.empty())
+        {
+          path_op.insert(
+            properties.openapi.cbegin(), properties.openapi.cend());
+        }
+      }
+
+      return true;
+    });
+  }
 }


### PR DESCRIPTION
Not critical, but helpful for parity with `js_generic` deployed apps. This means that the builtin `/api` endpoint will document endpoints defined in JS. One major benefit of this is that we can reuse more of the existing e2e tests (which check that certain endpoints are available, via `GET /api`) with the new app-space JS deployment flow.