### PR TITLE
Revert "Match standard HTTP semantics of inclusive end value in Range and Content-Range headers (#7632)"

### DIFF
--- a/include/ccf/http_consts.h
+++ b/include/ccf/http_consts.h
@@ -20,7 +20,6 @@ namespace ccf
       static constexpr auto DIGEST = "digest";
       static constexpr auto HOST = "host";
       static constexpr auto LOCATION = "location";
-      static constexpr auto RANGE = "range";
       static constexpr auto RETRY_AFTER = "retry-after";
       static constexpr auto TRAILER = "trailer";
       static constexpr auto WWW_AUTHENTICATE = "www-authenticate";

--- a/src/node/rpc/file_serving_handlers.h
+++ b/src/node/rpc/file_serving_handlers.h
@@ -160,8 +160,7 @@ namespace ccf::node
     size_t range_start = 0;
     size_t range_end = total_size;
     {
-      const auto range_header =
-        ctx.rpc_ctx->get_request_header(ccf::http::headers::RANGE);
+      const auto range_header = ctx.rpc_ctx->get_request_header("range");
       if (range_header.has_value())
       {
         LOG_TRACE_FMT("Parsing range header {}", range_header.value());
@@ -232,14 +231,10 @@ namespace ccf::node
 
           if (!s_range_end.empty())
           {
-            // Range end in header is inclusive, but we prefer to reason about
-            // exclusive range end (ie - one past the end)
-            size_t inclusive_range_end = 0;
-
             // Fully-specified range, like "X-Y"
             {
               const auto [p, ec] = std::from_chars(
-                s_range_end.begin(), s_range_end.end(), inclusive_range_end);
+                s_range_end.begin(), s_range_end.end(), range_end);
               if (ec != std::errc())
               {
                 ctx.rpc_ctx->set_error(
@@ -252,8 +247,6 @@ namespace ccf::node
                 return;
               }
             }
-
-            range_end = inclusive_range_end + 1;
 
             if (range_end > total_size)
             {
@@ -340,15 +333,11 @@ namespace ccf::node
       ccf::http::headervalues::contenttype::OCTET_STREAM);
     ctx.rpc_ctx->set_response_body(std::move(contents));
 
-    // Convert back to HTTP-style inclusive range end
-    const auto inclusive_range_end = range_end - 1;
-
     // Partial Content responses describe the current response in
     // Content-Range
     ctx.rpc_ctx->set_response_header(
       ccf::http::headers::CONTENT_RANGE,
-      fmt::format(
-        "bytes {}-{}/{}", range_start, inclusive_range_end, total_size));
+      fmt::format("bytes {}-{}/{}", range_start, range_end, total_size));
   }
 
   static void init_file_serving_handlers(

--- a/src/snapshots/fetch.h
+++ b/src/snapshots/fetch.h
@@ -43,7 +43,7 @@ namespace snapshots
   struct ContentRangeHeader
   {
     size_t range_start;
-    size_t inclusive_range_end;
+    size_t range_end;
     size_t total_size;
   };
 
@@ -93,7 +93,7 @@ namespace snapshots
 
     {
       const auto [p, ec] = std::from_chars(
-        range_end.begin(), range_end.end(), parsed_values.inclusive_range_end);
+        range_end.begin(), range_end.end(), parsed_values.range_end);
       if (ec != std::errc())
       {
         throw std::runtime_error(fmt::format(
@@ -142,7 +142,6 @@ namespace snapshots
       constexpr size_t range_size = 4L * 1024 * 1024;
       size_t range_start = 0;
       size_t range_end = range_size;
-      size_t inclusive_range_end = range_end - 1;
       bool fetched_all = false;
 
       auto process_partial_response =
@@ -161,29 +160,26 @@ namespace snapshots
 
           // The server may give us _less_ than we requested (since they know
           // where the file ends), but should never give us more
-          if (content_range.inclusive_range_end > inclusive_range_end)
+          if (content_range.range_end > range_end)
           {
             throw std::runtime_error(fmt::format(
               "Unexpected range response. Requested bytes {}-{}, received "
               "range ending at {}",
               range_start,
-              inclusive_range_end,
-              content_range.inclusive_range_end));
+              range_end,
+              content_range.range_end));
           }
 
-          const auto content_range_exclusive_range_end =
-            content_range.inclusive_range_end + 1;
-
           const auto range_size =
-            content_range_exclusive_range_end - content_range.range_start;
+            content_range.range_end - content_range.range_start;
           LOG_TRACE_FMT(
             "Received {}-byte chunk from {}. Now have {}/{}",
             range_size,
             request.get_url(),
-            content_range_exclusive_range_end,
+            content_range.range_end,
             content_range.total_size);
 
-          if (content_range_exclusive_range_end == content_range.total_size)
+          if (content_range.range_end == content_range.total_size)
           {
             fetched_all = true;
           }
@@ -192,7 +188,6 @@ namespace snapshots
             // Advance range for next request
             range_start = range_end;
             range_end = range_start + range_size;
-            inclusive_range_end = range_end - 1;
           }
         };
 
@@ -208,8 +203,7 @@ namespace snapshots
 
         ccf::curl::UniqueSlist headers;
         headers.append(
-          ccf::http::headers::RANGE,
-          fmt::format("bytes={}-{}", range_start, inclusive_range_end));
+          "Range", fmt::format("bytes={}-{}", range_start, range_end));
 
         CURLcode curl_response = CURLE_FAILED_INIT;
         long status_code = 0;
@@ -287,8 +281,7 @@ namespace snapshots
       {
         ccf::curl::UniqueSlist headers;
         headers.append(
-          ccf::http::headers::RANGE,
-          fmt::format("bytes={}-{}", range_start, inclusive_range_end));
+          "Range", fmt::format("bytes={}-{}", range_start, range_end));
 
         std::unique_ptr<ccf::curl::CurlRequest> snapshot_range_request;
         CURLcode curl_response = CURLE_OK;

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -357,37 +357,25 @@ def test_snapshot_access(network, args):
             assert r.headers["accept-ranges"] == "bytes", r.headers
             total_size = int(r.headers["content-length"])
 
-            # Use HTTP-style inclusive range end value
-            range_max = total_size - 1
-
             a = total_size // 3
             b = a * 2
             for start, end in [
                 (0, None),
-                (0, 0),
-                (0, range_max),
+                (0, total_size),
                 (0, a),
                 (a, a),
                 (a, b),
                 (b, b),
-                (b, range_max),
+                (b, total_size),
                 (b, None),
-                (range_max, range_max),
             ]:
                 range_header_value = f"{start}-{'' if end is None else end}"
                 r = do_request(
                     "GET", path, headers={"range": f"bytes={range_header_value}"}
                 )
                 assert r.status_code == http.HTTPStatus.PARTIAL_CONTENT.value, r
-                headers = r.headers
-                implied_end = range_max if end is None else end
-                assert int(headers["content-length"]) == implied_end - start + 1
-                assert (
-                    headers["content-range"]
-                    == f"bytes {start}-{implied_end}/{total_size}"
-                )
 
-                expected = snapshot_data[start : (None if end is None else end + 1)]
+                expected = snapshot_data[start:end]
                 actual = r.body.data()
                 assert (
                     expected == actual


### PR DESCRIPTION
This reverts commit b4be36f31659712976f094e38d05f848dfa72d35.

I think this has broken compatibility between 6.x and 7.x, but the original PR did not include `run_long_test` label to trigger `lts_compatibility` so this was missed. Worse, the failure is subtle and inconsistent (if the primary is a new node, we're fine, only affects snapshot join of a new node to an old node).

I can glimpse fixes, but these are rubbish and slow to test. I think we revert until we're confident that we have a compatibility story.