### PR TITLE
Minor cleanup - unused params in verifiers

### DIFF
--- a/src/crypto/openssl/cose_verifier.cpp
+++ b/src/crypto/openssl/cose_verifier.cpp
@@ -117,8 +117,6 @@ namespace ccf::crypto
       }
     }
 
-    X509_get_signature_info(cert, nullptr, nullptr, nullptr, nullptr);
-
     EVP_PKEY* pk = X509_get_pubkey(cert);
 
     if (EVP_PKEY_get_base_id(pk) == EVP_PKEY_EC)

--- a/src/crypto/openssl/verifier.cpp
+++ b/src/crypto/openssl/verifier.cpp
@@ -53,8 +53,6 @@ namespace ccf::crypto
       }
     }
 
-    X509_get_signature_info(cert, nullptr, nullptr, nullptr, nullptr);
-
     EVP_PKEY* pk = X509_get_pubkey(cert);
 
     auto base_id = EVP_PKEY_get_base_id(pk);


### PR DESCRIPTION
https://manpages.debian.org/experimental/libssl-doc/X509_get_signature_info.3ssl.en.html says:
> X509_get_signature_info() retrieves information about the signature of certificate x. The NID of the signing digest is written to *mdnid, the public key algorithm to *pknid, the effective security bits to *secbits and flag details to *flags. **Any of the parameters can be set to NULL if the information is not required**.

**UPD**. As spotted by Copilot, this function has no purpose after nulling its params out. Checked the doc for side effects, then removed this calls completely.