### PR TITLE
Fix verbose builds: Reset thread ID _after_ `flush_thread` completes

### DIFF
--- a/src/enclave/main.cpp
+++ b/src/enclave/main.cpp
@@ -177,13 +177,6 @@ extern "C"
 
     e.store(enclave);
 
-    // Reset the thread ID generator. This function will exit before any
-    // thread calls enclave_run, and without creating any new threads, so it
-    // is safe for the first thread that calls enclave_run to re-use this
-    // thread_id. That way they are both considered MAIN_THREAD_ID, even if
-    // they are actually distinct std::threads.
-    ccf::threading::reset_thread_id_generator();
-
     return CreateNodeStatus::OK;
   }
 

--- a/src/host/run.cpp
+++ b/src/host/run.cpp
@@ -916,6 +916,13 @@ namespace ccf
       ecall_completed.store(true);
       flusher_thread.join();
 
+      // Reset the thread ID generator. This function will exit before any
+      // thread calls enclave_run, and without creating any new threads, so it
+      // is safe for the first thread that calls enclave_run to re-use this
+      // thread_id. That way they are both considered MAIN_THREAD_ID, even if
+      // they are actually distinct std::threads.
+      ccf::threading::reset_thread_id_generator();
+
       if (create_status != CreateNodeStatus::OK)
       {
         LOG_FAIL_FMT(


### PR DESCRIPTION
#7128 broke verbose builds. This fixes it.

Attempted explanation: Because the enclave and host components now share a memory space, they also share a `thread_id` namespace. Currently both the enclave "main" thread and host "main" thread use ID 0. I intend to clean that up shortly, but it's fine for now. Then if there are any enclave worker threads, the first gets ID 1, the second ID 2, and so on. We had a call to `reset_thread_id_generator` at the end of the "create" ECALL, to avoid making the thread IDs even higher/sparser. However, if we do any logging _after_ we call this, but _before_ the enclave "main" thread has captured its ID, then that ends up getting ID 1, thinking it's a worker, and blowing up. In normal runs, we do no such logging so missed this bug. But with verbose logging enabled, it go boom.

This is a bodge, and this entire ID system deserves a revisit/rewrite.