### PR TITLE
Remove secp256k as unsupported by symcrypt on Mariner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+### Removed
+
+- Remove SECP256K1 support as a part of the migration to Azure Linux (#6592).
+
 ## [6.0.0-dev3]
 
 [6.0.0-dev3]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev3

--- a/include/ccf/crypto/curve.h
+++ b/include/ccf/crypto/curve.h
@@ -22,8 +22,6 @@ namespace ccf::crypto
     SECP384R1,
     /// The SECP256R1 curve
     SECP256R1,
-    /// The SECP256K1 curve
-    SECP256K1,
     /// The CURVE25519 curve
     CURVE25519,
     X25519
@@ -34,7 +32,6 @@ namespace ccf::crypto
     {{CurveID::NONE, "None"},
      {CurveID::SECP384R1, "Secp384R1"},
      {CurveID::SECP256R1, "Secp256R1"},
-     {CurveID::SECP256K1, "Secp256K1"},
      {CurveID::CURVE25519, "Curve25519"},
      {CurveID::X25519, "X25519"}});
 
@@ -49,8 +46,6 @@ namespace ccf::crypto
       case CurveID::SECP384R1:
         return MDType::SHA384;
       case CurveID::SECP256R1:
-        return MDType::SHA256;
-      case CurveID::SECP256K1:
         return MDType::SHA256;
       default:
       {

--- a/include/ccf/crypto/jwk.h
+++ b/include/ccf/crypto/jwk.h
@@ -38,16 +38,12 @@ namespace ccf::crypto
   enum class JsonWebKeyECCurve
   {
     P256 = 0,
-    P256K1 = 1,
-    P384 = 2,
-    P521 = 3
+    P384 = 1,
+    P521 = 2
   };
   DECLARE_JSON_ENUM(
     JsonWebKeyECCurve,
     {{JsonWebKeyECCurve::P256, "P-256"},
-     {JsonWebKeyECCurve::P256K1,
-      "secp256k1"}, // As per
-                    // https://www.rfc-editor.org/rfc/rfc8812#name-jose-and-cose-secp256k1-cur
      {JsonWebKeyECCurve::P384, "P-384"},
      {JsonWebKeyECCurve::P521, "P-521"}});
 
@@ -59,8 +55,6 @@ namespace ccf::crypto
         return JsonWebKeyECCurve::P384;
       case CurveID::SECP256R1:
         return JsonWebKeyECCurve::P256;
-      case CurveID::SECP256K1:
-        return JsonWebKeyECCurve::P256K1;
       default:
         throw std::logic_error(fmt::format("Unknown curve {}", curve_id));
     }
@@ -74,8 +68,6 @@ namespace ccf::crypto
         return CurveID::SECP384R1;
       case JsonWebKeyECCurve::P256:
         return CurveID::SECP256R1;
-      case JsonWebKeyECCurve::P256K1:
-        return CurveID::SECP256K1;
       default:
         throw std::logic_error(fmt::format("Unknown JWK curve {}", jwk_curve));
     }

--- a/js/ccf-app/src/global.ts
+++ b/js/ccf-app/src/global.ts
@@ -386,7 +386,7 @@ export interface CCFCrypto {
   /**
    * Generate an ECDSA key pair.
    *
-   * @param curve The name of the curve, one of "secp256r1", "secp256k1", "secp384r1".
+   * @param curve The name of the curve, one of "secp256r1", "secp384r1".
    */
   generateEcdsaKeyPair(curve: string): CryptoKeyPair;
 

--- a/js/ccf-app/test/polyfill.test.ts
+++ b/js/ccf-app/test/polyfill.test.ts
@@ -89,13 +89,6 @@ describe("polyfill", function () {
       assert.isTrue(pair.privateKey.startsWith("-----BEGIN PRIVATE KEY-----"));
     });
   });
-  describe("generateEcdsaKeyPair/secp256k1", function () {
-    it("generates a random ECDSA P256K1 key pair", function () {
-      const pair = ccf.crypto.generateEcdsaKeyPair("secp256k1");
-      assert.isTrue(pair.publicKey.startsWith("-----BEGIN PUBLIC KEY-----"));
-      assert.isTrue(pair.privateKey.startsWith("-----BEGIN PRIVATE KEY-----"));
-    });
-  });
   describe("generateEcdsaKeyPair/secp384r1", function () {
     it("generates a random ECDSA P384R1 key pair", function () {
       const pair = ccf.crypto.generateEcdsaKeyPair("secp384r1");
@@ -586,7 +579,7 @@ describe("polyfill", function () {
   describe("pemToJwk and jwkToPem", function () {
     it("EC", function () {
       const my_kid = "my_kid";
-      const curves = ["secp256r1", "secp256k1", "secp384r1"];
+      const curves = ["secp256r1", "secp384r1"];
       for (const curve of curves) {
         const pair = ccf.crypto.generateEcdsaKeyPair(curve);
         {

--- a/src/crypto/openssl/public_key.cpp
+++ b/src/crypto/openssl/public_key.cpp
@@ -138,8 +138,6 @@ namespace ccf::crypto
         return CurveID::SECP384R1;
       case NID_X9_62_prime256v1:
         return CurveID::SECP256R1;
-      case NID_secp256k1:
-        return CurveID::SECP256K1;
       default:
         throw std::runtime_error(fmt::format("Unknown OpenSSL curve {}", nid));
     }
@@ -163,10 +161,6 @@ namespace ccf::crypto
     {
       return NID_X9_62_prime256v1;
     }
-    else if (gname == SN_secp256k1)
-    {
-      return NID_secp256k1;
-    }
     else
     {
       throw std::runtime_error(fmt::format("Unknown OpenSSL group {}", gname));
@@ -187,8 +181,6 @@ namespace ccf::crypto
         return NID_secp384r1;
       case CurveID::SECP256R1:
         return NID_X9_62_prime256v1;
-      case CurveID::SECP256K1:
-        return NID_secp256k1;
       default:
         throw std::logic_error(
           fmt::format("unsupported OpenSSL CurveID {}", gid));

--- a/src/crypto/test/bench.cpp
+++ b/src/crypto/test/bench.cpp
@@ -154,9 +154,6 @@ namespace CREATE_KEYPAIRS
   auto create_256r1 = benchmark_create<KeyPair_OpenSSL, CurveID::SECP256R1>;
   PICOBENCH(create_256r1).iterations({1000}).samples(10);
 
-  auto create_256k1 = benchmark_create<KeyPair_OpenSSL, CurveID::SECP256K1>;
-  PICOBENCH(create_256k1).iterations({1000}).samples(10);
-
   auto create_384r1 = benchmark_create<KeyPair_OpenSSL, CurveID::SECP384R1>;
   PICOBENCH(create_384r1).iterations({1000}).samples(10);
 }
@@ -191,22 +188,6 @@ namespace SIGN_SECP256R1
   auto sign_256r1_ossl_100k =
     benchmark_sign<KeyPair_OpenSSL, CurveID::SECP256R1, 102400>;
   PICOBENCH(sign_256r1_ossl_100k).PICO_SUFFIX(CurveID::SECP256R1);
-}
-
-PICOBENCH_SUITE("sign secp256k1");
-namespace SIGN_SECP256K1
-{
-  auto sign_256k1_ossl_1byte =
-    benchmark_sign<KeyPair_OpenSSL, CurveID::SECP256K1, 1>;
-  PICOBENCH(sign_256k1_ossl_1byte).PICO_SUFFIX(CurveID::SECP256K1);
-
-  auto sign_256k1_ossl_1k =
-    benchmark_sign<KeyPair_OpenSSL, CurveID::SECP256K1, 1024>;
-  PICOBENCH(sign_256k1_ossl_1k).PICO_SUFFIX(CurveID::SECP256K1);
-
-  auto sign_256k1_ossl_100k =
-    benchmark_sign<KeyPair_OpenSSL, CurveID::SECP256K1, 102400>;
-  PICOBENCH(sign_256k1_ossl_100k).PICO_SUFFIX(CurveID::SECP256K1);
 }
 
 PICOBENCH_SUITE("verify secp384r1");
@@ -251,28 +232,6 @@ namespace SECP256R1
     CurveID::SECP256R1,
     102400>;
   PICOBENCH(verify_256r1_ossl_100k).PICO_SUFFIX(CurveID::SECP256R1);
-}
-
-PICOBENCH_SUITE("verify secp256k1");
-namespace SECP256K1
-{
-  auto verify_256k1_ossl_1byte =
-    benchmark_verify<KeyPair_OpenSSL, PublicKey_OpenSSL, CurveID::SECP256K1, 1>;
-  PICOBENCH(verify_256k1_ossl_1byte).PICO_SUFFIX(CurveID::SECP256K1);
-
-  auto verify_256k1_ossl_1k = benchmark_verify<
-    KeyPair_OpenSSL,
-    PublicKey_OpenSSL,
-    CurveID::SECP256K1,
-    1024>;
-  PICOBENCH(verify_256k1_ossl_1k).PICO_SUFFIX(CurveID::SECP256K1);
-
-  auto verify_256k1_ossl_100k = benchmark_verify<
-    KeyPair_OpenSSL,
-    PublicKey_OpenSSL,
-    CurveID::SECP256K1,
-    102400>;
-  PICOBENCH(verify_256k1_ossl_100k).PICO_SUFFIX(CurveID::SECP256K1);
 }
 
 PICOBENCH_SUITE("sign RSA-2048");

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -179,9 +179,9 @@ void corrupt(T& buf)
 }
 
 static constexpr CurveID supported_curves[] = {
-  CurveID::SECP384R1, CurveID::SECP256R1, CurveID::SECP256K1};
+  CurveID::SECP384R1, CurveID::SECP256R1};
 
-static constexpr char const* labels[] = {"secp384r1", "secp256r1", "secp256k1"};
+static constexpr char const* labels[] = {"secp384r1", "secp256r1"};
 
 ccf::crypto::Pem generate_self_signed_cert(
   const KeyPairPtr& kp, const std::string& name)
@@ -1045,7 +1045,7 @@ TEST_CASE("PEM to JWK and back")
 
   INFO("EC");
   {
-    auto curves = {CurveID::SECP384R1, CurveID::SECP256R1, CurveID::SECP256K1};
+    auto curves = {CurveID::SECP384R1, CurveID::SECP256R1};
 
     for (auto const& curve : curves)
     {

--- a/src/js/extensions/ccf/crypto.cpp
+++ b/src/js/extensions/ccf/crypto.cpp
@@ -132,10 +132,6 @@ namespace ccf::js::extensions
       {
         cid = ccf::crypto::CurveID::SECP256R1;
       }
-      else if (curve == "secp256k1")
-      {
-        cid = ccf::crypto::CurveID::SECP256K1;
-      }
       else if (curve == "secp384r1")
       {
         cid = ccf::crypto::CurveID::SECP384R1;
@@ -143,8 +139,7 @@ namespace ccf::js::extensions
       else
       {
         return JS_ThrowRangeError(
-          ctx,
-          "Unsupported curve id, supported: secp256r1, secp256k1, secp384r1");
+          ctx, "Unsupported curve id, supported: secp256r1, secp384r1");
       }
 
       try

--- a/tests/npm_tests.py
+++ b/tests/npm_tests.py
@@ -44,7 +44,7 @@ def generate_and_verify_jwk(client):
     assert r.status_code != http.HTTPStatus.OK
 
     # Elliptic curve
-    curves = [ec.SECP256R1, ec.SECP256K1, ec.SECP384R1]
+    curves = [ec.SECP256R1, ec.SECP384R1]
     for curve in curves:
         priv_pem, pub_pem = infra.crypto.generate_ec_keypair(curve)
         # Private
@@ -305,12 +305,6 @@ def test_npm_app(network, args):
             r.body.json()["privateKey"], r.body.json()["publicKey"]
         )
 
-        r = c.post("/app/generateEcdsaKeyPair", {"curve": "secp256k1"})
-        assert r.status_code == http.HTTPStatus.OK, r.status_code
-        assert infra.crypto.check_key_pair_pem(
-            r.body.json()["privateKey"], r.body.json()["publicKey"]
-        )
-
         r = c.post("/app/generateEcdsaKeyPair", {"curve": "secp384r1"})
         assert r.status_code == http.HTTPStatus.OK, r.status_code
         assert infra.crypto.check_key_pair_pem(
@@ -475,7 +469,7 @@ def test_npm_app(network, args):
             pass
 
         # Test ECDSA signing + verification
-        curves = [ec.SECP256R1, ec.SECP256K1, ec.SECP384R1]
+        curves = [ec.SECP256R1, ec.SECP384R1]
         for curve in curves:
             key_priv_pem, key_pub_pem = infra.crypto.generate_ec_keypair(curve)
             algorithm = {"name": "ECDSA", "hash": "SHA-256"}
@@ -577,7 +571,7 @@ def test_npm_app(network, args):
         assert r.status_code == http.HTTPStatus.OK, r.status_code
         assert r.body.json() is False, r.body
 
-        curves = [ec.SECP256R1, ec.SECP256K1, ec.SECP384R1]
+        curves = [ec.SECP256R1, ec.SECP384R1]
         for curve in curves:
             key_priv_pem, key_pub_pem = infra.crypto.generate_ec_keypair(curve)
             algorithm = {"name": "ECDSA", "hash": "SHA-256"}


### PR DESCRIPTION
Closes #6592 