### PR TITLE
Deprecate `get_js_plugins()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+and this project adheres Fto [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [6.0.0-dev11]
+
+[6.0.0-dev11]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev11
+
+### Deprecated
+
+- The function `ccf::get_js_plugins()` and associated FFI plugin system for JS is deprecated. Similar functionality should now be implemented through a `js::Extension` returned from `DynamicJSEndpointRegistry::get_extensions()`.
 
 ## [6.0.0-dev10]
 

--- a/doc/build_apps/api.rst
+++ b/doc/build_apps/api.rst
@@ -153,12 +153,6 @@ Indexing
    :project: CCF
    :members:
 
-JavaScript FFI Plugins
-----------------------
-
-.. doxygenfunction:: ccf::get_js_plugins
-   :project: CCF
-
 HTTP Entity Tags Matching
 -------------------------
 

--- a/include/ccf/app_interface.h
+++ b/include/ccf/app_interface.h
@@ -53,11 +53,12 @@ namespace ccf
    */
   std::unique_ptr<ccf::endpoints::EndpointRegistry> make_user_endpoints(
     ccf::AbstractNodeContext& context);
+  // SNIPPET_END: app_interface
 
   /** To be implemented by the application.
    *
    * @return Vector of JavaScript FFI plugins
    */
+  CCF_DEPRECATED("Deprecated from 6.0.0")
   std::vector<ccf::js::FFIPlugin> get_js_plugins();
-  // SNIPPET_END: app_interface
 }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ccf"
-version = "6.0.0-dev10"
+version = "6.0.0-dev11"
 authors = [
   { name="CCF Team", email="CCF-Sec@microsoft.com" },
 ]

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -193,7 +193,12 @@ namespace ccf
       rpc_map->register_frontend<ccf::ActorsType::acme_challenge>(
         std::make_unique<ccf::ACMERpcFrontend>(network, *context));
 
+// Suppress error about use of deprecated get_js_plugins(). This call, and all
+// references to FFIPlugins, should be removed after 6.0.0
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
       ccf::js::register_ffi_plugins(ccf::get_js_plugins());
+#pragma clang diagnostic pop
 
       LOG_TRACE_FMT("Initialize node");
       node->initialize(


### PR DESCRIPTION
This FFI plugin system is unused. Similar functionality is now available via `DynamicJSEndpointRegistry::get_extensions()`, and I think the similar naming of this is just confusing. Proposing that we deprecate it in 6.0.0, and remove implementation and all references shortly after.