### PR TITLE
Rework TSAN/ASAN symbols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,6 @@ jobs:
           cd build
           rm -rf /github/home/.cache
           mkdir -p /github/home/.cache
-          export ASAN_SYMBOLIZER_PATH=$(realpath /usr/bin/llvm-symbolizer-15)
           # Unit tests
           ./tests.sh --output-on-failure -L unit -j$(nproc --all)
           # End to end tests
@@ -192,7 +191,6 @@ jobs:
           cd build
           rm -rf /github/home/.cache
           mkdir -p /github/home/.cache
-          export ASAN_SYMBOLIZER_PATH=$(realpath /usr/bin/llvm-symbolizer-15)
           # Unit tests
           ./tests.sh --output-on-failure -L unit -j$(nproc --all)
           # End to end tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,6 @@ jobs:
           cd build
           rm -rf /github/home/.cache
           mkdir -p /github/home/.cache
-          export ASAN_SYMBOLIZER_PATH=$(realpath /usr/bin/llvm-symbolizer-15)
           # Unit tests
           ./tests.sh --output-on-failure -L unit -j$(nproc --all)
           # Suite tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,12 @@ if(CLANG_TIDY)
   message(STATUS "Using clang-tidy from: ${CLANG_TIDY_EXE}")
 endif()
 
+if (SAN OR TSAN)
+  find_program(LLVM_SYMBOLIZER NAMES "llvm-symbolizer")
+  message(STATUS "Using llvm symbolizer: ${LLVM_SYMBOLIZER}")
+endif()
+
+
 enable_language(ASM)
 
 set(CCF_GENERATED_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated)

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -26,6 +26,18 @@ function(add_unit_test name)
              "TSAN_OPTIONS=suppressions=${CCF_DIR}/tsan_env_suppressions"
   )
 
+  set_property(
+    TEST ${name}
+    APPEND
+    PROPERTY ENVIRONMENT "ASAN_SYMBOLIZER_PATH=${LLVM_SYMBOLIZER}"
+  )
+
+  set_property(
+    TEST ${name}
+    APPEND
+    PROPERTY ENVIRONMENT "TSAN_SYMBOLIZER_PATH=${LLVM_SYMBOLIZER}"
+  )
+
   target_compile_definitions(${name} PRIVATE CCF_LOGGER_NO_DEPRECATE)
 endfunction()
 
@@ -140,6 +152,18 @@ function(add_e2e_test)
     set_property(
       TEST ${PARSED_ARGS_NAME}
       APPEND
+      PROPERTY ENVIRONMENT "ASAN_SYMBOLIZER_PATH=${LLVM_SYMBOLIZER}"
+    )
+
+    set_property(
+      TEST ${PARSED_ARGS_NAME}
+      APPEND
+      PROPERTY ENVIRONMENT "TSAN_SYMBOLIZER_PATH=${LLVM_SYMBOLIZER}"
+    )
+
+    set_property(
+      TEST ${PARSED_ARGS_NAME}
+      APPEND
       PROPERTY LABELS e2e
     )
     set_property(
@@ -241,6 +265,17 @@ function(add_perf_test)
     PROPERTY ENVIRONMENT
              "TSAN_OPTIONS=suppressions=${CCF_DIR}/tsan_env_suppressions"
   )
+  set_property(
+    TEST ${TEST_NAME}
+    APPEND
+    PROPERTY ENVIRONMENT "ASAN_SYMBOLIZER_PATH=${LLVM_SYMBOLIZER}"
+  )
+
+  set_property(
+    TEST ${TEST_NAME}
+    APPEND
+    PROPERTY ENVIRONMENT "TSAN_SYMBOLIZER_PATH=${LLVM_SYMBOLIZER}"
+  )
 endfunction()
 
 # Helper for building end-to-end perf tests using the python infrastucture
@@ -312,6 +347,16 @@ function(add_piccolo_test)
     PROPERTY ENVIRONMENT
              "TSAN_OPTIONS=suppressions=${CCF_DIR}/tsan_env_suppressions"
   )
+  set_property(
+    TEST ${TEST_NAME}
+    APPEND
+    PROPERTY ENVIRONMENT "ASAN_SYMBOLIZER_PATH=${LLVM_SYMBOLIZER}"
+  )
+  set_property(
+    TEST ${TEST_NAME}
+    APPEND
+    PROPERTY ENVIRONMENT "TSAN_SYMBOLIZER_PATH=${LLVM_SYMBOLIZER}"
+  )
 endfunction()
 
 # Picobench wrapper
@@ -348,6 +393,16 @@ function(add_picobench name)
     APPEND
     PROPERTY ENVIRONMENT
              "TSAN_OPTIONS=suppressions=${CCF_DIR}/tsan_env_suppressions"
+  )
+  set_property(
+    TEST ${name}
+    APPEND
+    PROPERTY ENVIRONMENT "ASAN_SYMBOLIZER_PATH=${LLVM_SYMBOLIZER}"
+  )
+  set_property(
+    TEST ${name}
+    APPEND
+    PROPERTY ENVIRONMENT "TSAN_SYMBOLIZER_PATH=${LLVM_SYMBOLIZER}"
   )
   target_compile_definitions(${name} PRIVATE CCF_LOGGER_NO_DEPRECATE)
 endfunction()

--- a/src/enclave/virtual_enclave.h
+++ b/src/enclave/virtual_enclave.h
@@ -73,7 +73,7 @@ extern "C"
       path,
       RTLD_NOW
 #if defined(__has_feature)
-#  if __has_feature(address_sanitizer)
+#  if __has_feature(address_sanitizer) || __has_feature(thread_sanitizer)
         // Avoid unloading on delete under ASAN, so that leak checking can still
         // access symbols
         | RTLD_NODELETE

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -348,6 +348,7 @@ class CCFRemote(object):
             env["TSAN_OPTIONS"] = os.environ.get("TSAN_OPTIONS", "")
             env["ASAN_OPTIONS"] = os.environ.get("ASAN_OPTIONS", "")
             env["ASAN_SYMBOLIZER_PATH"] = os.environ.get("ASAN_SYMBOLIZER_PATH", "")
+            env["TSAN_SYMBOLIZER_PATH"] = os.environ.get("TSAN_SYMBOLIZER_PATH", "")
         elif enclave_platform == "snp":
             snp_security_context_directory_envvar = (
                 snp.ACI_SEV_SNP_ENVVAR_UVM_SECURITY_CONTEXT_DIR


### PR DESCRIPTION
Resolve #6870 

Experimentally have found proper variable name.

* Ensure not unloading .so if tsan
* Remove sporadic `export ASAN_SYMBOLIZER_PATH=$(realpath /usr/bin/llvm-symbolizer-15)` because
  * not relevant anymore (v==15) 
  * set where unnecessary, and not set where necessary
  * easy to forget in new workflows
* Instead
  * set via cmake
  * pass in e2e remote