### PR TITLE
Add static assertion that CMake-generated API strings are non-empty

### DIFF
--- a/src/node/gov/api_schema.h.in
+++ b/src/node/gov/api_schema.h.in
@@ -20,12 +20,12 @@ namespace ccf::gov::endpoints::schema
   static constexpr auto v2023_06_01_preview =
     R"!!!(@GOV_API_SCHEMA_2023_06_01_PREVIEW@)!!!";
 
-  static_assert(std::string_view(v2023_06_01_preview).size() != 0);
+  static_assert(!std::string_view(v2023_06_01_preview).empty());
 
   static constexpr auto v2024_07_01 =
     R"!!!(@GOV_API_SCHEMA_2024_07_01@)!!!";
 
-  static_assert(std::string_view(v2024_07_01).size() != 0);
+  static_assert(!std::string_view(v2024_07_01).empty());
 
 #pragma clang diagnostic pop
 


### PR DESCRIPTION
Avoid the CMake-configuration footgun noticed here: https://github.com/microsoft/CCF/pull/7448#issuecomment-3511903180