### PR TITLE
5.0.x allow SGX attestation checking on SNP and Virtual

### DIFF
--- a/include/ccf/pal/attestation.h
+++ b/include/ccf/pal/attestation.h
@@ -16,6 +16,9 @@
 
 #if !defined(INSIDE_ENCLAVE) || defined(VIRTUAL_ENCLAVE)
 #  include <sys/ioctl.h>
+#  ifdef SGX_ATTESTATION_VERIFICATION
+#    include <ccf/pal/attestation_sgx.h> 
+#  endif
 #else
 #  include "ccf/pal/attestation_sgx.h"
 #endif
@@ -207,6 +210,116 @@ namespace ccf::pal
     }
   }
 
+#ifdef SGX_ATTESTATION_VERIFICATION 
+  static void verify_sgx_quote(
+    const QuoteInfo& quote_info,
+    PlatformAttestationMeasurement& measurement,
+    PlatformAttestationReportData& report_data)
+  {
+    if (quote_info.format == QuoteFormat::insecure_virtual)
+    {
+      throw std::logic_error(fmt::format(
+        "Cannot verify virtual insecure attestation report on SGX platform"));
+    }
+    else if (quote_info.format == QuoteFormat::amd_sev_snp_v1)
+    {
+      verify_snp_attestation_report(quote_info, measurement, report_data);
+      return;
+    }
+
+    sgx::Claims claims;
+
+    auto rc = oe_verify_evidence(
+      &sgx::oe_quote_format,
+      quote_info.quote.data(),
+      quote_info.quote.size(),
+      quote_info.endorsements.data(),
+      quote_info.endorsements.size(),
+      nullptr,
+      0,
+      &claims.data,
+      &claims.length);
+    if (rc != OE_OK)
+    {
+      throw std::logic_error(fmt::format(
+        "Failed to verify evidence in SGX attestation report: {}",
+        oe_result_str(rc)));
+    }
+
+    std::optional<SgxAttestationMeasurement> claim_measurement = std::nullopt;
+    std::optional<SgxAttestationReportData> custom_claim_report_data =
+      std::nullopt;
+    for (size_t i = 0; i < claims.length; i++)
+    {
+      auto& claim = claims.data[i];
+      auto claim_name = std::string(claim.name);
+      if (claim_name == OE_CLAIM_UNIQUE_ID)
+      {
+        if (claim.value_size != SgxAttestationMeasurement::size())
+        {
+          throw std::logic_error(
+            fmt::format("SGX measurement claim is not of expected size"));
+        }
+
+        claim_measurement =
+          SgxAttestationMeasurement({claim.value, claim.value_size});
+      }
+      else if (claim_name == OE_CLAIM_CUSTOM_CLAIMS_BUFFER)
+      {
+        // Find sgx report data in custom claims
+        sgx::CustomClaims custom_claims;
+        rc = oe_deserialize_custom_claims(
+          claim.value,
+          claim.value_size,
+          &custom_claims.data,
+          &custom_claims.length);
+        if (rc != OE_OK)
+        {
+          throw std::logic_error(fmt::format(
+            "Failed to deserialise custom claims in SGX attestation report",
+            oe_result_str(rc)));
+        }
+
+        for (size_t j = 0; j < custom_claims.length; j++)
+        {
+          auto& custom_claim = custom_claims.data[j];
+          if (std::string(custom_claim.name) == sgx::report_data_claim_name)
+          {
+            if (custom_claim.value_size != SgxAttestationReportData::size())
+            {
+              throw std::logic_error(fmt::format(
+                "Expected claim {} of size {}, had size {}",
+                sgx::report_data_claim_name,
+                SgxAttestationReportData::size(),
+                custom_claim.value_size));
+            }
+
+            custom_claim_report_data = SgxAttestationReportData(
+              {custom_claim.value, custom_claim.value_size});
+
+            break;
+          }
+        }
+      }
+    }
+
+    if (!claim_measurement.has_value())
+    {
+      throw std::logic_error(
+        "Could not find measurement in SGX attestation report");
+    }
+
+    if (!custom_claim_report_data.has_value())
+    {
+      throw std::logic_error(
+        "Could not find report data in SGX attestation report");
+    }
+
+    measurement = claim_measurement.value();
+    report_data = custom_claim_report_data.value();
+  }
+#endif
+
 #if defined(PLATFORM_VIRTUAL)
 
   static void generate_quote(
@@ -276,6 +389,9 @@ namespace ccf::pal
     }
     else
     {
+#if defined(SGX_ATTESTATION_VERIFICATION)
+      verify_sgx_quote(quote_info, measurement, report_data);
+#else
       if (is_sev_snp)
       {
         throw std::logic_error(
@@ -286,6 +402,7 @@ namespace ccf::pal
         throw std::logic_error(
           "Cannot verify SGX attestation report if node is virtual");
       }
+#endif
     }
   }
 

--- a/include/ccf/pal/attestation.h
+++ b/include/ccf/pal/attestation.h
@@ -279,7 +279,7 @@ namespace ccf::pal
 
         for (size_t j = 0; j < custom_claims.length; j++)
         {
-          auto& custom_claim = custom_claims.data[j];
+          const auto& custom_claim = custom_claims.data[j];
           if (std::string(custom_claim.name) == sgx::report_data_claim_name)
           {
             if (custom_claim.value_size != SgxAttestationReportData::size())

--- a/include/ccf/pal/attestation.h
+++ b/include/ccf/pal/attestation.h
@@ -17,7 +17,7 @@
 #if !defined(INSIDE_ENCLAVE) || defined(VIRTUAL_ENCLAVE)
 #  include <sys/ioctl.h>
 #  ifdef SGX_ATTESTATION_VERIFICATION
-#    include <ccf/pal/attestation_sgx.h> 
+#    include <ccf/pal/attestation_sgx.h>
 #  endif
 #else
 #  include "ccf/pal/attestation_sgx.h"
@@ -210,7 +210,8 @@ namespace ccf::pal
     }
   }
 
-#if (defined(INSIDE_ENCLAVE) && !defined(VIRTUAL_ENCLAVE)) || defined(SGX_ATTESTATION_VERIFICATION)
+#if (defined(INSIDE_ENCLAVE) && !defined(VIRTUAL_ENCLAVE)) || \
+  defined(SGX_ATTESTATION_VERIFICATION)
   static void verify_sgx_quote(
     const QuoteInfo& quote_info,
     PlatformAttestationMeasurement& measurement,
@@ -218,7 +219,9 @@ namespace ccf::pal
   {
     if (quote_info.format != QuoteFormat::oe_sgx_v1)
     {
-      throw std::logic_error(fmt::format("Unexpected attestation quote to verify for SGX: {}", quote_info.format));
+      throw std::logic_error(fmt::format(
+        "Unexpected attestation quote to verify for SGX: {}",
+        quote_info.format));
     }
 
     sgx::Claims claims;
@@ -383,9 +386,9 @@ namespace ccf::pal
     }
     else
     {
-#if defined(SGX_ATTESTATION_VERIFICATION)
+#  if defined(SGX_ATTESTATION_VERIFICATION)
       verify_sgx_quote(quote_info, measurement, report_data);
-#else
+#  else
       if (is_sev_snp)
       {
         throw std::logic_error(
@@ -396,7 +399,7 @@ namespace ccf::pal
         throw std::logic_error(
           "Cannot verify SGX attestation report if node is virtual");
       }
-#endif
+#  endif
     }
   }
 

--- a/include/ccf/pal/attestation.h
+++ b/include/ccf/pal/attestation.h
@@ -210,21 +210,15 @@ namespace ccf::pal
     }
   }
 
-#ifdef SGX_ATTESTATION_VERIFICATION 
+#if (defined(INSIDE_ENCLAVE) && !defined(VIRTUAL_ENCLAVE)) || defined(SGX_ATTESTATION_VERIFICATION)
   static void verify_sgx_quote(
     const QuoteInfo& quote_info,
     PlatformAttestationMeasurement& measurement,
     PlatformAttestationReportData& report_data)
   {
-    if (quote_info.format == QuoteFormat::insecure_virtual)
+    if (quote_info.format != QuoteFormat::oe_sgx_v1)
     {
-      throw std::logic_error(fmt::format(
-        "Cannot verify virtual insecure attestation report on SGX platform"));
-    }
-    else if (quote_info.format == QuoteFormat::amd_sev_snp_v1)
-    {
-      verify_snp_attestation_report(quote_info, measurement, report_data);
-      return;
+      throw std::logic_error(fmt::format("Unexpected attestation quote to verify for SGX: {}", quote_info.format));
     }
 
     sgx::Claims claims;
@@ -482,96 +476,7 @@ namespace ccf::pal
       return;
     }
 
-    sgx::Claims claims;
-
-    auto rc = oe_verify_evidence(
-      &sgx::oe_quote_format,
-      quote_info.quote.data(),
-      quote_info.quote.size(),
-      quote_info.endorsements.data(),
-      quote_info.endorsements.size(),
-      nullptr,
-      0,
-      &claims.data,
-      &claims.length);
-    if (rc != OE_OK)
-    {
-      throw std::logic_error(fmt::format(
-        "Failed to verify evidence in SGX attestation report: {}",
-        oe_result_str(rc)));
-    }
-
-    std::optional<SgxAttestationMeasurement> claim_measurement = std::nullopt;
-    std::optional<SgxAttestationReportData> custom_claim_report_data =
-      std::nullopt;
-    for (size_t i = 0; i < claims.length; i++)
-    {
-      auto& claim = claims.data[i];
-      auto claim_name = std::string(claim.name);
-      if (claim_name == OE_CLAIM_UNIQUE_ID)
-      {
-        if (claim.value_size != SgxAttestationMeasurement::size())
-        {
-          throw std::logic_error(
-            fmt::format("SGX measurement claim is not of expected size"));
-        }
-
-        claim_measurement =
-          SgxAttestationMeasurement({claim.value, claim.value_size});
-      }
-      else if (claim_name == OE_CLAIM_CUSTOM_CLAIMS_BUFFER)
-      {
-        // Find sgx report data in custom claims
-        sgx::CustomClaims custom_claims;
-        rc = oe_deserialize_custom_claims(
-          claim.value,
-          claim.value_size,
-          &custom_claims.data,
-          &custom_claims.length);
-        if (rc != OE_OK)
-        {
-          throw std::logic_error(fmt::format(
-            "Failed to deserialise custom claims in SGX attestation report",
-            oe_result_str(rc)));
-        }
-
-        for (size_t j = 0; j < custom_claims.length; j++)
-        {
-          auto& custom_claim = custom_claims.data[j];
-          if (std::string(custom_claim.name) == sgx::report_data_claim_name)
-          {
-            if (custom_claim.value_size != SgxAttestationReportData::size())
-            {
-              throw std::logic_error(fmt::format(
-                "Expected claim {} of size {}, had size {}",
-                sgx::report_data_claim_name,
-                SgxAttestationReportData::size(),
-                custom_claim.value_size));
-            }
-
-            custom_claim_report_data = SgxAttestationReportData(
-              {custom_claim.value, custom_claim.value_size});
-
-            break;
-          }
-        }
-      }
-    }
-
-    if (!claim_measurement.has_value())
-    {
-      throw std::logic_error(
-        "Could not find measurement in SGX attestation report");
-    }
-
-    if (!custom_claim_report_data.has_value())
-    {
-      throw std::logic_error(
-        "Could not find report data in SGX attestation report");
-    }
-
-    measurement = claim_measurement.value();
-    report_data = custom_claim_report_data.value();
+    verify_sgx_quote(quote_info, measurement, report_data);
   }
 
 #endif

--- a/include/ccf/pal/attestation_sgx.h
+++ b/include/ccf/pal/attestation_sgx.h
@@ -2,7 +2,8 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
-#if (defined(INSIDE_ENCLAVE) && !defined(VIRTUAL_ENCLAVE)) || defined(SGX_ATTESTATION_VERIFICATION)
+#if (defined(INSIDE_ENCLAVE) && !defined(VIRTUAL_ENCLAVE)) || \
+  defined(SGX_ATTESTATION_VERIFICATION)
 
 #  include <array>
 #  include <openenclave/attestation/attester.h>

--- a/include/ccf/pal/attestation_sgx.h
+++ b/include/ccf/pal/attestation_sgx.h
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
-#if defined(INSIDE_ENCLAVE) && !defined(VIRTUAL_ENCLAVE)
+#if (defined(INSIDE_ENCLAVE) && !defined(VIRTUAL_ENCLAVE)) || defined(SGX_ATTESTATION_VERIFICATION)
 
 #  include <array>
 #  include <openenclave/attestation/attester.h>

--- a/include/ccf/pal/attestation_sgx.h
+++ b/include/ccf/pal/attestation_sgx.h
@@ -6,10 +6,12 @@
   defined(SGX_ATTESTATION_VERIFICATION)
 
 #  include <array>
-#  include <openenclave/attestation/attester.h>
 #  include <openenclave/attestation/custom_claims.h>
 #  include <openenclave/attestation/sgx/evidence.h>
 #  include <openenclave/attestation/verifier.h>
+#  if defined(INSIDE_ENCLAVE) && !defined(VIRTUAL_ENCLAVE)
+#    include <openenclave/attestation/attester.h>
+#  endif
 
 namespace ccf::pal
 {
@@ -49,6 +51,7 @@ namespace ccf::pal
       }
     };
 
+#  if defined(INSIDE_ENCLAVE) && !defined(VIRTUAL_ENCLAVE)
     struct Evidence
     {
       uint8_t* buffer = NULL;
@@ -70,6 +73,7 @@ namespace ccf::pal
         oe_free_endorsements(buffer);
       }
     };
+#  endif
 
     static constexpr oe_uuid_t oe_quote_format = {OE_FORMAT_UUID_SGX_ECDSA};
     static constexpr auto report_data_claim_name = OE_CLAIM_SGX_REPORT_DATA;


### PR DESCRIPTION
This PR should add support for checking that a SGX attestation report is valid on SNP and Virtual nodes, using the openenclave::hostverify package.

This should allow an SGX node to join a Virtual or SNP cluster.

