### PR TITLE
Use YAML anchors and aliases to avoid repeating workflow conditions

### DIFF
--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -15,7 +15,7 @@ permissions: read-all
 
 jobs:
   long-asan:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-test') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'}}
+    if: &check_trigger_conditions ${{ contains(github.event.pull_request.labels.*.name, 'run-long-test') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'}}
     name: "ASAN"
     runs-on:
       [
@@ -75,7 +75,7 @@ jobs:
           if-no-files-found: ignore
 
   long-tsan:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-test') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'}}
+    if: *check_trigger_conditions
     name: "TSAN"
     runs-on:
       [
@@ -138,7 +138,7 @@ jobs:
   # - Sanitizer builds may slightly differ.
   # - Test durations may also differ, which is important for -L "suite" because they have fixed timeouts.
   long-e2e-debug:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-test') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'}}
+    if: *check_trigger_conditions
     name: Long e2e - Debug
     runs-on:
       [
@@ -201,7 +201,7 @@ jobs:
 
   # All e2e tests in release mode (same as release build).
   long-e2e-release:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-test') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'}}
+    if: *check_trigger_conditions
     name: Long e2e - Release
     runs-on:
       [
@@ -265,7 +265,7 @@ jobs:
   # - Long LTS tests
   # - Ensure snmalloc linkage
   e2e-long-combined:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-test') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'}}
+    if: *check_trigger_conditions
     name: Long Shuffled/LTS/Snmalloc
     runs-on:
       [


### PR DESCRIPTION
It's rubbish that we keep repeating these complex conditions in every label-triggered job, and worse that they're slightly inaccurate (run on _any trigger if label is present_, rather than _this label was added_ and also _other trigger and label is present_).

Found a blog from _yesterday_ saying that we don't have to do the first part anymore!

https://github.blog/news-insights/product-news/lets-talk-about-github-actions/#h-yaml-anchors-reduce-duplication-in-complex-workflows
https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#yaml-anchors-and-aliases

The magic words here for future reference are "YAML anchors and aliases", and we could use them all over the place to deduplicate. For now I'm just experimenting with replacing the `long-test` label condition.