### PR TITLE
Disable confidential ci on 5.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
         if: success() || failure()
 
   build_caci:
+    if: ${{ false }}
     name: "Confidential Container (ACI) CI"
     runs-on: [self-hosted, 1ES.Pool=gha-caci-ne-release5x]
     needs: checks


### PR DESCRIPTION
The confidential ci has been failing without cause:
<img width="977" height="1128" alt="image" src="https://github.com/user-attachments/assets/5ed6f498-e953-4ea0-ab8b-70fe0d4fb067" />
This PR disables it for 5.x