### PR TITLE
Add az-dcap-client back to main for now, to enable LTS-compatible base images

### DIFF
--- a/getting_started/setup_vm/ccf-dev.yml
+++ b/getting_started/setup_vm/ccf-dev.yml
@@ -26,5 +26,8 @@
         name: lldb
         tasks_from: install.yml
     - import_role:
+        name: az_dcap
+        tasks_from: install.yml
+    - import_role:
         name: autoremove
         tasks_from: install.yml

--- a/getting_started/setup_vm/roles/az_dcap/tasks/install.yml
+++ b/getting_started/setup_vm/roles/az_dcap/tasks/install.yml
@@ -1,0 +1,18 @@
+- name: Add Microsoft repository key
+  apt_key:
+    url: "https://packages.microsoft.com/keys/microsoft.asc"
+    state: present
+  become: true
+
+- name: Add Microsoft sources list
+  apt_repository:
+    repo: "deb [arch=amd64] https://packages.microsoft.com/ubuntu/{{ ansible_distribution_version }}/prod {{ ansible_distribution_release }} main"
+    state: present
+  become: true
+
+- name: Install the Azure DCAP Client
+  apt:
+    name: az-dcap-client
+    state: present
+    force: true
+  become: true


### PR DESCRIPTION
Taking a step back after #6737 and #6739. We have been cutting CI images (`build/YYYY-MM-DD`) from `release/5.x` so as to get enough SGX attestation-verification dependencies to run the LTS compatibility tests in CI.
Local tests suggest that adding `az-dcap-client` is sufficient to start 5.x-era nodes (who link oehost), and is likely the smallest delta we can apply to be able to cut CI images from main. This in turn will let us make changes like #6739, which cannot be backported to 5.x without substantial associated changes and risk.