### PR TITLE
[release/4.x] Cherry pick: Update from Open Enclave 0.19.4 to 0.19.6 (#6262)

### DIFF
--- a/getting_started/setup_vm/roles/openenclave/vars/common.yml
+++ b/getting_started/setup_vm/roles/openenclave/vars/common.yml
@@ -1,6 +1,6 @@
-oe_ver: "0.19.3"
+oe_ver: "0.19.6"
 # Usually the same, except for rc, where ver is -rc and ver_ is _rc
-oe_ver_: "0.19.3"
+oe_ver_: "0.19.6"
 
 # Source install
 workspace: "/tmp/"


### PR DESCRIPTION
Backports the following commits to `release/4.x`:
 - [Update from Open Enclave 0.19.4 to 0.19.6 (#6262)](https://github.com/microsoft/CCF/pull/6262)