### PR TITLE
Remove SGX base image building

### DIFF
--- a/.github/workflows/ci-containers-ghcr.yml
+++ b/.github/workflows/ci-containers-ghcr.yml
@@ -35,12 +35,6 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/ci/default
 
-      - name: Extract metadata (tags, labels) for SGX image
-        id: meta_sgx
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}/ci/sgx
-
       - name: Build and push default container
         id: push_default
         uses: docker/build-push-action@v6
@@ -54,28 +48,9 @@ jobs:
           tags: ${{ steps.meta_default.outputs.tags }}
           labels: ${{ steps.meta_default.outputs.labels }}
 
-      - name: Build and push SGX container
-        id: push_sgx
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./docker/ccf_ci
-          build-args: |
-            platform=sgx
-          push: true
-          tags: ${{ steps.meta_sgx.outputs.tags }}
-          labels: ${{ steps.meta_sgx.outputs.labels }}
-
       - name: Attest default container
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/ci/default
           subject-digest: ${{ steps.push_default.outputs.digest }}
-          push-to-registry: true
-
-      - name: Attest SGX container
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/ci/sgx
-          subject-digest: ${{ steps.push_sgx.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
Not needed on main anymore, 5.x releases are best done using base images obtained by tagging `release/5.x`, which is already the case in practice.