### PR TITLE
Fix header parser comparator

### DIFF
--- a/src/http/http_accept.h
+++ b/src/http/http_accept.h
@@ -70,7 +70,11 @@ namespace http
 
       // Spec says these mime types are now equivalent. For stability, we
       // order them lexicographically
-      return mime_type < other.mime_type && mime_subtype < other.mime_subtype;
+      if (mime_type != other.mime_type)
+      {
+        return mime_type < other.mime_type;
+      }
+      return mime_subtype < other.mime_subtype;
     }
   };
 


### PR DESCRIPTION
Fixes non-deterministic sorting, which was found when migrating to Azure Linux.

Was `a.x < b.y AND a.y < b.y`, meaning that `if a.x < b.x` **but** `a.y > b.y` then arguments will be considered equal, which is clearly not intended (both due to test issue and comment inside the comparator code).
