### PR TITLE
Add logging and repro of nulled receipt of snapshot

### DIFF
--- a/src/node/snapshot_serdes.h
+++ b/src/node/snapshot_serdes.h
@@ -58,10 +58,8 @@ namespace ccf
       throw std::logic_error("No receipt included in snapshot");
     }
 
-    LOG_INFO_FMT(
-      "Deserialising snapshot receipt (size: {}).", receipt_size);
-    LOG_INFO_FMT("{}",
-      ds::to_hex(receipt_data, receipt_data + receipt_size));
+    LOG_INFO_FMT("Deserialising snapshot receipt (size: {}).", receipt_size);
+    LOG_INFO_FMT("{}", ds::to_hex(receipt_data, receipt_data + receipt_size));
 
     auto j = nlohmann::json::parse(receipt_data, receipt_data + receipt_size);
     auto receipt_p = j.get<ReceiptPtr>();

--- a/src/node/snapshot_serdes.h
+++ b/src/node/snapshot_serdes.h
@@ -58,6 +58,11 @@ namespace ccf
       throw std::logic_error("No receipt included in snapshot");
     }
 
+    LOG_INFO_FMT(
+      "Deserialising snapshot receipt (size: {}).", receipt_size);
+    LOG_INFO_FMT("{}",
+      ds::to_hex(receipt_data, receipt_data + receipt_size));
+
     auto j = nlohmann::json::parse(receipt_data, receipt_data + receipt_size);
     auto receipt_p = j.get<ReceiptPtr>();
     auto receipt = std::dynamic_pointer_cast<ccf::ProofReceipt>(receipt_p);

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -402,6 +402,37 @@ def test_empty_snapshot(network, args):
                     f"Expected empty snapshot file {snapshot_name} to be skipped in node logs"
                 )
 
+def test_nulled_snapshot(network, args):
+
+    with tempfile.TemporaryDirectory() as snapshots_dir:
+        LOG.debug(f"Using {snapshots_dir} as snapshots directory")
+
+        snapshot_name = "snapshot_1000_1500.committed"
+
+        with open(
+            os.path.join(snapshots_dir, snapshot_name), "wb+"
+        ) as temp_empty_snapshot:
+
+            LOG.debug(f"Created empty snapshot {temp_empty_snapshot.name}")
+            temp_empty_snapshot.write(b"\x00" * 64)
+
+        LOG.info("Attempt to join a node using the corrupted snapshot copy (should fail)")
+        new_node = network.create_node("local://localhost")
+        failed = False
+        try:
+            network.join_node(
+                new_node,
+                args.package,
+                args,
+                snapshots_dir=snapshots_dir,
+            )
+        except Exception as e:
+            failed = True
+            LOG.info(f"Node failed to join as expected: {e}")
+
+        # (Existing assertion logic retained)
+        assert failed, "Node should not have joined successfully"
+
 
 def split_all_ledger_files_in_dir(input_dir, output_dir):
     # A ledger file can only be split at a seqno that contains a signature
@@ -493,6 +524,7 @@ def run_file_operations(args):
                 test_large_snapshot(network, args)
                 test_snapshot_access(network, args)
                 test_empty_snapshot(network, args)
+                test_nulled_snapshot(network, args)
 
                 primary, _ = network.find_primary()
                 # Scoped transactions are not handled by historical range queries

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -402,6 +402,7 @@ def test_empty_snapshot(network, args):
                     f"Expected empty snapshot file {snapshot_name} to be skipped in node logs"
                 )
 
+
 def test_nulled_snapshot(network, args):
 
     with tempfile.TemporaryDirectory() as snapshots_dir:
@@ -416,7 +417,9 @@ def test_nulled_snapshot(network, args):
             LOG.debug(f"Created empty snapshot {temp_empty_snapshot.name}")
             temp_empty_snapshot.write(b"\x00" * 64)
 
-        LOG.info("Attempt to join a node using the corrupted snapshot copy (should fail)")
+        LOG.info(
+            "Attempt to join a node using the corrupted snapshot copy (should fail)"
+        )
         new_node = network.create_node("local://localhost")
         failed = False
         try:


### PR DESCRIPTION
ACL were seeing a json parse error on 5.x

From the log the only possible cause is during the parsing of the snapshot's receipt.

This PR adds a test for this and improves some of the logging around it.

```
73: 2025-09-17 12:44:14.158 | INFO     | {operations} infra.network:log_errors:155 - 2025-09-17T11:44:09.371161Z        0   [info ] CCF/src/node/snapshot_serdes.h:61    | Deserialising snapshot receipt (size: 56).
73: 2025-09-17 12:44:14.158 | INFO     | {operations} infra.network:log_errors:155 - 2025-09-17T11:44:09.371240Z        0   [info ] CCF/src/node/snapshot_serdes.h:63    | 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
73: 2025-09-17 12:44:14.158 | INFO     | {operations} infra.network:log_errors:155 - 2025-09-17T11:44:09.371766Z        0   [fail ] CCF/src/enclave/enclave.h:217        | Error starting node: [json.exception.parse_error.101] parse error at line 1, column 1: attempting to parse an empty input; check that your input string or stream contains the expected JSON
```