### PR TITLE
Disable verbose logging on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           git config --global --add safe.directory /__w/CCF/CCF
           mkdir build
           cd build
-          cmake -GNinja -DCOMPILE_TARGET=${{ matrix.platform.name }} -DCMAKE_BUILD_TYPE=Debug -DLVI_MITIGATIONS=OFF -DVERBOSE_LOGGING=ON ..
+          cmake -GNinja -DCOMPILE_TARGET=${{ matrix.platform.name }} -DCMAKE_BUILD_TYPE=Debug -DLVI_MITIGATIONS=OFF ..
           ninja
         shell: bash
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Confidential Consortium Framework [![CI](https://github.com/microsoft/CCF/actions/workflows/build.yml/badge.svg)](https://github.com/microsoft/CCF/actions/workflows/build.yml)
+# The Confidential Consortium Framework [![CI](https://github.com/microsoft/CCF/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/CCF/actions/workflows/ci.yml)
 
 <img alt="ccf" align="right" src="doc/_static/ccf.svg" width="200">
 

--- a/doc/contribute/build_ccf.rst
+++ b/doc/contribute/build_ccf.rst
@@ -78,7 +78,7 @@ Build Older Versions of CCF
 
 Building older versions of CCF may require a different toolchain than the one used to build the current ``main`` branch (e.g. 1.x CCF releases are built with `clang-8`).
 To build an old version of CCF locally without having to install another toolchain that may conflict with the current one, it is recommended to use the ``ccfciteam/ccf-ci`` docker image, later ``ccfmsrc.azurecr.io/ccf/ci`` and now ``ghcr.io/microsoft/ccf/ci/(default|sgx)`` since 5.0.0-rc0.
-The version tag of the ``cci-ci`` (later ``ccf/ci``) image used to build the old version can be found in the :ccf_repo:`.azure-pipelines.yml` YAML file (under ``resources:container:image``) before 5.0.0-rc0, and in the :ccf_repo:`.github/workflows/build.yml` YAML file afterwards.
+The version tag of the ``cci-ci`` (later ``ccf/ci``) image used to build the old version can be found in the :ccf_repo:`.azure-pipelines.yml` YAML file (under ``resources:container:image``) before 5.0.0-rc0, and in the :ccf_repo:`.github/workflows/ci.yml` YAML file afterwards.
 
 .. code-block:: bash
 


### PR DESCRIPTION
The CI is too slow, too expensive, and the logs too big.