### PR TITLE
Zero out idle time when deallocating the socket

### DIFF
--- a/src/host/rpc_connections.h
+++ b/src/host/rpc_connections.h
@@ -345,6 +345,8 @@ namespace asynchost
       // Invalidating the TCP socket will result in the handle being closed. No
       // more messages will be read from or written to the TCP socket.
       sockets[id] = nullptr;
+      idle_times.erase(id);
+
       RINGBUFFER_WRITE_MESSAGE(::tcp::tcp_close, to_enclave, id);
 
       return true;


### PR DESCRIPTION
Avoid spamming the output when session closure flow doesn't match idle times.

![image](https://github.com/user-attachments/assets/2b367b75-26b2-4755-b5c2-65ed743b6d19)
