### PR TITLE
Fix doc job

### DIFF
--- a/include/ccf/crypto/key_pair.h
+++ b/include/ccf/crypto/key_pair.h
@@ -180,7 +180,7 @@ namespace ccf::crypto
   /**
    * Create a public / private ECDSA key pair from existing private key data
    *
-   * @param pkey PEM key to load
+   * @param pem PEM key to load
    * @return Key pair
    */
   KeyPairPtr make_key_pair(const Pem& pem);


### PR DESCRIPTION
Main is red: https://github.com/microsoft/CCF/actions/runs/15109725288/job/42466245543

because `pkey` changed to `pem` in #7009 and doc string left unchanged.