### PR TITLE
Fix regression test suite - accept ledger difference when shutting down mid-recovery

### DIFF
--- a/tests/e2e_suite.py
+++ b/tests/e2e_suite.py
@@ -57,7 +57,7 @@ def run(args):
         if seed is None:
             seed = time.time()
         seed = int(seed)
-        LOG.success(f"Shuffling full suite with seed {seed}")
+        LOG.success(f"Shuffling suite with seed {seed}")
         random.seed(seed)
         random.shuffle(chosen_suite)
         # Only time reqs can be safely ignored is if they are produced from a randomly shuffled suite
@@ -168,12 +168,12 @@ def run(args):
         jwt_server.stop()
 
     if success:
-        LOG.success(f"Full suite passed. Ran {len(run_tests)}/{len(chosen_suite)}")
+        LOG.success(f"Suite passed. Ran {len(run_tests)}/{len(chosen_suite)}")
     else:
         LOG.error(f"Suite failed. Ran {len(run_tests)}/{len(chosen_suite)}")
 
     if seed:
-        LOG.info(f"Full suite was shuffled with seed: {seed}")
+        LOG.info(f"Suite was shuffled with seed: {seed}")
 
     for idx, test in run_tests.items():
         if "status" not in test:
@@ -197,7 +197,7 @@ if __name__ == "__main__":
     def add(parser):
         parser.add_argument(
             "--test-duration",
-            help="Duration of full suite (s)",
+            help="Duration of suite (s)",
             type=int,
             required=True,
         )

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -658,7 +658,10 @@ def test_recover_service_aborted(network, args, from_snapshot=False):
 
     # Check that all nodes have the same (recovery) ledger files
     aborted_network.stop_all_nodes(
-        skip_verification=True, read_recovery_ledger_files=True
+        skip_verification=True,
+        read_recovery_ledger_files=True,
+        # We've deliberately terminated mid-recovery, when it is likely that some nodes still have local-only .recovery
+        accept_ledger_diff=True,
     )
 
     current_ledger_dir, committed_ledger_dirs = primary.get_ledger()


### PR DESCRIPTION
CI caught a failure in one of the shuffled suites:

https://github.com/microsoft/CCF/actions/runs/17833433414/job/50704270344?pr=7304#step:7:462

Using this seed results in a failure of `regression_test_suite` ~50% of the time. The root cause is that the files differ between nodes, with one still holding a `.recovery` file. This seems expected in this test - we're explicitly shutting down "mid-recovery".

The second commit is tweaking the logging - we have an e2e test called `full_test_suite`, so I think it's confusing if the test named `regression_test_suite` logs things about the "Full suite". Our concept is a _suite_ of tests.