### PR TITLE
Fix LTS test by installing development package

### DIFF
--- a/tests/infra/github.py
+++ b/tests/infra/github.py
@@ -150,7 +150,7 @@ def get_major_version_from_branch_name(branch_name):
 
 def get_package_prefix_with_platform(tag_name, platform="snp"):
     tag_components = tag_name.split("-")
-    tag_components[0] += f"_{platform}"
+    tag_components[0] += f"_{platform}_devel"
     return "-".join(tag_components)
 
 


### PR DESCRIPTION
LTS test is broken since 6.0.0-rc2, as it expects to find `keyrecovery.sh` in the install but this is now only included in the development package.

Speculative fix - still building for a local repro.