### PR TITLE
Restore `smv_tag_whitelist`, matching nothing

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -218,6 +218,7 @@ breathe_default_project = "CCF"
 
 # Set up multiversion extension
 
+smv_tag_whitelist = r'(?!.*)' # Match nothing, build no tags. Docs suggest using None, but this produces a Warning
 smv_branch_whitelist = r"^(main)|(release\/([5-9]|\d\d\d*)\.x)$"
 smv_remote_whitelist = None
 smv_outputdir_format = "{ref.name}"


### PR DESCRIPTION
Removed in https://github.com/microsoft/CCF/pull/7170/files#diff-e170e9a7d787c21095c6c11bb25f0f1ff0294a42a46d45ba6fb5ed794e457624L221, because we get a Warning when it is `None`. But omitting it entirely means the docs attempt to build every single tag, including CI images, which a) takes a long time, and b) fails.

The official `sphinx-multiversion` docs here suggest using `None`:
https://sphinx-contrib.github.io/multiversion/main/configuration.html
> \# Whitelist pattern for tags (set to None to ignore all tags)
smv_tag_whitelist = r'^.*$'

But something in Sphinx considers this a type mismatch:
```
WARNING: The config value `smv_tag_whitelist' has type `NoneType', defaults to `str'.
```

So we set it to _a_ string, but one which is guaranteed to match nothing.