### PR TITLE
Add workaround for data race bug in libstdc++

### DIFF
--- a/src/host/run.cpp
+++ b/src/host/run.cpp
@@ -880,8 +880,7 @@ namespace ccf
     // initialisation by eagerly initialising every value now.
 #if defined(__GLIBCXX__)
     {
-      const auto& ct(
-        std::use_facet<std::ctype<char>>(std::locale()));
+      const auto& ct(std::use_facet<std::ctype<char>>(std::locale()));
 
       for (size_t i(0); i != 256; ++i)
       {


### PR DESCRIPTION
Should resolve #7446.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77704 for discussion of the bug, and the workaround we crib.