### PR TITLE
Make plain data encryption conditional

### DIFF
--- a/src/crypto/openssl/symmetric_key.cpp
+++ b/src/crypto/openssl/symmetric_key.cpp
@@ -62,7 +62,9 @@ namespace ccf::crypto
     CHECK1(EVP_EncryptInit_ex(ctx, NULL, NULL, key.data(), iv.data()));
     if (!aad.empty())
       CHECK1(EVP_EncryptUpdate(ctx, NULL, &len, aad.data(), aad.size()));
-    CHECK1(EVP_EncryptUpdate(ctx, cb.data(), &len, plain.data(), plain.size()));
+    if (!plain.empty())
+      CHECK1(
+        EVP_EncryptUpdate(ctx, cb.data(), &len, plain.data(), plain.size()));
     CHECK1(EVP_EncryptFinal_ex(ctx, cb.data() + len, &len));
     CHECK1(
       EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, GCM_SIZE_TAG, &tag[0]));
@@ -89,8 +91,10 @@ namespace ccf::crypto
     CHECK1(EVP_DecryptInit_ex(ctx, NULL, NULL, key.data(), iv.data()));
     if (!aad.empty())
       CHECK1(EVP_DecryptUpdate(ctx, NULL, &len, aad.data(), aad.size()));
-    CHECK1(
-      EVP_DecryptUpdate(ctx, pb.data(), &len, cipher.data(), cipher.size()));
+    if (!cipher.empty())
+      CHECK1(
+        EVP_DecryptUpdate(ctx, pb.data(), &len, cipher.data(), cipher.size()));
+
     CHECK1(EVP_CIPHER_CTX_ctrl(
       ctx, EVP_CTRL_GCM_SET_TAG, GCM_SIZE_TAG, (uint8_t*)tag));
 


### PR DESCRIPTION
During #6594 we revealed that symcrypt is not capable of encrypting empty play data:

```
NameError: name 'lldb' is not defined
* thread #1, name = 'historical_quer', stop reason = signal SIGSEGV: address not mapped to object (fault address: 0x1f0)
  * frame #0: 0x00007ffff735a9d4 libsymcrypt.so.103`SymCryptGHashAppendDataPclmulqdq + 100
    frame #1: 0x00007ffff735910f libsymcrypt.so.103`SymCryptGcmComputeTag + 303
    frame #2: 0x00007ffff73595ff libsymcrypt.so.103`SymCryptGcmEncryptFinal + 47
    frame #3: 0x00007ffff73e0c98 symcryptprovider.so`scossl_aes_gcm_cipher + 296
    frame #4: 0x00007ffff7bbde51 libcrypto.so.3`EVP_EncryptFinal_ex + 145
    frame #5: 0x000055555575b760 historical_queries_test`ccf::crypto::KeyAesGcm_OpenSSL::encrypt(this=0x000055555593d3f0, iv=span<const unsigned char, 18446744073709551615UL> @ 0x00007fffffff7eb0, plain=span<const unsigned char, 18446744073709551615UL> @ 0x00007fffffff7ea0, aad=span<const unsigned char, 18446744073709551615UL> @ 0x00007fffffff7f10, cipher=size=1, tag="") const at symmetric_key.cpp:68:12
```

I'm guessing this `if-` must compatible with both OpenSSL 1 and 3, so proposing to merge it for existing impl too.