### PR TITLE
Remove aad_len check on NULL out buffer

### DIFF
--- a/src/crypto/openssl/symmetric_key.cpp
+++ b/src/crypto/openssl/symmetric_key.cpp
@@ -69,13 +69,6 @@ namespace ccf::crypto
     {
       int aad_outl{0};
       CHECK1(EVP_EncryptUpdate(ctx, NULL, &aad_outl, aad.data(), aad.size()));
-
-// As we set out buffer to NULL, we expect the output length to be 0.
-// However, openssl 1.1.1 sets it to the input length, which doesn't break
-// the encryption, but still looks wrong.
-#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
-      assert(aad_outl == 0);
-#endif
     }
 
     std::vector<uint8_t> ciphertext(plain.size());
@@ -124,13 +117,6 @@ namespace ccf::crypto
     {
       int aad_outl{0};
       CHECK1(EVP_DecryptUpdate(ctx, NULL, &aad_outl, aad.data(), aad.size()));
-
-// As we set out buffer to NULL, we expect the output length to be 0.
-// However, openssl 1.1.1 sets it to the input length, which doesn't break
-// the encryption, but still looks wrong.
-#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
-      assert(aad_outl == 0);
-#endif
     }
 
     std::vector<uint8_t> plaintext(cipher.size());


### PR DESCRIPTION
This is not required to be set to something, but was check to freeze the existing implementation in #6610 when first migrating to AL3.0 and symcrypt. Now with the internal implementation changes this assertion is no longer true, therefore removed.

UPD. 99% sure this's the cause: https://github.com/openssl/openssl/pull/26658. Seems like error path fix, which also took away zeroing the data-written count.