### PR TITLE
Add test to validate historical ledgers and snapshots

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1336,9 +1336,14 @@ if(BUILD_TESTS)
       NAME schema_test_cft
       PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/schema.py
       ADDITIONAL_ARGS
-        --schema-dir ${CMAKE_SOURCE_DIR}/doc/schemas --ledger-tutorial
-        ${CMAKE_SOURCE_DIR}/python/ledger_tutorial.py --config-samples-dir
+        --schema-dir
+        ${CMAKE_SOURCE_DIR}/doc/schemas
+        --ledger-tutorial
+        ${CMAKE_SOURCE_DIR}/python/ledger_tutorial.py
+        --config-samples-dir
         ${CMAKE_SOURCE_DIR}/samples/config
+        --historical-testdata
+        ${CMAKE_SOURCE_DIR}/tests/testdata
     )
 
     list(APPEND LTS_TEST_ARGS --ccf-version ${CCF_VERSION})

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -607,10 +607,12 @@ class LedgerValidator(BaseValidator):
                 sig = base64.b64decode(signature["sig"])
 
                 # Check that key in cert matches that in node table
-                sig_cert = signature["cert"].encode("utf-8")
-                assert spki_from_cert(cert) == spki_from_cert(
-                    sig_cert
-                ), f"Mismatch in public key for node {signing_node}"
+                # when present
+                if "cert" in signature:
+                    sig_cert = signature["cert"].encode("utf-8")
+                    assert spki_from_cert(cert) == spki_from_cert(
+                        sig_cert
+                    ), f"Mismatch in public key for node {signing_node}"
 
                 tx_info = TxBundleInfo(
                     self.merkle,

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -200,6 +200,11 @@ if __name__ == "__main__":
             type=str,
             default=None,
         )
+        parser.add_argument(
+            "--historical-testdata",
+            help="Historical ledger test data directory",
+            type=str,
+        )
 
     cr = ConcurrentRunner(add)
 


### PR DESCRIPTION
Includes a small fix to `ledger.py` to support early (1.x) ledger files that do not include a cert in their signatures.