### PR TITLE
Don't process `work_stats` messages which aren't going to be logged

### DIFF
--- a/src/ds/messaging.h
+++ b/src/ds/messaging.h
@@ -175,12 +175,9 @@ namespace messaging
         throw e;
       }
 
-      if (ccf::logger::config().level() <= ccf::LoggerLevel::DEBUG)
-      {
-        auto& counts = message_counts[m];
-        counts.messages++;
-        counts.bytes += size;
-      }
+      auto& counts = message_counts[m];
+      counts.messages++;
+      counts.bytes += size;
     }
 
     MessageCounts retrieve_message_counts()

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -247,7 +247,7 @@ namespace ccf
           bp,
           AdminMessage::tick,
           [this, &disp = bp.get_dispatcher()](const uint8_t*, size_t) {
-            if (ccf::logger::config().level() <= ccf::LoggerLevel::DEBUG)
+            if (ccf::logger::config::level() <= ccf::LoggerLevel::DEBUG)
             {
               const auto message_counts = disp.retrieve_message_counts();
               const auto j = disp.convert_message_counts(message_counts);

--- a/src/host/load_monitor.h
+++ b/src/host/load_monitor.h
@@ -65,7 +65,7 @@ namespace asynchost
 
     void on_timer()
     {
-      if (ccf::logger::config().level() <= ccf::LoggerLevel::DEBUG)
+      if (ccf::logger::config::level() <= ccf::LoggerLevel::DEBUG)
       {
         const auto message_counts = dispatcher.retrieve_message_counts();
         const auto time_now =


### PR DESCRIPTION
Currently we're doing a bunch of book keeping + serialisation work that we drop on the floor. This is a quick test to see if this has a performance impact. We should remove these classes regardless, ahead of removing the ringbuffer, since they've never given us a useful signal in-practice.