### PR TITLE
Remove SGX-specific dependencies from release playbooks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,7 +16,7 @@ Steps to reproduce the behavior.
 A clear and concise description of what you expected to happen.
 
 **Environment information**
-Version of the code being used, versions of dependencies, relevant environment info where applicable (OS, SGX driver...).
+Version of the code being used, versions of dependencies, relevant environment info where applicable (OS, Platform component details...).
 
 **Additional context**
 Add any other context about the problem here.

--- a/getting_started/setup_vm/app-dev.yml
+++ b/getting_started/setup_vm/app-dev.yml
@@ -1,28 +1,12 @@
 - hosts: localhost
   vars:
     run_only: false
-    platform: "sgx"
-    clang_version: "11"
+    platform: "snp"
+    clang_version: "15"
   tasks:
     - import_role:
         name: llvm_repo
         tasks_from: install.yml
-      when: clang_version == "15"
-    - import_role:
-        name: intel
-        tasks_from: sgx-psw.yml
-      when: platform == "sgx"
-    - import_role:
-        name: intel
-        tasks_from: sgx-group.yml
-      when: platform == "sgx"
-    - import_role:
-        name: az_dcap
-        tasks_from: install.yml
-    - import_role:
-        name: openenclave
-        tasks_from: binary_install.yml
-      when: platform == "sgx"
     - import_role:
         name: ccf_build
         tasks_from: install.yml

--- a/getting_started/setup_vm/app-run.yml
+++ b/getting_started/setup_vm/app-run.yml
@@ -1,28 +1,12 @@
 - hosts: localhost
   vars:
     run_only: true
-    platform: "sgx"
-    clang_version: "11"
+    platform: "snp"
+    clang_version: "15"
   tasks:
     - import_role:
         name: llvm_repo
         tasks_from: install.yml
-      when: clang_version == "15"
-    - import_role:
-        name: intel
-        tasks_from: sgx-psw.yml
-      when: platform == "sgx"
-    - import_role:
-        name: intel
-        tasks_from: sgx-group.yml
-      when: platform == "sgx"
-    - import_role:
-        name: az_dcap
-        tasks_from: install.yml
-    - import_role:
-        name: openenclave
-        tasks_from: binary_install.yml
-      when: platform == "sgx"
     - import_role:
         name: ccf_install
         tasks_from: deb_install.yml


### PR DESCRIPTION
Next step in #6413, note that ccf-dev.yml retains SGX dependencies so we can continue to update build images from the main branch.