### PR TITLE
Ensure raft traces are always uploaded as workflow artifacts.

### DIFF
--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -250,7 +250,7 @@ jobs:
 
       - name: Upload artifacts.
         uses: actions/upload-artifact@v4
-        if: ${{ failure() }}
+        if: always()
         with:
           name: tlc
           path: |

--- a/tests/raft_scenarios_runner.py
+++ b/tests/raft_scenarios_runner.py
@@ -169,12 +169,14 @@ if __name__ == "__main__":
         with block(ostream, "diagram", 3, "mermaid", ["sequenceDiagram"]):
             ostream.write(mermaid)
 
-        with open(
-            os.path.join(output_dir, f"{os.path.basename(scenario)}.ndjson"),
-            "w",
-            encoding="utf-8",
-        ) as f:
-            f.write(log)
+        ## Do not create an empty ndjson file if log is emtpy.
+        if log:
+            with open(
+                os.path.join(output_dir, f"{os.path.basename(scenario)}.ndjson"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                f.write(log)
 
     write_error_report(err_list)
 


### PR DESCRIPTION
This change archives the traces, simplifying the process for users to experiment with TLA+ trace validation by eliminating the need to compile and run CCF.

The uncompresses traces only measure 124KB in size.