### PR TITLE
[release/5.x] Cherry pick: Extend pathlen for CAs (#6662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added OpenAPI support for `std::unordered_set`.
 
+### Changed
+
+- Service certificates and endorsements used for historical receipts now have a pathlen constraint of 1 instead of 0, reflecting the fact that there can be a single intermediate in endorsement chains. Historically the value had been 0, which happened to work because of a quirk in OpenSSL when Issuer and Subject match on an element in the chain.
+
 ### Fixed
 
 - Services upgrading from 4.x to 5.x may accidentally change their service's subject name, resulting in cryptographic errors when verifying anything endorsed by the old subject name. The subject name field is now correctly populated and retained across joins, renewals, and disaster recoveries.

--- a/src/crypto/openssl/key_pair.cpp
+++ b/src/crypto/openssl/key_pair.cpp
@@ -382,7 +382,9 @@ namespace ccf::crypto
     std::string constraints = "critical,CA:FALSE";
     if (ca)
     {
-      constraints = "critical,CA:TRUE,pathlen:0";
+      // 1 to allow for intermediate CAs with a different subject name,
+      // which can occur in service endorsements of some services.
+      constraints = "critical,CA:TRUE,pathlen:1";
     }
 
     // Add basic constraints

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1797,7 +1797,7 @@ def test_basic_constraints(network, args):
     )
     assert basic_constraints.critical is True
     assert basic_constraints.value.ca is True
-    assert basic_constraints.value.path_length == 0
+    assert basic_constraints.value.path_length == 1
 
     node_pem = primary.get_tls_certificate_pem()
     node_cert = load_pem_x509_certificate(node_pem.encode(), default_backend())


### PR DESCRIPTION
Backports the following commits to `release/5.x`:
 - [Extend pathlen for CAs (#6662)](https://github.com/microsoft/CCF/pull/6662)