### PR TITLE
Fix accessing invalid iterator in historical state

### DIFF
--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -265,14 +265,14 @@ namespace ccf::historical
           auto new_it = new_seqnos.begin();
           while (new_it != new_seqnos.end())
           {
-            if (*new_it == prev_it->first)
+            if (prev_it != my_stores.end() && *new_it == prev_it->first)
             {
               // Asking for a seqno which was also requested previously - do
               // nothing and advance to compare next entries
               ++new_it;
               ++prev_it;
             }
-            else if (*new_it > prev_it->first)
+            else if (prev_it != my_stores.end() && *new_it > prev_it->first)
             {
               // No longer looking for a seqno which was previously requested.
               // Remove it from my_stores


### PR DESCRIPTION
During investigation of #6594 I found out that we may read `map::end()`. It revealed as infinite loop in the debugger:


```
NameError: name 'lldb' is not defined
* thread #1, name = 'historical_quer', stop reason = signal SIGSTOP
  * frame #0: 0x00007ffff78273e7 libstdc++.so.6`std::_Rb_tree_increment(std::_Rb_tree_node_base*) + 23
    frame #1: 0x0000555555679b3c historical_queries_test`std::_Rb_tree_iterator<std::pair<unsigned long const, std::shared_ptr<ccf::historical::StateCacheImpl::StoreDetails>>>::operator++(this=0x00007fffffff9ba8) at stl_tree.h:287:12
    frame #2: 0x000055555567b53e historical_queries_test`std::_Rb_tree<unsigned long, std::pair<unsigned long const, std::shared_ptr<ccf::historical::StateCacheImpl::StoreDetails>>, std::_Select1st<std::pair<unsigned long const, std::shared_ptr<ccf::historical::StateCacheImpl::StoreDetails>>>, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, std::shared_ptr<ccf::historical::StateCacheImpl::StoreDetails>>>>::erase[abi:cxx11](this=0x0000555555939d58, __position=std::_Rb_tree<unsigned long, std::pair<const unsigned long, std::shared_ptr<ccf::historical::StateCacheImpl::StoreDetails> >, std::_Select1st<std::pair<const unsigned long, std::shared_ptr<ccf::historical::StateCacheImpl::StoreDetails> > >, std::less<unsigned long>, std::allocator<std::pair<const unsigned long, std::shared_ptr<ccf::historical::StateCacheImpl::StoreDetails> > > >::iterator @ 0x00007fffffff9ba0) at stl_tree.h:1209:2
    frame #3: 0x000055555567a3f5 historical_queries_test`std::map<unsigned long, std::shared_ptr<ccf::historical::StateCacheImpl::StoreDetails>, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, std::shared_ptr<ccf::historical::StateCacheImpl::StoreDetails>>>>::erase[abi:cxx11](this=size=1, __position=std::map<unsigned long, std::shared_ptr<ccf::historical::StateCacheImpl::StoreDetails>, std::less<unsigned long>, std::allocator<std::pair<const unsigned long, std::shared_ptr<ccf::historical::StateCacheImpl::StoreDetails> > > >::iterator @ 0x00007fffffff9bd0) at stl_map.h:1088:21
    frame #4: 0x000055555567504e historical_queries_test`ccf::historical::StateCacheImpl::Request::adjust_ranges(this=0x0000555555939d50, new_seqnos=0x00007fffffffa218, should_include_receipts=true, earliest_ledger_secret_seqno=1) at historical_queries.h:280:35
...
...
```

I've got no clue how why it always works out, seems like we either always skip the first two conditions and go to else, or we randomly just into those, but it's kinda harmless in the end, as soo as we use `removed` and `added` to maintain the cache only, which is probably robust to removing inexisting seqnos.

The major question I've got, after all, is why have we never hit the issue on ASAN builds. Don't we run historical tests there? Needs checking.