### PR TITLE
Extend pathlen for CAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.0.0-dev7]
+
+[6.0.0-dev7]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev7
+
+### Changed
+
+- Service certificates and endorsements used for historical receipts now have a pathlen constraint of 1 instead of 0, reflecting the fact that there can be a single intermediate in endorsement chains. Historically the value had been 0, which happened to work because of a quirk in OpenSSL when Issuer and Subject match on an element in the chain.
+
 ## [6.0.0-dev6]
 
 [6.0.0-dev6]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev6

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ccf"
-version = "6.0.0-dev6"
+version = "6.0.0-dev7"
 authors = [
   { name="CCF Team", email="CCF-Sec@microsoft.com" },
 ]

--- a/src/crypto/openssl/key_pair.cpp
+++ b/src/crypto/openssl/key_pair.cpp
@@ -382,7 +382,9 @@ namespace ccf::crypto
     std::string constraints = "critical,CA:FALSE";
     if (ca)
     {
-      constraints = "critical,CA:TRUE,pathlen:0";
+      // 1 to allow for intermediate CAs with a different subject name,
+      // which can occur in service endorsements of some services.
+      constraints = "critical,CA:TRUE,pathlen:1";
     }
 
     // Add basic constraints

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -1323,7 +1323,7 @@ TEST_CASE("Sign and verify a chain with an intermediate and different subjects")
   rc = verifier->verify_certificate(
     {&root_cert}, {}, true /* ignore time */
   );
-  
+
   REQUIRE(!rc);
 
   // Invalid root

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -1323,6 +1323,8 @@ TEST_CASE("Sign and verify a chain with an intermediate and different subjects")
   rc = verifier->verify_certificate(
     {&root_cert}, {}, true /* ignore time */
   );
+  
+  REQUIRE(!rc);
 
   // Invalid root
   rc = verifier->verify_certificate(

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -1292,3 +1292,42 @@ TEST_CASE("COSE sign & verify")
 
   REQUIRE(cose_verifier->verify_detached(cose_sign, {}));
 }
+
+TEST_CASE("Sign and verify a chain with an intermediate and different subjects")
+{
+  auto root_kp = ccf::crypto::make_key_pair(CurveID::SECP384R1);
+  auto root_cert = generate_self_signed_cert(root_kp, "CN=root");
+
+  auto intermediate_kp = ccf::crypto::make_key_pair(CurveID::SECP384R1);
+  auto intermediate_csr = intermediate_kp->create_csr("CN=intermediate", {});
+
+  std::string valid_from = "20210311000000Z";
+  std::string valid_to = "20230611235959Z";
+  auto intermediate_cert =
+    root_kp->sign_csr(root_cert, intermediate_csr, valid_from, valid_to, true);
+
+  auto leaf_kp = ccf::crypto::make_key_pair(CurveID::SECP384R1);
+  auto leaf_csr = leaf_kp->create_csr("CN=leaf", {});
+  auto leaf_cert = intermediate_kp->sign_csr(
+    intermediate_cert, leaf_csr, valid_from, valid_to, true);
+
+  auto verifier = ccf::crypto::make_verifier(leaf_cert.raw());
+  auto rc = verifier->verify_certificate(
+    {&root_cert}, {&intermediate_cert}, true /* ignore time */
+  );
+
+  // Failed with pathlen: 0
+  REQUIRE(rc);
+
+  // Missing intermediate
+  rc = verifier->verify_certificate(
+    {&root_cert}, {}, true /* ignore time */
+  );
+
+  // Invalid root
+  rc = verifier->verify_certificate(
+    {&leaf_cert}, {}, true /* ignore time */
+  );
+
+  REQUIRE(!rc);
+}

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1967,7 +1967,7 @@ def test_basic_constraints(network, args):
     )
     assert basic_constraints.critical is True
     assert basic_constraints.value.ca is True
-    assert basic_constraints.value.path_length == 0
+    assert basic_constraints.value.path_length == 1
 
     node_pem = primary.get_tls_certificate_pem()
     node_cert = load_pem_x509_certificate(node_pem.encode(), default_backend())


### PR DESCRIPTION
Complement to #6660 as a follow up for #5993, to fix service endorsements for networks that have updated their service subject_name, and generally avoid depending on the OpenSSL quirk described in https://github.com/blaufish/openssl-pathlen/blob/master/README.md#rfc5280-self-issued-loop-hole