### PR TITLE
[release/6.x] Cherry pick: Use full URL when redirecting to snapshots, for consistency with primary redirects (#7373)

### DIFF
--- a/doc/host_config_schema/cchost_config.json
+++ b/doc/host_config_schema/cchost_config.json
@@ -417,6 +417,11 @@
                     "type": "string",
                     "default": "1000ms",
                     "description": "Interval (time string) between retries to fetch a recent snapshot from the target node"
+                  },
+                  "fetch_snapshot_max_size": {
+                    "type": "string",
+                    "default": "10GB",
+                    "description": "Maximum size of snapshot this node is willing to fetch"
                   }
                 },
                 "required": ["target_rpc_address"],

--- a/include/ccf/ds/unit_strings.h
+++ b/include/ccf/ds/unit_strings.h
@@ -137,6 +137,11 @@ namespace ccf::ds
     {
       return value;
     }
+
+    size_t count_bytes() const
+    {
+      return value;
+    }
   };
 
   inline void from_json(const nlohmann::json& j, SizeString& s)

--- a/include/ccf/http_consts.h
+++ b/include/ccf/http_consts.h
@@ -14,6 +14,7 @@ namespace ccf
       static constexpr auto AUTHORIZATION = "authorization";
       static constexpr auto CACHE_CONTROL = "cache-control";
       static constexpr auto CONTENT_LENGTH = "content-length";
+      static constexpr auto CONTENT_RANGE = "content-range";
       static constexpr auto CONTENT_TYPE = "content-type";
       static constexpr auto DATE = "date";
       static constexpr auto DIGEST = "digest";

--- a/src/host/configuration.h
+++ b/src/host/configuration.h
@@ -152,6 +152,7 @@ namespace host
         bool fetch_recent_snapshot = true;
         size_t fetch_snapshot_max_attempts = 3;
         ccf::ds::TimeString fetch_snapshot_retry_interval = {"1000ms"};
+        ccf::ds::SizeString fetch_snapshot_max_size = {"10GB"};
 
         bool operator==(const Join&) const = default;
       };
@@ -216,7 +217,8 @@ namespace host
     follow_redirect,
     fetch_recent_snapshot,
     fetch_snapshot_max_attempts,
-    fetch_snapshot_retry_interval);
+    fetch_snapshot_retry_interval,
+    fetch_snapshot_max_size);
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(CCHostConfig::Command::Recover);
   DECLARE_JSON_REQUIRED_FIELDS(CCHostConfig::Command::Recover);

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -874,7 +874,8 @@ int main(int argc, char** argv) // NOLINT(bugprone-exception-escape)
           config.command.service_certificate_file,
           latest_local_idx,
           config.command.join.fetch_snapshot_max_attempts,
-          config.command.join.fetch_snapshot_retry_interval.count_ms());
+          config.command.join.fetch_snapshot_retry_interval.count_ms(),
+          config.command.join.fetch_snapshot_max_size.count_bytes());
 
         if (latest_peer_snapshot.has_value())
         {

--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -392,7 +392,7 @@ namespace ccf::curl
     CurlRequest(
       UniqueCURL&& curl_handle_,
       RESTVerb method_,
-      std::string&& url_,
+      const std::string& url_,
       UniqueSlist&& headers_,
       std::unique_ptr<RequestBody>&& request_body_,
       std::unique_ptr<ccf::curl::ResponseBody>&& response_,
@@ -532,9 +532,9 @@ namespace ccf::curl
       return response;
     }
 
-    [[nodiscard]] ResponseHeaders& get_response_headers()
+    [[nodiscard]] const ResponseHeaders::HeaderMap& get_response_headers() const
     {
-      return response_headers;
+      return response_headers.data;
     }
   };
 

--- a/src/node/quote_endorsements_client.h
+++ b/src/node/quote_endorsements_client.h
@@ -203,7 +203,7 @@ namespace ccf
         const auto& server = servers.front();
         const auto& endpoint = server.front();
         auto* response_body = request->get_response_body();
-        auto& response_headers = request->get_response_headers();
+        const auto& response_headers = request->get_response_headers();
 
         if (curl_response == CURLE_OK && status_code == HTTP_STATUS_OK)
         {
@@ -259,8 +259,8 @@ namespace ccf
             curl_response == CURLE_OK &&
             status_code == HTTP_STATUS_TOO_MANY_REQUESTS)
           {
-            auto h = response_headers.data.find(http::headers::RETRY_AFTER);
-            if (h != response_headers.data.end())
+            auto h = response_headers.find(http::headers::RETRY_AFTER);
+            if (h != response_headers.end())
             {
               const auto& retry_after_value = h->second;
               // If value is invalid, retry_after_s is unchanged

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -178,6 +178,59 @@ namespace ccf
     NetworkState& network;
     ccf::AbstractNodeOperation& node_operation;
 
+    std::optional<std::string> get_redirect_address_for_node(
+      const ccf::endpoints::ReadOnlyEndpointContext& ctx,
+      const ccf::NodeId& target_node)
+    {
+      auto nodes = ctx.tx.ro(network.nodes);
+
+      auto node_info = nodes->get(target_node);
+      if (!node_info.has_value())
+      {
+        LOG_FAIL_FMT("Node redirection error: Unknown node {}", target_node);
+        ctx.rpc_ctx->set_error(
+          HTTP_STATUS_INTERNAL_SERVER_ERROR,
+          ccf::errors::InternalError,
+          fmt::format(
+            "Cannot find node info to produce redirect response for node {}",
+            target_node));
+        return std::nullopt;
+      }
+
+      const auto interface_id =
+        ctx.rpc_ctx->get_session_context()->interface_id;
+      if (!interface_id.has_value())
+      {
+        LOG_FAIL_FMT("Node redirection error: Non-RPC request");
+        ctx.rpc_ctx->set_error(
+          HTTP_STATUS_INTERNAL_SERVER_ERROR,
+          ccf::errors::InternalError,
+          "Cannot redirect non-RPC request");
+        return std::nullopt;
+      }
+
+      const auto& interfaces = node_info->rpc_interfaces;
+      const auto interface_it = interfaces.find(interface_id.value());
+      if (interface_it == interfaces.end())
+      {
+        LOG_FAIL_FMT(
+          "Node redirection error: Target missing interface {}",
+          interface_id.value());
+        ctx.rpc_ctx->set_error(
+          HTTP_STATUS_INTERNAL_SERVER_ERROR,
+          ccf::errors::InternalError,
+          fmt::format(
+            "Cannot redirect request. Received on RPC interface {}, which is "
+            "not present on target node {}",
+            interface_id.value(),
+            target_node));
+        return std::nullopt;
+      }
+
+      const auto& interface = interface_it->second;
+      return interface.published_address;
+    }
+
     static std::pair<http_status, std::string> quote_verification_error(
       QuoteVerificationResult result)
     {
@@ -1861,77 +1914,87 @@ namespace ccf
 
       static constexpr auto snapshot_since_param_key = "since";
       // Redirects to endpoint for a single specific snapshot
-      auto find_snapshot = [this](ccf::endpoints::CommandEndpointContext& ctx) {
-        auto node_configuration_subsystem =
-          this->context.get_subsystem<NodeConfigurationSubsystem>();
-        if (!node_configuration_subsystem)
-        {
-          ctx.rpc_ctx->set_error(
-            HTTP_STATUS_INTERNAL_SERVER_ERROR,
-            ccf::errors::InternalError,
-            "NodeConfigurationSubsystem is not available");
-          return;
-        }
-
-        const auto& snapshots_config =
-          node_configuration_subsystem->get().node_config.snapshots;
-
-        size_t latest_idx = 0;
-        {
-          // Get latest_idx from query param, if present
-          const auto parsed_query =
-            http::parse_query(ctx.rpc_ctx->get_request_query());
-
-          std::string error_reason;
-          auto snapshot_since = http::get_query_value_opt<ccf::SeqNo>(
-            parsed_query, snapshot_since_param_key, error_reason);
-
-          if (snapshot_since.has_value())
+      auto find_snapshot =
+        [this](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
+          auto node_configuration_subsystem =
+            this->context.get_subsystem<NodeConfigurationSubsystem>();
+          if (!node_configuration_subsystem)
           {
-            if (error_reason != "")
-            {
-              ctx.rpc_ctx->set_error(
-                HTTP_STATUS_BAD_REQUEST,
-                ccf::errors::InvalidQueryParameterValue,
-                std::move(error_reason));
-              return;
-            }
-            latest_idx = snapshot_since.value();
+            ctx.rpc_ctx->set_error(
+              HTTP_STATUS_INTERNAL_SERVER_ERROR,
+              ccf::errors::InternalError,
+              "NodeConfigurationSubsystem is not available");
+            return;
           }
-        }
 
-        const auto orig_latest = latest_idx;
-        auto latest_committed_snapshot =
-          snapshots::find_latest_committed_snapshot_in_directory(
-            snapshots_config.directory, latest_idx);
+          const auto& snapshots_config =
+            node_configuration_subsystem->get().node_config.snapshots;
 
-        if (!latest_committed_snapshot.has_value())
-        {
-          ctx.rpc_ctx->set_error(
-            HTTP_STATUS_NOT_FOUND,
-            ccf::errors::ResourceNotFound,
-            fmt::format(
-              "This node has no committed snapshots since {}", orig_latest));
-          return;
-        }
+          size_t latest_idx = 0;
+          {
+            // Get latest_idx from query param, if present
+            const auto parsed_query =
+              http::parse_query(ctx.rpc_ctx->get_request_query());
 
-        const auto& snapshot_path = latest_committed_snapshot.value();
+            std::string error_reason;
+            auto snapshot_since = http::get_query_value_opt<ccf::SeqNo>(
+              parsed_query, snapshot_since_param_key, error_reason);
 
-        LOG_DEBUG_FMT("Redirecting to snapshot: {}", snapshot_path);
+            if (snapshot_since.has_value())
+            {
+              if (error_reason != "")
+              {
+                ctx.rpc_ctx->set_error(
+                  HTTP_STATUS_BAD_REQUEST,
+                  ccf::errors::InvalidQueryParameterValue,
+                  std::move(error_reason));
+                return;
+              }
+              latest_idx = snapshot_since.value();
+            }
+          }
 
-        auto redirect_url = fmt::format("/node/snapshot/{}", snapshot_path);
-        ctx.rpc_ctx->set_response_header(
-          ccf::http::headers::LOCATION, redirect_url);
-        ctx.rpc_ctx->set_response_status(HTTP_STATUS_PERMANENT_REDIRECT);
-      };
-      make_command_endpoint(
+          const auto orig_latest = latest_idx;
+          auto latest_committed_snapshot =
+            snapshots::find_latest_committed_snapshot_in_directory(
+              snapshots_config.directory, latest_idx);
+
+          if (!latest_committed_snapshot.has_value())
+          {
+            ctx.rpc_ctx->set_error(
+              HTTP_STATUS_NOT_FOUND,
+              ccf::errors::ResourceNotFound,
+              fmt::format(
+                "This node has no committed snapshots since {}", orig_latest));
+            return;
+          }
+
+          const auto& snapshot_path = latest_committed_snapshot.value();
+
+          const auto address =
+            get_redirect_address_for_node(ctx, this->context.get_node_id());
+          if (!address.has_value())
+          {
+            // Helper function should have populated error response, so return
+            // now
+            return;
+          }
+
+          auto redirect_url = fmt::format(
+            "https://{}/node/snapshot/{}", address.value(), snapshot_path);
+          LOG_DEBUG_FMT("Redirecting to snapshot: {}", redirect_url);
+          ctx.rpc_ctx->set_response_header(
+            ccf::http::headers::LOCATION, redirect_url);
+          ctx.rpc_ctx->set_response_status(HTTP_STATUS_PERMANENT_REDIRECT);
+        };
+      make_read_only_endpoint(
         "/snapshot", HTTP_HEAD, find_snapshot, no_auth_required)
         .set_forwarding_required(endpoints::ForwardingRequired::Never)
         .add_query_parameter<ccf::SeqNo>(
           snapshot_since_param_key, ccf::endpoints::OptionalParameter)
         .set_openapi_hidden(true)
         .install();
-      make_command_endpoint(
+      make_read_only_endpoint(
         "/snapshot", HTTP_GET, find_snapshot, no_auth_required)
         .set_forwarding_required(endpoints::ForwardingRequired::Never)
         .add_query_parameter<ccf::SeqNo>(
@@ -2177,7 +2240,7 @@ namespace ccf
         // Partial Content responses describe the current response in
         // Content-Range
         ctx.rpc_ctx->set_response_header(
-          "content-range",
+          ccf::http::headers::CONTENT_RANGE,
           fmt::format("bytes {}-{}/{}", range_start, range_end, total_size));
       };
       make_command_endpoint(

--- a/src/snapshots/fetch.h
+++ b/src/snapshots/fetch.h
@@ -40,26 +40,173 @@ namespace snapshots
     std::vector<uint8_t> snapshot_data;
   };
 
+  struct ContentRangeHeader
+  {
+    size_t range_start;
+    size_t range_end;
+    size_t total_size;
+  };
+
+  static ContentRangeHeader parse_content_range_header(
+    const ccf::curl::CurlRequest& request)
+  {
+    const auto& headers = request.get_response_headers();
+
+    auto it = headers.find(ccf::http::headers::CONTENT_RANGE);
+    if (it == headers.end())
+    {
+      throw std::runtime_error(
+        "Response is missing expected content-range header");
+    }
+
+    auto [unit, remaining] = ccf::nonstd::split_1(it->second, " ");
+    if (unit != "bytes")
+    {
+      throw std::runtime_error(
+        "Unexpected content-range unit. Only 'bytes' is supported");
+    }
+
+    auto [range, total_size] = ccf::nonstd::split_1(remaining, "/");
+    auto [range_start, range_end] = ccf::nonstd::split_1(range, "-");
+
+    if (range_start.empty() || range_end.empty() || total_size.empty())
+    {
+      throw std::runtime_error(fmt::format(
+        "Unsupported content-range header format. Expected 'bytes "
+        "<begin>-<end>/<total>', received: {}",
+        it->second));
+    }
+
+    ContentRangeHeader parsed_values;
+
+    {
+      const auto [p, ec] = std::from_chars(
+        range_start.begin(), range_start.end(), parsed_values.range_start);
+      if (ec != std::errc())
+      {
+        throw std::runtime_error(fmt::format(
+          "Could not parse range start ({}) from content-range header: {}",
+          range_start,
+          it->second));
+      }
+    }
+
+    {
+      const auto [p, ec] = std::from_chars(
+        range_end.begin(), range_end.end(), parsed_values.range_end);
+      if (ec != std::errc())
+      {
+        throw std::runtime_error(fmt::format(
+          "Could not parse range end ({}) from content-range header: {}",
+          range_end,
+          it->second));
+      }
+    }
+
+    {
+      const auto [p, ec] = std::from_chars(
+        total_size.begin(), total_size.end(), parsed_values.total_size);
+      if (ec != std::errc())
+      {
+        throw std::runtime_error(fmt::format(
+          "Could not parse total size ({}) from content-range header: {}",
+          total_size,
+          it->second));
+      }
+    }
+
+    return parsed_values;
+  }
+
   static std::optional<SnapshotResponse> try_fetch_from_peer(
     const std::string& peer_address,
-    const std::string& path_to_peer_cert,
-    size_t latest_local_snapshot)
+    const std::string& path_to_peer_ca,
+    size_t latest_local_snapshot,
+    size_t max_size)
   {
     try
     {
-      // Make initial request, which returns a redirect response to specific
-      // snapshot
-      std::string snapshot_url;
       ccf::curl::UniqueCURL curl_easy;
-      {
-        curl_easy.set_opt(CURLOPT_CAINFO, path_to_peer_cert.c_str());
+      curl_easy.set_opt(CURLOPT_CAINFO, path_to_peer_ca.c_str());
 
-        auto initial_url = fmt::format(
-          "https://{}/node/snapshot?since={}",
-          peer_address,
-          latest_local_snapshot);
+      auto response_body = std::make_unique<ccf::curl::ResponseBody>(max_size);
+
+      // Get snapshot. This may be redirected multiple times, and we follow
+      // these redirects ourself so we can extract the final URL. Once the
+      // redirects terminate, the final response is likely to be extremely large
+      // so is fetched over multiple requests for a sub-range, returning
+      // PARTIAL_CONTENT each time.
+      std::string snapshot_url = fmt::format(
+        "https://{}/node/snapshot?since={}",
+        peer_address,
+        latest_local_snapshot);
+
+      // Fetch 4MB chunks at a time
+      constexpr size_t range_size = 4L * 1024 * 1024;
+      size_t range_start = 0;
+      size_t range_end = range_size;
+      bool fetched_all = false;
+
+      auto process_partial_response =
+        [&](const ccf::curl::CurlRequest& request) {
+          auto content_range = parse_content_range_header(request);
+
+          if (content_range.range_start != range_start)
+          {
+            throw std::runtime_error(fmt::format(
+              "Unexpected range response. Requested bytes {}-{}, received "
+              "range starting at {}",
+              range_start,
+              range_end,
+              content_range.range_start));
+          }
+
+          // The server may give us _less_ than we requested (since they know
+          // where the file ends), but should never give us more
+          if (content_range.range_end > range_end)
+          {
+            throw std::runtime_error(fmt::format(
+              "Unexpected range response. Requested bytes {}-{}, received "
+              "range ending at {}",
+              range_start,
+              range_end,
+              content_range.range_end));
+          }
+
+          const auto range_size =
+            content_range.range_end - content_range.range_start;
+          LOG_TRACE_FMT(
+            "Received {}-byte chunk from {}. Now have {}/{}",
+            range_size,
+            request.get_url(),
+            content_range.range_end,
+            content_range.total_size);
+
+          if (content_range.range_end == content_range.total_size)
+          {
+            fetched_all = true;
+          }
+          else
+          {
+            // Advance range for next request
+            range_start = range_end;
+            range_end = range_start + range_size;
+          }
+        };
+
+      const auto max_redirects = 20;
+      for (auto redirect_count = 1; redirect_count <= max_redirects;
+           ++redirect_count)
+      {
+        LOG_DEBUG_FMT(
+          "Making snapshot discovery request {}/{} to {}",
+          redirect_count,
+          max_redirects,
+          snapshot_url);
 
         ccf::curl::UniqueSlist headers;
+        headers.append(
+          "Range", fmt::format("bytes={}-{}", range_start, range_end));
 
         CURLcode curl_response = CURLE_FAILED_INIT;
         long status_code = 0;
@@ -77,11 +224,11 @@ namespace snapshots
         ccf::curl::CurlRequest::synchronous_perform(
           std::make_unique<ccf::curl::CurlRequest>(
             std::move(curl_easy),
-            HTTP_HEAD,
-            std::move(initial_url),
+            HTTP_GET,
+            snapshot_url,
             std::move(headers),
             nullptr, // No request body
-            nullptr, // No response body
+            std::move(response_body),
             std::move(response_callback)));
 
         if (curl_response != CURLE_OK)
@@ -92,197 +239,97 @@ namespace snapshots
             curl_easy_strerror(curl_response),
             status_code));
         }
+
         if (status_code == HTTP_STATUS_NOT_FOUND)
         {
           LOG_INFO_FMT(
             "Peer has no snapshot newer than {}", latest_local_snapshot);
           return std::nullopt;
         }
+
+        if (status_code == HTTP_STATUS_PARTIAL_CONTENT)
+        {
+          process_partial_response(*request);
+
+          response_body = std::move(request->get_response_ptr());
+          curl_easy = std::move(request->get_easy_handle_ptr());
+          break;
+        }
+
         EXPECT_HTTP_RESPONSE_STATUS(
           request, status_code, HTTP_STATUS_PERMANENT_REDIRECT);
 
-        auto& response_headers = request->get_response_headers();
-        auto location_it =
-          response_headers.data.find(ccf::http::headers::LOCATION);
-        if (location_it == response_headers.data.end())
+        char* redirect_url = nullptr;
+        CHECK_CURL_EASY_GETINFO(
+          request->get_easy_handle(), CURLINFO_REDIRECT_URL, &redirect_url);
+        if (redirect_url == nullptr)
         {
-          throw std::runtime_error(fmt::format(
-            "Expected {} header in redirect response from {} {}, none found",
-            ccf::http::headers::LOCATION,
-            request->get_method().c_str(),
-            request->get_url()));
+          throw std::runtime_error(
+            "Redirect response found, but CURLINFO_REDIRECT_URL returned no "
+            "value");
         }
 
-        LOG_TRACE_FMT("Snapshot fetch redirected to {}", location_it->second);
+        LOG_DEBUG_FMT(
+          "Snapshot fetch received redirect response with location {}",
+          redirect_url);
+        snapshot_url = redirect_url;
 
-        snapshot_url =
-          fmt::format("https://{}{}", peer_address, location_it->second);
+        response_body = std::move(request->get_response_ptr());
         curl_easy = std::move(request->get_easy_handle_ptr());
       }
 
-      // Make follow-up request to redirected URL, to fetch total content size
-      size_t content_size = 0;
+      while (!fetched_all)
       {
-        curl_easy.set_opt(CURLOPT_CAINFO, path_to_peer_cert.c_str());
-
         ccf::curl::UniqueSlist headers;
+        headers.append(
+          "Range", fmt::format("bytes={}-{}", range_start, range_end));
 
-        std::string current_snapshot_url = snapshot_url;
-
-        std::unique_ptr<ccf::curl::CurlRequest> snapshot_size_request;
-        CURLcode snapshot_size_curl_code = CURLE_OK;
-        long snapshot_size_status_code = 0;
+        std::unique_ptr<ccf::curl::CurlRequest> snapshot_range_request;
+        CURLcode curl_response = CURLE_OK;
+        long snapshot_range_status_code = 0;
 
         ccf::curl::CurlRequest::ResponseCallback snapshot_response_callback =
           [&](
             std::unique_ptr<ccf::curl::CurlRequest>&& request_,
             CURLcode curl_response_,
             long status_code_) {
-            snapshot_size_request = std::move(request_);
-            snapshot_size_curl_code = curl_response_;
-            snapshot_size_status_code = status_code_;
+            snapshot_range_request = std::move(request_);
+            curl_response = curl_response_;
+            snapshot_range_status_code = status_code_;
           };
 
         ccf::curl::CurlRequest::synchronous_perform(
           std::make_unique<ccf::curl::CurlRequest>(
             std::move(curl_easy),
-            HTTP_HEAD,
-            std::move(current_snapshot_url),
+            HTTP_GET,
+            snapshot_url,
             std::move(headers),
             nullptr, // No request body
-            nullptr, // No response body
-            std::move(snapshot_response_callback)));
-
-        if (snapshot_size_curl_code != CURLE_OK)
+            std::move(response_body),
+            snapshot_response_callback));
+        if (curl_response != CURLE_OK)
         {
           throw std::runtime_error(fmt::format(
-            "Error fetching snapshot size from {}: {} ({})",
-            snapshot_size_request->get_url(),
-            curl_easy_strerror(snapshot_size_curl_code),
-            snapshot_size_status_code));
-        }
-
-        EXPECT_HTTP_RESPONSE_STATUS(
-          snapshot_size_request, snapshot_size_status_code, HTTP_STATUS_OK);
-
-        auto& snapshot_size_response_headers =
-          snapshot_size_request->get_response_headers();
-
-        auto content_size_it = snapshot_size_response_headers.data.find(
-          ccf::http::headers::CONTENT_LENGTH);
-
-        if (content_size_it == snapshot_size_response_headers.data.end())
-        {
-          throw std::runtime_error(fmt::format(
-            "Expected {} header in response from {} {}, none found",
-            ccf::http::headers::CONTENT_LENGTH,
-            snapshot_size_request->get_method().c_str(),
-            snapshot_size_request->get_url()));
-        }
-
-        const auto& content_size_s = content_size_it->second;
-        const auto [p, ec] = std::from_chars(
-          content_size_s.data(),
-          content_size_s.data() + content_size_s.size(),
-          content_size);
-        if (ec != std::errc())
-        {
-          throw std::runtime_error(fmt::format(
-            "Failed to parse {} header in response from {} {}: {}",
-            ccf::http::headers::CONTENT_LENGTH,
-            snapshot_size_request->get_method().c_str(),
-            snapshot_size_request->get_url(),
-            ec));
-        }
-        curl_easy = std::move(snapshot_size_request->get_easy_handle_ptr());
-      }
-
-      // Fetch 4MB chunks at a time
-      constexpr size_t range_size = 4L * 1024 * 1024;
-      LOG_TRACE_FMT(
-        "Preparing to fetch {}-byte snapshot from peer, {} bytes per-request",
-        content_size,
-        range_size);
-
-      auto snapshot_response =
-        std::make_unique<ccf::curl::ResponseBody>(content_size);
-
-      {
-        auto range_start = 0;
-        auto range_end = std::min(content_size, range_size);
-
-        while (true)
-        {
-          curl_easy.set_opt(CURLOPT_CAINFO, path_to_peer_cert.c_str());
-
-          ccf::curl::UniqueSlist headers;
-          headers.append(
-            "Range", fmt::format("bytes={}-{}", range_start, range_end));
-
-          std::string current_snapshot_url = snapshot_url;
-
-          std::unique_ptr<ccf::curl::CurlRequest> snapshot_range_request;
-          ;
-          CURLcode curl_response = CURLE_OK;
-          long snapshot_range_status_code = 0;
-
-          ccf::curl::CurlRequest::ResponseCallback snapshot_response_callback =
-            [&](
-              std::unique_ptr<ccf::curl::CurlRequest>&& request_,
-              CURLcode curl_response_,
-              long status_code_) {
-              snapshot_range_request = std::move(request_);
-              curl_response = curl_response_;
-              snapshot_range_status_code = status_code_;
-            };
-
-          ccf::curl::CurlRequest::synchronous_perform(
-            std::make_unique<ccf::curl::CurlRequest>(
-              std::move(curl_easy),
-              HTTP_GET,
-              std::move(current_snapshot_url),
-              std::move(headers),
-              nullptr, // No request body
-              std::move(snapshot_response),
-              snapshot_response_callback));
-          if (curl_response != CURLE_OK)
-          {
-            throw std::runtime_error(fmt::format(
-              "Error fetching snapshot chunk range from {}: {} ({})",
-              snapshot_range_request->get_url(),
-              curl_easy_strerror(curl_response),
-              snapshot_range_status_code));
-          }
-          EXPECT_HTTP_RESPONSE_STATUS(
-            snapshot_range_request,
-            snapshot_range_status_code,
-            HTTP_STATUS_PARTIAL_CONTENT);
-
-          LOG_TRACE_FMT(
-            "Received {}-byte chunk from {}: {} bytes",
-            range_end - range_start,
+            "Error fetching snapshot chunk range from {}: {} ({})",
             snapshot_range_request->get_url(),
-            snapshot_range_status_code);
-
-          snapshot_response =
-            std::move(snapshot_range_request->get_response_ptr());
-          curl_easy = std::move(snapshot_range_request->get_easy_handle_ptr());
-
-          if (range_end == content_size)
-          {
-            break;
-          }
-
-          range_start = range_end;
-          range_end = std::min(content_size, range_start + range_size);
+            curl_easy_strerror(curl_response),
+            snapshot_range_status_code));
         }
+        EXPECT_HTTP_RESPONSE_STATUS(
+          snapshot_range_request,
+          snapshot_range_status_code,
+          HTTP_STATUS_PARTIAL_CONTENT);
+
+        process_partial_response(*snapshot_range_request);
+
+        response_body = std::move(snapshot_range_request->get_response_ptr());
+        curl_easy = std::move(snapshot_range_request->get_easy_handle_ptr());
       }
 
       const auto url_components = ccf::nonstd::split(snapshot_url, "/");
       const std::string snapshot_name(url_components.back());
 
-      return SnapshotResponse{
-        snapshot_name, std::move(snapshot_response->buffer)};
+      return SnapshotResponse{snapshot_name, std::move(response_body->buffer)};
     }
     catch (const std::exception& e)
     {
@@ -293,10 +340,11 @@ namespace snapshots
 
   static std::optional<SnapshotResponse> fetch_from_peer(
     const std::string& peer_address,
-    const std::string& path_to_peer_cert,
+    const std::string& path_to_peer_ca,
     size_t latest_local_snapshot,
     size_t max_attempts,
-    size_t retry_delay_ms)
+    size_t retry_delay_ms,
+    size_t max_size)
   {
     for (size_t attempt = 0; attempt < max_attempts; ++attempt)
     {
@@ -312,7 +360,7 @@ namespace snapshots
       }
 
       auto response = try_fetch_from_peer(
-        peer_address, path_to_peer_cert, latest_local_snapshot);
+        peer_address, path_to_peer_ca, latest_local_snapshot, max_size);
       if (response.has_value())
       {
         return response;


### PR DESCRIPTION
Backports the following commits to `release/6.x`:
 - [Use full URL when redirecting to snapshots, for consistency with primary redirects (#7373)](https://github.com/microsoft/CCF/pull/7373)