### PR TITLE
Take `version_lock` when creating reserved Tx

### DIFF
--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -1255,8 +1255,7 @@ namespace ccf::kv
 
     ReservedTx create_reserved_tx(const TxID& tx_id)
     {
-      // version_lock should already been acquired in case term_of_last_version
-      // is incremented.
+      std::lock_guard<ccf::pal::Mutex> vguard(version_lock);
       return ReservedTx(this, term_of_last_version, tx_id, rollback_count);
     }
 


### PR DESCRIPTION
Without a lock, this is race-y access to `term_of_last_version` and `rollback_count`, which are normally protected by `version_lock`. There's a comment suggesting this should already have been acquired, but it definitely hasn't in the `MerkleTreeHistoryPendingTx::call()` path. It's not clear to me where it ever _was_ previously held.