### PR TITLE
Raw public keys support for JWT authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,15 @@ and this project adheres Fto [Semantic Versioning](http://semver.org/spec/v2.0.0
 - All definitions in CCF's public headers are now under the `ccf::` namespace. Any application code which references any of these types directly (notably `StartupConfig`, `http_status`, `LoggerLevel`), they will now need to be prefixed with the `ccf::` namespace.
 - `cchost` now requires `--config`.
 
+### Changed
+
+- JWT authentication now supports raw public keys along with certificates (#6601).
+  - Public key information ('n' and 'e', or 'x', 'y' and 'crv' fields) now have a priority if defined in JWK set, 'x5c' remains as a backup option.
+  - Has same side-effects as #5809 does please see the changelog entry for that change for more details. In short:
+    - stale JWKs may be used for JWT validation on older nodes during the upgrade.
+    - old tables are not cleaned up, #6222 is tracking those.
+- A deprecated `GET /gov/jwt_keys/all` has been altered because of #6601, as soon as JWT certificates are no longer stored in CCF. A new "public_key" field has been added, "cert" is now left empty.
+
 ## [6.0.0-dev7]
 
 [6.0.0-dev7]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev7

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -800,6 +800,24 @@
       },
       "OpenIDJWKMetadata": {
         "properties": {
+          "constraint": {
+            "$ref": "#/components/schemas/string"
+          },
+          "issuer": {
+            "$ref": "#/components/schemas/string"
+          },
+          "public_key": {
+            "$ref": "#/components/schemas/base64string"
+          }
+        },
+        "required": [
+          "issuer",
+          "public_key"
+        ],
+        "type": "object"
+      },
+      "OpenIDJWKMetadataLegacy": {
+        "properties": {
           "cert": {
             "$ref": "#/components/schemas/base64string"
           },
@@ -811,10 +829,16 @@
           }
         },
         "required": [
-          "cert",
-          "issuer"
+          "issuer",
+          "cert"
         ],
         "type": "object"
+      },
+      "OpenIDJWKMetadataLegacy_array": {
+        "items": {
+          "$ref": "#/components/schemas/OpenIDJWKMetadataLegacy"
+        },
+        "type": "array"
       },
       "OpenIDJWKMetadata_array": {
         "items": {
@@ -1225,6 +1249,12 @@
       "string_to_KeyIdInfo_array": {
         "additionalProperties": {
           "$ref": "#/components/schemas/KeyIdInfo_array"
+        },
+        "type": "object"
+      },
+      "string_to_OpenIDJWKMetadataLegacy_array": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/OpenIDJWKMetadataLegacy_array"
         },
         "type": "object"
       },
@@ -1752,6 +1782,31 @@
       "get": {
         "deprecated": true,
         "operationId": "GetGovKvJwtPublicSigningKeysMetadata",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/string_to_OpenIDJWKMetadataLegacy_array"
+                }
+              }
+            },
+            "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "summary": "This route is auto-generated from the KV schema.",
+        "x-ccf-forwarding": {
+          "$ref": "#/components/x-ccf-forwarding/sometimes"
+        }
+      }
+    },
+    "/gov/kv/jwt/public_signing_keys_metadata_v2": {
+      "get": {
+        "deprecated": true,
+        "operationId": "GetGovKvJwtPublicSigningKeysMetadataV2",
         "responses": {
           "200": {
             "content": {

--- a/include/ccf/crypto/ecdsa.h
+++ b/include/ccf/crypto/ecdsa.h
@@ -4,6 +4,7 @@
 
 #include "ccf/crypto/curve.h"
 
+#include <span>
 #include <vector>
 
 namespace ccf::crypto
@@ -28,7 +29,7 @@ namespace ccf::crypto
    * @param signature The signature in IEEE P1363 encoding
    */
   std::vector<uint8_t> ecdsa_sig_p1363_to_der(
-    const std::vector<uint8_t>& signature);
+    std::span<const uint8_t> signature);
 
   std::vector<uint8_t> ecdsa_sig_der_to_p1363(
     const std::vector<uint8_t>& signature, CurveID curveId);

--- a/include/ccf/crypto/jwk.h
+++ b/include/ccf/crypto/jwk.h
@@ -27,13 +27,12 @@ namespace ccf::crypto
     JsonWebKeyType kty;
     std::optional<std::string> kid = std::nullopt;
     std::optional<std::vector<std::string>> x5c = std::nullopt;
-    std::optional<std::string> issuer = std::nullopt;
 
     bool operator==(const JsonWebKey&) const = default;
   };
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(JsonWebKey);
   DECLARE_JSON_REQUIRED_FIELDS(JsonWebKey, kty);
-  DECLARE_JSON_OPTIONAL_FIELDS(JsonWebKey, kid, x5c, issuer);
+  DECLARE_JSON_OPTIONAL_FIELDS(JsonWebKey, kid, x5c);
 
   enum class JsonWebKeyECCurve
   {
@@ -46,6 +45,25 @@ namespace ccf::crypto
     {{JsonWebKeyECCurve::P256, "P-256"},
      {JsonWebKeyECCurve::P384, "P-384"},
      {JsonWebKeyECCurve::P521, "P-521"}});
+
+  struct JsonWebKeyData
+  {
+    JsonWebKeyType kty;
+    std::optional<std::string> kid = std::nullopt;
+    std::optional<std::vector<std::string>> x5c = std::nullopt;
+    std::optional<std::string> n = std::nullopt;
+    std::optional<std::string> e = std::nullopt;
+    std::optional<std::string> x = std::nullopt;
+    std::optional<std::string> y = std::nullopt;
+    std::optional<JsonWebKeyECCurve> crv = std::nullopt;
+    std::optional<std::string> issuer = std::nullopt;
+
+    bool operator==(const JsonWebKeyData&) const = default;
+  };
+  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(JsonWebKeyData);
+  DECLARE_JSON_REQUIRED_FIELDS(JsonWebKeyData, kty);
+  DECLARE_JSON_OPTIONAL_FIELDS(
+    JsonWebKeyData, kid, x5c, n, e, x, y, crv, issuer);
 
   static JsonWebKeyECCurve curve_id_to_jwk_curve(CurveID curve_id)
   {

--- a/include/ccf/crypto/rsa_public_key.h
+++ b/include/ccf/crypto/rsa_public_key.h
@@ -84,6 +84,13 @@ namespace ccf::crypto
       MDType md_type = MDType::NONE,
       size_t salt_legth = 0) = 0;
 
+    virtual bool verify_pkcs1(
+      const uint8_t* contents,
+      size_t contents_size,
+      const uint8_t* signature,
+      size_t signature_size,
+      MDType md_type = MDType::NONE) = 0;
+
     struct Components
     {
       std::vector<uint8_t> n;

--- a/include/ccf/endpoints/authentication/jwt_auth.h
+++ b/include/ccf/endpoints/authentication/jwt_auth.h
@@ -17,7 +17,7 @@ namespace ccf
     nlohmann::json payload;
   };
 
-  struct VerifiersCache;
+  struct PublicKeysCache;
 
   bool validate_issuer(
     const std::string& iss,
@@ -28,7 +28,7 @@ namespace ccf
   {
   protected:
     static const OpenAPISecuritySchema security_schema;
-    std::unique_ptr<VerifiersCache> verifiers;
+    std::unique_ptr<PublicKeysCache> keys_cache;
 
   public:
     static constexpr auto SECURITY_SCHEME_NAME = "jwt";

--- a/include/ccf/service/tables/jwt.h
+++ b/include/ccf/service/tables/jwt.h
@@ -37,27 +37,42 @@ namespace ccf
   using JwtIssuer = std::string;
   using JwtKeyId = std::string;
   using Cert = std::vector<uint8_t>;
+  using PublicKey = std::vector<uint8_t>;
 
   struct OpenIDJWKMetadata
+  {
+    PublicKey public_key;
+    JwtIssuer issuer;
+    std::optional<JwtIssuer> constraint;
+  };
+  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(OpenIDJWKMetadata);
+  DECLARE_JSON_REQUIRED_FIELDS(OpenIDJWKMetadata, issuer, public_key);
+  DECLARE_JSON_OPTIONAL_FIELDS(OpenIDJWKMetadata, constraint);
+
+  using JwtPublicSigningKeysMetadata =
+    ServiceMap<JwtKeyId, std::vector<OpenIDJWKMetadata>>;
+
+  struct OpenIDJWKMetadataLegacy
   {
     Cert cert;
     JwtIssuer issuer;
     std::optional<JwtIssuer> constraint;
   };
-  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(OpenIDJWKMetadata);
-  DECLARE_JSON_REQUIRED_FIELDS(OpenIDJWKMetadata, cert, issuer);
-  DECLARE_JSON_OPTIONAL_FIELDS(OpenIDJWKMetadata, constraint);
+  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(OpenIDJWKMetadataLegacy);
+  DECLARE_JSON_REQUIRED_FIELDS(OpenIDJWKMetadataLegacy, issuer, cert);
+  DECLARE_JSON_OPTIONAL_FIELDS(OpenIDJWKMetadataLegacy, constraint);
+
+  using JwtPublicSigningKeysMetadataLegacy =
+    ServiceMap<JwtKeyId, std::vector<OpenIDJWKMetadataLegacy>>;
 
   using JwtIssuers = ServiceMap<JwtIssuer, JwtIssuerMetadata>;
-  using JwtPublicSigningKeys =
-    ServiceMap<JwtKeyId, std::vector<OpenIDJWKMetadata>>;
 
   namespace Tables
   {
     static constexpr auto JWT_ISSUERS = "public:ccf.gov.jwt.issuers";
 
     static constexpr auto JWT_PUBLIC_SIGNING_KEYS_METADATA =
-      "public:ccf.gov.jwt.public_signing_keys_metadata";
+      "public:ccf.gov.jwt.public_signing_keys_metadata_v2";
 
     namespace Legacy
     {
@@ -65,6 +80,8 @@ namespace ccf
         "public:ccf.gov.jwt.public_signing_key";
       static constexpr auto JWT_PUBLIC_SIGNING_KEY_ISSUER =
         "public:ccf.gov.jwt.public_signing_key_issuer";
+      static constexpr auto JWT_PUBLIC_SIGNING_KEYS_METADATA =
+        "public:ccf.gov.jwt.public_signing_keys_metadata";
 
       using JwtPublicSigningKeys =
         ccf::kv::RawCopySerialisedMap<JwtKeyId, Cert>;
@@ -75,7 +92,7 @@ namespace ccf
 
   struct JsonWebKeySet
   {
-    std::vector<ccf::crypto::JsonWebKey> keys;
+    std::vector<ccf::crypto::JsonWebKeyData> keys;
 
     bool operator!=(const JsonWebKeySet& rhs) const
     {

--- a/samples/constitutions/default/actions.js
+++ b/samples/constitutions/default/actions.js
@@ -130,15 +130,28 @@ function checkJwks(value, field) {
   for (const [i, jwk] of value.keys.entries()) {
     checkType(jwk.kid, "string", `${field}.keys[${i}].kid`);
     checkType(jwk.kty, "string", `${field}.keys[${i}].kty`);
-    checkType(jwk.x5c, "array", `${field}.keys[${i}].x5c`);
-    checkLength(jwk.x5c, 1, null, `${field}.keys[${i}].x5c`);
-    for (const [j, b64der] of jwk.x5c.entries()) {
-      checkType(b64der, "string", `${field}.keys[${i}].x5c[${j}]`);
-      const pem =
-        "-----BEGIN CERTIFICATE-----\n" +
-        b64der +
-        "\n-----END CERTIFICATE-----";
-      checkX509CertBundle(pem, `${field}.keys[${i}].x5c[${j}]`);
+    if (jwk.x5c) {
+      checkType(jwk.x5c, "array", `${field}.keys[${i}].x5c`);
+      checkLength(jwk.x5c, 1, null, `${field}.keys[${i}].x5c`);
+      for (const [j, b64der] of jwk.x5c.entries()) {
+        checkType(b64der, "string", `${field}.keys[${i}].x5c[${j}]`);
+        const pem =
+          "-----BEGIN CERTIFICATE-----\n" +
+          b64der +
+          "\n-----END CERTIFICATE-----";
+        checkX509CertBundle(pem, `${field}.keys[${i}].x5c[${j}]`);
+      }
+    } else if (jwk.n && jwk.e) {
+      checkType(jwk.n, "string", `${field}.keys[${i}].n`);
+      checkType(jwk.e, "string", `${field}.keys[${i}].e`);
+    } else if (jwk.x && jwk.y) {
+      checkType(jwk.x, "string", `${field}.keys[${i}].x`);
+      checkType(jwk.y, "string", `${field}.keys[${i}].y`);
+      checkType(jwk.crv, "string", `${field}.keys[${i}].crv`);
+    } else {
+      throw new Error(
+        "JWK must contain either x5c, or n/e for RSA key type, or x/y/crv for EC key type",
+      );
     }
   }
 }

--- a/src/crypto/ecdsa.cpp
+++ b/src/crypto/ecdsa.cpp
@@ -45,7 +45,7 @@ namespace ccf::crypto
   }
 
   std::vector<uint8_t> ecdsa_sig_p1363_to_der(
-    const std::vector<uint8_t>& signature)
+    std::span<const uint8_t> signature)
   {
     auto half_size = signature.size() / 2;
     return ecdsa_sig_from_r_s(

--- a/src/crypto/openssl/rsa_public_key.h
+++ b/src/crypto/openssl/rsa_public_key.h
@@ -55,6 +55,13 @@ namespace ccf::crypto
       MDType md_type = MDType::NONE,
       size_t salt_length = 0) override;
 
+    virtual bool verify_pkcs1(
+      const uint8_t* contents,
+      size_t contents_size,
+      const uint8_t* signature,
+      size_t signature_size,
+      MDType md_type = MDType::NONE) override;
+
     virtual Components components() const override;
 
     static std::vector<uint8_t> bn_bytes(const BIGNUM* bn);

--- a/src/endpoints/authentication/jwt_auth.cpp
+++ b/src/endpoints/authentication/jwt_auth.cpp
@@ -137,8 +137,8 @@ namespace ccf
       {
         LOG_DEBUG_FMT("Verify der: {} as EC key", der);
 
-        const auto sig_der = ccf::crypto::ecdsa_sig_p1363_to_der(
-          std::vector<uint8_t>(signature, signature + signature_size));
+        const auto sig_der =
+          ccf::crypto::ecdsa_sig_p1363_to_der({signature, signature_size});
         return std::get<ccf::crypto::PublicKeyPtr>(key)->verify(
           contents,
           contents_size,

--- a/src/endpoints/authentication/jwt_auth.cpp
+++ b/src/endpoints/authentication/jwt_auth.cpp
@@ -3,6 +3,9 @@
 
 #include "ccf/endpoints/authentication/jwt_auth.h"
 
+#include "ccf/crypto/ecdsa.h"
+#include "ccf/crypto/public_key.h"
+#include "ccf/crypto/rsa_key_pair.h"
 #include "ccf/ds/nonstd.h"
 #include "ccf/pal/locking.h"
 #include "ccf/rpc_context.h"
@@ -82,34 +85,77 @@ namespace ccf
     return tenant_id && tid && *tid == *tenant_id;
   }
 
-  struct VerifiersCache
+  struct PublicKeysCache
   {
-    static constexpr size_t DEFAULT_MAX_VERIFIERS = 10;
+    static constexpr size_t DEFAULT_MAX_KEYS = 10;
 
     using DER = std::vector<uint8_t>;
-    ccf::pal::Mutex verifiers_lock;
-    LRU<DER, ccf::crypto::VerifierPtr> verifiers;
+    using KeyVariant =
+      std::variant<ccf::crypto::RSAPublicKeyPtr, ccf::crypto::PublicKeyPtr>;
+    ccf::pal::Mutex keys_lock;
+    LRU<DER, KeyVariant> keys;
 
-    VerifiersCache(size_t max_verifiers = DEFAULT_MAX_VERIFIERS) :
-      verifiers(max_verifiers)
-    {}
+    PublicKeysCache(size_t max_keys = DEFAULT_MAX_KEYS) : keys(max_keys) {}
 
-    ccf::crypto::VerifierPtr get_verifier(const DER& der)
+    bool verify(
+      const uint8_t* contents,
+      size_t contents_size,
+      const uint8_t* signature,
+      size_t signature_size,
+      const DER& der)
     {
-      std::lock_guard<ccf::pal::Mutex> guard(verifiers_lock);
+      std::lock_guard<ccf::pal::Mutex> guard(keys_lock);
 
-      auto it = verifiers.find(der);
-      if (it == verifiers.end())
+      auto it = keys.find(der);
+      if (it == keys.end())
       {
-        it = verifiers.insert(der, ccf::crypto::make_unique_verifier(der));
+        try
+        {
+          it = keys.insert(der, ccf::crypto::make_rsa_public_key(der));
+        }
+        catch (const std::exception&)
+        {
+          it = keys.insert(der, ccf::crypto::make_public_key(der));
+        }
       }
 
-      return it->second;
+      const auto& key = it->second;
+      if (std::holds_alternative<ccf::crypto::RSAPublicKeyPtr>(key))
+      {
+        LOG_DEBUG_FMT("Verify der: {} as RSA key", der);
+
+        // Obsolete PKCS1 padding is chosen for JWT, as explained in details in
+        // https://github.com/microsoft/CCF/issues/6601#issuecomment-2512059875.
+        return std::get<ccf::crypto::RSAPublicKeyPtr>(key)->verify_pkcs1(
+          contents,
+          contents_size,
+          signature,
+          signature_size,
+          ccf::crypto::MDType::SHA256);
+      }
+      else if (std::holds_alternative<ccf::crypto::PublicKeyPtr>(key))
+      {
+        LOG_DEBUG_FMT("Verify der: {} as EC key", der);
+
+        const auto sig_der = ccf::crypto::ecdsa_sig_p1363_to_der(
+          std::vector<uint8_t>(signature, signature + signature_size));
+        return std::get<ccf::crypto::PublicKeyPtr>(key)->verify(
+          contents,
+          contents_size,
+          sig_der.data(),
+          sig_der.size(),
+          ccf::crypto::MDType::SHA256);
+      }
+      else
+      {
+        LOG_DEBUG_FMT("Key not found for der: {}", der);
+        return false;
+      }
     }
   };
 
   JwtAuthnPolicy::JwtAuthnPolicy() :
-    verifiers(std::make_unique<VerifiersCache>())
+    keys_cache(std::make_unique<PublicKeysCache>())
   {}
 
   JwtAuthnPolicy::~JwtAuthnPolicy() = default;
@@ -129,11 +175,42 @@ namespace ccf
     }
 
     auto& token = token_opt.value();
-    auto keys = tx.ro<JwtPublicSigningKeys>(
+    auto keys = tx.ro<JwtPublicSigningKeysMetadata>(
       ccf::Tables::JWT_PUBLIC_SIGNING_KEYS_METADATA);
     const auto key_id = token.header_typed.kid;
     auto token_keys = keys->get(key_id);
 
+    // For metadata KID->(cert,issuer,constraint).
+    //
+    // Note, that Legacy keys are stored as certs, new approach is raw keys, so
+    // conversion from cert to raw key is needed.
+    if (!token_keys)
+    {
+      auto fallback_certs = tx.ro<JwtPublicSigningKeysMetadataLegacy>(
+        ccf::Tables::Legacy::JWT_PUBLIC_SIGNING_KEYS_METADATA);
+      auto fallback_data = fallback_certs->get(key_id);
+      if (fallback_data)
+      {
+        auto new_keys = std::vector<OpenIDJWKMetadata>();
+        for (const auto& metadata : *fallback_data)
+        {
+          auto verifier = ccf::crypto::make_unique_verifier(metadata.cert);
+          new_keys.push_back(OpenIDJWKMetadata{
+            .public_key = verifier->public_key_der(),
+            .issuer = metadata.issuer,
+            .constraint = metadata.constraint});
+        }
+        if (!new_keys.empty())
+        {
+          token_keys = new_keys;
+        }
+      }
+    }
+
+    // For metadata as two separate tables, KID->JwtIssuer and KID->Cert.
+    //
+    // Note, that Legacy keys are stored as certs, new approach is raw keys, so
+    // conversion from certs to keys is needed.
     if (!token_keys)
     {
       auto fallback_keys = tx.ro<Tables::Legacy::JwtPublicSigningKeys>(
@@ -141,11 +218,12 @@ namespace ccf
       auto fallback_issuers = tx.ro<Tables::Legacy::JwtPublicSigningKeyIssuer>(
         ccf::Tables::Legacy::JWT_PUBLIC_SIGNING_KEY_ISSUER);
 
-      auto fallback_key = fallback_keys->get(key_id);
-      if (fallback_key)
+      auto fallback_cert = fallback_keys->get(key_id);
+      if (fallback_cert)
       {
+        auto verifier = ccf::crypto::make_unique_verifier(*fallback_cert);
         token_keys = std::vector<OpenIDJWKMetadata>{OpenIDJWKMetadata{
-          .cert = *fallback_key,
+          .public_key = verifier->public_key_der(),
           .issuer = *fallback_issuers->get(key_id),
           .constraint = std::nullopt}};
       }
@@ -160,8 +238,12 @@ namespace ccf
 
     for (const auto& metadata : *token_keys)
     {
-      auto verifier = verifiers->get_verifier(metadata.cert);
-      if (!::http::JwtVerifier::validate_token_signature(token, verifier))
+      if (!keys_cache->verify(
+            (uint8_t*)token.signed_content.data(),
+            token.signed_content.size(),
+            token.signature.data(),
+            token.signature.size(),
+            metadata.public_key))
       {
         error_reason = "Signature verification failed";
         continue;
@@ -171,7 +253,7 @@ namespace ccf
       const size_t time_now = std::chrono::duration_cast<std::chrono::seconds>(
                                 ccf::get_enclave_time())
                                 .count();
-      if (time_now < token.payload_typed.nbf)
+      if (token.payload_typed.nbf && time_now < *token.payload_typed.nbf)
       {
         error_reason = fmt::format(
           "Current time {} is before token's Not Before (nbf) claim {}",

--- a/src/http/http_jwt.h
+++ b/src/http/http_jwt.h
@@ -16,9 +16,13 @@ namespace http
 {
   enum class JwtCryptoAlgorithm
   {
-    RS256
+    RS256,
+    ES256,
   };
-  DECLARE_JSON_ENUM(JwtCryptoAlgorithm, {{JwtCryptoAlgorithm::RS256, "RS256"}});
+  DECLARE_JSON_ENUM(
+    JwtCryptoAlgorithm,
+    {{JwtCryptoAlgorithm::RS256, "RS256"},
+     {JwtCryptoAlgorithm::ES256, "ES256"}});
 
   struct JwtHeader
   {
@@ -30,14 +34,14 @@ namespace http
 
   struct JwtPayload
   {
-    size_t nbf;
     size_t exp;
     std::string iss;
+    std::optional<size_t> nbf;
     std::optional<std::string> tid;
   };
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(JwtPayload)
-  DECLARE_JSON_REQUIRED_FIELDS(JwtPayload, nbf, exp, iss);
-  DECLARE_JSON_OPTIONAL_FIELDS(JwtPayload, tid)
+  DECLARE_JSON_REQUIRED_FIELDS(JwtPayload, exp, iss);
+  DECLARE_JSON_OPTIONAL_FIELDS(JwtPayload, nbf, tid);
 
   class JwtVerifier
   {

--- a/src/js/extensions/ccf/crypto.cpp
+++ b/src/js/extensions/ccf/crypto.cpp
@@ -1023,10 +1023,10 @@ namespace ccf::js::extensions
         }
 
         std::vector<uint8_t> sig(signature, signature + signature_size);
-
         if (algo_name == "ECDSA")
         {
-          sig = ccf::crypto::ecdsa_sig_p1363_to_der(sig);
+          sig =
+            ccf::crypto::ecdsa_sig_p1363_to_der({signature, signature_size});
         }
 
         auto is_cert = key.starts_with("-----BEGIN CERTIFICATE");

--- a/src/node/gov/handlers/service_state.h
+++ b/src/node/gov/handlers/service_state.h
@@ -600,7 +600,7 @@ namespace ccf::gov::endpoints
             auto keys = nlohmann::json::object();
 
             auto jwt_keys_handle =
-              ctx.tx.template ro<ccf::JwtPublicSigningKeys>(
+              ctx.tx.template ro<ccf::JwtPublicSigningKeysMetadata>(
                 ccf::Tables::JWT_PUBLIC_SIGNING_KEYS_METADATA);
 
             jwt_keys_handle->foreach(
@@ -612,11 +612,10 @@ namespace ccf::gov::endpoints
                 {
                   auto info = nlohmann::json::object();
 
-                  // cert is stored as DER - convert to PEM for API
-                  const auto cert_pem =
-                    ccf::crypto::cert_der_to_pem(metadata.cert);
-                  info["certificate"] = cert_pem.str();
-
+                  info["publicKey"] =
+                    ccf::crypto::make_rsa_public_key(metadata.public_key)
+                      ->public_key_pem()
+                      .str();
                   info["issuer"] = metadata.issuer;
                   info["constraint"] = metadata.constraint;
 

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -71,6 +71,7 @@ namespace ccf
   {
     JwtIssuer issuer;
     ccf::crypto::Pem cert;
+    std::string public_key;
   };
   DECLARE_JSON_TYPE(KeyIdInfo)
   DECLARE_JSON_REQUIRED_FIELDS(KeyIdInfo, issuer, cert)
@@ -1108,7 +1109,9 @@ namespace ccf
           for (const auto& metadata : v)
           {
             info.push_back(KeyIdInfo{
-              metadata.issuer, ccf::crypto::cert_der_to_pem(metadata.cert)});
+              .issuer = metadata.issuer,
+              .cert = ccf::crypto::Pem(),
+              .public_key = ccf::crypto::b64_from_raw(metadata.public_key)});
           }
           kmap.emplace(k, std::move(info));
           return true;

--- a/src/service/network_tables.h
+++ b/src/service/network_tables.h
@@ -154,8 +154,11 @@ namespace ccf
     //
     const CACertBundlePEMs ca_cert_bundles = {Tables::CA_CERT_BUNDLE_PEMS};
     const JwtIssuers jwt_issuers = {Tables::JWT_ISSUERS};
-    const JwtPublicSigningKeys jwt_public_signing_keys_metadata = {
+    const JwtPublicSigningKeysMetadata jwt_public_signing_keys_metadata = {
       Tables::JWT_PUBLIC_SIGNING_KEYS_METADATA};
+    const JwtPublicSigningKeysMetadataLegacy
+      legacy_jwt_public_signing_keys_metadata = {
+        Tables::Legacy::JWT_PUBLIC_SIGNING_KEYS_METADATA};
     const Tables::Legacy::JwtPublicSigningKeys legacy_jwt_public_signing_keys =
       {Tables::Legacy::JWT_PUBLIC_SIGNING_KEYS};
     const Tables::Legacy::JwtPublicSigningKeyIssuer
@@ -168,6 +171,7 @@ namespace ccf
         ca_cert_bundles,
         jwt_issuers,
         jwt_public_signing_keys_metadata,
+        legacy_jwt_public_signing_keys_metadata,
         legacy_jwt_public_signing_keys,
         legacy_jwt_public_signing_key_issuer);
     }

--- a/tests/infra/crypto.py
+++ b/tests/infra/crypto.py
@@ -307,10 +307,8 @@ def pub_key_pem_to_der(pem: str) -> bytes:
     return cert.public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo)
 
 
-def create_jwt(body_claims: dict, key_priv_pem: str, key_id: str) -> str:
-    return jwt.encode(
-        body_claims, key_priv_pem, algorithm="RS256", headers={"kid": key_id}
-    )
+def create_jwt(body_claims: dict, key_priv_pem: str, key_id: str, alg="RS256") -> str:
+    return jwt.encode(body_claims, key_priv_pem, algorithm=alg, headers={"kid": key_id})
 
 
 def cert_pem_to_der(pem: str) -> bytes:


### PR DESCRIPTION
Closes https://github.com/microsoft/CCF/issues/6601

**Key points**
* `JsonWebKeyData` created to avoid further changes in JsonWebKey, which is used for UVM endorsements parsing, as well as a base class for a plethora of key classes, which in turn are used in various key conversion APIs. Didn’t have enough courage to change that here.
* Crypto hierarchy issues ( #6673 ) are not addressed here, but using RSA keys instead of misused EC keys has been fixed.
* Following the approach of #6175, the new key metadata table has been introduced to work with the new tables, previous metadata becomes “legacy” alongside old `public_signing_key` and `public_signing_key_issuer` tables. These are to be pruned in #6222, the ticket has been updated to mention the current change.
* `nbf` claim is no longer mandatory, as it's Entra-specific, [details here](https://github.com/microsoft/CCF/issues/6601#issuecomment-2519775520).