### PR TITLE
Fix doc build on main

### DIFF
--- a/src/host/enclave.h
+++ b/src/host/enclave.h
@@ -75,6 +75,7 @@ namespace host
      * Create an uninitialized enclave hosting the given library.
      *
      * @param path Path to signed enclave library file
+     * @param type Type of enclave to load
      * @param platform Trusted Execution Platform of enclave, influencing what
      * flags should be passed to OE, or whether to dlload a virtual enclave
      */


### PR DESCRIPTION
Did too much in #6865, the `type` param is technically not necessary but passed as discussed in https://github.com/microsoft/CCF/pull/6865#discussion_r1975153697