### PR TITLE
Make embedded path reproducible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,10 @@ endif()
 
 include(GNUInstallDirs)
 
+# Use project directory name instead of absolute path for reproducible builds
+get_filename_component(REPRO_DIR ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+add_compile_options("-ffile-prefix-map=${CCF_DIR}=${REPRO_DIR}")
+
 set(CMAKE_MODULE_PATH "${CCF_DIR}/cmake;${CMAKE_MODULE_PATH}")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,9 +57,8 @@ endif()
 
 include(GNUInstallDirs)
 
-# Use project directory name instead of absolute path for reproducible builds
-get_filename_component(REPRO_DIR ${CMAKE_CURRENT_SOURCE_DIR} NAME)
-add_compile_options("-ffile-prefix-map=${CCF_DIR}=${REPRO_DIR}")
+# Use fixed name instead of absolute path for reproducible builds
+add_compile_options("-ffile-prefix-map=${CCF_DIR}=CCF")
 
 set(CMAKE_MODULE_PATH "${CCF_DIR}/cmake;${CMAKE_MODULE_PATH}")
 

--- a/reproduce/start_container_and_reproduce_rpm.sh
+++ b/reproduce/start_container_and_reproduce_rpm.sh
@@ -41,10 +41,8 @@ docker run --rm -it \
     COMMIT_ID=$(jq -r '.commit_sha' "/reproduce.json")
     echo "Cloning repo and checking out commit $COMMIT_ID"
     REPO_URL="https://github.com/microsoft/CCF"
-    mkdir -p /__w/CCF
-    cd /__w/CCF
     git clone "$REPO_URL" CCF
-    git config --global --add safe.directory $(pwd)/CCF
+    git config --global --add safe.directory CCF
     cd CCF
     git checkout "$COMMIT_ID"
    


### PR DESCRIPTION
Maps absolute path to project dir name to avoid embedding local paths in build output
