### PR TITLE
Log progress of deserialising ledger during recovery

### DIFF
--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -914,7 +914,10 @@ namespace ccf
       {
         auto entry = ::consensus::LedgerEnclave::get_entry(data, size);
 
-        LOG_INFO_FMT("Deserialising public ledger entry [{}]", entry.size());
+        LOG_INFO_FMT(
+          "Deserialising public ledger entry #{} [{} bytes]",
+          last_recovered_idx,
+          entry.size());
 
         // When reading the private ledger, deserialise in the recovery store
 


### PR DESCRIPTION
We've printed this pretty unhelpful line for a long time:

```
Deserialising public ledger entry [42]
```

42 is the number of bytes in this entry, we print no sign of how many entries we've actually processed, even though we know this. I think we should actually print summaries, but since we're already printing once-per-entry I've at least made it explicit which entry we think we're looking at.