### PR TITLE
[release/4.x] Cherry pick: Update dependencies for npm-app and protobuf import (#6253)

### DIFF
--- a/tests/npm-app/package.json
+++ b/tests/npm-app/package.json
@@ -11,23 +11,23 @@
   },
   "dependencies": {
     "@microsoft/ccf-app": "file:../../js/ccf-app",
-    "js-base64": "^3.5.2",
-    "jsrsasign": "^10.0.4",
-    "jsrsasign-util": "^1.0.2",
-    "jwt-decode": "^3.0.0",
-    "lodash-es": "^4.17.15",
-    "protobufjs": "^7.2.4"
+    "js-base64": "^3.7.7",
+    "jsrsasign": "^11.1.0",
+    "jsrsasign-util": "^1.0.5",
+    "jwt-decode": "^4.0.0",
+    "lodash-es": "^4.17.21",
+    "protobufjs": "^7.3.1"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^17.1.0",
-    "@rollup/plugin-node-resolve": "^11.2.0",
-    "@rollup/plugin-typescript": "^8.2.0",
-    "@types/jsrsasign": "^8.0.7",
-    "@types/lodash-es": "^4.17.3",
-    "del-cli": "^5.0.0",
-    "http-server": "^0.13.0",
-    "rollup": "^2.41.0",
-    "tslib": "^2.0.1",
-    "typescript": "^4.2.4"
+    "@rollup/plugin-commonjs": "^26.0.1",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-typescript": "^11.1.6",
+    "@types/jsrsasign": "^10.5.14",
+    "@types/lodash-es": "^4.17.12",
+    "del-cli": "^5.1.0",
+    "http-server": "^14.1.1",
+    "rollup": "^4.18.0",
+    "tslib": "^2.6.3",
+    "typescript": "^5.4.5"
   }
 }

--- a/tests/npm-app/src/endpoints/proto.ts
+++ b/tests/npm-app/src/endpoints/proto.ts
@@ -1,5 +1,4 @@
-// Importing the browser bundle works around https://github.com/protobufjs/protobuf.js/issues/1402.
-import protobuf from "protobufjs/dist/protobuf.js";
+import * as protobuf from "protobufjs/light";
 
 import * as ccfapp from "@microsoft/ccf-app";
 


### PR DESCRIPTION
Backports the following commits to `release/4.x`:
 - [Update dependencies for npm-app and protobuf import (#6253)](https://github.com/microsoft/CCF/pull/6253)