### PR TITLE
[release/5.x] Cherry pick: Prevent racey access to indexer state (#6886)

### DIFF
--- a/src/indexing/indexer.h
+++ b/src/indexing/indexer.h
@@ -68,6 +68,9 @@ namespace ccf::indexing
       update_commit(newly_committed);
 
       std::optional<ccf::SeqNo> min_requested = std::nullopt;
+
+      std::lock_guard<ccf::pal::Mutex> guard(lock);
+
       for (auto& strategy : strategies)
       {
         strategy->tick();


### PR DESCRIPTION
Backports the following commits to `release/5.x`:
 - [Prevent racey access to indexer state (#6886)](https://github.com/microsoft/CCF/pull/6886)