### PR TITLE
Stop passing nullptr to curl_multi_socket_action

### DIFF
--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -815,12 +815,13 @@ namespace ccf::curl
         }
 
         // Notify curl of the error
+        int running_handles = 0;
         CHECK_CURL_MULTI(
           curl_multi_socket_action,
           self->curl_request_curlm,
           socket_context->socket,
           CURL_CSELECT_ERR,
-          nullptr);
+          &running_handles);
         self->curl_request_curlm.perform();
         return;
       }


### PR DESCRIPTION
curl_multi_socket_action doesn't check if the running_handles arg is null before writing to it, causing a segfault.
I think this is the only case where this happens currently in the curl wrapper.