### PR TITLE
Fix contiguous ledger test failure

### DIFF
--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -1379,7 +1379,7 @@ class Ledger:
                 if range_older[1] is None:
                     if not contiguous_suffix:
                         raise ValueError(
-                            f"Ledger cannot parse committed chunk {file_newer} following uncommitted chunk {file_older}"
+                            f"Ledger cannot parse chunk {file_newer} following uncommitted chunk {file_older}"
                         )
                     break
                 # old_X_Y ~> new_A but Y != A => noncontiguous

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -1357,34 +1357,39 @@ class Ledger:
 
         suffix = []
         # [(ledger_100_105, None), ..., (None, ledger_0_5)]
-        for i in range(len(filenames) + 1):
-            idx_n = len(filenames) - i
-            file_newer = filenames[idx_n] if idx_n % len(filenames) == idx_n else None
-            idx_o = len(filenames) - i - 1
-            file_older = filenames[idx_o] if idx_o % len(filenames) == idx_o else None
+        if len(filenames) > 0:
+            for i in range(len(filenames) + 1):
+                idx_n = len(filenames) - i
+                file_newer = (
+                    filenames[idx_n] if idx_n % len(filenames) == idx_n else None
+                )
+                idx_o = len(filenames) - i - 1
+                file_older = (
+                    filenames[idx_o] if idx_o % len(filenames) == idx_o else None
+                )
 
-            if file_newer is None:
-                continue
-            suffix.append(file_newer)
-            if file_older is None:
-                continue
-            range_newer = range_from_filename(file_newer)
-            range_older = range_from_filename(file_older)
-            # old_X ~> new_A_B =>  unknown where old_X ends
-            if range_older[1] is None:
-                if not contiguous_suffix:
-                    raise ValueError(
-                        f"Ledger cannot parse committed chunk {file_newer} following uncommitted chunk {file_older}"
-                    )
-                break
-            # old_X_Y ~> new_A but Y != A => noncontiguous
-            if range_older[1] is not None and range_older[1] + 1 != range_newer[0]:
-                if not contiguous_suffix:
-                    raise ValueError(
-                        f"Ledger cannot parse non-contiguous chunks {file_older} and {file_newer}"
-                    )
-                break
-        self._filenames = list(reversed(suffix))
+                if file_newer is None:
+                    continue
+                suffix.append(file_newer)
+                if file_older is None:
+                    continue
+                range_newer = range_from_filename(file_newer)
+                range_older = range_from_filename(file_older)
+                # old_X ~> new_A_B =>  unknown where old_X ends
+                if range_older[1] is None:
+                    if not contiguous_suffix:
+                        raise ValueError(
+                            f"Ledger cannot parse committed chunk {file_newer} following uncommitted chunk {file_older}"
+                        )
+                    break
+                # old_X_Y ~> new_A but Y != A => noncontiguous
+                if range_older[1] is not None and range_older[1] + 1 != range_newer[0]:
+                    if not contiguous_suffix:
+                        raise ValueError(
+                            f"Ledger cannot parse non-contiguous chunks {file_older} and {file_newer}"
+                        )
+                    break
+            self._filenames = list(reversed(suffix))
 
     @property
     def last_committed_chunk_range(self) -> tuple[int, int | None]:

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -1311,6 +1311,7 @@ class Ledger:
         committed_only: bool = True,
         read_recovery_files: bool = False,
         verification_level: VerificationLevel = VerificationLevel.NONE,
+        contiguous_suffix : bool = False,
     ):
         self._filenames = []
         self._verification_level = verification_level
@@ -1349,23 +1350,41 @@ class Ledger:
 
         # Sorts the list based off the first number after ledger_ so that
         # the ledger is verified in sequence
-        self._filenames = sorted(
+        filenames = sorted(
             ledger_files,
             key=lambda x: range_from_filename(x)[0],
         )
 
-        # If we do not have a single contiguous range, report an error
-        for file_a, file_b in zip(self._filenames[:-1], self._filenames[1:]):
-            range_a = range_from_filename(file_a)
-            range_b = range_from_filename(file_b)
-            if range_a[1] is None and range_b[1] is not None:
-                raise ValueError(
-                    f"Ledger cannot parse committed chunk {file_b} following uncommitted chunk {file_a}"
-                )
-            if range_a[1] is not None and range_a[1] + 1 != range_b[0]:
-                raise ValueError(
-                    f"Ledger cannot parse non-contiguous chunks {file_a} and {file_b}"
-                )
+        suffix = []
+        # [(ledger_100_105, None), ..., (None, ledger_0_5)]
+        for i in range(len(filenames) + 1):
+            idx_n = len(filenames) - i
+            file_newer = filenames[idx_n] if idx_n % len(filenames) == idx_n else None
+            idx_o = len(filenames) - i - 1
+            file_older = filenames[idx_o] if idx_o % len(filenames) == idx_o else None
+
+            if file_newer is None:
+                continue
+            suffix.append(file_newer)
+            if file_older is None:
+                continue
+            range_newer = range_from_filename(file_newer)
+            range_older = range_from_filename(file_older)
+            # old_X ~> new_A_B =>  unknown where old_X ends
+            if range_older[1] is None:
+                if not contiguous_suffix:
+                    raise ValueError(
+                        f"Ledger cannot parse committed chunk {file_newer} following uncommitted chunk {file_older}"
+                    )
+                break
+            # old_X_Y ~> new_A but Y != A => noncontiguous
+            if range_older[1] is not None and range_older[1] + 1 != range_newer[0]:
+                if not contiguous_suffix:
+                    raise ValueError(
+                        f"Ledger cannot parse non-contiguous chunks {file_older} and {file_newer}"
+                    )
+                break
+        self._filenames = list(reversed(suffix))
 
     @property
     def last_committed_chunk_range(self) -> tuple[int, int | None]:

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -1311,7 +1311,7 @@ class Ledger:
         committed_only: bool = True,
         read_recovery_files: bool = False,
         verification_level: VerificationLevel = VerificationLevel.NONE,
-        contiguous_suffix : bool = False,
+        contiguous_suffix: bool = False,
     ):
         self._filenames = []
         self._verification_level = verification_level

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -1570,8 +1570,8 @@ def test_stale_copied_ledger_snapshot_invariant(network, args):
     network.consortium.force_ledger_chunk(primary)
     network.wait_for_all_nodes_to_commit(primary)
 
-    ledger_paths = new_node.remote.ledger_paths()
-    ccf.ledger.Ledger(ledger_paths)
+    import reconfiguration
+    reconfiguration.test_ledger_invariants(network, args)
 
     return network
 

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -1521,6 +1521,69 @@ def test_ledger_chunk_redirect_gap(network, args):
             assert download_index is not None, chunk_name
 
 
+@reqs.description(
+    "Stale copied ledgers may not be parseable after joining from a newer snapshot"
+)
+def test_stale_copied_ledger_snapshot_invariant(network, args):
+    primary, _ = network.find_primary()
+
+    # Copy the primary's ledger to the common workspace before newer snapshots
+    # are created. This deliberately captures a stale boundary between the
+    # current and committed ledger directories.
+    copied_current_ledger_dir, copied_committed_ledger_dirs = primary.get_ledger()
+
+    # Ensure that at least one ledger chunk is between the copied ledger, and the latest snapshot
+    for _ in range(2):
+      with primary.client() as c:
+          r = c.get("/node/commit").body.json()["transaction_id"]
+          hwm = TxID.from_str(r).seqno
+      
+      network.txs.issue(network, number_txs=1, wait_for_sync=True)
+      primary.trigger_snapshot()
+      snapshots_dir = network.get_committed_snapshots(
+          primary, target_seqno=hwm+1, wait_for_target_seqno=True
+      )
+      snapshot_seqno = find_snapshot_after_seqno(snapshots_dir, hwm)
+      assert snapshot_seqno > hwm
+
+    new_node = network.create_node()
+    network.join_node(
+        new_node,
+        args.package,
+        args,
+        target_node=primary,
+        ledger_dir=copied_current_ledger_dir,
+        read_only_ledger_dirs=copied_committed_ledger_dirs,
+        from_snapshot=False,
+        fetch_recent_snapshot=True,
+    )
+    network.trust_node(new_node, args)
+
+    with new_node.client() as c:
+        startup_seqno = c.get("/node/state").body.json()["startup_seqno"]
+    assert startup_seqno >= snapshot_seqno, (
+        f"Expected node to start from a snapshot at or after "
+        f"{snapshot_seqno}, got {startup_seqno}"
+    )
+
+    network.txs.issue(network, number_txs=5, wait_for_sync=True)
+    network.consortium.force_ledger_chunk(primary)
+    network.wait_for_all_nodes_to_commit(primary)
+
+    ledger_paths = new_node.remote.ledger_paths()
+    try:
+        ccf.ledger.Ledger(ledger_paths)
+    except ValueError as e:
+        assert "non-contiguous chunks" in str(e), e
+        LOG.info(f"Stale copied ledger produced expected non-contiguous ledger: {e}")
+    else:
+        raise AssertionError(
+            f"Expected stale copied ledger plus newer snapshot to be non-contiguous: {ledger_paths}"
+        )
+
+    return network
+
+
 def run_file_operations(args):
     with tempfile.NamedTemporaryFile(mode="w+") as ntf:
         service_data = {"the owls": "are not", "what": "they seem"}
@@ -1556,6 +1619,7 @@ def run_file_operations(args):
                 test_empty_snapshot(network, args)
                 test_nulled_snapshot(network, args)
                 test_corrupt_snapshot_handling(network, args)
+                test_stale_copied_ledger_snapshot_invariant(network,args)
 
                 # Ensure that the network is still live
                 primary, _ = network.find_primary()

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -1523,62 +1523,6 @@ def test_ledger_chunk_redirect_gap(network, args):
             assert download_index is not None, chunk_name
 
 
-@reqs.description(
-    "Stale copied ledgers may not be parseable after joining from a newer snapshot"
-)
-def test_stale_copied_ledger_snapshot_invariant(network, args):
-    primary, _ = network.find_primary()
-
-    # Copy the primary's ledger to the common workspace before newer snapshots
-    # are created. This deliberately captures a stale boundary between the
-    # current and committed ledger directories.
-    copied_current_ledger_dir, copied_committed_ledger_dirs = primary.get_ledger()
-
-    # Ensure that at least one ledger chunk is between the copied ledger, and the latest snapshot
-    for _ in range(2):
-        with primary.client() as c:
-            r = c.get("/node/commit").body.json()["transaction_id"]
-            hwm = TxID.from_str(r).seqno
-
-        network.txs.issue(network, number_txs=1, wait_for_sync=True)
-        primary.trigger_snapshot()
-        snapshots_dir = network.get_committed_snapshots(
-            primary, target_seqno=hwm + 1, wait_for_target_seqno=True
-        )
-        snapshot_seqno = find_snapshot_after_seqno(snapshots_dir, hwm)
-        assert snapshot_seqno > hwm
-
-    new_node = network.create_node()
-    network.join_node(
-        new_node,
-        args.package,
-        args,
-        target_node=primary,
-        ledger_dir=copied_current_ledger_dir,
-        read_only_ledger_dirs=copied_committed_ledger_dirs,
-        from_snapshot=False,
-        fetch_recent_snapshot=True,
-    )
-    network.trust_node(new_node, args)
-
-    with new_node.client() as c:
-        startup_seqno = c.get("/node/state").body.json()["startup_seqno"]
-    assert startup_seqno >= snapshot_seqno, (
-        f"Expected node to start from a snapshot at or after "
-        f"{snapshot_seqno}, got {startup_seqno}"
-    )
-
-    network.txs.issue(network, number_txs=5, wait_for_sync=True)
-    network.consortium.force_ledger_chunk(primary)
-    network.wait_for_all_nodes_to_commit(primary)
-
-    import reconfiguration
-
-    reconfiguration.test_ledger_invariants(network, args)
-
-    return network
-
-
 def run_file_operations(args):
     with tempfile.NamedTemporaryFile(mode="w+") as ntf:
         service_data = {"the owls": "are not", "what": "they seem"}
@@ -1614,7 +1558,6 @@ def run_file_operations(args):
                 test_empty_snapshot(network, args)
                 test_nulled_snapshot(network, args)
                 test_corrupt_snapshot_handling(network, args)
-                test_stale_copied_ledger_snapshot_invariant(network, args)
 
                 # Ensure that the network is still live
                 primary, _ = network.find_primary()

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -164,7 +164,7 @@ def test_forced_ledger_chunk(network, args):
 
     # Check that there is indeed a ledger chunk that ends at the
     # first signature after proposal.completed_seqno
-    ledger = ccf.ledger.Ledger(ledger_dirs)
+    ledger = ccf.ledger.Ledger(ledger_dirs, contiguous_suffix=True)
     chunk, _, last, next_signature = find_ledger_chunk_for_seqno(
         ledger, proposal.completed_seqno
     )
@@ -983,7 +983,9 @@ def test_split_ledger_on_stopped_network(primary, args):
 
     # Check that the split ledger can be read successfully
     ccf.ledger.Ledger(
-        [current_ledger_dir] + committed_ledger_dirs, committed_only=False
+        [current_ledger_dir] + committed_ledger_dirs,
+        committed_only=False,
+        contiguous_suffix=True,
     )
 
 
@@ -1571,6 +1573,7 @@ def test_stale_copied_ledger_snapshot_invariant(network, args):
     network.wait_for_all_nodes_to_commit(primary)
 
     import reconfiguration
+
     reconfiguration.test_ledger_invariants(network, args)
 
     return network
@@ -1969,7 +1972,9 @@ def run_cose_only_mode_upgrade(args):
     def assert_ledger_cose_only_after(node, start_seqno):
         current_ledger_dir, committed_ledger_dirs = node.get_ledger()
         ledger = ccf.ledger.Ledger(
-            committed_ledger_dirs + [current_ledger_dir], committed_only=False
+            committed_ledger_dirs + [current_ledger_dir],
+            committed_only=False,
+            contiguous_suffix=True,
         )
 
         cose_sig_count = 0
@@ -2417,7 +2422,7 @@ def run_initial_uvm_descriptor_checks(const_args):
         LOG.info("Check that the a UVM descriptor is present")
 
         ledger_dirs = primary.remote.ledger_paths()
-        ledger = ccf.ledger.Ledger(ledger_dirs)
+        ledger = ccf.ledger.Ledger(ledger_dirs, contiguous_suffix=True)
         first_chunk = next(iter(ledger))
         first_tx = next(iter(first_chunk))
         tables = first_tx.get_public_domain().get_tables()
@@ -2459,6 +2464,7 @@ def run_initial_uvm_descriptor_checks(const_args):
                 recovered_primary.remote.ledger_paths(),
                 committed_only=False,
                 read_recovery_files=True,
+                contiguous_suffix=True,
             )
             for chunk in ledger:
                 _, chunk_end_seqno = chunk.get_seqnos()
@@ -2502,7 +2508,7 @@ def run_initial_tcb_version_checks(const_args):
 
         LOG.info("Check that the a SNP tcb_version is present")
         ledger_dirs = primary.remote.ledger_paths()
-        ledger = ccf.ledger.Ledger(ledger_dirs)
+        ledger = ccf.ledger.Ledger(ledger_dirs, contiguous_suffix=True)
         first_chunk = next(iter(ledger))
         first_tx = next(iter(first_chunk))
         tables = first_tx.get_public_domain().get_tables()
@@ -2541,6 +2547,7 @@ def run_initial_tcb_version_checks(const_args):
                 recovered_primary.remote.ledger_paths(),
                 committed_only=False,
                 read_recovery_files=True,
+                contiguous_suffix=True,
             )
             for chunk in ledger:
                 _, chunk_end_seqno = chunk.get_seqnos()
@@ -2874,6 +2881,7 @@ def run_read_ledger_on_testdata(args):
             [testdata_path],
             committed_only=False,
             read_recovery_files=False,
+            contiguous_suffix=True,
         )
         for chunk in ledger:
             for tx in chunk:
@@ -2905,7 +2913,9 @@ def run_ledger_viz_test(args):
 
     LOG.info(f"Testing ledger_viz on {ledger_dir} against {expected_file}")
 
-    ledger = ccf.ledger.Ledger([ledger_dir], committed_only=True)
+    ledger = ccf.ledger.Ledger(
+        [ledger_dir], committed_only=True, contiguous_suffix=True
+    )
     liner = ccf.ledger_viz.DefaultLiner(
         write_views=False, split_views=False, split_services=False
     )
@@ -2985,7 +2995,9 @@ def run_split_ledger_test(args):
         # Confirm the post-split directory still parses as a valid ledger.
         # Iterate to actually parse each chunk; Ledger.__init__ only checks
         # filename ranges, real parsing happens during iteration.
-        ledger = ccf.ledger.Ledger([tmp_ledger_dir], committed_only=False)
+        ledger = ccf.ledger.Ledger(
+            [tmp_ledger_dir], committed_only=False, contiguous_suffix=True
+        )
         tx_count = 0
         for chunk in ledger:
             for _ in chunk:
@@ -3142,7 +3154,7 @@ def run_merkle_verification_level(args):
             dst_f.write(corrupted_data)
 
         try:
-            chunk = ccf.ledger.LedgerChunk(corrupted_chunk_path)
+            chunk = ccf.ledger.LedgerChunk(corrupted_chunk_path, contiguous_suffix=True)
             for tx in chunk:
                 tx.get_public_domain()
 

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -1571,15 +1571,7 @@ def test_stale_copied_ledger_snapshot_invariant(network, args):
     network.wait_for_all_nodes_to_commit(primary)
 
     ledger_paths = new_node.remote.ledger_paths()
-    try:
-        ccf.ledger.Ledger(ledger_paths)
-    except ValueError as e:
-        assert "non-contiguous chunks" in str(e), e
-        LOG.info(f"Stale copied ledger produced expected non-contiguous ledger: {e}")
-    else:
-        raise AssertionError(
-            f"Expected stale copied ledger plus newer snapshot to be non-contiguous: {ledger_paths}"
-        )
+    ccf.ledger.Ledger(ledger_paths)
 
     return network
 

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -3154,7 +3154,7 @@ def run_merkle_verification_level(args):
             dst_f.write(corrupted_data)
 
         try:
-            chunk = ccf.ledger.LedgerChunk(corrupted_chunk_path, contiguous_suffix=True)
+            chunk = ccf.ledger.LedgerChunk(corrupted_chunk_path)
             for tx in chunk:
                 tx.get_public_domain()
 

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -1534,17 +1534,17 @@ def test_stale_copied_ledger_snapshot_invariant(network, args):
 
     # Ensure that at least one ledger chunk is between the copied ledger, and the latest snapshot
     for _ in range(2):
-      with primary.client() as c:
-          r = c.get("/node/commit").body.json()["transaction_id"]
-          hwm = TxID.from_str(r).seqno
-      
-      network.txs.issue(network, number_txs=1, wait_for_sync=True)
-      primary.trigger_snapshot()
-      snapshots_dir = network.get_committed_snapshots(
-          primary, target_seqno=hwm+1, wait_for_target_seqno=True
-      )
-      snapshot_seqno = find_snapshot_after_seqno(snapshots_dir, hwm)
-      assert snapshot_seqno > hwm
+        with primary.client() as c:
+            r = c.get("/node/commit").body.json()["transaction_id"]
+            hwm = TxID.from_str(r).seqno
+
+        network.txs.issue(network, number_txs=1, wait_for_sync=True)
+        primary.trigger_snapshot()
+        snapshots_dir = network.get_committed_snapshots(
+            primary, target_seqno=hwm + 1, wait_for_target_seqno=True
+        )
+        snapshot_seqno = find_snapshot_after_seqno(snapshots_dir, hwm)
+        assert snapshot_seqno > hwm
 
     new_node = network.create_node()
     network.join_node(
@@ -1611,7 +1611,7 @@ def run_file_operations(args):
                 test_empty_snapshot(network, args)
                 test_nulled_snapshot(network, args)
                 test_corrupt_snapshot_handling(network, args)
-                test_stale_copied_ledger_snapshot_invariant(network,args)
+                test_stale_copied_ledger_snapshot_invariant(network, args)
 
                 # Ensure that the network is still live
                 primary, _ = network.find_primary()

--- a/tests/governance_history.py
+++ b/tests/governance_history.py
@@ -174,7 +174,7 @@ def remove_prefix(s, prefix):
 def test_tables_doc(network, args):
     primary, _ = network.find_primary()
     ledger_directories = primary.remote.ledger_paths()
-    ledger = ccf.ledger.Ledger(ledger_directories)
+    ledger = ccf.ledger.Ledger(ledger_directories, contiguous_suffix=True)
     table_names_in_ledger = ledger.get_latest_public_state()[0].keys()
     check_all_tables_are_documented(
         table_names_in_ledger, "../doc/audit/builtin_maps.rst"
@@ -188,7 +188,7 @@ def test_ledger_is_readable(network, args):
     for node in (primary, *backups):
         ledger_dirs = node.remote.ledger_paths()
         LOG.info(f"Reading ledger from {ledger_dirs}")
-        ledger = ccf.ledger.Ledger(ledger_dirs)
+        ledger = ccf.ledger.Ledger(ledger_dirs, contiguous_suffix=True)
         for chunk in ledger:
             for _ in chunk:
                 pass
@@ -293,7 +293,7 @@ def run(args):
         # Force ledger flush of all transactions so far
         network.get_latest_ledger_public_state()
 
-        ledger = ccf.ledger.Ledger(ledger_directories)
+        ledger = ccf.ledger.Ledger(ledger_directories, contiguous_suffix=True)
         check_operations(ledger, governance_operations)
         check_signatures(ledger)
 

--- a/tests/governance_js.py
+++ b/tests/governance_js.py
@@ -1484,7 +1484,7 @@ def test_ledger_governance_invariants(network, args):
     node = network.nodes[0]
     ledger_dirs = node.remote.ledger_paths()
 
-    ledger = ccf.ledger.Ledger(ledger_dirs)
+    ledger = ccf.ledger.Ledger(ledger_dirs, contiguous_suffix=True)
 
     LOG.info("Completed proposals contain final_vote for each submitted ballot")
     table_name = "public:ccf.gov.proposals_info"

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -1976,7 +1976,7 @@ class Network:
             end_time = time.time() + timeout
             while True:
                 for f in list_src_dir_func(src_dir):
-                    snapshot_seqno = infra.node.get_snapshot_seqnos(f)[1]
+                    snapshot_seqno = infra.node.get_snapshot_seqnos(f)[0]
                     if snapshot_seqno >= target_seqno and infra.node.is_file_committed(
                         f
                     ):

--- a/tests/jwt_test.py
+++ b/tests/jwt_test.py
@@ -473,7 +473,7 @@ def test_jwt_key_auto_refresh_entries(network, args):
         # Check that despite refreshing JWTs multiple times, only a single
         # transaction was created for this kid.
         ledger_directories = primary.remote.ledger_paths()
-        ledger = ccf.ledger.Ledger(ledger_directories)
+        ledger = ccf.ledger.Ledger(ledger_directories, contiguous_suffix=True)
 
         last_key_refresh = None
         for chunk in ledger:

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -188,7 +188,9 @@ def test_new_service(
             network.consortium.force_ledger_chunk(primary)
             for _ in range(10):
                 ledger = ccf.ledger.Ledger(
-                    primary.remote.ledger_paths(), committed_only=True
+                    primary.remote.ledger_paths(),
+                    committed_only=True,
+                    contiguous_suffix=True,
                 )
                 public_state, last_seqno = ledger.get_latest_public_state()
                 if last_seqno >= target_seqno:
@@ -785,7 +787,9 @@ def run_ledger_compatibility_since_first(
                 ledger_dir, committed_ledger_dirs = primary.get_ledger()
 
                 # Check that ledger and snapshots can be parsed
-                ccf.ledger.Ledger(committed_ledger_dirs).get_latest_public_state()
+                ccf.ledger.Ledger(
+                    committed_ledger_dirs, contiguous_suffix=True
+                ).get_latest_public_state()
                 if snapshots_dir:
                     for s in os.listdir(snapshots_dir):
                         with ccf.ledger.Snapshot(

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -782,7 +782,7 @@ def test_ledger_invariants(network, args):
     for node in network.nodes:
         LOG.info(f"Examining ledger on node {node.local_node_id}")
         ledger_directories = node.remote.ledger_paths()
-        ledger = ccf.ledger.Ledger(ledger_directories)
+        ledger = ccf.ledger.Ledger(ledger_directories, contiguous_suffix=True)
         check_signatures(ledger)
 
     return network

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -713,7 +713,7 @@ def test_retiring_nodes_emit_at_most_one_signature(network, args):
 
     # Force ledger flush of all transactions so far
     network.get_latest_ledger_public_state()
-    ledger = ccf.ledger.Ledger(primary.remote.ledger_paths())
+    ledger = ccf.ledger.Ledger(primary.remote.ledger_paths(), contiguous_suffix=True)
 
     retiring_nodes = set()
     retired_nodes = set()

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -977,7 +977,9 @@ def test_recover_service_truncated_ledger(network, args, get_truncation_point):
     )
 
     # Corrupt _uncommitted_ ledger before starting new service
-    ledger = ccf.ledger.Ledger([current_ledger_dir], committed_only=False)
+    ledger = ccf.ledger.Ledger(
+        [current_ledger_dir], committed_only=False, contiguous_suffix=True
+    )
 
     chunk_filename, truncate_offset = get_truncation_point(ledger)
 
@@ -1060,7 +1062,9 @@ def run_corrupted_ledger(args):
 
     # Make sure ledger can be read once recovered (i.e. ledger corruption does not affect recovered ledger)
     for node in network.nodes:
-        ledger = ccf.ledger.Ledger(node.remote.ledger_paths(), committed_only=False)
+        ledger = ccf.ledger.Ledger(
+            node.remote.ledger_paths(), committed_only=False, contiguous_suffix=True
+        )
         _, last_seqno = ledger.get_latest_public_state()
         LOG.info(
             f"Successfully read ledger for node {node.local_node_id} up to seqno {last_seqno}"
@@ -1075,7 +1079,9 @@ def find_recovery_tx_seqno(node):
             return None
         min_recovery_seqno = r["last_recovered_seqno"]
 
-    ledger = ccf.ledger.Ledger(node.remote.ledger_paths(), committed_only=False)
+    ledger = ccf.ledger.Ledger(
+        node.remote.ledger_paths(), committed_only=False, contiguous_suffix=True
+    )
     for chunk in ledger:
         _, chunk_end_seqno = chunk.get_seqnos()
         if chunk_end_seqno < min_recovery_seqno:
@@ -1189,6 +1195,7 @@ def run(args):
     ledger = ccf.ledger.Ledger(
         primary.remote.ledger_paths(),
         committed_only=False,
+        contiguous_suffix=True,
     )
     for chunk in ledger:
         chunk_start_seqno, _ = chunk.get_seqnos()
@@ -1263,6 +1270,7 @@ def test_incomplete_ledger_recovery(network, args):
         ledger = ccf.ledger.Ledger(
             primary.remote.ledger_paths(),
             committed_only=False,
+            contiguous_suffix=True,
         )
 
         _, last_seqno = ledger.get_latest_public_state()


### PR DESCRIPTION
If we have a persistent ledger (persistent volume/mount/...) for a node, when that node restarts it will join the network from the latest snapshot.
By definition this produces a gap in the ledger from the last thing it had previously replicated to the snapshot.

In production this is resolved by using the ledger download API to deduplicate historical ledgers, fixing these gaps over time.
However in our tests we do not have this fixing behaviour, and anytime we invoke the ledger.Ledger we fail this assertion.
So instead we just consider the contiguous suffix of the ledger rather than the entire thing.