### PR TITLE
Work around flaky partitions test with a sleep

### DIFF
--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -377,6 +377,10 @@ def test_expired_certs(network, args):
     # Restore connectivity with primary, an election may or may not happen
     network.wait_for_primary_unanimity(min_view=r.view + 1)
 
+    # Dropped partition, and even primary unanimity, do not mean node connectivity has been instantaneously restored.
+    # Sleep through potential delays in reconnection.
+    time.sleep(3)
+
     # Set valid node certs so that future clients can speak to these nodes
     set_certs(from_days_diff=-1, validity_period_days=7, nodes=(primary, backup_a))
 


### PR DESCRIPTION
Flaky test issue _somehow_ far more common in #7567, described in #7570, alternative fixes explored in #7571. Perhaps we could flush connection rules with `conntrack`, but that seems expensive. So add a bodgy workaround - sleep briefly.