### PR TITLE
Set NPM tag depending on release status

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -27,12 +27,11 @@ jobs:
 
       - name: Fetch NPM Package from release
         run: |
-          cd js/ccf-app
+          set -ex
           wget https://github.com/microsoft/CCF/releases/download/ccf-${{steps.tref.outputs.version}}/microsoft-ccf-app-${{steps.tref.outputs.version}}.tgz
+          echo "registry=https://registry.npmjs.org/" > .npmrc
+        working-directory: js/ccf-app
 
       - name: Publish NPM Package to https://www.npmjs.com/package/@microsoft/ccf-app
-        run: |
-          set -ex
-          cd js/ccf-app
-          echo "registry=https://registry.npmjs.org/" > .npmrc
-          npm publish microsoft-ccf-app*.tgz --access public
+        run: npm publish microsoft-ccf-app*.tgz --access public --tag ${{ github.event.release.prerelease && 'dev' || 'latest' }}
+        working-directory: js/ccf-app


### PR DESCRIPTION
After the upgrade to Node 24, `npm publish` demands that a tag [be set for prereleases](https://github.com/microsoft/CCF/actions/runs/21287388742/job/61271803184):

```
+ npm publish microsoft-ccf-app-7.0.0-dev8.tgz --access public
npm error You must specify a tag using --tag when publishing a prerelease version.
```

We have done this manually in #7614, and now we are doing this in such a way that even if we end up cutting full releases of 7.x from main, the tag will be set correctly.
