### PR TITLE
Prepare release notes for `6.0.0-dev13`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres Fto [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.0.0-dev13]
+
+[6.0.0-dev13]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev13
+
+### Added
+
+- Joining nodes can now request a snapshot from their peers at startup, rather than relying on file access. The joinee's snapshot will be fetched and used if it is more recent than the joiner has access to. This behaviour is enabled by default, but can be disabled via the `command.join.fetch_recent_snapshot` config option (#6758).
+
 ## [6.0.0-dev12]
 
 [6.0.0-dev12]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev12
@@ -13,10 +21,6 @@ and this project adheres Fto [Semantic Versioning](http://semver.org/spec/v2.0.0
 
 - nghttp2 is now picked up from the OS rather than vendored to enable libcurl usage
 - Misc dependency updates (#6725)
-
-### Added
-
-- Joining nodes can now request a snapshot from their peers at startup, rather than relying on file access. The joinee's snapshot will be fetched and used if it is more recent than the joiner has access to (#6758).
 
 ## [6.0.0-dev11]
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ccf"
-version = "6.0.0-dev12"
+version = "6.0.0-dev13"
 authors = [
   { name="CCF Team", email="CCF-Sec@microsoft.com" },
 ]


### PR DESCRIPTION
This new feature was incorrectly added to the `dev12` changelog section, after `dev12` had been cut.