### PR TITLE
Fix early exit of /log/public/historical/range when there are empty pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- logging app now correctly sets @nextLink across empty pages (#7869)
+- Fix early exit of /log/public/historical/range when there are empty pages (#7869)
 
 ## [7.0.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgraded QuickJS from 2024-01-13 to 2025-09-13 (#7849).
 - On a joiner's first attempt, the primary now requires the joiner's startup seqno to be at least as recent as the primary's latest committed snapshot on disk, preventing snapshot-less joiners from replaying the entire ledger (#7844).
 
+### Fixed
+
+- logging app now correctly sets @nextLink across empty pages
+
 ## [7.0.2]
 
 [7.0.2]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fix early exit of /log/public/historical/range when there are empty pages (#7869)
+- Fix early exit of /log/public/historical/range when there are empty pages (#7869).
 
 ## [7.0.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- logging app now correctly sets @nextLink across empty pages
+- logging app now correctly sets @nextLink across empty pages (#7869)
 
 ## [7.0.2]
 

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -1914,6 +1914,9 @@ namespace loggingapp
             std::min(to_seqno, next_page_start + max_seqno_per_page);
           const auto next_seqnos = index_per_public_key->get_write_txs_in_range(
             id, next_page_start, next_range_end);
+
+          // if we know the next page has some interesting seqnos, begin
+          // fetching them
           if (next_seqnos.has_value() && !next_seqnos->empty())
           {
             const auto next_page_end = next_seqnos->back();
@@ -1924,19 +1927,14 @@ namespace loggingapp
               next_page_handle, next_page_start, next_page_end);
           }
 
-          // If we don't yet know the next seqnos, or know for sure there are
-          // some, then set a next_link
-          if (!next_seqnos.has_value() || !next_seqnos->empty())
-          {
-            // NB: This path tells the caller to continue to ask until the end
-            // of the range, even if the next response is paginated
-            response.next_link = fmt::format(
-              "/app{}?from_seqno={}&to_seqno={}&id={}",
-              get_historical_range_path,
-              next_page_start,
-              to_seqno,
-              id);
-          }
+          // NB: This path tells the caller to continue to ask until the end
+          // of the range, even if the next response is paginated
+          response.next_link = fmt::format(
+            "/app{}?from_seqno={}&to_seqno={}&id={}",
+            get_historical_range_path,
+            next_page_start,
+            to_seqno,
+            id);
         }
 
         // Construct the HTTP response


### PR DESCRIPTION
When we reduced the logging page size in a recent test we had a failure where the range query did not turn up the entry.

This is because if there is is an empty page (not the first page), then the range query would exit early rather than directing the client to continue iterating past it.

One possible optimisation here is that the @nextLink could skip across that empty page, but this version is obviously correct, if slightly inefficient.

This was tested using a reduced page size of 10, and submitting 10 txs and their signatures. with an 11th tx which we then queried for.