### PR TITLE
Remove unnecessarily public + repeated singleton initialisation

### DIFF
--- a/src/consensus/aft/test/driver.cpp
+++ b/src/consensus/aft/test/driver.cpp
@@ -15,14 +15,6 @@
 
 using namespace std;
 
-std::unique_ptr<threading::ThreadMessaging>
-  threading::ThreadMessaging::singleton = nullptr;
-
-namespace threading
-{
-  std::map<std::thread::id, uint16_t> thread_ids;
-}
-
 constexpr auto shash = ccf::ds::fnv_1a<size_t>;
 
 int main(int argc, char** argv)

--- a/src/consensus/aft/test/main.cpp
+++ b/src/consensus/aft/test/main.cpp
@@ -7,9 +7,6 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 #include <doctest/doctest.h>
 
-std::unique_ptr<threading::ThreadMessaging>
-  threading::ThreadMessaging::singleton = nullptr;
-
 using ms = std::chrono::milliseconds;
 
 DOCTEST_TEST_CASE("Single node startup" * doctest::test_suite("single"))

--- a/src/ds/thread_messaging.h
+++ b/src/ds/thread_messaging.h
@@ -237,7 +237,11 @@ namespace threading
       return tasks[task_id];
     }
 
-    static std::unique_ptr<ThreadMessaging> singleton;
+    static std::unique_ptr<ThreadMessaging>& get_singleton()
+    {
+      static std::unique_ptr<ThreadMessaging> singleton = nullptr;
+      return singleton;
+    }
 
   public:
     static constexpr uint16_t max_num_threads = 24;
@@ -262,6 +266,7 @@ namespace threading
 
     static void init(uint16_t num_task_queues)
     {
+      auto& singleton = get_singleton();
       if (singleton != nullptr)
       {
         throw std::logic_error("Called init() multiple times");
@@ -272,11 +277,12 @@ namespace threading
 
     static void shutdown()
     {
-      singleton.reset();
+      get_singleton().reset();
     }
 
     static ThreadMessaging& instance()
     {
+      auto& singleton = get_singleton();
       if (singleton == nullptr)
       {
         throw std::logic_error(

--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -21,9 +21,6 @@ static std::atomic<ccf::Enclave*> e;
 std::atomic<uint16_t> num_pending_threads = 0;
 std::atomic<uint16_t> num_complete_threads = 0;
 
-std::unique_ptr<threading::ThreadMessaging>
-  threading::ThreadMessaging::singleton = nullptr;
-
 constexpr size_t min_gap_between_initiation_attempts_us =
   2'000'000; // 2 seconds
 std::chrono::microseconds ccf::Channel::min_gap_between_initiation_attempts(

--- a/src/indexing/test/indexing.cpp
+++ b/src/indexing/test/indexing.cpp
@@ -18,11 +18,6 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 #include <doctest/doctest.h>
 
-// Transitively see a header that tries to use ThreadMessaging, so need to
-// create static singleton
-std::unique_ptr<threading::ThreadMessaging>
-  threading::ThreadMessaging::singleton = nullptr;
-
 using IndexA = ccf::indexing::strategies::SeqnosByKey_InMemory<decltype(map_a)>;
 using LazyIndexA = ccf::indexing::LazyStrategy<IndexA>;
 

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -26,12 +26,6 @@
 #include <iostream>
 #include <string>
 
-namespace threading
-{
-  std::unique_ptr<::threading::ThreadMessaging> ThreadMessaging::singleton =
-    nullptr;
-};
-
 using namespace ccf;
 using namespace std;
 

--- a/src/node/test/channels.cpp
+++ b/src/node/test/channels.cpp
@@ -40,9 +40,6 @@ void sleep_to_reinitiate()
     2 * ccf::Channel::min_gap_between_initiation_attempts);
 }
 
-std::unique_ptr<threading::ThreadMessaging>
-  threading::ThreadMessaging::singleton = nullptr;
-
 class IORingbuffersFixture
 {
 protected:

--- a/src/node/test/historical_queries.cpp
+++ b/src/node/test/historical_queries.cpp
@@ -23,9 +23,6 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 #include <doctest/doctest.h>
 
-std::unique_ptr<threading::ThreadMessaging>
-  threading::ThreadMessaging::singleton = nullptr;
-
 using NumToString = ccf::kv::Map<size_t, std::string>;
 
 constexpr size_t certificate_validity_period_days = 365;

--- a/src/node/test/history.cpp
+++ b/src/node/test/history.cpp
@@ -18,9 +18,6 @@
 #include <doctest/doctest.h>
 #undef FAIL
 
-std::unique_ptr<threading::ThreadMessaging>
-  threading::ThreadMessaging::singleton = nullptr;
-
 using MapT = ccf::kv::Map<size_t, size_t>;
 
 constexpr size_t certificate_validity_period_days = 365;

--- a/src/node/test/history_bench.cpp
+++ b/src/node/test/history_bench.cpp
@@ -10,14 +10,6 @@
 #define PICOBENCH_IMPLEMENT
 #include <picobench/picobench.hpp>
 
-std::unique_ptr<threading::ThreadMessaging>
-  threading::ThreadMessaging::singleton = nullptr;
-
-namespace threading
-{
-  std::map<std::thread::id, uint16_t> thread_ids;
-}
-
 using namespace ccf;
 
 class DummyConsensus : public ccf::kv::test::StubConsensus

--- a/src/node/test/snapshot.cpp
+++ b/src/node/test/snapshot.cpp
@@ -14,9 +14,6 @@
 #undef FAIL
 #include <string>
 
-std::unique_ptr<threading::ThreadMessaging>
-  threading::ThreadMessaging::singleton = nullptr;
-
 TEST_CASE("Snapshot with merkle tree" * doctest::test_suite("snapshot"))
 {
   auto source_consensus = std::make_shared<ccf::kv::test::StubConsensus>();

--- a/src/node/test/snapshotter.cpp
+++ b/src/node/test/snapshotter.cpp
@@ -15,11 +15,6 @@
 #include <doctest/doctest.h>
 #include <string>
 
-// Because snapshot serialisation is costly, the snapshotter serialises
-// snapshots asynchronously.
-std::unique_ptr<threading::ThreadMessaging>
-  threading::ThreadMessaging::singleton = nullptr;
-
 constexpr auto buffer_size = 1024 * 16;
 auto node_kp = ccf::crypto::make_key_pair();
 


### PR DESCRIPTION
Inspired by discussion from #7118 about removing unnecessary initialisers, and noticed in passing.