### PR TITLE
Mount socker dockets in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,5 +36,8 @@
       }
     }
   },
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+  ],
   "postCreateCommand": "./.devcontainer/post_create_setup.sh"
 }


### PR DESCRIPTION
I don't know if we want this in `main`, but creating a PR for at-least general awareness - this is what we need to add to run `docker` commands in Codespaces.