### PR TITLE
Bump `pyproject.toml` version

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ccf"
-version = "6.0.4"
+version = "6.0.5"
 authors = [
   { name="CCF Team", email="CCF-Sec@microsoft.com" },
 ]

--- a/scripts/extract-release-notes.py
+++ b/scripts/extract-release-notes.py
@@ -73,7 +73,7 @@ def main():
                 if not release_notes:
                     assert (
                         log_version == pyproject_version
-                    ), f"First version in CHANGELOG must match version in pyproject.toml: {pyproject_version}"
+                    ), f"First version in CHANGELOG ({log_version}) must match version in pyproject.toml ({pyproject_version})"
                 release_notes[log_version] = current_release_notes
             elif match := link_definition.match(line):
                 link_version = match.group(1)


### PR DESCRIPTION
Also tweak for a nicer error:

```
First version in CHANGELOG must match version in pyproject.toml: 6.0.4

vs

First version in CHANGELOG (6.0.5) must match version in pyproject.toml (6.0.4)
```