### PR TITLE
Clear error messages when JWT auth succeeds

### DIFF
--- a/src/endpoints/authentication/jwt_auth.cpp
+++ b/src/endpoints/authentication/jwt_auth.cpp
@@ -267,7 +267,8 @@ namespace ccf
           token.payload_typed.nbf);
         continue;
       }
-      else if (time_now > token.payload_typed.exp)
+
+      if (time_now > token.payload_typed.exp)
       {
         error_reason = fmt::format(
           "Current time {} is after token's Expiration Time (exp) claim {}",
@@ -275,7 +276,9 @@ namespace ccf
           token.payload_typed.exp);
         continue;
       }
-      else if (
+
+      // Check that the contraint is met
+      if (
         metadata.constraint &&
         !validate_issuer(
           token.payload_typed.iss,
@@ -288,15 +291,14 @@ namespace ccf
           *metadata.constraint);
         continue;
       }
-      else
-      {
-        auto identity = std::make_unique<JwtAuthnIdentity>();
-        identity->key_issuer = metadata.issuer;
-        identity->header = token.header;
-        identity->payload = token.payload;
-        error_reason.clear();
-        return identity;
-      }
+
+      // Else all checks have passed; return this identity
+      auto identity = std::make_unique<JwtAuthnIdentity>();
+      identity->key_issuer = metadata.issuer;
+      identity->header = token.header;
+      identity->payload = token.payload;
+      error_reason.clear();
+      return identity;
     }
 
     return nullptr;

--- a/src/endpoints/authentication/jwt_auth.cpp
+++ b/src/endpoints/authentication/jwt_auth.cpp
@@ -277,7 +277,7 @@ namespace ccf
         continue;
       }
 
-      // Check that the contraint is met
+      // Check that the constraint is met
       if (
         metadata.constraint &&
         !validate_issuer(

--- a/src/endpoints/authentication/jwt_auth.cpp
+++ b/src/endpoints/authentication/jwt_auth.cpp
@@ -265,6 +265,7 @@ namespace ccf
           "Current time {} is before token's Not Before (nbf) claim {}",
           time_now,
           token.payload_typed.nbf);
+        continue;
       }
       else if (time_now > token.payload_typed.exp)
       {
@@ -272,6 +273,7 @@ namespace ccf
           "Current time {} is after token's Expiration Time (exp) claim {}",
           time_now,
           token.payload_typed.exp);
+        continue;
       }
       else if (
         metadata.constraint &&
@@ -284,6 +286,7 @@ namespace ccf
           "Kid {} failed issuer constraint validation {}",
           key_id,
           *metadata.constraint);
+        continue;
       }
       else
       {
@@ -291,6 +294,7 @@ namespace ccf
         identity->key_issuer = metadata.issuer;
         identity->header = token.header;
         identity->payload = token.payload;
+        error_reason.clear();
         return identity;
       }
     }


### PR DESCRIPTION
Resolves #7084.

Making sure misleading error messages don't leak through when auth succeeds. Also adding a consistent pattern of `error_reason = ...; continue;`, to try and prevent future code flow bugs.