### PR TITLE
Use `set_response_json` rather than re-implementing

### DIFF
--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -1108,11 +1108,7 @@ namespace loggingapp
           ctx.tx.template rw<RecordsMap>(private_records(ctx));
         records_handle->put(in.id, log_line);
 
-        ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
-        ctx.rpc_ctx->set_response_header(
-          ccf::http::headers::CONTENT_TYPE,
-          ccf::http::headervalues::contenttype::JSON);
-        ctx.rpc_ctx->set_response_body(nlohmann::json(true).dump());
+        ctx.rpc_ctx->set_response_json(true, HTTP_STATUS_OK);
       };
       make_endpoint(
         "/log/private/prefix_cert",
@@ -1665,12 +1661,7 @@ namespace loggingapp
         }
 
         // Construct the HTTP response
-        nlohmann::json j_response = response;
-        ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
-        ctx.rpc_ctx->set_response_header(
-          ccf::http::headers::CONTENT_TYPE,
-          ccf::http::headervalues::contenttype::JSON);
-        ctx.rpc_ctx->set_response_body(j_response.dump());
+        ctx.rpc_ctx->set_response_json(response, HTTP_STATUS_OK);
       };
       make_endpoint(
         get_historical_range_path,
@@ -1831,12 +1822,7 @@ namespace loggingapp
         }
 
         // Construct the HTTP response
-        nlohmann::json j_response = response;
-        ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
-        ctx.rpc_ctx->set_response_header(
-          ccf::http::headers::CONTENT_TYPE,
-          ccf::http::headervalues::contenttype::JSON);
-        ctx.rpc_ctx->set_response_body(j_response.dump());
+        ctx.rpc_ctx->set_response_json(response, HTTP_STATUS_OK);
       };
       make_endpoint(
         get_historical_sparse_path,
@@ -2000,12 +1986,7 @@ namespace loggingapp
             response.endorsements->push_back(endorsement);
           }
 
-          nlohmann::json j_response = response;
-          ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
-          ctx.rpc_ctx->set_response_header(
-            ccf::http::headers::CONTENT_TYPE,
-            ccf::http::headervalues::contenttype::JSON);
-          ctx.rpc_ctx->set_response_body(j_response.dump());
+          ctx.rpc_ctx->set_response_json(response, HTTP_STATUS_OK);
         };
       make_read_only_endpoint(
         "/log/public/cose_endorsements",
@@ -2036,12 +2017,7 @@ namespace loggingapp
         LoggingGetCoseSignature::Out response{
           .cose_signature = signature.value()};
 
-        nlohmann::json j_response = response;
-        ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
-        ctx.rpc_ctx->set_response_header(
-          ccf::http::headers::CONTENT_TYPE,
-          ccf::http::headervalues::contenttype::JSON);
-        ctx.rpc_ctx->set_response_body(j_response.dump());
+        ctx.rpc_ctx->set_response_json(response, HTTP_STATUS_OK);
       };
       make_read_only_endpoint(
         "/log/public/cose_signature",

--- a/samples/apps/programmability/programmability.cpp
+++ b/samples/apps/programmability/programmability.cpp
@@ -500,11 +500,7 @@ namespace programmabilityapp
           return;
         }
 
-        ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
-        ctx.rpc_ctx->set_response_header(
-          ccf::http::headers::CONTENT_TYPE,
-          ccf::http::headervalues::contenttype::JSON);
-        ctx.rpc_ctx->set_response_body(nlohmann::json(bundle).dump(2));
+        ctx.rpc_ctx->set_response_json(bundle, HTTP_STATUS_OK);
       };
 
       make_endpoint(
@@ -673,11 +669,7 @@ namespace programmabilityapp
             return;
           }
 
-          ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
-          ctx.rpc_ctx->set_response_header(
-            ccf::http::headers::CONTENT_TYPE,
-            ccf::http::headervalues::contenttype::JSON);
-          ctx.rpc_ctx->set_response_body(nlohmann::json(options).dump(2));
+          ctx.rpc_ctx->set_response_json(options, HTTP_STATUS_OK);
         };
       make_endpoint(
         "/custom_endpoints/runtime_options",
@@ -701,11 +693,7 @@ namespace programmabilityapp
           return;
         }
 
-        ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
-        ctx.rpc_ctx->set_response_header(
-          ccf::http::headers::CONTENT_TYPE,
-          ccf::http::headervalues::contenttype::JSON);
-        ctx.rpc_ctx->set_response_body(nlohmann::json(options).dump(2));
+        ctx.rpc_ctx->set_response_json(options, HTTP_STATUS_OK);
       };
       make_endpoint(
         "/custom_endpoints/runtime_options",

--- a/src/endpoints/json_handler.cpp
+++ b/src/endpoints/json_handler.cpp
@@ -60,7 +60,6 @@ namespace ccf
           }
           else
           {
-            ctx->set_response_status(HTTP_STATUS_OK);
             const auto accept_it =
               ctx->get_request_header(http::headers::ACCEPT);
             if (accept_it.has_value())
@@ -90,12 +89,7 @@ namespace ccf
               }
             }
 
-            const auto s = body->dump();
-            ctx->set_response_body(std::vector<uint8_t>(s.begin(), s.end()));
-
-            ctx->set_response_header(
-              http::headers::CONTENT_TYPE,
-              http::headervalues::contenttype::JSON);
+            ctx->set_response_json(*body, HTTP_STATUS_OK);
           }
         }
       }


### PR DESCRIPTION
The non-controversial bit of #7082 - use a common helper function rather than this multi-stage call everywhere. Then _if_ we ever add a way to request pretty-printed responses, it should be uniformly handled.