### PR TITLE
[release/5.x] Cherry pick: Address NPM version incompatibilities (#6679)

### DIFF
--- a/js/ccf-app/package.json
+++ b/js/ccf-app/package.json
@@ -29,7 +29,7 @@
     "mocha": "^10.0.0",
     "node-forge": "^1.2.0",
     "ts-node": "^10.4.0",
-    "typedoc": "^0.26.2",
-    "typescript": "^5.0.2"
+    "typedoc": "^0.27.0",
+    "typescript": "^5.7.2"
   }
 }

--- a/tests/js-interpreter-reuse/package.json
+++ b/tests/js-interpreter-reuse/package.json
@@ -9,14 +9,14 @@
   },
   "dependencies": {
     "@microsoft/ccf-app": "file:../../js/ccf-app",
-    "inversify": "^6.0.1",
-    "reflect-metadata": "^0.1.13"
+    "inversify": "^6.1.5"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@rollup/plugin-typescript": "^8.2.0",
     "del-cli": "^5.0.0",
-    "tslib": "^2.0.1"
+    "tslib": "^2.0.1",
+    "typescript": "^5.7.2"
   }
 }

--- a/tests/js-interpreter-reuse/src/SlowConstructorService.ts
+++ b/tests/js-interpreter-reuse/src/SlowConstructorService.ts
@@ -1,6 +1,5 @@
 import { injectable } from "inversify";
 import { fibonacci } from "./bad_fib";
-import "reflect-metadata";
 
 @injectable()
 export class SlowConstructorService {

--- a/tests/npm-app/package.json
+++ b/tests/npm-app/package.json
@@ -28,6 +28,6 @@
     "http-server": "^14.1.1",
     "rollup": "^4.18.0",
     "tslib": "^2.6.3",
-    "typescript": "^5.4.5"
+    "typescript": "^5.7.2"
   }
 }


### PR DESCRIPTION
Backports the following commits to `release/5.x`:
 - [Address NPM version incompatibilities (#6679)](https://github.com/microsoft/CCF/pull/6679)