### PR TITLE
Remove unused `RpcContextImpl::set_tx_id` function

### DIFF
--- a/src/http/http_rpc_context.h
+++ b/src/http/http_rpc_context.h
@@ -143,11 +143,6 @@ namespace http
       return ccf::FrameFormat::http;
     }
 
-    void set_tx_id(const ccf::TxID& tx_id) override
-    {
-      set_response_header(ccf::http::headers::CCF_TX_ID, tx_id.to_str());
-    }
-
     [[nodiscard]] const std::vector<uint8_t>& get_request_body() const override
     {
       return request_body;

--- a/src/node/rpc_context_impl.h
+++ b/src/node/rpc_context_impl.h
@@ -109,7 +109,6 @@ namespace ccf
     bool response_is_pending = false;
     bool terminate_session = false;
 
-    virtual void set_tx_id(const ccf::TxID& tx_id) = 0;
     [[nodiscard]] virtual bool should_apply_writes() const = 0;
     virtual void reset_response() = 0;
     [[nodiscard]] virtual std::vector<uint8_t> serialise_response() const = 0;


### PR DESCRIPTION
This is only visible in private headers, and is replaced by the `local_commit_func` system.