### PR TITLE
[release/5.x] Cherry pick: Correct node membership condition (#6849)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.0.14]
+
+[5.0.14]: https://github.com/microsoft/CCF/releases/tag/5.0.14
+
+### Fixed
+
+- `ccf.ledger`/`read_ledger.py` previously enforced too strict a condition on node membership when validating ledger files (#6849).
+
 ## [5.0.13]
 
 [5.0.13]: https://github.com/microsoft/CCF/releases/tag/5.0.13

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -527,14 +527,17 @@ class LedgerValidator:
     @staticmethod
     def _verify_node_status(tx_info: TxBundleInfo):
         """Verify item 1, The merkle root is signed by a valid node in the given network"""
-        # Note: A retired primary will still issue signature transactions until
-        # its retirement is committed
+        if tx_info.signing_node not in tx_info.node_activity:
+            raise UntrustedNodeException(
+                f"The signing node {tx_info.signing_node} is not part of the network"
+            )
         node_info = tx_info.node_activity[tx_info.signing_node]
         node_status = NodeStatus(node_info[0])
-        if node_status not in (
-            NodeStatus.TRUSTED,
-            NodeStatus.RETIRED,
-        ) or (node_status == NodeStatus.RETIRED and node_info[2]):
+        # Note: Even nodes that are Retired, and for which retired_committed is True
+        # may be issuing signatures, to ensure the liveness of a reconfiguring
+        # network. They will stop doing so once the transaction that sets retired_committed is itself committed,
+        # but that is unfortunately not observable from the ledger alone.
+        if node_status == NodeStatus.PENDING:
             raise UntrustedNodeException(
                 f"The signing node {tx_info.signing_node} has unexpected status {node_status.value}"
             )


### PR DESCRIPTION
Backports the following commits to `release/5.x`:
 - [Correct node membership condition (#6849)](https://github.com/microsoft/CCF/pull/6849)