### PR TITLE
Drop usage of npm colors package

### DIFF
--- a/js/ccf-app/package.json
+++ b/js/ccf-app/package.json
@@ -23,7 +23,6 @@
     "@types/node": "^24.2.0",
     "@types/node-forge": "^1.0.0",
     "chai": "^6.0.1",
-    "colors": "1.4.0",
     "cross-env": "^10.0.0",
     "get-func-name": "3.0.0",
     "mocha": "^11.0.1",


### PR DESCRIPTION
It looks like `colors` was once used by `mocho` (test fw), but has long been replaced by other (maintained) packages, most recently `picocolors`.