### PR TITLE
Fix polars deprecation warnings

### DIFF
--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -420,8 +420,8 @@ def run(args):
                         overall = rcvd.join(overall, on="messageID")
                         overall = overall.with_columns(
                             client=pl.lit(remote_client.name),
-                            requestSize=pl.col("request").map_elements(len),
-                            responseSize=pl.col("rawResponse").map_elements(len),
+                            requestSize=pl.col("request").len(),
+                            responseSize=pl.col("rawResponse").len(),
                         )
 
                         number_of_errors = overall.filter(
@@ -561,7 +561,7 @@ def run(args):
 
                 per_sec = (
                     sent_per_sec.join(recv_per_sec, on="second")
-                    .join(errors_per_sec, on="second", how="outer")
+                    .join(errors_per_sec, on="second", how="full")
                     .sort("second")
                     .fill_null(0)
                 )

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -420,8 +420,12 @@ def run(args):
                         overall = rcvd.join(overall, on="messageID")
                         overall = overall.with_columns(
                             client=pl.lit(remote_client.name),
-                            requestSize=pl.col("request").len(),
-                            responseSize=pl.col("rawResponse").len(),
+                            requestSize=pl.col("request").map_elements(
+                                len, return_dtype=pl.Int64
+                            ),
+                            responseSize=pl.col("rawResponse").map_elements(
+                                len, return_dtype=pl.Int64
+                            ),
                         )
 
                         number_of_errors = overall.filter(


### PR DESCRIPTION
Warnings before:
```
81: sys:1: MapWithoutReturnDtypeWarning: Calling `map_elements` without specifying `return_dtype` can lead to unpredictable results. Specify `return_dtype` to silence this warning.
81: sys:1: MapWithoutReturnDtypeWarning: Calling `map_elements` without specifying `return_dtype` can lead to unpredictable results. Specify `return_dtype` to silence this warning.
81: /data/src/2.CCF/tests/infra/basicperf.py:563: DeprecationWarning: Use of `how='outer'` should be replaced with `how='full'`.
```