### PR TITLE
Reduce fail->info on missing session id on close

### DIFF
--- a/src/host/rpc_connections.h
+++ b/src/host/rpc_connections.h
@@ -355,7 +355,7 @@ namespace asynchost
     {
       if (sockets.erase(id) < 1)
       {
-        LOG_FAIL_FMT("Cannot close id {}: does not exist", id);
+        LOG_DEBUG_FMT("Cannot close id {}: does not exist", id);
         return false;
       }
 


### PR DESCRIPTION
In #6358, we introduced tcp::tcp_closed confirmation even if the enclave doesn't now about the session (see PR for details on why).

This started triggering more fail logs in the flows like that
- host initiates cleanup() call from on_disconnect(), tcp_close is sent to enclave
- enclave fails to parse http request and decides to kill the session, goes through stop() and sends tcp_stop to the host
- host responds to stopping with another tcp_close (which is not good, but chaning this requires more verification, so not done here)
- first tcp_closed confimaton goes from TLSSession destructor
- seconds comes from the unconditional confimation introduced in #6358 as a side effect of that change.

The log level is now reduced to info as soon as there's no flow failure in here.