### PR TITLE
Pass sev_version_certificate as a chain rather than directly trusting it

### DIFF
--- a/include/ccf/pal/attestation.h
+++ b/include/ccf/pal/attestation.h
@@ -159,7 +159,7 @@ namespace ccf::pal
 
     auto chip_cert_verifier = ccf::crypto::make_verifier(chip_certificate);
     if (!chip_cert_verifier->verify_certificate(
-          {&root_certificate, &sev_version_certificate}))
+          {&root_certificate}, {&sev_version_certificate}))
     {
       throw std::logic_error(
         "SEV-SNP: The chain of signatures from the root of trust to this "


### PR DESCRIPTION
Just noticed that we pass the sev_version_certificate as a trusted cert rather than as just a chained cert.
This will need to be backported to 6 and possibly 5.