### PR TITLE
Increase IOCTL padding, and introduce non-0 sentinels to confirm padding safety

### DIFF
--- a/include/ccf/pal/snp_ioctl6.h
+++ b/include/ccf/pal/snp_ioctl6.h
@@ -41,6 +41,8 @@ namespace ccf::pal::snp::ioctl6
   {
     static constexpr size_t num_sentinel_bytes = 1024;
 
+    static constexpr uint8_t default_sentinel = 0x42;
+
     static constexpr uint8_t pre_sentinel_first = 0xAA;
     static constexpr uint8_t pre_sentinel_last = 0xBB;
 
@@ -53,9 +55,11 @@ namespace ccf::pal::snp::ioctl6
 
     IoctlSentinel()
     {
+      memset(pre_sentinels, default_sentinel, num_sentinel_bytes);
       pre_sentinels[0] = pre_sentinel_first;
       pre_sentinels[num_sentinel_bytes - 1] = pre_sentinel_last;
 
+      memset(post_sentinels, default_sentinel, num_sentinel_bytes);
       post_sentinels[0] = post_sentinel_first;
       post_sentinels[num_sentinel_bytes - 1] = post_sentinel_last;
     }
@@ -83,12 +87,12 @@ namespace ccf::pal::snp::ioctl6
       return std::all_of(
                std::next(std::begin(pre_sentinels)),
                std::prev(std::end(pre_sentinels)),
-               [](uint8_t e) { return e == 0; }) &&
+               [](uint8_t e) { return e == default_sentinel; }) &&
         std::all_of(
                std::next(std::begin(post_sentinels)),
                std::prev(std::end(post_sentinels)),
 
-               [](uint8_t e) { return e == 0; });
+               [](uint8_t e) { return e == default_sentinel; });
     }
   };
 #pragma pack(pop)

--- a/include/ccf/pal/snp_ioctl6.h
+++ b/include/ccf/pal/snp_ioctl6.h
@@ -197,7 +197,7 @@ namespace ccf::pal::snp::ioctl6
   // https://github.com/torvalds/linux/blob/master/include/uapi/linux/sev-guest.h
   // EDA: Temporarily decreased this, to confirm that tests now fail loudly. DO
   // NOT MERGE
-  using PaddedAttestationResp = PaddedTo<AttestationResp, 1500>;
+  using PaddedAttestationResp = PaddedTo<AttestationResp, 4000>;
   using PaddedDerivedKeyResp = PaddedTo<DerivedKeyResp, 4000>;
 
   using GuestRequestAttestation =

--- a/include/ccf/pal/snp_ioctl6.h
+++ b/include/ccf/pal/snp_ioctl6.h
@@ -23,21 +23,74 @@ namespace ccf::pal::snp::ioctl6
   constexpr auto DEVICE = "/dev/sev-guest";
 
 #pragma pack(push, 1)
-  template <typename T>
-  struct SafetyPadding
+  // Helper to add padding to a struct, so that the resulting struct has some
+  // minimum size. As a minor detail, the padding will be initialised to 0.
+  template <typename T, size_t N>
+  struct PaddedTo : public T
   {
-    T data;
-    uint8_t safety_padding[1024] = {0};
+    static_assert(
+      sizeof(T) < N, "No padding possible - struct is already N bytes");
+    static constexpr size_t num_padding_bytes = N - sizeof(T);
+    uint8_t padding[num_padding_bytes] = {0};
   };
 
+  // Helper which surrounds a struct with some sentinel bytes, to aid detection
+  // of out-of-bounds writes.
   template <typename T>
-  bool safety_padding_intact(SafetyPadding<T> data)
+  struct IoctlSentinel
   {
-    return std::all_of(
-      std::begin(data.safety_padding),
-      std::end(data.safety_padding),
-      [](uint8_t e) { return e == 0; });
-  }
+    static constexpr size_t num_sentinel_bytes = 1024;
+
+    static constexpr uint8_t pre_sentinel_first = 0xAA;
+    static constexpr uint8_t pre_sentinel_last = 0xBB;
+
+    static constexpr uint8_t post_sentinel_first = 0xCC;
+    static constexpr uint8_t post_sentinel_last = 0xDD;
+
+    uint8_t pre_sentinels[num_sentinel_bytes] = {0};
+    T data;
+    uint8_t post_sentinels[num_sentinel_bytes] = {0};
+
+    IoctlSentinel()
+    {
+      pre_sentinels[0] = pre_sentinel_first;
+      pre_sentinels[num_sentinel_bytes - 1] = pre_sentinel_last;
+
+      post_sentinels[0] = post_sentinel_first;
+      post_sentinels[num_sentinel_bytes - 1] = post_sentinel_last;
+    }
+
+    bool sentinels_intact() const
+    {
+      if (pre_sentinels[0] != pre_sentinel_first)
+      {
+        return false;
+      }
+      if (pre_sentinels[num_sentinel_bytes - 1] != pre_sentinel_last)
+      {
+        return false;
+      }
+
+      if (post_sentinels[0] != post_sentinel_first)
+      {
+        return false;
+      }
+      if (post_sentinels[num_sentinel_bytes - 1] != post_sentinel_last)
+      {
+        return false;
+      }
+
+      return std::all_of(
+               std::next(std::begin(pre_sentinels)),
+               std::prev(std::end(pre_sentinels)),
+               [](uint8_t e) { return e == 0; }) &&
+        std::all_of(
+               std::next(std::begin(post_sentinels)),
+               std::prev(std::end(post_sentinels)),
+
+               [](uint8_t e) { return e == 0; });
+    }
+  };
 #pragma pack(pop)
 
   // Table 22
@@ -135,10 +188,16 @@ namespace ccf::pal::snp::ioctl6
      * psp-sev.h) */
     ExitInfo exit_info;
   };
+
+  // This 4000 comes from the definition of snp_report_resp in
+  // https://github.com/torvalds/linux/blob/master/include/uapi/linux/sev-guest.h
+  using PaddedAttestationResp = PaddedTo<AttestationResp, 4000>;
+  using PaddedDerivedKeyResp = PaddedTo<DerivedKeyResp, 4000>;
+
   using GuestRequestAttestation =
-    GuestRequest<AttestationReq, SafetyPadding<AttestationResp>>;
+    GuestRequest<AttestationReq, PaddedAttestationResp>;
   using GuestRequestDerivedKey =
-    GuestRequest<DerivedKeyReq, SafetyPadding<DerivedKeyResp>>;
+    GuestRequest<DerivedKeyReq, PaddedDerivedKeyResp>;
 
   // From linux/include/uapi/linux/sev-guest.h
   constexpr char SEV_GUEST_IOC_TYPE = 'S';
@@ -154,7 +213,8 @@ namespace ccf::pal::snp::ioctl6
 
   class Attestation : public AttestationInterface
   {
-    SafetyPadding<AttestationResp> padded_resp = {};
+    IoctlSentinel<PaddedAttestationResp> resp_with_sentinel = {};
+    PaddedAttestationResp& padded_resp = resp_with_sentinel.data;
 
   public:
     Attestation(const PlatformAttestationReportData& report_data)
@@ -195,30 +255,32 @@ namespace ccf::pal::snp::ioctl6
         throw std::logic_error(msg);
       }
 
-      if (!safety_padding_intact(padded_resp))
+      if (!resp_with_sentinel.sentinels_intact())
       {
         // This occurs if a kernel/firmware upgrade causes the response to
-        // overflow the struct so it is better to fail early than deal with
-        // memory corruption.
-        throw std::logic_error("IOCTL overwrote safety padding.");
+        // overflow our struct. If that happens, it is better to fail early than
+        // deal with memory corruption.
+        throw std::logic_error(
+          "SEV_SNP_GUEST_MSG_REPORT IOCTL overwrote safety sentinels.");
       }
     }
 
     const snp::Attestation& get() const override
     {
-      return padded_resp.data.report;
+      return padded_resp.report;
     }
 
     std::vector<uint8_t> get_raw() override
     {
-      auto quote_bytes = reinterpret_cast<uint8_t*>(&padded_resp.data.report);
-      return {quote_bytes, quote_bytes + padded_resp.data.report_size};
+      auto quote_bytes = reinterpret_cast<uint8_t*>(&padded_resp.report);
+      return {quote_bytes, quote_bytes + padded_resp.report_size};
     }
   };
 
   class DerivedKey
   {
-    SafetyPadding<DerivedKeyResp> padded_resp = {};
+    IoctlSentinel<PaddedDerivedKeyResp> resp_with_sentinel = {};
+    PaddedDerivedKeyResp& padded_resp = resp_with_sentinel.data;
 
   public:
     DerivedKey()
@@ -248,31 +310,32 @@ namespace ccf::pal::snp::ioctl6
         throw std::logic_error(msg);
       }
 
-      if (!safety_padding_intact(padded_resp))
+      if (!resp_with_sentinel.sentinels_intact())
       {
         // This occurs if a kernel/firmware upgrade causes the response to
-        // overflow the struct so it is better to fail early than deal with
-        // memory corruption.
-        throw std::logic_error("IOCTL overwrote safety padding.");
+        // overflow our struct. If that happens, it is better to fail early than
+        // deal with memory corruption.
+        throw std::logic_error(
+          "SEV_SNP_GUEST_MSG_DERIVED_KEY IOCTL overwrote safety sentinels.");
       }
 
-      if (padded_resp.data.status != 0)
+      if (padded_resp.status != 0)
       {
         const auto msg = fmt::format(
           "Failed to issue ioctl SEV_SNP_GUEST_MSG_DERIVED_KEY: {}",
-          padded_resp.data.status);
+          padded_resp.status);
         throw std::logic_error(msg);
       }
     }
 
     ~DerivedKey()
     {
-      OPENSSL_cleanse(padded_resp.data.data, sizeof(padded_resp.data.data));
+      OPENSSL_cleanse(padded_resp.data, sizeof(padded_resp.data));
     }
 
     std::span<const uint8_t> get_raw()
     {
-      return std::span<const uint8_t>{padded_resp.data.data};
+      return std::span<const uint8_t>{padded_resp.data};
     }
   };
 }

--- a/include/ccf/pal/snp_ioctl6.h
+++ b/include/ccf/pal/snp_ioctl6.h
@@ -191,7 +191,9 @@ namespace ccf::pal::snp::ioctl6
 
   // This 4000 comes from the definition of snp_report_resp in
   // https://github.com/torvalds/linux/blob/master/include/uapi/linux/sev-guest.h
-  using PaddedAttestationResp = PaddedTo<AttestationResp, 4000>;
+  // EDA: Temporarily decreased this, to confirm that tests now fail loudly. DO
+  // NOT MERGE
+  using PaddedAttestationResp = PaddedTo<AttestationResp, 1500>;
   using PaddedDerivedKeyResp = PaddedTo<DerivedKeyResp, 4000>;
 
   using GuestRequestAttestation =

--- a/include/ccf/pal/snp_ioctl6.h
+++ b/include/ccf/pal/snp_ioctl6.h
@@ -195,8 +195,6 @@ namespace ccf::pal::snp::ioctl6
 
   // This 4000 comes from the definition of snp_report_resp in
   // https://github.com/torvalds/linux/blob/master/include/uapi/linux/sev-guest.h
-  // EDA: Temporarily decreased this, to confirm that tests now fail loudly. DO
-  // NOT MERGE
   using PaddedAttestationResp = PaddedTo<AttestationResp, 4000>;
   using PaddedDerivedKeyResp = PaddedTo<DerivedKeyResp, 4000>;
 

--- a/src/pal/test/snp_ioctl_test.cpp
+++ b/src/pal/test/snp_ioctl_test.cpp
@@ -12,6 +12,24 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 #include <doctest/doctest.h>
 
+TEST_CASE("SNP request attestation")
+{
+  using namespace ccf::pal;
+
+  SnpAttestationReportData snp_report_data;
+  std::iota(
+    snp_report_data.report_data.begin(), snp_report_data.report_data.end(), 0);
+
+  PlatformAttestationReportData report_data(snp_report_data);
+  snp::ioctl6::Attestation ioctl_attestation(report_data);
+
+  const snp::Attestation& attestation = ioctl_attestation.get();
+
+  SnpAttestationReportData attested_report_data(attestation.report_data);
+
+  REQUIRE_EQ(snp_report_data.report_data, attested_report_data.report_data);
+}
+
 TEST_CASE("SNP derive key")
 {
   using namespace ccf::pal;


### PR DESCRIPTION
Should resolve #6956.

Further discussion in that ticket, but in summary our IOCTL call to `SEV_SNP_GUEST_MSG_REPORT` was passing too-small a struct, resulting in memory corruption as the response was written to our stack. Our `SafetyPadding` protection didn't catch this because the additional bytes were all 0s - the IOCTL zero'd both the padding bytes _and_ further data.

This separates the padding (the IOCTL is going to write some large struct that we don't fully parse/specify) from the sentinel/protection bytes (we want to catch if it writes beyond these bytes). The padding is increased to create a 4k struct, matching the kernel definition, and the sentinel bytes now contain some non-0 values.

Additionally, we add a unit test that fetches the attestation, which should now fail if the padding/sentinel protection is violated.