### PR TITLE
Install dependencies before trying to get machine info

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -34,6 +34,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: "Install dependencies"
+        shell: bash
+        run: |
+          set -ex
+          ./scripts/setup-ci.sh
+
       - name: "Machine info"
         shell: bash
         run: &machine_info |
@@ -51,12 +57,6 @@ jobs:
           else
             echo "CCF_PLATFORM_SLUG=virtual" >> "$GITHUB_ENV"
           fi
-
-      - name: "Install dependencies"
-        shell: bash
-        run: |
-          set -ex
-          ./scripts/setup-ci.sh
 
       - name: "Confirm running on Virtual"
         run: |


### PR DESCRIPTION
#7851 just merged, but breaks the Bencher job: https://github.com/microsoft/CCF/actions/runs/25160593167/job/73753717210

```
++ awk '/^cpu family/{f=$NF} /^model\t/{m=$NF} /^stepping/{s=$NF; printf "%02x%02x%02x",f,m,s; exit}' /proc/cpuinfo
/__w/_temp/4be445c7-1a83-486c-9489-13c415051904.sh: line 6: awk: command not found
...
Error: Process completed with exit code 127.
```

If we install dependencies first, we should get `awk` from `build-essential`.