### PR TITLE
Check high-level liveness properties in simulation mode

### DIFF
--- a/tla/consensus/MCccfraft.cfg
+++ b/tla/consensus/MCccfraft.cfg
@@ -1,8 +1,9 @@
-SPECIFICATION mc_spec
+SPECIFICATION Spec
 
 CONSTANTS
     Servers <- ToServers
     
+    Init <- MCInit
     Timeout <- MCTimeout
     RcvProposeVoteRequest <- MCRcvProposeVoteRequest
     Send <- MCSend

--- a/tla/consensus/MCccfraft.tla
+++ b/tla/consensus/MCccfraft.tla
@@ -12,6 +12,7 @@ Configurations ==
             [] IOEnv.RAFT_CONFIGS = "1C2N" -> default
             [] IOEnv.RAFT_CONFIGS = "1C3N" -> <<{NodeOne, NodeTwo, NodeThree}>>
             [] IOEnv.RAFT_CONFIGS = "2C2N" -> <<{NodeOne}, {NodeTwo}>>
+            [] IOEnv.RAFT_CONFIGS = "2C3N" -> <<{NodeOne, NodeTwo}, {NodeTwo, NodeThree}>>
             [] IOEnv.RAFT_CONFIGS = "3C2N" -> <<{NodeOne}, {NodeOne, NodeTwo}, {NodeTwo}>>
             [] OTHER -> Print("Unsupported value for RAFT_CONFIGS, defaulting to 1C2N: <<{NodeOne, NodeTwo}>>.", default)
     ELSE Print("RAFT_CONFIGS is not set, defaulting to 1C2N: <<{NodeOne, NodeTwo}>>.", default)

--- a/tla/consensus/MCccfraft.tla
+++ b/tla/consensus/MCccfraft.tla
@@ -116,11 +116,6 @@ MCInit ==
        \* If we want to start with multiple nodes, we can start with a four-tx log with a reconfiguration already appended.
        ELSE InitLogConfigServerVars(Configurations[1], JoinedLog)
 
-\* Alternative to CCF!Spec that uses the above MCInit
-mc_spec ==   
-    /\ MCInit
-    /\ [][Next]_vars
-
 \* Symmetry set over possible servers. May dangerous and is only enabled
 \* via the Symmetry option in cfg file.
 Symmetry == Permutations(Servers)

--- a/tla/consensus/SIMccfraft.cfg
+++ b/tla/consensus/SIMccfraft.cfg
@@ -43,6 +43,8 @@ CONSTANTS
     ChangeConfigurationInt <-SIMChangeConfigurationInt
     CheckQuorum <- SIMCheckQuorum
 
+    Fairness <- SIMFairness
+
     InitReconfigurationVars <- SIMInitReconfigurationVars
 
     Extend <- [abs]ABSExtend
@@ -64,6 +66,9 @@ PROPERTIES
     PendingBecomesFollowerProp
     NeverCommitEntryPrevTermsProp
     RefinementToAbsProp
+
+    LeaderProp
+    LogMatchingProp
 
 \* ALIAS
 \*     \* DebugAlias

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -1278,11 +1278,7 @@ NextInt(i) ==
 Next ==
     \E i \in Servers: NextInt(i)
 
-\* The specification must start with the initial state and transition according
-\* to Next.
-Spec == 
-    /\ Init
-    /\ [][Next]_vars
+Fairness ==
     \* Network actions
     /\ \A i, j \in Servers : WF_vars(RcvDropIgnoredMessage(i, j))
     /\ \A i, j \in Servers : WF_vars(RcvUpdateTerm(i, j))
@@ -1300,6 +1296,13 @@ Spec ==
     /\ \A s \in Servers : WF_vars(BecomeLeader(s))
     /\ \A s \in Servers : WF_vars(Timeout(s))
     /\ \A s \in Servers : WF_vars(ChangeConfiguration(s))
+
+\* The specification must start with the initial state and transition according
+\* to Next.
+Spec == 
+    /\ Init
+    /\ [][Next]_vars
+    /\ Fairness
 
 ------------------------------------------------------------------------------
 \* Correctness invariants

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -1296,8 +1296,10 @@ Spec ==
     /\ \A s, t \in Servers : WF_vars(RequestVote(s, t))
     /\ \A s \in Servers : WF_vars(SignCommittableMessages(s))
     /\ \A s \in Servers : WF_vars(AdvanceCommitIndex(s))
+    /\ \A s \in Servers : WF_vars(AppendRetiredCommitted(s))
     /\ \A s \in Servers : WF_vars(BecomeLeader(s))
     /\ \A s \in Servers : WF_vars(Timeout(s))
+    /\ \A s \in Servers : WF_vars(ChangeConfiguration(s))
 
 ------------------------------------------------------------------------------
 \* Correctness invariants

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -1623,7 +1623,8 @@ LogMatchingProp ==
     \A i, j \in Servers : []<>(log[i] = log[j])
 
 LeaderProp ==
-    []<><<\E i \in Servers : leadershipState[i] = Leader>>_vars
+    \* There is repeatedly a non-retired leader.
+    []<><<\E i \in Servers : leadershipState[i] = Leader /\ membershipState[i] # RetiredCommitted>>_vars
 
 ------------------------------------------------------------------------------
 \* Refinement of the more high-level specification abs.tla that abstracts the


### PR DESCRIPTION
* There is repeatedly a non-retired leader
* Redefine the fairness constraint in simulation mode to exclude `RandomElement` conjuncts that interfere with enablement (background https://github.com/tlaplus/tlaplus/issues/1039#issue-2574569206)
* Include `AppendRetiredCommitted` and `ChangeConfiguration` in fairness constraint
* Do not redefine Spec but only Init to not "disable" the fairness constraint
* Add a two configurations with three nodes (2C3N) configuration to `MCccfraft`