### PR TITLE
Minor clarity improvement to KV max entry size header value

### DIFF
--- a/src/kv/serialised_entry_format.h
+++ b/src/kv/serialised_entry_format.h
@@ -17,20 +17,19 @@ namespace ccf::kv
     FORCE_LEDGER_CHUNK_BEFORE = 0x02
   };
 
-  // 6 bytes are used for the size of the serialised entry
-  static const size_t max_entry_size = 1UL << 48;
-
   struct SerialisedEntryHeader
   {
     uint8_t version = entry_format_v1;
     SerialisedEntryFlags flags = 0;
 
-    uint64_t size
-      : (sizeof(uint64_t) - sizeof(uint8_t) - sizeof(SerialisedEntryFlags)) *
-        CHAR_BIT;
+    static constexpr auto BITS_FOR_SIZE =
+      (sizeof(uint64_t) - sizeof(uint8_t) - sizeof(SerialisedEntryFlags)) *
+      CHAR_BIT;
+    uint64_t size : BITS_FOR_SIZE;
 
     void set_size(uint64_t size_)
     {
+      static constexpr size_t max_entry_size = 1UL << BITS_FOR_SIZE;
       CCF_ASSERT_FMT(
         size_ < max_entry_size,
         "Cannot serialise entry of size {} (max allowed size is {})",


### PR DESCRIPTION
While exploring primary-led chunking, I've stared at a lot of adjacent serialisation/flags code.

This is a very minor tweak - rather than declaring a "6 bytes are used" comment above, we reuse the calculated value in both places. We want `SerialisedEntryHeader` to fit in a `uint64_t`, 2 fields are already taking up space, so the maximum value for `size` is constrained to the remaining bits.