### PR TITLE
Focus SNP CI and make it identical across archs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,13 +201,13 @@ jobs:
           if-no-files-found: ignore
         if: success() || failure()
 
-  build_and_test_caci:
-    name: "Confidential Container CI"
+  aci_snp_milan:
+    name: "ACI SNP Milan"
     runs-on:
       [
         self-hosted,
         1ES.Pool=gha-c-aci-ci,
-        "JobId=ci_caci_milan-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}",
+        "JobId=aci_snp_milan-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}",
       ]
     needs: checks
 
@@ -233,10 +233,10 @@ jobs:
           echo "::endgroup::"
         shell: bash
 
-      - name: "Confirm running on SEV-SNP"
+      - name: "Confirm running on SEV-SNP Milan"
         run: |
           set -ex
-          python3 tests/infra/platform_detection.py snp
+          python3 tests/infra/platform_detection.py snp milan
         shell: bash
 
       - name: "Build Debug"
@@ -255,10 +255,8 @@ jobs:
           cd build
           rm -rf /github/home/.cache
           mkdir -p /github/home/.cache
-          # Unit tests
-          ./tests.sh --output-on-failure -L unit -j$(nproc --all)
-          # End to end tests
-          ./tests.sh --timeout 360 --output-on-failure -LE "benchmark|suite|unit"
+          ./tests.sh --timeout 360 --output-on-failure -C snp -L snp
+          ./tests.sh --timeout 360 --output-on-failure -R code_update
         shell: bash
 
       - name: "Capture dmesg"
@@ -274,7 +272,7 @@ jobs:
       - name: "Upload logs"
         uses: actions/upload-artifact@v5
         with:
-          name: logs-caci-snp
+          name: logs-aci-snp-milan
           path: |
             dmesg.log
             build/workspace/*/*.config.json
@@ -285,13 +283,13 @@ jobs:
           if-no-files-found: ignore
         if: success() || failure()
 
-  build_and_test_caci_genoa:
-    name: "Confidential Container CI on Genoa"
+  aci_snp_genoa:
+    name: "ACI SNP Genoa"
     runs-on:
       [
         self-hosted,
         1ES.Pool=gha-aci-genoa,
-        "JobId=ci_caci_genoa-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}",
+        "JobId=aci_snp_genoa-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}",
       ]
     needs: checks
 
@@ -299,11 +297,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
-      - name: "Ensure running on Genoa hardware"
-        run: |
-          cat /proc/cpuinfo | grep "model.*: 17"
-        shell: bash
 
       - name: "Dump environment"
         run: |
@@ -322,10 +315,10 @@ jobs:
           echo "::endgroup::"
         shell: bash
 
-      - name: "Confirm running on SEV-SNP"
+      - name: "Confirm running on SEV-SNP Genoa"
         run: |
           set -ex
-          python3 tests/infra/platform_detection.py snp
+          python3 tests/infra/platform_detection.py snp genoa
         shell: bash
 
       - name: "Build Debug"
@@ -344,11 +337,7 @@ jobs:
           cd build
           rm -rf /github/home/.cache
           mkdir -p /github/home/.cache
-          # Limited set of tests because Genoa pools have limited resources
-          # focusing on architecture-specific functionality.
-          # Unit test for sealing
-          ./tests.sh --output-on-failure -R snp_ioctl_test
-          # End to end tests for code update (attestation verification)
+          ./tests.sh --timeout 360 --output-on-failure -C snp -L snp
           ./tests.sh --timeout 360 --output-on-failure -R code_update
         shell: bash
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,19 +64,6 @@ else()
   set(PYTHON python3)
 endif()
 
-set(DISTRIBUTE_PERF_TESTS
-    ""
-    CACHE
-      STRING
-      "Hosts to which performance tests should be distributed, for example -n ssh://x.x.x.x -n ssh://x.x.x.x -n ssh://x.x.x.x"
-)
-
-if(DISTRIBUTE_PERF_TESTS)
-  separate_arguments(NODES UNIX_COMMAND ${DISTRIBUTE_PERF_TESTS})
-else()
-  unset(NODES)
-endif()
-
 option(
   VERBOSE_LOGGING
   "Enable verbose, potentially unsafe logging of enclave code. Affects logging level passed at run-time to end-to-end-tests."
@@ -496,12 +483,32 @@ if(BUILD_TESTS)
       snp_ioctl_test
       ${CMAKE_CURRENT_SOURCE_DIR}/src/pal/test/snp_ioctl_test.cpp
     )
+    set_property(
+      TEST snp_ioctl_test
+      APPEND
+      PROPERTY LABELS snp
+    )
+    set_property(
+      TEST snp_ioctl_test
+      APPEND
+      PROPERTY CONFIGURATIONS snp
+    )
 
     add_unit_test(
       snp_attestation_test
       ${CMAKE_CURRENT_SOURCE_DIR}/src/pal/test/snp_attestation_validation.cpp
     )
     target_link_libraries(snp_attestation_test PRIVATE ccf_pal ccfcrypto)
+    set_property(
+      TEST snp_attestation_test
+      APPEND
+      PROPERTY LABELS snp
+    )
+    set_property(
+      TEST snp_attestation_test
+      APPEND
+      PROPERTY CONFIGURATIONS snp
+    )
 
     add_unit_test(map_test ${CMAKE_CURRENT_SOURCE_DIR}/src/ds/test/map_test.cpp)
 
@@ -903,6 +910,7 @@ if(BUILD_TESTS)
     NAME commit_latency
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/commit_latency.py
     LABEL perf
+    CONFIGURATIONS perf
   )
 
   add_e2e_test(
@@ -1094,6 +1102,13 @@ if(BUILD_TESTS)
       ${CMAKE_SOURCE_DIR}/samples/config
       --historical-testdata
       ${CMAKE_SOURCE_DIR}/tests/testdata
+  )
+
+  add_e2e_test(
+    NAME snp_platform_tests
+    PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/amd_snp.py
+    LABEL snp
+    CONFIGURATIONS snp
   )
 
   list(APPEND LTS_TEST_ARGS --ccf-version ${CCF_VERSION})

--- a/tests/amd_snp.py
+++ b/tests/amd_snp.py
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+import infra.e2e_args
+from infra.runner import ConcurrentRunner
+import e2e_operations
+
+
+if __name__ == "__main__":
+    cr = ConcurrentRunner()
+
+    cr.add(
+        "platform",
+        e2e_operations.run_snp_tests,
+        package="samples/apps/logging/logging",
+        nodes=infra.e2e_args.min_nodes(cr.args, f=0),
+        initial_user_count=1,
+        ledger_chunk_bytes="1B",  # Chunk ledger at every signature transaction
+    )
+
+    cr.run()

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -1873,6 +1873,18 @@ def test_error_message_on_failure_to_fetch_snapshot(const_args):
         ), f"Did not find expected log messages: {expected_log_messages}"
 
 
+def run_snp_tests(args):
+    run_initial_uvm_descriptor_checks(args)
+    run_initial_tcb_version_checks(args)
+    run_recovery_local_unsealing(args)
+    run_recovery_local_unsealing(args, rekey=True)
+    run_recovery_local_unsealing(args, recovery_shares_refresh=True)
+    run_recovery_local_unsealing(args, recovery_f=1)
+    run_recovery_unsealing_corrupt(args)
+    run_recovery_unsealing_validate_audit(args)
+    test_error_message_on_failure_to_read_aci_sec_context(args)
+
+
 def run(args):
     run_max_uncommitted_tx_count(args)
     run_file_operations(args)
@@ -1886,16 +1898,5 @@ def run(args):
     run_cose_signatures_config_check(args)
     run_late_mounted_ledger_check(args)
     run_empty_ledger_dir_check(args)
-
-    if infra.platform_detection.is_snp():
-        run_initial_uvm_descriptor_checks(args)
-        run_initial_tcb_version_checks(args)
-        run_recovery_local_unsealing(args)
-        run_recovery_local_unsealing(args, rekey=True)
-        run_recovery_local_unsealing(args, recovery_shares_refresh=True)
-        run_recovery_local_unsealing(args, recovery_f=1)
-        run_recovery_unsealing_corrupt(args)
-        run_recovery_unsealing_validate_audit(args)
-        test_error_message_on_failure_to_read_aci_sec_context(args)
     run_read_ledger_on_testdata(args)
     run_ledger_chunk_bytes_check(args)


### PR DESCRIPTION
With the storage options available in CI pools at the moment, SNP CI is comparatively slow and prone to timeout. Most the functionality it exercises is identical to that tested on VMSS though.
This change:

- Focuses the SNP CI to run just SNP-relevant tests
- Makes the tests on Milan and Genoa identical