### PR TITLE
Update base image and release notes for 4.0.22

### DIFF
--- a/.azure-pipelines-release.yml
+++ b/.azure-pipelines-release.yml
@@ -8,15 +8,15 @@ pr: none
 resources:
   containers:
     - container: virtual
-      image: ghcr.io/microsoft/ccf/ci/default:build-28-08-2024-1
+      image: ghcr.io/microsoft/ccf/ci/default:build-26-09-2024
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: snp
-      image: ghcr.io/microsoft/ccf/ci/default:build-28-08-2024-1
+      image: ghcr.io/microsoft/ccf/ci/default:build-26-09-2024
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ghcr.io/microsoft/ccf/ci/sgx:build-28-08-2024-1
+      image: ghcr.io/microsoft/ccf/ci/sgx:build-26-09-2024
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /lib/modules:/lib/modules:ro
 
 variables:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.0.22]
+
+[4.0.22]: https://github.com/microsoft/CCF/releases/tag/ccf-4.0.22
+
+### Base image
+
+- Updated container base image.
+
 ## [4.0.21]
 
 [4.0.21]: https://github.com/microsoft/CCF/releases/tag/ccf-4.0.21


### PR DESCRIPTION
Barring unforeseen last minute patches, this will be the last 4.x release. Support for 4.x [ends on 25/10/2024](https://microsoft.github.io/CCF/main/build_apps/release_policy.html#support-calendar).