### PR TITLE
Upload non-devel RPM in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,7 +379,7 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           path: pkg
-          pattern: pkg-*
+          pattern: pkg*
           merge-multiple: true
       - name: Download Release Notes
         uses: actions/download-artifact@v5


### PR DESCRIPTION
`7.0.0-dev1` contains no non-devel `.rpm`, because we created build artifacts called `pkg` and `pkg-devel`, and then downloaded `pkg-*`. That pattern should now be `pkg*`.

Same as #7129, broken since we removed `COMPILE_TARGET` from builds.