### PR TITLE
Test mid-recovery election

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1026,7 +1026,7 @@ if(BUILD_TESTS)
     add_picobench(hash_bench SRCS src/ds/test/hash_bench.cpp)
 
     if(LONG_TESTS)
-      set(ADDITIONAL_RECOVERY_ARGS --with-load)
+      set(ADDITIONAL_RECOVERY_ARGS --with-load --with-election)
 
       add_e2e_test(
         NAME recovery_test_cft_api_0

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1269,6 +1269,11 @@ namespace ccf
 
       sm.expect(NodeStartupState::readingPrivateLedger);
 
+      LOG_INFO_FMT(
+        "Try end private recovery at {}. Is primary: {}",
+        recovery_v,
+        consensus->is_primary());
+
       if (recovery_v != recovery_store->current_version())
       {
         throw std::logic_error(fmt::format(
@@ -1298,6 +1303,10 @@ namespace ccf
       // Open the service
       if (consensus->can_replicate())
       {
+        LOG_INFO_FMT(
+          "Try end private recovery at {}. Trigger service opening",
+          recovery_v);
+
         auto tx = network.tables->create_tx();
 
         // Clear recovery shares that were submitted to initiate the recovery

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -464,6 +464,9 @@ class Node:
     def sigterm(self):
         self.remote.sigterm()
 
+    def sigkill(self):
+        self.remote.sigkill()
+
     def is_stopped(self):
         return self.network_state == NodeNetworkState.stopped
 

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -227,6 +227,9 @@ class LocalRemote(CmdMixin):
     def sigterm(self):
         self.proc.terminate()
 
+    def sigkill(self):
+        self.proc.send_signal(signal.SIGKILL)
+
     def stop(self):
         """
         Disconnect the client, and therefore shut down the command as well.
@@ -665,6 +668,9 @@ class CCFRemote(object):
 
     def sigterm(self):
         self.remote.sigterm()
+
+    def sigkill(self):
+        self.remote.sigkill()
 
     def stop(self):
         try:

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -147,7 +147,7 @@ def recover_with_primary_dying(args, recovered_network):
 
     primary, _ = recovered_network.find_primary()
     while not primary or primary.node_id == retired_id:
-        LOG.info("Kepp looking for new primary!")
+        LOG.info("Keep looking for new primary")
         time.sleep(0.1)
         primary, _ = recovered_network.find_primary()
 

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -199,7 +199,7 @@ def test_recover_service(
         # to allow election to happen if primary gets killed. These later get verified post-recovery (logging app verify_tx() thing).
         network.txs.issue(
             network,
-            number_txs=4000,
+            number_txs=10000,
             send_public=False,
             msg=str(bytes(random.getrandbits(8) for _ in range(512))),
         )

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -108,7 +108,7 @@ def verify_endorsements_chain(primary, endorsements, pubkey):
 
 
 def recover_with_primary_dying(args, recovered_network):
-    # Minimal copy-paste from network.recover() with primary assassination.
+    # Minimal copy-paste from network.recover() with primary shut down.
     recovered_network.consortium.activate(recovered_network.find_random_node())
     recovered_network.consortium.check_for_service(
         recovered_network.find_random_node(),


### PR DESCRIPTION
An attempt to address #3755.

Force election mid-recovery, but make sure (!) election finishes when all nodes are still in`ReadingPrivateLedger` state.

> (!) Note. This's important, because if no primary is elected at the moment of reading last private TX, the user frontend will never be opened due to the current recovery design, so this recovery has to be discarded. This PR doesn't test that particular case.

To give election enough time, ledger is populated with many thousands of TXs, which are later verified post-recovery.