### PR TITLE
Remove `pyopenssl`

### DIFF
--- a/python/src/ccf/receipt.py
+++ b/python/src/ccf/receipt.py
@@ -55,7 +55,9 @@ def check_endorsement(endorsee: Certificate, endorser: Certificate):
 
 
 def check_endorsements(
-    node_cert: Certificate, service_cert: Certificate, endorsements: List[Certificate]
+    node_cert: Certificate,
+    service_cert: Certificate,
+    endorsements: List[Certificate],
 ):
     """
     Check a node certificate is endorsed by a service certificate, transitively through a list of endorsements.
@@ -66,10 +68,18 @@ def check_endorsements(
         cert_i = endorsement
     check_endorsement(cert_i, service_cert)
 
-    # Use higher-level cryptography classes to verify the same chain, with
-    # additional default policy checks
+
+def check_cert_chain(
+    node_cert: Certificate,
+    service_cert: Certificate,
+    endorsements: List[Certificate],
+):
+    """
+    Use default cryptography policy to verify CCF cert chain
+    """
     builder = PolicyBuilder()
     builder = builder.store(Store([service_cert]))
+
     # This would ideally be `build_server_verifier`, but that requires a
     # Subject which is either a valid DNSName or IPAddress. Our node cert's
     # Subject is "CCF Node", and we may not have a better value in SAN

--- a/python/src/ccf/receipt.py
+++ b/python/src/ccf/receipt.py
@@ -5,6 +5,7 @@ import base64
 from hashlib import sha256
 from typing import List
 from cryptography.x509 import Certificate
+from cryptography.x509.verification import PolicyBuilder, Store
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, utils
 
@@ -64,3 +65,13 @@ def check_endorsements(
         check_endorsement(cert_i, endorsement)
         cert_i = endorsement
     check_endorsement(cert_i, service_cert)
+
+    # Use higher-level cryptography classes to verify the same chain, with
+    # additional default policy checks
+    builder = PolicyBuilder()
+    builder = builder.store(Store([service_cert]))
+    # This would ideally be `build_server_verifier`, but that requires a
+    # Subject which is either a valid DNSName or IPAddress. Our node cert's
+    # Subject is "CCF Node", and we may not have a better value in SAN
+    verifier = builder.build_client_verifier()
+    verifier.verify(leaf=node_cert, intermediates=endorsements)

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -599,7 +599,14 @@ def test_recover_service_from_files(
 
         if test_receipt:
             r = primary.get_receipt(2, 3)
-            verify_receipt(r.json(), network.cert)
+
+            verify_receipt(
+                r.json(),
+                network.cert,
+                # Even when we want to check that receipts are valid,
+                # these old services are likely to use expired certs
+                skip_cert_chain_checks=True,
+            )
 
 
 @reqs.description("Attempt to recover a service but abort before recovery is complete")

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -23,5 +23,5 @@ polars
 plotext
 boofuzz
 numpy<2
-cwt>=3.1
+cwt
 aiohttp

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -12,7 +12,6 @@ pyasn1
 Jinja2
 httpx[http2] == 0.23.*
 locust
-pyOpenSSL
 JWCrypto>=1.5.1 # x25519 support
 rich
 gelidum

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -23,5 +23,5 @@ polars
 plotext
 boofuzz
 numpy<2
-cwt
+cwt>=3.1
 aiohttp


### PR DESCRIPTION
No longer needed - `cryptography` can do the same.

~~I believe I've extended `receipt.check_endorsements` to do the equivalent checks via `cryptography`. Please check [the docs](https://cryptography.io/en/latest/x509/verification/) and see if there's anything you'd add/remove.~~

~~If this works, it should be preferable to #7296.~~

See discussion in comments for more accurate description. A new `receipt.check_cert_chain` function does roughly what PyOpenSSL was doing.