### PR TITLE
Set restrictive umask

### DIFF
--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -205,6 +205,10 @@ namespace asynchost
           file_path,
           std::strerror(errno))); // NOLINT(concurrency-mt-unsafe)
       }
+      std::filesystem::permissions(
+        file_path.c_str(),
+        std::filesystem::perms::owner_all | std::filesystem::perms::group_read,
+        std::filesystem::perm_options::add);
 
       // Header reserved for the offset to the position table
       fseeko(file, sizeof(positions_offset_header_t), SEEK_SET);


### PR DESCRIPTION
Attempt to address https://github.com/microsoft/CCF/security/code-scanning/973, but the more I think about it, the less I am convinced this is a good change.

The contention here is:

> On Unix systems, it is possible for the user who runs the program to restrict file creation permissions using umask. However, a program should not assume that the user will set an umask, and should still set restrictive permissions by default.

But it is not clear that this opinion is correct in the context of a user deploying a CCF system. Hardcoding a umask in CCF itself can create problems for operators one of two ways:

1. If it's more restrictive than their current settings, they may need to manually change file permissions when they export them.
2. If it's more permissive than their desired settings (perhaps they do not want to allow group reads), they won't be able to achieve the outcome they want.

It's possible to defer to the config, but this is not better than letting them set a umask. So I think I want to dismiss this alert, and perhaps update the doc to say "ledger files are created with the user's umask permissions". Thoughts?