### PR TITLE
In `ci-checks.sh`, call endgroup before exiting

### DIFF
--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -165,9 +165,10 @@ endgroup
 group "Summary"
 if [[ -n "$FAIL" ]]; then
   echo "The following checks failed: ${FAIL//;/, }"
+  endgroup
   exit 1
 else
   echo "All checks passed"
+  endgroup
   exit 0
 fi
-endgroup


### PR DESCRIPTION
Otherwise you stay inside a nested group when the script ends, folding subsequent input:

<img width="894" height="748" alt="image" src="https://github.com/user-attachments/assets/2bc53655-ff0d-4319-99d3-85d10552b204" />


<img width="1469" height="817" alt="image" src="https://github.com/user-attachments/assets/e96ba4b5-1c03-4648-a561-34a15dad5b0a" />
