### PR TITLE
Remove unnecessary double-linking

### DIFF
--- a/cmake/ccf_app.cmake
+++ b/cmake/ccf_app.cmake
@@ -10,7 +10,6 @@ if(USE_LIBCXX)
   elseif("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
     add_compile_options(-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST)
   endif()
-
 endif()
 
 # Enclave library wrapper
@@ -49,9 +48,7 @@ function(add_ccf_app name)
   add_tidy(${name})
 
   if(USE_SNMALLOC)
-    target_link_libraries(
-      ${name} INTERFACE snmalloc-new-override snmallocshim-static
-    )
+    target_link_libraries(${name} INTERFACE snmallocshim-static)
   endif()
 
   add_dependencies(${name} ${name})
@@ -89,8 +86,6 @@ function(add_ccf_static_library name)
   endif()
 
   if(USE_SNMALLOC)
-    target_link_libraries(
-      ${name} INTERFACE snmalloc-new-override snmallocshim-static
-    )
+    target_link_libraries(${name} INTERFACE snmallocshim-static)
   endif()
 endfunction()


### PR DESCRIPTION
_There's no ~smoke~ new/delete without ~fire~ malloc/free, they say._

Came out of https://github.com/microsoft/CCF/issues/7172.

snmalloc's cmake:

```
  set(MALLOC src/snmalloc/override/malloc.cc)
  set(NEW src/snmalloc/override/new.cc)
  set(MEMCPY src/snmalloc/override/memcpy.cc)

  set(ALLOC ${MALLOC} ${NEW})
  set(ALL ${ALLOC} ${MEMCPY})

  if (SNMALLOC_STATIC_LIBRARY)
    compile(snmallocshim-static STATIC ${ALLOC})
    target_compile_definitions(snmallocshim-static PRIVATE
            SNMALLOC_STATIC_LIBRARY_PREFIX=${SNMALLOC_STATIC_LIBRARY_PREFIX})
  endif ()

  compile(snmalloc-new-override STATIC ${NEW})
```

Confirmed by @mjp41, linking `snmallocshim-static` if just fine.



Will check bencher after merge to make sure no regression happened.