### PR TITLE
Add tag fields to `cgmanifest.json`

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -6,7 +6,8 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/nlohmann/json.git",
-          "commitHash": "bc889afb4c5bf1c0d8ee29ef35eaaf4c8bef8a5d"
+          "commitHash": "bc889afb4c5bf1c0d8ee29ef35eaaf4c8bef8a5d",
+          "tag": "v3.11.2"
         }
       }
     },
@@ -15,7 +16,8 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/onqtam/doctest.git",
-          "commitHash": "ae7a13539fb71f270b87eb2e874fbac80bc8dda2"
+          "commitHash": "ae7a13539fb71f270b87eb2e874fbac80bc8dda2",
+          "tag": "v2.4.11"
         }
       }
     },
@@ -24,7 +26,8 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/iboB/picobench.git",
-          "commitHash": "5f78fbd47e84af91c8e2409cba676577bd939ee7"
+          "commitHash": "5f78fbd47e84af91c8e2409cba676577bd939ee7",
+          "tag": "v2.00"
         }
       }
     },
@@ -33,7 +36,8 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/CLIUtils/CLI11.git",
-          "commitHash": "6c7b07a878ad834957b98d0f9ce1dbe0cb204fc9"
+          "commitHash": "6c7b07a878ad834957b98d0f9ce1dbe0cb204fc9",
+          "tag": "v2.4.2"
         }
       }
     },
@@ -42,7 +46,8 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/fmtlib/fmt",
-          "commitHash": "8303d140a1a11f19b982a9f664bbe59a1ccda3f4"
+          "commitHash": "8303d140a1a11f19b982a9f664bbe59a1ccda3f4",
+          "tag": "11.1.2"
         }
       }
     },
@@ -60,7 +65,8 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/microsoft/snmalloc",
-          "commitHash": "564c88b07c53728ec90a88d7d34d0f74d3b0bfff"
+          "commitHash": "564c88b07c53728ec90a88d7d34d0f74d3b0bfff",
+          "tag": "0.7.0"
         }
       }
     },
@@ -78,7 +84,8 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/nodejs/llhttp",
-          "commitHash": "610a87d755f6bae466cd871c2ba97574ccac5483"
+          "commitHash": "610a87d755f6bae466cd871c2ba97574ccac5483",
+          "tag": "release/v9.2.1"
         }
       }
     },
@@ -87,7 +94,8 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/microsoft/merklecpp",
-          "commitHash": "1a8a3a000c16fee62bc55d2efdb10d2ebd2b0173"
+          "commitHash": "1a8a3a000c16fee62bc55d2efdb10d2ebd2b0173",
+          "tag": "v1.1.0"
         }
       }
     },
@@ -96,7 +104,8 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/tristanpenman/valijson",
-          "commitHash": "fc9ddf14db683c9443c48ae3a6bf83e0ce3ad37c"
+          "commitHash": "fc9ddf14db683c9443c48ae3a6bf83e0ce3ad37c",
+          "tag": "v1.0.3"
         }
       }
     },
@@ -105,7 +114,8 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/laurencelundblade/QCBOR",
-          "commitHash": "24cd62a415161c2851327e96a023b47bb0897e64"
+          "commitHash": "24cd62a415161c2851327e96a023b47bb0897e64",
+          "tag": "v1.5"
         }
       }
     },
@@ -114,7 +124,8 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/laurencelundblade/t_cose",
-          "commitHash": "64fbc64dd5982a7f75834d2b9a2a8c9ba8207776"
+          "commitHash": "64fbc64dd5982a7f75834d2b9a2a8c9ba8207776",
+          "tag": "v1.1.3"
         }
       }
     },
@@ -123,7 +134,8 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/microsoft/didx509cpp",
-          "commitHash": "d6083ed6ec8437f77f44c2835c217f205ed24b86"
+          "commitHash": "d6083ed6ec8437f77f44c2835c217f205ed24b86",
+          "tag": "didx509cpp-0.11.0"
         }
       }
     }


### PR DESCRIPTION
We're still carting around this `cgmanifest.json` file. I don't think it's actually consumed by anything currently?
_But it could be a useful way of keeping track of our dependencies._
It only contains hashes! Those mean nothing!
_Its [schema](https://www.[schemastore.org/component-detection-manifest.json](https://www.schemastore.org/component-detection-manifest.json)) allows `tag` fields in these git elements, they would be actually useful._
But some of our dependency repos (`quickjs` and `SmallVector`) are from manual release blobs, they're not even tags in the source repos!
_Ok that's annoying, but progress is progress, let's do what we can._
