### PR TITLE
[release/5.x] Cherry pick: Removed default value for the redirection-kind param (#6872)

### DIFF
--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -233,7 +233,6 @@ if __name__ == "__main__":
         )
         parser.add_argument(
             "--redirection-kind",
-            default="node-by-role",
             choices=["node-by-role", "static-address"],
             help="The redirection kind to use in lieu of forwarding. Either node-by-role or static-address",
         )


### PR DESCRIPTION
Backports the following commits to `release/5.x`:
 - [Removed default value for the redirection-kind param (#6872)](https://github.com/microsoft/CCF/pull/6872)