### PR TITLE
Add curl as a dependency in cpack

### DIFF
--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -22,7 +22,7 @@ message(STATUS "Debian package version: ${CPACK_DEBIAN_PACKAGE_VERSION}")
 # 1.1.1f, which corresponds to the OpenSSL 1.1.1t release (latest security
 # patches).
 set(CCF_DEB_BASE_DEPENDENCIES
-    "libuv1 (>= 1.34.2);openssl (>=1.1.1f);libnghttp2-14 (>=1.40.0)"
+    "libuv1 (>= 1.34.2);openssl (>=1.1.1f);libnghttp2-14 (>=1.40.0);curl (>=7.68.0)"
 )
 set(CCF_DEB_DEPENDENCIES ${CCF_DEB_BASE_DEPENDENCIES})
 


### PR DESCRIPTION
Missed when curl was added as a dependency, meaning the 6.0.0-dev12 deb has a missing dependency.