### PR TITLE
Remove JWT key filter from docs

### DIFF
--- a/doc/audit/builtin_maps.rst
+++ b/doc/audit/builtin_maps.rst
@@ -376,9 +376,6 @@ JWT issuers.
    :project: CCF
    :members:
 
-.. doxygenenum:: ccf::JwtIssuerKeyFilter
-   :project: CCF
-
 ``jwt.public_signing_keys``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/build_apps/auth/jwt.rst
+++ b/doc/build_apps/auth/jwt.rst
@@ -21,7 +21,6 @@ Before adding public token signing keys to a running CCF network, the IdP has to
           "name": "set_jwt_issuer",
           "args": {
             "issuer": "my_issuer",
-            "key_filter": "all",
             "auto_refresh": false
           }
         }
@@ -95,7 +94,6 @@ Now the issuer can be created with auto-refresh enabled:
           "name": "set_jwt_issuer",
           "args": {
             "issuer": "https://login.microsoftonline.com/common/v2.0",
-            "key_filter": "all",
             "ca_cert_bundle_name": "jwt_ms",
             "auto_refresh": true
           }

--- a/doc/schemas/gov/2023-06-01-preview/examples/ServiceState_GetJwkInfo.json
+++ b/doc/schemas/gov/2023-06-01-preview/examples/ServiceState_GetJwkInfo.json
@@ -9,7 +9,6 @@
       "body": {
         "issuers": {
           "idprovider.myservice.example.com": {
-            "keyFilter": "All",
             "autoRefresh": true,
             "caCertBundleName": "MyIdProviderCa"
           }

--- a/doc/schemas/gov/2024-07-01/examples/ServiceState_GetJwkInfo.json
+++ b/doc/schemas/gov/2024-07-01/examples/ServiceState_GetJwkInfo.json
@@ -9,7 +9,6 @@
       "body": {
         "issuers": {
           "idprovider.myservice.example.com": {
-            "keyFilter": "All",
             "autoRefresh": true,
             "caCertBundleName": "MyIdProviderCa"
           }

--- a/doc/schemas/gov/2024-07-01/gov.json
+++ b/doc/schemas/gov/2024-07-01/gov.json
@@ -1914,10 +1914,6 @@
       "type": "object",
       "description": "Description of a JWT issuer or identity provider that the current service will trust tokens from.",
       "properties": {
-        "keyFilter": {
-          "$ref": "#/definitions/ServiceState.JwtIssuerKeyFilter",
-          "description": "Adds restrictions on whether keys should be accepted from this issuer."
-        },
         "keyPolicy": {
           "type": "object",
           "description": "Collection of claims which must be present in SGX attestation to permit updates from this issuer.",
@@ -1935,33 +1931,8 @@
         }
       },
       "required": [
-        "keyFilter",
         "autoRefresh"
       ]
-    },
-    "ServiceState.JwtIssuerKeyFilter": {
-      "type": "string",
-      "description": "Possible restrictions on what keys will be accepted from a JWT issuer.",
-      "enum": [
-        "All",
-        "Sgx"
-      ],
-      "x-ms-enum": {
-        "name": "JwtIssuerKeyFilter",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "All",
-            "value": "All",
-            "description": "Accepts any JWT issuer."
-          },
-          {
-            "name": "Sgx",
-            "value": "Sgx",
-            "description": "Only accepts JWTs issued by a token provider running in SGX, which provides a suitable attestation and additional claims."
-          }
-        ]
-      }
     },
     "ServiceState.Member": {
       "type": "object",

--- a/doc/schemas/gov_openapi.json
+++ b/doc/schemas/gov_openapi.json
@@ -271,12 +271,6 @@
         },
         "type": "object"
       },
-      "JwtIssuerKeyFilter": {
-        "enum": [
-          "all"
-        ],
-        "type": "string"
-      },
       "JwtIssuerMetadata": {
         "properties": {
           "auto_refresh": {
@@ -284,9 +278,6 @@
           },
           "ca_cert_bundle_name": {
             "$ref": "#/components/schemas/string"
-          },
-          "key_filter": {
-            "$ref": "#/components/schemas/JwtIssuerKeyFilter"
           }
         },
         "type": "object"
@@ -1348,7 +1339,7 @@
   "info": {
     "description": "This API is used to submit and query proposals which affect CCF's public governance tables.",
     "title": "CCF Governance API",
-    "version": "4.6.0"
+    "version": "4.6.1"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/include/ccf/service/tables/jwt.h
+++ b/include/ccf/service/tables/jwt.h
@@ -21,8 +21,6 @@ namespace ccf
 
   struct JwtIssuerMetadata
   {
-    /// JWT issuer key filter, kept for compatibility with existing ledgers
-    JwtIssuerKeyFilter key_filter = JwtIssuerKeyFilter::All;
     /// Optional CA bundle name used for authentication when auto-refreshing
     std::optional<std::string> ca_cert_bundle_name;
     /// Whether to auto-refresh keys from the issuer
@@ -32,7 +30,7 @@ namespace ccf
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(JwtIssuerMetadata);
   DECLARE_JSON_REQUIRED_FIELDS(JwtIssuerMetadata);
   DECLARE_JSON_OPTIONAL_FIELDS(
-    JwtIssuerMetadata, key_filter, ca_cert_bundle_name, auto_refresh);
+    JwtIssuerMetadata, ca_cert_bundle_name, auto_refresh);
 
   using JwtIssuer = std::string;
   using JwtKeyId = std::string;

--- a/src/node/rpc/member_frontend.h
+++ b/src/node/rpc/member_frontend.h
@@ -610,7 +610,7 @@ namespace ccf
       openapi_info.description =
         "This API is used to submit and query proposals which affect CCF's "
         "public governance tables.";
-      openapi_info.document_version = "4.6.0";
+      openapi_info.document_version = "4.6.1";
     }
 
     static std::optional<MemberId> get_caller_member_id(

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -644,6 +644,9 @@ class Consortium:
     def set_jwt_issuer(self, remote_node, json_path):
         obj = slurp_json(json_path)
         args = {
+            # Key filter is no longer used, but kept for compatibility with
+            # lts_compatibility tests.
+            "key_filter": "all",
             "issuer": obj["issuer"],
             "ca_cert_bundle_name": obj.get("ca_cert_bundle_name"),
             "auto_refresh": obj.get("auto_refresh", False),

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -644,9 +644,6 @@ class Consortium:
     def set_jwt_issuer(self, remote_node, json_path):
         obj = slurp_json(json_path)
         args = {
-            # Key filter is no longer used, but kept for compatibility with
-            # lts_compatibility tests.
-            "key_filter": "all",
             "issuer": obj["issuer"],
             "ca_cert_bundle_name": obj.get("ca_cert_bundle_name"),
             "auto_refresh": obj.get("auto_refresh", False),


### PR DESCRIPTION
Purge remaining references to (deprecated, long-unused) JWT key filter. This includes removing the vestigial field from some structs and related serialisers, which technically means that if nodes after this change try to interop with very old nodes, they might cause KV serialisation errors. That's unsupported, the `lts_compatibility` test covers exactly which versions are interoperable, and the only thing we need to maintain for _that_ is the field in `set_jwt_issuer` (for when this Python infra is speaking to a constitution which still requires the field).

Resolves #6589.