### PR TITLE
Correct and enforce schema on CBOR proofs

### DIFF
--- a/cddl/ccf-tree-alg.cddl
+++ b/cddl/ccf-tree-alg.cddl
@@ -1,0 +1,15 @@
+ccf-inclusion-proof = {
+  &(leaf: 1) => ccf-leaf
+  &(path: 2) => [+ ccf-proof-element]
+}
+
+ccf-leaf = [
+  internal-transaction-hash: bstr .size 32 ; a string of HASH_SIZE(32) bytes
+  internal-evidence: tstr .size (1..1024)  ; a string of at most 1024 bytes
+  data-hash: bstr .size 32                 ; a string of HASH_SIZE(32) bytes
+]
+
+ccf-proof-element = [
+  left: bool                               ; position of the element
+  hash: bstr .size 32                      ; hash of the proof element (string of HASH_SIZE(32) bytes)
+]

--- a/getting_started/setup_vm/roles/ccf_build/tasks/install.yml
+++ b/getting_started/setup_vm/roles/ccf_build/tasks/install.yml
@@ -57,3 +57,9 @@
   args:
     chdir: "{{ workspace }}/doxygen-{{ doxygen_ver }}"
   become: true
+
+- name: Install cddl checker
+  gem:
+    name: cddl
+    state: present
+  become: yes

--- a/src/node/historical_queries_adapter.cpp
+++ b/src/node/historical_queries_adapter.cpp
@@ -47,7 +47,7 @@ namespace
       std::vector<uint8_t> hash{node.hash};
 
       QCBOREncode_OpenArray(&ctx);
-      QCBOREncode_AddInt64(&ctx, dir);
+      QCBOREncode_AddBool(&ctx, dir);
       QCBOREncode_AddBytes(&ctx, {hash.data(), hash.size()});
       QCBOREncode_CloseArray(&ctx);
     }


### PR DESCRIPTION
Requires an update to the base image to include the cddl tool, to be done separately.

Also see https://github.com/ietf-scitt/draft-birkholz-cose-cometre-ccf-profile/pull/5