### PR TITLE
Add `operator==` to `ccf::ODataError`

### DIFF
--- a/include/ccf/odata_error.h
+++ b/include/ccf/odata_error.h
@@ -38,6 +38,8 @@ namespace ccf
     std::string code;
     std::string message;
     std::vector<nlohmann::json> details = {};
+
+    bool operator==(const ODataError&) const = default;
   };
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(ODataError);


### PR DESCRIPTION
Enables `std::optional` use of `ccf::ODataError` without unnecessary code duplication as in https://github.com/microsoft/scitt-ccf-ledger/blob/2e315354b26bc81cdb29664a7984f9b8071f680e/app/src/odata_error.h#L12