### PR TITLE
Configure Trusted Publishing for NPM

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -4,7 +4,9 @@ on:
   release:
     types: [published]
 
-permissions: read-all
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   build_and_publish:
@@ -12,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
 
       - name: Get release number from git tag (release) or latest (branch)
         run: |
@@ -31,5 +34,5 @@ jobs:
         run: |
           set -ex
           cd js/ccf-app
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+          echo "registry=https://registry.npmjs.org/" > .npmrc
           npm publish microsoft-ccf-app*.tgz --access public

--- a/js/ccf-app/package.json
+++ b/js/ccf-app/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@microsoft/ccf-app",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/ccf"
+  },
   "version": "0.0.0",
   "description": "CCF app support package",
   "main": "index.js",


### PR DESCRIPTION
Note that this is a little different from #7585 on line 35: it does not disable provenance.

Instead we configure the repo url in package.json, because https://github.com/microsoft/CCF/actions/runs/21148316560/job/60818819120 failed with:

> npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@microsoft%2fccf-app - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/microsoft/CCF" from provenance

I will try a dev release with these settings, and if it works, will backport the fix to 6.x as well.