### PR TITLE
Only run CI and TLA jobs on pushes to main, not to other branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -2,8 +2,7 @@ name: "TLA+ Spec Verification"
 
 on:
   push:
-    paths:
-      - "tla/**"
+    branches: [main]
   pull_request:
     paths:
       - "tla/**"

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -42,8 +42,7 @@ class TSimpleFrontend : public RpcFrontend
 public:
   Registry registry;
 
-  TSimpleFrontend(
-    ccf::kv::Store& tables, ccf::AbstractNodeContext& context) :
+  TSimpleFrontend(ccf::kv::Store& tables, ccf::AbstractNodeContext& context) :
     RpcFrontend(tables, registry, context),
     registry(context)
   {}


### PR DESCRIPTION
Too many runs otherwise, especially when working on the release pipeline, which needs a branch + tags.