### PR TITLE
Capture a single SOURCE_DATE_EPOCH per release run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,8 +108,8 @@ jobs:
           echo "Setting SOURCE_DATE_EPOCH env variable to ${{ needs.image_digest.outputs.SOURCE_DATE_EPOCH }}"
           echo "SOURCE_DATE_EPOCH=${{ needs.image_digest.outputs.SOURCE_DATE_EPOCH }}" >> $GITHUB_ENV
           gpg --import /etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY
-          tdnf --snapshottime=${{ needs.image_digest.outputs.SOURCE_DATE_EPOCH }} -y update
-          tdnf --snapshottime=${{ needs.image_digest.outputs.SOURCE_DATE_EPOCH }} -y install ca-certificates git
+          tdnf --snapshottime=$SOURCE_DATE_EPOCH -y update
+          tdnf --snapshottime=$SOURCE_DATE_EPOCH -y install ca-certificates git
 
       - uses: actions/checkout@v6
         with:
@@ -277,7 +277,7 @@ jobs:
           cat <<EOF > $filename
           {
             "build_container_image": "${{needs.image_digest.outputs.image_digest}}",
-            "tdnf_snapshottime": ${{ needs.image_digest.outputs.SOURCE_DATE_EPOCH }},
+            "tdnf_snapshottime": $SOURCE_DATE_EPOCH,
             "commit_sha": "$commit_id"
           }
           EOF


### PR DESCRIPTION
Closes #7604 by moving the SOURCE_DATE_EPOCH capture out of the matrix and to the single `image_digest` job that is a dependency for the build matrix.

Note that this is _not_ a fix for #7597.