### PR TITLE
Hexstring tcb

### DIFF
--- a/include/ccf/pal/attestation.h
+++ b/include/ccf/pal/attestation.h
@@ -229,8 +229,10 @@ namespace ccf::pal
           sizeof(snp::TcbVersion)));
       }
 
-      snp::TcbVersion tcb = *reinterpret_cast<snp::TcbVersion*>(raw_tcb.data());
-      if (tcb != quote.reported_tcb)
+      if (
+        memcmp(
+          raw_tcb.data(), &quote.reported_tcb.data, sizeof(snp::TcbVersion)) !=
+        0)
       {
         auto* reported_tcb = reinterpret_cast<uint8_t*>(&quote.reported_tcb);
         throw std::logic_error(fmt::format(

--- a/include/ccf/pal/sev_snp_cpuid.h
+++ b/include/ccf/pal/sev_snp_cpuid.h
@@ -15,6 +15,7 @@ namespace ccf::pal::snp
   {
     Milan,
     Genoa,
+    Turin
   };
 
   inline std::string to_string(ProductName product)
@@ -25,6 +26,8 @@ namespace ccf::pal::snp
         return "Milan";
       case ProductName::Genoa:
         return "Genoa";
+      case ProductName::Turin:
+        return "Turin";
       default:
         throw std::logic_error("Unknown SEV-SNP product");
     }
@@ -35,6 +38,7 @@ namespace ccf::pal::snp
     {
       {ProductName::Milan, "Milan"},
       {ProductName::Genoa, "Genoa"},
+      {ProductName::Turin, "Turin"},
     });
 
   using AMDFamily = uint8_t;
@@ -42,13 +46,23 @@ namespace ccf::pal::snp
 
   inline ProductName get_sev_snp_product(AMDFamily family, AMDModel model)
   {
-    if (family == 0x19 && model == 0x01)
+    constexpr uint8_t milan_family = 0x19;
+    constexpr uint8_t milan_model = 0x01;
+    if (family == milan_family && model == milan_model)
     {
       return ProductName::Milan;
     }
-    if (family == 0x19 && model == 0x11)
+    constexpr uint8_t genoa_family = 0x19;
+    constexpr uint8_t genoa_model = 0x11;
+    if (family == genoa_family && model == genoa_model)
     {
       return ProductName::Genoa;
+    }
+    constexpr uint8_t turin_family = 0x1A;
+    constexpr uint8_t turin_model = 0x01;
+    if (family == turin_family && model == turin_model)
+    {
+      return ProductName::Turin;
     }
     throw std::logic_error(fmt::format(
       "SEV-SNP: Unsupported CPUID family {} model {}", family, model));

--- a/src/js/extensions/snp_attestation.cpp
+++ b/src/js/extensions/snp_attestation.cpp
@@ -20,7 +20,9 @@ namespace ccf::js::extensions
   static JSValue make_js_tcb_version(
     js::core::Context& jsctx, pal::snp::TcbVersion tcb)
   {
-    auto data_hex = jsctx.new_string(ds::to_hex(tcb.data));
+    auto span = std::span<const uint8_t>(
+      tcb.data, sizeof(tcb.data) / sizeof(tcb.data[0]));
+    auto data_hex = jsctx.new_string(ds::to_hex(span));
     JS_CHECK_EXC(data_hex);
     return data_hex.take();
   }

--- a/src/js/extensions/snp_attestation.cpp
+++ b/src/js/extensions/snp_attestation.cpp
@@ -20,14 +20,9 @@ namespace ccf::js::extensions
   static JSValue make_js_tcb_version(
     js::core::Context& jsctx, pal::snp::TcbVersion tcb)
   {
-    auto js_tcb = jsctx.new_obj();
-    JS_CHECK_EXC(js_tcb);
-
-    JS_CHECK_SET(js_tcb.set_uint32("boot_loader", tcb.boot_loader));
-    JS_CHECK_SET(js_tcb.set_uint32("tee", tcb.tee));
-    JS_CHECK_SET(js_tcb.set_uint32("snp", tcb.snp));
-    JS_CHECK_SET(js_tcb.set_uint32("microcode", tcb.microcode));
-    return js_tcb.take();
+    auto data_hex = jsctx.new_string(ds::to_hex(tcb.data));
+    JS_CHECK_EXC(data_hex);
+    return data_hex.take();
   }
 
   static JSValue JS_NewArrayBuffer2(

--- a/src/pal/test/snp_attestation_validation.cpp
+++ b/src/pal/test/snp_attestation_validation.cpp
@@ -4,6 +4,7 @@
 #include "ccf/ds/hex.h"
 #include "ccf/ds/quote_info.h"
 #include "ccf/pal/attestation.h"
+#include "ccf/pal/attestation_sev_snp.h"
 #include "ccf/pal/measurement.h"
 #include "ccf/pal/report_data.h"
 #include "crypto/openssl/hash.h"
@@ -80,6 +81,53 @@ TEST_CASE("Mismatched attestation and endorsements fail")
       what.find("SEV-SNP: The root of trust public key for this attestation "
                 "was not the expected one") != std::string::npos);
   }
+}
+
+TEST_CASE("Parsing of Tcb versions from strings")
+{
+  const auto milan_tcb_version_full = ccf::pal::snp::TcbVersion::from_hex("d315000000000004");
+  CHECK_EQ(
+    nlohmann::json(milan_tcb_version_full).dump(),
+    "\"d315000000000004\""
+  );
+
+  const auto milan_tcb_version = milan_tcb_version_full.to_MilanGenoa();
+  CHECK_EQ(
+    milan_tcb_version.microcode, 0xd3);
+  CHECK_EQ(
+    milan_tcb_version.snp, 0x15);
+  CHECK_EQ(
+    milan_tcb_version.tee, 0x00);
+  CHECK_EQ(
+    milan_tcb_version.boot_loader, 0x04);
+
+
+  const auto turin_tcb_version = ccf::pal::snp::TcbVersion::from_hex("1100000022334455").to_Turin();
+  CHECK_EQ(
+    turin_tcb_version.microcode, 0x11);
+  CHECK_EQ(
+    turin_tcb_version.snp, 0x22);
+  CHECK_EQ(
+    turin_tcb_version.tee, 0x33);
+  CHECK_EQ(
+    turin_tcb_version.boot_loader, 0x44);
+  CHECK_EQ(
+    turin_tcb_version.fmc, 0x55);
+}
+
+TEST_CASE("Parsing tcb versions from attestaion")
+{
+  auto milan_attestation =
+    *reinterpret_cast<const ccf::pal::snp::Attestation*>(ccf::pal::snp::testing::milan_attestation.data());
+  auto milan_tcb = milan_attestation.reported_tcb.to_MilanGenoa();
+  CHECK_EQ(
+    milan_tcb.microcode, 0xdb);
+  CHECK_EQ(
+    milan_tcb.snp, 0x18);
+  CHECK_EQ(
+    milan_tcb.tee, 0x00);
+  CHECK_EQ(
+    milan_tcb.boot_loader, 0x04);
 }
 
 int main(int argc, char** argv)

--- a/src/service/internal_tables_access.h
+++ b/src/service/internal_tables_access.h
@@ -840,7 +840,12 @@ namespace ccf
         .extended_family = 0x0A,
         .reserved2 = 0};
       // Reported by ACI for minimum Milan version
-      constexpr pal::snp::TcbVersion milan_tcb_version{.data=ds::from_hex("d315000000000004")};
+      const auto vec_milan_tcb_version = ds::from_hex("d315000000000004");
+      pal::snp::TcbVersion milan_tcb_version{};
+      memcpy(
+        milan_tcb_version.data,
+        vec_milan_tcb_version.data(),
+        sizeof(milan_tcb_version.data));
       h->put(milan_chip_id.hex_str(), milan_tcb_version);
       h->put(milan_x_chip_id.hex_str(), milan_tcb_version);
     }

--- a/src/service/internal_tables_access.h
+++ b/src/service/internal_tables_access.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ccf/crypto/verifier.h"
+#include "ccf/ds/hex.h"
 #include "ccf/pal/attestation_sev_snp.h"
 #include "ccf/service/tables/code_id.h"
 #include "ccf/service/tables/constitution.h"
@@ -830,14 +831,6 @@ namespace ccf
         .extended_model = 0x0,
         .extended_family = 0x0A,
         .reserved2 = 0};
-      constexpr pal::snp::TcbVersion milan_tcb_version = {
-        .boot_loader = 0,
-        .tee = 0,
-        .reserved = {0},
-        .snp = 0x18,
-        .microcode = 0xDB};
-      h->put(milan_chip_id.hex_str(), milan_tcb_version);
-
       constexpr pal::snp::CPUID milan_x_chip_id{
         .stepping = 0x2,
         .base_model = 0x1,
@@ -846,45 +839,10 @@ namespace ccf
         .extended_model = 0x0,
         .extended_family = 0x0A,
         .reserved2 = 0};
-      constexpr pal::snp::TcbVersion milan_x_tcb_version = {
-        .boot_loader = 0,
-        .tee = 0,
-        .reserved = {0},
-        .snp = 0x18,
-        .microcode = 0x44};
-      h->put(milan_x_chip_id.hex_str(), milan_x_tcb_version);
-
-      constexpr pal::snp::CPUID genoa_chip_id{
-        .stepping = 0x1,
-        .base_model = 0x1,
-        .base_family = 0xF,
-        .reserved = 0,
-        .extended_model = 0x1,
-        .extended_family = 0x0A,
-        .reserved2 = 0};
-      constexpr pal::snp::TcbVersion genoa_tcb_version = {
-        .boot_loader = 0,
-        .tee = 0,
-        .reserved = {0},
-        .snp = 0x17,
-        .microcode = 0x54};
-      h->put(genoa_chip_id.hex_str(), genoa_tcb_version);
-
-      constexpr pal::snp::CPUID genoa_x_chip_id{
-        .stepping = 0x2,
-        .base_model = 0x1,
-        .base_family = 0xF,
-        .reserved = 0,
-        .extended_model = 0x1,
-        .extended_family = 0x0A,
-        .reserved2 = 0};
-      constexpr pal::snp::TcbVersion genoa_x_tcb_version = {
-        .boot_loader = 0,
-        .tee = 0,
-        .reserved = {0},
-        .snp = 0x17,
-        .microcode = 0x4F};
-      h->put(genoa_x_chip_id.hex_str(), genoa_x_tcb_version);
+      // Reported by ACI for minimum Milan version
+      constexpr pal::snp::TcbVersion milan_tcb_version{.data=ds::from_hex("d315000000000004")};
+      h->put(milan_chip_id.hex_str(), milan_tcb_version);
+      h->put(milan_x_chip_id.hex_str(), milan_tcb_version);
     }
 
     static void trust_node_snp_tcb_version(


### PR DESCRIPTION
In the future we need to support Turin CPUs and with Turin comes a new TCB version format.

Hence in this PR we make TCB versions a raw byte array which can be converted into these TCB version formats.

TODO
- [ ] update js interface and governance