### PR TITLE
Remove redefinitions of Terms in refinement mapping.

### DIFF
--- a/tla/consensus/MCabs.cfg
+++ b/tla/consensus/MCabs.cfg
@@ -6,6 +6,7 @@ CONSTANTS
     NodeThree = n3
     Servers <- MCServers
     Terms <- MCTerms
+    StartTerm <- MCStartTerm
     Seq <- MCSeq
     TypeOK <- MCTypeOK
 

--- a/tla/consensus/MCabs.tla
+++ b/tla/consensus/MCabs.tla
@@ -1,6 +1,6 @@
 ---- MODULE MCabs ----
 
-EXTENDS abs, TLC, SequencesExt
+EXTENDS abs, TLC, SequencesExt, FiniteSetsExt
 
 Symmetry ==
       Permutations(Servers)
@@ -9,6 +9,7 @@ CONSTANTS NodeOne, NodeTwo, NodeThree
 
 MCServers == {NodeOne, NodeTwo, NodeThree}
 MCTerms == 2..4
+MCStartTerm == Min(MCTerms)
 MaxExtend == 3
 
 MCTypeOK ==

--- a/tla/consensus/MCccfraft.cfg
+++ b/tla/consensus/MCccfraft.cfg
@@ -44,7 +44,6 @@ CONSTANTS
     NodeTwo = n2
     NodeThree = n3
 
-    RefinementToAbsProp <- MCRefinementToAbsProp
     Extend <- [abs]ABSExtend
     CopyMaxAndExtend <- [abs]ABSCopyMaxAndExtend
 

--- a/tla/consensus/MCccfraft.tla
+++ b/tla/consensus/MCccfraft.tla
@@ -173,8 +173,7 @@ PostConditions ==
 ----
 \* Refinement
 
-MCRefinementToAbsProp == MappingToAbs(StartTerm..StartTerm + TermCount)!AbsSpec
+ABSExtend(i) == MappingToAbs!ExtendAxiom(i)
+ABSCopyMaxAndExtend(i) == MappingToAbs!CopyMaxAndExtendAxiom(i)
 
-ABSExtend(i) == MappingToAbs(StartTerm..StartTerm + TermCount)!ExtendAxiom(i)
-ABSCopyMaxAndExtend(i) == MappingToAbs(StartTerm..StartTerm + TermCount)!CopyMaxAndExtendAxiom(i)
 ===================================

--- a/tla/consensus/SIMccfraft.cfg
+++ b/tla/consensus/SIMccfraft.cfg
@@ -45,7 +45,6 @@ CONSTANTS
 
     InitReconfigurationVars <- SIMInitReconfigurationVars
 
-    RefinementToAbsProp <- MCRefinementToAbsProp
     Extend <- [abs]ABSExtend
     CopyMaxAndExtend <- [abs]ABSCopyMaxAndExtend
 

--- a/tla/consensus/SIMccfraft.tla
+++ b/tla/consensus/SIMccfraft.tla
@@ -48,10 +48,8 @@ DebugInvUpToDepth ==
 ----
 \* Refinement
 
-MCRefinementToAbsProp == MappingToAbs(Nat \ 0..StartTerm-1)!AbsSpec
-
-ABSExtend(i) == MappingToAbs(Nat \ 0..StartTerm-1)!ExtendAxiom(i)
-ABSCopyMaxAndExtend(i) == MappingToAbs(Nat \ 0..StartTerm-1)!CopyMaxAndExtendAxiom(i)
+ABSExtend(i) == MappingToAbs!ExtendAxiom(i)
+ABSCopyMaxAndExtend(i) == MappingToAbs!CopyMaxAndExtendAxiom(i)
 
 =============================================================================
 

--- a/tla/consensus/abs.tla
+++ b/tla/consensus/abs.tla
@@ -2,7 +2,7 @@
 \* Abstract specification for a distributed consensus algorithm.
 \* Assumes that any node can atomically inspect the state of all other nodes. 
 
-EXTENDS Sequences, SequencesExt, Naturals, FiniteSets, FiniteSetsExt, Relation
+EXTENDS Sequences, SequencesExt, Naturals, FiniteSets, Relation
 
 CONSTANT Servers
 ASSUME IsFiniteSet(Servers)
@@ -12,14 +12,16 @@ CONSTANT Terms
 ASSUME /\ IsStrictlyTotallyOrderedUnder(<, Terms) 
        /\ \E min \in Terms : \A t \in Terms : t <= min
 
+CONSTANT StartTerm
+ASSUME /\ StartTerm \in Terms
+       /\ \A t \in Terms : StartTerm <= t
+
 \* Commit logs from each node
 \* Each log is append-only and the logs will never diverge.
 VARIABLE cLogs
 
 TypeOK ==
     cLogs \in [Servers -> Seq(Terms)]
-
-StartTerm == Min(Terms)
 
 InitialLogs == 
     UNION {[ 1..n -> {StartTerm} ] : n \in {0,2,4}}

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -1625,13 +1625,14 @@ LeaderProp ==
 \* asynchronous network and the message passing between nodes.  Instead, any
 \* node may atomically observe the state of any other node.
 
-MappingToAbs(T) == 
+MappingToAbs == 
   INSTANCE abs WITH
     Servers <- Servers,
-    Terms <- T,
+    StartTerm <- StartTerm,
+    Terms <- Nat \ 0..StartTerm-1,
     cLogs <- [i \in Servers |-> [j \in 1..commitIndex[i] |-> log[i][j].term]]
 
-RefinementToAbsProp == \EE T : MappingToAbs(T)!AbsSpec
+RefinementToAbsProp == MappingToAbs!AbsSpec
 THEOREM Spec => RefinementToAbsProp
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Declared `abs!StartTerm` as a constant because TLC cannot evaluate non-enumerable `Min(Nat \ 0..StartTerm-1)`.

[Refactor]