### PR TITLE
[release/6.x] Cherry pick: Remove race on `Ledger::last_idx` (#7287)

### DIFF
--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -727,7 +727,7 @@ namespace asynchost
     ccf::pal::Mutex read_cache_lock;
 
     const size_t chunk_threshold;
-    size_t last_idx = 0;
+    std::atomic<size_t> last_idx = 0;
     size_t committed_idx = 0;
 
     size_t end_of_committed_files_idx = 0;


### PR DESCRIPTION
Backports the following commits to `release/6.x`:
 - [Remove race on `Ledger::last_idx` (#7287)](https://github.com/microsoft/CCF/pull/7287)