### PR TITLE
Remove deprecated fields

### DIFF
--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -785,7 +785,6 @@ namespace ccf
       join_params.certificate_signing_request = node_sign_kp->create_csr(
         config.node_certificate.subject_name, subject_alt_names);
       join_params.node_data = config.node_data;
-      join_params.consensus_type = ConsensusType::CFT;
 
       LOG_DEBUG_FMT(
         "Sending join request to {}", config.join.target_rpc_address);

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -83,9 +83,6 @@ namespace ccf
       NodeInfoNetwork node_info_network;
       QuoteInfo quote_info;
       ccf::crypto::Pem public_encryption_key;
-      // Always set by the joiner (node_state.h), but defaults to nullopt here
-      // to make sure serialisation does take place now that it is OPTIONAL.
-      std::optional<ConsensusType> consensus_type = std::nullopt;
       std::optional<ccf::kv::Version> startup_seqno = std::nullopt;
       std::optional<ccf::crypto::Pem> certificate_signing_request =
         std::nullopt;
@@ -103,10 +100,6 @@ namespace ccf
       {
         bool public_only = false;
         ccf::kv::Version last_recovered_signed_idx = ccf::kv::NoVersion;
-        ConsensusType consensus_type = ConsensusType::CFT;
-        std::optional<ReconfigurationType> reconfiguration_type =
-          std::nullopt; // Unused, but kept for backwards compatibility
-
         LedgerSecretsMap ledger_secrets;
         NetworkIdentity identity;
         std::optional<ServiceStatus> service_status = std::nullopt;
@@ -118,14 +111,12 @@ namespace ccf
         NetworkInfo(
           bool public_only,
           ccf::kv::Version last_recovered_signed_idx,
-          ReconfigurationType reconfiguration_type,
           const LedgerSecretsMap& ledger_secrets,
           const NetworkIdentity& identity,
           ServiceStatus service_status,
           const std::optional<ccf::crypto::Pem>& endorsed_certificate) :
           public_only(public_only),
           last_recovered_signed_idx(last_recovered_signed_idx),
-          reconfiguration_type(reconfiguration_type),
           ledger_secrets(ledger_secrets),
           identity(identity),
           service_status(service_status),
@@ -136,8 +127,6 @@ namespace ccf
         {
           return public_only == other.public_only &&
             last_recovered_signed_idx == other.last_recovered_signed_idx &&
-            consensus_type == other.consensus_type &&
-            reconfiguration_type == other.reconfiguration_type &&
             ledger_secrets == other.ledger_secrets &&
             identity == other.identity &&
             service_status == other.service_status &&

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -366,7 +366,6 @@ namespace ccf
         rep.network_info = JoinNetworkNodeToNode::Out::NetworkInfo{
           node_operation.is_part_of_public_network(),
           node_operation.get_last_recovered_signed_idx(),
-          ReconfigurationType::ONE_TRANSACTION,
           this->network.ledger_secrets->get(tx),
           *this->network.identity.get(),
           service_status,
@@ -480,7 +479,6 @@ namespace ccf
             rep.network_info = JoinNetworkNodeToNode::Out::NetworkInfo(
               node_operation.is_part_of_public_network(),
               node_operation.get_last_recovered_signed_idx(),
-              ReconfigurationType::ONE_TRANSACTION,
               this->network.ledger_secrets->get(
                 args.tx, existing_node_info->ledger_secret_seqno),
               *this->network.identity.get(),
@@ -556,7 +554,6 @@ namespace ccf
             rep.network_info = JoinNetworkNodeToNode::Out::NetworkInfo(
               node_operation.is_part_of_public_network(),
               node_operation.get_last_recovered_signed_idx(),
-              ReconfigurationType::ONE_TRANSACTION,
               this->network.ledger_secrets->get(
                 args.tx, existing_node_info->ledger_secret_seqno),
               *this->network.identity.get(),

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -35,8 +35,7 @@ namespace ccf
   DECLARE_JSON_OPTIONAL_FIELDS(
     JoinNetworkNodeToNode::In,
     certificate_signing_request,
-    node_data,
-    consensus_type)
+    node_data)
 
   DECLARE_JSON_ENUM(
     ccf::IdentityType,
@@ -58,9 +57,7 @@ namespace ccf
   DECLARE_JSON_OPTIONAL_FIELDS(
     JoinNetworkNodeToNode::Out::NetworkInfo,
     service_status,
-    endorsed_certificate,
-    reconfiguration_type,
-    consensus_type)
+    endorsed_certificate)
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(JoinNetworkNodeToNode::Out)
   DECLARE_JSON_REQUIRED_FIELDS(JoinNetworkNodeToNode::Out, node_status)
   DECLARE_JSON_OPTIONAL_FIELDS(

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -33,9 +33,7 @@ namespace ccf
     public_encryption_key,
     startup_seqno)
   DECLARE_JSON_OPTIONAL_FIELDS(
-    JoinNetworkNodeToNode::In,
-    certificate_signing_request,
-    node_data)
+    JoinNetworkNodeToNode::In, certificate_signing_request, node_data)
 
   DECLARE_JSON_ENUM(
     ccf::IdentityType,


### PR DESCRIPTION
Looking at the join RPC while adding COSE signatures issuer and subject, and these are unused.