### PR TITLE
Fix SNP deploy step

### DIFF
--- a/.azure-pipelines-templates/deploy_aci.yml
+++ b/.azure-pipelines-templates/deploy_aci.yml
@@ -65,7 +65,7 @@ jobs:
             --aci-type dynamic-agent \
             --deployment-name ci-$(Build.BuildNumber) \
             --aci-image ccfmsrc.azurecr.io/ccf/ci:pr-`git rev-parse HEAD` \
-            --managed-identity $(CCF_SNP_CI_MANAGED_IDENTITY_ID)
+            --managed-identity $(CCF_SNP_CI_MANAGED_IDENTITY_ID) \
             --ports 22 \
             --aci-setup-timeout 300 \
             --aci-private-key-b64 $(sshKey) \

--- a/scripts/azure_deployment/arm_aci.py
+++ b/scripts/azure_deployment/arm_aci.py
@@ -411,6 +411,10 @@ def check_aci_deployment(
     container_group_b 10.10.10.11
     """
 
+    print("!!!!!")
+    print("Checking deployment, output_resources are:")
+    print(json.dumps(deployment.properties.output_resources, indent=2))
+    print("!!!!!")
     container_client = ContainerInstanceManagementClient(
         AzureCliCredential(), args.subscription_id
     )

--- a/scripts/azure_deployment/arm_aci.py
+++ b/scripts/azure_deployment/arm_aci.py
@@ -411,10 +411,6 @@ def check_aci_deployment(
     container_group_b 10.10.10.11
     """
 
-    print("!!!!!")
-    print("Checking deployment, output_resources are:")
-    print(json.dumps(deployment.properties.output_resources, indent=2))
-    print("!!!!!")
     container_client = ContainerInstanceManagementClient(
         AzureCliCredential(), args.subscription_id
     )


### PR DESCRIPTION
Trying to work out why SNP is failing in check deployment.

![image](https://github.com/user-attachments/assets/9442f197-e6ca-4923-bd53-69586ae1ea11)

Guessing that we now create some new kind of resource (a delegated manged identity?) that doesn't contain an `ip_address` field. Simplest debugging method is to dump the whole object.

EDIT - the problem was [a missing escape](https://github.com/microsoft/CCF/pull/6398/commits/d9fdb0386a8ddf15de466600ccf034418bdc60f7).
