### PR TITLE
Add curl multi integration with libuv

### DIFF
--- a/src/common/configuration.h
+++ b/src/common/configuration.h
@@ -16,6 +16,7 @@
 #include "common/enclave_interface_types.h"
 #include "consensus/consensus_types.h"
 #include "ds/oversized.h"
+#include "http/curl.h"
 #include "service/tables/config.h"
 
 #include <optional>
@@ -39,6 +40,8 @@ struct EnclaveConfig
   ringbuffer::Offsets* from_enclave_buffer_offsets;
 
   oversized::WriterConfig writer_config = {};
+
+  ccf::curl::CurlmLibuvContext* curl_libuv_context;
 };
 
 static constexpr auto node_to_node_interface_name = "node_to_node_interface";

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -76,17 +76,16 @@ extern "C"
     auto writer_factory = std::make_unique<oversized::WriterFactory>(
       *basic_writer_factory, ec.writer_config);
 
-    auto& curl_context = ccf::curl::CurlmLibuvContextSingleton::get_instance_unsafe();
+    auto& curl_context =
+      ccf::curl::CurlmLibuvContextSingleton::get_instance_unsafe();
     if (curl_context == nullptr)
     {
-      LOG_FAIL_FMT(
-        "Curl context singleton already initialized");
+      LOG_FAIL_FMT("Curl context singleton already initialized");
       return CreateNodeStatus::InternalError;
-    } 
+    }
     if (ec.curl_libuv_context == nullptr)
     {
-      LOG_FAIL_FMT(
-        "Enclave config curl context is null");
+      LOG_FAIL_FMT("Enclave config curl context is null");
       return CreateNodeStatus::InternalError;
     }
     curl_context = ec.curl_libuv_context;

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -28,6 +28,7 @@
 #include "enclave.h"
 #include "handle_ring_buffer.h"
 #include "host/env.h"
+#include "http/curl.h"
 #include "json_schema.h"
 #include "lfs_file_handler.h"
 #include "load_monitor.h"
@@ -356,6 +357,11 @@ int main(int argc, char** argv) // NOLINT(bugprone-exception-escape)
   // Write PID to disk
   files::dump(fmt::format("{}", ::getpid()), config.output_files.pid_file);
 
+  // Initialise curlm libuv interface
+  ccf::curl::CurlmLibuvContext curl_libuv_context(uv_default_loop());
+  ccf::curl::CurlmLibuvContextSingleton::get_instance_unsafe() =
+    &curl_libuv_context;
+
   // set the host log level
   ccf::logger::config::level() = config.logging.host_level;
 
@@ -601,6 +607,9 @@ int main(int argc, char** argv) // NOLINT(bugprone-exception-escape)
     enclave_config.from_enclave_buffer_offsets = &from_enclave_offsets;
 
     enclave_config.writer_config = writer_config;
+
+    enclave_config.curl_libuv_context =
+      &ccf::curl::CurlmLibuvContextSingleton::get_instance();
 
     ccf::StartupConfig startup_config(config);
 

--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -25,6 +25,17 @@
 #define CHECK_CURL_EASY_GETINFO(handle, info, arg) \
   CHECK_CURL_EASY(curl_easy_getinfo, handle, info, arg)
 
+#define CHECK_CURL_MULTI(fn, ...) \
+  do \
+  { \
+    const auto res = fn(__VA_ARGS__); \
+    if (res != CURLM_OK) \
+    { \
+      throw std::runtime_error(fmt::format( \
+        "Error calling " #fn ": {} ({})", res, curl_multi_strerror(res))); \
+    } \
+  } while (0)
+
 namespace ccf::curl
 {
 
@@ -43,6 +54,26 @@ namespace ccf::curl
     }
 
     operator CURL*() const
+    {
+      return p.get();
+    }
+  };
+
+  class UniqueCURLM
+  {
+  protected:
+    std::unique_ptr<CURLM, void (*)(CURLM*)> p;
+
+  public:
+    UniqueCURLM() : p(curl_multi_init(), [](auto x) { curl_multi_cleanup(x); })
+    {
+      if (!p.get())
+      {
+        throw std::runtime_error("Error initialising curl multi request");
+      }
+    }
+
+    operator CURLM*() const
     {
       return p.get();
     }
@@ -67,4 +98,180 @@ namespace ccf::curl
     }
   };
 
+  class RequestBody
+  {
+    std::vector<uint8_t> buffer_vec;
+    std::span<const uint8_t> buffer_span;
+
+  public:
+    RequestBody(std::vector<uint8_t>& buffer) : buffer_vec(std::move(buffer))
+    {
+      buffer_span =
+        std::span<const uint8_t>(buffer_vec.data(), buffer_vec.size());
+    }
+
+    template <typename Jsonable>
+    RequestBody(Jsonable jsonable)
+    {
+      auto json_str = nlohmann::json(jsonable).dump();
+      buffer_vec = std::vector<uint8_t>(
+        json_str.begin(), json_str.end()); // Convert to vector of bytes
+      buffer_span =
+        std::span<const uint8_t>(buffer_vec.data(), buffer_vec.size());
+    }
+
+    static size_t send_data(
+      char* ptr, size_t size, size_t nitems, void* userdata)
+    {
+      auto* data = static_cast<RequestBody*>(userdata);
+      auto bytes_to_copy = std::min(data->buffer_span.size(), size * nitems);
+      memcpy(ptr, data->buffer_span.data(), bytes_to_copy);
+      data->buffer_span = data->buffer_span.subspan(bytes_to_copy);
+      return bytes_to_copy;
+    }
+
+    void attach_to_curl(CURL* curl)
+    {
+      CHECK_CURL_EASY_SETOPT(curl, CURLOPT_READDATA, this);
+      CHECK_CURL_EASY_SETOPT(curl, CURLOPT_READFUNCTION, send_data);
+      CHECK_CURL_EASY_SETOPT(
+        curl, CURLOPT_INFILESIZE, static_cast<curl_off_t>(buffer_span.size()));
+    }
+  };
+
+  class ResponseBody
+  {
+  public:
+    std::vector<uint8_t> buffer;
+
+    static size_t write_response_chunk(
+      char* ptr, size_t size, size_t nmemb, void* userdata)
+    {
+      auto* data = static_cast<ResponseBody*>(userdata);
+      auto bytes_to_copy = size * nmemb;
+      data->buffer.insert(
+        data->buffer.end(), (uint8_t*)ptr, (uint8_t*)ptr + bytes_to_copy);
+      // Should probably set a maximum response size here
+      return bytes_to_copy;
+    }
+
+    void attach_to_curl(CURL* curl)
+    {
+      CHECK_CURL_EASY_SETOPT(curl, CURLOPT_WRITEDATA, this);
+      // Called one or more times to add more data
+      CHECK_CURL_EASY_SETOPT(curl, CURLOPT_WRITEFUNCTION, write_response_chunk);
+    }
+  };
+
+  class CurlRequest
+  {
+  public:
+    UniqueCURL curl_handle;
+    std::string url;
+    std::unique_ptr<ccf::curl::RequestBody> request_body = nullptr;
+    std::unique_ptr<ccf::curl::ResponseBody> response_body = nullptr;
+    ccf::curl::UniqueSlist headers;
+    std::optional<std::function<void(const ResponseBody&)>> response_callback =
+      std::nullopt;
+
+    void attach_to_curl() const
+    {
+      CHECK_CURL_EASY_SETOPT(curl_handle, CURLOPT_URL, url.c_str());
+      if (request_body != nullptr)
+      {
+        request_body->attach_to_curl(curl_handle);
+        CHECK_CURL_EASY_SETOPT(curl_handle, CURLOPT_UPLOAD, 1L);
+      }
+      if (response_body != nullptr)
+      {
+        response_body->attach_to_curl(curl_handle);
+      }
+      CHECK_CURL_EASY_SETOPT(curl_handle, CURLOPT_HTTPHEADER, headers.get());
+    }
+
+    void set_url(const std::string& new_url)
+    {
+      url = new_url;
+      CHECK_CURL_EASY_SETOPT(curl_handle, CURLOPT_URL, url.c_str());
+    }
+
+    void set_blob_opt(auto option, const uint8_t* data, size_t length)
+    {
+      struct curl_blob blob
+      {
+        .data = const_cast<uint8_t*>(data), .len = length,
+        .flags = CURL_BLOB_COPY,
+      };
+
+      CHECK_CURL_EASY_SETOPT(curl_handle, option, blob);
+    }
+
+    void set_response_callback(
+      std::function<void(const ResponseBody&)> callback)
+    {
+      if (response_body != nullptr || response_callback.has_value())
+      {
+        throw std::logic_error(
+          "Only one response callback can be set for a request.");
+      }
+      response_callback = std::move(callback);
+      response_body = std::make_unique<ResponseBody>();
+    }
+
+    static void attach_to_multi_curl(
+      CURLM* curl_multi, std::unique_ptr<CurlRequest>& request)
+    {
+      request->attach_to_curl();
+      CURL* curl_handle = request->curl_handle;
+      CHECK_CURL_EASY_SETOPT(curl_handle, CURLOPT_PRIVATE, request.release());
+      CHECK_CURL_MULTI(curl_multi_add_handle, curl_multi, curl_handle);
+    }
+  };
+
+  inline int iter_CURLM_CurlRequest(UniqueCURLM& p)
+  {
+    int running_handles = 0;
+    CHECK_CURL_MULTI(curl_multi_perform, p, &running_handles);
+
+    // handle all completed curl requests
+    int msgq = 0;
+    CURLMsg* msg = nullptr;
+    do
+    {
+      msg = curl_multi_info_read(p, &msgq);
+
+      if ((msg != nullptr) && msg->msg == CURLMSG_DONE)
+      {
+        auto* easy = msg->easy_handle;
+        auto result = msg->data.result;
+
+        LOG_INFO_FMT(
+          "CURL request response handling with result: {} ({})",
+          result,
+          curl_easy_strerror(result));
+
+        // retrieve the request data and attach a lifetime to it
+        ccf::curl::CurlRequest* request_data = nullptr;
+        curl_easy_getinfo(easy, CURLINFO_PRIVATE, &request_data);
+        std::unique_ptr<ccf::curl::CurlRequest> request_data_ptr(request_data);
+
+        // Clean up the easy handle and corresponding resources
+        curl_multi_remove_handle(p, easy);
+        if (request_data->response_callback.has_value())
+        {
+          if (request_data->response_body != nullptr)
+          {
+            request_data->response_callback.value()(
+              *request_data->response_body);
+          }
+        }
+        // Handled by the destructor of CurlRequest
+        LOG_INFO_FMT(
+          "Finished handling CURLMSG: msg_nullptr: {}, remaining: {}",
+          msg != nullptr,
+          msgq);
+      }
+    } while (msgq > 0);
+    return running_handles;
+  }
 } // namespace ccf::curl

--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -489,4 +489,23 @@ namespace ccf::curl
       return curl_request_curlm;
     }
   };
+
+  class CurlmLibuvContextSingleton
+  {
+    static CurlmLibuvContext* curlm_libuv_context_instance;
+  public:
+    static CurlmLibuvContext*& get_instance_unsafe()
+    {
+      return curlm_libuv_context_instance;
+    }
+    static CurlmLibuvContext& get_instance()
+    {
+      if (curlm_libuv_context_instance == nullptr)
+      {
+        throw std::logic_error(
+          "CurlmLibuvContextSingleton instance not initialized");
+      }
+      return *curlm_libuv_context_instance;
+    }
+  };
 } // namespace ccf::curl

--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -508,4 +508,7 @@ namespace ccf::curl
       return *curlm_libuv_context_instance;
     }
   };
+
+  inline CurlmLibuvContext* CurlmLibuvContextSingleton::curlm_libuv_context_instance =
+    nullptr;
 } // namespace ccf::curl

--- a/src/node/quote_endorsements_client.h
+++ b/src/node/quote_endorsements_client.h
@@ -4,6 +4,7 @@
 
 #include "ccf/pal/attestation.h"
 #include "enclave/rpc_sessions.h"
+#include "http/curl.h"
 
 namespace ccf
 {
@@ -82,44 +83,165 @@ namespace ccf
       size_t request_id;
     };
 
-    std::shared_ptr<ClientSession> create_unauthenticated_client()
+    void handle_success_response(
+      std::vector<uint8_t>&& data, const EndpointInfo& response_endpoint)
     {
-      // Note: server CA is not checked here as this client is not sending
-      // private data. If the server was malicious and the certificate chain was
-      // bogus, the verification of the endorsement of the quote would fail
-      // anyway.
-      return rpcsessions->create_client(std::make_shared<::tls::Cert>(
-        nullptr, std::nullopt, std::nullopt, std::nullopt, false));
-    }
-
-    std::shared_ptr<ClientSession> create_unencrypted_client()
-    {
-      return rpcsessions->create_unencrypted_client();
-    }
-
-    void send_request(
-      const std::shared_ptr<ClientSession>& client,
-      const EndpointInfo& endpoint)
-    {
+      // We may receive a response to an in-flight request after having
+      // fetched all endorsements
+      auto& server = config.servers.front();
+      if (server.empty())
       {
-        ::http::Request r(endpoint.uri, HTTP_GET);
-        for (auto const& [k, v] : endpoint.params)
-        {
-          r.set_query_param(k, v);
-        }
-        for (auto const& [k, v] : endpoint.headers)
-        {
-          r.set_header(k, v);
-        }
-        r.set_header(http::headers::HOST, endpoint.host);
-
-        LOG_INFO_FMT(
-          "Fetching endorsements for attestation report at {}{}{}",
-          endpoint,
-          r.get_path(),
-          r.get_formatted_query());
-        client->send_request(std::move(r));
+        return;
       }
+      auto endpoint = server.front();
+      if (has_completed || response_endpoint != endpoint)
+      {
+        return;
+      }
+
+      if (response_endpoint.response_is_der)
+      {
+        auto raw = ccf::crypto::cert_der_to_pem(data).raw();
+        endorsements_pem.insert(endorsements_pem.end(), raw.begin(), raw.end());
+      }
+      else if (response_endpoint.response_is_thim_json)
+      {
+        auto j = nlohmann::json::parse(data);
+        auto vcekCert = j.at("vcekCert").get<std::string>();
+        auto certificateChain = j.at("certificateChain").get<std::string>();
+        endorsements_pem.insert(
+          endorsements_pem.end(), vcekCert.begin(), vcekCert.end());
+        endorsements_pem.insert(
+          endorsements_pem.end(),
+          certificateChain.begin(),
+          certificateChain.end());
+      }
+      else
+      {
+        endorsements_pem.insert(
+          endorsements_pem.end(), data.begin(), data.end());
+      }
+
+      server.pop_front();
+      if (server.empty())
+      {
+        LOG_INFO_FMT("Complete endorsement chain successfully retrieved");
+        LOG_INFO_FMT(
+          "{}", std::string(endorsements_pem.begin(), endorsements_pem.end()));
+        has_completed = true;
+        done_cb(std::move(endorsements_pem));
+      }
+      else
+      {
+        fetch(server);
+      }
+    }
+
+    std::string get_formatted_query(
+      const std::map<std::string, std::string> params) const
+    {
+      std::string formatted_query;
+      bool first = true;
+      for (const auto& it : params)
+      {
+        formatted_query +=
+          fmt::format("{}{}={}", (first ? '?' : '&'), it.first, it.second);
+        first = false;
+      }
+      return formatted_query;
+    }
+
+    void fetch(const Server& server)
+    {
+      auto endpoint = server.front();
+
+      std::unique_ptr<curl::CurlRequest> request;
+
+      // set curl get
+      CHECK_CURL_EASY_SETOPT(request->get_easy_handle(), CURLOPT_HTTPGET, 1L);
+
+      request->url = fmt::format(
+        "{}://{}:{}/{}{}",
+        endpoint.tls ? "https" : "http",
+        endpoint.host,
+        endpoint.port,
+        endpoint.uri,
+        get_formatted_query(endpoint.params));
+
+      if (endpoint.tls)
+      {
+        // Note: server CA is not checked here as this client is not sending
+        // private data. If the server was malicious and the certificate chain
+        // was bogus, the verification of the endorsement of the quote would
+        // fail anyway.
+        CHECK_CURL_EASY_SETOPT(
+          request->get_easy_handle(), CURLOPT_SSL_VERIFYHOST, 0L);
+        CHECK_CURL_EASY_SETOPT(
+          request->get_easy_handle(), CURLOPT_SSL_VERIFYPEER, 0L);
+        CHECK_CURL_EASY_SETOPT(
+          request->get_easy_handle(), CURLOPT_SSL_VERIFYSTATUS, 0L);
+      }
+
+      for (auto const& [k, v] : endpoint.headers)
+      {
+        request->set_header(k, v);
+      }
+      request->set_header(http::headers::HOST, endpoint.host);
+
+      request->set_response_callback([this, server, endpoint](
+                                       curl::CurlRequest& request) {
+        std::lock_guard<ccf::pal::Mutex> guard(this->lock);
+        auto response = *request.response.release();
+
+        last_received_request_id++;
+
+        if (request.response->status_code == HTTP_STATUS_OK)
+        {
+          LOG_INFO_FMT(
+            "Successfully retrieved endorsements for attestation report: "
+            "{} bytes",
+            request.response->buffer.size());
+
+          handle_success_response(std::move(response.buffer), endpoint);
+          return;
+        }
+
+        LOG_DEBUG_FMT(
+          "Error fetching endorsements for attestation report: {}",
+          response.status_code);
+        if (response.status_code == HTTP_STATUS_TOO_MANY_REQUESTS)
+        {
+          constexpr size_t default_retry_after_s = 3;
+          size_t retry_after_s = default_retry_after_s;
+          auto h = response.headers.find(http::headers::RETRY_AFTER);
+          if (h != response.headers.end())
+          {
+            const auto& retry_after_value = h->second;
+            // If value is invalid, retry_after_s is unchanged
+            std::from_chars(
+              retry_after_value.data(),
+              retry_after_value.data() + retry_after_value.size(),
+              retry_after_s);
+          }
+
+          auto msg =
+            std::make_unique<::threading::Tmsg<QuoteEndorsementsClientMsg>>(
+              [](std::unique_ptr<::threading::Tmsg<QuoteEndorsementsClientMsg>>
+                   msg) { msg->data.self->fetch(msg->data.server); },
+              shared_from_this(),
+              server);
+
+          LOG_INFO_FMT(
+            "{} endorsements endpoint had too many requests. Retrying "
+            "in {}s",
+            endpoint,
+            retry_after_s);
+
+          ::threading::ThreadMessaging::instance().add_task_after(
+            std::move(msg), std::chrono::milliseconds(retry_after_s * 1000));
+        }
+        return;
+      });
 
       // Start watchdog to send request on new server if it is unresponsive
       auto msg = std::make_unique<
@@ -177,133 +299,12 @@ namespace ccf
       ::threading::ThreadMessaging::instance().add_task_after(
         std::move(msg),
         std::chrono::milliseconds(server_connection_timeout_s * 1000));
-    }
 
-    void handle_success_response(
-      std::vector<uint8_t>&& data, const EndpointInfo& response_endpoint)
-    {
-      // We may receive a response to an in-flight request after having
-      // fetched all endorsements
-      auto& server = config.servers.front();
-      if (server.empty())
-      {
-        return;
-      }
-      auto endpoint = server.front();
-      if (has_completed || response_endpoint != endpoint)
-      {
-        return;
-      }
+      LOG_INFO_FMT(
+        "Fetching endorsements for attestation report at {}", request->url);
 
-      if (response_endpoint.response_is_der)
-      {
-        auto raw = ccf::crypto::cert_der_to_pem(data).raw();
-        endorsements_pem.insert(endorsements_pem.end(), raw.begin(), raw.end());
-      }
-      else if (response_endpoint.response_is_thim_json)
-      {
-        auto j = nlohmann::json::parse(data);
-        auto vcekCert = j.at("vcekCert").get<std::string>();
-        auto certificateChain = j.at("certificateChain").get<std::string>();
-        endorsements_pem.insert(
-          endorsements_pem.end(), vcekCert.begin(), vcekCert.end());
-        endorsements_pem.insert(
-          endorsements_pem.end(),
-          certificateChain.begin(),
-          certificateChain.end());
-      }
-      else
-      {
-        endorsements_pem.insert(
-          endorsements_pem.end(), data.begin(), data.end());
-      }
-
-      server.pop_front();
-      if (server.empty())
-      {
-        LOG_INFO_FMT("Complete endorsement chain successfully retrieved");
-        LOG_INFO_FMT(
-          "{}", std::string(endorsements_pem.begin(), endorsements_pem.end()));
-        has_completed = true;
-        done_cb(std::move(endorsements_pem));
-      }
-      else
-      {
-        fetch(server);
-      }
-    }
-
-    void fetch(const Server& server)
-    {
-      auto endpoint = server.front();
-
-      auto c = endpoint.tls ? create_unauthenticated_client() :
-                              create_unencrypted_client();
-      c->connect(
-        endpoint.host,
-        endpoint.port,
-        [this, server, endpoint](
-          ccf::http_status status,
-          http::HeaderMap&& headers,
-          std::vector<uint8_t>&& data) {
-          std::lock_guard<ccf::pal::Mutex> guard(this->lock);
-
-          last_received_request_id++;
-
-          if (status == HTTP_STATUS_OK)
-          {
-            LOG_INFO_FMT(
-              "Successfully retrieved endorsements for attestation report: "
-              "{} bytes",
-              data.size());
-
-            handle_success_response(std::move(data), endpoint);
-            return;
-          }
-
-          LOG_DEBUG_FMT(
-            "Error fetching endorsements for attestation report: {}", status);
-          if (status == HTTP_STATUS_TOO_MANY_REQUESTS)
-          {
-            constexpr size_t default_retry_after_s = 3;
-            size_t retry_after_s = default_retry_after_s;
-            auto h = headers.find(http::headers::RETRY_AFTER);
-            if (h != headers.end())
-            {
-              const auto& retry_after_value = h->second;
-              // If value is invalid, retry_after_s is unchanged
-              std::from_chars(
-                retry_after_value.data(),
-                retry_after_value.data() + retry_after_value.size(),
-                retry_after_s);
-            }
-
-            auto msg =
-              std::make_unique<::threading::Tmsg<QuoteEndorsementsClientMsg>>(
-                [](
-                  std::unique_ptr<::threading::Tmsg<QuoteEndorsementsClientMsg>>
-                    msg) { msg->data.self->fetch(msg->data.server); },
-                shared_from_this(),
-                server);
-
-            LOG_INFO_FMT(
-              "{} endorsements endpoint had too many requests. Retrying "
-              "in {}s",
-              endpoint,
-              retry_after_s);
-
-            ::threading::ThreadMessaging::instance().add_task_after(
-              std::move(msg), std::chrono::milliseconds(retry_after_s * 1000));
-          }
-          return;
-        },
-        [endpoint](const std::string& error_msg) {
-          LOG_FAIL_FMT(
-            "TLS error when connecting to quote endorsements endpoint {}: {}",
-            endpoint,
-            error_msg);
-        });
-      send_request(c, endpoint);
+      curl::CurlRequest::attach_to_multi_curl(
+        curl::CurlmLibuvContextSingleton::get_instance().curlm(), request);
     }
 
   public:


### PR DESCRIPTION
This PR adds support for a global curl multi singleton who's sockets are integrated into the libuv loop.

In comparison to our current synchronous uses of libcurl's easy interface, the multi interface is asynchronous, and hence it is a drop in replacement for our current enclave side http client which operates asynchronously over the ringbuffer.
When we remove the enclave vs host side distinction, the only necessary change from this will be to remove the initialisation of the curl multi instance.

As this PR migrates quote_endorsements_client.h to use the new interface, the tests should exercise the response and callback portions of the change.

The main challenge of this integration is managing the lifetimes of objects over the asynchronous callback.
I've tried to provide a reasonable interface to ensure that all required memory is attached to the single `CurlRequest` which is then deleted when the request completes.

TODO:
- [ ] Better testing via a python side http server
- [ ] Synchronous requests? (snapshot fetching)