### PR TITLE
[release/6.x] Cherry pick: Update line-length for ruff (#7421)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,2 +1,1 @@
-extend-exclude = ["*_pb2*.py"]
-line-length = 2000
+line-length = 320


### PR DESCRIPTION
Backports the following commits to `release/6.x`:
 - [Update line-length for ruff (#7421)](https://github.com/microsoft/CCF/pull/7421)