### PR TITLE
Extend set_unprotected_header() to allow setting an empty header, and verify_receipt() to check claim_digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Updated `ccf::cose::edit::set_unprotected_header()` API, to allow removing the unprotected header altogether (#6607).
+- Updated `ccf.cose.verify_receipt()` to support checking the claim_digest against a reference value (#6607).
 
 ## [6.0.0-dev4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.0.0-dev5]
+
+[6.0.0-dev5]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev5
+
+### Added
+
+- Updated `ccf::cose::edit::set_unprotected_header()` API, to allow removing the unprotected header altogether (#6607).
+
 ## [6.0.0-dev4]
 
 [6.0.0-dev4]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev4
@@ -24,7 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Set VMPL value when creating SNP attestations, and check VMPL value is in guest range when verifiying attestation, since recent [updates allow host-initiated attestations](https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/programmer-references/56860.pdf) (#6583).
-- Added ccf::cose::edit::set_unprotected_header() API, to allow easy injection of proofs in signatures, and of receipts in signed statements (#6586).
+- Added `ccf::cose::edit::set_unprotected_header()` API, to allow easy injection of proofs in signatures, and of receipts in signed statements (#6586).
 
 ## [6.0.0-dev2]
 

--- a/include/ccf/crypto/cose.h
+++ b/include/ccf/crypto/cose.h
@@ -23,27 +23,33 @@ namespace ccf::cose::edit
     using Type = std::variant<InArray, AtKey>;
   }
 
+  namespace desc
+  {
+    struct Empty
+    {};
+
+    struct Value
+    {
+      pos::Type position;
+      int64_t key;
+      const std::vector<uint8_t>& value;
+    };
+
+    using Type = std::variant<Empty, Value>;
+  }
+
   /**
-   * Set the unprotected header of a COSE_Sign1 message, to a map containing
-   * @p key and depending on the value of @p position, either an array
-   * containing
-   * @p value, or a map with key @p subkey and value @p value.
+   * Set the unprotected header of a COSE_Sign1 message, according to a
+   * descriptor.
    *
-   * Useful to add a proof to a signature to turn it into a receipt, or to
+   * Useful to add a proof to a signature to turn it into a receipt, to
    * add a receipt to a signed statement to turn it into a transparent
-   * statement.
+   * statement, or simply to strip the unprotected header from a COSE Sign1.
    *
    * @param cose_input The COSE_Sign1 message to edit.
-   * @param key The key at which to insert either an array or a map.
-   * @param position Either InArray or AtKey, to determine whether to insert an
-   *                 array or a map.
-   * @param value The value to insert either in the array or the map.
-   *
-   * @return The COSE_Sign1 message with the new unprotected header.
+   * @param descriptor An object describing whether and how to set the
+   * unprotected header.
    */
   std::vector<uint8_t> set_unprotected_header(
-    const std::span<const uint8_t>& cose_input,
-    int64_t key,
-    pos::Type position,
-    const std::vector<uint8_t> value);
+    const std::span<const uint8_t>& cose_input, const desc::Type& descriptor);
 }

--- a/include/ccf/crypto/cose.h
+++ b/include/ccf/crypto/cose.h
@@ -16,7 +16,7 @@ namespace ccf::cose::edit
 
     struct AtKey
     {
-      /// @brief  The key at which to insert the value.
+      /// @brief  The sub-key at which to insert the value.
       int64_t key;
     };
 
@@ -30,8 +30,11 @@ namespace ccf::cose::edit
 
     struct Value
     {
+      /// @brief The type of position at which to insert the value.
       pos::Type position;
+      /// @brief The top-level key at which to insert the value.
       int64_t key;
+      /// @brief The value to insert in the unprotected header.
       const std::vector<uint8_t>& value;
     };
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ccf"
-version = "6.0.0-dev4"
+version = "6.0.0-dev5"
 authors = [
   { name="CCF Team", email="CCF-Sec@microsoft.com" },
 ]

--- a/python/src/ccf/cose.py
+++ b/python/src/ccf/cose.py
@@ -201,7 +201,9 @@ def validate_cose_sign1(pubkey, cose_sign1, payload=None):
         raise ValueError("signature is invalid")
 
 
-def verify_receipt(receipt_bytes: bytes, key: CertificatePublicKeyTypes):
+def verify_receipt(
+    receipt_bytes: bytes, key: CertificatePublicKeyTypes, claim_digest: bytes
+):
     """
     Verify a COSE Sign1 receipt as defined in https://datatracker.ietf.org/doc/draft-ietf-cose-merkle-tree-proofs/,
     using the CCF tree algorithm defined in https://datatracker.ietf.org/doc/draft-birkholz-cose-receipts-ccf-profile/
@@ -239,6 +241,8 @@ def verify_receipt(receipt_bytes: bytes, key: CertificatePublicKeyTypes):
                 accumulator = sha256(accumulator + digest).digest()
         if not receipt.verify_signature(accumulator):
             raise ValueError("Signature verification failed")
+        if claim_digest != leaf[2]:
+            raise ValueError(f"Claim digest mismatch: {leaf[2]!r} != {claim_digest!r}")
 
 
 _SIGN_DESCRIPTION = """Create and sign a COSE Sign1 message for CCF governance

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -2065,11 +2065,13 @@ namespace loggingapp
           return;
         }
 
-        size_t vdp = 396;
+        int64_t vdp = 396;
         auto inclusion_proof = ccf::cose::edit::pos::AtKey{-1};
 
-        auto cose_receipt = ccf::cose::edit::set_unprotected_header(
-          *signature, vdp, inclusion_proof, *proof);
+        ccf::cose::edit::desc::Value desc{inclusion_proof, vdp, *proof};
+
+        auto cose_receipt =
+          ccf::cose::edit::set_unprotected_header(*signature, desc);
 
         ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
         ctx.rpc_ctx->set_response_header(

--- a/src/crypto/test/cose.cpp
+++ b/src/crypto/test/cose.cpp
@@ -111,8 +111,8 @@ TEST_CASE("Verification and payload invariant")
     {
       for (const auto& position : positions)
       {
-        auto csp_set =
-          ccf::cose::edit::set_unprotected_header(csp, key, position, value);
+        ccf::cose::edit::desc::Value desc{position, key, value};
+        auto csp_set = ccf::cose::edit::set_unprotected_header(csp, desc);
 
         signer.verify(csp_set);
       }
@@ -132,11 +132,11 @@ TEST_CASE("Idempotence")
     {
       for (const auto& position : positions)
       {
-        auto csp_set_once =
-          ccf::cose::edit::set_unprotected_header(csp, key, position, value);
+        ccf::cose::edit::desc::Value desc{position, key, value};
+        auto csp_set_once = ccf::cose::edit::set_unprotected_header(csp, desc);
 
-        auto csp_set_twice = ccf::cose::edit::set_unprotected_header(
-          csp_set_once, key, position, value);
+        auto csp_set_twice =
+          ccf::cose::edit::set_unprotected_header(csp_set_once, desc);
         REQUIRE(csp_set_once == csp_set_twice);
       }
     }
@@ -155,8 +155,8 @@ TEST_CASE("Check unprotected header")
     {
       for (const auto& position : positions)
       {
-        auto csp_set =
-          ccf::cose::edit::set_unprotected_header(csp, key, position, value);
+        ccf::cose::edit::desc::Value desc{position, key, value};
+        auto csp_set = ccf::cose::edit::set_unprotected_header(csp, desc);
 
         std::vector<uint8_t> ref(1024);
         {

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1015,6 +1015,12 @@ def test_cose_signature_schema(network, args):
 def test_cose_receipt_schema(network, args):
     primary, _ = network.find_nodes()
 
+    # Make sure the last transaction does not contain application claims
+    member = network.consortium.get_any_active_member()
+    r = member.update_ack_state_digest(primary)
+    with primary.client() as client:
+        client.wait_for_commit(r)
+
     service_cert_path = os.path.join(network.common_dir, "service_cert.pem")
     service_cert = load_pem_x509_certificate(
         open(service_cert_path, "rb").read(), default_backend()
@@ -1037,6 +1043,7 @@ def test_cose_receipt_schema(network, args):
                     headers={infra.clients.CCF_TX_ID_HEADER: txid},
                     log_capture=[],  # Do not emit raw binary to stdout
                 )
+
                 if r.status_code == http.HTTPStatus.OK:
                     cbor_proof = r.body.data()
                     ccf.cose.verify_receipt(cbor_proof, service_key, b"\0" * 32)

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1039,7 +1039,7 @@ def test_cose_receipt_schema(network, args):
                 )
                 if r.status_code == http.HTTPStatus.OK:
                     cbor_proof = r.body.data()
-                    ccf.cose.verify_receipt(cbor_proof, service_key)
+                    ccf.cose.verify_receipt(cbor_proof, service_key, b"\0" * 32)
                     cbor_proof_filename = os.path.join(
                         network.common_dir, f"receipt_{txid}.cose"
                     )


### PR DESCRIPTION
- [x] Add support for `desc::Empty`
- [x] Add tests for `desc::Empty`
- [x] Add support for custom claim to `cose.verify_receipt()`
- [x] Add test for custom claim to `cose.verify_receipt()`