### PR TITLE
Simplify `NetworkIdentity` type

### DIFF
--- a/include/ccf/node/cose_signatures_config.h
+++ b/include/ccf/node/cose_signatures_config.h
@@ -6,13 +6,16 @@
 
 #include <string>
 
-struct COSESignaturesConfig
+namespace ccf
 {
-  std::string issuer = "";
-  std::string subject = "";
+  struct COSESignaturesConfig
+  {
+    std::string issuer = "";
+    std::string subject = "";
 
-  bool operator==(const COSESignaturesConfig& other) const = default;
-};
+    bool operator==(const COSESignaturesConfig& other) const = default;
+  };
 
-DECLARE_JSON_TYPE(COSESignaturesConfig);
-DECLARE_JSON_REQUIRED_FIELDS(COSESignaturesConfig, issuer, subject);
+  DECLARE_JSON_TYPE(COSESignaturesConfig);
+  DECLARE_JSON_REQUIRED_FIELDS(COSESignaturesConfig, issuer, subject);
+}

--- a/include/ccf/node/startup_config.h
+++ b/include/ccf/node/startup_config.h
@@ -85,8 +85,6 @@ struct StartupConfig : CCFConfig
   size_t snapshot_tx_interval = 10'000;
 
   // Only if starting or recovering
-  // TODO: Put these into one of the nested structures, to ensure they only
-  // exist in the right mode?
   size_t initial_service_certificate_validity_days = 1;
   std::string service_subject_name = "CN=CCF Service";
   ccf::COSESignaturesConfig cose_signatures;

--- a/include/ccf/node/startup_config.h
+++ b/include/ccf/node/startup_config.h
@@ -85,9 +85,11 @@ struct StartupConfig : CCFConfig
   size_t snapshot_tx_interval = 10'000;
 
   // Only if starting or recovering
+  // TODO: Put these into one of the nested structures, to ensure they only
+  // exist in the right mode?
   size_t initial_service_certificate_validity_days = 1;
   std::string service_subject_name = "CN=CCF Service";
-  COSESignaturesConfig cose_signatures;
+  ccf::COSESignaturesConfig cose_signatures;
 
   nlohmann::json service_data = nullptr;
 

--- a/src/host/configuration.h
+++ b/src/host/configuration.h
@@ -144,7 +144,7 @@ namespace host
         ccf::ServiceConfiguration service_configuration;
         size_t initial_service_certificate_validity_days = 1;
         std::string service_subject_name = "CN=CCF Service";
-        COSESignaturesConfig cose_signatures;
+        ccf::COSESignaturesConfig cose_signatures;
 
         bool operator==(const Start&) const = default;
       };

--- a/src/js/extensions/ccf/network.cpp
+++ b/src/js/extensions/ccf/network.cpp
@@ -163,7 +163,7 @@ namespace ccf::js::extensions
 
       try
       {
-        auto renewed_cert = network->identity->issue_certificate(
+        auto renewed_cert = network->identity->renew_certificate(
           valid_from, validity_period_days);
 
         return JS_NewString(ctx, renewed_cert.str().c_str());

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -428,6 +428,7 @@ namespace ccf::kv
     virtual void set_service_signing_identity(
       std::shared_ptr<ccf::crypto::KeyPair_OpenSSL> keypair,
       const COSESignaturesConfig& cose_signatures) = 0;
+    virtual const ccf::COSESignaturesConfig& get_cose_signatures_config() = 0;
   };
 
   class Consensus : public ConfigurableConsensus

--- a/src/node/history.h
+++ b/src/node/history.h
@@ -587,8 +587,8 @@ namespace ccf
 
     struct ServiceSigningContext
     {
-      std::shared_ptr<ccf::crypto::KeyPair_OpenSSL> service_kp;
-      ccf::COSESignaturesConfig cose_signatures_config;
+      const std::shared_ptr<ccf::crypto::KeyPair_OpenSSL> service_kp;
+      const ccf::COSESignaturesConfig cose_signatures_config;
     };
 
     std::optional<ServiceSigningContext> signing_context = std::nullopt;
@@ -623,8 +623,8 @@ namespace ccf
           "Called set_service_signing_identity() multiple times");
       }
 
-      signing_context =
-        ServiceSigningContext{service_kp_, cose_signatures_config_};
+      signing_context.emplace(
+        ServiceSigningContext{service_kp_, cose_signatures_config_});
 
       LOG_INFO_FMT(
         "Setting service signing identity to iss: {} sub: {}",

--- a/src/node/identity.h
+++ b/src/node/identity.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ccf/crypto/curve.h"
+#include "ccf/crypto/verifier.h"
 #include "ccf/node/cose_signatures_config.h"
 #include "crypto/certs.h"
 #include "crypto/openssl/key_pair.h"
@@ -91,7 +92,8 @@ namespace ccf
     }
 
     ReplicatedNetworkIdentity(const NetworkIdentity& other) :
-      NetworkIdentity(other.subject_name, other.cose_signatures_config)
+      NetworkIdentity(
+        ccf::crypto::get_subject_name(other.cert), other.cose_signatures_config)
     {
       if (type != other.type)
       {

--- a/src/node/identity.h
+++ b/src/node/identity.h
@@ -14,17 +14,10 @@
 
 namespace ccf
 {
-  enum class IdentityType
-  {
-    REPLICATED,
-    SPLIT
-  };
-
   struct NetworkIdentity
   {
     ccf::crypto::Pem priv_key;
     ccf::crypto::Pem cert;
-    std::optional<IdentityType> type = IdentityType::REPLICATED;
     std::string subject_name = "CN=CCF Service";
     COSESignaturesConfig cose_signatures_config;
     std::shared_ptr<ccf::crypto::KeyPair_OpenSSL> kp{};
@@ -42,14 +35,13 @@ namespace ccf
     bool operator==(const NetworkIdentity& other) const
     {
       return cert == other.cert && priv_key == other.priv_key &&
-        type == other.type && subject_name == other.subject_name &&
+        subject_name == other.subject_name &&
         cose_signatures_config == other.cose_signatures_config;
     }
 
     NetworkIdentity(
       const std::string& subject_name_,
       const COSESignaturesConfig& cose_signatures_config_) :
-      type(IdentityType::REPLICATED),
       subject_name(subject_name_),
       cose_signatures_config(cose_signatures_config_)
     {}
@@ -95,10 +87,6 @@ namespace ccf
       NetworkIdentity(
         ccf::crypto::get_subject_name(other.cert), other.cose_signatures_config)
     {
-      if (type != other.type)
-      {
-        throw std::runtime_error("invalid identity type conversion");
-      }
       priv_key = other.priv_key;
       cert = other.cert;
     }

--- a/src/node/identity.h
+++ b/src/node/identity.h
@@ -19,10 +19,7 @@ namespace ccf
     ccf::crypto::Pem priv_key;
     ccf::crypto::Pem cert;
 
-    bool operator==(const NetworkIdentity& other) const
-    {
-      return cert == other.cert && priv_key == other.priv_key;
-    }
+    bool operator==(const NetworkIdentity& other) const = default;
 
     NetworkIdentity(
       const std::string& subject_name,

--- a/src/node/identity.h
+++ b/src/node/identity.h
@@ -42,7 +42,6 @@ namespace ccf
         validity_period_days);
     }
 
-    // TODO :Revisit this constructor
     NetworkIdentity(const NetworkIdentity& other) = default;
 
     NetworkIdentity() = default;

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -502,8 +502,7 @@ namespace ccf
             config.service_subject_name,
             curve_id,
             config.startup_host_time,
-            config.initial_service_certificate_validity_days,
-            config.cose_signatures);
+            config.initial_service_certificate_validity_days);
 
           network.ledger_secrets->init();
 
@@ -543,8 +542,7 @@ namespace ccf
             ccf::crypto::get_subject_name(previous_service_identity_cert),
             curve_id,
             config.startup_host_time,
-            config.initial_service_certificate_validity_days,
-            config.cose_signatures);
+            config.initial_service_certificate_validity_days);
 
           history->set_service_signing_identity(
             network.identity->get_key_pair(), config.cose_signatures);
@@ -1759,6 +1757,18 @@ namespace ccf
     {
       std::lock_guard<pal::Mutex> guard(lock);
       return self_signed_node_cert;
+    }
+
+    const ccf::COSESignaturesConfig& get_cose_signatures_config() override
+    {
+      if (history == nullptr)
+      {
+        throw std::logic_error(
+          "Attempting to access COSE signatures config before history has been "
+          "constructed");
+      }
+
+      return history->get_cose_signatures_config();
     }
 
   private:

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -498,7 +498,7 @@ namespace ccf
       {
         case StartType::Start:
         {
-          network.identity = std::make_unique<ReplicatedNetworkIdentity>(
+          network.identity = std::make_unique<ccf::NetworkIdentity>(
             config.service_subject_name,
             curve_id,
             config.startup_host_time,
@@ -539,7 +539,7 @@ namespace ccf
           ccf::crypto::Pem previous_service_identity_cert(
             config.recover.previous_service_identity.value());
 
-          network.identity = std::make_unique<ReplicatedNetworkIdentity>(
+          network.identity = std::make_unique<ccf::NetworkIdentity>(
             ccf::crypto::get_subject_name(previous_service_identity_cert),
             curve_id,
             config.startup_host_time,
@@ -664,7 +664,7 @@ namespace ccf
               throw std::logic_error("Expected network info in join response");
             }
 
-            network.identity = std::make_unique<ReplicatedNetworkIdentity>(
+            network.identity = std::make_unique<ccf::NetworkIdentity>(
               resp.network_info->identity);
             network.ledger_secrets->init_from_map(
               std::move(resp.network_info->ledger_secrets));

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -106,7 +106,7 @@ namespace ccf
         std::optional<ServiceStatus> service_status = std::nullopt;
 
         std::optional<ccf::crypto::Pem> endorsed_certificate = std::nullopt;
-        std::optional<COSESignaturesConfig> cose_signatures_config =
+        std::optional<ccf::COSESignaturesConfig> cose_signatures_config =
           std::nullopt;
 
         NetworkInfo() {}
@@ -118,7 +118,8 @@ namespace ccf
           const NetworkIdentity& identity,
           ServiceStatus service_status,
           const std::optional<ccf::crypto::Pem>& endorsed_certificate,
-          const std::optional<COSESignaturesConfig>& cose_signatures_config_) :
+          const std::optional<ccf::COSESignaturesConfig>&
+            cose_signatures_config_) :
           public_only(public_only),
           last_recovered_signed_idx(last_recovered_signed_idx),
           ledger_secrets(ledger_secrets),

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -370,7 +370,7 @@ namespace ccf
           *this->network.identity.get(),
           service_status,
           endorsed_certificate,
-          std::nullopt /* cose_signatures_config */};
+          node_operation.get_cose_signatures_config()};
       }
       return make_success(rep);
     }
@@ -485,7 +485,7 @@ namespace ccf
               *this->network.identity.get(),
               active_service->status,
               existing_node_info->endorsed_certificate,
-              std::nullopt /* cose_signatures_config */);
+              node_operation.get_cose_signatures_config());
 
             return make_success(rep);
           }
@@ -561,7 +561,7 @@ namespace ccf
               *this->network.identity.get(),
               active_service->status,
               existing_node_info->endorsed_certificate,
-              std::nullopt /* cose_signatures_config */);
+              node_operation.get_cose_signatures_config());
 
             return make_success(rep);
           }

--- a/src/node/rpc/node_interface.h
+++ b/src/node/rpc/node_interface.h
@@ -59,6 +59,7 @@ namespace ccf
     virtual SessionMetrics get_session_metrics() = 0;
     virtual size_t get_jwt_attempts() = 0;
     virtual ccf::crypto::Pem get_self_signed_certificate() = 0;
+    virtual const ccf::COSESignaturesConfig& get_cose_signatures_config() = 0;
     virtual const StartupConfig& get_node_config() const = 0;
     virtual ccf::crypto::Pem get_network_cert() = 0;
     virtual void stop_notice() = 0;

--- a/src/node/rpc/node_operation.h
+++ b/src/node/rpc/node_operation.h
@@ -104,5 +104,10 @@ namespace ccf
     {
       return impl.get_self_signed_certificate();
     }
+
+    const ccf::COSESignaturesConfig& get_cose_signatures_config() override
+    {
+      return impl.get_cose_signatures_config();
+    }
   };
 }

--- a/src/node/rpc/node_operation_interface.h
+++ b/src/node/rpc/node_operation_interface.h
@@ -4,6 +4,7 @@
 
 #include "ccf/crypto/pem.h"
 #include "ccf/ds/quote_info.h"
+#include "ccf/node/cose_signatures_config.h"
 #include "ccf/node/quote.h"
 #include "ccf/node_startup_state.h"
 #include "ccf/node_subsystem_interface.h"
@@ -57,5 +58,7 @@ namespace ccf
     virtual void initiate_private_recovery(ccf::kv::Tx& tx) = 0;
 
     virtual ccf::crypto::Pem get_self_signed_node_certificate() = 0;
+
+    virtual const ccf::COSESignaturesConfig& get_cose_signatures_config() = 0;
   };
 }

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -35,9 +35,8 @@ namespace ccf
   DECLARE_JSON_OPTIONAL_FIELDS(
     JoinNetworkNodeToNode::In, certificate_signing_request, node_data)
 
-  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(NetworkIdentity)
+  DECLARE_JSON_TYPE(NetworkIdentity)
   DECLARE_JSON_REQUIRED_FIELDS(NetworkIdentity, cert, priv_key)
-  DECLARE_JSON_OPTIONAL_FIELDS(NetworkIdentity, subject_name)
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(
     JoinNetworkNodeToNode::Out::NetworkInfo)

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -35,13 +35,9 @@ namespace ccf
   DECLARE_JSON_OPTIONAL_FIELDS(
     JoinNetworkNodeToNode::In, certificate_signing_request, node_data)
 
-  DECLARE_JSON_ENUM(
-    ccf::IdentityType,
-    {{ccf::IdentityType::REPLICATED, "Replicated"},
-     {ccf::IdentityType::SPLIT, "Split"}})
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(NetworkIdentity)
   DECLARE_JSON_REQUIRED_FIELDS(NetworkIdentity, cert, priv_key)
-  DECLARE_JSON_OPTIONAL_FIELDS(NetworkIdentity, type, subject_name)
+  DECLARE_JSON_OPTIONAL_FIELDS(NetworkIdentity, subject_name)
   DECLARE_JSON_TYPE_WITH_BASE(ReplicatedNetworkIdentity, NetworkIdentity)
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -38,7 +38,6 @@ namespace ccf
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(NetworkIdentity)
   DECLARE_JSON_REQUIRED_FIELDS(NetworkIdentity, cert, priv_key)
   DECLARE_JSON_OPTIONAL_FIELDS(NetworkIdentity, subject_name)
-  DECLARE_JSON_TYPE_WITH_BASE(ReplicatedNetworkIdentity, NetworkIdentity)
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(
     JoinNetworkNodeToNode::Out::NetworkInfo)

--- a/src/node/rpc/test/frontend_test_infra.h
+++ b/src/node/rpc/test/frontend_test_infra.h
@@ -119,7 +119,7 @@ std::unique_ptr<ccf::NetworkIdentity> make_test_network_ident()
   using namespace std::literals;
   const auto valid_from =
     ::ds::to_x509_time_string(std::chrono::system_clock::now() - 24h);
-  return std::make_unique<ReplicatedNetworkIdentity>(
+  return std::make_unique<ccf::NetworkIdentity>(
     "CN=CCF test network",
     ccf::crypto::service_identity_curve_choice,
     valid_from,

--- a/src/node/rpc/test/frontend_test_infra.h
+++ b/src/node/rpc/test/frontend_test_infra.h
@@ -123,8 +123,7 @@ std::unique_ptr<ccf::NetworkIdentity> make_test_network_ident()
     "CN=CCF test network",
     ccf::crypto::service_identity_curve_choice,
     valid_from,
-    2,
-    COSESignaturesConfig{});
+    2);
 }
 
 void init_network(NetworkState& network)

--- a/src/node/rpc/test/node_stub.h
+++ b/src/node/rpc/test/node_stub.h
@@ -15,6 +15,7 @@ namespace ccf
   {
   public:
     bool is_public = false;
+    ccf::COSESignaturesConfig cose_signatures_config = {};
 
     ExtendedState state() override
     {
@@ -107,7 +108,7 @@ namespace ccf
 
     const ccf::COSESignaturesConfig& get_cose_signatures_config() override
     {
-      throw std::logic_error("Unimplemented");
+      return cose_signatures_config;
     }
   };
 

--- a/src/node/rpc/test/node_stub.h
+++ b/src/node/rpc/test/node_stub.h
@@ -104,6 +104,11 @@ namespace ccf
     {
       return {};
     }
+
+    const ccf::COSESignaturesConfig& get_cose_signatures_config() override
+    {
+      throw std::logic_error("Unimplemented");
+    }
   };
 
   class StubGovernanceEffects : public ccf::AbstractGovernanceEffects

--- a/src/node/test/historical_queries.cpp
+++ b/src/node/test/historical_queries.cpp
@@ -62,7 +62,7 @@ TestState create_and_init_state(bool initialise_ledger_rekey = true)
   auto h =
     std::make_shared<ccf::MerkleTxHistory>(*ts.kv_store, node_id, *ts.node_kp);
   h->set_endorsed_certificate({});
-  h->set_service_signing_identity(ts.service_kp, COSESignaturesConfig{});
+  h->set_service_signing_identity(ts.service_kp, ccf::COSESignaturesConfig{});
   ts.kv_store->set_history(h);
   ts.kv_store->initialise_term(2);
 

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -88,7 +88,7 @@ TEST_CASE("Check signature verification")
       primary_store, ccf::kv::test::PrimaryNodeId, *node_kp);
   primary_history->set_endorsed_certificate(self_signed);
   primary_history->set_service_signing_identity(
-    service_kp, COSESignaturesConfig{});
+    service_kp, ccf::COSESignaturesConfig{});
   primary_store.set_history(primary_history);
   primary_store.initialise_term(store_term);
 
@@ -99,7 +99,7 @@ TEST_CASE("Check signature verification")
       backup_store, ccf::kv::test::FirstBackupNodeId, *node_kp);
   backup_history->set_endorsed_certificate(self_signed);
   backup_history->set_service_signing_identity(
-    service_kp, COSESignaturesConfig{});
+    service_kp, ccf::COSESignaturesConfig{});
   backup_store.set_history(backup_history);
   backup_store.initialise_term(store_term);
 
@@ -166,7 +166,7 @@ TEST_CASE("Check signing works across rollback")
       primary_store, ccf::kv::test::PrimaryNodeId, *node_kp);
   primary_history->set_endorsed_certificate(self_signed);
   primary_history->set_service_signing_identity(
-    service_kp, COSESignaturesConfig{});
+    service_kp, ccf::COSESignaturesConfig{});
   primary_store.set_history(primary_history);
   primary_store.initialise_term(store_term);
 
@@ -176,7 +176,7 @@ TEST_CASE("Check signing works across rollback")
       backup_store, ccf::kv::test::FirstBackupNodeId, *node_kp);
   backup_history->set_endorsed_certificate(self_signed);
   backup_history->set_service_signing_identity(
-    service_kp, COSESignaturesConfig{});
+    service_kp, ccf::COSESignaturesConfig{});
   backup_store.set_history(backup_history);
   backup_store.set_encryptor(encryptor);
   backup_store.initialise_term(store_term);

--- a/src/node/test/snapshot.cpp
+++ b/src/node/test/snapshot.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Snapshot with merkle tree" * doctest::test_suite("snapshot"))
     source_store, source_node_id, *source_node_kp);
   source_history->set_endorsed_certificate({});
   source_history->set_service_signing_identity(
-    service_kp, COSESignaturesConfig{});
+    service_kp, ccf::COSESignaturesConfig{});
   source_store.set_history(source_history);
   source_store.initialise_term(2);
 
@@ -104,7 +104,7 @@ TEST_CASE("Snapshot with merkle tree" * doctest::test_suite("snapshot"))
         target_store, ccf::kv::test::PrimaryNodeId, *target_node_kp);
       target_history->set_endorsed_certificate({});
       target_history->set_service_signing_identity(
-        service_kp, COSESignaturesConfig{});
+        service_kp, ccf::COSESignaturesConfig{});
       target_store.set_history(target_history);
     }
 

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -717,14 +717,14 @@ if __name__ == "__main__":
             {"with previous LTS": latest_lts_version}
         )
 
-        # # Compatibility with latest LTS on the same release branch
-        # # (e.g. when releasing 2.0.1, check compatibility with existing 2.0.0)
-        # latest_lts_version = run_live_compatibility_with_latest(
-        #     args, repo, local_branch, this_release_branch_only=True
-        # )
-        # compatibility_report["live compatibility"].update(
-        #     {"with same LTS": latest_lts_version}
-        # )
+        # Compatibility with latest LTS on the same release branch
+        # (e.g. when releasing 2.0.1, check compatibility with existing 2.0.0)
+        latest_lts_version = run_live_compatibility_with_latest(
+            args, repo, local_branch, this_release_branch_only=True
+        )
+        compatibility_report["live compatibility"].update(
+            {"with same LTS": latest_lts_version}
+        )
 
         if args.check_ledger_compatibility:
             compatibility_report["data compatibility"] = {}


### PR DESCRIPTION
Following #6660, this PR simplifies the `NetworkIdentity` type by flattening it to a single type. The core of the changes are those in `identity.h`, which removes `ReplicatedNetworkIdentity` and several fields from `NetworkIdentity`. This touches a bunch of other files for 2 reasons:

- Moved `COSESignaturesConfig` under the `ccf::` namespace, since it is in a public header.
- Rather than accessing `cose_signatures_config` from `NetworkIdentity`, the `/join` endpoint in `node_frontend.h` now accesses the single instance stored in/owned by `history.h`, which takes a few hops to reach. I think some of these hops are helpful, some may be unnecessary, but regardless this fits the existing style.

While we're doing this, be slightly stricter about the order of calls to history, and ensure we throw errors if `set_service_signing_identity` is called multiple times, or if `set_service_signing_identity` was not called before either `get_cose_signatures_config` or `emit_signature`.