### PR TITLE
Thread safety: Remove race in RingbufferLogger

### DIFF
--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -317,8 +317,7 @@ extern "C"
       }
 
       while (num_pending_threads != 0)
-      {
-      }
+      {}
 
       LOG_INFO_FMT("All threads are ready!");
 
@@ -327,8 +326,7 @@ extern "C"
         auto s = e.load()->run_main();
         while (num_complete_threads !=
                threading::ThreadMessaging::instance().thread_count() - 1)
-        {
-        }
+        {}
         threading::ThreadMessaging::shutdown();
         return s;
       }

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -117,8 +117,7 @@ extern "C"
 
     // Note: because logger uses ringbuffer, logger can only be initialised once
     // ringbuffer memory has been verified
-    auto new_logger = std::make_unique<ccf::RingbufferLogger>(
-      writer_factory->create_writer_to_outside());
+    auto new_logger = std::make_unique<ccf::RingbufferLogger>(*writer_factory);
     auto ringbuffer_logger = new_logger.get();
     ccf::logger::config::loggers().push_back(std::move(new_logger));
 
@@ -318,7 +317,8 @@ extern "C"
       }
 
       while (num_pending_threads != 0)
-      {}
+      {
+      }
 
       LOG_INFO_FMT("All threads are ready!");
 
@@ -327,7 +327,8 @@ extern "C"
         auto s = e.load()->run_main();
         while (num_complete_threads !=
                threading::ThreadMessaging::instance().thread_count() - 1)
-        {}
+        {
+        }
         threading::ThreadMessaging::shutdown();
         return s;
       }


### PR DESCRIPTION
Writers should not be shared between threads, so make RingbufferLogger use a `thread_local` Writer.

I don't have the stack, but this was also found by TSAN in #6616.