### PR TITLE
Move "wait for commit" to a runtime decision rather than static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.0.0-rc2]
+
+[7.0.0-rc2]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.0-rc2
+
+### Changed
+
+- `set_consensus_committed_function()` has moved from an endpoint-registration-time decorator (`Endpoint::set_consensus_committed_function()`) to a runtime call on the RPC context (`ctx.rpc_ctx->set_consensus_committed_function()`). This allows the same endpoint to conditionally block until committed based on query parameters, headers, or other per-request state. The endpoint-level method has been removed. See the logging sample app (`/log/private/optional_commit`) for example usage.
+
 ## [7.0.0-rc1]
 
 [7.0.0-rc1]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.0-rc1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - `set_consensus_committed_function()` has moved from an endpoint-registration-time decorator (`Endpoint::set_consensus_committed_function()`) to a runtime call on the RPC context (`ctx.rpc_ctx->set_consensus_committed_function()`). This allows the same endpoint to conditionally block until committed based on query parameters, headers, or other per-request state. The endpoint-level method has been removed. See the logging sample app (`/log/private/optional_commit`) for example usage.
+
 ### Removed
 
 - Removed `aes_gcm_encrypt()`, `aes_gcm_decrypt()`, and `default_iv` from `ccf::crypto` (#7811).

--- a/doc/build_apps/example_cpp.rst
+++ b/doc/build_apps/example_cpp.rst
@@ -365,3 +365,36 @@ DELETE /app/log/public/{idx}
     :dedent:
 
 The framework provides a :cpp:class:`ccf::http::Matcher` class, which can be used to evaluate these conditions.
+
+Deferring Response Until Commit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, CCF sends the HTTP response as soon as a transaction is locally committed (assigned a :term:`Transaction ID`), without waiting for it to be globally committed by consensus. This means a successful response indicates the transaction has been `accepted` but not yet `durably replicated` across the network. Clients that need stronger guarantees — for example, to know a write is durable before proceeding — can poll the ``/commit`` endpoint or the transaction status API.
+
+CCF also supports deferring the HTTP response until the transaction reaches a terminal consensus state: either globally committed, or invalidated (e.g. due to a view change). This is controlled per-request from within the endpoint handler by calling ``set_consensus_committed_function()`` on the RPC context, passing a callback that will be invoked once the transaction's fate is known.
+
+The simplest use is to unconditionally block:
+
+.. literalinclude:: ../../samples/apps/logging/logging.cpp
+    :language: cpp
+    :start-after: SNIPPET_START: blocking_record
+    :end-before: SNIPPET_END: blocking_record
+    :dedent:
+
+The ``default_respond_on_commit`` callback used here is defined in the sample apps (``samples/apps/common/default_on_commit.h``), not in the CCF public API. It simply returns the original response on commit, or replaces it with an error if the transaction was invalidated. The same file also contains ``make_respond_with_receipt_on_commit``, which constructs an inline COSE receipt at commit time. Applications should use these as reference implementations and write their own callbacks to suit their needs.
+
+Because this is a runtime decision made inside the handler, the `same` endpoint can conditionally block based on query parameters, headers, or other request state. This is useful for APIs where some callers want the convenience of fire-and-forget while others need commit confirmation:
+
+.. literalinclude:: ../../samples/apps/logging/logging.cpp
+    :language: cpp
+    :start-after: SNIPPET_START: optional_commit
+    :end-before: SNIPPET_END: optional_commit
+    :dedent:
+
+The callback receives a ``CommittedTxInfo`` struct containing the ``TxID``, ``FinalTxStatus`` (``Committed`` or ``Invalid``), and — for write transactions — the ``write_set_digest``, ``commit_evidence``, and ``claims_digest`` needed to construct a receipt.
+
+.. note::
+
+    This feature is currently supported on HTTP/1.1 connections only. HTTP/2 sessions send responses immediately regardless of whether a consensus-committed callback is set.
+
+    Read-only endpoints may also use this mechanism to confirm that their response reflects committed state. However, attempting to construct a receipt for a read-only transaction will throw, since read-only transactions do not produce the write set digest or commit evidence required for receipt construction.

--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -257,7 +257,7 @@
   "info": {
     "description": "This CCF sample app implements a simple logging application, securely recording messages at client-specified IDs. It demonstrates most of the features available to CCF apps.",
     "title": "CCF Sample Logging App",
-    "version": "2.8.2"
+    "version": "2.8.3"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -417,25 +417,8 @@
       },
       "post": {
         "operationId": "PostAppLogBlockingPrivate",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LoggingRecord__In"
-              }
-            }
-          },
-          "description": "Auto-generated request body schema"
-        },
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/boolean"
-                }
-              }
-            },
             "description": "Default response description"
           },
           "default": {
@@ -1054,6 +1037,40 @@
         },
         "x-ccf-forwarding": {
           "$ref": "#/components/x-ccf-forwarding/sometimes"
+        }
+      }
+    },
+    "/app/log/private/optional_commit": {
+      "post": {
+        "operationId": "PostAppLogPrivateOptionalCommit",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "wait_for_commit",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default response description"
+          },
+          "default": {
+            "$ref": "#/components/responses/default"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "user_cose_sign1": []
+          }
+        ],
+        "x-ccf-forwarding": {
+          "$ref": "#/components/x-ccf-forwarding/always"
         }
       }
     },

--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -417,8 +417,25 @@
       },
       "post": {
         "operationId": "PostAppLogBlockingPrivate",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoggingRecord__In"
+              }
+            }
+          },
+          "description": "Auto-generated request body schema"
+        },
         "responses": {
           "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/boolean"
+                }
+              }
+            },
             "description": "Default response description"
           },
           "default": {
@@ -1049,12 +1066,29 @@
             "name": "wait_for_commit",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/string"
+              "$ref": "#/components/schemas/boolean"
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoggingRecord__In"
+              }
+            }
+          },
+          "description": "Auto-generated request body schema"
+        },
         "responses": {
           "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/boolean"
+                }
+              }
+            },
             "description": "Default response description"
           },
           "default": {

--- a/include/ccf/endpoint.h
+++ b/include/ccf/endpoint.h
@@ -264,11 +264,6 @@ namespace ccf::endpoints
     // committed (ie - assigned a transaction ID)
     LocallyCommittedEndpointFunction locally_committed_func;
 
-    // Functor which is invoked to modify the response after it reaches a
-    // terminal consensus state (ie - it is either globally committed, or
-    // invalidated)
-    ConsensusCommittedEndpointFunction consensus_committed_func;
-
     struct Installer
     {
       virtual void install(Endpoint&) = 0;
@@ -494,9 +489,6 @@ namespace ccf::endpoints
 
     Endpoint& set_locally_committed_function(
       const LocallyCommittedEndpointFunction& lcf);
-
-    Endpoint& set_consensus_committed_function(
-      const ConsensusCommittedEndpointFunction& ccf_);
 
     void install();
   };

--- a/include/ccf/rpc_context.h
+++ b/include/ccf/rpc_context.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ccf/claims_digest.h"
+#include "ccf/endpoint_context.h"
 #include "ccf/frame_format.h"
 #include "ccf/http_consts.h"
 #include "ccf/http_header_map.h"
@@ -190,6 +191,16 @@ namespace ccf
     /// the transaction serialisation format or what is stored in the KV.
     /// The digest will be included in receipts issued for that transaction.
     virtual void set_claims_digest(ccf::ClaimsDigest::Digest&& digest) = 0;
+
+    /// Tells the framework to hold the response for this request until the
+    /// transaction reaches a terminal consensus state (committed or
+    /// invalidated). The provided callback will be invoked with a
+    /// CommittedTxInfo describing the outcome, and may inspect or modify the
+    /// response before it is sent to the client. If this method is not called
+    /// during endpoint execution, the response is sent immediately after local
+    /// commit.
+    virtual void set_consensus_committed_function(
+      ccf::endpoints::ConsensusCommittedEndpointFunction func) = 0;
     ///@}
   };
 }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ccf"
-version = "7.0.0.rc1"
+version = "7.0.0.rc2"
 authors = [
   { name="CCF Team", email="CCF-Sec@microsoft.com" },
 ]

--- a/samples/apps/basic/basic.cpp
+++ b/samples/apps/basic/basic.cpp
@@ -63,10 +63,15 @@ namespace basicapp
         .install();
 
       make_endpoint(
-        "/records/blocking/{key}", HTTP_PUT, put, {ccf::user_cert_auth_policy})
+        "/records/blocking/{key}",
+        HTTP_PUT,
+        [put](ccf::endpoints::EndpointContext& ctx) {
+          ctx.rpc_ctx->set_consensus_committed_function(
+            ccf::samples::default_respond_on_commit);
+          put(ctx);
+        },
+        {ccf::user_cert_auth_policy})
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
-        .set_consensus_committed_function(
-          ccf::samples::default_respond_on_commit)
         .install();
 
       auto get = [this](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
@@ -106,10 +111,15 @@ namespace basicapp
         .install();
 
       make_read_only_endpoint(
-        "/records/blocking/{key}", HTTP_GET, get, {ccf::user_cert_auth_policy})
+        "/records/blocking/{key}",
+        HTTP_GET,
+        [get](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
+          ctx.rpc_ctx->set_consensus_committed_function(
+            ccf::samples::default_respond_on_commit);
+          get(ctx);
+        },
+        {ccf::user_cert_auth_policy})
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
-        .set_consensus_committed_function(
-          ccf::samples::default_respond_on_commit)
         .install();
 
       auto post = [](ccf::endpoints::EndpointContext& ctx) {

--- a/samples/apps/basic/basic.cpp
+++ b/samples/apps/basic/basic.cpp
@@ -111,12 +111,11 @@ namespace basicapp
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
         .install();
 
-      auto blocking_get =
-        [get](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
-          ctx.rpc_ctx->set_consensus_committed_function(
-            ccf::samples::default_respond_on_commit);
-          get(ctx);
-        };
+      auto blocking_get = [get](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
+        ctx.rpc_ctx->set_consensus_committed_function(
+          ccf::samples::default_respond_on_commit);
+        get(ctx);
+      };
       make_read_only_endpoint(
         "/records/blocking/{key}",
         HTTP_GET,

--- a/samples/apps/basic/basic.cpp
+++ b/samples/apps/basic/basic.cpp
@@ -62,14 +62,15 @@ namespace basicapp
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
         .install();
 
+      auto blocking_put = [put](ccf::endpoints::EndpointContext& ctx) {
+        ctx.rpc_ctx->set_consensus_committed_function(
+          ccf::samples::default_respond_on_commit);
+        put(ctx);
+      };
       make_endpoint(
         "/records/blocking/{key}",
         HTTP_PUT,
-        [put](ccf::endpoints::EndpointContext& ctx) {
-          ctx.rpc_ctx->set_consensus_committed_function(
-            ccf::samples::default_respond_on_commit);
-          put(ctx);
-        },
+        blocking_put,
         {ccf::user_cert_auth_policy})
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
         .install();
@@ -110,14 +111,16 @@ namespace basicapp
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
         .install();
 
-      make_read_only_endpoint(
-        "/records/blocking/{key}",
-        HTTP_GET,
+      auto blocking_get =
         [get](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
           ctx.rpc_ctx->set_consensus_committed_function(
             ccf::samples::default_respond_on_commit);
           get(ctx);
-        },
+        };
+      make_read_only_endpoint(
+        "/records/blocking/{key}",
+        HTTP_GET,
+        blocking_get,
         {ccf::user_cert_auth_policy})
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
         .install();

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -564,23 +564,62 @@ namespace loggingapp
         .install();
       // SNIPPET_END: install_record
 
+      auto blocking_record = [record](auto& ctx, nlohmann::json&& params) {
+        ctx.rpc_ctx->set_consensus_committed_function(
+          ccf::samples::default_respond_on_commit);
+        return record(ctx, std::move(params));
+      };
       make_endpoint(
         "/log/blocking/private",
         HTTP_POST,
-        ccf::json_adapter(record),
+        ccf::json_adapter(blocking_record),
         auth_policies)
         .set_auto_schema<LoggingRecord::In, bool>()
-        .set_consensus_committed_function(
-          ccf::samples::default_respond_on_commit)
         .install();
 
+      auto blocking_record_with_receipt =
+        [this, record](auto& ctx, nlohmann::json&& params) {
+          ctx.rpc_ctx->set_consensus_committed_function(
+            ccf::samples::make_respond_with_receipt_on_commit(context));
+          return record(ctx, std::move(params));
+        };
       make_endpoint(
         "/log/blocking/private/receipt",
         HTTP_POST,
-        ccf::json_adapter(record),
+        ccf::json_adapter(blocking_record_with_receipt),
         auth_policies)
-        .set_consensus_committed_function(
-          ccf::samples::make_respond_with_receipt_on_commit(context))
+        .install();
+
+      // Demonstrates per-request opt-in to blocking-until-committed via a
+      // query parameter. The same endpoint can return immediately or hold
+      // the response depending on the caller's choice.
+      auto optional_commit_record =
+        [record](auto& ctx, nlohmann::json&& params) {
+          const auto parsed_query =
+            ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
+          std::string error_reason;
+          std::string wait_for_commit;
+          // Safe to ignore the return value of get_query_value here as we'll
+          // just treat any failure to parse the parameter as meaning "don't
+          // wait for commit"
+          ccf::http::get_query_value(
+            parsed_query, "wait_for_commit", wait_for_commit, error_reason);
+          if (wait_for_commit == "true")
+          {
+            ctx.rpc_ctx->set_consensus_committed_function(
+              ccf::samples::default_respond_on_commit);
+          }
+          return record(ctx, std::move(params));
+        };
+      make_endpoint(
+        "/log/private/optional_commit",
+        HTTP_POST,
+        ccf::json_adapter(optional_commit_record),
+        auth_policies)
+        .set_auto_schema<LoggingRecord::In, bool>()
+        .add_query_parameter<std::string>(
+          "wait_for_commit",
+          ccf::endpoints::QueryParamPresence::OptionalParameter)
         .install();
 
       auto add_txid_in_body_put = [](auto& ctx, const auto& tx_id) {
@@ -689,15 +728,18 @@ namespace loggingapp
         .install();
       // SNIPPET_END: install_get
 
+      auto blocking_get = [get](auto& ctx, nlohmann::json&& params) {
+        ctx.rpc_ctx->set_consensus_committed_function(
+          ccf::samples::default_respond_on_commit);
+        return get(ctx, std::move(params));
+      };
       make_read_only_endpoint(
         "/log/blocking/private",
         HTTP_GET,
-        ccf::json_read_only_adapter(get),
+        ccf::json_read_only_adapter(blocking_get),
         auth_policies)
         .set_auto_schema<void, LoggingGet::Out>()
         .add_query_parameter<size_t>("id")
-        .set_consensus_committed_function(
-          ccf::samples::default_respond_on_commit)
         .install();
 
       make_read_only_endpoint(

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -575,6 +575,7 @@ namespace loggingapp
         HTTP_POST,
         ccf::json_adapter(blocking_record),
         auth_policies)
+        .set_auto_schema<LoggingRecord::In, bool>()
         .install();
       // SNIPPET_END: blocking_record
 
@@ -618,9 +619,10 @@ namespace loggingapp
         HTTP_POST,
         ccf::json_adapter(optional_commit_record),
         auth_policies)
-        .add_query_parameter<std::string>(
+        .add_query_parameter<bool>(
           "wait_for_commit",
           ccf::endpoints::QueryParamPresence::OptionalParameter)
+        .set_auto_schema<LoggingRecord::In, bool>()
         .install();
       // SNIPPET_END: optional_commit
 

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -515,7 +515,7 @@ namespace loggingapp
         "recording messages at client-specified IDs. It demonstrates most of "
         "the features available to CCF apps.";
 
-      openapi_info.document_version = "2.8.2";
+      openapi_info.document_version = "2.8.3";
     };
 
     void init_handlers() override
@@ -574,7 +574,6 @@ namespace loggingapp
         HTTP_POST,
         ccf::json_adapter(blocking_record),
         auth_policies)
-        .set_auto_schema<LoggingRecord::In, bool>()
         .install();
 
       auto blocking_record_with_receipt =
@@ -616,7 +615,6 @@ namespace loggingapp
         HTTP_POST,
         ccf::json_adapter(optional_commit_record),
         auth_policies)
-        .set_auto_schema<LoggingRecord::In, bool>()
         .add_query_parameter<std::string>(
           "wait_for_commit",
           ccf::endpoints::QueryParamPresence::OptionalParameter)

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -564,6 +564,7 @@ namespace loggingapp
         .install();
       // SNIPPET_END: install_record
 
+      // SNIPPET_START: blocking_record
       auto blocking_record = [record](auto& ctx, nlohmann::json&& params) {
         ctx.rpc_ctx->set_consensus_committed_function(
           ccf::samples::default_respond_on_commit);
@@ -575,6 +576,7 @@ namespace loggingapp
         ccf::json_adapter(blocking_record),
         auth_policies)
         .install();
+      // SNIPPET_END: blocking_record
 
       auto blocking_record_with_receipt =
         [this, record](auto& ctx, nlohmann::json&& params) {
@@ -592,6 +594,7 @@ namespace loggingapp
       // Demonstrates per-request opt-in to blocking-until-committed via a
       // query parameter. The same endpoint can return immediately or hold
       // the response depending on the caller's choice.
+      // SNIPPET_START: optional_commit
       auto optional_commit_record =
         [record](auto& ctx, nlohmann::json&& params) {
           const auto parsed_query =
@@ -619,6 +622,7 @@ namespace loggingapp
           "wait_for_commit",
           ccf::endpoints::QueryParamPresence::OptionalParameter)
         .install();
+      // SNIPPET_END: optional_commit
 
       auto add_txid_in_body_put = [](auto& ctx, const auto& tx_id) {
         static constexpr auto CCF_TX_ID = "x-ms-ccf-transaction-id";

--- a/src/endpoints/endpoint.cpp
+++ b/src/endpoints/endpoint.cpp
@@ -103,13 +103,6 @@ namespace ccf::endpoints
     return *this;
   }
 
-  Endpoint& Endpoint::set_consensus_committed_function(
-    const ConsensusCommittedEndpointFunction& ccf_)
-  {
-    consensus_committed_func = ccf_;
-    return *this;
-  }
-
   Endpoint& Endpoint::set_openapi_description(const std::string& description)
   {
     openapi_description = description;

--- a/src/http/http_rpc_context.h
+++ b/src/http/http_rpc_context.h
@@ -299,6 +299,7 @@ namespace http
       response_body.clear();
       response_status = HTTP_STATUS_OK;
       explicit_apply_writes.reset();
+      consensus_committed_func = nullptr;
     }
 
     [[nodiscard]] std::vector<uint8_t> serialise_response() const override

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -815,29 +815,22 @@ namespace ccf
           ccf::kv::CommittableTx& tx = *args.owned_tx;
 
           // Only capture write set digest and commit evidence if the
-          // endpoint has a consensus committed callback that may need
+          // handler has set a consensus committed callback that may need
           // them for receipt construction. Avoids unnecessary hashing
           // on the common path.
           ccf::crypto::Sha256Hash captured_ws_digest;
           std::string captured_commit_evidence;
           ccf::kv::CommittableTx::WriteSetObserver ws_observer = nullptr;
           ccf::endpoints::ConsensusCommittedEndpointFunction committed_func =
-            nullptr;
+            ctx->consensus_committed_func;
+          if (committed_func != nullptr)
           {
-            const auto* concrete_endpoint =
-              dynamic_cast<const endpoints::Endpoint*>(endpoint.get());
-            if (
-              concrete_endpoint != nullptr &&
-              concrete_endpoint->consensus_committed_func != nullptr)
-            {
-              committed_func = concrete_endpoint->consensus_committed_func;
-              ws_observer = [&captured_ws_digest, &captured_commit_evidence](
-                              const ccf::crypto::Sha256Hash& ws_digest,
-                              const std::string& ce) {
-                captured_ws_digest = ws_digest;
-                captured_commit_evidence = ce;
-              };
-            }
+            ws_observer = [&captured_ws_digest, &captured_commit_evidence](
+                            const ccf::crypto::Sha256Hash& ws_digest,
+                            const std::string& ce) {
+              captured_ws_digest = ws_digest;
+              captured_commit_evidence = ce;
+            };
           }
 
           ccf::kv::CommitResult result =

--- a/src/node/rpc_context_impl.h
+++ b/src/node/rpc_context_impl.h
@@ -107,6 +107,15 @@ namespace ccf
         http::headervalues::contenttype::JSON);
     }
 
+    ccf::endpoints::ConsensusCommittedEndpointFunction
+      consensus_committed_func = nullptr;
+
+    void set_consensus_committed_function(
+      ccf::endpoints::ConsensusCommittedEndpointFunction func) override
+    {
+      consensus_committed_func = std::move(func);
+    }
+
     bool response_is_pending = false;
     bool terminate_session = false;
 

--- a/tests/e2e_logging.py
+++ b/tests/e2e_logging.py
@@ -2306,6 +2306,8 @@ def test_blocking_calls(network, args):
         "/log/private",
         "/log/blocking/private",
         "/log/blocking/private/receipt",
+        "/log/private/optional_commit",
+        "/log/private/optional_commit?wait_for_commit=true",
     ]
     n_requests = 5
     request_order = paths * n_requests
@@ -2372,6 +2374,13 @@ def test_blocking_calls(network, args):
     assert (
         mean_commit_deltas["/log/blocking/private/receipt"]
         < mean_commit_deltas["/log/private"]
+    )
+    # The optional_commit endpoint with wait_for_commit=true should behave
+    # like the blocking endpoints, while without the parameter it should
+    # behave like the non-blocking endpoint.
+    assert (
+        mean_commit_deltas["/log/private/optional_commit?wait_for_commit=true"]
+        < mean_commit_deltas["/log/private/optional_commit"]
     )
 
     return network


### PR DESCRIPTION
This pull request introduces a significant change to how HTTP endpoints in CCF can defer responses until transactions are globally committed, shifting this control from endpoint registration time to runtime within the request handler. This allows endpoints to conditionally block until commit based on request-specific logic, improving flexibility and enabling per-request commit confirmation. The changes are reflected in the core API, sample apps, documentation, OpenAPI spec, and tests.