### PR TITLE
Fix `lts_compatibility`: Handle unfindable packages from old (unsupported) platforms

### DIFF
--- a/tests/infra/github.py
+++ b/tests/infra/github.py
@@ -190,7 +190,7 @@ class GitEnv:
     def has_release_for_tag_name(self, tag_name):
         try:
             package_url = get_package_url_from_tag_name(tag_name)
-        except ValueError as v:
+        except ValueError:
             return False
 
         return (

--- a/tests/infra/github.py
+++ b/tests/infra/github.py
@@ -188,9 +188,14 @@ class GitEnv:
         ]
 
     def has_release_for_tag_name(self, tag_name):
+        try:
+            package_url = get_package_url_from_tag_name(tag_name)
+        except ValueError as v:
+            return False
+
         return (
             requests.head(
-                get_package_url_from_tag_name(tag_name),
+                package_url,
                 allow_redirects=True,
                 timeout=30,
             ).status_code


### PR DESCRIPTION
Following #7000, the `lts_compatibility` test has failed with the following error:

```
74:   File "/home/edashton/3.CCF/tests/infra/github.py", line 193, in has_release_for_tag_name
74:     get_package_url_from_tag_name(tag_name),
74:     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
74:   File "/home/edashton/3.CCF/tests/infra/github.py", line 168, in get_package_url_from_tag_name
74:     raise ValueError(f"Unsupported tag name: {tag_name} for platform {platform}")
74: ValueError: Unsupported tag name: ccf-5.0.16 for platform snp
1/1 Test #74: lts_compatibility ................***Failed    6.21 sec
```

We'd previously fail one step later but politely - returning a junk 404 URL from this function and a `False` from the one above. Now we catch this `ValueError` one layer above and return `False`.