### PR TITLE
Curl snagging

### DIFF
--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -714,12 +714,6 @@ namespace ccf::curl
     static void libuv_socket_poll_callback(
       uv_poll_t* req, int status, int events)
     {
-      if (status < 0)
-      {
-        LOG_FAIL_FMT("Socket poll error: {}", uv_strerror(status));
-        return;
-      }
-
       auto* socket_context = static_cast<SocketContextImpl*>(req->data);
       if (socket_context == nullptr)
       {
@@ -736,7 +730,27 @@ namespace ccf::curl
 
       if (self->is_stopping)
       {
-        LOG_FAIL_FMT("libuv_socket_poll_callback called while stopping");
+        LOG_FAIL_FMT(
+          "libuv_socket_poll_callback called on {} while stopped",
+          socket_context->socket);
+        return;
+      }
+
+      if (status < 0)
+      {
+        LOG_INFO_FMT(
+          "Socket poll error on {}: {}",
+          socket_context->socket,
+          uv_strerror(status));
+
+        // Notify curl of the error
+        CHECK_CURL_MULTI(
+          curl_multi_socket_action,
+          self->curl_request_curlm,
+          socket_context->socket,
+          CURL_CSELECT_ERR,
+          nullptr);
+        self->curl_request_curlm.perform();
         return;
       }
 
@@ -779,15 +793,17 @@ namespace ccf::curl
         case CURL_POLL_OUT:
         case CURL_POLL_INOUT:
         {
-          // Possibly called during shutdown
+          LOG_INFO_FMT(
+            "Curl socket callback: listen on socket {}, {}",
+            static_cast<int>(s),
+            static_cast<int>(action));
+
+          // During shutdown ignore requests to add new sockets
           if (self->is_stopping)
           {
-            LOG_FAIL_FMT("curl_socket_callback called while stopping");
             return 0;
           }
 
-          LOG_INFO_FMT(
-            "Curl socket callback: listen on socket {}", static_cast<int>(s));
           if (socket_context == nullptr)
           {
             auto socket_context_ptr = std::make_unique<SocketContextImpl>();


### PR DESCRIPTION
Two warnings were seen recently during testing, EBADF from the libuv polling of the socket and CURL_POLL_IN during shutdown.

When libuv receives a POLLERR from its epoll it surfaces that as EBADF in the poll callback.
This can happen when the other side of a tcp connection abruptly disconnects.
Previously we FAIL logged this and otherwise ignored it, now we pass the error back to curl (CURL_CSELECT_ERR), and INFO log it.

Next, supposing there are several requests to the same address, curl will cache and reuse the socket for this.
However this means that come shutdown the socket may still be alive.
When curl_multi_cleanup is called, this causes the socket to try to poll for any remaining data or a disconnect via CURL_POLL_IN, before immediately calling CURL_POLL_REMOVE. 
In this case we simply want curl to shutdown the relevant sockets and thus do not register the new polling.