### PR TITLE
Enable known operator features in default `start_network` nodes

### DIFF
--- a/tests/start_network.py
+++ b/tests/start_network.py
@@ -54,6 +54,8 @@ def run(args):
                     ),
                 )
 
+            interface.enabled_operator_features = ["SnapshotRead", "LedgerChunkRead"]
+
             hosts.append(
                 infra.interfaces.HostSpec(
                     rpc_interfaces={infra.interfaces.PRIMARY_RPC_INTERFACE: interface}


### PR DESCRIPTION
It is awkward to manually test the snapshot and ledger endpoints, because when you create a network with `sandbox.sh` it does not enable the necessary features (has a single node with a single interface, without these features).

This is a quick fix, but I think sufficient - add these features to the manually-constructed `RpcInterface` in `start_network.py`, called by `sandbox.sh`.