### PR TITLE
[release/6.x] Cherry pick: Avoid time-based cert checks in lts_compatibility_test (#7305)

### DIFF
--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -1752,7 +1752,7 @@ def test_random_receipts(
                             network.cert,
                             claims=additional_seqnos.get(s),
                             generic=True,
-                            skip_endorsement_check=lts,
+                            skip_cert_chain_checks=lts,
                         )
                     break
                 elif rc.status_code == http.HTTPStatus.ACCEPTED:


### PR DESCRIPTION
backport #7305 