### PR TITLE
Initialize variable

### DIFF
--- a/src/js/interpreter_cache.h
+++ b/src/js/interpreter_cache.h
@@ -14,7 +14,7 @@ namespace ccf::js
     // Locks access to all internal fields
     ccf::pal::Mutex lock;
     LRU<std::string, std::shared_ptr<js::core::Context>> lru;
-    size_t cache_build_marker;
+    size_t cache_build_marker = 0;
 
     InterpreterFactory interpreter_factory = nullptr;
 


### PR DESCRIPTION
Noticed in a verbose log that this can potentially start uninitialized.