### PR TITLE
[release/6.x] Cherry pick: Compatibility with TypeScript 5.9 (#7171)

### DIFF
--- a/js/ccf-app/package.json
+++ b/js/ccf-app/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@types/chai": "^5.0.0",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^24.0.3",
+    "@types/node": "^24.2.0",
     "@types/node-forge": "^1.0.0",
     "chai": "^5.0.0",
     "colors": "1.4.0",
@@ -30,7 +30,7 @@
     "node-forge": "^1.2.0",
     "ts-node": "^10.4.0",
     "typedoc": "^0.28.1",
-    "typescript": "^5.7.2"
+    "typescript": "^5.9.2"
   },
   "bin": {
     "ccf-build-bundle": "scripts/build_bundle.js"

--- a/js/ccf-app/src/converters.ts
+++ b/js/ccf-app/src/converters.ts
@@ -22,6 +22,7 @@
  */
 
 import { ccf } from "./global.js";
+import { toArrayBuffer } from "./utils.js";
 
 // This should eventually cover all JSON-compatible values.
 // There are attempts at https://github.com/microsoft/TypeScript/issues/1897
@@ -257,7 +258,9 @@ export interface TypedArrayConstructor<T extends TypedArray> {
 class TypedArrayConverter<T extends TypedArray> implements DataConverter<T> {
   constructor(private clazz: TypedArrayConstructor<T>) {}
   encode(val: T): ArrayBuffer {
-    return val.buffer.slice(val.byteOffset, val.byteOffset + val.byteLength);
+    return toArrayBuffer(
+      val.buffer.slice(val.byteOffset, val.byteOffset + val.byteLength),
+    );
   }
   decode(buf: ArrayBuffer): T {
     return new this.clazz(buf);

--- a/js/ccf-app/src/utils.ts
+++ b/js/ccf-app/src/utils.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+
+// toUint8ArrayBuffer(buffer) converts the buffer into a Uint8Array<ArrayBuffer>
+// If the input is already a Uint8Array<ArrayBuffer>, it returns it directly
+// Otherwise it will copy the data into a new Uint8Array<ArrayBuffer>
+export function toUint8ArrayBuffer(
+  buffer: Uint8Array<ArrayBufferLike>,
+): Uint8Array<ArrayBuffer> {
+  if (buffer.buffer instanceof ArrayBuffer) {
+    return buffer as Uint8Array<ArrayBuffer>;
+  }
+  if (buffer.buffer instanceof SharedArrayBuffer) {
+    const view = new Uint8Array(
+      new ArrayBuffer((buffer.buffer as SharedArrayBuffer).byteLength),
+    );
+    view.set(buffer);
+    return new Uint8Array(view.buffer, buffer.byteOffset, buffer.byteLength);
+  }
+  throw new Error("Unsupported buffer type");
+}
+
+// toArrayBuffer(buffer) converts the buffer to an ArrayBuffer
+// If the input is already an ArrayBuffer, it returns it directly
+// Otherwise it will copy the data into a new ArrayBuffer
+export function toArrayBuffer(
+  buffer: ArrayBufferLike | Buffer | Uint8Array,
+): ArrayBuffer {
+  if (buffer instanceof ArrayBuffer) {
+    return buffer;
+  }
+  if (buffer instanceof SharedArrayBuffer) {
+    const view = new Uint8Array(buffer);
+    return toUint8ArrayBuffer(view).buffer;
+  }
+  if (buffer instanceof Uint8Array || (buffer as any) instanceof Buffer) {
+    return toArrayBuffer(
+      buffer.buffer.slice(
+        buffer.byteOffset,
+        buffer.byteOffset + buffer.byteLength,
+      ),
+    );
+  }
+  throw new Error("Unsupported buffer type");
+}

--- a/js/ccf-app/test/polyfill.test.ts
+++ b/js/ccf-app/test/polyfill.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../src/global.js";
 import * as textcodec from "../src/textcodec.js";
 import { generateSelfSignedCert, generateCertChain } from "./crypto.js";
+import { toArrayBuffer } from "../src/utils.js";
 
 beforeEach(function () {
   // clear KV before each test
@@ -206,7 +207,7 @@ describe("polyfill", function () {
             hash: "SHA-256",
           },
           publicKey,
-          signature,
+          toArrayBuffer(signature),
           data,
         ),
       );
@@ -271,7 +272,7 @@ describe("polyfill", function () {
             hash: "SHA-256",
           },
           publicKey,
-          signature,
+          toArrayBuffer(signature),
           data,
         ),
       );
@@ -365,20 +366,24 @@ describe("polyfill", function () {
 
           {
             // Re-calculate directly, check for match
-            let node_hmac = crypto
-              .createHmac(nodeHash, key)
-              .update(new Uint8Array(data))
-              .digest();
+            let node_hmac = toArrayBuffer(
+              crypto
+                .createHmac(nodeHash, key)
+                .update(new Uint8Array(data))
+                .digest(),
+            );
             assert.deepEqual(signature, node_hmac);
           }
           assert.deepEqual(5, 6);
 
           {
             // Check for mismatch
-            let node_hmac = crypto
-              .createHmac(nodeHash, key)
-              .update(new Uint8Array(ccf.strToBuf("bar")))
-              .digest();
+            let node_hmac = toArrayBuffer(
+              crypto
+                .createHmac(nodeHash, key)
+                .update(new Uint8Array(ccf.strToBuf("bar")))
+                .digest(),
+            );
             assert.notDeepEqual(signature, node_hmac);
           }
         });
@@ -404,7 +409,7 @@ describe("polyfill", function () {
             hash: "SHA-256",
           },
           cert,
-          signature,
+          toArrayBuffer(signature),
           data,
         ),
       );
@@ -415,7 +420,7 @@ describe("polyfill", function () {
             hash: "SHA-256",
           },
           publicKey,
-          signature,
+          toArrayBuffer(signature),
           data,
         ),
       );
@@ -426,7 +431,7 @@ describe("polyfill", function () {
             hash: "SHA-256",
           },
           cert,
-          signature,
+          toArrayBuffer(signature),
           ccf.strToBuf("bar"),
         ),
       );
@@ -437,7 +442,7 @@ describe("polyfill", function () {
             hash: "SHA-256",
           },
           publicKey,
-          signature,
+          toArrayBuffer(signature),
           data,
         ),
       );
@@ -471,7 +476,7 @@ describe("polyfill", function () {
             hash: "SHA-256",
           },
           publicKey,
-          signature,
+          toArrayBuffer(signature),
           data,
         ),
       );
@@ -482,7 +487,7 @@ describe("polyfill", function () {
             hash: "SHA-256",
           },
           publicKey,
-          signature,
+          toArrayBuffer(signature),
           ccf.strToBuf("bar"),
         ),
       );
@@ -493,7 +498,7 @@ describe("polyfill", function () {
             hash: "SHA-256",
           },
           publicKey,
-          signature,
+          toArrayBuffer(signature),
           data,
         ),
       );
@@ -521,7 +526,7 @@ describe("polyfill", function () {
             name: "EdDSA",
           },
           publicKey,
-          signature,
+          toArrayBuffer(signature),
           data,
         ),
       );
@@ -531,7 +536,7 @@ describe("polyfill", function () {
             name: "EdDSA",
           },
           publicKey,
-          signature,
+          toArrayBuffer(signature),
           ccf.strToBuf("bar"),
         ),
       );
@@ -542,7 +547,7 @@ describe("polyfill", function () {
             hash: "SHA-256",
           },
           publicKey,
-          signature,
+          toArrayBuffer(signature),
           data,
         ),
       );

--- a/js/ccf-app/test/utils.test.ts
+++ b/js/ccf-app/test/utils.test.ts
@@ -1,0 +1,93 @@
+import { assert } from "chai";
+import * as util from "../src/utils.js";
+
+function uint8ArrayBufferEquality(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+describe("utils", function () {
+  it("toUint8ArrayBuffer(Uint8Array<ArrayBuffer>", function () {
+    const buffer = new Uint8Array([1, 2, 3]).buffer;
+    const uint8Array = new Uint8Array(buffer);
+    const result = util.toUint8ArrayBuffer(uint8Array);
+    assert.instanceOf(result, Uint8Array);
+    assert.strictEqual(result.buffer, buffer);
+  });
+  it("toUint8ArrayBuffer(Uint8Array<SharedArrayBuffer>)", function () {
+    const sharedBuffer = new SharedArrayBuffer(3);
+    const view = new Uint8Array(sharedBuffer);
+    view.set([1, 2, 3]);
+    const uint8Array = new Uint8Array(sharedBuffer);
+    const result = util.toUint8ArrayBuffer(uint8Array);
+    assert.instanceOf(result, Uint8Array);
+    assert.notStrictEqual(result.buffer as any, sharedBuffer as any);
+    assert.isTrue(uint8ArrayBufferEquality(result, new Uint8Array([1, 2, 3])));
+  });
+
+  it("toArrayBuffer(ArrayBuffer)", function () {
+    const buffer = new Uint8Array([1, 2, 3]).buffer;
+    const result = util.toArrayBuffer(buffer);
+    assert.instanceOf(result, ArrayBuffer);
+    assert.strictEqual(result, buffer);
+  });
+  it("toArrayBuffer(SharedArrayBuffer)", function () {
+    const buffer = new SharedArrayBuffer(3);
+    const view = new Uint8Array(buffer);
+    view.set([1, 2, 3]);
+    const result = util.toArrayBuffer(buffer);
+    assert.instanceOf(result, ArrayBuffer);
+    assert.notStrictEqual(result as any, buffer as any);
+    assert.isTrue(
+      uint8ArrayBufferEquality(
+        new Uint8Array(result),
+        new Uint8Array([1, 2, 3]),
+      ),
+    );
+  });
+  it("toArrayBuffer(Uint8Array<ArrayBuffer>)", function () {
+    const buffer = new Uint8Array([1, 2, 3]);
+    const result = util.toArrayBuffer(buffer);
+    assert.instanceOf(result, ArrayBuffer);
+    assert.deepEqual(new Uint8Array(result), buffer);
+  });
+  it("toArrayBuffer(Uint8Array<SharedArrayBuffer>)", function () {
+    const sharedBuffer = new SharedArrayBuffer(3);
+    const view = new Uint8Array(sharedBuffer);
+    view.set([1, 2, 3]);
+    const buffer = new Uint8Array(sharedBuffer);
+    const result = util.toArrayBuffer(buffer);
+    assert.instanceOf(result, ArrayBuffer);
+    assert.notStrictEqual(result as any, sharedBuffer as any);
+    assert.isTrue(
+      uint8ArrayBufferEquality(
+        new Uint8Array(result),
+        new Uint8Array([1, 2, 3]),
+      ),
+    );
+  });
+  it("toArrayBuffer(Buffer)", function () {
+    const buffer = Buffer.from([1, 2, 3]);
+    const result = util.toArrayBuffer(buffer);
+    assert.instanceOf(result, ArrayBuffer);
+    assert.isTrue(
+      uint8ArrayBufferEquality(
+        new Uint8Array(result),
+        new Uint8Array([1, 2, 3]),
+      ),
+    );
+  });
+  it("toArrayBuffer(unsupported type)", function () {
+    assert.throws(
+      () => util.toArrayBuffer("string" as any),
+      /Unsupported buffer type/,
+    );
+  });
+});

--- a/tests/js-interpreter-reuse/package.json
+++ b/tests/js-interpreter-reuse/package.json
@@ -17,6 +17,6 @@
     "@rollup/plugin-typescript": "^8.2.0",
     "del-cli": "^5.0.0",
     "tslib": "^2.0.1",
-    "typescript": "^5.7.2"
+    "typescript": "^5.9.2"
   }
 }

--- a/tests/npm-app/package.json
+++ b/tests/npm-app/package.json
@@ -28,6 +28,6 @@
     "http-server": "^14.1.1",
     "rollup": "^4.18.0",
     "tslib": "^2.6.3",
-    "typescript": "^5.7.2"
+    "typescript": "^5.9.2"
   }
 }

--- a/tests/npm-app/src/endpoints/crypto.ts
+++ b/tests/npm-app/src/endpoints/crypto.ts
@@ -3,6 +3,7 @@ import { Base64 } from "js-base64";
 
 import * as ccfapp from "@microsoft/ccf-app";
 import * as ccfcrypto from "@microsoft/ccf-app/crypto";
+import { toArrayBuffer } from "@microsoft/ccf-app/utils";
 
 interface CryptoResponse {
   available: boolean;
@@ -342,7 +343,7 @@ export function eddsaJwkToPem(
 }
 
 function b64ToBuf(b64: string): ArrayBuffer {
-  return Base64.toUint8Array(b64).buffer;
+  return toArrayBuffer(Base64.toUint8Array(b64).buffer);
 }
 
 function hex(buf: ArrayBuffer) {

--- a/tests/npm-app/src/endpoints/snp_attestation.ts
+++ b/tests/npm-app/src/endpoints/snp_attestation.ts
@@ -2,6 +2,7 @@ import { Base64 } from "js-base64";
 
 import * as ccfapp from "@microsoft/ccf-app";
 import * as ccfsnp from "@microsoft/ccf-app/snp_attestation";
+import { toUint8ArrayBuffer } from "@microsoft/ccf-app/utils";
 
 interface ErrorResponse {
   error: {
@@ -88,15 +89,17 @@ export function verifySnpAttestation(
     const body = request.body.json();
     const evidence = ccfapp
       .typedArray(Uint8Array)
-      .encode(Base64.toUint8Array(body.evidence));
+      .encode(toUint8ArrayBuffer(Base64.toUint8Array(body.evidence)));
     const endorsements = ccfapp
       .typedArray(Uint8Array)
-      .encode(Base64.toUint8Array(body.endorsements));
+      .encode(toUint8ArrayBuffer(Base64.toUint8Array(body.endorsements)));
     const uvm_endorsements =
       body.uvm_endorsements !== undefined
         ? ccfapp
             .typedArray(Uint8Array)
-            .encode(Base64.toUint8Array(body.uvm_endorsements))
+            .encode(
+              toUint8ArrayBuffer(Base64.toUint8Array(body.uvm_endorsements)),
+            )
         : undefined;
 
     const r = ccfsnp.verifySnpAttestation(


### PR DESCRIPTION
Backports the following commits to `release/6.x`:
 - [Compatibility with TypeScript 5.9 (#7171)](https://github.com/microsoft/CCF/pull/7171)