### PR TITLE
Make LLDB work in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "dockerfile": "Dockerfile",
     "context": "."
   },
-  "runArgs": [],
+  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
   "hostRequirements": {
     "cpus": 16,
     "memory": "64gb",


### PR DESCRIPTION
https://containers.dev/implementors/json_reference/ says

<img width="1182" height="153" alt="image" src="https://github.com/user-attachments/assets/506774d3-ed72-424f-b36c-8a4eb42ea1e1" />
