### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # https://help.github.com/en/articles/about-code-owners
 
 # Every review will request the CCF team as reviewer, unless a later match takes precedence
-* @Microsoft/ccf-code-reviewers
+* @Microsoft/ccf


### PR DESCRIPTION
Nuking the ccf-code-reviewers team, rolling that into the parent ccf team.