### PR TITLE
Remove unused LVI_MITIGATIONS flag

### DIFF
--- a/.azure-pipelines-templates/daily-matrix.yml
+++ b/.azure-pipelines-templates/daily-matrix.yml
@@ -27,10 +27,10 @@ parameters:
       cmake_args: "-DCOMPILE_TARGET=sgx"
       cmake_env: ""
     SNPCC:
-      cmake_args: "-DCOMPILE_TARGET=snp -DLVI_MITIGATIONS=OFF -DLONG_TESTS=OFF"
+      cmake_args: "-DCOMPILE_TARGET=snp -DLONG_TESTS=OFF"
       cmake_env: "CC=`which clang-15` CXX=`which clang++-15`"
     debug:
-      cmake_args: "-DCMAKE_BUILD_TYPE=Debug -DLVI_MITIGATIONS=OFF"
+      cmake_args: "-DCMAKE_BUILD_TYPE=Debug"
       cmake_env: ""
     ASAN:
       cmake_args: "-DSAN=ON"
@@ -39,7 +39,7 @@ parameters:
       cmake_args: "-DTSAN=ON -DWORKER_THREADS=2"
       cmake_env: ""
     unsafe:
-      cmake_args: "-DLVI_MITIGATIONS=OFF -DVERBOSE_LOGGING=ON -DUNSAFE_VERSION=ON"
+      cmake_args: "-DVERBOSE_LOGGING=ON -DUNSAFE_VERSION=ON"
       cmake_env: ""
 
 jobs:

--- a/.azure-pipelines-templates/release-matrix.yaml
+++ b/.azure-pipelines-templates/release-matrix.yaml
@@ -30,7 +30,7 @@ parameters:
       cmake_env: ""
       ninja_targets: "default"
     SNPCC:
-      cmake_args: "-DCOMPILE_TARGET=snp -DLVI_MITIGATIONS=OFF -DLONG_TESTS=OFF"
+      cmake_args: "-DCOMPILE_TARGET=snp -DLONG_TESTS=OFF"
       cmake_env: "CC=`which clang-15` CXX=`which clang++-15`"
       ninja_targets: "default"
     release:
@@ -38,7 +38,7 @@ parameters:
       cmake_env: ""
       ninja_targets: "default"
     unsafe:
-      cmake_args: "-DLVI_MITIGATIONS=OFF -DVERBOSE_LOGGING=ON -DUNSAFE_VERSION=ON"
+      cmake_args: "-DVERBOSE_LOGGING=ON -DUNSAFE_VERSION=ON"
       cmake_env: ""
       ninja_targets: "default"
 

--- a/.github/workflows/ci-verification.yml
+++ b/.github/workflows/ci-verification.yml
@@ -175,7 +175,7 @@ jobs:
           git config --global --add safe.directory /__w/CCF/CCF
           mkdir build
           cd build
-          cmake -L -GNinja .. -DCMAKE_BUILD_TYPE=Debug -DLVI_MITIGATIONS=OFF -DVERBOSE_LOGGING=ON -DCOMPILE_TARGET=virtual -DCCF_RAFT_TRACING=ON
+          cmake -L -GNinja .. -DCMAKE_BUILD_TYPE=Debug -DVERBOSE_LOGGING=ON -DCOMPILE_TARGET=virtual -DCCF_RAFT_TRACING=ON
           ninja raft_driver
         shell: bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           git config --global --add safe.directory /__w/CCF/CCF
           mkdir build
           cd build
-          cmake -GNinja -DCOMPILE_TARGET=${{ matrix.platform.name }} -DCMAKE_BUILD_TYPE=Debug -DLVI_MITIGATIONS=OFF ..
+          cmake -GNinja -DCOMPILE_TARGET=${{ matrix.platform.name }} -DCMAKE_BUILD_TYPE=Debug ..
           ninja
         shell: bash
 
@@ -132,7 +132,7 @@ jobs:
           git config --global --add safe.directory /__w/CCF/CCF
           mkdir build
           cd build
-          CC=`which clang` CXX=`which clang++` cmake -GNinja -DCOMPILE_TARGET=virtual -DCMAKE_BUILD_TYPE=Debug -DLVI_MITIGATIONS=OFF -DUSE_LIBCXX=OFF ..
+          CC=`which clang` CXX=`which clang++` cmake -GNinja -DCOMPILE_TARGET=virtual -DCMAKE_BUILD_TYPE=Debug -DUSE_LIBCXX=OFF ..
           ninja
         shell: bash
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -56,7 +56,7 @@ jobs:
           set -ex
           mkdir build
           cd build
-          cmake -DCOMPILE_TARGET=virtual -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=OFF -DLVI_MITIGATIONS=OFF ..
+          cmake -DCOMPILE_TARGET=virtual -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=OFF ..
         name: Run CMake
 
       - run: |

--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -53,7 +53,7 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           mkdir build
           cd build
-          cmake -GNinja -DCOMPILE_TARGET=virtual -DCMAKE_BUILD_TYPE=Debug -DLONG_TESTS=ON -DLVI_MITIGATIONS=OFF -DSAN=ON ..
+          cmake -GNinja -DCOMPILE_TARGET=virtual -DCMAKE_BUILD_TYPE=Debug -DLONG_TESTS=ON -DSAN=ON ..
           ninja
 
       - name: "Test"
@@ -91,7 +91,7 @@ jobs:
           git config --global --add safe.directory /__w/CCF/CCF
           mkdir build
           cd build
-          cmake -GNinja -DCOMPILE_TARGET=virtual -DCMAKE_BUILD_TYPE=Debug -DLONG_TESTS=ON -DLVI_MITIGATIONS=OFF -DTSAN=ON -DWORKER_THREADS=2 ..
+          cmake -GNinja -DCOMPILE_TARGET=virtual -DCMAKE_BUILD_TYPE=Debug -DLONG_TESTS=ON -DTSAN=ON -DWORKER_THREADS=2 ..
           ninja
 
       - name: "Test"
@@ -129,7 +129,7 @@ jobs:
           git config --global --add safe.directory /__w/CCF/CCF
           mkdir build
           cd build
-          cmake -GNinja -DCOMPILE_TARGET=virtual -DCMAKE_BUILD_TYPE=Debug -DLONG_TESTS=ON -DLVI_MITIGATIONS=OFF -DWORKER_THREADS=2 ..
+          cmake -GNinja -DCOMPILE_TARGET=virtual -DCMAKE_BUILD_TYPE=Debug -DLONG_TESTS=ON -DWORKER_THREADS=2 ..
           ninja
 
       - name: "Test"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,20 +132,6 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/tools.cmake DESTINATION cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ccf_app.cmake)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ccf_app.cmake DESTINATION cmake)
 
-if(SAN AND LVI_MITIGATIONS)
-  message(
-    FATAL_ERROR
-      "Building with both SAN and LVI mitigations is unsafe and deadlocks - choose one"
-  )
-endif()
-
-if(TSAN AND LVI_MITIGATIONS)
-  message(
-    FATAL_ERROR
-      "Building with both TSAN and LVI mitigations is unsafe and deadlocks - choose one"
-  )
-endif()
-
 # Copy and install CCF utilities
 set(CCF_UTILITIES keygenerator.sh submit_recovery_share.sh verify_quote.sh)
 foreach(UTILITY ${CCF_UTILITIES})


### PR DESCRIPTION
Unused since SGX removal, but did not trigger any warnings because the conflict check with *SAN effectively "used" the flag.