### PR TITLE
Model `max_uncommitted_tx_count` of raft.h in abs.tla

### DIFF
--- a/tla/consensus/MCabs.cfg
+++ b/tla/consensus/MCabs.cfg
@@ -6,7 +6,7 @@ CONSTANTS
     NodeThree = n3
     Servers <- MCServers
     Terms <- MCTerms
-    MaxLogLength <- MCMaxLogLength
+    MaxUncommittedCount = 3
 
 INVARIANTS
     NoConflicts

--- a/tla/consensus/MCabs.cfg
+++ b/tla/consensus/MCabs.cfg
@@ -17,3 +17,6 @@ PROPERTIES
 
 SYMMETRY 
     Symmetry
+
+CONSTRAINT 
+    MaxLogLengthConstraint

--- a/tla/consensus/MCabs.tla
+++ b/tla/consensus/MCabs.tla
@@ -9,6 +9,5 @@ CONSTANTS NodeOne, NodeTwo, NodeThree
 
 MCServers == {NodeOne, NodeTwo, NodeThree}
 MCTerms == 2..4
-MCMaxLogLength == 7
 
 ====

--- a/tla/consensus/MCabs.tla
+++ b/tla/consensus/MCabs.tla
@@ -10,4 +10,8 @@ CONSTANTS NodeOne, NodeTwo, NodeThree
 MCServers == {NodeOne, NodeTwo, NodeThree}
 MCTerms == 2..4
 
+\* Limit length of logs to terminate model checking.
+MaxLogLengthConstraint ==
+    \A i \in Servers :
+        Len(cLogs[i]) <= 7
 ====

--- a/tla/consensus/MCccfraft.tla
+++ b/tla/consensus/MCccfraft.tla
@@ -138,7 +138,7 @@ MappingToAbs ==
   INSTANCE abs WITH
     Servers <- Servers,
     Terms <- StartTerm..MaxTermLimit,
-    MaxLogLength <- MaxLogLength,
+    MaxUncommittedCount <- MaxLogLength,
     cLogs <- [i \in Servers |-> [j \in 1..commitIndex[i] |-> log[i][j].term]]
 
 RefinementToAbsProp == MappingToAbs!AbsSpec


### PR DESCRIPTION
Align spec with CCF by replacing global upper bound `MaxLogLength` with `MaxUncommittedCount` (see `max_uncommitted_tx_count` in raft.h) that restricts the length by which a log may be extended in each step.

These two commits were previously part of https://github.com/microsoft/CCF/pull/6475.  @heidihoward approved them in https://github.com/microsoft/CCF/pull/6475#issuecomment-2358932112.