### PR TITLE
Update `protobufjs`

### DIFF
--- a/tests/npm-app/package.json
+++ b/tests/npm-app/package.json
@@ -16,7 +16,7 @@
     "jsrsasign-util": "^1.0.2",
     "jwt-decode": "^3.0.0",
     "lodash-es": "^4.17.15",
-    "protobufjs": "^7.2.4"
+    "protobufjs": "7.2.4"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",

--- a/tests/npm-app/package.json
+++ b/tests/npm-app/package.json
@@ -16,7 +16,7 @@
     "jsrsasign-util": "^1.0.2",
     "jwt-decode": "^3.0.0",
     "lodash-es": "^4.17.15",
-    "protobufjs": "7.2.4"
+    "protobufjs": "^7.3.2"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",


### PR DESCRIPTION
Steps towards resolving CI failures.

A recent version of `protobufjs` has reorganised the internal files, meaning the browser bundle include we previously used to work around https://github.com/protobufjs/protobuf.js/issues/1402 was no longer available. I'm pinning to protobufjs `7.2.4` for now. Once we've resolved the other CI failures, I'll see if we can move to the more recent release and remove the import workaround.

EDIT: Thought I was losing my mind investigating this, because it suddenly started working again. That's because there's a [new-new release of protobuf](https://github.com/protobufjs/protobuf.js/releases/tag/protobufjs-v7.3.2).
> Also fixes an issue with 7.3.1, where the dist/ folder containing the build artifacts was missing on npm.

Updated version requirement to `^7.3.2`.