### PR TITLE
Make headers-are-included.sh work post-build

### DIFF
--- a/scripts/headers-are-included.sh
+++ b/scripts/headers-are-included.sh
@@ -8,7 +8,7 @@
 find src/ include/ -type f -print0 | xargs -0 grep -h "#include" | grep -E "include .?ccf/" | cut -d " " -f 2 | jq -r . | grep -v "ccf/version.h" | sort -u  > /tmp/CCF_INCLUDED
 
 pushd include/ || exit 1
-find ccf -type f -name "*.h" | sort -u > /tmp/CCF_HEADERS
+find ccf -type f -name "*.h" | grep -v "ccf/version.h" | sort -u > /tmp/CCF_HEADERS
 popd || exit 1
 
 diff -y --suppress-common-lines /tmp/CCF_HEADERS /tmp/CCF_INCLUDED


### PR DESCRIPTION
The script currently fails after `version.h` is generated, which doesn't show in CI because it always runs pre-build. This is annoying in local dev. 