### PR TITLE
Fix download action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,7 +328,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: DOWNLOAD_DIR
-          pattern: pkg-*
+          pattern: pkg*
           merge-multiple: true
       - name: Download Reproducibility Metadata
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Fix for https://github.com/microsoft/CCF/actions/runs/16463458106/job/46537926845, we want to download "pkg" and "pkg-devel", and so we need "pkg*", not "pkg-*".