### PR TITLE
Stop cat from failing on missing permissions in ACI environment dump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
           set -ex
           # Dump environment variables, extract Fabric_NodeIPOrFQDN
           # and save it to a file for reconfiguration test using THIM.
-          cat /proc/*/environ | tr '\000' '\n' | sort -u | grep Fabric_NodeIPOrFQDN > /Fabric_NodeIPOrFQDN
+          { cat /proc/*/environ 2>/dev/null || true; } | tr '\000' '\n' | sort -u | grep Fabric_NodeIPOrFQDN > /Fabric_NodeIPOrFQDN
           echo "::group::Disk usage"
           df -kh
           echo "::endgroup::"
@@ -281,7 +281,7 @@ jobs:
           set -ex
           # Dump environment variables, extract Fabric_NodeIPOrFQDN
           # and save it to a file for reconfiguration test using THIM.
-          cat /proc/*/environ | tr '\000' '\n' | sort -u | grep Fabric_NodeIPOrFQDN > /Fabric_NodeIPOrFQDN
+          { cat /proc/*/environ 2>/dev/null || true; } | tr '\000' '\n' | sort -u | grep Fabric_NodeIPOrFQDN > /Fabric_NodeIPOrFQDN
           echo "::group::Disk usage"
           df -kh
           echo "::endgroup::"


### PR DESCRIPTION
I got another instance of:
```
+ tr '\000' '\n'
+ cat /proc/1/environ /proc/199/environ /proc/250/environ /proc/254/environ /proc/272/environ /proc/32/environ /proc/38/environ /proc/425/environ /proc/426/environ /proc/432/environ /proc/433/environ /proc/44/environ /proc/self/environ /proc/thread-self/environ
+ sort -u
+ grep Fabric_NodeIPOrFQDN
cat: /proc/425/environ: Permission denied
```

The problem being that cat barfs if it can't read a file.
So we can pass a `|| true` and wrap the cat in a subshell, it will output all the relevant bits and set the incorrect error code.
If the Fabric_... doesn't exist then the grep will fail.

<details>
<summary>Here is an incredibly verbose vibe-demo of this working if you want to double check.</summary>

```bash
#!/bin/bash
set -e -o pipefail

# Simulate /proc/*/environ files: NUL-delimited env vars,
# some readable, one unreadable (permission denied).

TMPDIR=$(mktemp -d)
trap 'rm -rf "$TMPDIR"' EXIT

PROC="$TMPDIR/proc"
mkdir -p "$PROC/1" "$PROC/2" "$PROC/3"

# Process 1: unreadable (simulates a root-owned process)
printf 'SECRET=classified\000' > "$PROC/1/environ"
chmod 000 "$PROC/1/environ"

# Process 2: has the variable we want
printf 'HOME=/root\000Fabric_NodeIPOrFQDN=10.0.0.1\000PATH=/usr/bin\000' > "$PROC/2/environ"

# Process 3: readable but irrelevant
printf 'HOME=/home/user\000LANG=en_US.UTF-8\000' > "$PROC/3/environ"

OUTPUT="$TMPDIR/Fabric_NodeIPOrFQDN"

echo "=== Old approach (cat | tr | sort | grep) ==="
if cat "$PROC"/*/environ | tr '\000' '\n' | sort -u | grep Fabric_NodeIPOrFQDN > "$OUTPUT" 2>&1; then
    echo "PASS (unexpected): $(cat "$OUTPUT")"
else
    echo "FAIL (expected): exit code $? — pipeline killed by permission denied + pipefail"
fi

echo ""
echo "=== New approach with || true ==="
if { cat "$PROC"/*/environ 2>/dev/null || true; } | tr '\000' '\n' | sort -u | grep Fabric_NodeIPOrFQDN > "$OUTPUT"; then
    echo "PASS (expected): $(cat "$OUTPUT")"
else
    echo "FAIL (unexpected): exit code $?"
fi

echo ""
echo "=== New approach with || true without a valid find ==="
if { cat "$PROC"/1/environ 2>/dev/null || true; } | tr '\000' '\n' | sort -u | grep Fabric_NodeIPOrFQDN > "$OUTPUT"; then
    echo "PASS (Unexpected): $(cat "$OUTPUT")"
else
    echo "FAIL (Expected): exit code $? — pipeline killed by missing grep match + pipefail"
fi
```
</details>