### PR TITLE
Fix snmalloc linking regression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,12 @@ endif()
 option(USE_SNMALLOC "Link against snmalloc" ON)
 if(USE_SNMALLOC)
   set(SNMALLOC_BUILD_TESTING OFF)
-  set(SNMALLOC_STATIC_LIBRARY_PREFIX "")
+  # It is necessary to override the cached value, to ensure that the snmalloc
+  # CMakeLists.txt picks up this change and applies it correctly.
+  set(SNMALLOC_STATIC_LIBRARY_PREFIX
+      ""
+      CACHE STRING "Prefix for snmalloc static library"
+  )
   add_subdirectory(3rdparty/exported/snmalloc EXCLUDE_FROM_ALL)
 endif()
 


### PR DESCRIPTION
Fix for regression introduced in #7137 that resulted in end to end binaries no longer actually using snmalloc, because the setting of SNMALLOC_STATIC_LIBRARY_PREFIX is scoped too narrowly and does not result in a static libraries with the un-prefixed malloc, free etc symbols being produced.