### PR TITLE
Refactor abstract consensus specification

### DIFF
--- a/tla/consensus/MCabs.cfg
+++ b/tla/consensus/MCabs.cfg
@@ -14,4 +14,6 @@ INVARIANTS
 
 PROPERTIES 
     AppendOnlyProp
-    
+
+SYMMETRY 
+    Symmetry

--- a/tla/consensus/MCabs.tla
+++ b/tla/consensus/MCabs.tla
@@ -1,6 +1,9 @@
 ---- MODULE MCabs ----
 
-EXTENDS abs
+EXTENDS abs, TLC
+
+Symmetry ==
+      Permutations(Servers)
 
 CONSTANTS NodeOne, NodeTwo, NodeThree
 

--- a/tla/consensus/abs.tla
+++ b/tla/consensus/abs.tla
@@ -2,9 +2,18 @@
 \* Abstract specification for a distributed consensus algorithm.
 \* Assumes that any node can atomically inspect the state of all other nodes. 
 
-EXTENDS Sequences, SequencesExt, Naturals, FiniteSets, FiniteSetsExt
+EXTENDS Sequences, SequencesExt, Naturals, FiniteSets, FiniteSetsExt, Relation
 
-CONSTANT Servers, Terms, MaxLogLength
+CONSTANT Servers
+ASSUME IsFiniteSet(Servers)
+
+\* Terms is (strictly) totally ordered with a smallest element.
+CONSTANT Terms
+ASSUME /\ IsStrictlyTotallyOrderedUnder(<, Terms) 
+       /\ \E min \in Terms : \A t \in Terms : t <= min
+
+CONSTANT MaxLogLength
+ASSUME MaxLogLength \in Nat
 
 \* Commit logs from each node
 \* Each log is append-only and the logs will never diverge.

--- a/tla/consensus/abs.tla
+++ b/tla/consensus/abs.tla
@@ -24,10 +24,8 @@ TypeOK ==
 
 StartTerm == Min(Terms)
 
-InitialLogs == {
-    <<>>,
-    <<StartTerm, StartTerm>>,
-    <<StartTerm, StartTerm, StartTerm, StartTerm>>}
+InitialLogs == 
+    UNION {[ 1..n -> {StartTerm} ] : n \in {0,2,4}}
     
 Init ==
     cLogs \in [Servers -> InitialLogs]

--- a/tla/consensus/abs.tla
+++ b/tla/consensus/abs.tla
@@ -11,8 +11,7 @@ CONSTANT Servers, Terms, MaxLogLength
 VARIABLE cLogs
 
 TypeOK ==
-    /\ cLogs \in [Servers -> 
-        UNION {[1..l -> Terms] : l \in 0..MaxLogLength}]
+    cLogs \in [Servers -> Seq(Terms)]
 
 StartTerm == Min(Terms)
 


### PR DESCRIPTION
* Refactor (simplify) TypeOK to use (more concise) Sequences!Seq operator.
* Define InitialLogs less explicitly.
* Add assumptions about abs.tla's constants (TLAPS will likely need those assumptions should we attempt writing a proof).
* Mitigate state-space explosion during explicit-state model checking by declaring constant Servers to be symmetric.