### PR TITLE
Update azp base images

### DIFF
--- a/.azure-pipelines-gh-pages.yml
+++ b/.azure-pipelines-gh-pages.yml
@@ -11,7 +11,7 @@ jobs:
     variables:
       Codeql.SkipTaskAutoInjection: true
       skipComponentGovernanceDetection: true
-    container: ccfmsrc.azurecr.io/ccf/ci:2024-06-26-virtual-clang15
+    container: ghcr.io/microsoft/ccf/ci/default:latest
     pool:
       vmImage: ubuntu-20.04
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "CCF Development Environment",
-  "image": "ccfmsrc.azurecr.io/ccf/ci:2024-06-26-virtual-clang15",
+  "image": "ghcr.io/microsoft/ccf/ci/default:latest",
   "runArgs": [],
   "extensions": [
     "eamodio.gitlens",

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -11,7 +11,7 @@ jobs:
     name: Continuous Benchmarking with Bencher
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
-      image: ccfmsrc.azurecr.io/ccf/ci:2024-06-26-virtual-clang15
+      image: ghcr.io/microsoft/ccf/ci/default:build-26-06-2024
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/azure_deployment/arm_aci.py
+++ b/scripts/azure_deployment/arm_aci.py
@@ -130,10 +130,7 @@ def make_dev_container(id, name, image, command, ports, with_volume):
 def parse_aci_args(parser: ArgumentParser) -> Namespace:
     # Generic options
     parser.add_argument(
-        "--aci-image",
-        help="The name of the image to deploy in the ACI",
-        type=str,
-        required=True,
+        "--aci-image", help="The name of the image to deploy in the ACI", type=str
     )
     parser.add_argument(
         "--aci-type",

--- a/scripts/azure_deployment/arm_aci.py
+++ b/scripts/azure_deployment/arm_aci.py
@@ -133,7 +133,7 @@ def parse_aci_args(parser: ArgumentParser) -> Namespace:
         "--aci-image",
         help="The name of the image to deploy in the ACI",
         type=str,
-        default="ccfmsrc.azurecr.io/ccf/ci:2024-06-26-snp",
+        required=True
     )
     parser.add_argument(
         "--aci-type",

--- a/scripts/azure_deployment/arm_aci.py
+++ b/scripts/azure_deployment/arm_aci.py
@@ -133,7 +133,7 @@ def parse_aci_args(parser: ArgumentParser) -> Namespace:
         "--aci-image",
         help="The name of the image to deploy in the ACI",
         type=str,
-        required=True
+        required=True,
     )
     parser.add_argument(
         "--aci-type",

--- a/src/endpoints/endpoint_utils.cpp
+++ b/src/endpoints/endpoint_utils.cpp
@@ -3,6 +3,7 @@
 
 #include "endpoint_utils.h"
 
+#define FMT_HEADER_ONLY
 #include <fmt/format.h>
 #include <regex>
 


### PR DESCRIPTION
Documentation is still on ADO for now, but switched to `:latest`, so does the dev container. Neither requires reproducibility.

Bencher updates to a versioned CI image from GHCR.