### PR TITLE
The extended suite life

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
           export ASAN_SYMBOLIZER_PATH=$(realpath /usr/bin/llvm-symbolizer-15)
           # Unit tests
           ./tests.sh --output-on-failure -L unit -j$(nproc --all)
-          ./tests.sh --timeout 360 --output-on-failure -LE "benchmark|unit"
+          ./tests.sh --timeout 600 --output-on-failure -LE "benchmark|unit"
         shell: bash
         if: "${{ matrix.platform.name != 'snp' }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,10 @@ jobs:
           export ASAN_SYMBOLIZER_PATH=$(realpath /usr/bin/llvm-symbolizer-15)
           # Unit tests
           ./tests.sh --output-on-failure -L unit -j$(nproc --all)
-          ./tests.sh --timeout 600 --output-on-failure -LE "benchmark|unit"
+          # Suite tests
+          ./tests.sh --timeout 600 --output-on-failure -L "suite"
+          # Most tests
+          ./tests.sh --timeout 360 --output-on-failure -LE "benchmark|unit|suite"
         shell: bash
         if: "${{ matrix.platform.name != 'snp' }}"
 


### PR DESCRIPTION
Some release Actions are failing because the suite tests time out:

https://github.com/microsoft/CCF/actions/runs/12951151818/job/36125572126#step:7:11549
![image](https://github.com/user-attachments/assets/2ca37908-43fc-486e-b661-a67842722a52)


Locally, this suite gets near the 360s limit:

```
      Start 49: recovery_test_suite
 5/32 Test #49: recovery_test_suite ..............   Passed  336.82 sec
```

So let's give the suites (and only the suites!) a little longer.

(When we run this in `long_tests`, we give these suites 1600s. I don't think we need _that_ long, but it would be good to feed these from the same source...)