### PR TITLE
Fix get_committed_snapshots

### DIFF
--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -1976,7 +1976,7 @@ class Network:
             end_time = time.time() + timeout
             while True:
                 for f in list_src_dir_func(src_dir):
-                    snapshot_seqno = infra.node.get_snapshot_seqnos(f)[1]
+                    snapshot_seqno = infra.node.get_snapshot_seqnos(f)[0]
                     if snapshot_seqno >= target_seqno and infra.node.is_file_committed(
                         f
                     ):


### PR DESCRIPTION
get_committed_snapshots with target_seqno should be done off of seqn not evidence_seqno

To clarify: snapshot_5_6 is the snapshot of seqno 5, with evidence at 6.
So get_committed_snapshots should be based off of 5 not 6.