### PR TITLE
Run CodeQL in container

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -77,6 +77,8 @@ jobs:
         name: Install dependencies
 
       - run: |
+          set -ex
+          git config --global --add safe.directory /__w/CCF/CCF
           mkdir build
           cd build
           cmake -DCOMPILE_TARGET=virtual -DREQUIRE_OPENENCLAVE=OFF -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=OFF -DLVI_MITIGATIONS=OFF -DCMAKE_C_COMPILER=`which clang-11` -DCMAKE_CXX_COMPILER=`which clang++-11` ..

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
       image: ccfmsrc.azurecr.io/ccf/ci:2024-06-26-virtual-clang15
+      options: --user root
 
     permissions:
       security-events: write

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,8 @@ jobs:
     name: Analyze
     # Insufficient space to run on public runner, so use custom pool
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
+    container:
+      image: ccfmsrc.azurecr.io/ccf/ci:2024-06-26-virtual-clang15
 
     permissions:
       security-events: write


### PR DESCRIPTION
With the CI job now run in-container, and with executors being re-used in the private pool to improve efficiency, there end up being directories created by root (inside the container) that the checkout step on non-container jobs is unable to clean up.

One possible solution is to move all jobs run in private pools to container images. I remembered, probably incorrectly, that CodeQL could not be run in a container. But that does not seem to be the case now, there are only a few requirements, which I think we meet: https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/running-codeql-code-scanning-in-a-container