### PR TITLE
Pin typescript to 5.8.3

### DIFF
--- a/js/ccf-app/package.json
+++ b/js/ccf-app/package.json
@@ -30,7 +30,7 @@
     "node-forge": "^1.2.0",
     "ts-node": "^10.4.0",
     "typedoc": "^0.28.1",
-    "typescript": "^5.7.2"
+    "typescript": "5.8.3"
   },
   "bin": {
     "ccf-build-bundle": "scripts/build_bundle.js"

--- a/tests/js-interpreter-reuse/package.json
+++ b/tests/js-interpreter-reuse/package.json
@@ -17,6 +17,6 @@
     "@rollup/plugin-typescript": "^8.2.0",
     "del-cli": "^5.0.0",
     "tslib": "^2.0.1",
-    "typescript": "^5.7.2"
+    "typescript": "5.8.3"
   }
 }

--- a/tests/npm-app/package.json
+++ b/tests/npm-app/package.json
@@ -28,6 +28,6 @@
     "http-server": "^14.1.1",
     "rollup": "^4.18.0",
     "tslib": "^2.6.3",
-    "typescript": "^5.7.2"
+    "typescript": "5.8.3"
   }
 }


### PR DESCRIPTION
Alternative to #7156. Rather than playing whack-a-mole with these casts across multiple tests, pin to a fixed version. This is a temporary workaround while we try to create a release, should be revisited with an unpinned fix.