### PR TITLE
Allow manual runs of long verification

### DIFF
--- a/.github/workflows/long-verification.yml
+++ b/.github/workflows/long-verification.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   model-checking-with-atomic-reconfig-consensus:
     name: Model Checking With Atomic Reconfig - Consensus
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-verification') || github.event_name == "workflow_dispatch" }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-verification') || github.event_name == 'workflow_dispatch' }}
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
       image: ghcr.io/microsoft/ccf/ci/default:build-07-10-2024-2
@@ -47,7 +47,7 @@ jobs:
 
   model-checking-with-reconfig-consensus:
     name: Model Checking With Reconfig - Consensus
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-verification') || github.event_name == "workflow_dispatch" }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-verification') || github.event_name == 'workflow_dispatch' }}
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
       image: ghcr.io/microsoft/ccf/ci/default:build-07-10-2024-2
@@ -75,7 +75,7 @@ jobs:
 
   simulation-consensus:
     name: Simulation - Consensus
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-verification') || github.event_name == "workflow_dispatch" }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-verification') || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/long-verification.yml
+++ b/.github/workflows/long-verification.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   model-checking-with-atomic-reconfig-consensus:
     name: Model Checking With Atomic Reconfig - Consensus
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-verification') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-verification') || github.event_name == "workflow_dispatch" }}
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
       image: ghcr.io/microsoft/ccf/ci/default:build-07-10-2024-2
@@ -47,7 +47,7 @@ jobs:
 
   model-checking-with-reconfig-consensus:
     name: Model Checking With Reconfig - Consensus
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-verification') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-verification') || github.event_name == "workflow_dispatch" }}
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
       image: ghcr.io/microsoft/ccf/ci/default:build-07-10-2024-2
@@ -75,7 +75,7 @@ jobs:
 
   simulation-consensus:
     name: Simulation - Consensus
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-verification') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-verification') || github.event_name == "workflow_dispatch" }}
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
The trigger works, but the jobs get skipped: https://github.com/microsoft/CCF/actions/runs/11224798043

Adding labels just because that's an easy way to get a run before this gets merged.