### PR TITLE
Update Backport branches

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,7 +1,7 @@
 {
   "repoOwner": "microsoft",
   "repoName": "ccf",
-  "targetBranchChoices": ["release/3.x", "release/4.x"],
+  "targetBranchChoices": ["release/4.x", "release/5.x"],
   "branchLabelMapping": {
     "^(.+)-todo$": "release/$1"
   },


### PR DESCRIPTION
`3.x` is out of support, `release/5.x` is imminent.