### PR TITLE
Wait for all nodes to finish self-healing-open before completing

### DIFF
--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -906,7 +906,7 @@ class Network:
                     verify_ca=False,
                 )
                 LOG.info(f"{node.local_node_id} opened")
-                return
+                waiting_nodes.remove(node)
             except Exception as e:
                 is_timeout = isinstance(e, (CCFIOException, TimeoutError)) or (
                     isinstance(e, RuntimeError) and "node is stopped" in str(e)


### PR DESCRIPTION
If the first node queried was still live and had opened, then the script would immediately exit making the next request to the submit_recovery_shares fail, if it chose a failed node.

This way the only exit is either the all complete path, or the timeout path.
