### PR TITLE
Fix flaky chunk size test

### DIFF
--- a/src/kv/deserialise.h
+++ b/src/kv/deserialise.h
@@ -22,6 +22,7 @@ namespace ccf::kv
       bool public_only,
       ccf::kv::Version& v,
       ccf::kv::Term& view,
+      ccf::kv::EntryFlags& entry_flags,
       ccf::kv::OrderedChanges& changes,
       ccf::kv::MapCollection& new_maps,
       ccf::ClaimsDigest& claims_digest,
@@ -47,6 +48,7 @@ namespace ccf::kv
     bool public_only;
     ccf::kv::Version version;
     Term term;
+    EntryFlags entry_flags;
     OrderedChanges changes;
     MapCollection new_maps;
     ccf::kv::ConsensusHookPtrs hooks;
@@ -89,6 +91,7 @@ namespace ccf::kv
             public_only,
             version,
             term,
+            entry_flags,
             changes,
             new_maps,
             claims_digest,
@@ -178,6 +181,16 @@ namespace ccf::kv
       if (chunker)
       {
         chunker->append_entry_size(data.size());
+
+        if (entry_flags & ccf::kv::EntryFlags::FORCE_LEDGER_CHUNK_BEFORE)
+        {
+          chunker->produced_chunk_at(version - 1);
+        }
+
+        if (entry_flags & ccf::kv::EntryFlags::FORCE_LEDGER_CHUNK_AFTER)
+        {
+          chunker->produced_chunk_at(version);
+        }
       }
 
       return success;

--- a/src/kv/generic_serialise_wrapper.h
+++ b/src/kv/generic_serialise_wrapper.h
@@ -300,6 +300,7 @@ namespace ccf::kv
       const uint8_t* data,
       size_t size,
       ccf::kv::Term& term,
+      EntryFlags& flags,
       bool historical_hint = false)
     {
       current_reader = &public_reader;
@@ -308,6 +309,8 @@ namespace ccf::kv
 
       const auto tx_header =
         serialized::read<SerialisedEntryHeader>(data_, size_);
+
+      flags = static_cast<EntryFlags>(tx_header.flags);
 
       if (tx_header.size != size_)
       {

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -409,7 +409,8 @@ namespace ccf::kv
                       std::optional<ccf::kv::SecurityDomain>());
 
       ccf::kv::Term term;
-      auto v_ = d.init(data, size, term, is_historical);
+      ccf::kv::EntryFlags entry_flags;
+      auto v_ = d.init(data, size, term, entry_flags, is_historical);
       if (!v_.has_value())
       {
         LOG_FAIL_FMT("Initialisation of deserialise object failed");
@@ -714,6 +715,7 @@ namespace ccf::kv
       bool public_only,
       ccf::kv::Version& v,
       ccf::kv::Term& view,
+      ccf::kv::EntryFlags& entry_flags,
       OrderedChanges& changes,
       MapCollection& new_maps,
       ccf::ClaimsDigest& claims_digest,
@@ -732,7 +734,8 @@ namespace ccf::kv
         public_only ? ccf::kv::SecurityDomain::PUBLIC :
                       std::optional<ccf::kv::SecurityDomain>());
 
-      auto v_ = d.init(data.data(), data.size(), view, is_historical);
+      auto v_ =
+        d.init(data.data(), data.size(), view, entry_flags, is_historical);
       if (!v_.has_value())
       {
         LOG_FAIL_FMT("Initialisation of deserialise object failed");

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -1613,6 +1613,9 @@ def run_ledger_chunk_bytes_check(const_args):
                 c.wait_for_commit(r)
 
             force_become_primary(smallest_node)
+            # Sleep long enough that this new primary node can produce a new time-based signature,
+            # if they want to, to ensure they're tracking chunk sizes accurately
+            time.sleep(args.sig_ms_interval / 1000)
             with smallest_node.client("user0") as c:
                 r = c.get("/node/commit")
                 assert r.status_code == http.HTTPStatus.OK, r


### PR DESCRIPTION
Resolving an occasional test failure, that's become consistent with other timing tweaks in https://github.com/microsoft/CCF/pull/7153.

Basically, the chunk size calculations on backups weren't accurate, because we didn't apply the chunks they'd produced to our own `LedgerChunker`. That was missed in the unit tests because we stub out more of the stack there, and don't accurately mimic the primary/backup flows. This adds a consistent repro of the failure (sleep after making a new primary, long enough for them to emit a time-based signature, and chunk if they think there's sufficient unchunked state). The fix is to extract the `EntryFlags` during the deserialise flow (they're currently examined on the _host_, but have no effect on the in-enclave execution) and pass them up the stack a bit to where we interact with a `chunker`.