### PR TITLE
Libstdc++ compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,24 @@ jobs:
             build/workspace/*/err
           if-no-files-found: ignore
         if: success() || failure()
+
+  build_libstdcxx:
+    needs: checks
+    runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
+    container:
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-10-2024
+      options: --user root --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Build Debug with libstdc++"
+        run: |
+          set -ex
+          git config --global --add safe.directory /__w/CCF/CCF
+          mkdir build
+          cd build
+          cmake -GNinja -DCOMPILE_TARGET=virtual -DCMAKE_BUILD_TYPE=Debug -DLVI_MITIGATIONS=OFF -DUSE_LIBCXX=OFF ..
+          ninja
+        shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,9 @@ endif()
 # openenclave::oesnmalloc
 option(USE_SNMALLOC "Link virtual build against snmalloc" ON)
 
+# Default inherited from Open Enclave usage
+option(USE_LIBCXX "Use libc++ instead of libstdc++" ON)
+
 enable_language(ASM)
 
 set(CCF_GENERATED_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated)

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -19,8 +19,10 @@ if(NOT COMPILE_TARGET IN_LIST ALLOWED_TARGETS)
 endif()
 message(STATUS "Compile target platform: ${COMPILE_TARGET}")
 
-list(APPEND COMPILE_LIBCXX -stdlib=libc++)
-list(APPEND LINK_LIBCXX -lc++ -lc++abi -stdlib=libc++)
+if (USE_LIBCXX)
+  list(APPEND COMPILE_LIBCXX -stdlib=libc++)
+  list(APPEND LINK_LIBCXX -lc++ -lc++abi -stdlib=libc++)
+endif()
 
 # Enclave library wrapper
 function(add_ccf_app name)

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -19,7 +19,7 @@ if(NOT COMPILE_TARGET IN_LIST ALLOWED_TARGETS)
 endif()
 message(STATUS "Compile target platform: ${COMPILE_TARGET}")
 
-if (USE_LIBCXX)
+if(USE_LIBCXX)
   list(APPEND COMPILE_LIBCXX -stdlib=libc++)
   list(APPEND LINK_LIBCXX -lc++ -lc++abi -stdlib=libc++)
 endif()

--- a/src/ds/lru.h
+++ b/src/ds/lru.h
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include <cstddef>
 #include <list>
 #include <map>
 

--- a/src/ds/test/dl_list.cpp
+++ b/src/ds/test/dl_list.cpp
@@ -3,6 +3,7 @@
 
 #include "ds/dl_list.h"
 
+#include <cstddef>
 #include <doctest/doctest.h>
 
 using namespace ds;

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -353,7 +353,7 @@ namespace ccf
 
       std::vector<uint8_t> primary_sig;
 
-      const std::vector<const uint8_t> root_hash{
+      std::vector<uint8_t> root_hash{
         root.h.data(), root.h.data() + root.h.size()};
       primary_sig = node_kp.sign_hash(root_hash.data(), root_hash.size());
 
@@ -734,7 +734,7 @@ namespace ccf
       }
 
       const auto raw_cert = service_info->cert.raw();
-      const std::vector<const uint8_t> root_hash{
+      std::vector<uint8_t> root_hash{
         root.h.data(), root.h.data() + root.h.size()};
 
       return cose_verifier_cached(raw_cert)->verify_detached(

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -711,7 +711,7 @@ TEST_CASE("JsonWrappedEndpointFunction")
   auto response = parse_response(rpc_ctx->serialise_response());
   CHECK(response.status == HTTP_STATUS_OK);
 
-  const auto response_body = parse_response_body(response.body);
+  const UserId response_body = parse_response_body(response.body);
   CHECK(response_body == user_id);
 }
 }


### PR DESCRIPTION
Pre-requisite to Azure Linux migration. Adds a `USE_LIBCXX` cmake flag, make the few tweaks needed for the build to work with the version we have easily available on Ubuntu 20.04, and add a CI job to avoid regression before we complete the move.