### PR TITLE
Support BIO read/write retries in OpenSSL 3.3

### DIFF
--- a/src/enclave/tls_session.h
+++ b/src/enclave/tls_session.h
@@ -648,7 +648,8 @@ namespace ccf
         // WANTS_WRITE
         if (put == TLS_WRITING)
         {
-#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3 && \
+  defined(OPENSSL_VERSION_MINOR) && OPENSSL_VERSION_MINOR >= 3
           BIO_set_retry_write(b);
 #endif
           LOG_TRACE_FMT("TLS Session::send_cb() : WANTS_WRITE");
@@ -700,7 +701,8 @@ namespace ccf
         // WANTS_READ
         if (got == TLS_READING)
         {
-#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3 && \
+  defined(OPENSSL_VERSION_MINOR) && OPENSSL_VERSION_MINOR >= 3
           BIO_set_retry_read(b);
 #endif
           LOG_TRACE_FMT("TLS Session::recv_cb() : WANTS_READ");

--- a/src/enclave/tls_session.h
+++ b/src/enclave/tls_session.h
@@ -648,6 +648,9 @@ namespace ccf
         // WANTS_WRITE
         if (put == TLS_WRITING)
         {
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+          BIO_set_retry_write(b);
+#endif
           LOG_TRACE_FMT("TLS Session::send_cb() : WANTS_WRITE");
           *processed = 0;
           return -1;
@@ -697,6 +700,9 @@ namespace ccf
         // WANTS_READ
         if (got == TLS_READING)
         {
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+          BIO_set_retry_read(b);
+#endif
           LOG_TRACE_FMT("TLS Session::recv_cb() : WANTS_READ");
           *processed = 0;
           return -1;


### PR DESCRIPTION
Resolves #6619 

Checked w/o the macro on virtual (openssl 1.1.1), adding these calls doesn't really break anything, but I'm inclined to keep them until we remove all ssl macros in the future.