### PR TITLE
[release/5.x] Cherry pick: Fix pctx leak with RAII wrapper (#6845)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ###
 
+- Memory leak during EC key creation is fixed (#6845).
 - Fixed thread-safety issues when CCF nodes attempted to contact non-TLS servers. This previously could cause errors when running SNP builds with multiple worker threads (#6836).
-- Add config option in start-network.py choose redirection kind (#6732, #6755)
+- Add config option in start-network.py to choose redirection kind (#6732, #6755)
 
 ## [5.0.12]
 

--- a/src/crypto/openssl/public_key.cpp
+++ b/src/crypto/openssl/public_key.cpp
@@ -296,7 +296,7 @@ namespace ccf::crypto
       OSSL_PKEY_PARAM_PUB_KEY, (void*)raw.data(), raw.size());
     params[2] = OSSL_PARAM_construct_end();
 
-    auto pctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
+    Unique_EVP_PKEY_CTX pctx("EC");
     CHECK1(EVP_PKEY_fromdata_init(pctx));
 
     EVP_PKEY* pkey = NULL;


### PR DESCRIPTION
Backports the following commits to `release/5.x`:
 - [Fix pctx leak with RAII wrapper (#6845)](https://github.com/microsoft/CCF/pull/6845)