### PR TITLE
Extend CMake util function `add_ccf_static_library`

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -14,6 +14,12 @@ with section("parse"):
                 "LINK_LIBS": "*",
             },
         },
+        "add_ccf_static_library": {
+            "kwargs": {
+                "SRCS": "*",
+                "LINK_LIBS": "*",
+            },
+        },
         "add_e2e_test": {
             "kwargs": {
                 "NAME": "*",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,34 +202,12 @@ set(HTTP_PARSER_SOURCES
     ${CCF_3RD_PARTY_EXPORTED_DIR}/llhttp/llhttp.c
 )
 
-set(CCF_ENDPOINTS_SOURCES
-    ${CCF_DIR}/src/endpoints/endpoint.cpp
-    ${CCF_DIR}/src/endpoints/endpoint_registry.cpp
-    ${CCF_DIR}/src/endpoints/base_endpoint_registry.cpp
-    ${CCF_DIR}/src/endpoints/common_endpoint_registry.cpp
-    ${CCF_DIR}/src/endpoints/user_endpoint_registry.cpp
-    ${CCF_DIR}/src/endpoints/json_handler.cpp
-    ${CCF_DIR}/src/endpoints/authentication/cose_auth.cpp
-    ${CCF_DIR}/src/endpoints/authentication/cert_auth.cpp
-    ${CCF_DIR}/src/endpoints/authentication/empty_auth.cpp
-    ${CCF_DIR}/src/endpoints/authentication/jwt_auth.cpp
-    ${CCF_DIR}/src/endpoints/authentication/all_of_auth.cpp
-    ${CCF_DIR}/src/endpoints/endpoint_utils.cpp
-    ${CCF_DIR}/src/enclave/enclave_time.cpp
-    ${CCF_DIR}/src/indexing/strategies/seqnos_by_key_bucketed.cpp
-    ${CCF_DIR}/src/indexing/strategies/seqnos_by_key_in_memory.cpp
-    ${CCF_DIR}/src/indexing/strategies/visit_each_entry_in_map.cpp
-    ${CCF_DIR}/src/node/historical_queries_adapter.cpp
-    ${CCF_DIR}/src/node/historical_queries_utils.cpp
-    ${CCF_DIR}/src/node/receipt.cpp
-)
-
 include(${CCF_DIR}/cmake/crypto.cmake)
 include(${CCF_DIR}/cmake/quickjs.cmake)
 include(${CCF_DIR}/cmake/qcbor.cmake)
 include(${CCF_DIR}/cmake/t_cose.cmake)
 
-# Host Executable
+# Launcher library
 if(SAN
    OR TSAN
    OR NOT USE_SNMALLOC
@@ -247,37 +225,21 @@ list(APPEND CCF_LAUNCHER_SOURCES ${CCF_DIR}/src/host/run.cpp
      ${CCF_DIR}/src/host/env.cpp
 )
 
-add_library(ccf_launcher STATIC ${CCF_LAUNCHER_SOURCES})
-
-add_san(ccf_launcher)
-add_tidy(ccf_launcher)
-add_warning_checks(ccf_launcher)
-
-target_compile_options(
-  ccf_launcher PRIVATE ${COMPILE_LIBCXX} ${SNMALLOC_COMPILE_OPTIONS}
+add_ccf_static_library(
+  ccf_launcher
+  SRCS ${CCF_LAUNCHER_SOURCES}
+  LINK_LIBS uv
+            ${TLS_LIBRARY}
+            ${CMAKE_DL_LIBS}
+            ${CMAKE_THREAD_LIBS_INIT}
+            ${LINK_LIBCXX}
+            ccfcrypto
+            curl
+            http_parser
 )
+
 target_include_directories(
   ccf_launcher PRIVATE ${CCF_GENERATED_DIR} ${SNMALLOC_INCLUDE_DIRS}
-)
-
-target_link_libraries(
-  ccf_launcher
-  PRIVATE uv
-          ${TLS_LIBRARY}
-          ${CMAKE_DL_LIBS}
-          ${CMAKE_THREAD_LIBS_INIT}
-          ${LINK_LIBCXX}
-          ccfcrypto
-          curl
-          http_parser
-)
-target_compile_definitions(ccf_launcher PRIVATE CCF_LOGGER_NO_DEPRECATE)
-set_property(TARGET ccf_launcher PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-install(
-  TARGETS ccf_launcher
-  EXPORT ccf
-  DESTINATION lib
 )
 
 # HTTP parser
@@ -291,47 +253,59 @@ if(CCF_DEVEL)
   )
 endif()
 
-# CCF js libs
-set(CCF_JS_SOURCES
-    ${CCF_DIR}/src/js/global_class_ids.cpp
-    ${CCF_DIR}/src/js/core/wrapped_value.cpp
-    ${CCF_DIR}/src/js/core/runtime.cpp
-    ${CCF_DIR}/src/js/core/context.cpp
-    ${CCF_DIR}/src/js/extensions/console.cpp
-    ${CCF_DIR}/src/js/extensions/math/random.cpp
-    ${CCF_DIR}/src/js/extensions/snp_attestation.cpp
-    ${CCF_DIR}/src/js/extensions/ccf/consensus.cpp
-    ${CCF_DIR}/src/js/extensions/ccf/converters.cpp
-    ${CCF_DIR}/src/js/extensions/ccf/crypto.cpp
-    ${CCF_DIR}/src/js/extensions/ccf/gov_effects.cpp
-    ${CCF_DIR}/src/js/extensions/ccf/historical.cpp
-    ${CCF_DIR}/src/js/extensions/ccf/host.cpp
-    ${CCF_DIR}/src/js/extensions/ccf/kv.cpp
-    ${CCF_DIR}/src/js/extensions/ccf/network.cpp
-    ${CCF_DIR}/src/js/extensions/ccf/node.cpp
-    ${CCF_DIR}/src/js/extensions/ccf/rpc.cpp
-    ${CCF_DIR}/src/js/extensions/ccf/request.cpp
-    ${CCF_DIR}/src/js/registry.cpp
-)
-
+# CCF js lib
 add_ccf_static_library(
   ccf_js
-  SRCS "${CCF_JS_SOURCES}"
+  SRCS ${CCF_DIR}/src/js/global_class_ids.cpp
+       ${CCF_DIR}/src/js/core/wrapped_value.cpp
+       ${CCF_DIR}/src/js/core/runtime.cpp
+       ${CCF_DIR}/src/js/core/context.cpp
+       ${CCF_DIR}/src/js/extensions/console.cpp
+       ${CCF_DIR}/src/js/extensions/math/random.cpp
+       ${CCF_DIR}/src/js/extensions/snp_attestation.cpp
+       ${CCF_DIR}/src/js/extensions/ccf/consensus.cpp
+       ${CCF_DIR}/src/js/extensions/ccf/converters.cpp
+       ${CCF_DIR}/src/js/extensions/ccf/crypto.cpp
+       ${CCF_DIR}/src/js/extensions/ccf/gov_effects.cpp
+       ${CCF_DIR}/src/js/extensions/ccf/historical.cpp
+       ${CCF_DIR}/src/js/extensions/ccf/host.cpp
+       ${CCF_DIR}/src/js/extensions/ccf/kv.cpp
+       ${CCF_DIR}/src/js/extensions/ccf/network.cpp
+       ${CCF_DIR}/src/js/extensions/ccf/node.cpp
+       ${CCF_DIR}/src/js/extensions/ccf/rpc.cpp
+       ${CCF_DIR}/src/js/extensions/ccf/request.cpp
+       ${CCF_DIR}/src/js/registry.cpp
   LINK_LIBS ccfcrypto quickjs
 )
 
-# CCF kv libs
-set(CCF_KV_SOURCES
-    ${CCF_DIR}/src/kv/tx.cpp ${CCF_DIR}/src/kv/untyped_map_handle.cpp
-    ${CCF_DIR}/src/kv/untyped_map_diff.cpp
+# CCF kv lib
+add_ccf_static_library(
+  ccf_kv SRCS ${CCF_DIR}/src/kv/tx.cpp ${CCF_DIR}/src/kv/untyped_map_handle.cpp
+              ${CCF_DIR}/src/kv/untyped_map_diff.cpp
 )
-
-add_ccf_static_library(ccf_kv SRCS "${CCF_KV_SOURCES}")
 
 # CCF endpoints lib
 add_ccf_static_library(
   ccf_endpoints
-  SRCS "${CCF_ENDPOINTS_SOURCES}"
+  SRCS ${CCF_DIR}/src/endpoints/endpoint.cpp
+       ${CCF_DIR}/src/endpoints/endpoint_registry.cpp
+       ${CCF_DIR}/src/endpoints/base_endpoint_registry.cpp
+       ${CCF_DIR}/src/endpoints/common_endpoint_registry.cpp
+       ${CCF_DIR}/src/endpoints/user_endpoint_registry.cpp
+       ${CCF_DIR}/src/endpoints/json_handler.cpp
+       ${CCF_DIR}/src/endpoints/authentication/cose_auth.cpp
+       ${CCF_DIR}/src/endpoints/authentication/cert_auth.cpp
+       ${CCF_DIR}/src/endpoints/authentication/empty_auth.cpp
+       ${CCF_DIR}/src/endpoints/authentication/jwt_auth.cpp
+       ${CCF_DIR}/src/endpoints/authentication/all_of_auth.cpp
+       ${CCF_DIR}/src/endpoints/endpoint_utils.cpp
+       ${CCF_DIR}/src/enclave/enclave_time.cpp
+       ${CCF_DIR}/src/indexing/strategies/seqnos_by_key_bucketed.cpp
+       ${CCF_DIR}/src/indexing/strategies/seqnos_by_key_in_memory.cpp
+       ${CCF_DIR}/src/indexing/strategies/visit_each_entry_in_map.cpp
+       ${CCF_DIR}/src/node/historical_queries_adapter.cpp
+       ${CCF_DIR}/src/node/historical_queries_utils.cpp
+       ${CCF_DIR}/src/node/receipt.cpp
   LINK_LIBS qcbor t_cose http_parser ccfcrypto ccf_kv
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,21 +314,11 @@ set(CCF_JS_SOURCES
     ${CCF_DIR}/src/js/registry.cpp
 )
 
-add_host_library(ccf_js "${CCF_JS_SOURCES}")
-
-add_san(ccf_js)
-add_tidy(ccf_js)
-add_warning_checks(ccf_js)
-
-target_link_libraries(ccf_js PUBLIC ccfcrypto quickjs)
-target_compile_definitions(ccf_js PRIVATE CCF_LOGGER_NO_DEPRECATE)
-if(CCF_DEVEL)
-  install(
-    TARGETS ccf_js
-    EXPORT ccf
-    DESTINATION lib
-  )
-endif()
+add_ccf_static_library(
+  ccf_js
+  SRCS "${CCF_JS_SOURCES}"
+  LINK_LIBS ccfcrypto quickjs
+)
 
 # CCF kv libs
 set(CCF_KV_SOURCES
@@ -336,39 +326,14 @@ set(CCF_KV_SOURCES
     ${CCF_DIR}/src/kv/untyped_map_diff.cpp
 )
 
-add_host_library(ccf_kv "${CCF_KV_SOURCES}")
-
-add_san(ccf_kv)
-add_tidy(ccf_kv)
-add_warning_checks(ccf_kv)
-
-target_compile_definitions(ccf_kv PRIVATE CCF_LOGGER_NO_DEPRECATE)
-if(CCF_DEVEL)
-  install(
-    TARGETS ccf_kv
-    EXPORT ccf
-    DESTINATION lib
-  )
-endif()
+add_ccf_static_library(ccf_kv SRCS "${CCF_KV_SOURCES}")
 
 # CCF endpoints lib
-add_host_library(ccf_endpoints "${CCF_ENDPOINTS_SOURCES}")
-target_link_libraries(
-  ccf_endpoints PUBLIC qcbor t_cose http_parser ccfcrypto ccf_kv
+add_ccf_static_library(
+  ccf_endpoints
+  SRCS "${CCF_ENDPOINTS_SOURCES}"
+  LINK_LIBS qcbor t_cose http_parser ccfcrypto ccf_kv
 )
-
-add_san(ccf_endpoints)
-add_tidy(ccf_endpoints)
-add_warning_checks(ccf_endpoints)
-
-target_compile_definitions(ccf_endpoints PRIVATE CCF_LOGGER_NO_DEPRECATE)
-if(CCF_DEVEL)
-  install(
-    TARGETS ccf_endpoints
-    EXPORT ccf
-    DESTINATION lib
-  )
-endif()
 
 # Common test args for Python scripts starting up CCF networks
 set(WORKER_THREADS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,28 +240,28 @@ else()
   add_subdirectory(3rdparty/exported/snmalloc EXCLUDE_FROM_ALL)
   set(SNMALLOC_COMPILE_OPTIONS "-mcx16")
   set(SNMALLOC_INCLUDE_DIRS 3rdparty/exported/snmalloc/src)
-  list(APPEND CCHOST_SOURCES src/host/snmalloc.cpp)
+  list(APPEND CCF_LAUNCHER_SOURCES src/host/snmalloc.cpp)
 endif()
 
-list(APPEND CCHOST_SOURCES ${CCF_DIR}/src/host/run.cpp
+list(APPEND CCF_LAUNCHER_SOURCES ${CCF_DIR}/src/host/run.cpp
      ${CCF_DIR}/src/host/env.cpp
 )
 
-add_library(cchost STATIC ${CCHOST_SOURCES})
+add_library(ccf_launcher STATIC ${CCF_LAUNCHER_SOURCES})
 
-add_san(cchost)
-add_tidy(cchost)
-add_warning_checks(cchost)
+add_san(ccf_launcher)
+add_tidy(ccf_launcher)
+add_warning_checks(ccf_launcher)
 
 target_compile_options(
-  cchost PRIVATE ${COMPILE_LIBCXX} ${SNMALLOC_COMPILE_OPTIONS}
+  ccf_launcher PRIVATE ${COMPILE_LIBCXX} ${SNMALLOC_COMPILE_OPTIONS}
 )
 target_include_directories(
-  cchost PRIVATE ${CCF_GENERATED_DIR} ${SNMALLOC_INCLUDE_DIRS}
+  ccf_launcher PRIVATE ${CCF_GENERATED_DIR} ${SNMALLOC_INCLUDE_DIRS}
 )
 
 target_link_libraries(
-  cchost
+  ccf_launcher
   PRIVATE uv
           ${TLS_LIBRARY}
           ${CMAKE_DL_LIBS}
@@ -271,11 +271,11 @@ target_link_libraries(
           curl
           http_parser
 )
-target_compile_definitions(cchost PRIVATE CCF_LOGGER_NO_DEPRECATE)
-set_property(TARGET cchost PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_compile_definitions(ccf_launcher PRIVATE CCF_LOGGER_NO_DEPRECATE)
+set_property(TARGET ccf_launcher PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 install(
-  TARGETS cchost
+  TARGETS ccf_launcher
   EXPORT ccf
   DESTINATION lib
 )
@@ -434,10 +434,18 @@ set(CCF_IMPL_SOURCE
     ${CCF_DIR}/src/node/uvm_endorsements.cpp
 )
 
-add_library(ccf STATIC ${CCF_IMPL_SOURCE})
-
-target_compile_options(ccf PUBLIC ${COMPILE_LIBCXX})
-target_compile_definitions(ccf PRIVATE CCF_LOGGER_NO_DEPRECATE)
+add_ccf_static_library(
+  ccf
+  SRCS ${CCF_IMPL_SOURCE}
+  LINK_LIBS ${LINK_LIBCXX}
+            http_parser
+            ccf_js
+            ccf_endpoints
+            ccfcrypto
+            ccf_kv
+            nghttp2
+            ${CMAKE_THREAD_LIBS_INIT}
+)
 
 target_include_directories(
   ccf SYSTEM
@@ -448,32 +456,6 @@ target_include_directories(
          $<INSTALL_INTERFACE:include/>
          $<INSTALL_INTERFACE:include/3rdparty/>
 )
-
-target_link_libraries(
-  ccf
-  PUBLIC ${LINK_LIBCXX}
-         http_parser
-         ccf_js
-         ccf_endpoints
-         ccfcrypto
-         ccf_kv
-         nghttp2
-         ${CMAKE_THREAD_LIBS_INIT}
-)
-
-set_property(TARGET ccf PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-add_san(ccf)
-add_tidy(ccf)
-add_warning_checks(ccf)
-
-if(CCF_DEVEL)
-  install(
-    TARGETS ccf
-    EXPORT ccf
-    DESTINATION lib
-  )
-endif()
 
 add_dependencies(ccf ccf)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,7 @@ add_ccf_static_library(
 target_include_directories(
   ccf_launcher PRIVATE ${CCF_GENERATED_DIR} ${SNMALLOC_INCLUDE_DIRS}
 )
+target_compile_options(ccf_launcher PRIVATE ${SNMALLOC_COMPILE_OPTIONS})
 
 # HTTP parser
 add_library(http_parser "${HTTP_PARSER_SOURCES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,7 +353,6 @@ endif()
 
 # CCF endpoints lib
 add_host_library(ccf_endpoints "${CCF_ENDPOINTS_SOURCES}")
-target_include_directories(ccf_endpoints PRIVATE ${CCF_DIR}/src/endpoints)
 target_link_libraries(
   ccf_endpoints PUBLIC qcbor t_cose http_parser ccfcrypto ccf_kv
 )

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -30,7 +30,7 @@ function(add_ccf_app name)
   )
   add_warning_checks(${name})
 
-  target_link_libraries(${name} PRIVATE ${PARSED_ARGS_LINK_LIBS} ccf cchost)
+  target_link_libraries(${name} PRIVATE ${PARSED_ARGS_LINK_LIBS} ccf ccf_launcher)
 
   if(NOT (SAN OR TSAN))
     target_link_options(${name} PRIVATE LINKER:--no-undefined)
@@ -59,9 +59,9 @@ endfunction()
 function(add_ccf_static_library name)
   cmake_parse_arguments(PARSE_ARGV 1 PARSED_ARGS "" "" "SRCS;LINK_LIBS")
 
-  add_library(${name} ${PARSED_ARGS_SRCS})
+  add_library(${name} STATIC ${PARSED_ARGS_SRCS})
 
-  target_link_libraries(${name} PUBLIC ${PARSED_ARGS_LINK_LIBS})
+  target_link_libraries(${name} PUBLIC ${PARSED_ARGS_LINK_LIBS} ${LINK_LIBCXX})
 
   target_compile_options(${name} PUBLIC ${COMPILE_LIBCXX})
   target_compile_definitions(${name} PRIVATE CCF_LOGGER_NO_DEPRECATE)

--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -56,10 +56,27 @@ function(add_ccf_app name)
   endif()
 endfunction()
 
-function(add_host_library name)
-  cmake_parse_arguments(PARSE_ARGV 1 PARSED_ARGS "" "" "")
-  set(files ${PARSED_ARGS_UNPARSED_ARGUMENTS})
-  add_library(${name} ${files})
+function(add_ccf_static_library name)
+  cmake_parse_arguments(PARSE_ARGV 1 PARSED_ARGS "" "" "SRCS;LINK_LIBS")
+
+  add_library(${name} ${PARSED_ARGS_SRCS})
+
+  target_link_libraries(${name} PUBLIC ${PARSED_ARGS_LINK_LIBS})
+
   target_compile_options(${name} PUBLIC ${COMPILE_LIBCXX})
+  target_compile_definitions(${name} PRIVATE CCF_LOGGER_NO_DEPRECATE)
+
   set_property(TARGET ${name} PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+  add_san(${name})
+  add_tidy(${name})
+  add_warning_checks(${name})
+
+  if(CCF_DEVEL)
+    install(
+      TARGETS ${name}
+      EXPORT ccf
+      DESTINATION lib
+    )
+  endif()
 endfunction()


### PR DESCRIPTION
Resolves #7130.

Less repetition, progress towards standalone-but-correctly-built libraries.