### PR TITLE
`fuzz_test`: Reduce logging spam at allocation quotas, to avoid test timeouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,8 +72,10 @@ jobs:
           export ASAN_SYMBOLIZER_PATH=$(realpath /usr/bin/llvm-symbolizer-15)
           # Unit tests
           ./tests.sh --output-on-failure -L unit -j$(nproc --all)
+          # Fuzz test, verbose every time
+          ./tests.sh --timeout 360 -VV -R "fuzz"
           # All other acceptably fast tests, mostly end-to-end
-          ./tests.sh --timeout 360 --output-on-failure -LE "benchmark|perf|protocolstest|vegeta|suite|unit"
+          ./tests.sh --timeout 360 --output-on-failure -LE "benchmark|perf|protocolstest|vegeta|suite|unit" -E "fuzz"
           # Partitions tests
           ./tests.sh --timeout 360 --output-on-failure -LE "benchmark|perf|protocolstest|vegeta|suite"
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,13 +71,14 @@ jobs:
           mkdir -p /github/home/.cache
           export ASAN_SYMBOLIZER_PATH=$(realpath /usr/bin/llvm-symbolizer-15)
           # Unit tests
-          ./tests.sh --output-on-failure -L unit -j$(nproc --all)
+          # TODO: Restore
+          #./tests.sh --output-on-failure -L unit -j$(nproc --all)
           # Fuzz test, verbose every time
           ./tests.sh --timeout 360 -VV -R "fuzz"
           # All other acceptably fast tests, mostly end-to-end
-          ./tests.sh --timeout 360 --output-on-failure -LE "benchmark|perf|protocolstest|vegeta|suite|unit" -E "fuzz"
+          #./tests.sh --timeout 360 --output-on-failure -LE "benchmark|perf|protocolstest|vegeta|suite|unit" -E "fuzz"
           # Partitions tests
-          ./tests.sh --timeout 360 --output-on-failure -LE "benchmark|perf|protocolstest|vegeta|suite"
+          #./tests.sh --timeout 360 --output-on-failure -LE "benchmark|perf|protocolstest|vegeta|suite"
         shell: bash
         if: "${{ matrix.platform.name != 'snp' }}" # Needs 1ES Pool support
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,14 +71,11 @@ jobs:
           mkdir -p /github/home/.cache
           export ASAN_SYMBOLIZER_PATH=$(realpath /usr/bin/llvm-symbolizer-15)
           # Unit tests
-          # TODO: Restore
-          #./tests.sh --output-on-failure -L unit -j$(nproc --all)
-          # Fuzz test, verbose every time
-          ./tests.sh --timeout 360 -VV -R "fuzz"
+          ./tests.sh --output-on-failure -L unit -j$(nproc --all)
           # All other acceptably fast tests, mostly end-to-end
-          #./tests.sh --timeout 360 --output-on-failure -LE "benchmark|perf|protocolstest|vegeta|suite|unit" -E "fuzz"
+          ./tests.sh --timeout 360 --output-on-failure -LE "benchmark|perf|protocolstest|vegeta|suite|unit"
           # Partitions tests
-          #./tests.sh --timeout 360 --output-on-failure -LE "benchmark|perf|protocolstest|vegeta|suite"
+          ./tests.sh --timeout 360 --output-on-failure -LE "benchmark|perf|protocolstest|vegeta|suite"
         shell: bash
         if: "${{ matrix.platform.name != 'snp' }}" # Needs 1ES Pool support
 

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -48,8 +48,12 @@ using namespace std::chrono_literals;
 using ResolvedAddresses = std::
   map<ccf::NodeInfoNetwork::RpcInterfaceID, ccf::NodeInfoNetwork::NetAddress>;
 
-size_t asynchost::TCPImpl::remaining_read_quota;
-size_t asynchost::UDPImpl::remaining_read_quota;
+size_t asynchost::TCPImpl::remaining_read_quota =
+  asynchost::TCPImpl::max_read_quota;
+bool asynchost::TCPImpl::alloc_quota_logged = false;
+
+size_t asynchost::UDPImpl::remaining_read_quota =
+  asynchost::UDPImpl::max_read_quota;
 
 std::chrono::microseconds asynchost::TimeBoundLogger::default_max_time(10'000);
 

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -29,6 +29,7 @@ namespace asynchost
     // Each uv iteration, read only a capped amount from all sockets.
     static constexpr auto max_read_quota = max_read_size * 4;
     static size_t remaining_read_quota;
+    static bool alloc_quota_logged;
 
     enum Status
     {
@@ -127,6 +128,7 @@ namespace asynchost
     static void reset_read_quota()
     {
       remaining_read_quota = max_read_quota;
+      alloc_quota_logged = false;
     }
 
     void set_behaviour(std::unique_ptr<SocketBehaviour<TCP>> b)
@@ -743,10 +745,13 @@ namespace asynchost
 
       alloc_size = std::min(alloc_size, remaining_read_quota);
       remaining_read_quota -= alloc_size;
-      LOG_TRACE_FMT(
-        "Allocating {} bytes for TCP read ({} of quota remaining)",
-        alloc_size,
-        remaining_read_quota);
+      if (alloc_size != 0)
+      {
+        LOG_TRACE_FMT(
+          "Allocating {} bytes for TCP read ({} of quota remaining)",
+          alloc_size,
+          remaining_read_quota);
+      }
 
       buf->base = new char[alloc_size];
       buf->len = alloc_size;
@@ -772,7 +777,11 @@ namespace asynchost
 
       if (sz == UV_ENOBUFS)
       {
-        LOG_DEBUG_FMT("TCP on_read reached allocation quota");
+        if (!alloc_quota_logged)
+        {
+          LOG_DEBUG_FMT("TCP on_read reached allocation quota");
+          alloc_quota_logged = true;
+        }
         on_free(buf);
         return;
       }

--- a/tests/fuzzing.py
+++ b/tests/fuzzing.py
@@ -14,6 +14,7 @@ class CCFFuzzLogger(boofuzz.IFuzzLogger):
         self.print_period = print_period
         self.last_printed = None
         self.keep_lines = keep_lines
+        self.last_fuzzed_count = 0
 
         self.session = None
 
@@ -24,10 +25,15 @@ class CCFFuzzLogger(boofuzz.IFuzzLogger):
         if self.session is not None:
             now = datetime.datetime.now()
             if self.last_printed is None or now - self.last_printed > self.print_period:
+                fuzzed_this_period = (
+                    self.session.num_cases_actually_fuzzed - self.last_fuzzed_count
+                )
+                fuzzing_rate = fuzzed_this_period / self.print_period.seconds
                 LOG.info(
-                    f"Fuzzed {self.session.num_cases_actually_fuzzed} total cases in {self.session.runtime:.2f}s (rate={self.session.exec_speed:.2f}/s)"
+                    f"Fuzzed {self.session.num_cases_actually_fuzzed} total cases in {self.session.runtime:.2f}s (current rate={fuzzing_rate:.2f}/s)"
                 )
                 self.last_printed = now
+                self.last_fuzzed_count = self.session.num_cases_actually_fuzzed
 
     def open_test_case(self, test_case_id, name, index, *args, **kwargs):
         self._store_line(f"Test case: {name} ({index=})")

--- a/tests/fuzzing.py
+++ b/tests/fuzzing.py
@@ -149,6 +149,7 @@ def fuzz_node_to_node(network, args):
     )
     fuzz_logger.session = session
 
+    LOG.info(f"Loggers before monkey-patch: {session._fuzz_data_logger._fuzz_loggers}")
     # Monkey-patch: Remove any Db loggers from the boofuzz session. We never
     # use them, and they're reliant on disk IO (for db commits) so sometimes very slow
     session._fuzz_data_logger._fuzz_loggers = [
@@ -156,6 +157,7 @@ def fuzz_node_to_node(network, args):
         for logger in session._fuzz_data_logger._fuzz_loggers
         if not isinstance(logger, boofuzz.fuzz_logger_db.FuzzLoggerDb)
     ]
+    LOG.info(f"Loggers after monkey-patch: {session._fuzz_data_logger._fuzz_loggers}")
 
     session.connect(req)
 

--- a/tests/fuzzing.py
+++ b/tests/fuzzing.py
@@ -163,6 +163,7 @@ def fuzz_node_to_node(network, args):
         for logger in session._fuzz_data_logger._fuzz_loggers
         if not isinstance(logger, boofuzz.fuzz_logger_db.FuzzLoggerDb)
     ]
+    session._db_logger = None
     LOG.info(f"Loggers after monkey-patch: {session._fuzz_data_logger._fuzz_loggers}")
 
     session.connect(req)


### PR DESCRIPTION
`fuzz_test` is still extremely flaky following #6308, with some runs having a very low throughput (<200/s) and eventually timing out.

Adding some logging to confirm the monkey-patch is present and has made a difference.

EDIT - After additional investigation, got local repro (requires SGX Debug Verbose), and found the spammy logs that are slowing things down.