### PR TITLE
Use a hard-coded string for virtual measurement

### DIFF
--- a/src/pal/quote_generation.h
+++ b/src/pal/quote_generation.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "ds/files.h"
-#include "ds/system.h"
 
 #include <nlohmann/json.hpp>
 #include <string>
@@ -23,13 +22,7 @@ namespace ccf::pal
 
     auto j = nlohmann::json::object();
 
-    const auto uname = ccf::ds::system::exec("uname -a");
-    if (!uname.has_value())
-    {
-      throw std::runtime_error("Error calling uname");
-    }
-
-    j["measurement"] = uname.value();
+    j["measurement"] = "Insecure hard-coded virtual measurement v1";
     j["host_data"] = package_hash.hex_str();
 
     files::dump(j.dump(2), virtual_attestation_path("measurement"));

--- a/tests/code_update.py
+++ b/tests/code_update.py
@@ -51,7 +51,7 @@ def test_verify_quotes(network, args):
             j = r.body.json()
             if j["format"] == "Insecure_Virtual":
                 # A virtual attestation makes 3 claims:
-                # - The measurement (same on many nodes) is the result of calling `uname -a`
+                # - The measurement (same on any virtual node) is a hard-coded string, currently unmodifiable
                 claimed_measurement = j["measurement"]
                 # For consistency with other platforms, this endpoint always returns a hex-string.
                 # But for virtual, it's encoding some ASCII string, not a digest, so decode it for readability

--- a/tests/infra/utils.py
+++ b/tests/infra/utils.py
@@ -8,8 +8,7 @@ import infra.proc
 
 def get_measurement(enclave_type, enclave_platform, package, library_dir="."):
     if enclave_platform == "virtual":
-        result = infra.proc.ccall("uname", "-a")
-        return result.stdout.decode().strip()
+        return "Insecure hard-coded virtual measurement v1"
 
     else:
         raise ValueError(f"Cannot get measurement on {enclave_platform}")


### PR DESCRIPTION
We were previously calling `uname -a`, which includes node name, which obviously differs across real networked/containerised nodes.

We could call something that will be common across nodes (`uname -s -r`), but I think this is an unnecessary risk - it _still_ means we may get virtual nodes refusing to join because they are running in different environments, and doesn't actually get us any benefit. This call to `uname` was used so that we could add a shim to modify it without using a custom envvar/additional config value, but we don't actually have a use for modifying it. We test that measurement policy is applied by _removing_ the trusted measurement, rather than starting a node with an alternative measurement. Shipping anything that modifies it (a `uname` bash script shim, or some separate script to be called) alongside `cchost` is awkward even within our test infra.

If we ever have a use case for modifying the measurement, we can revisit.