### PR TITLE
Remove writing state-space statistics after the demise of cimetrics.

### DIFF
--- a/tla/consensus/MCccfraft.cfg
+++ b/tla/consensus/MCccfraft.cfg
@@ -60,9 +60,6 @@ POSTCONDITION
 CONSTRAINTS
     CoverageExpressions
 
-_PERIODIC
-    SerializeCoverage
-
 PROPERTIES
     CommittedLogAppendOnlyProp
     MonotonicTermProp

--- a/tla/consensus/MCccfraft.tla
+++ b/tla/consensus/MCccfraft.tla
@@ -1,5 +1,5 @@
 ---------- MODULE MCccfraft ----------
-EXTENDS ccfraft, StatsFile, MCAliases, TLC, IOUtils
+EXTENDS ccfraft, MCAliases, TLC, IOUtils
 
 CONSTANTS
     NodeOne, NodeTwo, NodeThree
@@ -168,8 +168,7 @@ AreAllCovered ==
 ----
 
 PostConditions ==
-    /\ WriteStatsFile
-    /\ AreAllCovered
+    AreAllCovered
 
 ----
 \* Refinement

--- a/tla/consensus/SIMccfraft.cfg
+++ b/tla/consensus/SIMccfraft.cfg
@@ -39,9 +39,6 @@ CONSTANTS
     NodeFour = n4
     NodeFive = n5
 
-    StatsFilename = "SIMccfraft_stats.json"
-    CoverageFilename = "SIMccraft_coverage.json"
-
     Timeout <- SIMTimeout
     ChangeConfigurationInt <-SIMChangeConfigurationInt
     CheckQuorum <- SIMCheckQuorum
@@ -68,9 +65,6 @@ PROPERTIES
     PendingBecomesFollowerProp
     NeverCommitEntryPrevTermsProp
     RefinementToAbsProp
-
-POSTCONDITION
-    WriteStatsFile
 
 \* ALIAS
 \*     \* DebugAlias

--- a/tla/consensus/SIMccfraft.tla
+++ b/tla/consensus/SIMccfraft.tla
@@ -1,5 +1,5 @@
 ---------- MODULE SIMccfraft ----------
-EXTENDS ccfraft, TLC, Integers, StatsFile, IOUtils, MCAliases
+EXTENDS ccfraft, TLC, Integers, IOUtils, MCAliases
 
 CONSTANTS
     NodeOne, NodeTwo, NodeThree, NodeFour, NodeFive


### PR DESCRIPTION
Part of "Run TLA+ consensus/consistency from vscode" #6490

https://github.com/microsoft/CCF/issues/6490