### PR TITLE
Verbose logging for cert renewals

### DIFF
--- a/src/kv/untyped_map.h
+++ b/src/kv/untyped_map.h
@@ -730,6 +730,10 @@ namespace ccf::kv::untyped
       {
         for (auto& [version, writes] : commit_deltas)
         {
+          LOG_TRACE_FMT(
+            "Executing global hook on table {} at version {}",
+            get_name(),
+            version);
           global_hook(version, writes);
         }
       }
@@ -834,6 +838,10 @@ namespace ccf::kv::untyped
     {
       if (hook && !writes.empty())
       {
+        LOG_TRACE_FMT(
+          "Executing local hook on table {} at version {}",
+          get_name(),
+          version);
         return hook(version, writes);
       }
       return nullptr;

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -2209,22 +2209,42 @@ namespace ccf
             ccf::kv::Version hook_version,
             const NodeEndorsedCertificates::Write& w)
             -> ccf::kv::ConsensusHookPtr {
+            LOG_INFO_FMT(
+              "[local] node_endorsed_certificates local hook at version {}, "
+              "with {} writes",
+              hook_version,
+              w.size());
             for (auto const& [node_id, endorsed_certificate] : w)
             {
               if (node_id != self)
               {
+                LOG_INFO_FMT(
+                  "[local] Ignoring endorsed certificate for other node {}",
+                  node_id);
                 continue;
               }
 
               if (!endorsed_certificate.has_value())
               {
+                LOG_FAIL_FMT(
+                  "[local] Endorsed cert for self ({}) has been deleted", self);
                 throw std::logic_error(fmt::format(
                   "Could not find endorsed node certificate for {}", self));
               }
 
               std::lock_guard<pal::Mutex> guard(lock);
 
+              if (endorsed_node_cert.has_value())
+              {
+                LOG_INFO_FMT(
+                  "[local] Previous endorsed node cert was:\n{}",
+                  endorsed_node_cert->str());
+              }
+
               endorsed_node_cert = endorsed_certificate.value();
+              LOG_INFO_FMT(
+                "[local] Under lock, setting endorsed node cert to:\n{}",
+                endorsed_node_cert->str());
               history->set_endorsed_certificate(endorsed_node_cert.value());
               n2n_channels->set_endorsed_node_cert(endorsed_node_cert.value());
             }
@@ -2238,21 +2258,33 @@ namespace ccf
           [this](
             ccf::kv::Version hook_version,
             const NodeEndorsedCertificates::Write& w) {
+            LOG_INFO_FMT(
+              "[global] node_endorsed_certificates global hook at version {}, "
+              "with {} writes",
+              hook_version,
+              w.size());
             for (auto const& [node_id, endorsed_certificate] : w)
             {
               if (node_id != self)
               {
+                LOG_INFO_FMT(
+                  "[global] Ignoring endorsed certificate for other node {}",
+                  node_id);
                 continue;
               }
 
               if (!endorsed_certificate.has_value())
               {
+                LOG_FAIL_FMT(
+                  "[global] Endorsed cert for self ({}) has been deleted",
+                  self);
                 throw std::logic_error(fmt::format(
                   "Could not find endorsed node certificate for {}", self));
               }
 
               std::lock_guard<pal::Mutex> guard(lock);
 
+              LOG_INFO_FMT("[global] Accepting network connections");
               accept_network_tls_connections();
 
               if (is_member_frontend_open_unsafe())
@@ -2266,15 +2298,31 @@ namespace ccf
                 auto [valid_from, valid_to] =
                   ccf::crypto::make_verifier(endorsed_node_cert.value())
                     ->validity_period();
+                LOG_INFO_FMT(
+                  "[global] Member frontend is open, so refreshing self-signed "
+                  "node cert");
+                LOG_INFO_FMT(
+                  "[global] Previously:\n{}", self_signed_node_cert.str());
                 self_signed_node_cert = create_self_signed_cert(
                   node_sign_kp,
                   config.node_certificate.subject_name,
                   subject_alt_names,
                   valid_from,
                   valid_to);
+                LOG_INFO_FMT("[global] Now:\n{}", self_signed_node_cert.str());
+
+                LOG_INFO_FMT("[global] Accepting node connections");
                 accept_node_tls_connections();
               }
+              else
+              {
+                LOG_INFO_FMT("[global] Member frontend is NOT open");
+                LOG_INFO_FMT(
+                  "[global] Self-signed node cert remains:\n{}",
+                  self_signed_node_cert.str());
+              }
 
+              LOG_INFO_FMT("[global] Opening members frontend");
               open_frontend(ActorsType::members);
             }
           }));
@@ -2302,6 +2350,13 @@ namespace ccf
                 w->cert.str());
               return;
             }
+
+            LOG_INFO_FMT(
+              "Executing global hook for service table at {}, to service "
+              "status {}. Cert is:\n{}",
+              hook_version,
+              w->status,
+              w->cert.str());
 
             network.identity->set_certificate(w->cert);
             if (w->status == ServiceStatus::OPEN)

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -938,8 +938,12 @@ namespace ccf
     void open() override
     {
       std::lock_guard<ccf::pal::Mutex> mguard(open_lock);
-      is_open_ = true;
-      endpoints.init_handlers();
+      if (!is_open_)
+      {
+        LOG_INFO_FMT("Opening frontend");
+        is_open_ = true;
+        endpoints.init_handlers();
+      }
     }
 
     bool is_open() override


### PR DESCRIPTION
Trying to track down sporadic failures around cert renewal operations. Adding logging to aid diagnosis in live instances.