### PR TITLE
Smart wait for msg to arrive in channel test

### DIFF
--- a/src/node/test/channels.cpp
+++ b/src/node/test/channels.cpp
@@ -1550,12 +1550,39 @@ TEST_CASE_FIXTURE(IORingbuffersFixture, "Key rotation")
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
   }
 
-  // Assume this sleep is long enough for channel threads to fully catch up
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Wait for channel threads to fully catch up.
+  constexpr int wait_finish_attemtps = 100;
+  for (int attempt = 0; attempt < wait_finish_attemtps; attempt++)
+  {
+    bool skip_waiting{false};
+    {
+      std::lock_guard<std::mutex> guard(sent_by_1.lock);
+      skip_waiting |= sent_by_1.to_send.empty();
+    }
+    {
+      std::lock_guard<std::mutex> guard(sent_by_2.lock);
+      skip_waiting |= sent_by_2.to_send.empty();
+    }
+    if (skip_waiting)
+    {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
   finished.store(true);
 
   channels1.join();
   channels2.join();
+
+  {
+    std::lock_guard<std::mutex> guard(sent_by_1.lock);
+    REQUIRE(sent_by_1.to_send.empty());
+  }
+  {
+    std::lock_guard<std::mutex> guard(sent_by_2.lock);
+    REQUIRE(sent_by_2.to_send.empty());
+  }
 
   // Validate results
   REQUIRE(received_by_1 == expected_received_by_1);

--- a/src/node/test/channels.cpp
+++ b/src/node/test/channels.cpp
@@ -1551,8 +1551,8 @@ TEST_CASE_FIXTURE(IORingbuffersFixture, "Key rotation")
   }
 
   // Wait for channel threads to fully catch up.
-  constexpr int wait_finish_attemtps = 100;
-  for (int attempt = 0; attempt < wait_finish_attemtps; attempt++)
+  constexpr int wait_finish_attempts = 100;
+  for (int attempt = 0; attempt < wait_finish_attempts; attempt++)
   {
     bool skip_waiting{false};
     {


### PR DESCRIPTION
Closes #5853

- Was able to repro same sort of failure locally by playing around with `sleep`s.
- Changing pure sleep to a more robust waiting + additional checks for messages to arrive.
- In case it reproduces, we'll be able to distinguish corrupted messages from messages never sent.