### PR TITLE
CA should be set in all trusted certs

### DIFF
--- a/src/crypto/openssl/verifier.cpp
+++ b/src/crypto/openssl/verifier.cpp
@@ -117,6 +117,17 @@ namespace ccf::crypto
         return false;
       }
 
+      auto rc = X509_check_ca(tc);
+      // trusted certs should be a CA
+      // (x509v3 basic constraints CA:TRUE or self-signed x509v1)
+      // Excludes KeyUsage extensions and outdated Netscape extensions
+      auto is_ca = (rc == 1 || rc == 3);
+      if (!is_ca)
+      {
+        LOG_DEBUG_FMT("Trusted certificate is not a CA: {}", pem->str());
+        return false;
+      }
+
       CHECK1(X509_STORE_add_cert(store, tc));
     }
 

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -1351,3 +1351,30 @@ TEST_CASE("Decrypt should validate integrity")
 
   CHECK_THROWS(ccf::crypto::aes_gcm_decrypt(key, broken_ciphertext));
 }
+
+TEST_CASE("Do not trust non-ca certs")
+{
+  auto kp = ccf::crypto::make_key_pair(CurveID::SECP384R1);
+  auto ca_cert = generate_self_signed_cert(kp, "CN=name");
+
+  auto ca_cert_verifier = ccf::crypto::make_verifier(ca_cert.raw());
+  // CA cert is accepted as a trusted root (self-signed, CA:TRUE).
+  REQUIRE(ca_cert_verifier->verify_certificate({&ca_cert}, {}, true));
+
+  ccf::crypto::Pem non_ca_cert;
+  {
+    constexpr size_t certificate_validity_period_days = 365;
+    using namespace std::literals;
+    auto valid_from =
+      ccf::ds::to_x509_time_string(std::chrono::system_clock::now() - 24h);
+    auto valid_to = compute_cert_valid_to_string(
+      valid_from, certificate_validity_period_days);
+    std::vector<SubjectAltName> subject_alt_names = {};
+    non_ca_cert =
+      kp->self_sign("CN=name", valid_from, valid_to, subject_alt_names, false);
+  }
+
+  auto non_ca_cert_verifier = ccf::crypto::make_verifier(non_ca_cert.raw());
+  // Non-CA cert must NOT be accepted as a trusted root (self-signed but CA:FALSE).
+  REQUIRE_FALSE(non_ca_cert_verifier->verify_certificate({&non_ca_cert}, {}, true));
+}

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -1375,6 +1375,8 @@ TEST_CASE("Do not trust non-ca certs")
   }
 
   auto non_ca_cert_verifier = ccf::crypto::make_verifier(non_ca_cert.raw());
-  // Non-CA cert must NOT be accepted as a trusted root (self-signed but CA:FALSE).
-  REQUIRE_FALSE(non_ca_cert_verifier->verify_certificate({&non_ca_cert}, {}, true));
+  // Non-CA cert must NOT be accepted as a trusted root (self-signed but
+  // CA:FALSE).
+  REQUIRE_FALSE(
+    non_ca_cert_verifier->verify_certificate({&non_ca_cert}, {}, true));
 }

--- a/tests/npm_tests.py
+++ b/tests/npm_tests.py
@@ -722,8 +722,12 @@ def test_npm_app(network, args):
             priv_key_pem3, cn="3", issuer_priv_key_pem=priv_key_pem2, issuer_cn="2"
         )
         # validates chains with target being trusted directly
-        r = c.post("/app/isValidX509CertChain", {"chain": pem3, "trusted": pem3})
+        r = c.post("/app/isValidX509CertChain", {"chain": pem2, "trusted": pem2})
         assert r.body.json(), r.body
+        # does not validate trusted certificates where CA=False
+        r = c.post("/app/isValidX509CertChain", {"chain": pem3, "trusted": pem3})
+        assert r.status_code == 200, r.status_code
+        assert r.body.text() == "false", r.body
         # validates chains without intermediates
         r = c.post("/app/isValidX509CertChain", {"chain": pem2, "trusted": pem1})
         assert r.body.json(), r.body


### PR DESCRIPTION
Replacement for #7236 

We should validate that all trusted certs are CAs and therefore can endorse the certificate we are testing.