### PR TITLE
Add cast from ArrayBufferLike to ArrayBuffer

### DIFF
--- a/tests/npm-app/src/endpoints/crypto.ts
+++ b/tests/npm-app/src/endpoints/crypto.ts
@@ -342,7 +342,7 @@ export function eddsaJwkToPem(
 }
 
 function b64ToBuf(b64: string): ArrayBuffer {
-  return Base64.toUint8Array(b64).buffer;
+  return Base64.toUint8Array(b64).buffer as ArrayBuffer;
 }
 
 function hex(buf: ArrayBuffer) {

--- a/tests/npm-app/src/endpoints/snp_attestation.ts
+++ b/tests/npm-app/src/endpoints/snp_attestation.ts
@@ -91,12 +91,18 @@ export function verifySnpAttestation(
       .encode(Base64.toUint8Array(body.evidence) as Uint8Array<ArrayBuffer>);
     const endorsements = ccfapp
       .typedArray(Uint8Array)
-      .encode(Base64.toUint8Array(body.endorsements) as Uint8Array<ArrayBuffer>);
+      .encode(
+        Base64.toUint8Array(body.endorsements) as Uint8Array<ArrayBuffer>,
+      );
     const uvm_endorsements =
       body.uvm_endorsements !== undefined
         ? ccfapp
             .typedArray(Uint8Array)
-            .encode(Base64.toUint8Array(body.uvm_endorsements) as Uint8Array<ArrayBuffer>)
+            .encode(
+              Base64.toUint8Array(
+                body.uvm_endorsements,
+              ) as Uint8Array<ArrayBuffer>,
+            )
         : undefined;
 
     const r = ccfsnp.verifySnpAttestation(

--- a/tests/npm-app/src/endpoints/snp_attestation.ts
+++ b/tests/npm-app/src/endpoints/snp_attestation.ts
@@ -88,15 +88,15 @@ export function verifySnpAttestation(
     const body = request.body.json();
     const evidence = ccfapp
       .typedArray(Uint8Array)
-      .encode(Base64.toUint8Array(body.evidence));
+      .encode(Base64.toUint8Array(body.evidence) as Uint8Array<ArrayBuffer>);
     const endorsements = ccfapp
       .typedArray(Uint8Array)
-      .encode(Base64.toUint8Array(body.endorsements));
+      .encode(Base64.toUint8Array(body.endorsements) as Uint8Array<ArrayBuffer>);
     const uvm_endorsements =
       body.uvm_endorsements !== undefined
         ? ccfapp
             .typedArray(Uint8Array)
-            .encode(Base64.toUint8Array(body.uvm_endorsements))
+            .encode(Base64.toUint8Array(body.uvm_endorsements) as Uint8Array<ArrayBuffer>)
         : undefined;
 
     const r = ccfsnp.verifySnpAttestation(


### PR DESCRIPTION
`toUint8Array` returns `Uint8Array<ArrayBufferLike>` where `ArrayBufferLike` is a union of `SharedArrayBuffer` and `ArrayBuffer`.
In practise this should only be the `ArrayBuffer` so we can narrow cast it.