### PR TITLE
Use a deterministic thread numbering scheme

### DIFF
--- a/include/ccf/threading/thread_ids.h
+++ b/include/ccf/threading/thread_ids.h
@@ -20,5 +20,6 @@ namespace ccf::threading
   static constexpr ThreadID MAIN_THREAD_ID = 0;
 
   uint16_t get_current_thread_id();
+  void set_current_thread_id(ThreadID to);
   void reset_thread_id_generator(ThreadID to = MAIN_THREAD_ID);
 }

--- a/src/enclave/thread_local.cpp
+++ b/src/enclave/thread_local.cpp
@@ -6,10 +6,20 @@ namespace ccf::threading
 {
   static std::atomic<ThreadID> next_thread_id = MAIN_THREAD_ID;
 
-  uint16_t get_current_thread_id()
+  uint16_t& get_current_thread_id_unsafe()
   {
     thread_local ThreadID this_thread_id = next_thread_id.fetch_add(1);
     return this_thread_id;
+  }
+
+  uint16_t get_current_thread_id()
+  {
+    return get_current_thread_id_unsafe();
+  }
+
+  void set_current_thread_id(ThreadID to)
+  {
+    get_current_thread_id_unsafe() = to;
   }
 
   void reset_thread_id_generator(ThreadID to)

--- a/src/enclave/thread_local.cpp
+++ b/src/enclave/thread_local.cpp
@@ -6,7 +6,7 @@ namespace ccf::threading
 {
   static std::atomic<ThreadID> next_thread_id = MAIN_THREAD_ID;
 
-  uint16_t& get_current_thread_id_unsafe()
+  uint16_t& current_thread_id()
   {
     thread_local ThreadID this_thread_id = next_thread_id.fetch_add(1);
     return this_thread_id;

--- a/src/enclave/thread_local.cpp
+++ b/src/enclave/thread_local.cpp
@@ -14,7 +14,7 @@ namespace ccf::threading
 
   uint16_t get_current_thread_id()
   {
-    return get_current_thread_id_unsafe();
+    return current_thread_id();
   }
 
   void set_current_thread_id(ThreadID to)

--- a/src/enclave/thread_local.cpp
+++ b/src/enclave/thread_local.cpp
@@ -19,7 +19,7 @@ namespace ccf::threading
 
   void set_current_thread_id(ThreadID to)
   {
-    get_current_thread_id_unsafe() = to;
+    current_thread_id() = to;
   }
 
   void reset_thread_id_generator(ThreadID to)

--- a/src/host/run.cpp
+++ b/src/host/run.cpp
@@ -975,7 +975,8 @@ namespace ccf
           config.command.service_certificate_file);
       }
 
-      auto enclave_thread_start = [&]() {
+      auto enclave_thread_start = [&](threading::ThreadID thread_id) {
+        threading::set_current_thread_id(thread_id);
         try
         {
           bool ret = enclave_run();
@@ -1003,7 +1004,7 @@ namespace ccf
       std::vector<std::thread> threads;
       for (uint32_t i = 0; i < (config.worker_threads + 1); ++i)
       {
-        threads.emplace_back(enclave_thread_start);
+        threads.emplace_back(enclave_thread_start, i);
       }
 
       LOG_INFO_FMT("Entering event loop");


### PR DESCRIPTION
Closes #7165 

The issue was that a host side `ledger.h` thread logged between when the thread counters were reset and the first enclave thread was created giving it thread id 1 rather than 0, causing the enclave side task system to crash.

This PR instead explicitly passes a thread id into each enclave thread, which then updates the thread_local storage as soon as it starts to reflect this.

The result is that if we want to change the way the task system interacts with thread ids, at least for enclave threads, this will now be deterministic and relatively simple to update.