### PR TITLE
Remove unused `LABEL` from `add_perf_test`

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -176,10 +176,7 @@ endfunction()
 function(add_perf_test)
 
   cmake_parse_arguments(
-    PARSE_ARGV
-    0
-    PARSED_ARGS
-    ""
+    PARSE_ARGV 0 PARSED_ARGS ""
     "NAME;PYTHON_SCRIPT;CONSTITUTION;CLIENT_BIN;VERIFICATION_FILE;PERF_LABEL"
     "ADDITIONAL_ARGS"
   )


### PR DESCRIPTION
Someone's pet robot spotted this, but the suggested fix was wrong.

We don't use `PARSED_ARGS_LABEL` in `add_perf_test`, only `PARSED_ARGS_PERF_LABEL`. The only caller of `add_perf_test` remaining is in `tpcc.cmake`, passing `PERF_LABEL` and no `LABEL`. Remove the `LABEL` arg, retain the `PERF_LABEL` arg.