### PR TITLE
Allow term change in MCccfraft.cfg and disable abs model refinement

### DIFF
--- a/tla/consensus/MCccfraft.cfg
+++ b/tla/consensus/MCccfraft.cfg
@@ -4,7 +4,7 @@ CONSTANTS
     Configurations <- 1Configuration
     Servers <- ToServers
 
-    MaxTermLimit = 2
+    MaxTermLimit = 3
     RequestLimit = 3
 
     StatsFilename = "MCccfraft_stats.json"
@@ -68,7 +68,7 @@ PROPERTIES
     MembershipStateTransitionsProp
     PendingBecomesFollowerProp
     NeverCommitEntryPrevTermsProp
-    RefinementToAbsProp
+    \* RefinementToAbsProp
 
 INVARIANTS
     LogInv

--- a/tla/consensus/MCccfraft.cfg
+++ b/tla/consensus/MCccfraft.cfg
@@ -68,7 +68,7 @@ PROPERTIES
     MembershipStateTransitionsProp
     PendingBecomesFollowerProp
     NeverCommitEntryPrevTermsProp
-    \* RefinementToAbsProp
+    RefinementToAbsProp
 
 INVARIANTS
     LogInv

--- a/tla/consensus/MCccfraft.tla
+++ b/tla/consensus/MCccfraft.tla
@@ -5,7 +5,7 @@ CONSTANTS
     NodeOne, NodeTwo, NodeThree
 
 \* No reconfiguration
-1Configuration == <<{NodeOne, NodeTwo, NodeThree}>>
+1Configuration == <<{NodeOne, NodeTwo}>>
 \* Atomic reconfiguration from NodeOne to NodeTwo
 2Configurations == <<{NodeOne}, {NodeTwo}>>
 \* Incremental reconfiguration from NodeOne to NodeOne and NodeTwo, and then to NodeTwo


### PR DESCRIPTION
Experiment following discussion in https://github.com/microsoft/CCF/pull/6493#issuecomment-2373299937.

Tried to run locally, but this seems very slow either way, so offloading to the CI. On runs lasting a few minutes, it looks like refinement lowers the state exploration rate from ~1.2m to ~800k.

Goal: find out if it is practical to raise the term limit in MCccfraft.tla.