### PR TITLE
Fixed the backup redirection config in the start_network.py

### DIFF
--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -35,7 +35,11 @@ def run(args):
                 LOG.warning("Redirection with node-by-role is enabled")
                 interface.redirections = infra.interfaces.RedirectionConfig(
                     to_primary=infra.interfaces.NodeByRoleResolver(),
-                    to_backup=infra.interfaces.NodeByRoleResolver(),
+                    to_backup=infra.interfaces.NodeByRoleResolver(
+                        target=infra.interfaces.TargetRole(
+                            infra.interfaces.NodeRole.backup
+                        )
+                    ),
                 )
             elif args.redirection_kind == "static-address":
                 LOG.warning("Redirection with static-address is enabled")


### PR DESCRIPTION
This PR fixes a bug in the backup redirection config which is incorrectly pointing to the primary node. 