### PR TITLE
Ensure the right version of libstdc++(11) is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres Fto [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.0.0-dev14]
+
+[6.0.0-dev14]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev14
+
+### Fixed
+
+- All containers now include the correct version of libstdc++/libstdc++-dev, and the Debian package captures the runtime requirement as well.
+
 ## [6.0.0-dev13]
 
 [6.0.0-dev13]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev13

--- a/cmake/cpack_settings.cmake
+++ b/cmake/cpack_settings.cmake
@@ -22,7 +22,7 @@ message(STATUS "Debian package version: ${CPACK_DEBIAN_PACKAGE_VERSION}")
 # 1.1.1f, which corresponds to the OpenSSL 1.1.1t release (latest security
 # patches).
 set(CCF_DEB_BASE_DEPENDENCIES
-    "libuv1 (>= 1.34.2);openssl (>=1.1.1f);libnghttp2-14 (>=1.40.0);curl (>=7.68.0)"
+    "libuv1 (>= 1.34.2);openssl (>=1.1.1f);libnghttp2-14 (>=1.40.0);curl (>=7.68.0);libstdc++6 (>=11.0.0)"
 )
 set(CCF_DEB_DEPENDENCIES ${CCF_DEB_BASE_DEPENDENCIES})
 

--- a/getting_started/setup_vm/roles/ccf_build/tasks/install.yml
+++ b/getting_started/setup_vm/roles/ccf_build/tasks/install.yml
@@ -1,6 +1,13 @@
 - name: Include vars for Clang
   include_vars: "clang{{ clang_version }}.yml"
 
+- name: Add stdcxx APT repository
+  apt_repository:
+    repo: "ppa:ubuntu-toolchain-r/test"
+    state: present
+    update_cache: yes
+  become: true
+
 - name: Install debs
   apt:
     name: "{{ debs }}"

--- a/getting_started/setup_vm/roles/ccf_build/vars/clang15.yml
+++ b/getting_started/setup_vm/roles/ccf_build/vars/clang15.yml
@@ -5,8 +5,7 @@ debs:
   - apt-transport-https
   - ninja-build
   - libuv1-dev
-  - libc++-{{ clang_ver }}-dev
-  - libc++abi-{{ clang_ver }}-dev
+  - libstdc++-11-dev
   - python3.8-dev
   - python3.8-venv
   - llvm-{{ clang_ver }}

--- a/getting_started/setup_vm/roles/ccf_run/tasks/install.yml
+++ b/getting_started/setup_vm/roles/ccf_run/tasks/install.yml
@@ -1,6 +1,13 @@
 - name: Include vars for Clang
   include_vars: "clang{{ clang_version }}.yml"
 
+- name: Add stdcxx APT repository
+  apt_repository:
+    repo: "ppa:ubuntu-toolchain-r/test"
+    state: present
+    update_cache: yes
+  become: true
+
 - name: Install debs
   apt:
     name: "{{ debs }}"

--- a/getting_started/setup_vm/roles/ccf_run/vars/clang15.yml
+++ b/getting_started/setup_vm/roles/ccf_run/vars/clang15.yml
@@ -1,6 +1,5 @@
 workspace: "/tmp/"
 debs:
-  - libc++abi1-15
-  - libc++1-15
+  - libstdc++6
   - libuv1
   - libnghttp2-14

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ccf"
-version = "6.0.0-dev13"
+version = "6.0.0-dev14"
 authors = [
   { name="CCF Team", email="CCF-Sec@microsoft.com" },
 ]


### PR DESCRIPTION
Follow up to #6772, which had optimistically assumed that the Ubuntu 20.04 default (-9) was satisfactory. That is not in fact the case, it is missing `<span>` for example. -11 is installed in CI/ccf-dev contests through piccolo->parquet, which was hiding this problem until an application tried to use a -dev container.