### PR TITLE
Don't exit early on ci-checks.sh

### DIFF
--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-set -o pipefail
-
 if [ "$1" == "-f" ]; then
   FIX=1
 else


### PR DESCRIPTION
Currently when a failure occurs in the ci-checks.sh we exit. Instead we should run all checks and let the user know that some have failed.

A fancier way to do this would be with something like ctest, but this PR should work for now.