### PR TITLE
Run long tests in release mode too

### DIFF
--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -265,7 +265,7 @@ jobs:
           git config --global --add safe.directory /__w/CCF/CCF
           mkdir build
           cd build
-          cmake -GNinja -DCOMPILE_TARGET=virtual -DCMAKE_BUILD_TYPE=Release -DCLIENT_PROTOCOLS_TEST=ON ..
+          cmake -GNinja -DCOMPILE_TARGET=virtual -DCMAKE_BUILD_TYPE=Release -DCLIENT_PROTOCOLS_TEST=ON -DLONG_TESTS=ON ..
           ninja
 
       - name: "Test"


### PR DESCRIPTION
Should be harmless, it's still faster then Debug/ASAN, so comes at no cost

UPD. CI is red because see https://github.com/microsoft/CCF/pull/6979