### PR TITLE
[release/5.x] Cherry pick: Support v3 SNP attestations (#6841)

### DIFF
--- a/include/ccf/pal/attestation.h
+++ b/include/ccf/pal/attestation.h
@@ -57,12 +57,12 @@ namespace ccf::pal
     auto quote =
       *reinterpret_cast<const snp::Attestation*>(quote_info.quote.data());
 
-    if (quote.version != snp::attestation_version)
+    if (quote.version < snp::minimum_attestation_version)
     {
       throw std::logic_error(fmt::format(
-        "SEV-SNP: Attestation version is {} not expected {}",
+        "SEV-SNP: Attestation version is {} not >= expected minimum {}",
         quote.version,
-        snp::attestation_version));
+        snp::minimum_attestation_version));
     }
 
     if (quote.flags.signing_key != snp::attestation_flags_signing_key_vcek)

--- a/include/ccf/pal/attestation_sev_snp.h
+++ b/include/ccf/pal/attestation_sev_snp.h
@@ -116,7 +116,7 @@ QPHfbkH0CyPfhl1jWhJFZasCAwEAAQ==
 #pragma pack(push, 1)
   // Table 21
 
-  static constexpr uint32_t attestation_version = 2;
+  static constexpr uint32_t minimum_attestation_version = 2;
   static constexpr uint32_t attestation_policy_abi_major = 1;
 
   struct Attestation


### PR DESCRIPTION
Backports the following commits to `release/5.x`:
 - [Support v3 SNP attestations (#6841)](https://github.com/microsoft/CCF/pull/6841)