### PR TITLE
Don't cancel in-progress runs on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !contains(github.ref, 'main')}}
 
 permissions:
   contents: read


### PR DESCRIPTION
Following #6348, we can only have a single CI running on `main` at once. I think this is rubbish - we can manually trigger, if something looks flaky I want N runs in parallel, not in series.

![image](https://github.com/user-attachments/assets/360e0614-e534-400e-a0f5-b8a3f8d5867f)

Based on the docs [here](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-on-specific-branches), I think this skips `cancel-in-progress` on `main`.