### PR TITLE
Fix long tests: Forbid SAN or TSAN alongside snmalloc

### DIFF
--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -45,7 +45,7 @@ jobs:
           git config --global --add safe.directory /__w/CCF/CCF
           mkdir build
           cd build
-          cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DLONG_TESTS=ON -DSAN=ON ..
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DLONG_TESTS=ON -DSAN=ON -DUSE_SNMALLOC=OFF ..
           ninja
 
       - name: "Test"
@@ -99,7 +99,7 @@ jobs:
           git config --global --add safe.directory /__w/CCF/CCF
           mkdir build
           cd build
-          cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DLONG_TESTS=ON -DTSAN=ON -DWORKER_THREADS=2 ..
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DLONG_TESTS=ON -DTSAN=ON -DUSE_SNMALLOC=OFF -DWORKER_THREADS=2 ..
           ninja
 
       - name: "Test"

--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -203,7 +203,7 @@ jobs:
           set -ex
           ./scripts/setup-ci.sh
           # This run requires libc++ to run with hardening mode
-          tdnf -y install libcxx-devel libunwind-devel
+          tdnf -y install libcxx-devel llvm-libunwind-static
 
       - name: "Build"
         run: |

--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -203,7 +203,7 @@ jobs:
           set -ex
           ./scripts/setup-ci.sh
           # This run requires libc++ to run with hardening mode
-          tdnf -y install libcxx-devel llvm-libunwind-static
+          tdnf -y install libcxx-devel libunwind-devel
 
       - name: "Build"
         run: |
@@ -211,7 +211,7 @@ jobs:
           mkdir build
           cd build
           # Use libc++ to enable hardening/bounds checking during tests
-          cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DLONG_TESTS=ON -DUSE_LIBCXX=ON ..
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DLONG_TESTS=ON -DUSE_LIBCXX=ON -DUSE_SNMALLOC=OFF ..
           ninja
 
       - name: "Test"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,10 @@ endif()
 if(SAN OR TSAN)
   find_program(LLVM_SYMBOLIZER NAMES "llvm-symbolizer")
   message(STATUS "Using llvm symbolizer: ${LLVM_SYMBOLIZER}")
+
+  if(USE_SNMALLOC)
+    message(FATAL_ERROR "snmalloc cannot be used with SAN or TSAN")
+  endif()
 endif()
 
 enable_language(ASM)


### PR DESCRIPTION
Various failures in the Long Tests job seemingly stemming from the switch to broader use of `snmalloc`. This is a broad hammer fix - forbid both options being set at once.