### PR TITLE
`upload-artifact` Github action fails because of non-unique artifact names.

### DIFF
--- a/.github/workflows/tlaplus.yml
+++ b/.github/workflows/tlaplus.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: tlc
+          name: tlc-model-checking-consistency
           path: |
             tla/consistency/*_TTrace_*.tla
             tla/*.json
@@ -111,7 +111,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: tlc
+          name: tlc-simulation-consistency
           path: |
             tla/consistency/*_TTrace_*.tla
             tla/*.json
@@ -151,7 +151,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: tlc
+          name: tlc-model-checking-consensus
           path: |
             tla/consensus/*_TTrace_*.tla
             tla/*.json
@@ -179,7 +179,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: tlc
+          name: tlc-model-checking-with-reconfig-consensus
           path: |
             tla/consensus/*_TTrace_*.tla
             tla/*.json
@@ -207,7 +207,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: tlc
+          name: tlc-simulation-consensus
           path: |
             tla/*
 
@@ -258,6 +258,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: tlc
+          name: tlc-trace-validation-consensus
           path: |
             tla/traces/*


### PR DESCRIPTION
"Error: Failed to CreateArtifact: Received non-retryable error: Faile…d request: (409) Conflict: an artifact with this name already exists on the workflow run"

Failed e.g. in https://github.com/microsoft/CCF/actions/runs/10968475748/job/30459866526