### PR TITLE
Iteration TLC wrapper script

### DIFF
--- a/.github/workflows/ci-verification.yml
+++ b/.github/workflows/ci-verification.yml
@@ -35,27 +35,27 @@ jobs:
       - name: consistency/MCSingleNode.cfg
         run: |
           cd tla/
-          ./tlc.sh -workers auto consistency/MCSingleNode.tla -dumpTrace json MCSingleNode.json
+          ./tlc.py consistency/MCSingleNode.tla
 
       - name: consistency/MCSingleNodeReads.cfg
         run: |
           cd tla/
-          ./tlc.sh -workers auto consistency/MCSingleNodeReads.tla -dumpTrace json MCSingleNodeReads.json
+          ./tlc.py consistency/MCSingleNodeReads.tla
 
       - name: consistency/MCMultiNode.cfg
         run: |
           cd tla/
-          ./tlc.sh -workers auto consistency/MCMultiNode.tla -dumpTrace json MCMultiNode.json
+          ./tlc.py consistency/MCMultiNode.tla
 
       - name: consistency/MCMultiNodeReads.cfg
         run: |
           cd tla/
-          ./tlc.sh -workers auto consistency/MCMultiNodeReads.tla -dumpTrace json MCMultiNodeReads.json
+          ./tlc.py consistency/MCMultiNodeReads.tla
 
       - name: consistency/MCMultiNodeReadsAlt.cfg
         run: |
           cd tla/
-          ./tlc.sh -workers auto consistency/MCMultiNodeReadsAlt.tla -dumpTrace json MCMultiNodeReadsAlt.json
+          ./tlc.py consistency/MCMultiNodeReadsAlt.tla
 
       - name: Upload TLC's out file as an artifact. Can be imported into the TLA+ Toolbox.
         uses: actions/upload-artifact@v4
@@ -77,22 +77,22 @@ jobs:
       - name: consistency/MCSingleNodeCommitReachability.cfg
         run: |
           cd tla/
-          ./tlc_debug.sh -workers auto -config consistency/MCSingleNodeCommitReachability.cfg consistency/MCSingleNodeReads.tla
+          ./tlc_debug.sh --config consistency/MCSingleNodeCommitReachability.cfg consistency/MCSingleNodeReads.tla
 
       - name: consistency/MCMultiNodeCommitReachability.cfg
         run: |
           cd tla/
-          ./tlc_debug.sh -workers auto -config consistency/MCMultiNodeCommitReachability.cfg consistency/MCMultiNodeReads.tla
+          ./tlc_debug.sh --config consistency/MCMultiNodeCommitReachability.cfg consistency/MCMultiNodeReads.tla
 
       - name: consistency/MCMultiNodeInvalidReachability.cfg
         run: |
           cd tla/
-          ./tlc_debug.sh -workers auto -config consistency/MCMultiNodeInvalidReachability.cfg consistency/MCMultiNodeReads.tla
+          ./tlc_debug.sh --config consistency/MCMultiNodeInvalidReachability.cfg consistency/MCMultiNodeReads.tla
 
       - name: consistency/MCMultiNodeReadsNotLinearizable.cfg
         run: |
           cd tla/
-          ./tlc_debug.sh -workers auto -config consistency/MCMultiNodeReadsNotLinearizable.cfg consistency/MCMultiNodeReads.tla
+          ./tlc_debug.sh --config consistency/MCMultiNodeReadsNotLinearizable.cfg consistency/MCMultiNodeReads.tla
 
   simulation-consistency:
     name: Simulation - Consistency

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -109,9 +109,9 @@ endgroup
 
 group "Python format"
 if [ $FIX -ne 0 ]; then
-  git ls-files tests/ python/ scripts/ .cmake-format.py | grep -e '\.py$' | xargs black
+  git ls-files tests/ python/ scripts/ tla/ .cmake-format.py | grep -e '\.py$' | xargs black
 else
-  git ls-files tests/ python/ scripts/ .cmake-format.py | grep -e '\.py$' | xargs black --check
+  git ls-files tests/ python/ scripts/ tla/ .cmake-format.py | grep -e '\.py$' | xargs black --check
 fi
 endgroup
 

--- a/scripts/notice-check.py
+++ b/scripts/notice-check.py
@@ -25,7 +25,11 @@ PREFIX_BY_FILETYPE = {
     ".cpp": [SLASH_PREFIXED],
     ".h": HEADERS_WITH_PRAGMAS,
     ".hpp": HEADERS_WITH_PRAGMAS,
-    ".py": [HASH_PREFIXED],
+    ".py": [
+        HASH_PREFIXED,
+        # May have a shebang before the license
+        "#!/usr/bin/env python3" + os.linesep + HASH_PREFIXED,
+    ],
     ".sh": [
         HASH_PREFIXED,
         # May have a shebang before the license

--- a/tla/actions.py
+++ b/tla/actions.py
@@ -21,7 +21,7 @@ SerializeCoverage ==
 
 """
 
-TOP=5
+TOP = 5
 
 if __name__ == "__main__":
     ts = defaultdict(list)
@@ -40,7 +40,9 @@ if __name__ == "__main__":
     top_TOP = [x[0] for x in col_max[-TOP:]]
     df_TOP = df[top_TOP]
     print(df_TOP)
-    plot = df_TOP.plot.line(y=df_TOP.columns, width=1200, height=600, title=f"Top {TOP} distinct actions")
+    plot = df_TOP.plot.line(
+        y=df_TOP.columns, width=1200, height=600, title=f"Top {TOP} distinct actions"
+    )
     if len(sys.argv) > 1:
         hvplot.save(plot, sys.argv[1])
     else:

--- a/tla/install_deps.py
+++ b/tla/install_deps.py
@@ -79,7 +79,9 @@ def _parse_args() -> argparse.Namespace:
 
 def install_tlc():
     java = "java"
-    tlaplus_path = "~/.vscode-remote/extensions/tlaplus.vscode-ide-*/tools/tla2tools.jar"
+    tlaplus_path = (
+        "~/.vscode-remote/extensions/tlaplus.vscode-ide-*/tools/tla2tools.jar"
+    )
     copy_tlaplus = f"-cp {tlaplus_path} tlc2.TLC"
 
     set_alias("tlcrepl", f"{java} -cp {tlaplus_path} tlc2.REPL")

--- a/tla/loc.py
+++ b/tla/loc.py
@@ -4,6 +4,7 @@
 import dataclasses
 import sys
 
+
 @dataclasses.dataclass
 class LOC:
     code: int = 0
@@ -21,8 +22,9 @@ class LOC:
         return LOC(
             self.code + other.code,
             self.comment + other.comment,
-            self.blank + other.blank
+            self.blank + other.blank,
         )
+
 
 def is_comment(line: str) -> bool:
     if line.startswith(r"\*"):
@@ -33,14 +35,18 @@ def is_comment(line: str) -> bool:
         return True
     return False
 
+
 def is_multiline_comment_start(line: str) -> bool:
     return line.startswith("(*")
+
 
 def is_footer(line: str) -> bool:
     return all(c == "=" for c in line)
 
+
 def is_multiline_comment_end(line: str) -> bool:
     return line.endswith("*)")
+
 
 def count_loc(lines) -> LOC:
     loc = LOC()
@@ -67,6 +73,7 @@ def count_loc(lines) -> LOC:
         else:
             loc.code += 1
     return loc
+
 
 JUST_CODE = r"""
 ---------- MODULE MCccfraft ----------
@@ -127,6 +134,7 @@ IsAppendEntriesRequest(msg, dst, src, logline) ==
     /\ msg.prevLogIndex = logline.msg.packet.prev_idx
 """
 
+
 def test_loc():
     """
     Run with py.test loc.py
@@ -135,7 +143,10 @@ def test_loc():
     assert count_loc(CODE_AND_COMMENTS.splitlines()) == LOC(code=2, comment=2, blank=1)
     assert count_loc(FOOTER.splitlines()) == LOC(code=0, comment=9, blank=1)
     assert count_loc(MULTILINE_COMMENT.splitlines()) == LOC(code=2, comment=4, blank=2)
-    assert count_loc(MULTILINE_COMMENT_2.splitlines()) == LOC(code=7, comment=12, blank=1)
+    assert count_loc(MULTILINE_COMMENT_2.splitlines()) == LOC(
+        code=7, comment=12, blank=1
+    )
+
 
 if __name__ == "__main__":
     locs = []

--- a/tla/tlc.py
+++ b/tla/tlc.py
@@ -13,36 +13,84 @@
 import os
 import argparse
 import pprint
+import pathlib
 
 DEFAULT_JVM_ARGS = [
-    "-XX:+UseParallelGC", # Use parallel garbage collection, for performance
+    "-XX:+UseParallelGC",  # Use parallel garbage collection, for performance
 ]
 
 
-DEFAULT_CLASSPATH_ARGS = [
-    '-cp', 'tla2tools.jar:CommunityModules-deps.jar'
-]
+DEFAULT_CLASSPATH_ARGS = ["-cp", "tla2tools.jar:CommunityModules-deps.jar"]
 
 
 def cli():
-    parser = argparse.ArgumentParser(description="TLC model checker wrapper for the CCF project")
-    parser.add_argument("--disable-cdot", action="store_true", help="Disable \\\cdot support")
-    parser.add_argument("--jmx", action="store_true", help="Enable JMX to allow monitoring, use echo 'get -b tlc2.tool:type=ModelChecker CurrentState' | jmxterm -l localhost:55449 -i to query")
-    parser.add_argument("-v", action="store_true", help="Print out command and environment before running")
-    parser.add_argument("--workers", type=str, default="auto", help="Number of workers to use, default is 'auto'")
-    parser.add_argument("--checkpoint", type=int, default=0, help="Checkpoint interval, default is 0")
-    parser.add_argument("--lncheck", type=str, choices=["final", "default"], default="final", help="Liveness check, set to 'default' to run periodically or 'final' to run once at the end, default is final")
-    parser.add_argument("spec", help="Path to the TLA+ specification")
+    parser = argparse.ArgumentParser(
+        description="TLC model checker wrapper for the CCF project"
+    )
+    parser.add_argument(
+        "--disable-cdot", action="store_true", help="Disable \\\cdot support"
+    )
+    parser.add_argument(
+        "--jmx",
+        action="store_true",
+        help="Enable JMX to allow monitoring, use echo 'get -b tlc2.tool:type=ModelChecker CurrentState' | jmxterm -l localhost:55449 -i to query",
+    )
+    parser.add_argument(
+        "-v",
+        action="store_true",
+        help="Print out command and environment before running",
+    )
+    parser.add_argument(
+        "--workers",
+        type=str,
+        default="auto",
+        help="Number of workers to use, default is 'auto'",
+    )
+    parser.add_argument(
+        "--checkpoint", type=int, default=0, help="Checkpoint interval, default is 0"
+    )
+    parser.add_argument(
+        "--lncheck",
+        type=str,
+        choices=["final", "default"],
+        default="final",
+        help="Liveness check, set to 'default' to run periodically or 'final' to run once at the end, default is final",
+    )
+    parser.add_argument(
+        "--config",
+        type=pathlib.Path,
+        default=None,
+        help="Path to the TLA+ configuration",
+    )
+    parser.add_argument(
+        "spec", type=pathlib.Path, help="Path to the TLA+ specification"
+    )
     return parser
+
 
 if __name__ == "__main__":
     env = os.environ.copy()
     args = cli().parse_args()
     jvm_args = DEFAULT_JVM_ARGS
+    cp_args = DEFAULT_CLASSPATH_ARGS
+    tlc_args = [
+        "-workers",
+        args.workers,
+        "-checkpoint",
+        str(args.checkpoint),
+        "-lncheck",
+        args.lncheck,
+    ]
+    trace_name = os.path.basename(args.spec).replace(".tla", "")
+
     if "CI" in env:
         # When run in CI, format output for GitHub, and participate in statistics collection
         jvm_args.append("-Dtlc2.TLC.ide=Github")
-        jvm_args.append("-Dutil.ExecutionStatisticsCollector.id=be29f6283abeed2fb1fd0be898bc6601")
+        jvm_args.append(
+            "-Dutil.ExecutionStatisticsCollector.id=be29f6283abeed2fb1fd0be898bc6601"
+        )
+        # When run in CI, always dump a JSON trace
+        tlc_args.extend(["-dumpTrace", "json", f"{trace_name}.json"])
     if args.jmx:
         jvm_args.append("-Dcom.sun.management.jmxremote")
         jvm_args.append("-Dcom.sun.management.jmxremote.port=55449")
@@ -50,14 +98,11 @@ if __name__ == "__main__":
         jvm_args.append("-Dcom.sun.management.jmxremote.authenticate=false")
     if not args.disable_cdot:
         jvm_args.append("-Dtlc2.tool.impl.Tool.cdot=true")
-    cp_args = DEFAULT_CLASSPATH_ARGS
-    tlc_args = [
-        "-workers", args.workers,
-        "-checkpoint", str(args.checkpoint),
-        "-lncheck", args.lncheck,
-    ]
-    cmd = ['java'] + jvm_args +  cp_args + ['tlc2.TLC'] + tlc_args + [args.spec]
+    if args.config:
+        tlc_args.extend(["-config", args.config])
+
+    cmd = ["java"] + jvm_args + cp_args + ["tlc2.TLC"] + tlc_args + [args.spec]
     if args.v:
         pprint.pprint(env)
         pprint.pprint(cmd)
-    os.execvpe('java', cmd, env)
+    os.execvpe("java", cmd, env)

--- a/tla/tlc.py
+++ b/tla/tlc.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+#
+# Python TLC wrapper script for the CCF project
+# Goals:
+# - No dependencies, no venv, no pip install
+# - Set sensible defaults with an eye on performance
+# - Capture useful switches for CI, debugging
+# - Expose specification configuration through CLI
+# - Provide a useful --help, and basic sanity checks
+
+import os
+import argparse
+import pprint
+
+DEFAULT_JVM_ARGS = [
+    "-XX:+UseParallelGC", # Use parallel garbage collection, for performance
+]
+
+
+DEFAULT_CLASSPATH_ARGS = [
+    '-cp', 'tla2tools.jar:CommunityModules-deps.jar'
+]
+
+
+def cli():
+    parser = argparse.ArgumentParser(description="TLC model checker wrapper for the CCF project")
+    parser.add_argument("--disable-cdot", action="store_true", help="Disable \\\cdot support")
+    parser.add_argument("--jmx", action="store_true", help="Enable JMX to allow monitoring, use echo 'get -b tlc2.tool:type=ModelChecker CurrentState' | jmxterm -l localhost:55449 -i to query")
+    parser.add_argument("-v", action="store_true", help="Print out command and environment before running")
+    parser.add_argument("--workers", type=str, default="auto", help="Number of workers to use, default is 'auto'")
+    parser.add_argument("--checkpoint", type=int, default=0, help="Checkpoint interval, default is 0")
+    parser.add_argument("--lncheck", type=str, choices=["final", "default"], default="final", help="Liveness check, set to 'default' to run periodically or 'final' to run once at the end, default is final")
+    parser.add_argument("spec", help="Path to the TLA+ specification")
+    return parser
+
+if __name__ == "__main__":
+    env = os.environ.copy()
+    args = cli().parse_args()
+    jvm_args = DEFAULT_JVM_ARGS
+    if "CI" in env:
+        # When run in CI, format output for GitHub, and participate in statistics collection
+        jvm_args.append("-Dtlc2.TLC.ide=Github")
+        jvm_args.append("-Dutil.ExecutionStatisticsCollector.id=be29f6283abeed2fb1fd0be898bc6601")
+    if args.jmx:
+        jvm_args.append("-Dcom.sun.management.jmxremote")
+        jvm_args.append("-Dcom.sun.management.jmxremote.port=55449")
+        jvm_args.append("-Dcom.sun.management.jmxremote.ssl=false")
+        jvm_args.append("-Dcom.sun.management.jmxremote.authenticate=false")
+    if not args.disable_cdot:
+        jvm_args.append("-Dtlc2.tool.impl.Tool.cdot=true")
+    cp_args = DEFAULT_CLASSPATH_ARGS
+    tlc_args = [
+        "-workers", args.workers,
+        "-checkpoint", str(args.checkpoint),
+        "-lncheck", args.lncheck,
+    ]
+    cmd = ['java'] + jvm_args +  cp_args + ['tlc2.TLC'] + tlc_args + [args.spec]
+    if args.v:
+        pprint.pprint(env)
+        pprint.pprint(cmd)
+    os.execvpe('java', cmd, env)

--- a/tla/tlc_debug.sh
+++ b/tla/tlc_debug.sh
@@ -6,7 +6,7 @@
 # The debug invariant(s) should be the only invariant(s), otherwise 
 # this script might falsely return without errors
 
-./tlc.sh "$@"
+./tlc.py "$@"
 status=$?
 
 # TLC safety violation returns error code 12 

--- a/tla/trace2scen.py
+++ b/tla/trace2scen.py
@@ -5,27 +5,41 @@ import sys
 import json
 import os
 
+
 def comment(action):
     return f"# {action['name']} {action['location']['module']}:{action['location']['beginLine']}"
 
+
 def term(ctx, pre):
-    return str(pre["currentTerm"][ctx['i']])
+    return str(pre["currentTerm"][ctx["i"]])
+
 
 def noop(ctx, pre, post):
     return ["# Noop"]
 
+
 MAP = {
     "ClientRequest": lambda ctx, pre, post: ["replicate", term(ctx, pre), "42"],
     "MCClientRequest": lambda ctx, pre, post: ["replicate", term(ctx, pre), "42"],
-    "CheckQuorum": lambda ctx, pre, post: ["periodic_one", ctx['i'], "110"],
-    "Timeout": lambda ctx, pre, post: ["periodic_one",  ctx['i'], "110"],
-    "MCTimeout": lambda ctx, pre, post: ["periodic_one",  ctx['i'], "110"],
+    "CheckQuorum": lambda ctx, pre, post: ["periodic_one", ctx["i"], "110"],
+    "Timeout": lambda ctx, pre, post: ["periodic_one", ctx["i"], "110"],
+    "MCTimeout": lambda ctx, pre, post: ["periodic_one", ctx["i"], "110"],
     "RequestVote": noop,
     "AppendEntries": lambda _, __, ___: ["dispatch_all"],
     "BecomeLeader": noop,
-    "SignCommittableMessages": lambda ctx, pre, post: ["emit_signature", term(ctx, pre)],
-    "MCSignCommittableMessages": lambda ctx, pre, post: ["emit_signature", term(ctx, pre)],
-    "ChangeConfigurationInt": lambda ctx, pre, post: ["replicate_new_configuration", term(ctx, pre), *ctx["newConfiguration"]],
+    "SignCommittableMessages": lambda ctx, pre, post: [
+        "emit_signature",
+        term(ctx, pre),
+    ],
+    "MCSignCommittableMessages": lambda ctx, pre, post: [
+        "emit_signature",
+        term(ctx, pre),
+    ],
+    "ChangeConfigurationInt": lambda ctx, pre, post: [
+        "replicate_new_configuration",
+        term(ctx, pre),
+        *ctx["newConfiguration"],
+    ],
     "AdvanceCommitIndex": noop,
     "HandleRequestVoteRequest": lambda _, __, ___: ["dispatch_all"],
     "HandleRequestVoteResponse": noop,
@@ -38,28 +52,43 @@ MAP = {
     "RcvRequestVoteResponse": noop,
 }
 
+
 def post_commit(post):
-    return [["assert_commit_idx", node, str(idx)] for node, idx in post["commitIndex"].items()]
+    return [
+        ["assert_commit_idx", node, str(idx)]
+        for node, idx in post["commitIndex"].items()
+    ]
+
 
 def post_state(post):
     entries = []
     for node, state in post["state"].items():
-            entries.append(["assert_detail", "leadership_state", node, state])
+        entries.append(["assert_detail", "leadership_state", node, state])
     return entries
 
+
 def step_to_action(pre_state, action, post_state):
-    return os.linesep.join([
-        comment(action),
-        ','.join(MAP[action['name']](action['context'], pre_state[1], post_state[1]))])
+    return os.linesep.join(
+        [
+            comment(action),
+            ",".join(
+                MAP[action["name"]](action["context"], pre_state[1], post_state[1])
+            ),
+        ]
+    )
+
 
 def asserts(pre_state, action, post_state, assert_gen):
-    return os.linesep.join([','.join(assertion) for assertion in assert_gen(post_state[1])])
+    return os.linesep.join(
+        [",".join(assertion) for assertion in assert_gen(post_state[1])]
+    )
+
 
 if __name__ == "__main__":
     with open(sys.argv[1]) as trace:
         steps = json.load(trace)["action"]
         initial_state = steps[0][0][1]
-        initial_node, = [node for node, log in initial_state["log"].items() if log]
+        (initial_node,) = [node for node, log in initial_state["log"].items() if log]
         print(f"start_node,{initial_node}")
         print(f"emit_signature,2")
         for step in steps:


### PR DESCRIPTION
We have centralised some useful things in `tlc.sh`, but a lot of flags remain expanded inline in YAML, and tend to be copy paste per invocation. We also increasingly rely on environment variables, which are not necessarily validated nor discoverable.