### PR TITLE
Add detection for AMD Turin to `platform_detection.py`

### DIFF
--- a/tests/infra/platform_detection.py
+++ b/tests/infra/platform_detection.py
@@ -31,6 +31,7 @@ def _detect_amd_platform_name():
     pattern = re.compile(r"model name\s*:\s*AMD EPYC (....) ")
     milan = re.compile(r"7..3")
     genoa = re.compile(r"9..4")
+    turin = re.compile(r"9..5")
     with open("/proc/cpuinfo", "r") as cpuinfo_file:
         for line in cpuinfo_file:
             match = pattern.match(line)
@@ -40,6 +41,8 @@ def _detect_amd_platform_name():
                     return "milan"
                 elif genoa.match(num):
                     return "genoa"
+                elif turin.match(num):
+                    return "turin"
     return "unknown"
 
 


### PR DESCRIPTION
Spotted we didn't have this while doing #7851. Since it's unrelated, pulled out here.