### PR TITLE
Remove unused `get_version()` method

### DIFF
--- a/src/kv/committable_tx.h
+++ b/src/kv/committable_tx.h
@@ -305,16 +305,7 @@ namespace ccf::kv
       return pimpl->commit_view;
     }
 
-    /** Version for the transaction set
-     *
-     * @return Committed version, or `ccf::kv::NoVersion` otherwise
-     */
-    [[nodiscard]] Version get_version() const
-    {
-      return version;
-    }
-
-    std::optional<TxID> get_txid()
+    [[nodiscard]] std::optional<TxID> get_txid() const
     {
       if (!committed)
       {

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -2792,7 +2792,7 @@ TEST_CASE("Reported TxID after commit")
     // No map handle acquired
 
     // Tx is not yet committed
-    REQUIRE_THROWS_AS(tx.get_txid(), std::logic_error);
+    REQUIRE_THROWS_AS(auto _ = tx.get_txid(), std::logic_error);
 
     REQUIRE(tx.commit() == ccf::kv::CommitResult::SUCCESS);
 


### PR DESCRIPTION
And while we're there, make the neighbouring `get_txid()` const! Which then needs `[[nodiscard]]`, which then needs a test case tweak. A win? You decide.