### PR TITLE
Fix app run container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres Fto [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [6.0.0-dev14]
+## [6.0.0-dev15]
 
-[6.0.0-dev14]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev14
+[6.0.0-dev15]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev15
 
 ### Fixed
 
 - All containers now include the correct version of libstdc++/libstdc++-dev, and the Debian package captures the runtime requirement as well.
+- RPMs for Azure Linux 3.0 are now included in releases.
+
+## [6.0.0-dev14]
+
+[6.0.0-dev14]: https://github.com/microsoft/CCF/releases/tag/6.0.0-dev14
+
+Not all containers are available for this release, please see 6.0.0-dev15.
 
 ## [6.0.0-dev13]
 

--- a/getting_started/setup_vm/roles/ccf_install/tasks/deb_install.yml
+++ b/getting_started/setup_vm/roles/ccf_install/tasks/deb_install.yml
@@ -1,6 +1,13 @@
 - name: Include vars
   include_vars: common.yml
 
+- name: Add stdcxx APT repository
+  apt_repository:
+    repo: "ppa:ubuntu-toolchain-r/test"
+    state: present
+    update_cache: yes
+  become: true
+
 - name: Get package url
   shell:
     cmd: |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ccf"
-version = "6.0.0-dev14"
+version = "6.0.0-dev15"
 authors = [
   { name="CCF Team", email="CCF-Sec@microsoft.com" },
 ]


### PR DESCRIPTION
`app-run` image building failed in dev14 because the ppa is not added in the corresponding playbook.