### PR TITLE
 Add path prefix to reproduce script

### DIFF
--- a/doc/reproduce_app/index.rst
+++ b/doc/reproduce_app/index.rst
@@ -20,10 +20,10 @@ To reproduce a package:
     # Alternatively, set this manually, e.g.:
     # export CCF_VERSION=6.0.0
     $ export PLATFORM=virtual
-    $ wget https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/reproduce_${PLATFORM}.json
+    $ wget https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/reproduce-${PLATFORM}.json
     $ wget https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/start_container_and_reproduce_rpm.sh
-
-    $ ./start_container_and_reproduce_rpm.sh reproduce_${PLATFORM}.json
+    $ chmod +x ./start_container_and_reproduce_rpm.sh 
+    $ ./start_container_and_reproduce_rpm.sh reproduce-${PLATFORM}.json
 
 This builds the RPM in a container and outputs it to ``./reproduced/``. You can then compare it with the official RPM to verify they are identical:
 

--- a/reproduce/reproduce_rpm.sh
+++ b/reproduce/reproduce_rpm.sh
@@ -24,6 +24,7 @@ install_deps() {
 }
 
 build_pkg() {
+  mkdir -p /tmp/reproduced
   mkdir -p build && cd build
   echo "Reproducing devel package..."
   cmake -G Ninja -DCOMPILE_TARGET="$PLATFORM" -DCLIENT_PROTOCOLS_TEST=ON -DCMAKE_BUILD_TYPE=Release ..

--- a/reproduce/start_container_and_reproduce_rpm.sh
+++ b/reproduce/start_container_and_reproduce_rpm.sh
@@ -14,6 +14,10 @@ usage() {
 }
 
 setup_env() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: jq is not installed. Please install jq to continue."
+    exit 1
+  fi
   IMAGE=$(jq -r '.build_container_image' "$REPRO_JSON")
   SOURCE_DATE_EPOCH=$(jq -r '.tdnf_snapshottime' "$REPRO_JSON")
   export SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH"
@@ -29,19 +33,21 @@ setup_env
 docker run --rm -it \
   -e SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH" \
   -v "$(pwd)/reproduced":/tmp/reproduced \
-  -v $REPRO_JSON:/reproduce.json \
+  --mount type=bind,src="$(pwd)/$REPRO_JSON",dst=/reproduce.json \
   "$IMAGE" \
   bash -c '
     set -ex
-    tdnf install --snapshottime=$SOURCE_DATE_EPOCH -y git jq
+    tdnf install --snapshottime=$SOURCE_DATE_EPOCH -y git jq ca-certificates
     COMMIT_ID=$(jq -r '.commit_sha' "/reproduce.json")
     echo "Cloning repo and checking out commit $COMMIT_ID"
     REPO_URL="https://github.com/microsoft/CCF"
-    git clone "$REPO_URL" /CCF
-    git config --global --add safe.directory /CCF
-    cd /CCF
+    mkdir -p /__w/CCF
+    cd /__w/CCF
+    git clone "$REPO_URL" CCF
+    git config --global --add safe.directory $(pwd)/CCF
+    cd CCF
     git checkout "$COMMIT_ID"
-    
+   
     echo "Running reproduce script..."
     chmod +x ./reproduce/reproduce_rpm.sh
     ./reproduce/reproduce_rpm.sh /reproduce.json


### PR DESCRIPTION
This PR adds a temporary fix for an embedded file path mismatch between the GitHub Actions produced package and the locally produced package. It also fixes file bind syntax in docker.