### PR TITLE
Add `git_describe_command` for `setuptools_scm`

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -36,6 +36,7 @@ script-files = [
 [tool.setuptools_scm]
 version_file = "src/ccf/version.py"
 root = ".."
+git_describe_command = "git describe --dirty --tags --long --match ccf-*"
 
 [project.urls]
 Homepage = "https://github.com/microsoft/ccf"


### PR DESCRIPTION
Default describe picks up all tags, some of which are not versions.

```
$ git describe --tags --long
build/25-07-2024-1-g71b6758f0

$ git describe --tags --long --match ccf-*
ccf-5.0.0-17-g71b6758f0
```