### PR TITLE
Bring back e2e debug tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -790,31 +790,33 @@ if(BUILD_TESTS)
     )
   endif()
 
-  if(NOT (TSAN OR USE_LIBCXX))
-    # Picobench benchmarks
-    add_picobench(map_bench SRCS src/ds/test/map_bench.cpp)
-    add_picobench(logger_bench SRCS src/ds/test/logger_bench.cpp)
-    add_picobench(json_bench SRCS src/ds/test/json_bench.cpp)
-    add_picobench(ring_buffer_bench SRCS src/ds/test/ring_buffer_bench.cpp)
-    add_picobench(
-      crypto_bench
-      SRCS src/crypto/test/bench.cpp
-      LINK_LIBS
-    )
-    add_picobench(
-      history_bench
-      SRCS src/node/test/history_bench.cpp src/enclave/thread_local.cpp
-           ${CMAKE_CURRENT_SOURCE_DIR}/src/enclave/enclave_time.cpp
-      LINK_LIBS ccf_kv
-    )
+  if(NOT TSAN)
+    if(NOT USE_LIBCXX)
+      # Picobench benchmarks
+      add_picobench(map_bench SRCS src/ds/test/map_bench.cpp)
+      add_picobench(logger_bench SRCS src/ds/test/logger_bench.cpp)
+      add_picobench(json_bench SRCS src/ds/test/json_bench.cpp)
+      add_picobench(ring_buffer_bench SRCS src/ds/test/ring_buffer_bench.cpp)
+      add_picobench(
+        crypto_bench
+        SRCS src/crypto/test/bench.cpp
+        LINK_LIBS
+      )
+      add_picobench(
+        history_bench
+        SRCS src/node/test/history_bench.cpp src/enclave/thread_local.cpp
+             ${CMAKE_CURRENT_SOURCE_DIR}/src/enclave/enclave_time.cpp
+        LINK_LIBS ccf_kv
+      )
 
-    add_picobench(
-      kv_bench
-      SRCS src/kv/test/kv_bench.cpp src/enclave/thread_local.cpp
-      LINK_LIBS ccf_kv
-    )
-    add_picobench(merkle_bench SRCS src/node/test/merkle_bench.cpp)
-    add_picobench(hash_bench SRCS src/ds/test/hash_bench.cpp)
+      add_picobench(
+        kv_bench
+        SRCS src/kv/test/kv_bench.cpp src/enclave/thread_local.cpp
+        LINK_LIBS ccf_kv
+      )
+      add_picobench(merkle_bench SRCS src/node/test/merkle_bench.cpp)
+      add_picobench(hash_bench SRCS src/ds/test/hash_bench.cpp)
+    endif()
 
     if(LONG_TESTS)
       set(ADDITIONAL_RECOVERY_ARGS --with-load --with-election


### PR DESCRIPTION
Seems like [#7106](https://github.com/microsoft/CCF/pull/7106/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR858) accidentally removed e2e tests in DEBUG mode.

We have not been running LONG_TESTS + hardening (libc) since then 😿 

In belief that the intention was to only avoid running picobench for libc, here's the change to resurrect missing tests.

<img width="1908" height="760" alt="image" src="https://github.com/user-attachments/assets/5fcf6c06-42a1-43e2-a311-35edbe0e5702" />
