### PR TITLE
Add fail logging if 100x the expected time bound

### DIFF
--- a/src/host/time_bound_logger.h
+++ b/src/host/time_bound_logger.h
@@ -49,7 +49,13 @@ namespace asynchost
     {
       const auto end_time = TClock::now();
       const auto elapsed = end_time - start_time;
-      if (elapsed > max_time)
+      constexpr auto out_of_distribution_multiplier = 100;
+      if (elapsed > max_time * out_of_distribution_multiplier)
+      {
+        LOG_FAIL_FMT(
+          "Operation took too long ({}): {}", human_time(elapsed), message);
+      }
+      else if (elapsed > max_time)
       {
         LOG_INFO_FMT(
           "Operation took too long ({}): {}", human_time(elapsed), message);


### PR DESCRIPTION
We have a couple of CI runs where the time-bound-logger shows that disk operations are taking >1s.
The problem is that they are not visible unless we download the logs.

This PR makes >1s time bounds surface as `LOG_FAIL`s and hence appear in the CI logs when that node is closed.
This should help to simplify the diagnosis process.