### PR TITLE
Fix node debugging in e2e tests

### DIFF
--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -51,6 +51,13 @@ def max_f(args, number_nodes):
     return (number_nodes - 1) // 2
 
 
+def default_platform():
+    if os.path.exists("PLATFORM"):
+        with open("PLATFORM") as f:
+            return f.read().strip()
+    return "virtual"
+
+
 def cli_args(
     add=lambda x: None,
     parser=None,
@@ -110,7 +117,9 @@ def cli_args(
         "-t",
         "--enclave-platform",
         help="Enclave platform (Trusted Execution Environment)",
-        default=os.getenv("TEST_ENCLAVE", os.getenv("DEFAULT_ENCLAVE_PLATFORM", "sgx")),
+        default=os.getenv(
+            "TEST_ENCLAVE", os.getenv("DEFAULT_ENCLAVE_PLATFORM", default_platform())
+        ),
         choices=("sgx", "snp", "virtual"),
     )
     log_level_choices = ("trace", "debug", "info", "fail", "fatal")

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -19,7 +19,7 @@ from packaging.version import (  # type: ignore
 
 from loguru import logger as LOG
 
-DBG = os.getenv("DBG", "cgdb")
+DBG = os.getenv("DBG", "lldb")
 
 # Duration after which unresponsive node is declared as crashed on startup
 REMOTE_STARTUP_TIMEOUT_S = 5
@@ -269,7 +269,7 @@ class LocalRemote(CmdMixin):
 
     def debug_node_cmd(self):
         cmd = " ".join(self.cmd)
-        return f"cd {self.root} && {DBG} --args {cmd}"
+        return f"cd {self.root} && {DBG} -- {cmd}"
 
     def check_done(self):
         return self.proc is not None and self.proc.poll() is not None


### PR DESCRIPTION
- Change default debugger to lldb
- Update DEFAULT_ENCLAVE_PLATFORM to use PLATFORM file, as `sandbox.sh` does

Without these changes, running an e2e test with `-d 0` resulted in generating an SGX directory and command, using cgdb, which does not work well with the current binaries.