### PR TITLE
Refactor out generically useful bit of fetch.h into curl.h

### DIFF
--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ccf/ds/logger.h"
+#include "ccf/ds/nonstd.h"
+
+#include <curl/curl.h>
+#include <memory>
+#include <span>
+
+#define CHECK_CURL_EASY(fn, ...) \
+  do \
+  { \
+    const auto res = fn(__VA_ARGS__); \
+    if (res != CURLE_OK) \
+    { \
+      throw std::runtime_error(fmt::format( \
+        "Error calling " #fn ": {} ({})", res, curl_easy_strerror(res))); \
+    } \
+  } while (0)
+
+#define CHECK_CURL_EASY_SETOPT(handle, info, arg) \
+  CHECK_CURL_EASY(curl_easy_setopt, handle, info, arg)
+#define CHECK_CURL_EASY_GETINFO(handle, info, arg) \
+  CHECK_CURL_EASY(curl_easy_getinfo, handle, info, arg)
+
+namespace ccf::curl
+{
+
+  class UniqueCURL
+  {
+  protected:
+    std::unique_ptr<CURL, void (*)(CURL*)> p;
+
+  public:
+    UniqueCURL() : p(curl_easy_init(), [](auto x) { curl_easy_cleanup(x); })
+    {
+      if (!p.get())
+      {
+        throw std::runtime_error("Error initialising curl easy request");
+      }
+    }
+
+    operator CURL*() const
+    {
+      return p.get();
+    }
+  };
+
+  class UniqueSlist
+  {
+  protected:
+    std::unique_ptr<curl_slist, void (*)(curl_slist*)> p;
+
+  public:
+    UniqueSlist() : p(nullptr, [](auto x) { curl_slist_free_all(x); }) {}
+
+    void append(const char* str)
+    {
+      p.reset(curl_slist_append(p.release(), str));
+    }
+
+    curl_slist* get() const
+    {
+      return p.get();
+    }
+  };
+
+} // namespace ccf::curl

--- a/src/snapshots/fetch.h
+++ b/src/snapshots/fetch.h
@@ -5,6 +5,7 @@
 #include "ccf/ds/logger.h"
 #include "ccf/ds/nonstd.h"
 #include "ccf/rest_verb.h"
+#include "http/http_builder.h"
 #include "http/curl.h"
 
 #include <charconv>

--- a/src/snapshots/fetch.h
+++ b/src/snapshots/fetch.h
@@ -5,31 +5,14 @@
 #include "ccf/ds/logger.h"
 #include "ccf/ds/nonstd.h"
 #include "ccf/rest_verb.h"
-#include "http/http_builder.h"
+#include "http/curl.h"
 
 #include <charconv>
 #include <curl/curl.h>
-#include <filesystem>
 #include <optional>
 #include <span>
 #include <string>
 #include <vector>
-
-#define CHECK_CURL_EASY(fn, ...) \
-  do \
-  { \
-    const auto res = fn(__VA_ARGS__); \
-    if (res != CURLE_OK) \
-    { \
-      throw std::runtime_error(fmt::format( \
-        "Error calling " #fn ": {} ({})", res, curl_easy_strerror(res))); \
-    } \
-  } while (0)
-
-#define CHECK_CURL_EASY_SETOPT(handle, info, arg) \
-  CHECK_CURL_EASY(curl_easy_setopt, handle, info, arg)
-#define CHECK_CURL_EASY_GETINFO(handle, info, arg) \
-  CHECK_CURL_EASY(curl_easy_getinfo, handle, info, arg)
 
 #define EXPECT_HTTP_RESPONSE_STATUS(request, response, expected) \
   do \
@@ -115,46 +98,6 @@ namespace snapshots
     long status_code;
     HeaderMap headers;
   };
-
-  class UniqueCURL
-  {
-  protected:
-    std::unique_ptr<CURL, void (*)(CURL*)> p;
-
-  public:
-    UniqueCURL() : p(curl_easy_init(), [](auto x) { curl_easy_cleanup(x); })
-    {
-      if (!p.get())
-      {
-        throw std::runtime_error("Error initialising curl easy request");
-      }
-    }
-
-    operator CURL*() const
-    {
-      return p.get();
-    }
-  };
-
-  class UniqueSlist
-  {
-  protected:
-    std::unique_ptr<curl_slist, void (*)(curl_slist*)> p;
-
-  public:
-    UniqueSlist() : p(nullptr, [](auto x) { curl_slist_free_all(x); }) {}
-
-    void append(const char* str)
-    {
-      p.reset(curl_slist_append(p.release(), str));
-    }
-
-    curl_slist* get() const
-    {
-      return p.get();
-    }
-  };
-
   static inline SimpleHTTPResponse make_curl_request(
     const SimpleHTTPRequest& request)
   {

--- a/src/snapshots/fetch.h
+++ b/src/snapshots/fetch.h
@@ -5,8 +5,8 @@
 #include "ccf/ds/logger.h"
 #include "ccf/ds/nonstd.h"
 #include "ccf/rest_verb.h"
-#include "http/http_builder.h"
 #include "http/curl.h"
+#include "http/http_builder.h"
 
 #include <charconv>
 #include <curl/curl.h>

--- a/src/snapshots/fetch.h
+++ b/src/snapshots/fetch.h
@@ -101,7 +101,7 @@ namespace snapshots
   static inline SimpleHTTPResponse make_curl_request(
     const SimpleHTTPRequest& request)
   {
-    UniqueCURL curl;
+    ccf::curl::UniqueCURL curl;
 
     CHECK_CURL_EASY_SETOPT(curl, CURLOPT_URL, request.url.c_str());
     if (request.method == HTTP_HEAD)
@@ -124,7 +124,7 @@ namespace snapshots
 
     curl_easy_setopt(curl, CURLOPT_CAINFO, request.ca_path.c_str());
 
-    UniqueSlist list;
+    ccf::curl::UniqueSlist list;
     for (const auto& [k, v] : request.headers)
     {
       list.append(fmt::format("{}: {}", k, v).c_str());


### PR DESCRIPTION
Refactor out these the curl bits such that if anything breaks, it does so in this PR rather than the auto-dr one.