### PR TITLE
Load OpenSSL error strings

### DIFF
--- a/src/crypto/openssl/openssl_wrappers.h
+++ b/src/crypto/openssl/openssl_wrappers.h
@@ -44,7 +44,10 @@ namespace ccf::crypto
       if (ec)
       {
         std::string err(256, '\0');
+        ERR_load_crypto_strings();
+        SSL_load_error_strings();
         ERR_error_string_n((unsigned long)ec, err.data(), err.size());
+        ERR_free_strings();
         // Remove any trailing NULs before returning
         err.resize(std::strlen(err.c_str()));
         return err;


### PR DESCRIPTION
Memory used to be a hard constraint, it's not so bad now. I don't think we ever produce error strings in the hot-path, so I've opted to load these at the last minute rather than in static setup/teardown functions.

The result is that you get the same output as `openssl errstr`, rather than list of opaque codes, eg

```
error:068000A8:lib(13)::reason(168)
```

becomes

```
error:068000A8:digital envelope routines:func(2048):invalid fips mode
```