### PR TITLE
Restrict tests on Genoa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,10 +271,12 @@ jobs:
           cd build
           rm -rf /github/home/.cache
           mkdir -p /github/home/.cache
-          # Unit tests
-          ./tests.sh --output-on-failure -L unit -j$(nproc --all)
-          # End to end tests
-          ./tests.sh --timeout 360 --output-on-failure -LE "benchmark|suite|unit"
+          # Limited set of tests because Genoa pools have limited resources
+          # focusing on architecture-specific functionality.
+          # Unit test for sealing
+          ./tests.sh --output-on-failure -R snp_ioctl_test
+          # End to end tests for code update (attestation verification)
+          ./tests.sh --timeout 360 --output-on-failure -R code_update
         shell: bash
 
       - name: "Capture dmesg"


### PR DESCRIPTION
Since large SKUs are not readily available for CI on Genoa, run minimal tests that cover architecture-specific differences to avoid slow and flaky test runs.