### PR TITLE
Update line-length for ruff

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,1 @@
+line-length = 320


### PR DESCRIPTION
Previous line-length (1000) is longer than ruff actually allows, but the error was swallowed before 0.14.3.