### PR TITLE
Update TLA+ dev container to include new TLA+ vscode extension

### DIFF
--- a/.devcontainer/tlaplus/devcontainer.json
+++ b/.devcontainer/tlaplus/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "TLA+ CCF",
   "extensions": [
-    "alygin.vscode-tlaplus-nightly",
+    "tlaplus.vscode-ide",
     "joaompinto.vscode-graphviz",
     "EFanZh.graphviz-preview",
     "cssho.vscode-svgviewer"

--- a/tla/install_deps.py
+++ b/tla/install_deps.py
@@ -79,7 +79,7 @@ def _parse_args() -> argparse.Namespace:
 
 def install_tlc():
     java = "java"
-    tlaplus_path = "~/.vscode-remote/extensions/alygin.vscode-tlaplus-nightly-*/tools/tla2tools.jar"
+    tlaplus_path = "~/.vscode-remote/extensions/tlaplus.vscode-ide-*/tools/tla2tools.jar"
     copy_tlaplus = f"-cp {tlaplus_path} tlc2.TLC"
 
     set_alias("tlcrepl", f"{java} -cp {tlaplus_path} tlc2.REPL")


### PR DESCRIPTION
TLA+ vscode extension moved, as described here https://github.com/tlaplus/vscode-tlaplus/issues/318