### PR TITLE
Python ledger optimisations: Add a `--quiet` flag, and reuse calculated values in MerkleTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.0.0-dev9]
+
+[6.0.0-dev9]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev9
+
+### Changed
+
+- The `read_ledger.py` tool now has a `--quiet` option which avoids printing anything per-transaction, as well as other performance improvements, which should make it more useful in verifying the integrity of large ledgers.
+
 ## [6.0.0-dev8]
 
 [6.0.0-dev8]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev8

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ccf"
-version = "6.0.0-dev8"
+version = "6.0.0-dev9"
 authors = [
   { name="CCF Team", email="CCF-Sec@microsoft.com" },
 ]

--- a/python/src/ccf/merkletree.py
+++ b/python/src/ccf/merkletree.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache 2.0 License.
 
 from hashlib import sha256
+import math
 
 
 class MerkleTree(object):
@@ -13,16 +14,19 @@ class MerkleTree(object):
         self.reset_tree()
 
     def reset_tree(self):
-        self.leaves = list()
-        self.levels = None
+        self._levels = [[]]
         self._root = None
 
     def add_leaf(self, values: bytes, do_hash=True):
         digest = values
         if do_hash:
             digest = sha256(values).digest()
-        self.leaves.append(digest)
+        self._levels[0].append(digest)
         self._root = None  # Need to recalculate
+
+    @property
+    def leaves(self):
+        return self._levels[0]
 
     def get_leaf(self, index: int) -> bytes:
         return self.leaves[index]
@@ -32,47 +36,55 @@ class MerkleTree(object):
 
     def get_merkle_root(self) -> bytes:
         if self._root is None:
-            # Always make tree before getting root
+            # Make tree before getting root if root not already calculated
             self._make_tree()
             assert (
-                self.levels is not None
+                self._levels is not None
             ), "Unexpected error while getting root. MerkleTree has no levels."
-            self._root = self.levels[0][0]
+            self._root = self._levels[-1][0]
 
         return self._root
 
-    def _calculate_next_level(self):
-        solo_leaf = None
-        # number of leaves on the level
-        number_of_leaves_on_current_level = len(self.levels[0])
+    def _recalculate_level(self, level):
+        assert len(self._levels) > level - 1
+        prev_level = self._levels[level - 1]
+        number_of_leaves_on_prev_level = len(prev_level)
 
         assert (
-            number_of_leaves_on_current_level > 1
+            number_of_leaves_on_prev_level > 1
         ), "Merkle Tree should have more than one leaf at every level"
 
+        solo_leaf = None
+
         if (
-            number_of_leaves_on_current_level % 2 == 1
+            number_of_leaves_on_prev_level % 2 == 1
         ):  # if odd number of leaves on the level
             # Get the solo leaf (last leaf in-case the leaves are odd numbered)
-            solo_leaf = self.levels[0][-1]
-            number_of_leaves_on_current_level -= 1
+            solo_leaf = prev_level[-1]
+            number_of_leaves_on_prev_level -= 1
 
-        new_level = []
+        if not len(self._levels) > level:
+            self._levels.append([])
+
+        # Reuse existing level as much as possible
+        current_level = self._levels[level]
+
+        # Since we may have copied a solo-leaf to the rightmost node last time, pop and re-calculate it
+        if len(current_level):
+            current_level.pop(-1)
+
+        done = len(current_level)
+
         for left_node, right_node in zip(
-            self.levels[0][0:number_of_leaves_on_current_level:2],
-            self.levels[0][1:number_of_leaves_on_current_level:2],
+            prev_level[done * 2 : number_of_leaves_on_prev_level : 2],
+            prev_level[done * 2 + 1 : number_of_leaves_on_prev_level : 2],
         ):
-            new_level.append(sha256(left_node + right_node).digest())
+            current_level.append(sha256(left_node + right_node).digest())
         if solo_leaf is not None:
-            new_level.append(solo_leaf)
-        self.levels = [
-            new_level,
-        ] + self.levels  # prepend new level
+            current_level.append(solo_leaf)
 
     def _make_tree(self):
         if self.get_leaf_count() > 0:
-            self.levels = [
-                self.leaves,
-            ]
-            while len(self.levels[0]) > 1:
-                self._calculate_next_level()
+            num_levels = 1 + math.ceil(math.log(self.get_leaf_count(), 2))
+            for level in range(1, num_levels):
+                self._recalculate_level(level)

--- a/python/src/ccf/merkletree.py
+++ b/python/src/ccf/merkletree.py
@@ -10,18 +10,19 @@ class MerkleTree(object):
     """
 
     def __init__(self):
-        self.levels = None
         self.reset_tree()
 
     def reset_tree(self):
         self.leaves = list()
         self.levels = None
+        self._root = None
 
     def add_leaf(self, values: bytes, do_hash=True):
         digest = values
         if do_hash:
             digest = sha256(values).digest()
         self.leaves.append(digest)
+        self._root = None  # Need to recalculate
 
     def get_leaf(self, index: int) -> bytes:
         return self.leaves[index]
@@ -30,13 +31,15 @@ class MerkleTree(object):
         return len(self.leaves)
 
     def get_merkle_root(self) -> bytes:
-        # Always make tree before getting root
-        self._make_tree()
-        assert (
-            self.levels is not None
-        ), "Unexpected error while getting root. MerkleTree has no levels."
+        if self._root is None:
+            # Always make tree before getting root
+            self._make_tree()
+            assert (
+                self.levels is not None
+            ), "Unexpected error while getting root. MerkleTree has no levels."
+            self._root = self.levels[0][0]
 
-        return self.levels[0][0]
+        return self._root
 
     def _calculate_next_level(self):
         solo_leaf = None

--- a/tests/governance_history.py
+++ b/tests/governance_history.py
@@ -222,11 +222,16 @@ def test_read_ledger_utility(network, args):
     primary, backups = network.find_nodes()
     for node in (primary, *backups):
         ledger_dirs = node.remote.ledger_paths()
-        assert ccf.read_ledger.run(paths=ledger_dirs, tables_format_rules=format_rule)
+        assert ccf.read_ledger.run(
+            paths=ledger_dirs,
+            print_mode=ccf.read_ledger.PrintMode.Contents,
+            tables_format_rules=format_rule,
+        )
 
     snapshot_dir = network.get_committed_snapshots(primary)
     assert ccf.read_ledger.run(
         paths=[os.path.join(snapshot_dir, os.listdir(snapshot_dir)[-1])],
+        print_mode=ccf.read_ledger.PrintMode.Contents,
         is_snapshot=True,
         tables_format_rules=format_rule,
     )


### PR DESCRIPTION
We noticed the `read_ledger.py` tool was surprisingly slow, meaning it was not helpful for verifying the integrity of large ledgers. This PR includes a few isolated, relatively non-controversial improvements:

- Add a `--quiet` flag to `read_ledger.py`. Printing a digest to terminal, per-transaction, was a major bottleneck. Further options to pipe transaction contents or summaries to files might be helpful in future, but aren't needed now.
- After that, the merkle tree's `get_merkle_root` was taking most of our time.
- First we cache the root for a given tree, rather than re-calculating it each time `get_merkle_root()` is called (for an otherwise unchanged tree). We get the root from separate calls for COSE signatures vs old signatures, without modifying the tree
- Then we change the `_make_tree()`/`_calculate_next_level()` functions to extend an existing tree/levels, rather than re-calculating from scratch every time.

The merkle tree improvements massively reduce the time spent digesting, as shown in speedscope traces:

### Before
![image](https://github.com/user-attachments/assets/1c81b74f-16be-488c-b457-0b337c028572)

### After
![image](https://github.com/user-attachments/assets/3b86d6b0-dbe2-47c7-8e95-6dbee7f4088a)

I've tested these improvements on ledgers* of 100k transactions (~27MB, ~15s down to ~2.5s), and 1mil transactions (~265MB, ~5m7s down to ~25s).

\* Caveat: These are ledgers produced from the logging performance test, so contain uniform, small transactions. Characteristics will differ on ledgers with different distributions.

There's a few follow-up tasks to consider:
- Profiling shows the file reading in a few different places, `_read_header` and `get_raw_tx`. Maybe we could simplify and improve this by reading larger chunks up-front, and making fewer IO calls.
- We don't use the positions table for random access to transactions at all in Python. Although this doesn't offer a clear perf win in the current models (which need to scan each transaction in-order), it might be useful for other tools/test code. Needs a significant refactor to separate iteration from the Python `Transaction` object.
- We don't parse serialised mini-trees at all in Python, so we have to load every historical transaction to verify merkle roots. If we added this, we could do point-based verification (eg - per-chunk, chunk-to-chunk), and do so in parallel. Slightly simpler - we could add a mode to verify that signatures are valid without checking that the root is coherent, and do verification in parallel with this.

I think these are all backlog for now.