### PR TITLE
Require a recent version of Python CWT

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -24,5 +24,5 @@ polars
 plotext
 boofuzz
 numpy<2
-cwt
+cwt>=3.1
 aiohttp


### PR DESCRIPTION
Dependency fun - a recent release of Python cryptography is not compatible with recent `python-cwt`, so we installed cwt @ 1.something and got broken imports on all of our test runs. We need recent `python-cwt`, so add a minimum version here and accept whatever `cryptography` _it_ pulls in.