### PR TITLE
Ensure fds are closed after exiting ioctl

### DIFF
--- a/include/ccf/ds/nonstd.h
+++ b/include/ccf/ds/nonstd.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <unistd.h>
 #include <vector>
 
 #define FMT_HEADER_ONLY
@@ -202,5 +203,19 @@ namespace ccf::nonstd
       f(std::get<I>(t));
       tuple_for_each<I + 1>(t, f);
     }
+  }
+
+  static void close_fd(int* fd)
+  {
+    if (fd != nullptr && *fd >= 0)
+    {
+      close(*fd);
+      *fd = -1;
+    }
+  }
+  using CloseFdGuard = std::unique_ptr<int, decltype(&close_fd)>;
+  static inline CloseFdGuard make_close_fd_guard(int* fd)
+  {
+    return CloseFdGuard(fd, close_fd);
   }
 }

--- a/include/ccf/pal/snp_ioctl5.h
+++ b/include/ccf/pal/snp_ioctl5.h
@@ -106,8 +106,16 @@ namespace ccf::pal::snp::ioctl5
       int fd = open(DEVICE, O_RDWR | O_CLOEXEC);
       if (fd < 0)
       {
-        throw std::logic_error(fmt::format("Failed to open \"{}\"", DEVICE));
+        throw std::logic_error(
+          fmt::format("Failed to open \"{}\" ({})", DEVICE, fd));
       }
+      auto close_fd = [&fd]() {
+        if (fd >= 0)
+        {
+          close(fd);
+        }
+      };
+      std::unique_ptr<int, decltype(close_fd)> fd_guard(&fd, close_fd);
 
       // Documented at
       // https://www.kernel.org/doc/html/latest/virt/coco/sev-guest.html

--- a/include/ccf/pal/snp_ioctl5.h
+++ b/include/ccf/pal/snp_ioctl5.h
@@ -109,10 +109,10 @@ namespace ccf::pal::snp::ioctl5
         throw std::logic_error(
           fmt::format("Failed to open \"{}\" ({})", DEVICE, fd));
       }
-      auto close_fd = [&fd]() {
-        if (fd >= 0)
+      auto close_fd = [](int* fd) {
+        if (fd != nullptr && *fd >= 0)
         {
-          close(fd);
+          close(*fd);
         }
       };
       std::unique_ptr<int, decltype(close_fd)> fd_guard(&fd, close_fd);

--- a/include/ccf/pal/snp_ioctl5.h
+++ b/include/ccf/pal/snp_ioctl5.h
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ccf/ds/nonstd.h"
 #include "ccf/pal/attestation_sev_snp.h"
 
 #include <fcntl.h>
@@ -109,13 +110,7 @@ namespace ccf::pal::snp::ioctl5
         throw std::logic_error(
           fmt::format("Failed to open \"{}\" ({})", DEVICE, fd));
       }
-      auto close_fd = [](int* fd) {
-        if (fd != nullptr && *fd >= 0)
-        {
-          close(*fd);
-        }
-      };
-      std::unique_ptr<int, decltype(close_fd)> fd_guard(&fd, close_fd);
+      auto close_guard = nonstd::make_close_fd_guard(&fd);
 
       // Documented at
       // https://www.kernel.org/doc/html/latest/virt/coco/sev-guest.html

--- a/include/ccf/pal/snp_ioctl6.h
+++ b/include/ccf/pal/snp_ioctl6.h
@@ -12,6 +12,7 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include "ccf/ds/nonstd.h"
 
 // Based on the SEV-SNP ABI Spec document at
 // https://www.amd.com/system/files/TechDocs/56860.pdf
@@ -229,13 +230,7 @@ namespace ccf::pal::snp::ioctl6
         throw std::logic_error(
           fmt::format("Failed to open \"{}\" ({})", DEVICE, fd));
       }
-      auto close_fd = [](int* fd) {
-        if (fd != nullptr && *fd >= 0)
-        {
-          close(*fd);
-        }
-      };
-      std::unique_ptr<int, decltype(close_fd)> fd_guard(&fd, close_fd);
+      auto close_guard = nonstd::make_close_fd_guard(&fd);
 
       // Documented at
       // https://www.kernel.org/doc/html/latest/virt/coco/sev-guest.html
@@ -290,13 +285,7 @@ namespace ccf::pal::snp::ioctl6
         throw std::logic_error(
           fmt::format("Failed to open \"{}\" ({})", DEVICE, fd));
       }
-      auto close_fd = [](int* fd) {
-        if (fd != nullptr && *fd >= 0)
-        {
-          close(*fd);
-        }
-      };
-      std::unique_ptr<int, decltype(close_fd)> fd_guard(&fd, close_fd);
+      auto close_guard = nonstd::make_close_fd_guard(&fd);
 
       // This req by default mixes in HostData and the CPU VCEK
       DerivedKeyReq req = {};

--- a/include/ccf/pal/snp_ioctl6.h
+++ b/include/ccf/pal/snp_ioctl6.h
@@ -229,13 +229,20 @@ namespace ccf::pal::snp::ioctl6
         throw std::logic_error(
           fmt::format("Failed to open \"{}\" ({})", DEVICE, fd));
       }
+      auto close_fd = [&fd]() {
+        if (fd >= 0)
+        {
+          close(fd);
+        }
+      };
+      std::unique_ptr<int, decltype(close_fd)> fd_guard(&fd, close_fd);
 
       // Documented at
       // https://www.kernel.org/doc/html/latest/virt/coco/sev-guest.html
       GuestRequestAttestation payload = {
         .req_data = &req, .resp_wrapper = &padded_resp, .exit_info = {0}};
 
-      int rc = ioctl(fd, SEV_SNP_GUEST_MSG_REPORT, &payload);
+      int rc = ioctl(*fd_ptr, SEV_SNP_GUEST_MSG_REPORT, &payload);
       if (rc < 0)
       {
         const auto msg = fmt::format(
@@ -283,6 +290,13 @@ namespace ccf::pal::snp::ioctl6
         throw std::logic_error(
           fmt::format("Failed to open \"{}\" ({})", DEVICE, fd));
       }
+      auto close_fd = [&fd]() {
+        if (fd >= 0)
+        {
+          close(fd);
+        }
+      };
+      std::unique_ptr<int, decltype(close_fd)> fd_guard(&fd, close_fd);
 
       // This req by default mixes in HostData and the CPU VCEK
       DerivedKeyReq req = {};

--- a/include/ccf/pal/snp_ioctl6.h
+++ b/include/ccf/pal/snp_ioctl6.h
@@ -229,10 +229,10 @@ namespace ccf::pal::snp::ioctl6
         throw std::logic_error(
           fmt::format("Failed to open \"{}\" ({})", DEVICE, fd));
       }
-      auto close_fd = [&fd]() {
-        if (fd >= 0)
+      auto close_fd = [](int* fd) {
+        if (fd != nullptr && *fd >= 0)
         {
-          close(fd);
+          close(*fd);
         }
       };
       std::unique_ptr<int, decltype(close_fd)> fd_guard(&fd, close_fd);
@@ -242,7 +242,7 @@ namespace ccf::pal::snp::ioctl6
       GuestRequestAttestation payload = {
         .req_data = &req, .resp_wrapper = &padded_resp, .exit_info = {0}};
 
-      int rc = ioctl(*fd_ptr, SEV_SNP_GUEST_MSG_REPORT, &payload);
+      int rc = ioctl(fd, SEV_SNP_GUEST_MSG_REPORT, &payload);
       if (rc < 0)
       {
         const auto msg = fmt::format(
@@ -290,10 +290,10 @@ namespace ccf::pal::snp::ioctl6
         throw std::logic_error(
           fmt::format("Failed to open \"{}\" ({})", DEVICE, fd));
       }
-      auto close_fd = [&fd]() {
-        if (fd >= 0)
+      auto close_fd = [](int* fd) {
+        if (fd != nullptr && *fd >= 0)
         {
-          close(fd);
+          close(*fd);
         }
       };
       std::unique_ptr<int, decltype(close_fd)> fd_guard(&fd, close_fd);

--- a/include/ccf/pal/snp_ioctl6.h
+++ b/include/ccf/pal/snp_ioctl6.h
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ccf/ds/nonstd.h"
 #include "ccf/pal/attestation_sev_snp.h"
 
 #include <algorithm>
@@ -12,7 +13,6 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include "ccf/ds/nonstd.h"
 
 // Based on the SEV-SNP ABI Spec document at
 // https://www.amd.com/system/files/TechDocs/56860.pdf


### PR DESCRIPTION
This PR uses a unique_ptr to ensure that the file descriptor cannot leak when we do the ioctls to /dev/guest-sev.