### PR TITLE
Revert "Set constitution during recovery (#7155)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Allow changing the constitution during disaster recovery via the `command.recover.constitution_files` entry in cchost. (#7155)
 - Added `toArrayBuffer` to `ccfapp/utils` which converts `ArrayBufferLike` to `ArrayBuffer`. (#7171)
 - `ccf/crypto/openssl_init.h` header exposing `ccf::crypt::openssl_sha256_init()` and `ccf::crypto::openssl_sha256_shutdown()` for unit tests using `ccfcrypto.a`. (#7118)
 

--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -417,13 +417,6 @@
                   "previous_sealed_ledger_secret_location": {
                     "type": ["string"],
                     "description": "Path to the sealed ledger secret folder, the ledger secrets for the recovered service will be unsealed from here instead of reconstructed from recovery shares."
-                  },
-                  "constitution_files": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "List of constitution files. These typically include actions.js, validate.js, resolve.js and apply.js"
                   }
                 },
                 "required": ["previous_service_identity_file"],

--- a/include/ccf/node/startup_config.h
+++ b/include/ccf/node/startup_config.h
@@ -146,7 +146,6 @@ namespace ccf
         std::nullopt;
       std::optional<std::string> previous_sealed_ledger_secret_location =
         std::nullopt;
-      std::optional<std::string> constitution = std::nullopt;
     };
     Recover recover = {};
   };

--- a/src/common/configuration.h
+++ b/src/common/configuration.h
@@ -5,7 +5,6 @@
 
 #include "ccf/crypto/curve.h"
 #include "ccf/crypto/pem.h"
-#include "ccf/ds/json.h"
 #include "ccf/ds/logger.h"
 #include "ccf/ds/unit_strings.h"
 #include "ccf/node/startup_config.h"
@@ -126,12 +125,11 @@ namespace ccf
     service_cert,
     follow_redirect);
 
-  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(StartupConfig::Recover);
+  DECLARE_JSON_TYPE(StartupConfig::Recover);
   DECLARE_JSON_REQUIRED_FIELDS(
     StartupConfig::Recover,
     previous_service_identity,
     previous_sealed_ledger_secret_location);
-  DECLARE_JSON_OPTIONAL_FIELDS(StartupConfig::Recover, constitution);
 
   DECLARE_JSON_TYPE_WITH_BASE(StartupConfig, CCFConfig);
   DECLARE_JSON_REQUIRED_FIELDS(

--- a/src/host/configuration.h
+++ b/src/host/configuration.h
@@ -118,7 +118,6 @@ namespace host
         std::string previous_service_identity_file;
         std::optional<std::string> previous_sealed_ledger_secret_location =
           std::nullopt;
-        std::vector<std::string> constitution_files = {};
         bool operator==(const Recover&) const = default;
       };
       Recover recover = {};
@@ -169,8 +168,7 @@ namespace host
     CCHostConfig::Command::Recover,
     initial_service_certificate_validity_days,
     previous_service_identity_file,
-    previous_sealed_ledger_secret_location,
-    constitution_files);
+    previous_sealed_ledger_secret_location);
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(CCHostConfig::Command);
   DECLARE_JSON_REQUIRED_FIELDS(CCHostConfig::Command, type);

--- a/src/host/run.cpp
+++ b/src/host/run.cpp
@@ -800,26 +800,6 @@ namespace ccf
         LOG_INFO_FMT("Reading previous service identity from {}", idf);
         startup_config.recover.previous_service_identity = files::slurp(idf);
 
-        if (!config.command.recover.constitution_files.empty())
-        {
-          LOG_INFO_FMT(
-            "Reading [{}] constitution file(s) for recovery",
-            fmt::join(config.command.recover.constitution_files, ", "));
-          startup_config.recover.constitution = "";
-          for (const auto& constitution_path :
-               config.command.recover.constitution_files)
-          {
-            // Separate with single newlines
-            if (!startup_config.recover.constitution->empty())
-            {
-              startup_config.recover.constitution.value() += '\n';
-            }
-
-            startup_config.recover.constitution.value() +=
-              files::slurp_string(constitution_path);
-          }
-        }
-
         if (config.command.recover.previous_sealed_ledger_secret_location
               .has_value())
         {

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -392,7 +392,6 @@ namespace ccf
       {
         case StartType::Start:
         {
-          LOG_INFO_FMT("Creating boot request");
           create_and_send_boot_request(
             aft::starting_view_change, true /* Create new consortium */);
           return;
@@ -2127,16 +2126,6 @@ namespace ccf
       if (create_consortium)
       {
         create_params.genesis_info = config.start;
-      }
-      create_params.recovery_constitution = config.recover.constitution;
-      LOG_INFO_FMT("serialise_create_request, set recovery_constitution to:");
-      if (create_params.recovery_constitution.has_value())
-      {
-        LOG_INFO_FMT("{}", create_params.recovery_constitution.value());
-      }
-      else
-      {
-        LOG_INFO_FMT("No recovery constitution provided");
       }
 
       create_params.node_id = self;

--- a/src/node/rpc/node_call_types.h
+++ b/src/node/rpc/node_call_types.h
@@ -74,8 +74,6 @@ namespace ccf
 
       // Only set on genesis transaction, but not on recovery
       std::optional<ccf::StartupConfig::Start> genesis_info = std::nullopt;
-      // Constitution to set on recovery
-      std::optional<std::string> recovery_constitution = std::nullopt;
     };
   };
 

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -1568,11 +1568,6 @@ namespace ccf
         }
         else
         {
-          if (in.recovery_constitution.has_value())
-          {
-            InternalTablesAccess::set_constitution(
-              ctx.tx, in.recovery_constitution.value());
-          }
           // On recovery, force a new ledger chunk
           auto tx_ = static_cast<ccf::kv::CommittableTx*>(&ctx.tx);
           if (tx_ == nullptr)

--- a/src/node/rpc/serialization.h
+++ b/src/node/rpc/serialization.h
@@ -73,7 +73,6 @@ namespace ccf
   DECLARE_JSON_OPTIONAL_FIELDS(
     CreateNetworkNodeToNode::In,
     genesis_info,
-    recovery_constitution,
     node_data,
     service_data,
     snp_security_policy,

--- a/tests/config.jinja
+++ b/tests/config.jinja
@@ -55,8 +55,7 @@
       {% if previous_sealed_ledger_secret_location %}
         "previous_sealed_ledger_secret_location": "{{ previous_sealed_ledger_secret_location }}",
       {% endif %}
-      "previous_service_identity_file": "{{ previous_service_identity_file }}"{% if recovery_constitution_files %},
-      "constitution_files": {{ recovery_constitution_files|tojson }} {% endif %}
+      "previous_service_identity_file": "{{ previous_service_identity_file }}"
     }
   },
   "ledger":

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -1419,55 +1419,6 @@ def run_recovery_unsealing_corrupt(const_args, recovery_f=0):
             prev_network = recovery_network
 
 
-def run_recovery_change_constitution(const_args):
-    LOG.info("Running recovery with constitution change")
-    args = copy.deepcopy(const_args)
-    args.nodes = infra.e2e_args.min_nodes(args, f=0)
-    with tempfile.NamedTemporaryFile("w") as c_new:
-        c_new.write(
-            """
-actions.set(
-    "hello_world",
-    new Action(
-        function validate(args) { console.log("Validating hello") },
-        function apply(args, proposalId) { console.log("Applying hello")}
-    )
-)"""
-        )
-        c_new.flush()
-
-        network = infra.network.Network(args.nodes, args.binary_dir)
-        network.start_and_open(args)
-        network.save_service_identity(args)
-        network.stop_all_nodes()
-
-        recovery_args = copy.deepcopy(args)
-        recovery_args.recovery_constitution_files = args.constitution + [c_new.name]
-
-        recovery_network = infra.network.Network(
-            recovery_args.nodes,
-            recovery_args.binary_dir,
-            existing_network=network,
-        )
-
-        current_ledger_dir, committed_ledger_dirs = network.nodes[0].get_ledger()
-        recovery_network.start_in_recovery(
-            recovery_args,
-            ledger_dir=current_ledger_dir,
-            committed_ledger_dirs=committed_ledger_dirs,
-        )
-        recovery_network.recover(recovery_args, set_constitution=False)
-
-        primary, _ = recovery_network.find_primary()
-        proposal_body, vote = network.consortium.make_proposal("hello_world")
-        proposal = network.consortium.get_any_active_member().propose(
-            primary, proposal_body
-        )
-        network.consortium.vote_using_majority(primary, proposal, vote)
-
-        recovery_network.stop_all_nodes()
-
-
 def run_read_ledger_on_testdata(args):
     for testdata_dir in os.scandir(args.historical_testdata):
         assert testdata_dir.is_dir()
@@ -1691,4 +1642,3 @@ def run(args):
         run_recovery_unsealing_validate_audit(args)
     run_read_ledger_on_testdata(args)
     run_ledger_chunk_bytes_check(args)
-    run_recovery_change_constitution(args)

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -204,7 +204,6 @@ class Network:
         "idle_connection_timeout_s",
         "enable_local_sealing",
         "previous_sealed_ledger_secret_location",
-        "recovery_constitution_files",
     ]
 
     # Maximum delay (seconds) for updates to propagate from the primary to backups
@@ -757,7 +756,6 @@ class Network:
         expected_recovery_count=None,
         via_recovery_owner=False,
         via_local_sealing=False,
-        set_constitution=True,
     ):
         """
         Recovers a CCF network previously started in recovery mode.
@@ -775,10 +773,9 @@ class Network:
         )
         self.wait_for_all_nodes_to_be_trusted(self.find_random_node())
 
-        if set_constitution:
-            # The new service may be running a newer version of the constitution,
-            # so we make sure that we're running the right one.
-            self.consortium.set_constitution(random_node, args.constitution)
+        # The new service may be running a newer version of the constitution,
+        # so we make sure that we're running the right one.
+        self.consortium.set_constitution(random_node, args.constitution)
 
         prev_service_identity = None
         if args.previous_service_identity_file:

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -286,7 +286,6 @@ class Node:
         members_info=None,
         enable_local_sealing=False,
         previous_sealed_ledger_secret_location=None,
-        recovery_constitution_files=None,
         **kwargs,
     ):
         """
@@ -315,8 +314,6 @@ class Node:
             previous_sealed_ledger_secret_location
         )
 
-        self.recovery_constitution_files = recovery_constitution_files or []
-
         self.certificate_validity_days = kwargs.get("initial_node_cert_validity_days")
         self.remote = infra.remote.CCFRemote(
             start_type,
@@ -339,7 +336,6 @@ class Node:
             enable_local_sealing=enable_local_sealing,
             sealed_ledger_secret_location=self.sealed_ledger_secret_location,
             previous_sealed_ledger_secret_location=previous_sealed_ledger_secret_location,
-            recovery_constitution_files=recovery_constitution_files,
             **kwargs,
         )
         self.remote.setup()

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -317,7 +317,6 @@ class CCFRemote(object):
         cose_signatures_subject="ledger.signature",
         sealed_ledger_secret_location=None,
         previous_sealed_ledger_secret_location=None,
-        recovery_constitution_files=None,
         **kwargs,
     ):
         """
@@ -525,7 +524,6 @@ class CCFRemote(object):
                 historical_cache_soft_limit=historical_cache_soft_limit,
                 cose_signatures_issuer=cose_signatures_issuer,
                 cose_signatures_subject=cose_signatures_subject,
-                recovery_constitution_files=recovery_constitution_files or [],
                 **auto_dr_args,
                 **kwargs,
             )


### PR DESCRIPTION
This changed the quorum required for constitution upgrades, and the points where constitutions must be audited. Previously it required constitutional approval, which may be distinct from the operator identities capable of restarting a node, or the recovery-member consortium capable of starting a DR. It's desirable to move to retain as much governance as possible through purely-constitutional control, and only allow the minimal unavoidable (code update) to vary during DR.