### PR TITLE
Select newest clang be default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
           git config --global --add safe.directory /__w/CCF/CCF
           mkdir build
           cd build
-          CC=`which clang` CXX=`which clang++` cmake -GNinja -DCOMPILE_TARGET=${{ matrix.platform.name }} -DCMAKE_BUILD_TYPE=Debug ..
+          cmake -GNinja -DCOMPILE_TARGET=${{ matrix.platform.name }} -DCMAKE_BUILD_TYPE=Debug ..
           ninja
         shell: bash
 

--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -311,7 +311,7 @@ jobs:
           git config --global --add safe.directory /__w/CCF/CCF
           mkdir build
           cd build
-          CC=`which clang` CXX=`which clang++` cmake -GNinja -DCOMPILE_TARGET=virtual -DCMAKE_BUILD_TYPE=Debug -DLONG_TEST=ON ..
+          cmake -GNinja -DCOMPILE_TARGET=virtual -DCMAKE_BUILD_TYPE=Debug -DLONG_TEST=ON ..
           ninja
         shell: bash
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
           git config --global --add safe.directory /__w/CCF/CCF
           mkdir build
           cd build
-          CC=`which clang` CXX=`which clang++` cmake -GNinja -DCOMPILE_TARGET=${{ matrix.platform.name }} -DCLIENT_PROTOCOLS_TEST=ON -DCMAKE_BUILD_TYPE=Release ..
+          cmake -GNinja -DCOMPILE_TARGET=${{ matrix.platform.name }} -DCLIENT_PROTOCOLS_TEST=ON -DCMAKE_BUILD_TYPE=Release ..
           ninja -v | tee build.log
 
       - name: "Install Extended Testing Tools"

--- a/cmake/preproject.cmake
+++ b/cmake/preproject.cmake
@@ -3,7 +3,7 @@
 
 # Note: this needs to be done before project(), otherwise CMAKE_*_COMPILER is
 # already set by CMake. If the user has not expressed any choice, we attempt to
-# default to Clang >= 11. If they have expressed even a partial choice, the
+# set a default Clang choice. If they have expressed even a partial choice, the
 # usual CMake selection logic applies. If we cannot find both a suitable clang
 # and a suitable clang++, the usual CMake selection logic applies
 if((NOT CMAKE_C_COMPILER)
@@ -11,12 +11,12 @@ if((NOT CMAKE_C_COMPILER)
    AND "$ENV{CC}" STREQUAL ""
    AND "$ENV{CXX}" STREQUAL ""
 )
-  find_program(FOUND_CMAKE_C_COMPILER NAMES clang-15)
-  find_program(FOUND_CMAKE_CXX_COMPILER NAMES clang++-15)
+  find_program(FOUND_CMAKE_C_COMPILER NAMES clang)
+  find_program(FOUND_CMAKE_CXX_COMPILER NAMES clang++)
   if(NOT (FOUND_CMAKE_C_COMPILER AND FOUND_CMAKE_CXX_COMPILER))
     message(
       WARNING
-        "Clang 11 or Clang 15 not found, will use default compiler. "
+        "Clang not found, will use default compiler. "
         "Override the compiler by setting CC and CXX environment variables."
     )
   else()
@@ -24,15 +24,6 @@ if((NOT CMAKE_C_COMPILER)
     # both, or none at all.
     set(CMAKE_C_COMPILER "${FOUND_CMAKE_C_COMPILER}")
     set(CMAKE_CXX_COMPILER "${FOUND_CMAKE_CXX_COMPILER}")
-  endif()
-endif()
-
-if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-  if(CMAKE_C_COMPILER_VERSION VERSION_LESS 11)
-    message(WARNING "CCF officially supports Clang >= 11 only, "
-                    "but your Clang version (${CMAKE_C_COMPILER_VERSION}) "
-                    "is older than that. Build problems may occur."
-    )
   endif()
 endif()
 

--- a/cmake/preproject.cmake
+++ b/cmake/preproject.cmake
@@ -13,6 +13,14 @@ if((NOT CMAKE_C_COMPILER)
 )
   find_program(FOUND_CMAKE_C_COMPILER NAMES clang)
   find_program(FOUND_CMAKE_CXX_COMPILER NAMES clang++)
+
+  # vvvvv Ubuntu-20.04, to be removed after support dropped. vvvvv #
+  if(NOT (FOUND_CMAKE_C_COMPILER AND FOUND_CMAKE_CXX_COMPILER))
+    find_program(FOUND_CMAKE_C_COMPILER NAMES clang-15)
+    find_program(FOUND_CMAKE_CXX_COMPILER NAMES clang++-15)
+  endif()
+  # ^^^^^ Ubuntu-20.04, to be removed after support dropped. ^^^^^ #
+
   if(NOT (FOUND_CMAKE_C_COMPILER AND FOUND_CMAKE_CXX_COMPILER))
     message(
       WARNING


### PR DESCRIPTION
Removing back-and-forth clang version shuffling in CMake, doesn't seem relevant anymore, hence no need to specify CC= CXX= on Azure Linux, for instance.