### PR TITLE
Fix task system unit tests: Cancel periodic tasks at end of each test

### DIFF
--- a/src/tasks/test/delayed_tasks.cpp
+++ b/src/tasks/test/delayed_tasks.cpp
@@ -205,6 +205,10 @@ TEST_CASE("ExplicitTicks" * doctest::test_suite("delayed_tasks"))
 
   ccf::tasks::tick(3ms);
   do_all_check_and_reset("34ms", false, true, false);
+
+  set_a->cancel_task();
+  set_b->cancel_task();
+  set_c->cancel_task();
 }
 
 TEST_CASE("TickEnqueue" * doctest::test_suite("delayed_tasks"))
@@ -226,4 +230,6 @@ TEST_CASE("TickEnqueue" * doctest::test_suite("delayed_tasks"))
   REQUIRE(n.load() == 1);
   do_all_tasks();
   REQUIRE(n.load() == 1);
+
+  incrementer->cancel_task();
 }


### PR DESCRIPTION
ASAN spotted this. If you push tasks onto a global singleton in unit tests, make sure you clean them up in each test.

Incoming refactor will localise the impact of these, since most tests just want to deal with a local `JobBoard` rather than the global singleton.