### PR TITLE
Pass through ASAN_SYMBOLIZER_PATH

### DIFF
--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -347,6 +347,7 @@ class CCFRemote(object):
                 env["UBSAN_OPTIONS"] += ":" + ubsan_opts
             env["TSAN_OPTIONS"] = os.environ.get("TSAN_OPTIONS", "")
             env["ASAN_OPTIONS"] = os.environ.get("ASAN_OPTIONS", "")
+            env["ASAN_SYMBOLIZER_PATH"] = os.environ.get("ASAN_SYMBOLIZER_PATH", "")
         elif enclave_platform == "snp":
             snp_security_context_directory_envvar = (
                 snp.ACI_SEV_SNP_ENVVAR_UVM_SECURITY_CONTEXT_DIR


### PR DESCRIPTION
This allows us to get symbols on AzureLinux3.0 by:
```
export ASAN_SYMBOLIZER_PATH=${which llvm-symbolizer}
```