### PR TITLE
Workaround private pem missmatch in e2e tests

### DIFF
--- a/tests/npm_tests.py
+++ b/tests/npm_tests.py
@@ -94,8 +94,16 @@ def generate_and_verify_jwk(client):
 
         r = client.post("/app/rsaJwkToPem", body={"jwk": body})
         body = r.body.json()
-        assert r.status_code == http.HTTPStatus.OK
-        assert body["pem"] == priv_pem
+        converted_pem = body["pem"]
+
+        # PEMs may very because of discrepancies of RSA key private components
+        # computation, in particular, using Euler VS Carmichael totient
+        # functions. For more details check the thread:
+        # https://github.com/microsoft/CCF/issues/6588#issuecomment-2568037993.
+        algorithm = {"name": "RSA-PSS", "hash": "SHA-256"}
+        data = rand_bytes(random.randint(2, 50))
+        signature = infra.crypto.sign(algorithm, converted_pem, data)
+        infra.crypto.verify_signature(algorithm, signature, data, pub_pem)
 
         # Public
         ref_pub_jwk = jwk.JWK.from_pem(pub_pem.encode()).export(as_dict=True)

--- a/tests/npm_tests.py
+++ b/tests/npm_tests.py
@@ -96,7 +96,7 @@ def generate_and_verify_jwk(client):
         body = r.body.json()
         converted_pem = body["pem"]
 
-        # PEMs may very because of discrepancies of RSA key private components
+        # PEMs may vary because of discrepancies of RSA key private components
         # computation, in particular, using Euler VS Carmichael totient
         # functions. For more details check the thread:
         # https://github.com/microsoft/CCF/issues/6588#issuecomment-2568037993.


### PR DESCRIPTION
Partially closes #6588 ([check this out](https://github.com/microsoft/CCF/issues/6588#issuecomment-2568037993) + related comments in the thread for more details on the issue).

PEM differs after being converted to JWK and back due to math missmatch in openssl implementation (see ticket for details).

Replaced PEM comparison with signature verification.