### PR TITLE
Fix flaky `work_beacon` test

### DIFF
--- a/src/ds/test/work_beacon.cpp
+++ b/src/ds/test/work_beacon.cpp
@@ -194,11 +194,19 @@ TEST_CASE("WorkBeacon" * doctest::test_suite("workbeacon"))
           // First assert the order
           REQUIRE(wakes_with_beacon == 0);
           REQUIRE(wakes_with_beacon <= wakes_with_waits);
-          REQUIRE(wakes_with_waits <= wakes_with_spinloop);
 
-          // Then try to be a little more precise, allowing head-room for
-          // different build configs and cosmic rays
-          REQUIRE(wakes_with_waits * 10 < wakes_with_spinloop);
+          // In occasional runs on some build configurations, we see 0 wakes
+          // when using the spinloop. This is surprising, but not impossible. In
+          // this instance we obviously don't see any improvement in the waiting
+          // scheme, so skip the following assertions
+          if (wakes_with_spinloop > 0)
+          {
+            REQUIRE(wakes_with_waits < wakes_with_spinloop);
+
+            // Then try to be a little more precise, allowing head-room for
+            // different build configs and cosmic rays
+            REQUIRE(wakes_with_waits * 10 < wakes_with_spinloop);
+          }
         }
       }
     }


### PR DESCRIPTION
Partial fix in #6925 missed the assertion on the next line. This adds an explanatory comment. Pulled out of #6926.