### PR TITLE
Remove race on `Ledger::last_idx`

### DIFF
--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -723,7 +723,7 @@ namespace asynchost
     std::list<std::shared_ptr<LedgerFile>> files_read_cache;
     ccf::pal::Mutex read_cache_lock;
 
-    size_t last_idx = 0;
+    std::atomic<size_t> last_idx = 0;
     size_t committed_idx = 0;
 
     size_t end_of_committed_files_idx = 0;


### PR DESCRIPTION
This seems to resolve #7266.

This feels like a partial solution. We're not avoiding any other shared state in a principled way, but we do currently appear to avoid any other races (and eventually access a definitely-shared cache under a mutex lock). Evidence that this is _some_ kind of fix, is it dropping the failure rate of the `auth` e2e test under TSAN from ~1/3 to 0/10. I think that this is a worthwhile step towards stable TSAN, though we should remember to revisit the Ledger interaction when time permits.