### PR TITLE
Update `check-format.sh` to prefer `clang-format-18`

### DIFF
--- a/scripts/check-format.sh
+++ b/scripts/check-format.sh
@@ -29,9 +29,11 @@ else
 fi
 
 CLANG_FORMAT=clang-format
-if [ -x "$(command -v clang-format-11)" ]; then
-    CLANG_FORMAT=clang-format-11
+if [ -x "$(command -v clang-format-18)" ]; then
+    CLANG_FORMAT=clang-format-18
 fi
+
+echo "Using $(${CLANG_FORMAT} --version)"
 
 file_name_regex="^[[:lower:]0-9_]+$"
 unformatted_files=""


### PR DESCRIPTION
Since #6815, we format our C++ files with `clang-format-18` (on Azure Linux) rather than `clang-format-11` (on Ubuntu).

This updates the script to ensure we use `18` if it's available. I discovered that `clang-format-18` _is_ available on Ubuntu, but a slightly different version that seems to produce different results, so dev on Ubuntu is still deprecated.