### PR TITLE
Cleaner error when we can't open a new snapshot file

### DIFF
--- a/src/host/snapshots.h
+++ b/src/host/snapshots.h
@@ -270,17 +270,25 @@ namespace asynchost
             {
               std::ofstream snapshot_file(
                 full_snapshot_path, std::ios::app | std::ios::binary);
-              const auto& snapshot = it->second.snapshot;
-              snapshot_file.write(
-                reinterpret_cast<const char*>(snapshot->data()),
-                snapshot->size());
-              snapshot_file.write(
-                reinterpret_cast<const char*>(receipt_data), receipt_size);
+              if (!snapshot_file.good())
+              {
+                LOG_FAIL_FMT(
+                  "Cannot write snapshot: error opening file {}", file_name);
+              }
+              else
+              {
+                const auto& snapshot = it->second.snapshot;
+                snapshot_file.write(
+                  reinterpret_cast<const char*>(snapshot->data()),
+                  snapshot->size());
+                snapshot_file.write(
+                  reinterpret_cast<const char*>(receipt_data), receipt_size);
 
-              LOG_INFO_FMT(
-                "New snapshot file written to {} [{} bytes]",
-                file_name,
-                static_cast<size_t>(snapshot_file.tellp()));
+                LOG_INFO_FMT(
+                  "New snapshot file written to {} [{} bytes]",
+                  file_name,
+                  static_cast<size_t>(snapshot_file.tellp()));
+              }
             }
 
             pending_snapshots.erase(it);


### PR DESCRIPTION
Noticed while debugging something else. If we can't open a snapshot (eg - reached fd limit), this code won't blow up but will log what's clearly an error (roughly `New snapshot file written to 5.snapshot [99999999999 bytes]`). This catches the OP failure earlier, and reports it as such.

Note that we're already robust to this failure in the sense that all snapshot attempts are best-effort - if the file already existed, or this fails, we still clear the `pending_snapshot`.