### PR TITLE
Remove `/[app|gov|node]/code` endpoints

### DIFF
--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -31,44 +31,6 @@
         },
         "type": "object"
       },
-      "CodeStatus": {
-        "enum": [
-          "AllowedToJoin"
-        ],
-        "type": "string"
-      },
-      "GetCode__Out": {
-        "properties": {
-          "versions": {
-            "$ref": "#/components/schemas/GetCode__Version_array"
-          }
-        },
-        "required": [
-          "versions"
-        ],
-        "type": "object"
-      },
-      "GetCode__Version": {
-        "properties": {
-          "digest": {
-            "$ref": "#/components/schemas/string"
-          },
-          "status": {
-            "$ref": "#/components/schemas/CodeStatus"
-          }
-        },
-        "required": [
-          "digest",
-          "status"
-        ],
-        "type": "object"
-      },
-      "GetCode__Version_array": {
-        "items": {
-          "$ref": "#/components/schemas/GetCode__Version"
-        },
-        "type": "array"
-      },
       "GetCommit__Out": {
         "properties": {
           "transaction_id": {
@@ -295,7 +257,7 @@
   "info": {
     "description": "This CCF sample app implements a simple logging application, securely recording messages at client-specified IDs. It demonstrates most of the features available to CCF apps.",
     "title": "CCF Sample Logging App",
-    "version": "2.6.0"
+    "version": "2.7.0"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -318,32 +280,6 @@
           }
         },
         "summary": "OpenAPI schema",
-        "x-ccf-forwarding": {
-          "$ref": "#/components/x-ccf-forwarding/sometimes"
-        }
-      }
-    },
-    "/app/code": {
-      "get": {
-        "deprecated": true,
-        "description": "This endpoint is deprecated from 5.0.0. It is replaced by GET /gov/service/join-policy",
-        "operationId": "GetAppCode",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetCode__Out"
-                }
-              }
-            },
-            "description": "Default response description"
-          },
-          "default": {
-            "$ref": "#/components/responses/default"
-          }
-        },
-        "summary": "Permitted SGX code identities",
         "x-ccf-forwarding": {
           "$ref": "#/components/x-ccf-forwarding/sometimes"
         }

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -190,38 +190,6 @@
         ],
         "type": "object"
       },
-      "GetCode__Out": {
-        "properties": {
-          "versions": {
-            "$ref": "#/components/schemas/GetCode__Version_array"
-          }
-        },
-        "required": [
-          "versions"
-        ],
-        "type": "object"
-      },
-      "GetCode__Version": {
-        "properties": {
-          "digest": {
-            "$ref": "#/components/schemas/string"
-          },
-          "status": {
-            "$ref": "#/components/schemas/CodeStatus"
-          }
-        },
-        "required": [
-          "digest",
-          "status"
-        ],
-        "type": "object"
-      },
-      "GetCode__Version_array": {
-        "items": {
-          "$ref": "#/components/schemas/GetCode__Version"
-        },
-        "type": "array"
-      },
       "GetCommit__Out": {
         "properties": {
           "transaction_id": {
@@ -1333,7 +1301,7 @@
   "info": {
     "description": "This API is used to submit and query proposals which affect CCF's public governance tables.",
     "title": "CCF Governance API",
-    "version": "4.4.0"
+    "version": "4.5.0"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -1421,32 +1389,6 @@
           }
         },
         "summary": "OpenAPI schema",
-        "x-ccf-forwarding": {
-          "$ref": "#/components/x-ccf-forwarding/sometimes"
-        }
-      }
-    },
-    "/gov/code": {
-      "get": {
-        "deprecated": true,
-        "description": "This endpoint is deprecated from 5.0.0. It is replaced by GET /gov/service/join-policy",
-        "operationId": "GetGovCode",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetCode__Out"
-                }
-              }
-            },
-            "description": "Default response description"
-          },
-          "default": {
-            "$ref": "#/components/responses/default"
-          }
-        },
-        "summary": "Permitted SGX code identities",
         "x-ccf-forwarding": {
           "$ref": "#/components/x-ccf-forwarding/sometimes"
         }

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -40,12 +40,6 @@
         },
         "type": "object"
       },
-      "CodeStatus": {
-        "enum": [
-          "AllowedToJoin"
-        ],
-        "type": "string"
-      },
       "Configuration": {
         "properties": {
           "idx": {
@@ -182,38 +176,6 @@
           "authority"
         ],
         "type": "object"
-      },
-      "GetCode__Out": {
-        "properties": {
-          "versions": {
-            "$ref": "#/components/schemas/GetCode__Version_array"
-          }
-        },
-        "required": [
-          "versions"
-        ],
-        "type": "object"
-      },
-      "GetCode__Version": {
-        "properties": {
-          "digest": {
-            "$ref": "#/components/schemas/string"
-          },
-          "status": {
-            "$ref": "#/components/schemas/CodeStatus"
-          }
-        },
-        "required": [
-          "digest",
-          "status"
-        ],
-        "type": "object"
-      },
-      "GetCode__Version_array": {
-        "items": {
-          "$ref": "#/components/schemas/GetCode__Version"
-        },
-        "type": "array"
       },
       "GetCommit__Out": {
         "properties": {
@@ -896,7 +858,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "4.10.3"
+    "version": "4.11.0"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -937,32 +899,6 @@
         },
         "x-ccf-forwarding": {
           "$ref": "#/components/x-ccf-forwarding/never"
-        }
-      }
-    },
-    "/node/code": {
-      "get": {
-        "deprecated": true,
-        "description": "This endpoint is deprecated from 5.0.0. It is replaced by GET /gov/service/join-policy",
-        "operationId": "GetNodeCode",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetCode__Out"
-                }
-              }
-            },
-            "description": "Default response description"
-          },
-          "default": {
-            "$ref": "#/components/responses/default"
-          }
-        },
-        "summary": "Permitted SGX code identities",
-        "x-ccf-forwarding": {
-          "$ref": "#/components/x-ccf-forwarding/sometimes"
         }
       }
     },

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -470,7 +470,7 @@ namespace loggingapp
         "recording messages at client-specified IDs. It demonstrates most of "
         "the features available to CCF apps.";
 
-      openapi_info.document_version = "2.6.0";
+      openapi_info.document_version = "2.7.0";
 
       index_per_public_key = std::make_shared<RecordsIndexingStrategy>(
         PUBLIC_RECORDS, context, 10000, 20);

--- a/src/endpoints/common_endpoint_registry.cpp
+++ b/src/endpoints/common_endpoint_registry.cpp
@@ -246,28 +246,6 @@ namespace ccf
         "Invalid.")
       .install();
 
-    auto get_code = [](auto& ctx, nlohmann::json&&) {
-      GetCode::Out out;
-
-      auto codes_ids = ctx.tx.template ro<CodeIDs>(Tables::NODE_CODE_IDS);
-      codes_ids->foreach(
-        [&out](
-          const ccf::pal::SgxAttestationMeasurement& measurement,
-          const ccf::CodeStatus& status) {
-          auto digest = measurement.hex_str();
-          out.versions.push_back({digest, status});
-          return true;
-        });
-
-      return make_success(out);
-    };
-    make_read_only_endpoint(
-      "/code", HTTP_GET, json_read_only_adapter(get_code), no_auth_required)
-      .set_auto_schema<void, GetCode::Out>()
-      .set_openapi_summary("Permitted SGX code identities")
-      .set_openapi_deprecated_replaced("5.0.0", "GET /gov/service/join-policy")
-      .install();
-
     auto openapi = [this](auto& ctx) { this->api_endpoint(ctx); };
     make_read_only_endpoint("/api", HTTP_GET, openapi, no_auth_required)
       .set_auto_schema<void, GetAPI::Out>()

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -599,7 +599,7 @@ namespace ccf
       openapi_info.description =
         "This API is used to submit and query proposals which affect CCF's "
         "public governance tables.";
-      openapi_info.document_version = "4.4.0";
+      openapi_info.document_version = "4.5.0";
     }
 
     static std::optional<MemberId> get_caller_member_id(

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -404,7 +404,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
-      openapi_info.document_version = "4.10.3";
+      openapi_info.document_version = "4.11.0";
     }
 
     void init_handlers() override


### PR DESCRIPTION
Deprecated in 5.0. Closes #6622.