### PR TITLE
[release/5.x] Cherry pick: Schema support for std::unordered_set (#6634)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.0.10]
+
+[5.0.10]: https://github.com/microsoft/CCF/releases/tag/ccf-5.0.10
+
+- Added OpenAPI support for `std::unordered_set`.
+
 ## [5.0.9]
 
 [5.0.9]: https://github.com/microsoft/CCF/releases/tag/ccf-5.0.9

--- a/include/ccf/ds/json_schema.h
+++ b/include/ccf/ds/json_schema.h
@@ -9,6 +9,7 @@
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 #include <set>
+#include <unordered_set>
 
 namespace ccf::ds
 {
@@ -113,7 +114,9 @@ namespace ccf::ds
           return fmt::format("{}_array", schema_name<typename T::value_type>());
         }
       }
-      else if constexpr (ccf::nonstd::is_specialization<T, std::set>::value)
+      else if constexpr (
+        ccf::nonstd::is_specialization<T, std::set>::value ||
+        ccf::nonstd::is_specialization<T, std::unordered_set>::value)
       {
         return fmt::format("{}_set", schema_name<typename T::value_type>());
       }
@@ -204,7 +207,8 @@ namespace ccf::ds
       }
       else if constexpr (
         ccf::nonstd::is_specialization<T, std::vector>::value ||
-        ccf::nonstd::is_specialization<T, std::set>::value)
+        ccf::nonstd::is_specialization<T, std::set>::value ||
+        ccf::nonstd::is_specialization<T, std::unordered_set>::value)
       {
         if constexpr (std::is_same<T, std::vector<uint8_t>>::value)
         {

--- a/include/ccf/ds/openapi.h
+++ b/include/ccf/ds/openapi.h
@@ -12,6 +12,7 @@
 #include <regex>
 #include <set>
 #include <string_view>
+#include <unordered_set>
 
 namespace ccf::ds
 {
@@ -281,7 +282,8 @@ namespace ccf::ds
         }
         else if constexpr (
           ccf::nonstd::is_specialization<T, std::vector>::value ||
-          ccf::nonstd::is_specialization<T, std::set>::value)
+          ccf::nonstd::is_specialization<T, std::set>::value ||
+          ccf::nonstd::is_specialization<T, std::unordered_set>::value)
         {
           if constexpr (std::is_same<T, std::vector<uint8_t>>::value)
           {

--- a/src/ds/test/openapi.cpp
+++ b/src/ds/test/openapi.cpp
@@ -160,6 +160,8 @@ TEST_CASE("Complex custom types")
     doc, "/app/complex", HTTP_POST);
   openapi::add_response_schema<std::map<Baz, std::vector<Buzz>>>(
     doc, "/app/complex", HTTP_POST, HTTP_STATUS_OK);
+  openapi::add_response_schema<std::unordered_set<Baz>>(
+    doc, "/app/complex", HTTP_POST, HTTP_STATUS_OK);
 
   required_doc_elements(doc);
 }


### PR DESCRIPTION
Backports the following commits to `release/5.x`:
 - [Schema support for std::unordered_set (#6634)](https://github.com/microsoft/CCF/pull/6634)