### PR TITLE
Prevent racey access to indexer state

### DIFF
--- a/include/ccf/indexing/indexer_interface.h
+++ b/include/ccf/indexing/indexer_interface.h
@@ -4,6 +4,7 @@
 
 #include "ccf/indexing/strategy.h"
 #include "ccf/node_subsystem_interface.h"
+#include "ccf/pal/locking.h"
 
 #include <map>
 #include <memory>
@@ -19,6 +20,7 @@ namespace ccf::indexing
   class IndexingStrategies : public ccf::AbstractNodeSubSystem
   {
   protected:
+    ccf::pal::Mutex lock;
     std::set<StrategyPtr> strategies;
 
   public:
@@ -36,11 +38,13 @@ namespace ccf::indexing
         throw std::logic_error("Tried to install null strategy");
       }
 
+      std::lock_guard<ccf::pal::Mutex> guard(lock);
       return strategies.insert(strategy).second;
     }
 
     void uninstall_strategy(const StrategyPtr& strategy)
     {
+      std::lock_guard<ccf::pal::Mutex> guard(lock);
       if (strategy == nullptr || strategies.find(strategy) == strategies.end())
       {
         throw std::logic_error("Strategy doesn't exist");
@@ -51,6 +55,7 @@ namespace ccf::indexing
 
     nlohmann::json describe() const
     {
+      std::lock_guard<ccf::pal::Mutex> guard(lock);
       auto j = nlohmann::json::array();
 
       for (const auto& strategy : strategies)

--- a/include/ccf/indexing/indexer_interface.h
+++ b/include/ccf/indexing/indexer_interface.h
@@ -53,7 +53,7 @@ namespace ccf::indexing
       strategies.erase(strategy);
     }
 
-    nlohmann::json describe() const
+    nlohmann::json describe()
     {
       std::lock_guard<ccf::pal::Mutex> guard(lock);
       auto j = nlohmann::json::array();

--- a/src/indexing/indexer.h
+++ b/src/indexing/indexer.h
@@ -68,6 +68,9 @@ namespace ccf::indexing
       update_commit(newly_committed);
 
       std::optional<ccf::SeqNo> min_requested = std::nullopt;
+
+      std::lock_guard<ccf::pal::Mutex> guard(lock);
+
       for (auto& strategy : strategies)
       {
         strategy->tick();


### PR DESCRIPTION
Another fix pulled out from #6616.