### PR TITLE
Pick up symbols from inside the .so where possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,10 +505,18 @@ endif()
 add_custom_target(ccf ALL)
 
 set(CCF_IMPL_SOURCE
-    ${CCF_DIR}/src/host/snmalloc.cpp ${CCF_DIR}/src/enclave/main.cpp
-    ${CCF_DIR}/src/enclave/enclave_time.cpp
+    ${CCF_DIR}/src/enclave/main.cpp ${CCF_DIR}/src/enclave/enclave_time.cpp
     ${CCF_DIR}/src/enclave/thread_local.cpp ${CCF_DIR}/src/node/quote.cpp
 )
+
+if(SAN
+   OR TSAN
+   OR NOT USE_SNMALLOC
+)
+  # Do nothing, SNMALLOC_COMPILE_OPTIONS is empty already
+else()
+  list(APPEND CCF_IMPL_SOURCE ${CCF_DIR}/src/host/snmalloc.cpp)
+endif()
 
 # Same as virtual for the time being but will diverge soon
 if(COMPILE_TARGET STREQUAL "snp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,7 +505,8 @@ endif()
 add_custom_target(ccf ALL)
 
 set(CCF_IMPL_SOURCE
-    ${CCF_DIR}/src/enclave/main.cpp ${CCF_DIR}/src/enclave/enclave_time.cpp
+    ${CCF_DIR}/src/host/snmalloc.cpp ${CCF_DIR}/src/enclave/main.cpp
+    ${CCF_DIR}/src/enclave/enclave_time.cpp
     ${CCF_DIR}/src/enclave/thread_local.cpp ${CCF_DIR}/src/node/quote.cpp
 )
 
@@ -520,7 +521,9 @@ if(COMPILE_TARGET STREQUAL "snp")
                    _LIBCPP_HAS_THREAD_API_PTHREAD PLATFORM_SNP
   )
 
-  target_compile_options(ccf.snp PUBLIC ${COMPILE_LIBCXX})
+  target_compile_options(
+    ccf.snp PUBLIC ${COMPILE_LIBCXX} ${SNMALLOC_COMPILE_OPTIONS}
+  )
   add_warning_checks(ccf.snp)
 
   target_include_directories(
@@ -569,7 +572,9 @@ elseif(COMPILE_TARGET STREQUAL "virtual")
                        _LIBCPP_HAS_THREAD_API_PTHREAD PLATFORM_VIRTUAL
   )
 
-  target_compile_options(ccf.virtual PUBLIC ${COMPILE_LIBCXX})
+  target_compile_options(
+    ccf.virtual PUBLIC ${COMPILE_LIBCXX} ${SNMALLOC_COMPILE_OPTIONS}
+  )
   add_warning_checks(ccf.virtual)
 
   target_include_directories(

--- a/src/enclave/virtual_enclave.h
+++ b/src/enclave/virtual_enclave.h
@@ -71,7 +71,8 @@ extern "C"
   {
     auto virtual_enclave_handle = dlopen(
       path,
-      RTLD_NOW
+      RTLD_NOW |
+        RTLD_DEEPBIND
 #if defined(__has_feature)
 #  if __has_feature(address_sanitizer)
         // Avoid unloading on delete under ASAN, so that leak checking can still


### PR DESCRIPTION
The recent PR to add snapshot download (#6727) highlighted the risk of external dependencies being picked up through `cchost` and being used inside the `.so` inadvertently. This change reverses the priority when resolving symbols, and links in snmalloc explicitly on the `.so` side (since it is no longer picked up).

```
       RTLD_DEEPBIND (since glibc 2.3.4)
              Place the lookup scope of the symbols in this shared
              object ahead of the global scope.  This means that a self-
              contained object will use its own symbols in preference to
              global symbols with the same name contained in objects
              that have already been loaded.
```