### PR TITLE
Fix uploading ledger files in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
             build/workspace/*/*.config.json
             build/workspace/*/out
             build/workspace/*/err
-            build/workspace/*.ledger/*
+            build/workspace/*/*.ledger/*
           if-no-files-found: ignore
         if: success() || failure()
 
@@ -193,6 +193,6 @@ jobs:
             build/workspace/*/*.config.json
             build/workspace/*/out
             build/workspace/*/err
-            build/workspace/*.ledger/*
+            build/workspace/*/*.ledger/*
           if-no-files-found: ignore
         if: success() || failure()

--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -63,7 +63,7 @@ jobs:
             build/workspace/*/*.config.json
             build/workspace/*/out
             build/workspace/*/err
-            build/workspace/*.ledger/*
+            build/workspace/*/*.ledger/*
           if-no-files-found: ignore
 
   long-tsan:
@@ -117,7 +117,7 @@ jobs:
             build/workspace/*/*.config.json
             build/workspace/*/out
             build/workspace/*/err
-            build/workspace/*.ledger/*
+            build/workspace/*/*.ledger/*
           if-no-files-found: ignore
 
   long-lts:
@@ -170,7 +170,7 @@ jobs:
             build/workspace/*/*.config.json
             build/workspace/*/out
             build/workspace/*/err
-            build/workspace/*.ledger/*
+            build/workspace/*/*.ledger/*
           if-no-files-found: ignore
 
   # All e2e tests without sanitizers in debug mode; needed because:
@@ -229,7 +229,7 @@ jobs:
             build/workspace/*/*.config.json
             build/workspace/*/out
             build/workspace/*/err
-            build/workspace/*.ledger/*
+            build/workspace/*/*.ledger/*
           if-no-files-found: ignore
 
   # All e2e tests in release mode (same as release build).
@@ -283,7 +283,7 @@ jobs:
             build/workspace/*/*.config.json
             build/workspace/*/out
             build/workspace/*/err
-            build/workspace/*.ledger/*
+            build/workspace/*/*.ledger/*
           if-no-files-found: ignore
 
   # End-to-end test suites with shuffling enabled.
@@ -337,5 +337,5 @@ jobs:
             build/workspace/*/*.config.json
             build/workspace/*/out
             build/workspace/*/err
-            build/workspace/*.ledger/*
+            build/workspace/*/*.ledger/*
           if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
             build/workspace/*/*.config.json
             build/workspace/*/out
             build/workspace/*/err
-            build/workspace/*.ledger/*
+            build/workspace/*/*.ledger/*
           if-no-files-found: ignore
 
       - name: "Make .rpm (devel) Package"


### PR DESCRIPTION
Turns out the current filter doesn't really work

```
maxtropets@al-vm-test-2 [ ~/workspace/CCF/build ]$ ls -lah workspace/*.ledger/*
ls: cannot access 'workspace/*.ledger/*': No such file or directory

maxtropets@al-vm-test-2 [ ~/workspace/CCF/build ]$ ls -lah workspace/*/*.ledger/*
-rw-rw-r-- 1 maxtropets maxtropets  61K Apr  9 16:38 workspace/app_space_js_e2e_logging_cft_0/0.ledger/ledger_1-2.committed
-rw-rw-r-- 1 maxtropets maxtropets 5.4K Apr  9 16:39 workspace/app_space_js_e2e_logging_cft_0/0.ledger/ledger_3
```

This PR should fix it.