### PR TITLE
Remove direct usage of log in public headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
-- Internal logging macros (`LOG_INFO_FMT`, `LOG_DEBUG_FMT` etc) deprecated in 3.0 (#4024), have been removed and can no longer be used by application code. Replace with the `CCF_APP_*` equivalent.
+- Internal logging macros (`LOG_INFO_FMT`, `LOG_DEBUG_FMT` etc) deprecated in 3.0 (#4024), have been removed and can no longer be used by application code. Replace with the `CCF_APP_*` equivalent (#6908).
 
 ## [6.0.0-rc1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.0.0-rc2]
+
+[6.0.0-rc2]: https://github.com/microsoft/CCF/releases/tag/6.0.0-rc2
+
+### Removed
+
+- Internal logging macros (`LOG_INFO_FMT`, `LOG_DEBUG_FMT` etc) deprecated in 3.0 (#4024), have been removed and can no longer be used by application code. Replace with the `CCF_APP_*` equivalent.
+
 ## [6.0.0-rc1]
 
 [6.0.0-rc1]: https://github.com/microsoft/CCF/releases/tag/6.0.0-rc1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,7 @@ if(COMPILE_TARGET STREQUAL "snp")
   add_host_library(ccf_js.snp "${CCF_JS_SOURCES}")
   add_san(ccf_js.snp)
   target_link_libraries(ccf_js.snp PUBLIC ccfcrypto.snp quickjs.snp)
-  target_compile_definitions(ccf_js.host PRIVATE CCF_LOGGER_NO_DEPRECATE)
+  target_compile_definitions(ccf_js.snp PRIVATE CCF_LOGGER_NO_DEPRECATE)
   add_warning_checks(ccf_js.snp)
   install(
     TARGETS ccf_js.snp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,7 @@ target_link_libraries(
           curl
           http_parser.host
 )
+target_compile_definitions(cchost PRIVATE CCF_LOGGER_NO_DEPRECATE)
 
 install(TARGETS cchost DESTINATION bin)
 
@@ -315,6 +316,7 @@ if(COMPILE_TARGET STREQUAL "snp")
   add_host_library(ccf_js.snp "${CCF_JS_SOURCES}")
   add_san(ccf_js.snp)
   target_link_libraries(ccf_js.snp PUBLIC ccfcrypto.snp quickjs.snp)
+  target_compile_definitions(ccf_js.host PRIVATE CCF_LOGGER_NO_DEPRECATE)
   add_warning_checks(ccf_js.snp)
   install(
     TARGETS ccf_js.snp
@@ -326,6 +328,7 @@ endif()
 add_host_library(ccf_js.host "${CCF_JS_SOURCES}")
 add_san(ccf_js.host)
 target_link_libraries(ccf_js.host PUBLIC ccfcrypto.host quickjs.host)
+target_compile_definitions(ccf_js.host PRIVATE CCF_LOGGER_NO_DEPRECATE)
 add_warning_checks(ccf_js.host)
 if(INSTALL_VIRTUAL_LIBRARIES)
   install(
@@ -345,6 +348,7 @@ if(COMPILE_TARGET STREQUAL "snp")
   add_host_library(ccf_kv.snp "${CCF_KV_SOURCES}")
   add_san(ccf_kv.snp)
   add_warning_checks(ccf_kv.snp)
+  target_compile_definitions(ccf_kv.snp PRIVATE CCF_LOGGER_NO_DEPRECATE)
   install(
     TARGETS ccf_kv.snp
     EXPORT ccf
@@ -355,6 +359,7 @@ endif()
 add_host_library(ccf_kv.host "${CCF_KV_SOURCES}")
 add_san(ccf_kv.host)
 add_warning_checks(ccf_kv.host)
+target_compile_definitions(ccf_kv.host PRIVATE CCF_LOGGER_NO_DEPRECATE)
 if(INSTALL_VIRTUAL_LIBRARIES)
   install(
     TARGETS ccf_kv.host
@@ -373,6 +378,7 @@ if(COMPILE_TARGET STREQUAL "snp")
   )
   add_san(ccf_endpoints.snp)
   add_warning_checks(ccf_endpoints.snp)
+  target_compile_definitions(ccf_endpoints.snp PRIVATE CCF_LOGGER_NO_DEPRECATE)
   install(
     TARGETS ccf_endpoints.snp
     EXPORT ccf
@@ -388,7 +394,7 @@ target_link_libraries(
 )
 add_san(ccf_endpoints.host)
 add_warning_checks(ccf_endpoints.host)
-
+target_compile_definitions(ccf_endpoints.host PRIVATE CCF_LOGGER_NO_DEPRECATE)
 if(INSTALL_VIRTUAL_LIBRARIES)
   install(
     TARGETS ccf_endpoints.host
@@ -483,10 +489,6 @@ option(BUILD_UNIT_TESTS "Build unit tests" ON)
 option(CLIENT_PROTOCOLS_TEST "Test client protocols (TLS, HTTP/2)" OFF)
 option(BUILD_TPCC "Build TPPC sample app and clients" OFF)
 
-# Allow framework code to use LOG_*_FMT macros. These will be removed from
-# public headers in future
-add_compile_definitions(CCF_LOGGER_NO_DEPRECATE)
-
 option(CCF_RAFT_TRACING "Enable tracing of Raft consensus" OFF)
 if(CCF_RAFT_TRACING)
   add_compile_definitions(CCF_RAFT_TRACING)
@@ -513,6 +515,7 @@ if(COMPILE_TARGET STREQUAL "snp")
 
   target_compile_options(ccf.snp PUBLIC ${COMPILE_LIBCXX})
   add_warning_checks(ccf.snp)
+  target_compile_definitions(ccf.snp PRIVATE CCF_LOGGER_NO_DEPRECATE)
 
   target_include_directories(
     ccf.snp SYSTEM
@@ -562,6 +565,7 @@ elseif(COMPILE_TARGET STREQUAL "virtual")
 
   target_compile_options(ccf.virtual PUBLIC ${COMPILE_LIBCXX})
   add_warning_checks(ccf.virtual)
+  target_compile_definitions(ccf.virtual PRIVATE CCF_LOGGER_NO_DEPRECATE)
 
   target_include_directories(
     ccf.virtual SYSTEM
@@ -920,6 +924,7 @@ if(BUILD_TESTS)
       merkle_mem PRIVATE ${CMAKE_THREAD_LIBS_INIT} ${LINK_LIBCXX}
                          ccfcrypto.host
     )
+    target_compile_definitions(merkle_mem PRIVATE CCF_LOGGER_NO_DEPRECATE)
 
     # Raft driver and scenario test
     add_executable(
@@ -928,6 +933,7 @@ if(BUILD_TESTS)
     )
     target_link_libraries(raft_driver PRIVATE ccfcrypto.host)
     target_include_directories(raft_driver PRIVATE src/aft)
+    target_compile_definitions(raft_driver PRIVATE CCF_LOGGER_NO_DEPRECATE)
 
     add_test(
       NAME raft_scenario_test

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -26,6 +26,7 @@ function(add_unit_test name)
              "TSAN_OPTIONS=suppressions=${CCF_DIR}/tsan_env_suppressions"
   )
 
+  target_compile_definitions(${name} PRIVATE CCF_LOGGER_NO_DEPRECATE)
 endfunction()
 
 # Test binary wrapper
@@ -357,4 +358,5 @@ function(add_picobench name)
     PROPERTY ENVIRONMENT
              "TSAN_OPTIONS=suppressions=${CCF_DIR}/tsan_env_suppressions"
   )
+  target_compile_definitions(${name} PRIVATE CCF_LOGGER_NO_DEPRECATE)
 endfunction()

--- a/cmake/crypto.cmake
+++ b/cmake/crypto.cmake
@@ -40,6 +40,7 @@ if(COMPILE_TARGET STREQUAL "snp")
   target_link_libraries(ccfcrypto.snp PUBLIC crypto)
   target_link_libraries(ccfcrypto.snp PUBLIC ssl)
   set_property(TARGET ccfcrypto.snp PROPERTY POSITION_INDEPENDENT_CODE ON)
+  target_compile_definitions(ccfcrypto.snp PRIVATE CCF_LOGGER_NO_DEPRECATE)
 
   install(
     TARGETS ccfcrypto.snp
@@ -61,6 +62,7 @@ target_link_libraries(ccfcrypto.host PUBLIC t_cose.host)
 target_link_libraries(ccfcrypto.host PUBLIC crypto)
 target_link_libraries(ccfcrypto.host PUBLIC ssl)
 set_property(TARGET ccfcrypto.host PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_compile_definitions(ccfcrypto.host PRIVATE CCF_LOGGER_NO_DEPRECATE)
 
 if(INSTALL_VIRTUAL_LIBRARIES)
   install(

--- a/include/ccf/ds/ccf_exception.h
+++ b/include/ccf/ds/ccf_exception.h
@@ -40,3 +40,12 @@ namespace ccf
     {}
   };
 };
+
+// Convenient wrapper to report exception errors. Exception message is only
+// displayed in debug mode
+#define LOG_FAIL_EXC(msg) \
+  do \
+  { \
+    LOG_FAIL_FMT("Exception in {}", __PRETTY_FUNCTION__); \
+    LOG_DEBUG_FMT("Error: {}", msg); \
+  } while (0)

--- a/include/ccf/ds/ccf_exception.h
+++ b/include/ccf/ds/ccf_exception.h
@@ -40,12 +40,3 @@ namespace ccf
     {}
   };
 };
-
-// Convenient wrapper to report exception errors. Exception message is only
-// displayed in debug mode
-#define LOG_FAIL_EXC(msg) \
-  do \
-  { \
-    LOG_FAIL_FMT("Exception in {}", __PRETTY_FUNCTION__); \
-    LOG_DEBUG_FMT("Error: {}", msg); \
-  } while (0)

--- a/include/ccf/pal/snp_ioctl6.h
+++ b/include/ccf/pal/snp_ioctl6.h
@@ -186,13 +186,13 @@ namespace ccf::pal::snp::ioctl6
       int rc = ioctl(fd, SEV_SNP_GUEST_MSG_REPORT, &payload);
       if (rc < 0)
       {
-        LOG_FAIL_FMT("IOCTL call failed: {}", strerror(errno));
-        LOG_FAIL_FMT(
-          "Exit info, fw_error: {} vmm_error: {}",
+        const auto msg = fmt::format(
+          "Failed to issue ioctl SEV_SNP_GUEST_MSG_REPORT: {} fw_error: {} "
+          "vmm_error: {}",
+          strerror(errno),
           payload.exit_info.errors.fw,
           payload.exit_info.errors.vmm);
-        throw std::logic_error(
-          "Failed to issue ioctl SEV_SNP_GUEST_MSG_REPORT");
+        throw std::logic_error(msg);
       }
 
       if (!safety_padding_intact(padded_resp))
@@ -239,13 +239,13 @@ namespace ccf::pal::snp::ioctl6
       int rc = ioctl(fd, SEV_SNP_GUEST_MSG_DERIVED_KEY, &payload);
       if (rc < 0)
       {
-        LOG_FAIL_FMT("IOCTL call failed: {}", strerror(errno));
-        LOG_FAIL_FMT(
-          "Exit info, fw_error: {} vmm_error: {}",
+        const auto msg = fmt::format(
+          "Failed to issue ioctl SEV_SNP_GUEST_MSG_DERIVED_KEY: {} fw_error: "
+          "{} vmm_error: {}",
+          strerror(errno),
           payload.exit_info.errors.fw,
           payload.exit_info.errors.vmm);
-        throw std::logic_error(
-          "Failed to issue ioctl SEV_SNP_GUEST_MSG_DERIVED_KEY");
+        throw std::logic_error(msg);
       }
 
       if (!safety_padding_intact(padded_resp))
@@ -258,10 +258,10 @@ namespace ccf::pal::snp::ioctl6
 
       if (padded_resp.data.status != 0)
       {
-        LOG_FAIL_FMT(
-          "SNP_GUEST_DERIVED_KEY failed: {}", padded_resp.data.status);
-        throw std::logic_error(
-          "Failed to issue ioctl SEV_SNP_GUEST_MSG_DERIVED_KEY");
+        const auto msg = fmt::format(
+          "Failed to issue ioctl SEV_SNP_GUEST_MSG_DERIVED_KEY: {}",
+          padded_resp.data.status);
+        throw std::logic_error(msg);
       }
     }
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ccf"
-version = "6.0.0-rc1"
+version = "6.0.0-rc2"
 authors = [
   { name="CCF Team", email="CCF-Sec@microsoft.com" },
 ]

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,6 +1,3 @@
-# Ensure sample apps are built as external apps, with old logging macros unavailable
-remove_definitions(-DCCF_LOGGER_NO_DEPRECATE)
-
 # Add Logging app
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/apps/logging)
 

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -815,7 +815,8 @@ namespace aft
       }
       catch (const std::exception& e)
       {
-        LOG_FAIL_EXC(e.what());
+        LOG_FAIL_FMT("Exception in {}", __PRETTY_FUNCTION__);
+        LOG_DEBUG_FMT("Error: {}", e.what());
         return;
       }
     }

--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -815,8 +815,7 @@ namespace aft
       }
       catch (const std::exception& e)
       {
-        LOG_FAIL_FMT("Exception in {}", __PRETTY_FUNCTION__);
-        LOG_DEBUG_FMT("Error: {}", e.what());
+        LOG_FAIL_EXC(e.what());
         return;
       }
     }

--- a/src/ds/test/map_test.cpp
+++ b/src/ds/test/map_test.cpp
@@ -138,7 +138,7 @@ std::vector<std::unique_ptr<Op<M>>> gen_ops(size_t n)
 {
   std::random_device rand_dev;
   auto seed = rand_dev();
-  LOG_INFO_FMT("Seed: {}", seed);
+  CCF_APP_INFO("Seed: {}", seed);
   std::mt19937 gen(seed);
   std::uniform_int_distribution<> gen_op(0, 3);
 
@@ -194,7 +194,7 @@ TEST_CASE_TEMPLATE("Persistent map operations", M, RBMap, ChampMap)
   auto ops = gen_ops<M>(500);
   for (auto& op : ops)
   {
-    LOG_DEBUG_FMT("{}", op->str());
+    CCF_APP_DEBUG("{}", op->str());
     auto r = op->apply(model, map);
     auto model_new = r.first;
     auto map_new = r.second;

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -1156,7 +1156,8 @@ namespace ccf
       }
       catch (const std::exception& e)
       {
-        LOG_FAIL_EXC(e.what());
+        LOG_FAIL_FMT("Exception in {}", __PRETTY_FUNCTION__);
+        LOG_DEBUG_FMT("Error: {}", e.what());
         return false;
       }
     }

--- a/src/node/channels.h
+++ b/src/node/channels.h
@@ -1156,8 +1156,7 @@ namespace ccf
       }
       catch (const std::exception& e)
       {
-        LOG_FAIL_FMT("Exception in {}", __PRETTY_FUNCTION__);
-        LOG_DEBUG_FMT("Error: {}", e.what());
+        LOG_FAIL_EXC(e.what());
         return false;
       }
     }

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -537,7 +537,8 @@ namespace ccf
       }
       catch (const std::exception& e)
       {
-        LOG_FAIL_EXC(e.what());
+        LOG_FAIL_FMT("Exception in {}", __PRETTY_FUNCTION__);
+        LOG_DEBUG_FMT("Error: {}", e.what());
         return;
       }
     }

--- a/src/node/rpc/forwarder.h
+++ b/src/node/rpc/forwarder.h
@@ -537,8 +537,7 @@ namespace ccf
       }
       catch (const std::exception& e)
       {
-        LOG_FAIL_FMT("Exception in {}", __PRETTY_FUNCTION__);
-        LOG_DEBUG_FMT("Error: {}", e.what());
+        LOG_FAIL_EXC(e.what());
         return;
       }
     }

--- a/tests/perf-system/submitter/CMakeLists.txt
+++ b/tests/perf-system/submitter/CMakeLists.txt
@@ -4,8 +4,12 @@ add_executable(
   submit ${SUBMITTER_DIR}/submit.cpp ${SUBMITTER_DIR}/handle_arguments.h
          ${SUBMITTER_DIR}/parquet_data.h
 )
+target_compile_definitions(submit PRIVATE CCF_LOGGER_NO_DEPRECATE)
 
 add_library(stdcxxhttp_parser.host "${HTTP_PARSER_SOURCES}")
+target_compile_definitions(
+  stdcxxhttp_parser.host PRIVATE CCF_LOGGER_NO_DEPRECATE
+)
 
 set(CCFCRYPTO_SRC
     ${CCF_DIR}/src/crypto/base64.cpp
@@ -34,6 +38,7 @@ add_library(stdcxxccfcrypto.host STATIC "${CCFCRYPTO_SRC}")
 target_link_libraries(stdcxxccfcrypto.host PUBLIC crypto)
 target_link_libraries(stdcxxccfcrypto.host PUBLIC ssl)
 target_link_libraries(stdcxxccfcrypto.host PUBLIC qcbor.host)
+target_compile_definitions(stdcxxccfcrypto.host PRIVATE CCF_LOGGER_NO_DEPRECATE)
 
 target_link_libraries(
   submit PRIVATE stdcxxhttp_parser.host stdcxxccfcrypto.host arrow parquet


### PR DESCRIPTION
Closing the removal of internal LOG_* macros in public headers, following their deprecation in 3.0. 