### PR TITLE
Check the endorsed tcb and chip id match those in the attestation.

### DIFF
--- a/include/ccf/pal/attestation_sev_snp.h
+++ b/include/ccf/pal/attestation_sev_snp.h
@@ -198,10 +198,21 @@ pRb21iI1NlNCfOGUPIhVpWECAwEAAQ==
   struct TcbVersionRaw
   {
   private:
-    uint8_t underlying_data[snp_tcb_version_size];
+    uint8_t underlying_data[snp_tcb_version_size]{};
 
   public:
     bool operator==(const TcbVersionRaw& other) const = default;
+
+    TcbVersionRaw(std::vector<uint8_t> data = {})
+    {
+      if (data.size() != snp_tcb_version_size)
+      {
+        throw std::logic_error(
+          fmt::format("Invalid TCB version raw data size: {}", data.size()));
+      }
+      std::memcpy(
+        static_cast<void*>(underlying_data), data.data(), snp_tcb_version_size);
+    }
 
     [[nodiscard]] std::vector<uint8_t> data() const
     {


### PR DESCRIPTION
This PR adds checks in `verify_snp_attestation_report` to check the tcb version in the retrieved endorsements against those in the attestation, and additionally validates the chip_id in the endorsements.

If the relevant oids in the certificate are not set, then the check is ignored as the certificate must still have the correct root signature, and hence their omission can only be intentional.
Otherwise if the check fails, it will throw an exception.