### PR TITLE
Update 5-to-6 migration docs to recommend going directly to 6.0.2

### DIFF
--- a/doc/build_apps/migration_5_x_to_6_0.rst
+++ b/doc/build_apps/migration_5_x_to_6_0.rst
@@ -80,7 +80,7 @@ Version live compatibility
 
 When upgrading CCF services from one major version to the next, our usual recommendation is to upgrade first to the initial release in the new major version before attempting upgrade to later versions; ``N.latest`` transitions to ``N+1.0.0``. Interoperation between other versions is not guaranteed.
 
-**We make an exception for upgrades from 5.x to 6.0, and recommend that services upgrade directly to 6.0.2.**
+.. warning:: We make an exception for upgrades from 5.x to 6.0, and recommend that services upgrade from 5.latest directly to 6.0.2.
 
 There is a bug in ``6.0.0`` and ``6.0.1`` which can cause a node to crash when running in a mixed-version service. This is described in detail in `GitHub issue #7002 <https://github.com/microsoft/CCF/issues/7002>`_, but a brief summary is that if a ``5.x`` node becomes primary and emits a signature `after` a ``6.0.0`` or ``6.0.1`` node has been primary, then the resulting ledger transactions will be unparseable by a ``6.0.0`` or ``6.0.1`` node. Any such node receiving these errors will report ``Failed to deserialise`` errors in its log. It is not guaranteed that multi-versioned services will hit this - if the upgrade and node rotation happens smoothly then it is possible for the service to reach a point where all nodes are running ``6.0.0`` and it is safe from this issue.
 

--- a/doc/build_apps/migration_5_x_to_6_0.rst
+++ b/doc/build_apps/migration_5_x_to_6_0.rst
@@ -14,7 +14,6 @@ Specifically on C-ACI, new SNP nodes will populate ``nodes.snp.host_data``, ``no
 
 The benefit is that if new nodes are deployed on homogenous hardware and software stacks, then the join policy will automatically be populated with the correct values.
 
-
 SNP TCB version
 ~~~~~~~~~~~~~~~
 
@@ -75,3 +74,14 @@ CCF release distribution
 ------------------------
 
 Binary releases now target Azure Linux 3.0, and are provided as RPM packages, `ccf_devel` for application development, and `ccf` for the runtime. Containers and Debian packages are no longer published.
+
+Version live compatibility
+--------------------------
+
+When upgrading CCF services from one major version to the next, our usual recommendation is to upgrade first to the initial release in the new major version before attempting upgrade to later versions; ``N.latest`` transitions to ``N+1.0.0``. Interoperation between other versions is not guaranteed.
+
+**We make an exception for upgrades from ``5.x`` to ``6.0``, and recommend that services upgrade directly to ``6.0.2``.**
+
+There is a bug in ``6.0.0`` and ``6.0.1`` which can cause a node to crash when running in a mixed-version service. This is described in detail in `GitHub issue #7002 <https://github.com/microsoft/CCF/issues/7002>`_, but a brief summary is that if a ``5.x`` node becomes primary and emits a signature `after` a ``6.0.0`` or ``6.0.1`` node has been primary, then the resulting ledger transactions will be unparseable by a ``6.0.0`` or ``6.0.1`` node. Any such node receiving these errors will report ``Failed to deserialise`` errors in its log. It is not guaranteed that multi-versioned services will hit this - if the upgrade and node rotation happens smoothly then it is possible for the service to reach a point where all nodes are running ``6.0.0`` and it is safe from this issue.
+
+This bug is resolved in ``6.0.2``, and does not affect the ledger history - it is purely an issue with how ``6.0.0`` and ``6.0.1`` nodes `parse` these entries, rather than with the entries themselves. If an upgrade to ``6.0.0`` or ``6.0.1`` has been attempted, and results in nodes failing with ``Failed to deserialise`` errors, then it may be necessary to run a disaster recovery process to reach the ``6.0.2`` version and restore the service.

--- a/doc/build_apps/migration_5_x_to_6_0.rst
+++ b/doc/build_apps/migration_5_x_to_6_0.rst
@@ -80,7 +80,7 @@ Version live compatibility
 
 When upgrading CCF services from one major version to the next, our usual recommendation is to upgrade first to the initial release in the new major version before attempting upgrade to later versions; ``N.latest`` transitions to ``N+1.0.0``. Interoperation between other versions is not guaranteed.
 
-**We make an exception for upgrades from ``5.x`` to ``6.0``, and recommend that services upgrade directly to ``6.0.2``.**
+**We make an exception for upgrades from 5.x to 6.0, and recommend that services upgrade directly to 6.0.2.**
 
 There is a bug in ``6.0.0`` and ``6.0.1`` which can cause a node to crash when running in a mixed-version service. This is described in detail in `GitHub issue #7002 <https://github.com/microsoft/CCF/issues/7002>`_, but a brief summary is that if a ``5.x`` node becomes primary and emits a signature `after` a ``6.0.0`` or ``6.0.1`` node has been primary, then the resulting ledger transactions will be unparseable by a ``6.0.0`` or ``6.0.1`` node. Any such node receiving these errors will report ``Failed to deserialise`` errors in its log. It is not guaranteed that multi-versioned services will hit this - if the upgrade and node rotation happens smoothly then it is possible for the service to reach a point where all nodes are running ``6.0.0`` and it is safe from this issue.
 


### PR DESCRIPTION
Closing #7002.

Following discussion there, we've confirmed that interop between 5.latest and 6.0.2 is possible, so the docs now recommend that users skip 6.0.0 and 6.0.1.