### PR TITLE
Add reproducible build documentation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -57,6 +57,13 @@ CCF Documentation
 
     ---
 
+    :fa:`sync` :doc:`reproduce_app/index`
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    Reproduce CCF RPM package from the source code.
+
+    ---
+
     :fa:`code-branch` :doc:`contribute/index`
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -86,6 +93,7 @@ CCF Documentation
     operations/index.rst
     governance/index.rst
     audit/index.rst
+    reproduce_app/index.rst
     contribute/index.rst
     architecture/index.rst
     research/index.rst

--- a/doc/reproduce_app/index.rst
+++ b/doc/reproduce_app/index.rst
@@ -1,0 +1,37 @@
+Reproducible Build
+==========================
+
+This section explains how :term:`Users` can reproduce CCF RPM packages using published build manifests.
+
+Reproducible builds enables our published packages to be independently verified. For each official CCF release, we provide:
+
+- A ``reproduce_${PLATFORM}.json`` manifest containing the platform, container image, snapshot time, and git commit.
+- A ``start_container_and_reproduce_rpm.sh`` script needed to reproduce the RPM build.
+
+To reproduce a package:
+
+1. Download the ``reproduce_${PLATFORM}.json`` file for the desired release.
+2. Run the ``start_container_and_reproduce_rpm.sh`` script with the manifest as input:
+
+.. code-block:: bash
+
+    # Set CCF_VERSION to most recent LTS release
+    $ export CCF_VERSION=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/microsoft/CCF/releases/latest | sed 's/^.*ccf-//')
+    # Alternatively, set this manually, e.g.:
+    # export CCF_VERSION=6.0.0
+    $ export PLATFORM=virtual
+    $ wget https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/reproduce_${PLATFORM}.json
+    $ wget https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/start_container_and_reproduce_rpm.sh
+
+    $ ./start_container_and_reproduce_rpm.sh reproduce_${PLATFORM}.json
+
+This builds the RPM in a container and outputs it to ``./reproduced/``. You can then compare it with the official RPM to verify they are identical:
+
+.. code-block:: bash
+
+    # Set CCF_VERSION to most recent LTS release
+    $ export CCF_VERSION=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/microsoft/CCF/releases/latest | sed 's/^.*ccf-//')
+    # Alternatively, set this manually, e.g.:
+    # export CCF_VERSION=6.0.0
+    $ wget https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/ccf_virtual_devel_${CCF_VERSION}_x86_64.rpm
+    $ cmp ./ccf_virtual_devel_${CCF_VERSION}_x86_64.rpm ./reproduced/ccf_virtual_devel_${CCF_VERSION}_x86_64.rpm


### PR DESCRIPTION
This PR updates the documentation to include how to reproduce and verify CCF packages.
Depends on #7069 