### PR TITLE
Compatibility for cose_signatures_config field in /join response

### DIFF
--- a/src/node/rpc/cose_signatures_config.h
+++ b/src/node/rpc/cose_signatures_config.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ccf/ds/json.h"
+
+#include <string>
+
+struct COSESignaturesConfig
+{
+  std::string issuer;
+  std::string subject;
+
+  bool operator==(const COSESignaturesConfig& other) const = default;
+};
+
+DECLARE_JSON_TYPE(COSESignaturesConfig);
+DECLARE_JSON_REQUIRED_FIELDS(COSESignaturesConfig, issuer, subject);

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -14,6 +14,7 @@
 #include "enclave/interface.h"
 #include "node/identity.h"
 #include "node/ledger_secrets.h"
+#include "node/rpc/cose_signatures_config.h"
 #include "node/uvm_endorsements.h"
 
 #include <nlohmann/json.hpp>
@@ -112,6 +113,8 @@ namespace ccf
         std::optional<ServiceStatus> service_status = std::nullopt;
 
         std::optional<ccf::crypto::Pem> endorsed_certificate = std::nullopt;
+        std::optional<COSESignaturesConfig> cose_signatures_config =
+          std::nullopt;
 
         NetworkInfo() {}
 
@@ -122,14 +125,16 @@ namespace ccf
           const LedgerSecretsMap& ledger_secrets,
           const NetworkIdentity& identity,
           ServiceStatus service_status,
-          const std::optional<ccf::crypto::Pem>& endorsed_certificate) :
+          const std::optional<ccf::crypto::Pem>& endorsed_certificate,
+          const std::optional<COSESignaturesConfig>& cose_signatures_config_) :
           public_only(public_only),
           last_recovered_signed_idx(last_recovered_signed_idx),
           reconfiguration_type(reconfiguration_type),
           ledger_secrets(ledger_secrets),
           identity(identity),
           service_status(service_status),
-          endorsed_certificate(endorsed_certificate)
+          endorsed_certificate(endorsed_certificate),
+          cose_signatures_config(cose_signatures_config_)
         {}
 
         bool operator==(const NetworkInfo& other) const
@@ -141,7 +146,8 @@ namespace ccf
             ledger_secrets == other.ledger_secrets &&
             identity == other.identity &&
             service_status == other.service_status &&
-            endorsed_certificate == other.endorsed_certificate;
+            endorsed_certificate == other.endorsed_certificate &&
+            cose_signatures_config == other.cose_signatures_config;
         }
 
         bool operator!=(const NetworkInfo& other) const

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -370,7 +370,8 @@ namespace ccf
           this->network.ledger_secrets->get(tx),
           *this->network.identity.get(),
           service_status,
-          endorsed_certificate};
+          endorsed_certificate,
+          std::nullopt /* cose_signatures_config */};
       }
       return make_success(rep);
     }
@@ -485,7 +486,8 @@ namespace ccf
                 args.tx, existing_node_info->ledger_secret_seqno),
               *this->network.identity.get(),
               active_service->status,
-              existing_node_info->endorsed_certificate);
+              existing_node_info->endorsed_certificate,
+              std::nullopt /* cose_signatures_config */);
 
             return make_success(rep);
           }
@@ -561,7 +563,8 @@ namespace ccf
                 args.tx, existing_node_info->ledger_secret_seqno),
               *this->network.identity.get(),
               active_service->status,
-              existing_node_info->endorsed_certificate);
+              existing_node_info->endorsed_certificate,
+              std::nullopt /* cose_signatures_config */);
 
             return make_success(rep);
           }

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -60,7 +60,8 @@ namespace ccf
     service_status,
     endorsed_certificate,
     reconfiguration_type,
-    consensus_type)
+    consensus_type,
+    cose_signatures_config)
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(JoinNetworkNodeToNode::Out)
   DECLARE_JSON_REQUIRED_FIELDS(JoinNetworkNodeToNode::Out, node_status)
   DECLARE_JSON_OPTIONAL_FIELDS(


### PR DESCRIPTION
Prelude to adding support for COSE signatures issuer and subject configuration, which needs to be backported to 5.x to allow join compatibility.