### PR TITLE
When joining, always retrieve the service's `subject_name` from the given cert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.0.0-dev7]
+
+[6.0.0-dev7]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev7
+
+### Fixed
+
+- Services upgrading from 4.x to 5.x may accidentally change their service's subject name, resulting in cryptographic errors when verifying anything endorsed by the old subject name. The subject name field is now correctly populated and retained across joins, renewals, and disaster recoveries.
+
 ## [6.0.0-dev6]
 
 [6.0.0-dev6]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev6

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ccf"
-version = "6.0.0-dev6"
+version = "6.0.0-dev7"
 authors = [
   { name="CCF Team", email="CCF-Sec@microsoft.com" },
 ]

--- a/src/node/identity.h
+++ b/src/node/identity.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ccf/crypto/curve.h"
+#include "ccf/crypto/verifier.h"
 #include "ccf/node/cose_signatures_config.h"
 #include "crypto/certs.h"
 #include "crypto/openssl/key_pair.h"
@@ -91,7 +92,8 @@ namespace ccf
     }
 
     ReplicatedNetworkIdentity(const NetworkIdentity& other) :
-      NetworkIdentity(other.subject_name, other.cose_signatures_config)
+      NetworkIdentity(
+        ccf::crypto::get_subject_name(other.cert), other.cose_signatures_config)
     {
       if (type != other.type)
       {

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -717,14 +717,14 @@ if __name__ == "__main__":
             {"with previous LTS": latest_lts_version}
         )
 
-        # # Compatibility with latest LTS on the same release branch
-        # # (e.g. when releasing 2.0.1, check compatibility with existing 2.0.0)
-        # latest_lts_version = run_live_compatibility_with_latest(
-        #     args, repo, local_branch, this_release_branch_only=True
-        # )
-        # compatibility_report["live compatibility"].update(
-        #     {"with same LTS": latest_lts_version}
-        # )
+        # Compatibility with latest LTS on the same release branch
+        # (e.g. when releasing 2.0.1, check compatibility with existing 2.0.0)
+        latest_lts_version = run_live_compatibility_with_latest(
+            args, repo, local_branch, this_release_branch_only=True
+        )
+        compatibility_report["live compatibility"].update(
+            {"with same LTS": latest_lts_version}
+        )
 
         if args.check_ledger_compatibility:
             compatibility_report["data compatibility"] = {}


### PR DESCRIPTION
Follow-up to #5993.

When 5.x nodes join from pre-5.x nodes, they end up with a default `subject_name` (they get it in the join response, where it wasn't populated so had a default value). If they then try to renew the service cert, they'll cause a change in the service name. This is the minimal fix - ignore the serialised `subject_name` field, and always extract it from the given service identity.

This includes a small extension to the `lts_compatibility` test to verify this behaviour. When run on the 5.x branch, this caused a failure without the C++ change, and passes with the C++ change.

I'd like to make a more systematic cleanup of `identity.h` to remove some dead code and simplify the constructor paths, but will do that separately from this minimal fix.