### PR TITLE
Fix empty committed snapshots: Restore behaviour of writing to temporary uncommitted file and renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [6.0.4]: https://github.com/microsoft/CCF/releases/tag/ccf-6.0.4
 
+### Fixed
+
+- CCF will no longer create in-progress snapshot files with a `.committed` suffix. It will only rename files to `.committed` when they are complete and ready for reading (#7029).
+
 ### Changed
 
 - Templated URL parsing will no longer allow `:` within regex matched components, since `:` is already used to delimit actions. Concretely, a call to `GET .../state-digests/abcd:update` should now correctly return a 404, rather than dispatching to `GET .../state-digests/{memberId}` and returning `No ACK record exists for member m[abcd:update]`.

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -1194,4 +1194,4 @@ class UnknownTransaction(Exception):
 
 
 class InvalidSnapshotException(Exception):
-    """The given snapshot file has size 0"""
+    """The given snapshot file is invalid and cannot be parsed"""

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -86,6 +86,10 @@ def is_ledger_chunk_committed(file_name):
     return file_name.endswith(COMMITTED_FILE_SUFFIX)
 
 
+def is_snapshot_file_committed(file_name):
+    return file_name.endswith(COMMITTED_FILE_SUFFIX)
+
+
 def digest(data):
     return sha256(data).digest()
 

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -817,6 +817,9 @@ class Snapshot(Entry):
         self._filename = filename
         self._file_size = os.path.getsize(filename)
 
+        if self._file_size == 0:
+            raise InvalidSnapshotException(f"{filename} is currently empty")
+
         entry_start_pos = super()._read_header()
 
         # 1.x snapshots do not include evidence
@@ -824,7 +827,13 @@ class Snapshot(Entry):
             receipt_pos = entry_start_pos + self._header.size
             receipt_bytes = _peek_all(self._file, pos=receipt_pos)
 
-            receipt = json.loads(receipt_bytes.decode("utf-8"))
+            try:
+                receipt = json.loads(receipt_bytes.decode("utf-8"))
+            except:
+                raise InvalidSnapshotException(
+                    f"Cannot read receipt from snapshot {os.path.basename(self._filename)}: Receipt starts at {receipt_pos} (file is {self._file_size} bytes), and contains {receipt_bytes}"
+                )
+
             # Receipts included in snapshots always contain leaf components,
             # including a claims digest and commit evidence, from 2.0.0-rc0 onwards.
             # This verification code deliberately does not support snapshots
@@ -1178,3 +1187,7 @@ class UntrustedNodeException(Exception):
 
 class UnknownTransaction(Exception):
     """The transaction at seqno does not exist in ledger"""
+
+
+class InvalidSnapshotException(Exception):
+    """The given snapshot file has size 0"""

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -833,10 +833,10 @@ class Snapshot(Entry):
 
             try:
                 receipt = json.loads(receipt_bytes.decode("utf-8"))
-            except:
+            except json.decoder.JSONDecodeError as e:
                 raise InvalidSnapshotException(
                     f"Cannot read receipt from snapshot {os.path.basename(self._filename)}: Receipt starts at {receipt_pos} (file is {self._file_size} bytes), and contains {receipt_bytes}"
-                )
+                ) from e
 
             # Receipts included in snapshots always contain leaf components,
             # including a claims digest and commit evidence, from 2.0.0-rc0 onwards.

--- a/src/snapshots/snapshot_manager.h
+++ b/src/snapshots/snapshot_manager.h
@@ -131,7 +131,7 @@ namespace snapshots
                 snapshot_file.write(
                   reinterpret_cast<const char*>(receipt_data), receipt_size);
 
-                snapshot_file.flush();
+                snapshot_file.close();
                 LOG_INFO_FMT(
                   "New snapshot file written to {} [{} bytes]",
                   file_name,

--- a/src/snapshots/snapshot_manager.h
+++ b/src/snapshots/snapshot_manager.h
@@ -96,15 +96,14 @@ namespace snapshots
         {
           if (snapshot_idx == it->first)
           {
-            // e.g. snapshot_100_105.committed
+            // e.g. snapshot_100_105
             auto file_name = fmt::format(
-              "{}{}{}{}{}{}",
+              "{}{}{}{}{}",
               snapshot_file_prefix,
               snapshot_idx_delimiter,
               it->first,
               snapshot_idx_delimiter,
-              it->second.evidence_idx,
-              snapshot_committed_suffix);
+              it->second.evidence_idx);
             auto full_snapshot_path = snapshot_dir / file_name;
 
             if (fs::exists(full_snapshot_path))
@@ -136,6 +135,18 @@ namespace snapshots
                   "New snapshot file written to {} [{} bytes]",
                   file_name,
                   static_cast<size_t>(snapshot_file.tellp()));
+
+                // e.g. snapshot_100_105.committed
+                const auto committed_file_name =
+                  fmt::format("{}{}", file_name, snapshot_committed_suffix);
+                const auto full_committed_path =
+                  snapshot_dir / committed_file_name;
+
+                files::rename(full_snapshot_path, full_committed_path);
+                LOG_INFO_FMT(
+                  "Renamed temporary snapshot {} to committed {}",
+                  file_name,
+                  committed_file_name);
               }
             }
 

--- a/src/snapshots/snapshot_manager.h
+++ b/src/snapshots/snapshot_manager.h
@@ -131,6 +131,7 @@ namespace snapshots
                 snapshot_file.write(
                   reinterpret_cast<const char*>(receipt_data), receipt_size);
 
+                snapshot_file.flush();
                 LOG_INFO_FMT(
                   "New snapshot file written to {} [{} bytes]",
                   file_name,

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -84,6 +84,7 @@ def test_parse_snapshot_file(network, args):
                             ), "No public table in snapshot"
                             LOG.success(f"Successfully parsed snapshot: {snapshot}")
             LOG.info(f"Tested {len(seen)} snapshots")
+            assert len(seen) > 0, f"No snapshots seen, so this tested nothing"
 
     class WriterThread(infra.concurrency.StoppableThread):
         def __init__(self, network, reader):

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -84,7 +84,7 @@ def test_parse_snapshot_file(network, args):
                             ), "No public table in snapshot"
                             LOG.success(f"Successfully parsed snapshot: {snapshot}")
             LOG.info(f"Tested {len(seen)} snapshots")
-            assert len(seen) > 0, f"No snapshots seen, so this tested nothing"
+            assert len(seen) > 0, "No snapshots seen, so this tested nothing"
 
     class WriterThread(infra.concurrency.StoppableThread):
         def __init__(self, network, reader):


### PR DESCRIPTION
#5273 introduced an unnoticed break from our documented behaviour - snapshots were written directly to a `.committed` file (in multiple `fwrite()` calls), rather than being renamed from an intermediate file. This means any consumer of `.committed` snapshots could read invalid files (incomplete, perhaps entirely empty, depending how they interleaved with the `fwrite()` calls and implicit flushing), and could not distinguish these from correct files without attempting to parse the file.

This PR modifies an existing e2e test to reproduce this behaviour - aggressively reading snapshots directly from the node's output directory, as they are being written. It also includes the fix of restoring the intermediate file - CCF will again (as documented) write to a temporary file `snapshot_X-Y` file, and then rename it to `snapshot_X-Y.committed` file once it is complete and ready for reading.