### PR TITLE
Ignore empty header line in libcurl callback

### DIFF
--- a/src/snapshots/fetch.h
+++ b/src/snapshots/fetch.h
@@ -64,8 +64,8 @@ namespace snapshots
     const std::string_view header =
       ccf::nonstd::trim(std::string_view(buffer, nitems));
 
-    // Ignore HTTP status line
-    if (!header.starts_with("HTTP/1.1"))
+    // Ignore HTTP status line, and empty line
+    if (!header.empty() && !header.starts_with("HTTP/1.1"))
     {
       const auto [field, value] = ccf::nonstd::split_1(header, ": ");
       if (!value.empty())


### PR DESCRIPTION
Just noticed we have a bunch of spam like this at node startup:

```
[info ] ../src/snapshots/fetch.h:77          | Ignoring invalid-looking HTTP Header ''
[info ] ../src/snapshots/fetch.h:77          | Ignoring invalid-looking HTTP Header ''
[info ] ../src/snapshots/fetch.h:77          | Ignoring invalid-looking HTTP Header ''
```

Looks like the curl callback that gives us headers also gives us the empty newline that terminates headers. This doesn't seem ideal, but whatever - we should ignore it.