### PR TITLE
Fix memory corruption for COSE headers construction

### DIFF
--- a/src/service/internal_tables_access.h
+++ b/src/service/internal_tables_access.h
@@ -426,7 +426,7 @@ namespace ccf
           return false;
         }
 
-        const auto root = previous_service_last_signed_root->get().value();
+        const auto& root = previous_service_last_signed_root->get().value();
         previous_root.assign(root.h.begin(), root.h.end());
       }
       else

--- a/src/service/internal_tables_access.h
+++ b/src/service/internal_tables_access.h
@@ -395,6 +395,7 @@ namespace ccf
       ccf::CoseEndorsement endorsement{};
       std::vector<ccf::crypto::COSEParametersFactory> pheaders{};
       std::vector<uint8_t> key_to_endorse{};
+      std::vector<uint8_t> previous_root{};
 
       endorsement.endorsing_key = service_key.public_key_der();
 
@@ -426,9 +427,7 @@ namespace ccf
         }
 
         const auto root = previous_service_last_signed_root->get().value();
-        pheaders.push_back(ccf::crypto::cose_params_string_bytes(
-          ccf::crypto::COSE_PHEADER_KEY_MERKLE_ROOT,
-          std::vector<uint8_t>(root.h.begin(), root.h.end())));
+        previous_root.assign(root.h.begin(), root.h.end());
       }
       else
       {
@@ -449,6 +448,11 @@ namespace ccf
         pheaders.push_back(ccf::crypto::cose_params_string_string(
           ccf::crypto::COSE_PHEADER_KEY_RANGE_END,
           endorsement.endorsement_epoch_end->to_str()));
+      }
+      if (!previous_root.empty())
+      {
+        pheaders.push_back(ccf::crypto::cose_params_string_bytes(
+          ccf::crypto::COSE_PHEADER_KEY_MERKLE_ROOT, previous_root));
       }
 
       try

--- a/src/service/internal_tables_access.h
+++ b/src/service/internal_tables_access.h
@@ -426,7 +426,7 @@ namespace ccf
           return false;
         }
 
-        const auto& root = previous_service_last_signed_root->get().value();
+        const auto root = previous_service_last_signed_root->get().value();
         previous_root.assign(root.h.begin(), root.h.end());
       }
       else


### PR DESCRIPTION
Missed during #6555. A temporary passed to headers factory, UB at construction.