### PR TITLE
Add az-dcap-client back to main for now, to enable LTS-compatible base images

### DIFF
--- a/.azure-pipelines-release.yml
+++ b/.azure-pipelines-release.yml
@@ -8,15 +8,15 @@ pr: none
 resources:
   containers:
     - container: virtual
-      image: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: snp
-      image: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
     - container: sgx
-      image: ghcr.io/microsoft/ccf/ci/sgx:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/sgx:build-08-01-2025-1
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx -v /lib/modules:/lib/modules:ro
 
 variables:

--- a/.azure-pipelines-templates/deploy_aci.yml
+++ b/.azure-pipelines-templates/deploy_aci.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           ACR_REGISTRY_RESOURCE_NAME: ccfmsrc
           ACR_REGISTRY: ccfmsrc.azurecr.io
-          BASE_IMAGE: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+          BASE_IMAGE: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
 
       - script: |
           set -ex

--- a/.azure_pipelines_snp.yml
+++ b/.azure_pipelines_snp.yml
@@ -22,7 +22,7 @@ schedules:
 resources:
   containers:
     - container: virtual
-      image: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
       options: --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
 
 jobs:

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -13,7 +13,7 @@ jobs:
     name: Continuous Benchmarking with Bencher
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
-      image: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-verification.yml
+++ b/.github/workflows/ci-verification.yml
@@ -24,7 +24,7 @@ jobs:
     name: Model Checking - Consistency
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
-      image: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
     defaults:
       run:
         working-directory: tla
@@ -102,7 +102,7 @@ jobs:
     name: Model Checking - Consensus
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
-      image: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
     defaults:
       run:
         working-directory: tla
@@ -158,7 +158,7 @@ jobs:
     name: Trace Validation - Consensus
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
-      image: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   checks:
     name: "Format and License Checks"
     runs-on: ubuntu-latest
-    container: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+    container: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
 
     steps:
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -44,7 +44,7 @@ jobs:
             options: --user root --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
     runs-on: ${{ matrix.platform.nodes }}
     container:
-      image: ghcr.io/microsoft/ccf/ci/${{ matrix.platform.image }}:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/${{ matrix.platform.image }}:build-08-01-2025-1
       options: ${{ matrix.platform.options }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
     # Insufficient space to run on public runner, so use custom pool
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
-      image: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
       options: --user root
 
     permissions:

--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-test') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
-      image: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-test') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
-      image: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
 
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
     name: TSAN
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
-      image: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
 
     steps:
       - uses: actions/checkout@v4
@@ -117,7 +117,7 @@ jobs:
     name: LTS
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
-      image: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/long-verification.yml
+++ b/.github/workflows/long-verification.yml
@@ -22,7 +22,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-verification') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
-      image: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
     defaults:
       run:
         working-directory: tla
@@ -50,7 +50,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-verification') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     runs-on: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     container:
-      image: ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
     defaults:
       run:
         working-directory: tla

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
             nodes: [self-hosted, 1ES.Pool=gha-virtual-ccf-sub]
     runs-on: ${{ matrix.platform.nodes }}
     container:
-      image: ghcr.io/microsoft/ccf/ci/${{ matrix.platform.image }}:build-05-12-2024
+      image: ghcr.io/microsoft/ccf/ci/${{ matrix.platform.image }}:build-08-01-2025-1
       options: "--user root --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro ${{ matrix.platform.container_options }}"
     steps:
       - uses: actions/checkout@v4

--- a/docker/ccf_ci_built
+++ b/docker/ccf_ci_built
@@ -3,7 +3,7 @@
 # Also contains CCF source and build directory
 
 # Latest image as of this change
-ARG base=ghcr.io/microsoft/ccf/ci/default:build-05-12-2024
+ARG base=ghcr.io/microsoft/ccf/ci/default:build-08-01-2025-1
 FROM ${base}
 
 # SSH. Note that this could (should) be done in the base ccf_ci image instead

--- a/getting_started/setup_vm/ccf-dev.yml
+++ b/getting_started/setup_vm/ccf-dev.yml
@@ -26,5 +26,8 @@
         name: lldb
         tasks_from: install.yml
     - import_role:
+        name: az_dcap
+        tasks_from: install.yml
+    - import_role:
         name: autoremove
         tasks_from: install.yml

--- a/getting_started/setup_vm/roles/az_dcap/tasks/install.yml
+++ b/getting_started/setup_vm/roles/az_dcap/tasks/install.yml
@@ -1,0 +1,18 @@
+- name: Add Microsoft repository key
+  apt_key:
+    url: "https://packages.microsoft.com/keys/microsoft.asc"
+    state: present
+  become: true
+
+- name: Add Microsoft sources list
+  apt_repository:
+    repo: "deb [arch=amd64] https://packages.microsoft.com/ubuntu/{{ ansible_distribution_version }}/prod {{ ansible_distribution_release }} main"
+    state: present
+  become: true
+
+- name: Install the Azure DCAP Client
+  apt:
+    name: az-dcap-client
+    state: present
+    force: true
+  become: true


### PR DESCRIPTION
Taking a step back after #6737 and #6739. We have been cutting CI images (`build/YYYY-MM-DD`) from `release/5.x` so as to get enough SGX attestation-verification dependencies to run the LTS compatibility tests in CI.
Local tests suggest that adding `az-dcap-client` is sufficient to start 5.x-era nodes (who link oehost), and is likely the smallest delta we can apply to be able to cut CI images from main. This in turn will let us make changes like #6739, which cannot be backported to 5.x without substantial associated changes and risk.