### PR TITLE
Disable election-mid-recovery test

### DIFF
--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -1414,15 +1414,6 @@ checked. Note that the key for each logging message is unique (per table).
     )
 
     cr.add(
-        "recovery_with_election",
-        run_recovery_with_election,
-        package="samples/apps/logging/liblogging",
-        nodes=infra.e2e_args.min_nodes(cr.args, f=1),
-        ledger_chunk_bytes="50KB",
-        snapshot_tx_interval=30,
-    )
-
-    cr.add(
         "recovery_with_incomplete_ledger",
         run_recovery_with_incomplete_ledger,
         package="samples/apps/logging/liblogging",


### PR DESCRIPTION
Added in #6920.

I've been monitoring the job for quite a bit, this test has around 80% success rate, when adding around 10 minutes (or more in ASAN).

I don't think it's worth it, it has to be more robust then that. Playing with timeout didn't pay off, it's depends too much on a HW situation and seems to be completely random in CI.

I suggest excluding it from the run for now, created a ticket to revisit it (#7032).