### PR TITLE
Fix commit/rollback race on last_replicated

### DIFF
--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -1002,7 +1002,8 @@ namespace ccf::kv
         // two contiguous signatures are fine
         if (success_ != CommitResult::SUCCESS)
         {
-          LOG_DEBUG_FMT("Failed Tx commit {}", last_replicated + offset);
+          LOG_DEBUG_FMT(
+            "Failed Tx commit {}", previous_last_replicated + offset);
         }
 
         if (h)
@@ -1020,13 +1021,17 @@ namespace ccf::kv
 
         LOG_DEBUG_FMT(
           "Batching {} ({}) during commit of {}.{}",
-          last_replicated + offset,
+          previous_last_replicated + offset,
           data_shared->size(),
           txid.term,
           txid.version);
 
         batch.emplace_back(
-          last_replicated + offset, data_shared, committable_, hooks_shared);
+          previous_last_replicated + offset,
+          data_shared,
+          committable_,
+          hooks_shared);
+
         offset++;
       }
 


### PR DESCRIPTION
Resolves a part of #7201.

Read https://github.com/microsoft/CCF/issues/7201#issuecomment-3210630730. Results:
```
Running tests 10 times...
Command: ./tests.sh -VV -L partitions -C partitions
----------------------------------------
Run 1/10...
  -> out1.txt does not contain ThreadSanitizer
Run 2/10...
  -> out2.txt does not contain ThreadSanitizer
Run 3/10...
  -> out3.txt does not contain ThreadSanitizer
Run 4/10...
  -> out4.txt does not contain ThreadSanitizer
Run 5/10...
  -> out5.txt does not contain ThreadSanitizer
Run 6/10...
  -> out6.txt does not contain ThreadSanitizer
Run 7/10...
  -> out7.txt does not contain ThreadSanitizer
Run 8/10...
  -> out8.txt does not contain ThreadSanitizer
Run 9/10...
  -> out9.txt does not contain ThreadSanitizer
Run 10/10...
  -> out10.txt does not contain ThreadSanitizer
```