### PR TITLE
Fix TPCC build, add scheduled Bencher runs

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -1,6 +1,8 @@
 name: "Bencher: Run Benchmarks"
 
 on:
+  schedule:
+    - cron: "0 0 * * 0"
   push:
     branches:
       - main

--- a/src/apps/tpcc/app/tpcc.cpp
+++ b/src/apps/tpcc/app/tpcc.cpp
@@ -4,6 +4,7 @@
 #include "../tpcc_serializer.h"
 #include "ccf/app_interface.h"
 #include "ccf/common_auth_policies.h"
+#include "ccf/ds/logger.h"
 #include "tpcc_setup.h"
 #include "tpcc_tables.h"
 #include "tpcc_transactions.h"


### PR DESCRIPTION
Including juggling of #6684 broke the TPCC build, which we only see in Bencher runs, which are only triggered on `main` commits.

This fixes the includes, and while we're here adds a cronjob schedule trigger for Bencher runs.