### PR TITLE
Update CI triggers

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -30,21 +30,21 @@ File: `ci-containers-ghcr.yml`
 
 # CI
 
-Main continuous integration job. Builds CCF for all target platforms, runs unit, end to end and partition tests for SGX and Virtual. Run on every commit, including PRs from forks, gates merging.
+Main continuous integration job. Builds CCF for all target platforms, runs unit, end to end and partition tests for SGX and Virtual. Run on every commit, including PRs from forks, gates merging. Also runs once a week, regardless of commits.
 
 File: `ci.yml`
 3rd party dependencies: None
 
 # CodeQL analysis
 
-Builds CCF with CodeQL, and runs the security-extended checks. Triggered on every commit on main, plus PRs that affect ".github/workflows/codeql-analysis.yml".
+Builds CCF with CodeQL, and runs the security-extended checks. Triggered on PRs that affect ".github/workflows/codeql-analysis.yml", and once a week on main.
 
 File: `codeql-analysis.yml`
 3rd party dependencies: None
 
 # Release
 
-Produces CCF release artefacts from 5.0.0-rc0 onwards, for all languages and platforms. Triggered on tag matching "ccf-5.\*". The output of the job is a draft release, which needs to be published manually. Publishing triggers the downstream jobs listed below.
+Produces CCF release artefacts from 5.0.0-rc0 onwards, for all languages and platforms. Triggered on tags matching "ccf-5.\*". The output of the job is a draft release, which needs to be published manually. Publishing triggers the downstream jobs listed below.
 
 File: `release.yml`
 3rd party dependencies: None

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
   workflow_dispatch:
   merge_group:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  schedule:
+    - cron: "0 0 * * 0"
   pull_request:
   workflow_dispatch:
   merge_group:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   workflow_dispatch:
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,10 +6,7 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
     paths:
       - ".github/workflows/codeql-analysis.yml"
   workflow_dispatch:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,8 @@
 name: "CodeQL"
 
 on:
+  schedule:
+    - cron: "0 0 * * 0"
   pull_request:
     paths:
       - ".github/workflows/codeql-analysis.yml"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,10 @@ on:
       - ".github/workflows/codeql-analysis.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -8,6 +8,10 @@ on:
       - "tla/**"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   actions: read
   contents: read

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -1,6 +1,8 @@
 name: "TLA+ Spec Verification"
 
 on:
+  schedule:
+    - cron: "0 0 * * 0"
   pull_request:
     paths:
       - "tla/**"

--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -1,8 +1,6 @@
 name: "TLA+ Spec Verification"
 
 on:
-  push:
-    branches: [main]
   pull_request:
     paths:
       - "tla/**"


### PR DESCRIPTION
1. Remove re-triggers on push on main, for things that have just been tested on the branch. Our enforcement of linear history means we run the same build twice, unnecessarily.
2. Add weekly trigger for such jobs, so that they are triggered periodically enough to detect externally induced breaks, even if their normal trigger condition is not met for a while.
3. Cancel jobs running against older commits: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency