### PR TITLE
Add ballotSubmitters field to proposal API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3663,3 +3663,4 @@ Initial pre-release
 [5.0.0]: https://github.com/microsoft/CCF/releases/tag/ccf-5.0.0
 [7.0.0-dev0]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.0-dev0
 [7.0.1]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.1
+[7.0.2]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- The governance proposal endpoints now include a `ballotSubmitters` field in their responses, containing the list of member IDs that have submitted a ballot for the proposal.
+- The governance proposal endpoints now include a `ballotSubmitters` field in their responses, containing the list of member IDs that have submitted a ballot for the proposal (#7840).
 
 ## [7.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [7.0.1]
+## [7.0.2]
 
 ### Added
 
 - The governance proposal endpoints now include a `ballotSubmitters` field in their responses, containing the list of member IDs that have submitted a ballot for the proposal.
+
+## [7.0.1]
 
 ## [7.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [7.0.2]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.2
+## [7.0.2]
+
+[7.0.2]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.2
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [7.0.2]
+## [7.0.2]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.2
 
 ### Added
 
@@ -3668,5 +3668,3 @@ Initial pre-release
 [3.0.0-rc2]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.0-rc2
 [5.0.0]: https://github.com/microsoft/CCF/releases/tag/ccf-5.0.0
 [7.0.0-dev0]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.0-dev0
-[7.0.1]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.1
-[7.0.2]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.0.1]
+
+### Added
+
+- The governance proposal endpoints now include a `ballotSubmitters` field in their responses, containing the list of member IDs that have submitted a ballot for the proposal.
+
 ## [7.0.0]
 
 [7.0.0]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.0
@@ -3654,3 +3660,4 @@ Initial pre-release
 [3.0.0-rc2]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.0-rc2
 [5.0.0]: https://github.com/microsoft/CCF/releases/tag/ccf-5.0.0
 [7.0.0-dev0]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.0-dev0
+[7.0.1]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.1

--- a/doc/schemas/gov/2023-06-01-preview/gov.json
+++ b/doc/schemas/gov/2023-06-01-preview/gov.json
@@ -1382,6 +1382,13 @@
           "$ref": "#/definitions/safeuint",
           "description": "Count of how many ballots have been submitted for this proposal."
         },
+        "ballotSubmitters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/memberId"
+          },
+          "description": "List of member IDs who have submitted a ballot for this proposal."
+        },
         "finalVotes": {
           "$ref": "#/definitions/Proposals.MemberVotes",
           "description": "If a proposal is not open, then this contains the result of each ballot when the proposal transitioned from open."
@@ -1399,7 +1406,8 @@
         "proposalId",
         "proposerId",
         "proposalState",
-        "ballotCount"
+        "ballotCount",
+        "ballotSubmitters"
       ]
     },
     "Proposals.ProposalActions": {

--- a/doc/schemas/gov/2024-07-01/gov.json
+++ b/doc/schemas/gov/2024-07-01/gov.json
@@ -1494,6 +1494,13 @@
           "$ref": "#/definitions/safeuint",
           "description": "Count of how many ballots have been submitted for this proposal."
         },
+        "ballotSubmitters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/memberId"
+          },
+          "description": "List of member IDs who have submitted a ballot for this proposal."
+        },
         "finalVotes": {
           "$ref": "#/definitions/Proposals.MemberVotes",
           "description": "If a proposal is not open, then this contains the result of each ballot when the proposal transitioned from open."
@@ -1511,7 +1518,8 @@
         "proposalId",
         "proposerId",
         "proposalState",
-        "ballotCount"
+        "ballotCount",
+        "ballotSubmitters"
       ]
     },
     "Proposals.ProposalActions": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ccf"
-version = "7.0.1"
+version = "7.0.2"
 authors = [
   { name="CCF Team", email="CCF-Sec@microsoft.com" },
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ccf"
-version = "7.0.0"
+version = "7.0.1"
 authors = [
   { name="CCF Team", email="CCF-Sec@microsoft.com" },
 ]

--- a/src/node/gov/handlers/proposals.h
+++ b/src/node/gov/handlers/proposals.h
@@ -359,7 +359,13 @@ namespace ccf::gov::endpoints
       response_body["ballotCount"] = summary.ballots.size();
 
       auto ballot_submitters = nlohmann::json::array();
+      std::vector<ccf::MemberId> submitter_ids;
       for (const auto& [member_id, _] : summary.ballots)
+      {
+        submitter_ids.push_back(member_id);
+      }
+      std::sort(submitter_ids.begin(), submitter_ids.end());
+      for (const auto& member_id : submitter_ids)
       {
         ballot_submitters.push_back(member_id);
       }

--- a/src/node/gov/handlers/proposals.h
+++ b/src/node/gov/handlers/proposals.h
@@ -358,6 +358,13 @@ namespace ccf::gov::endpoints
       response_body["proposalState"] = summary.state;
       response_body["ballotCount"] = summary.ballots.size();
 
+      auto ballot_submitters = nlohmann::json::array();
+      for (const auto& [member_id, _] : summary.ballots)
+      {
+        ballot_submitters.push_back(member_id);
+      }
+      response_body["ballotSubmitters"] = ballot_submitters;
+
       std::optional<ccf::jsgov::Votes> votes = summary.final_votes;
 
       if (votes.has_value())

--- a/tests/governance_js.py
+++ b/tests/governance_js.py
@@ -405,6 +405,8 @@ def test_pure_proposals(network, args):
             r = c.post("/gov/members/proposals:create", prop)
             assert r.status_code == 200, r.body.text()
             assert r.body.json()["proposalState"] == state, r.body.json()
+            assert "finalVotes" in r.body.json(), r.body.json()
+            assert r.body.json()["finalVotes"] == {}, r.body.json()
             proposal_id = r.body.json()["proposalId"]
 
             ballot = ballot_yes
@@ -568,6 +570,10 @@ def test_proposals_with_votes(network, args):
             )
             assert r.status_code == 200, r.body.text()
             assert r.body.json()["proposalState"] == state, r.body.json()
+            assert "finalVotes" in r.body.json(), r.body.json()
+            assert r.body.json()["finalVotes"] == {
+                member_id: direction == "true"
+            }, r.body.json()
 
             infra.clients.get_clock().advance()
 
@@ -585,6 +591,10 @@ def test_proposals_with_votes(network, args):
             )
             assert r.status_code == 200, r.body.text()
             assert r.body.json()["proposalState"] == state, r.body.json()
+            assert "finalVotes" in r.body.json(), r.body.json()
+            assert r.body.json()["finalVotes"] == {
+                member_id: direction == "true"
+            }, r.body.json()
 
         for prop, state, ballot in [
             (always_accept_with_two_votes, "Accepted", ballot_yes),
@@ -619,6 +629,12 @@ def test_proposals_with_votes(network, args):
                 assert set(r.body.json()["ballotSubmitters"]) == {
                     member_id,
                     other_member_id,
+                }, r.body.json()
+                assert "finalVotes" in r.body.json(), r.body.json()
+                expected_vote = state == "Accepted"
+                assert r.body.json()["finalVotes"] == {
+                    member_id: expected_vote,
+                    other_member_id: expected_vote,
                 }, r.body.json()
 
     return network
@@ -674,6 +690,8 @@ def test_vote_failure_reporting(network, args):
         LOG.warning(rj)
         assert rj["proposalState"] == "Accepted", r.body.json()
         assert set(rj["ballotSubmitters"]) == {member0_id, member1_id}, rj
+        assert "finalVotes" in rj, rj
+        assert rj["finalVotes"] == {member1_id: True}, rj
         assert len(rj["voteFailures"]) == 1, rj["voteFailures"]
         assert rj["voteFailures"][member0_id]["reason"] == f"Error: {error_body}", rj[
             "voteFailures"
@@ -700,6 +718,7 @@ def test_operator_proposals_and_votes(network, args):
         )
         assert r.status_code == 200, r.body.text()
         assert r.body.json()["proposalState"] == "Accepted", r.body.json()
+        assert r.body.json()["finalVotes"] == {member_id: True}, r.body.json()
 
         r = c.post(
             "/gov/members/proposals:create", always_accept_if_proposed_by_operator

--- a/tests/governance_js.py
+++ b/tests/governance_js.py
@@ -261,6 +261,7 @@ def test_proposal_storage(network, args):
                 "proposalState": "Open",
                 "proposalId": proposal_id,
                 "ballotCount": 0,
+                "ballotSubmitters": [],
             }
             assert r.body.json() == expected, r.body.json()
 
@@ -306,6 +307,7 @@ def test_proposal_withdrawal(network, args):
                 "proposalState": "Open",
                 "proposalId": proposal_id,
                 "ballotCount": 0,
+                "ballotSubmitters": [],
             }
             assert r.body.json() == expected, r.body.json()
 
@@ -316,6 +318,7 @@ def test_proposal_withdrawal(network, args):
                 "proposalState": "Withdrawn",
                 "proposalId": proposal_id,
                 "ballotCount": 0,
+                "ballotSubmitters": [],
             }
             assert r.body.json() == expected, r.body.json()
 

--- a/tests/governance_js.py
+++ b/tests/governance_js.py
@@ -593,6 +593,7 @@ def test_proposals_with_votes(network, args):
             r = c.post("/gov/members/proposals:create", prop)
             assert r.status_code == 200, r.body.text()
             assert r.body.json()["proposalState"] == "Open", r.body.json()
+            assert r.body.json()["ballotSubmitters"] == [], r.body.json()
             proposal_id = r.body.json()["proposalId"]
 
             r = c.post(
@@ -601,6 +602,7 @@ def test_proposals_with_votes(network, args):
             )
             assert r.status_code == 200, r.body.text()
             assert r.body.json()["proposalState"] == "Open", r.body.json()
+            assert r.body.json()["ballotSubmitters"] == [member_id], r.body.json()
 
             with node.api_versioned_client(
                 None, None, "member1", api_version=args.gov_api_version
@@ -614,6 +616,10 @@ def test_proposals_with_votes(network, args):
                 )
                 assert r.status_code == 200, r.body.text()
                 assert r.body.json()["proposalState"] == state, r.body.json()
+                assert set(r.body.json()["ballotSubmitters"]) == {
+                    member_id,
+                    other_member_id,
+                }, r.body.json()
 
     return network
 
@@ -640,34 +646,36 @@ def test_vote_failure_reporting(network, args):
     with node.api_versioned_client(
         None, None, "member0", api_version=args.gov_api_version
     ) as c:
-        member_id = network.consortium.get_member_by_local_id("member0").service_id
+        member0_id = network.consortium.get_member_by_local_id("member0").service_id
         r = c.post("/gov/members/proposals:create", always_accept_with_one_vote)
         assert r.status_code == 200, r.body.text()
         assert r.body.json()["proposalState"] == "Open", r.body.json()
+        assert r.body.json()["ballotSubmitters"] == [], r.body.json()
         proposal_id = r.body.json()["proposalId"]
 
         ballot = vote(f'throw new Error("{error_body}")')
         r = c.post(
-            f"/gov/members/proposals/{proposal_id}/ballots/{member_id}:submit", ballot
+            f"/gov/members/proposals/{proposal_id}/ballots/{member0_id}:submit", ballot
         )
         assert r.status_code == 200, r.body.text()
         assert r.body.json()["proposalState"] == "Open", r.body.json()
+        assert r.body.json()["ballotSubmitters"] == [member0_id], r.body.json()
 
     with node.api_versioned_client(
         None, None, "member1", api_version=args.gov_api_version
     ) as c:
         ballot = ballot_yes
-        member_id = network.consortium.get_member_by_local_id("member1").service_id
+        member1_id = network.consortium.get_member_by_local_id("member1").service_id
         r = c.post(
-            f"/gov/members/proposals/{proposal_id}/ballots/{member_id}:submit", ballot
+            f"/gov/members/proposals/{proposal_id}/ballots/{member1_id}:submit", ballot
         )
         assert r.status_code == 200, r.body.text()
         rj = r.body.json()
         LOG.warning(rj)
         assert rj["proposalState"] == "Accepted", r.body.json()
+        assert set(rj["ballotSubmitters"]) == {member0_id, member1_id}, rj
         assert len(rj["voteFailures"]) == 1, rj["voteFailures"]
-        member_id = network.consortium.get_member_by_local_id("member0").service_id
-        assert rj["voteFailures"][member_id]["reason"] == f"Error: {error_body}", rj[
+        assert rj["voteFailures"][member0_id]["reason"] == f"Error: {error_body}", rj[
             "voteFailures"
         ]
 
@@ -1392,10 +1400,20 @@ def test_final_proposal_visibility(network, args):
         LOG.info("Confirm that finalVotes is present in submit-ballot response")
         body = response.body.json()
         assert "finalVotes" in body, body
+        assert set(body["ballotSubmitters"]) == {
+            booster.service_id,
+            turncoat.service_id,
+            fairweather.service_id,
+        }, body
 
         LOG.info("Confirm that finalVotes is present in get-proposal response")
         body = consortium.get_proposal_raw(primary, third.proposal_id)
         assert "finalVotes" in body, body
+        assert set(body["ballotSubmitters"]) == {
+            booster.service_id,
+            turncoat.service_id,
+            fairweather.service_id,
+        }, body
 
     LOG.info("Confirm that expected values were actually written to the KV")
     # To avoid creating an extra endpoint in the app, we smuggle a read into a new

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -318,8 +318,10 @@ class Consortium:
             raise infra.proposal.ProposalNotAccepted(proposal, response)
 
         raw = self.get_proposal_raw(remote_node, proposal.proposal_id)
-        final_votes = raw.get("finalVotes", {})
-        assert final_votes, f"Expected finalVotes to be populated, got: {raw}"
+        assert (
+            "finalVotes" in raw
+        ), f"Expected finalVotes field to be present, got: {raw}"
+        final_votes = raw["finalVotes"]
         for voter_id in proposal.voters:
             assert (
                 voter_id in final_votes

--- a/tests/infra/consortium.py
+++ b/tests/infra/consortium.py
@@ -317,6 +317,17 @@ class Consortium:
             )
             raise infra.proposal.ProposalNotAccepted(proposal, response)
 
+        raw = self.get_proposal_raw(remote_node, proposal.proposal_id)
+        final_votes = raw.get("finalVotes", {})
+        assert final_votes, f"Expected finalVotes to be populated, got: {raw}"
+        for voter_id in proposal.voters:
+            assert (
+                voter_id in final_votes
+            ), f"Voter {voter_id} not found in finalVotes: {final_votes}"
+            assert (
+                final_votes[voter_id] is True
+            ), f"Voter {voter_id} vote is not true: {final_votes[voter_id]}"
+
         return proposal
 
     def get_proposal_raw(self, remote_node, proposal_id):


### PR DESCRIPTION
See #6107, implements https://github.com/microsoft/CCF/issues/6107#issuecomment-4325420423 specifically:

- Add a field to GET /gov/members/proposals/{proposalId} listed the memberIds that have submitted a ballot for the proposal so far.
- Confirm that finalVotes is always being populated correctly.