### PR TITLE
Recovery and Join snapshot ledger offset fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed recovery and node joins from a snapshot when the local ledger ends at or before the snapshot seqno, so subsequent recovery writes resume from the snapshot boundary (#7901).
+- Nodes started in recovery or join mode from a snapshot more recent than the latest ledger file now correctly resume writing from the snapshot boundary (#7901).
 
 ## [7.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - JSON parsing can now reject inputs whose object/array nesting depth exceeds a certain value, defaulting to 64 levels and overridable per call site via `ccf::parse_json_safe`'s `max_depth` parameter (#7896).
 
+### Fixed
+
+- Fixed recovery and node joins from a snapshot when the local ledger ends at or before the snapshot seqno, so subsequent recovery writes resume from the snapshot boundary (#7901).
+
 ## [7.0.3]
 
 [7.0.3]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.3

--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -1520,16 +1520,19 @@ namespace asynchost
         return;
       }
 
-      // During recovery, a snapshot can be after the current end of the host ledger.
-      // Regular truncation requires that the truncation index is within the ledger and otherwise skips the truncation.
-      // This is a special case to handle the recovery forward truncation
+      // During recovery, a snapshot can be after the current end of the host
+      // ledger. Regular truncation requires that the truncation index is within
+      // the ledger and otherwise skips the truncation. This is a special case
+      // to handle the recovery forward truncation
       if (recovery_mode && idx >= last_idx)
       {
-        // Close any open files as the ledger should restart cleanly from a new chunk.
+        // Close any open files as the ledger should restart cleanly from a new
+        // chunk.
         files.clear();
         // Don't use any of the files on disk for writing
         use_existing_files = false;
-        // Set last_idx to the recovery idx, which may be past the current end of the ledger
+        // Set last_idx to the recovery idx, which may be past the current end
+        // of the ledger
         last_idx = idx;
         return;
       }

--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -1520,19 +1520,16 @@ namespace asynchost
         return;
       }
 
-      // During recovery, a snapshot can be at or after the current end of the
-      // host ledger. Establish the recovered snapshot boundary without running
-      // the file-level truncation path, which assumes the target index exists
-      // in the local ledger.
+      // During recovery, a snapshot can be after the current end of the host ledger.
+      // Regular truncation requires that the truncation index is within the ledger and otherwise skips the truncation.
+      // This is a special case to handle the recovery forward truncation
       if (recovery_mode && idx >= last_idx)
       {
-        auto file = get_latest_file();
-        if (file != nullptr)
-        {
-          file->complete();
-        }
+        // Close any open files as the ledger should restart cleanly from a new chunk.
+        files.clear();
+        // Don't use any of the files on disk for writing
         use_existing_files = false;
-        last_idx_on_init.reset();
+        // Set last_idx to the recovery idx, which may be past the current end of the ledger
         last_idx = idx;
         return;
       }

--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -1528,9 +1528,14 @@ namespace asynchost
       {
         // Close any open files as the ledger should restart cleanly from a new
         // chunk.
-        files.clear();
+        auto file = get_latest_file();
+        if (file != nullptr)
+        {
+          file->complete();
+        }
         // Don't use any of the files on disk for writing
         use_existing_files = false;
+        last_idx_on_init.reset();
         // Set last_idx to the recovery idx, which may be past the current end
         // of the ledger
         last_idx = idx;

--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -902,17 +902,9 @@ namespace asynchost
             return idx >= f->get_start_idx();
           });
 
-        if (f != files.rend())
+        if (f != files.rend() && idx <= (*f)->get_last_idx())
         {
-          if (idx <= (*f)->get_last_idx())
-          {
-            return *f;
-          }
-          
-          LOG_INFO_FMT(
-            "File {} open for writing but prev-check would accept idx {}",
-            (*f)->get_last_idx(),
-            idx);
+          return *f;
         }
       }
 

--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -902,7 +902,7 @@ namespace asynchost
             return idx >= f->get_start_idx();
           });
 
-        if (f != files.rend())
+        if (f != files.rend() && idx <= (*f)->get_last_idx())
         {
           return *f;
         }
@@ -1500,18 +1500,54 @@ namespace asynchost
       return last_idx;
     }
 
-    void truncate(size_t idx)
+    void truncate(size_t idx, bool recovery_mode = false)
     {
       TimeBoundLogger log_if_slow(fmt::format("Truncating ledger at {}", idx));
 
       std::unique_lock<ccf::pal::Mutex> guard(state_lock);
 
-      LOG_DEBUG_FMT("Ledger truncate: {}/{}", idx, last_idx);
+      LOG_DEBUG_FMT(
+        "Ledger truncate: {}/{} [recovery: {}]", idx, last_idx, recovery_mode);
 
-      // Conservative check to avoid truncating to future indices, or dropping
-      // committed entries. If the ledger is being initialised from a snapshot
-      // alone, the first truncation effectively sets the last index.
-      if (last_idx != 0 && (idx >= last_idx || idx < committed_idx))
+      // Conservative check to avoid dropping committed entries.
+      if (last_idx != 0 && idx < committed_idx)
+      {
+        LOG_DEBUG_FMT(
+          "Ignoring truncate to {} - last_idx: {}, committed_idx: {}",
+          idx,
+          last_idx,
+          committed_idx);
+        return;
+      }
+
+      // During recovery, a snapshot can be at or after the current end of the
+      // host ledger. Establish the recovered snapshot boundary without running
+      // the file-level truncation path, which assumes the target index exists
+      // in the local ledger.
+      if (recovery_mode && idx >= last_idx)
+      {
+        recovery_start_idx = idx;
+
+        if (idx > committed_idx)
+        {
+          committed_idx = idx;
+        }
+
+        auto file = get_latest_file();
+        if (file != nullptr)
+        {
+          file->complete();
+        }
+        use_existing_files = false;
+        last_idx_on_init.reset();
+        last_idx = idx;
+        return;
+      }
+
+      // Conservative check to avoid truncating to future indices. If the
+      // ledger is being initialised from a snapshot alone, the first truncation
+      // effectively sets the last index.
+      if (last_idx != 0 && idx >= last_idx)
       {
         LOG_DEBUG_FMT(
           "Ignoring truncate to {} - last_idx: {}, committed_idx: {}",
@@ -1732,7 +1768,7 @@ namespace asynchost
         [this](const uint8_t* data, size_t size) {
           auto idx = serialized::read<::consensus::Index>(data, size);
           auto recovery_mode = serialized::read<bool>(data, size);
-          truncate(idx);
+          truncate(idx, recovery_mode);
           if (recovery_mode)
           {
             set_recovery_start_idx(idx);

--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -902,9 +902,17 @@ namespace asynchost
             return idx >= f->get_start_idx();
           });
 
-        if (f != files.rend() && idx <= (*f)->get_last_idx())
+        if (f != files.rend())
         {
-          return *f;
+          if (idx <= (*f)->get_last_idx())
+          {
+            return *f;
+          }
+          
+          LOG_INFO_FMT(
+            "File {} open for writing but prev-check would accept idx {}",
+            (*f)->get_last_idx(),
+            idx);
         }
       }
 

--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -1526,8 +1526,6 @@ namespace asynchost
       // in the local ledger.
       if (recovery_mode && idx >= last_idx)
       {
-        recovery_start_idx = idx;
-
         auto file = get_latest_file();
         if (file != nullptr)
         {

--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -1528,11 +1528,6 @@ namespace asynchost
       {
         recovery_start_idx = idx;
 
-        if (idx > committed_idx)
-        {
-          committed_idx = idx;
-        }
-
         auto file = get_latest_file();
         if (file != nullptr)
         {

--- a/src/host/test/ledger.cpp
+++ b/src/host/test/ledger.cpp
@@ -1736,6 +1736,108 @@ TEST_CASE("Recovery")
   size_t chunk_threshold = 30;
   size_t entries_per_chunk = get_entries_per_chunk(chunk_threshold);
 
+  SUBCASE("Future non-recovery truncate remains a no-op")
+  {
+    Ledger ledger(ledger_dir, wf);
+    TestEntrySubmitter entry_submitter(ledger, chunk_threshold);
+
+    entry_submitter.write(true);
+    const auto last_idx = ledger.get_last_idx();
+
+    ledger.truncate(last_idx + 4);
+    REQUIRE(ledger.get_last_idx() == last_idx);
+
+    entry_submitter.write(true);
+    REQUIRE(ledger.get_last_idx() == last_idx + 1);
+    REQUIRE(number_of_recovery_files_in_ledger_dir() == 0);
+  }
+
+  SUBCASE("Recovery truncate beyond ledger end positions recovery writes")
+  {
+    Ledger ledger(ledger_dir, wf);
+    TestEntrySubmitter entry_submitter(ledger, chunk_threshold);
+
+    entry_submitter.write(true);
+    const auto recovery_idx = ledger.get_last_idx() + 4;
+
+    ledger.truncate(recovery_idx, true);
+    REQUIRE(ledger.get_last_idx() == recovery_idx);
+
+    TestEntrySubmitter recovery_submitter(
+      ledger, chunk_threshold, recovery_idx);
+    recovery_submitter.write(true);
+
+    REQUIRE(ledger.get_last_idx() == recovery_idx + 1);
+    REQUIRE(number_of_recovery_files_in_ledger_dir() == 1);
+    read_entry_from_ledger(ledger, recovery_idx + 1);
+  }
+
+  SUBCASE("Recovery truncate beyond empty ledger end positions recovery writes")
+  {
+    Ledger ledger(ledger_dir, wf);
+    const auto recovery_idx = 5;
+
+    ledger.truncate(recovery_idx, true);
+    REQUIRE(ledger.get_last_idx() == recovery_idx);
+
+    ledger.truncate(recovery_idx - 1);
+    REQUIRE(ledger.get_last_idx() == recovery_idx);
+
+    TestEntrySubmitter recovery_submitter(
+      ledger, chunk_threshold, recovery_idx);
+    recovery_submitter.write(true);
+
+    REQUIRE(ledger.get_last_idx() == recovery_idx + 1);
+    REQUIRE(number_of_recovery_files_in_ledger_dir() == 1);
+    read_entry_from_ledger(ledger, recovery_idx + 1);
+  }
+
+  SUBCASE("Recovery truncate at ledger end positions recovery writes")
+  {
+    Ledger ledger(ledger_dir, wf);
+    TestEntrySubmitter entry_submitter(ledger, chunk_threshold);
+
+    entry_submitter.write(true);
+    const auto recovery_idx = ledger.get_last_idx();
+
+    ledger.truncate(recovery_idx, true);
+    REQUIRE(ledger.get_last_idx() == recovery_idx);
+    read_entry_from_ledger(ledger, recovery_idx);
+
+    entry_submitter.write(true);
+
+    REQUIRE(ledger.get_last_idx() == recovery_idx + 1);
+    REQUIRE(number_of_recovery_files_in_ledger_dir() == 1);
+    read_entry_from_ledger(ledger, recovery_idx + 1);
+  }
+
+  SUBCASE("Recovery truncate inside ledger positions recovery writes")
+  {
+    Ledger ledger(ledger_dir, wf);
+    TestEntrySubmitter entry_submitter(ledger, chunk_threshold);
+
+    for (size_t i = 0; i < 5; ++i)
+    {
+      entry_submitter.write(true);
+    }
+
+    const auto recovery_idx = ledger.get_last_idx() - 2;
+    ledger.truncate(recovery_idx, true);
+    REQUIRE(ledger.get_last_idx() == recovery_idx);
+
+    ledger.truncate(recovery_idx - 1);
+    REQUIRE(ledger.get_last_idx() == recovery_idx);
+    read_entry_from_ledger(ledger, recovery_idx);
+
+    TestEntrySubmitter recovery_submitter(
+      ledger, chunk_threshold, recovery_idx);
+    recovery_submitter.write(true);
+
+    REQUIRE(ledger.get_last_idx() == recovery_idx + 1);
+    REQUIRE(number_of_recovery_files_in_ledger_dir() == 1);
+    read_entry_from_ledger(ledger, recovery_idx + 1);
+  }
+
   SUBCASE("Enable and complete recovery")
   {
     Ledger ledger(ledger_dir, wf);

--- a/src/host/test/ledger.cpp
+++ b/src/host/test/ledger.cpp
@@ -1787,8 +1787,7 @@ TEST_CASE("Recovery")
 
     TestEntrySubmitter replay_submitter(
       ledger, chunk_threshold, recovery_idx - 1);
-    replay_submitter.write(
-      true, ccf::kv::EntryFlags::FORCE_LEDGER_CHUNK_AFTER);
+    replay_submitter.write(true, ccf::kv::EntryFlags::FORCE_LEDGER_CHUNK_AFTER);
     REQUIRE(ledger.get_last_idx() == recovery_idx);
     REQUIRE(number_of_recovery_files_in_ledger_dir() == 0);
 
@@ -1839,8 +1838,7 @@ TEST_CASE("Recovery")
 
     TestEntrySubmitter replay_submitter(
       ledger, chunk_threshold, recovery_idx - 1);
-    replay_submitter.write(
-      true, ccf::kv::EntryFlags::FORCE_LEDGER_CHUNK_AFTER);
+    replay_submitter.write(true, ccf::kv::EntryFlags::FORCE_LEDGER_CHUNK_AFTER);
     REQUIRE(ledger.get_last_idx() == recovery_idx);
     REQUIRE(number_of_recovery_files_in_ledger_dir() == 0);
 

--- a/src/host/test/ledger.cpp
+++ b/src/host/test/ledger.cpp
@@ -1761,6 +1761,7 @@ TEST_CASE("Recovery")
     const auto recovery_idx = ledger.get_last_idx() + 4;
 
     ledger.truncate(recovery_idx, true);
+    ledger.set_recovery_start_idx(recovery_idx);
     REQUIRE(ledger.get_last_idx() == recovery_idx);
 
     TestEntrySubmitter recovery_submitter(
@@ -1778,14 +1779,20 @@ TEST_CASE("Recovery")
     const auto recovery_idx = 5;
 
     ledger.truncate(recovery_idx, true);
+    ledger.set_recovery_start_idx(recovery_idx);
     REQUIRE(ledger.get_last_idx() == recovery_idx);
 
     ledger.truncate(recovery_idx - 1);
-    REQUIRE(ledger.get_last_idx() == recovery_idx);
+    REQUIRE(ledger.get_last_idx() == recovery_idx - 1);
 
-    TestEntrySubmitter recovery_submitter(
-      ledger, chunk_threshold, recovery_idx);
-    recovery_submitter.write(true);
+    TestEntrySubmitter replay_submitter(
+      ledger, chunk_threshold, recovery_idx - 1);
+    replay_submitter.write(
+      true, ccf::kv::EntryFlags::FORCE_LEDGER_CHUNK_AFTER);
+    REQUIRE(ledger.get_last_idx() == recovery_idx);
+    REQUIRE(number_of_recovery_files_in_ledger_dir() == 0);
+
+    replay_submitter.write(true);
 
     REQUIRE(ledger.get_last_idx() == recovery_idx + 1);
     REQUIRE(number_of_recovery_files_in_ledger_dir() == 1);
@@ -1801,6 +1808,7 @@ TEST_CASE("Recovery")
     const auto recovery_idx = ledger.get_last_idx();
 
     ledger.truncate(recovery_idx, true);
+    ledger.set_recovery_start_idx(recovery_idx);
     REQUIRE(ledger.get_last_idx() == recovery_idx);
     read_entry_from_ledger(ledger, recovery_idx);
 
@@ -1823,15 +1831,20 @@ TEST_CASE("Recovery")
 
     const auto recovery_idx = ledger.get_last_idx() - 2;
     ledger.truncate(recovery_idx, true);
+    ledger.set_recovery_start_idx(recovery_idx);
     REQUIRE(ledger.get_last_idx() == recovery_idx);
 
     ledger.truncate(recovery_idx - 1);
-    REQUIRE(ledger.get_last_idx() == recovery_idx);
-    read_entry_from_ledger(ledger, recovery_idx);
+    REQUIRE(ledger.get_last_idx() == recovery_idx - 1);
 
-    TestEntrySubmitter recovery_submitter(
-      ledger, chunk_threshold, recovery_idx);
-    recovery_submitter.write(true);
+    TestEntrySubmitter replay_submitter(
+      ledger, chunk_threshold, recovery_idx - 1);
+    replay_submitter.write(
+      true, ccf::kv::EntryFlags::FORCE_LEDGER_CHUNK_AFTER);
+    REQUIRE(ledger.get_last_idx() == recovery_idx);
+    REQUIRE(number_of_recovery_files_in_ledger_dir() == 0);
+
+    replay_submitter.write(true);
 
     REQUIRE(ledger.get_last_idx() == recovery_idx + 1);
     REQUIRE(number_of_recovery_files_in_ledger_dir() == 1);

--- a/tests/infra/utils.py
+++ b/tests/infra/utils.py
@@ -6,6 +6,11 @@ import infra.snp as snp
 from infra.node import strip_version
 from packaging.version import Version  # type: ignore
 import os
+import ccf
+import ccf.ledger
+import ccf.split_ledger
+
+from loguru import logger as LOG
 
 
 def get_measurement(enclave_platform, package, library_dir="."):
@@ -32,3 +37,39 @@ def get_host_data_and_security_policy(
         return hash.hexdigest(), None
     else:
         raise ValueError(f"Cannot get security policy on {enclave_platform}")
+
+
+def write_ledger_chunk(outdir, entries, end_seqno, complete):
+    os.makedirs(outdir, exist_ok=True)
+    selected_entries = [(s, raw) for s, raw in entries if s <= end_seqno]
+    assert selected_entries, f"No entries selected up to {end_seqno}"
+
+    ledger_file = ccf.split_ledger.create_new_ledger_file(outdir)
+    if complete:
+        final_seqno, final_raw_tx = selected_entries[-1]
+        flagged_final_raw_tx = bytearray(final_raw_tx)
+        flagged_final_raw_tx[
+            ccf.ledger.TransactionHeader.VERSION_LENGTH
+        ] |= ccf.ledger.TransactionFlags.FORCE_CHUNK_AFTER.value
+        selected_entries[-1] = (final_seqno, bytes(flagged_final_raw_tx))
+
+    entry_positions = []
+    for _, raw_tx in selected_entries:
+        entry_positions.append(ledger_file.tell())
+        ledger_file.write(raw_tx)
+
+    start_seqno = selected_entries[0][0]
+    final_seqno = selected_entries[-1][0]
+    final_file_name = ccf.split_ledger.make_final_ledger_file_name(
+        start_seqno,
+        final_seqno,
+        is_complete=complete,
+        is_committed=False,
+    )
+    ccf.split_ledger.close_ledger_file(
+        ledger_file, entry_positions, final_file_name, complete_file=complete
+    )
+    LOG.info(
+        f"Created recovery ledger variant {outdir}: {final_file_name} "
+        f"complete={complete}"
+    )

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -952,7 +952,6 @@ def test_joining_nodes_snapshot_ledger_offset(network, args):
 
             network.retire_node(primary, new_node)
             new_node.stop()
-            network.ledger_files_invariant([new_node])
         finally:
             if not new_node.is_stopped():
                 new_node.stop()

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -5,6 +5,7 @@ import infra.network
 import infra.proc
 import infra.platform_detection
 import infra.net
+import infra.utils
 import infra.logging_app as app
 from infra.tx_status import TxStatus
 import suite.test_requirements as reqs
@@ -788,6 +789,179 @@ def test_ledger_invariants(network, args):
     return network
 
 
+@reqs.description("Join nodes with snapshot and ledger offsets")
+def test_joining_nodes_snapshot_ledger_offset(network, args):
+    primary, _ = network.find_primary()
+
+    network.consortium.force_ledger_chunk(primary)
+    network.get_latest_ledger_public_state()
+
+    network.txs.issue(network, number_txs=5, send_private=False, send_public=True)
+    network.txs.issue(network, number_txs=5, send_private=False, send_public=True)
+
+    snapshot_trigger_txid = primary.trigger_snapshot()
+    committed_snapshots_dir = network.get_committed_snapshots(
+        primary,
+        target_seqno=snapshot_trigger_txid.seqno,
+        wait_for_target_seqno=True,
+    )
+    committed_snapshots = sorted(
+        [
+            f
+            for f in os.listdir(committed_snapshots_dir)
+            if f.startswith("snapshot_") and ccf.ledger.is_snapshot_file_committed(f)
+        ],
+        key=lambda f: ccf.ledger.snapshot_index_from_filename(f)[0],
+    )
+    assert (
+        committed_snapshots
+    ), f"Expected committed snapshots in {committed_snapshots_dir}"
+    snapshot_file = committed_snapshots[-1]
+    snapshot_seqno, _ = ccf.ledger.snapshot_index_from_filename(snapshot_file)
+
+    snapshot_dir = os.path.join(
+        network.common_dir, "joining_nodes_snapshot_ledger_offset.snapshots"
+    )
+    rmtree(snapshot_dir, ignore_errors=True)
+    os.makedirs(snapshot_dir)
+    copy(os.path.join(committed_snapshots_dir, snapshot_file), snapshot_dir)
+
+    rest_txid = network.txs.issue(
+        network, number_txs=5, send_private=False, send_public=True
+    )
+    network.get_latest_ledger_public_state()
+
+    assert snapshot_trigger_txid.seqno < snapshot_seqno < rest_txid.seqno, (
+        snapshot_trigger_txid,
+        snapshot_seqno,
+        rest_txid,
+    )
+
+    current_ledger_dir, committed_ledger_dirs = primary.get_ledger()
+    ledger = ccf.ledger.Ledger(
+        [current_ledger_dir] + committed_ledger_dirs,
+        committed_only=False,
+        contiguous_suffix=True,
+    )
+
+    snapshot_chunk_start = None
+    snapshot_chunk_entries = None
+    post_snapshot_entries = []
+    for chunk in ledger:
+        entries = [
+            (tx.get_public_domain().get_seqno(), tx.get_raw_tx()) for tx in chunk
+        ]
+        if not entries:
+            continue
+
+        chunk_start = entries[0][0]
+        chunk_end = entries[-1][0]
+        if chunk_start <= snapshot_seqno <= chunk_end:
+            snapshot_chunk_start = chunk_start
+            snapshot_chunk_entries = entries
+            assert (
+                chunk_end == snapshot_seqno
+            ), f"Expected snapshot seqno {snapshot_seqno} at chunk boundary, got chunk {chunk_start}-{chunk_end}"
+
+        post_snapshot_entries.extend(
+            (seqno, raw_tx)
+            for seqno, raw_tx in entries
+            if snapshot_seqno < seqno <= rest_txid.seqno
+        )
+
+    assert (
+        snapshot_chunk_start is not None
+    ), f"Could not find ledger chunk ending at snapshot seqno {snapshot_seqno}"
+    assert snapshot_chunk_entries is not None
+    if snapshot_chunk_start <= snapshot_trigger_txid.seqno < snapshot_seqno:
+        mid_chunk_seqno = snapshot_trigger_txid.seqno
+    else:
+        mid_chunk_seqno = next(
+            seqno
+            for seqno, _ in reversed(snapshot_chunk_entries)
+            if seqno < snapshot_seqno
+        )
+    assert (
+        post_snapshot_entries
+    ), f"Expected ledger entries after snapshot {snapshot_seqno}"
+    assert post_snapshot_entries[0][0] == snapshot_seqno + 1, post_snapshot_entries[0]
+
+    base_dir = os.path.join(network.common_dir, "joining_nodes_snapshot_ledger_offset")
+    rmtree(base_dir, ignore_errors=True)
+    os.makedirs(base_dir)
+
+    variants = [
+        (
+            "incomplete_mid_chunk",
+            [(snapshot_chunk_entries, mid_chunk_seqno, False)],
+        ),
+        ("complete_mid_chunk", [(snapshot_chunk_entries, mid_chunk_seqno, True)]),
+        ("incomplete_snapshot", [(snapshot_chunk_entries, snapshot_seqno, False)]),
+        ("complete_snapshot", [(snapshot_chunk_entries, snapshot_seqno, True)]),
+        (
+            "incomplete_rest",
+            [
+                (snapshot_chunk_entries, snapshot_seqno, True),
+                (post_snapshot_entries, rest_txid.seqno, False),
+            ],
+        ),
+    ]
+
+    for variant_name, chunks_to_write in variants:
+        variant_dir = os.path.join(base_dir, variant_name)
+        current_dir = os.path.join(variant_dir, "ledger.current")
+        prefix_dir = os.path.join(variant_dir, "ledger.committed")
+        os.makedirs(current_dir)
+        os.makedirs(prefix_dir)
+
+        for source_dir in [current_ledger_dir] + committed_ledger_dirs:
+            for f in os.listdir(source_dir):
+                if not f.endswith(ccf.ledger.COMMITTED_FILE_SUFFIX):
+                    continue
+                _, range_end = ccf.ledger.range_from_filename(f)
+                if range_end is not None and range_end < snapshot_chunk_start:
+                    copy(os.path.join(source_dir, f), prefix_dir)
+
+        for entries, end_seqno, complete in chunks_to_write:
+            infra.utils.write_ledger_chunk(current_dir, entries, end_seqno, complete)
+
+        LOG.info(
+            "Joining node with {} ledger variant from snapshot {}",
+            variant_name,
+            snapshot_file,
+        )
+        new_node = network.create_node()
+        try:
+            network.join_node(
+                new_node,
+                args.package,
+                args,
+                target_node=primary,
+                ledger_dir=current_dir,
+                read_only_ledger_dirs=[prefix_dir],
+                from_snapshot=True,
+                snapshots_dir=snapshot_dir,
+                copy_ledger=False,
+                fetch_recent_snapshot=False,
+                timeout=10,
+            )
+
+            out_path, _ = new_node.get_logs()
+            with open(out_path, encoding="utf-8") as out:
+                assert f"snapshot_{snapshot_seqno}_" in out.read()
+
+            network.retire_node(primary, new_node)
+            new_node.stop()
+            network.ledger_files_invariant([new_node])
+        finally:
+            if not new_node.is_stopped():
+                new_node.stop()
+            if new_node in network.nodes:
+                network.nodes.remove(new_node)
+
+    return network
+
+
 def run_all(args):
     txs = app.LoggingTxs("user0")
     with infra.network.network(
@@ -822,6 +996,7 @@ def run_all(args):
         test_add_node_from_snapshot(network, args)
         test_add_node_from_snapshot(network, args, from_backup=True)
         test_add_node_from_snapshot(network, args, copy_ledger=False)
+        test_joining_nodes_snapshot_ledger_offset(network, args)
 
         test_node_filter(network, args)
         test_retiring_nodes_emit_at_most_one_signature(network, args)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -851,7 +851,6 @@ def test_joining_nodes_snapshot_ledger_offset(network, args):
     rest_txid = network.txs.issue(
         network, number_txs=5, send_private=False, send_public=True
     )
-    network.get_latest_ledger_public_state()
 
     assert snapshot_trigger_txid.seqno < snapshot_seqno < rest_txid.seqno, (
         snapshot_trigger_txid,
@@ -859,10 +858,13 @@ def test_joining_nodes_snapshot_ledger_offset(network, args):
         rest_txid,
     )
 
-    current_ledger_dir, committed_ledger_dirs = primary.get_ledger()
+    # flush ledger to disk from commit index
+    network.get_latest_ledger_public_state()
+    # Only use the committed ledger files flushed from above
+    _, committed_ledger_dirs = primary.get_ledger()
     ledger = ccf.ledger.Ledger(
-        [current_ledger_dir] + committed_ledger_dirs,
-        committed_only=False,
+        committed_ledger_dirs,
+        committed_only=True,
         contiguous_suffix=True,
     )
 
@@ -936,7 +938,7 @@ def test_joining_nodes_snapshot_ledger_offset(network, args):
         os.makedirs(current_dir)
         os.makedirs(prefix_dir)
 
-        for source_dir in [current_ledger_dir] + committed_ledger_dirs:
+        for source_dir in committed_ledger_dirs:
             for f in os.listdir(source_dir):
                 if not f.endswith(ccf.ledger.COMMITTED_FILE_SUFFIX):
                     continue

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -1950,9 +1950,7 @@ def run_recover_snapshot_ledger_offset(args):
             ),
         ]
 
-        for variant_index, (variant_name, chunks_to_write) in enumerate(
-            variants
-        ):
+        for variant_index, (variant_name, chunks_to_write) in enumerate(variants):
             LOG.info("Recovering service with {} ledger variant", variant_name)
             variant_dir = os.path.join(base_dir, variant_name)
             current_dir = os.path.join(variant_dir, "ledger.current")

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -1810,6 +1810,210 @@ def run_recovery_cose_only(args):
     run_recovery_cose_only_network(args)
 
 
+def run_recover_snapshot_ledger_offset(args):
+    txs = app.LoggingTxs("user0")
+    with infra.network.network(
+        args.nodes, args.binary_dir, args.debug_nodes, txs=txs
+    ) as network:
+        network.start_and_open(args)
+        primary, _ = network.find_primary()
+
+        network.consortium.force_ledger_chunk(primary)
+        network.get_latest_ledger_public_state()
+
+        network.txs.issue(network, number_txs=5, send_private=False, send_public=True)
+        network.txs.issue(network, number_txs=5, send_private=False, send_public=True)
+
+        snapshot_trigger_txid = primary.trigger_snapshot()
+        committed_snapshots_dir = network.get_committed_snapshots(
+            primary,
+            target_seqno=snapshot_trigger_txid.seqno,
+            wait_for_target_seqno=True,
+        )
+        committed_snapshots = sorted(
+            [
+                f
+                for f in os.listdir(committed_snapshots_dir)
+                if f.startswith("snapshot_")
+                and ccf.ledger.is_snapshot_file_committed(f)
+            ],
+            key=lambda f: ccf.ledger.snapshot_index_from_filename(f)[0],
+        )
+        assert (
+            committed_snapshots
+        ), f"Expected committed snapshots in {committed_snapshots_dir}"
+        snapshot_file = committed_snapshots[-1]
+        snapshot_seqno, _ = ccf.ledger.snapshot_index_from_filename(snapshot_file)
+
+        source_snapshot_dir = os.path.join(
+            network.common_dir, "recovery_snapshot_ledger_offset.snapshots"
+        )
+        shutil.rmtree(source_snapshot_dir, ignore_errors=True)
+        os.makedirs(source_snapshot_dir)
+        shutil.copy(
+            os.path.join(committed_snapshots_dir, snapshot_file), source_snapshot_dir
+        )
+
+        rest_txid = network.txs.issue(
+            network, number_txs=5, send_private=False, send_public=True
+        )
+        network.get_latest_ledger_public_state()
+
+        assert snapshot_trigger_txid.seqno < snapshot_seqno < rest_txid.seqno, (
+            snapshot_trigger_txid,
+            snapshot_seqno,
+            rest_txid,
+        )
+
+        network.save_service_identity(args)
+        network.stop_all_nodes(skip_verification=True)
+        current_ledger_dir, committed_ledger_dirs = primary.get_ledger()
+        ledger = ccf.ledger.Ledger(
+            [current_ledger_dir] + committed_ledger_dirs,
+            committed_only=False,
+            contiguous_suffix=True,
+        )
+
+        snapshot_chunk_start = None
+        snapshot_chunk_entries = None
+        post_snapshot_entries = []
+        for chunk in ledger:
+            entries = [
+                (tx.get_public_domain().get_seqno(), tx.get_raw_tx()) for tx in chunk
+            ]
+            if not entries:
+                continue
+
+            chunk_start = entries[0][0]
+            chunk_end = entries[-1][0]
+            if chunk_start <= snapshot_seqno <= chunk_end:
+                snapshot_chunk_start = chunk_start
+                snapshot_chunk_entries = entries
+                assert (
+                    chunk_end == snapshot_seqno
+                ), f"Expected snapshot seqno {snapshot_seqno} at chunk boundary, got chunk {chunk_start}-{chunk_end}"
+
+            post_snapshot_entries.extend(
+                (seqno, raw_tx)
+                for seqno, raw_tx in entries
+                if snapshot_seqno < seqno <= rest_txid.seqno
+            )
+
+        assert (
+            snapshot_chunk_start is not None
+        ), f"Could not find ledger chunk ending at snapshot seqno {snapshot_seqno}"
+        assert snapshot_chunk_entries is not None
+        if snapshot_chunk_start <= snapshot_trigger_txid.seqno < snapshot_seqno:
+            mid_chunk_seqno = snapshot_trigger_txid.seqno
+        else:
+            mid_chunk_seqno = next(
+                seqno
+                for seqno, _ in reversed(snapshot_chunk_entries)
+                if seqno < snapshot_seqno
+            )
+        assert (
+            post_snapshot_entries
+        ), f"Expected ledger entries after snapshot {snapshot_seqno}"
+        assert post_snapshot_entries[0][0] == snapshot_seqno + 1, post_snapshot_entries[
+            0
+        ]
+
+        base_dir = os.path.join(
+            args.workspace, f"{args.label}_recovery_snapshot_ledger_offset"
+        )
+        shutil.rmtree(base_dir, ignore_errors=True)
+        os.makedirs(base_dir)
+
+        variants = [
+            (
+                "incomplete_mid_chunk",
+                [(snapshot_chunk_entries, mid_chunk_seqno, False)],
+            ),
+            (
+                "complete_mid_chunk",
+                [(snapshot_chunk_entries, mid_chunk_seqno, True)],
+            ),
+            (
+                "incomplete_snapshot",
+                [(snapshot_chunk_entries, snapshot_seqno, False)],
+            ),
+            (
+                "complete_snapshot",
+                [(snapshot_chunk_entries, snapshot_seqno, True)],
+            ),
+            (
+                "incomplete_rest",
+                [
+                    (snapshot_chunk_entries, snapshot_seqno, True),
+                    (post_snapshot_entries, rest_txid.seqno, False),
+                ],
+            ),
+        ]
+
+        for variant_index, (variant_name, chunks_to_write) in enumerate(
+            variants
+        ):
+            LOG.info("Recovering service with {} ledger variant", variant_name)
+            variant_dir = os.path.join(base_dir, variant_name)
+            current_dir = os.path.join(variant_dir, "ledger.current")
+            prefix_dir = os.path.join(variant_dir, "ledger.committed")
+            snapshots_dir = os.path.join(variant_dir, "snapshots")
+            variant_common_dir = os.path.join(variant_dir, "common")
+            os.makedirs(current_dir)
+            os.makedirs(prefix_dir)
+            os.makedirs(snapshots_dir)
+            shutil.copytree(network.common_dir, variant_common_dir)
+            shutil.copy(os.path.join(source_snapshot_dir, snapshot_file), snapshots_dir)
+
+            for source_dir in [current_ledger_dir] + committed_ledger_dirs:
+                for f in os.listdir(source_dir):
+                    if not f.endswith(ccf.ledger.COMMITTED_FILE_SUFFIX):
+                        continue
+                    _, range_end = ccf.ledger.range_from_filename(f)
+                    if range_end is not None and range_end < snapshot_chunk_start:
+                        shutil.copy(os.path.join(source_dir, f), prefix_dir)
+
+            for entries, end_seqno, complete in chunks_to_write:
+                infra.utils.write_ledger_chunk(
+                    current_dir, entries, end_seqno, complete
+                )
+
+            recovered_args = copy.deepcopy(args)
+            recovered_args.label = f"{args.label}_{variant_name}"
+            recovered_network = infra.network.Network(
+                infra.e2e_args.min_nodes(recovered_args, f=0),
+                recovered_args.binary_dir,
+                recovered_args.debug_nodes,
+                txs=network.txs,
+                jwt_issuer=network.jwt_issuer,
+                next_node_id=variant_index,
+            )
+            recovered_network.ignore_errors_on_shutdown()
+            try:
+                recovered_network.start_in_recovery(
+                    recovered_args,
+                    ledger_dir=current_dir,
+                    committed_ledger_dirs=[prefix_dir],
+                    snapshots_dir=snapshots_dir,
+                    common_dir=variant_common_dir,
+                )
+                recovered_primary, _ = recovered_network.find_primary()
+                out_path, _ = recovered_primary.get_logs()
+                with open(out_path, encoding="utf-8") as out:
+                    assert f"snapshot_{snapshot_seqno}_" in out.read()
+
+                recovered_network.recover(recovered_args)
+                with recovered_primary.client() as c:
+                    r = c.get("/node/ready/app")
+                    assert r.status_code == http.HTTPStatus.NO_CONTENT.value, r
+            finally:
+                recovered_network.stop_all_nodes(
+                    skip_verification=True,
+                    skip_verify_chunking=True,
+                    accept_ledger_diff=True,
+                )
+
+
 if __name__ == "__main__":
 
     def add(parser):
@@ -1939,6 +2143,15 @@ checked. Note that the key for each logging message is unique (per table).
         nodes=infra.e2e_args.min_nodes(cr.args, f=1),
         ledger_chunk_bytes="50KB",
         snapshot_tx_interval=30,
+    )
+
+    cr.add(
+        "recovery_snapshot_ledger_offset",
+        run_recover_snapshot_ledger_offset,
+        package="samples/apps/logging/logging",
+        nodes=infra.e2e_args.min_nodes(cr.args, f=1),
+        ledger_chunk_bytes="50MB",
+        snapshot_tx_interval=50,
     )
 
     cr.run()

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -2013,7 +2013,7 @@ def run_recover_snapshot_ledger_offset(args):
                 recovered_network.stop_all_nodes(
                     skip_verification=True,
                     skip_verify_chunking=True,
-                    accept_ledger_diff=True,
+                    check_file_invariants=True,
                 )
 
 


### PR DESCRIPTION
Per #7891 we had poor test coverage if a snapshot was after the end of the ledger.
This PR adds better coverage for that, reproducing the issue where recovering nodes fail when there is a gap between the end of the ledger and the starting snapshot.
It also adds a fix for that issue.

Supersedes: #7890 