### PR TITLE
Refactor .py signatures infra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [7.0.5]
 
+[7.0.5]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.5
+
 ### Deprecated
 
 - Accessing ledger-signature names (table names, exception classes) via `ccf.ledger` now emits a `DeprecationWarning`; import them from `ccf.signatures` instead (#7904).
+
+### Fixed
+
+- `ccf.ledger` `MERKLE` verification level now also verifies COSE-only ledgers (previously a silent no-op) (#7904).
 
 ## [7.0.4]
 
@@ -3706,3 +3712,4 @@ Initial pre-release
 [3.0.0-rc2]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.0-rc2
 [5.0.0]: https://github.com/microsoft/CCF/releases/tag/ccf-5.0.0
 [7.0.0-dev0]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.0-dev0
+[7.0.5]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3712,4 +3712,3 @@ Initial pre-release
 [3.0.0-rc2]: https://github.com/microsoft/CCF/releases/tag/ccf-3.0.0-rc2
 [5.0.0]: https://github.com/microsoft/CCF/releases/tag/ccf-5.0.0
 [7.0.0-dev0]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.0-dev0
-[7.0.5]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.0.5]
+
+### Deprecated
+
+- Accessing ledger-signature names (table names, exception classes) via `ccf.ledger` now emits a `DeprecationWarning`; import them from `ccf.signatures` instead (#7904).
+
 ## [7.0.4]
 
 [7.0.4]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.4

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ccf"
-version = "7.0.4"
+version = "7.0.5"
 authors = [
   { name="CCF Team", email="CCF-Sec@microsoft.com" },
 ]

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -712,11 +712,12 @@ class LedgerValidator:
                     )
                     verified_count += 1
 
-                assert verified_count > 0, (
-                    f"Signature transaction {transaction.gcm_header.view}."
-                    f"{transaction.gcm_header.seqno} contained no verifiable "
-                    "signature blob"
-                )
+                if verified_count == 0:
+                    raise ValueError(
+                        f"Signature transaction {transaction.gcm_header.view}."
+                        f"{transaction.gcm_header.seqno} contained no verifiable "
+                        "signature blob"
+                    )
 
                 self.last_verified_seqno = transaction.gcm_header.seqno
                 self.last_verified_view = transaction.gcm_header.view

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -16,29 +16,39 @@ from ccf.tx_id import TxID
 import ccf.cose
 import ccf.receipt
 
-# Re-exports for backwards compatibility — these are imported from
-# ``ccf.ledger`` by external callers.
-from ccf.signatures import (
-    COSE_SIGNATURE_TX_TABLE_NAME as COSE_SIGNATURE_TX_TABLE_NAME,
-    InvalidRootCoseSignatureException as InvalidRootCoseSignatureException,
-    InvalidRootException as InvalidRootException,
-    InvalidRootSignatureException as InvalidRootSignatureException,
-    SIGNATURE_TX_TABLE_NAME as SIGNATURE_TX_TABLE_NAME,
-    UntrustedNodeException as UntrustedNodeException,
-    WELL_KNOWN_SINGLETON_TABLE_KEY as WELL_KNOWN_SINGLETON_TABLE_KEY,
-    is_signature_transaction as is_signature_transaction,
-    parse_classical_signatures as parse_classical_signatures,
-    parse_cose_signature as parse_cose_signature,
-)
-
-from ccf.signatures import (
-    spki_from_cert,
-    verify_cose_root_signature,
-    verify_merkle_root,
-    verify_root_signature,
-)
-
+import warnings
 from hashlib import sha256
+
+from ccf import signatures
+
+# Names that used to live in ``ccf.ledger`` and now live in ``ccf.signatures``.
+# Accessing them through ``ccf.ledger`` emits a DeprecationWarning; import
+# directly from ``ccf.signatures`` instead.
+_DEPRECATED_SIGNATURE_REEXPORTS = frozenset(
+    {
+        "COSE_SIGNATURE_TX_TABLE_NAME",
+        "InvalidRootCoseSignatureException",
+        "InvalidRootException",
+        "InvalidRootSignatureException",
+        "SIGNATURE_TX_TABLE_NAME",
+        "UntrustedNodeException",
+        "WELL_KNOWN_SINGLETON_TABLE_KEY",
+        "spki_from_cert",
+    }
+)
+
+
+def __getattr__(name: str):
+    if name in _DEPRECATED_SIGNATURE_REEXPORTS:
+        warnings.warn(
+            f"ccf.ledger.{name} is deprecated; "
+            f"import {name} from ccf.signatures instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(signatures, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 GCM_SIZE_TAG = 16
 GCM_SIZE_IV = 12
@@ -640,7 +650,9 @@ class LedgerValidator:
             and SERVICE_INFO_TABLE_NAME in tables
         ):
             service_table = tables[SERVICE_INFO_TABLE_NAME]
-            updated_service = service_table.get(WELL_KNOWN_SINGLETON_TABLE_KEY)
+            updated_service = service_table.get(
+                signatures.WELL_KNOWN_SINGLETON_TABLE_KEY
+            )
             updated_service_json = json.loads(updated_service)
             updated_status = updated_service_json["status"]
             if updated_status == "Opening":
@@ -664,7 +676,7 @@ class LedgerValidator:
             self.service_status = updated_status
             self.service_cert = updated_service_json["cert"]
 
-        is_signature_tx = is_signature_transaction(tables)
+        is_signature_tx = signatures.is_signature_transaction(tables)
         if is_signature_tx:
             self.signature_count += 1
 
@@ -672,23 +684,28 @@ class LedgerValidator:
             if self.verification_level >= VerificationLevel.FULL:
                 verified_count = 0
 
-                for payload in parse_classical_signatures(tables):
+                payload = signatures.parse_raw_signature_from_tx(tables)
+                if payload is not None:
                     self._verify_signing_node_status(payload.signing_node)
                     cert = self.node_certificates[payload.signing_node]
                     if payload.embedded_cert is not None:
-                        assert spki_from_cert(cert) == spki_from_cert(
+                        assert signatures.spki_from_cert(
+                            cert
+                        ) == signatures.spki_from_cert(
                             payload.embedded_cert
                         ), f"Mismatch in public key for node {payload.signing_node}"
-                    verify_root_signature(cert, payload.root, payload.signature)
-                    verify_merkle_root(self.merkle, payload.root)
+                    signatures.verify_raw_root_signature(
+                        cert, payload.root, payload.signature
+                    )
+                    signatures.verify_merkle_root(self.merkle, payload.root)
                     verified_count += 1
 
-                cose_sign1 = parse_cose_signature(tables)
+                cose_sign1 = signatures.parse_cose_signature_from_tx(tables)
                 if cose_sign1 is not None:
                     assert (
                         self.service_cert is not None
                     ), "Cannot verify COSE root signature without a known service certificate"
-                    verify_cose_root_signature(
+                    signatures.verify_cose_root_signature(
                         self.service_cert,
                         self.merkle.get_merkle_root(),
                         cose_sign1,
@@ -704,22 +721,25 @@ class LedgerValidator:
                 self.last_verified_seqno = transaction.gcm_header.seqno
                 self.last_verified_view = transaction.gcm_header.view
             else:
-                # MERKLE level: classical-only. Seed the running tree from the
-                # embedded mini-tree on the first classical signature, then
+                # MERKLE level: raw-only. Seed the running tree from the
+                # embedded mini-tree on the first raw signature, then
                 # check subsequent roots against it.
-                for payload in parse_classical_signatures(tables):
+                payload = signatures.parse_raw_signature_from_tx(tables)
+                if payload is not None:
                     if not self.first_signature_seen:
                         tree_table = tables.get(TREE_TABLE_NAME)
                         if (
                             tree_table is not None
-                            and WELL_KNOWN_SINGLETON_TABLE_KEY in tree_table
+                            and signatures.WELL_KNOWN_SINGLETON_TABLE_KEY in tree_table
                         ):
-                            tree_data = tree_table[WELL_KNOWN_SINGLETON_TABLE_KEY]
+                            tree_data = tree_table[
+                                signatures.WELL_KNOWN_SINGLETON_TABLE_KEY
+                            ]
                             self.merkle = MerkleTree()
                             self.merkle.deserialise(tree_data)
                             self.first_signature_seen = True
                     else:
-                        verify_merkle_root(self.merkle, payload.root)
+                        signatures.verify_merkle_root(self.merkle, payload.root)
 
                     self.last_verified_seqno = payload.seqno
                     self.last_verified_view = payload.view
@@ -742,13 +762,13 @@ class LedgerValidator:
         ``Pending`` nodes are rejected here.
         """
         if signing_node not in self.node_activity_status:
-            raise UntrustedNodeException(
+            raise signatures.UntrustedNodeException(
                 f"The signing node {signing_node} is not part of the network"
             )
         node_info = self.node_activity_status[signing_node]
         node_status = NodeStatus(node_info[0])
         if node_status == NodeStatus.PENDING:
-            raise UntrustedNodeException(
+            raise signatures.UntrustedNodeException(
                 f"The signing node {signing_node} has unexpected status {node_status.value}"
             )
 
@@ -972,7 +992,7 @@ class Snapshot(Entry):
                 "Snapshot is missing service info table for COSE receipt verification"
             )
 
-        service_info = service_info_table.get(WELL_KNOWN_SINGLETON_TABLE_KEY)
+        service_info = service_info_table.get(signatures.WELL_KNOWN_SINGLETON_TABLE_KEY)
         if service_info is None:
             raise InvalidSnapshotException(
                 "Snapshot is missing service info for COSE receipt verification"

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -5,23 +5,39 @@ import struct
 import os
 from enum import Enum, IntEnum, Flag, auto
 
-from typing import NamedTuple
-
 import json
-import base64
 from dataclasses import dataclass
-import functools
 
 from cryptography.x509 import load_pem_x509_certificate
-from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.backends import default_backend
-from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives.asymmetric import utils, ec
 
 from ccf.merkletree import MerkleTree
 from ccf.tx_id import TxID
 import ccf.cose
 import ccf.receipt
+
+# Re-exports for backwards compatibility — these are imported from
+# ``ccf.ledger`` by external callers. ``X as X`` is the PEP 484 explicit
+# re-export form.
+from ccf.signatures import (
+    COSE_SIGNATURE_TX_TABLE_NAME as COSE_SIGNATURE_TX_TABLE_NAME,
+    InvalidRootCoseSignatureException as InvalidRootCoseSignatureException,
+    InvalidRootException as InvalidRootException,
+    InvalidRootSignatureException as InvalidRootSignatureException,
+    SIGNATURE_TX_TABLE_NAME as SIGNATURE_TX_TABLE_NAME,
+    UntrustedNodeException as UntrustedNodeException,
+    is_signature_transaction as is_signature_transaction,
+    parse_classical_signatures as parse_classical_signatures,
+    parse_cose_signature as parse_cose_signature,
+)
+
+from ccf.signatures import (
+    spki_from_cert,
+    verify_cose_root_signature,
+    verify_merkle_root,
+    verify_root_signature,
+)
+
 from hashlib import sha256
 
 GCM_SIZE_TAG = 16
@@ -29,9 +45,7 @@ GCM_SIZE_IV = 12
 LEDGER_DOMAIN_SIZE = 8
 LEDGER_HEADER_SIZE = 8
 
-# Public table names as defined in CCF
-SIGNATURE_TX_TABLE_NAME = "public:ccf.internal.signatures"
-COSE_SIGNATURE_TX_TABLE_NAME = "public:ccf.internal.cose_signatures"
+# Public table names as defined in CCF.
 TREE_TABLE_NAME = "public:ccf.internal.tree"
 NODES_TABLE_NAME = "public:ccf.gov.nodes.info"
 ENDORSED_NODE_CERTIFICATES_TABLE_NAME = "public:ccf.gov.nodes.endorsed_certificates"
@@ -137,15 +151,6 @@ def unpack_array(buf, fmt):
         except StopIteration:
             break
     return ret
-
-
-@functools.lru_cache(maxsize=64)
-def spki_from_cert(cert: bytes) -> bytes:
-    cert_obj = load_pem_x509_certificate(cert)
-    return cert_obj.public_key().public_bytes(
-        encoding=serialization.Encoding.DER,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
 
 
 def range_from_filename(filename: str) -> tuple[int, int | None]:
@@ -430,99 +435,7 @@ def _peek_all(file: SimpleBuffer, pos=None):
     return buffer
 
 
-class TxBundleInfo(NamedTuple):
-    """Bundle for transaction information required for validation"""
-
-    merkle_tree: MerkleTree
-    existing_root: bytes
-    node_cert: bytes
-    signature: bytes
-    node_activity: dict
-    signing_node: str
-
-
-class BaseValidator:
-    @staticmethod
-    def _verify_tx_bundle(tx_info: TxBundleInfo):
-        """
-        Verify items 1, 2, and 3 for all the transactions up until a signature.
-        """
-        # 1) The merkle root is signed by a Trusted node in the given network, else throws
-        BaseValidator._verify_node_status(tx_info)
-        # 2) The merkle root and signature are verified with the node cert, else throws
-        BaseValidator._verify_root_signature(
-            tx_info.node_cert, tx_info.existing_root, tx_info.signature
-        )
-        # 3) The merkle root is correct for the set of transactions and matches with the one extracted from the ledger, else throws
-        BaseValidator._verify_merkle_root(tx_info.merkle_tree, tx_info.existing_root)
-
-    @staticmethod
-    def _verify_node_status(tx_info: TxBundleInfo):
-        """Verify item 1, The merkle root is signed by a valid node in the given network"""
-        if tx_info.signing_node not in tx_info.node_activity:
-            raise UntrustedNodeException(
-                f"The signing node {tx_info.signing_node} is not part of the network"
-            )
-        node_info = tx_info.node_activity[tx_info.signing_node]
-        node_status = NodeStatus(node_info[0])
-        # Note: Even nodes that are Retired, and for which retired_committed is True
-        # may be issuing signatures, to ensure the liveness of a reconfiguring
-        # network. They will stop doing so once the transaction that sets retired_committed is itself committed,
-        # but that is unfortunately not observable from the ledger alone.
-        if node_status == NodeStatus.PENDING:
-            raise UntrustedNodeException(
-                f"The signing node {tx_info.signing_node} has unexpected status {node_status.value}"
-            )
-
-    @staticmethod
-    def _verify_root_signature(node_cert: bytes, root: bytes, signature: bytes):
-        """Verify item 2, that the Merkle root signature validates against the node certificate"""
-        try:
-            cert = load_pem_x509_certificate(node_cert)
-            pub_key = cert.public_key()
-
-            assert isinstance(pub_key, ec.EllipticCurvePublicKey)
-            pub_key.verify(
-                signature,
-                root,
-                ec.ECDSA(utils.Prehashed(hashes.SHA256())),
-            )  # type: ignore[override]
-        # This exception is thrown from x509, catch for logging and raise our own
-        except InvalidSignature:
-            raise InvalidRootSignatureException(
-                "Signature verification failed:"
-                + f"\nCertificate: {node_cert.decode()}"
-                + f"\nSignature: {base64.b64encode(signature).decode()}"
-                + f"\nRoot: {root.hex()}"
-            ) from InvalidSignature
-
-    @staticmethod
-    def _verify_root_cose_signature(service_cert, root, cose_sign1):
-        try:
-            ccf.cose.verify_cose_sign1_with_cert(
-                certificate=service_cert.encode("ascii"),
-                cose_sign1=cose_sign1,
-                use_key=True,
-                payload=root,
-            )
-        except Exception as exc:
-            raise InvalidRootCoseSignatureException(
-                "Signature verification failed:"
-                + f"\nCertificate: {service_cert}"
-                + f"\nRoot: {root}"
-            ) from exc
-
-    @staticmethod
-    def _verify_merkle_root(merkletree: MerkleTree, existing_root: bytes):
-        """Verify item 3, by comparing the roots from the merkle tree that's maintained by this class and from the one extracted from the ledger"""
-        root = merkletree.get_merkle_root()
-        if root != existing_root:
-            raise InvalidRootException(
-                f"\nComputed root: {root.hex()} \nExisting root from ledger: {existing_root.hex()}"
-            )
-
-
-class LedgerValidator(BaseValidator):
+class LedgerValidator:
     """
     Ledger Validator contains the logic to verify that the ledger hasn't been tampered with.
     It has the ability to take transactions and it maintains a MerkleTree data structure similar to CCF.
@@ -724,79 +637,13 @@ class LedgerValidator(BaseValidator):
                 else:
                     self.node_certificates[node_id] = endorsed_node_cert
 
-        # This is a merkle root/signature tx if either signature table exists
-        is_signature_tx = (
-            SIGNATURE_TX_TABLE_NAME in tables or COSE_SIGNATURE_TX_TABLE_NAME in tables
-        )
+        is_signature_tx = is_signature_transaction(tables)
         if is_signature_tx:
             self.signature_count += 1
 
-        if SIGNATURE_TX_TABLE_NAME in tables:
-            if self.verification_level >= VerificationLevel.MERKLE:
-                signature_table = tables[SIGNATURE_TX_TABLE_NAME]
-
-                for _, signature in signature_table.items():
-                    signature = json.loads(signature)
-                    current_seqno = signature["seqno"]
-                    current_view = signature["view"]
-                    signing_node = signature["node"]
-
-                    # Get binary representations for the cert, existing root, and signature
-                    existing_root = bytes.fromhex(signature["root"])
-
-                    if self.verification_level >= VerificationLevel.FULL:
-                        # Full verification includes signature validation
-                        cert = self.node_certificates[signing_node]
-                        sig = base64.b64decode(signature["sig"])
-
-                        # Check that key in cert matches that in node table
-                        # when present
-                        if "cert" in signature:
-                            sig_cert = signature["cert"].encode("utf-8")
-                            assert spki_from_cert(cert) == spki_from_cert(
-                                sig_cert
-                            ), f"Mismatch in public key for node {signing_node}"
-
-                        tx_info = TxBundleInfo(
-                            self.merkle,
-                            existing_root,
-                            cert,
-                            sig,
-                            self.node_activity_status,
-                            signing_node,
-                        )
-
-                        # validations for 1, 2 and 3
-                        # throws if ledger validation failed.
-                        self._verify_tx_bundle(tx_info)
-                    else:
-                        # MERKLE level: trust first signature, verify subsequent ones
-                        if not self.first_signature_seen:
-                            # Trust the first signature: reinitialize merkle tree from the mini-tree
-                            # This allows verifying isolated chunks without the full ledger history
-                            if TREE_TABLE_NAME in tables:
-                                tree_table = tables[TREE_TABLE_NAME]
-                                if WELL_KNOWN_SINGLETON_TABLE_KEY in tree_table:
-                                    tree_data = tree_table[
-                                        WELL_KNOWN_SINGLETON_TABLE_KEY
-                                    ]
-                                    # Deserialize the merkle tree from the binary format
-                                    self.merkle = MerkleTree()
-                                    self.merkle.deserialise(tree_data)
-                                    self.first_signature_seen = True
-                            # If no tree table (old ledger format), we cannot do partial
-                            # Merkle verification - first_signature_seen stays False and
-                            # subsequent signatures won't be verified
-                        else:
-                            # Verify subsequent signatures against computed merkle root
-                            BaseValidator._verify_merkle_root(
-                                self.merkle, existing_root
-                            )
-
-                    self.last_verified_seqno = current_seqno
-                    self.last_verified_view = current_view
-
-        # Check service status transitions (only for FULL verification)
+        # Apply any service-info update *before* signature verification so the
+        # COSE branch sees the new service cert if the same tx happens to
+        # carry both (only meaningful at FULL).
         if (
             self.verification_level >= VerificationLevel.FULL
             and SERVICE_INFO_TABLE_NAME in tables
@@ -826,17 +673,61 @@ class LedgerValidator(BaseValidator):
             self.service_status = updated_status
             self.service_cert = updated_service_json["cert"]
 
-        if (
-            self.verification_level >= VerificationLevel.FULL
-            and COSE_SIGNATURE_TX_TABLE_NAME in tables
-        ):
-            cose_signature_table = tables[COSE_SIGNATURE_TX_TABLE_NAME]
-            cose_signature = cose_signature_table.get(WELL_KNOWN_SINGLETON_TABLE_KEY)
-            signature = json.loads(cose_signature)
-            cose_sign1 = base64.b64decode(signature)
-            self._verify_root_cose_signature(
-                self.service_cert, self.merkle.get_merkle_root(), cose_sign1
-            )
+        if is_signature_tx and self.verification_level >= VerificationLevel.MERKLE:
+            if self.verification_level >= VerificationLevel.FULL:
+                verified_count = 0
+
+                for payload in parse_classical_signatures(tables):
+                    self._verify_signing_node_status(payload.signing_node)
+                    cert = self.node_certificates[payload.signing_node]
+                    if payload.embedded_cert is not None:
+                        assert spki_from_cert(cert) == spki_from_cert(
+                            payload.embedded_cert
+                        ), f"Mismatch in public key for node {payload.signing_node}"
+                    verify_root_signature(cert, payload.root, payload.signature)
+                    verify_merkle_root(self.merkle, payload.root)
+                    verified_count += 1
+
+                cose_sign1 = parse_cose_signature(tables)
+                if cose_sign1 is not None:
+                    assert (
+                        self.service_cert is not None
+                    ), "Cannot verify COSE root signature without a known service certificate"
+                    verify_cose_root_signature(
+                        self.service_cert,
+                        self.merkle.get_merkle_root(),
+                        cose_sign1,
+                    )
+                    verified_count += 1
+
+                assert verified_count > 0, (
+                    f"Signature transaction {transaction.gcm_header.view}."
+                    f"{transaction.gcm_header.seqno} contained no verifiable "
+                    "signature blob"
+                )
+
+                self.last_verified_seqno = transaction.gcm_header.seqno
+                self.last_verified_view = transaction.gcm_header.view
+            else:
+                # MERKLE level: classical-only. Seed the running tree from the
+                # embedded mini-tree on the first classical signature, then
+                # check subsequent roots against it.
+                for payload in parse_classical_signatures(tables):
+                    if not self.first_signature_seen:
+                        tree_table = tables.get(TREE_TABLE_NAME)
+                        if (
+                            tree_table is not None
+                            and WELL_KNOWN_SINGLETON_TABLE_KEY in tree_table
+                        ):
+                            tree_data = tree_table[WELL_KNOWN_SINGLETON_TABLE_KEY]
+                            self.merkle = MerkleTree()
+                            self.merkle.deserialise(tree_data)
+                            self.first_signature_seen = True
+                    else:
+                        verify_merkle_root(self.merkle, payload.root)
+
+                    self.last_verified_seqno = payload.seqno
+                    self.last_verified_view = payload.view
 
         # Checks complete, add this transaction to tree (for MERKLE and above)
         if self.verification_level >= VerificationLevel.MERKLE:
@@ -847,6 +738,24 @@ class LedgerValidator(BaseValidator):
                     self.merkle.add_leaf(transaction.get_tx_digest(), False)
             else:
                 self.merkle.add_leaf(transaction.get_tx_digest(), False)
+
+    def _verify_signing_node_status(self, signing_node: str) -> None:
+        """Verify that ``signing_node`` is a known, non-pending member of the network.
+
+        Retired nodes may legitimately still issue signatures to keep a
+        reconfiguring network live until the retirement is committed; only
+        ``Pending`` nodes are rejected here.
+        """
+        if signing_node not in self.node_activity_status:
+            raise UntrustedNodeException(
+                f"The signing node {signing_node} is not part of the network"
+            )
+        node_info = self.node_activity_status[signing_node]
+        node_status = NodeStatus(node_info[0])
+        if node_status == NodeStatus.PENDING:
+            raise UntrustedNodeException(
+                f"The signing node {signing_node} has unexpected status {node_status.value}"
+            )
 
 
 @dataclass
@@ -1480,24 +1389,8 @@ class Ledger:
         return public_tables, latest_seqno
 
 
-class InvalidRootException(Exception):
-    """MerkleTree root doesn't match with the root reported in the signature's table"""
-
-
-class InvalidRootSignatureException(Exception):
-    """Signature of the MerkleRoot doesn't match with the signature that's reported in the signature's table"""
-
-
-class InvalidRootCoseSignatureException(Exception):
-    """COSE signature of the MerkleRoot doesn't pass COSE verification"""
-
-
 class CommitIdRangeException(Exception):
     """Missing ledger chunk in the ledger directory"""
-
-
-class UntrustedNodeException(Exception):
-    """The signing node wasn't part of the network"""
 
 
 class UnknownTransaction(Exception):

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -722,28 +722,27 @@ class LedgerValidator:
                 self.last_verified_seqno = transaction.gcm_header.seqno
                 self.last_verified_view = transaction.gcm_header.view
             else:
-                # MERKLE level: raw-only. Seed the running tree from the
-                # embedded mini-tree on the first raw signature, then
-                # check subsequent roots against it.
-                payload = signatures.parse_raw_signature_from_tx(tables)
-                if payload is not None:
+                # MERKLE level: trust the first signature, then verify
+                # subsequent ones against the embedded mini-tree's root.
+                # Uses TREE_TABLE rather than the raw-signature payload
+                # so this also works on COSE-only ledgers.
+                tree_table = tables.get(TREE_TABLE_NAME)
+                if (
+                    tree_table is not None
+                    and signatures.WELL_KNOWN_SINGLETON_TABLE_KEY in tree_table
+                ):
+                    tree_data = tree_table[signatures.WELL_KNOWN_SINGLETON_TABLE_KEY]
+                    embedded_tree = MerkleTree()
+                    embedded_tree.deserialise(tree_data)
                     if not self.first_signature_seen:
-                        tree_table = tables.get(TREE_TABLE_NAME)
-                        if (
-                            tree_table is not None
-                            and signatures.WELL_KNOWN_SINGLETON_TABLE_KEY in tree_table
-                        ):
-                            tree_data = tree_table[
-                                signatures.WELL_KNOWN_SINGLETON_TABLE_KEY
-                            ]
-                            self.merkle = MerkleTree()
-                            self.merkle.deserialise(tree_data)
-                            self.first_signature_seen = True
+                        self.merkle = embedded_tree
+                        self.first_signature_seen = True
                     else:
-                        signatures.verify_merkle_root(self.merkle, payload.root)
-
-                    self.last_verified_seqno = payload.seqno
-                    self.last_verified_view = payload.view
+                        signatures.verify_merkle_root(
+                            self.merkle, embedded_tree.get_merkle_root()
+                        )
+                    self.last_verified_seqno = transaction.gcm_header.seqno
+                    self.last_verified_view = transaction.gcm_header.view
 
         # Checks complete, add this transaction to tree (for MERKLE and above)
         if self.verification_level >= VerificationLevel.MERKLE:

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -686,6 +686,16 @@ class LedgerValidator:
 
                 payload = signatures.parse_raw_signature_from_tx(tables)
                 if payload is not None:
+                    if (
+                        payload.view != transaction.gcm_header.view
+                        or payload.seqno != transaction.gcm_header.seqno
+                    ):
+                        raise ValueError(
+                            f"Signature payload position "
+                            f"{payload.view}.{payload.seqno} does not match "
+                            f"transaction header position "
+                            f"{transaction.gcm_header.view}.{transaction.gcm_header.seqno}"
+                        )
                     self._verify_signing_node_status(payload.signing_node)
                     cert = self.node_certificates[payload.signing_node]
                     if payload.embedded_cert is not None:

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -17,8 +17,7 @@ import ccf.cose
 import ccf.receipt
 
 # Re-exports for backwards compatibility — these are imported from
-# ``ccf.ledger`` by external callers. ``X as X`` is the PEP 484 explicit
-# re-export form.
+# ``ccf.ledger`` by external callers.
 from ccf.signatures import (
     COSE_SIGNATURE_TX_TABLE_NAME as COSE_SIGNATURE_TX_TABLE_NAME,
     InvalidRootCoseSignatureException as InvalidRootCoseSignatureException,
@@ -26,6 +25,7 @@ from ccf.signatures import (
     InvalidRootSignatureException as InvalidRootSignatureException,
     SIGNATURE_TX_TABLE_NAME as SIGNATURE_TX_TABLE_NAME,
     UntrustedNodeException as UntrustedNodeException,
+    WELL_KNOWN_SINGLETON_TABLE_KEY as WELL_KNOWN_SINGLETON_TABLE_KEY,
     is_signature_transaction as is_signature_transaction,
     parse_classical_signatures as parse_classical_signatures,
     parse_cose_signature as parse_cose_signature,
@@ -54,9 +54,6 @@ SERVICE_INFO_TABLE_NAME = "public:ccf.gov.service.info"
 COMMITTED_FILE_SUFFIX = ".committed"
 RECOVERY_FILE_SUFFIX = ".recovery"
 IGNORED_FILE_SUFFIX = ".ignored"
-
-# Key used by CCF to record single-key tables
-WELL_KNOWN_SINGLETON_TABLE_KEY = bytes(bytearray(8))
 
 SHA256_DIGEST_SIZE = sha256().digest_size
 ENCODED_COSE_SIGN1_TAG = 0xD2
@@ -637,13 +634,6 @@ class LedgerValidator:
                 else:
                     self.node_certificates[node_id] = endorsed_node_cert
 
-        is_signature_tx = is_signature_transaction(tables)
-        if is_signature_tx:
-            self.signature_count += 1
-
-        # Apply any service-info update *before* signature verification so the
-        # COSE branch sees the new service cert if the same tx happens to
-        # carry both (only meaningful at FULL).
         if (
             self.verification_level >= VerificationLevel.FULL
             and SERVICE_INFO_TABLE_NAME in tables
@@ -672,6 +662,10 @@ class LedgerValidator:
                 assert self.service_status is None, self.service_status
             self.service_status = updated_status
             self.service_cert = updated_service_json["cert"]
+
+        is_signature_tx = is_signature_transaction(tables)
+        if is_signature_tx:
+            self.signature_count += 1
 
         if is_signature_tx and self.verification_level >= VerificationLevel.MERKLE:
             if self.verification_level >= VerificationLevel.FULL:

--- a/python/src/ccf/ledger_viz.py
+++ b/python/src/ccf/ledger_viz.py
@@ -106,7 +106,7 @@ def try_get_service_info(public_tables):
     return (
         json.loads(
             public_tables[ccf.ledger.SERVICE_INFO_TABLE_NAME][
-                ccf.ledger.WELL_KNOWN_SINGLETON_TABLE_KEY
+                ccf.signatures.WELL_KNOWN_SINGLETON_TABLE_KEY
             ]
         )
         if ccf.ledger.SERVICE_INFO_TABLE_NAME in public_tables

--- a/python/src/ccf/ledger_viz.py
+++ b/python/src/ccf/ledger_viz.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache 2.0 License.
 
 import ccf.ledger
+import ccf.signatures
 import argparse
 import shutil
 import json
@@ -132,10 +133,7 @@ def visualise(ledger, liner, validator=None):
             view = tx.gcm_header.view
             seqno = tx.gcm_header.seqno
             if not has_private:
-                if (
-                    ccf.ledger.SIGNATURE_TX_TABLE_NAME in public
-                    or ccf.ledger.COSE_SIGNATURE_TX_TABLE_NAME in public
-                ):
+                if ccf.signatures.is_signature_transaction(public):
                     liner.entry("Signature", view, seqno)
                 else:
                     if all(

--- a/python/src/ccf/signatures.py
+++ b/python/src/ccf/signatures.py
@@ -5,7 +5,7 @@ import base64
 import functools
 import json
 from dataclasses import dataclass
-from typing import Any, Container, List, Mapping, Optional
+from typing import Any, Container, Mapping, Optional
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
@@ -21,7 +21,7 @@ from ccf.merkletree import MerkleTree
 
 
 SIGNATURE_TX_TABLE_NAME: str = "public:ccf.internal.signatures"
-"""KV table carrying the classical ECDSA signature over the Merkle root."""
+"""KV table carrying the raw ECDSA signature over the Merkle root."""
 
 COSE_SIGNATURE_TX_TABLE_NAME: str = "public:ccf.internal.cose_signatures"
 """KV table carrying the COSE Sign1 signature over the Merkle root."""
@@ -35,14 +35,14 @@ WELL_KNOWN_SINGLETON_TABLE_KEY: bytes = bytes(bytearray(8))
 """Key used by CCF to record entries in single-row KV tables."""
 
 
-def is_signature_transaction(tables: Container[str]) -> bool:
-    """Return ``True`` if ``tables`` contains any signature table.
+def is_signature_transaction(tx_tables: Container[str]) -> bool:
+    """Return ``True`` if ``tx_tables`` contains any signature table.
 
-    ``tables`` is any object supporting ``in`` over table names. Typical
+    ``tx_tables`` is any object supporting ``in`` over table names. Typical
     callers pass the dict returned by
     ``transaction.get_public_domain().get_tables()``.
     """
-    return any(name in tables for name in SIGNATURE_TABLE_NAMES)
+    return any(name in tx_tables for name in SIGNATURE_TABLE_NAMES)
 
 
 # ---------------------------------------------------------------------------
@@ -87,8 +87,8 @@ def spki_from_cert(cert: bytes) -> bytes:
 
 
 @dataclass(frozen=True)
-class ClassicalSignaturePayload:
-    """A single classical-signature entry parsed from a signature transaction.
+class RawSignaturePayload:
+    """A single raw-signature entry parsed from a signature transaction.
 
     Every field is derived from the per-tx contents of
     :data:`SIGNATURE_TX_TABLE_NAME`; nothing here depends on validator state.
@@ -104,50 +104,47 @@ class ClassicalSignaturePayload:
     signature entry (``"cert"`` field), or ``None`` if absent."""
 
 
-def parse_classical_signatures(
-    tables: Mapping[str, Any],
-) -> List[ClassicalSignaturePayload]:
-    """Return all classical signature payloads in this tx.
+def parse_raw_signature_from_tx(
+    tx_tables: Mapping[str, Any],
+) -> Optional[RawSignaturePayload]:
+    """Return the raw signature payload in this tx, or ``None`` if absent.
 
-    A signature transaction may contain multiple classical signature entries
-    (e.g. one per signing node during a reconfiguration window); each becomes
-    a :class:`ClassicalSignaturePayload`. Returns ``[]`` when the table is
-    absent.
+    The signature table is a singleton (one entry per tx, keyed by
+    :data:`WELL_KNOWN_SINGLETON_TABLE_KEY`), so at most one payload exists.
     """
-    signature_table = tables.get(SIGNATURE_TX_TABLE_NAME)
+    signature_table = tx_tables.get(SIGNATURE_TX_TABLE_NAME)
     if signature_table is None:
-        return []
+        return None
 
-    payloads: List[ClassicalSignaturePayload] = []
-    for _, raw in signature_table.items():
-        sig = json.loads(raw)
-        embedded_cert = sig["cert"].encode("utf-8") if "cert" in sig else None
-        payloads.append(
-            ClassicalSignaturePayload(
-                seqno=sig["seqno"],
-                view=sig["view"],
-                signing_node=sig["node"],
-                root=bytes.fromhex(sig["root"]),
-                signature=base64.b64decode(sig["sig"]),
-                embedded_cert=embedded_cert,
-            )
-        )
-    return payloads
+    encoded = signature_table.get(WELL_KNOWN_SINGLETON_TABLE_KEY)
+    if encoded is None:
+        return None
+
+    sig = json.loads(encoded)
+    embedded_cert = sig["cert"].encode("utf-8") if "cert" in sig else None
+    return RawSignaturePayload(
+        seqno=sig["seqno"],
+        view=sig["view"],
+        signing_node=sig["node"],
+        root=bytes.fromhex(sig["root"]),
+        signature=base64.b64decode(sig["sig"]),
+        embedded_cert=embedded_cert,
+    )
 
 
-def parse_cose_signature(tables: Mapping[str, Any]) -> Optional[bytes]:
+def parse_cose_signature_from_tx(tx_tables: Mapping[str, Any]) -> Optional[bytes]:
     """Return the COSE Sign1 bytes from this tx, or ``None`` if absent.
 
     Strips the JSON-string + base64 wrapper used in the KV table and returns
-    the raw COSE Sign1 bytes ready for :func:`verify_cose_root_signature`.
+    the decoded COSE Sign1 bytes ready for :func:`verify_cose_root_signature`.
     """
-    cose_table = tables.get(COSE_SIGNATURE_TX_TABLE_NAME)
+    cose_table = tx_tables.get(COSE_SIGNATURE_TX_TABLE_NAME)
     if cose_table is None:
         return None
-    raw = cose_table.get(WELL_KNOWN_SINGLETON_TABLE_KEY)
-    if raw is None:
+    encoded = cose_table.get(WELL_KNOWN_SINGLETON_TABLE_KEY)
+    if encoded is None:
         return None
-    return base64.b64decode(json.loads(raw))
+    return base64.b64decode(json.loads(encoded))
 
 
 # ---------------------------------------------------------------------------
@@ -155,8 +152,8 @@ def parse_cose_signature(tables: Mapping[str, Any]) -> Optional[bytes]:
 # ---------------------------------------------------------------------------
 
 
-def verify_root_signature(node_cert: bytes, root: bytes, signature: bytes) -> None:
-    """Verify a classical ECDSA signature over a (prehashed) Merkle root.
+def verify_raw_root_signature(node_cert: bytes, root: bytes, signature: bytes) -> None:
+    """Verify a raw ECDSA signature over a (prehashed) Merkle root.
 
     Raises :class:`InvalidRootSignatureException` if verification fails.
     """

--- a/python/src/ccf/signatures.py
+++ b/python/src/ccf/signatures.py
@@ -1,0 +1,211 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+import base64
+import functools
+import json
+from dataclasses import dataclass
+from typing import Any, Container, List, Mapping, Optional
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, utils
+from cryptography.x509 import load_pem_x509_certificate
+
+import ccf.cose
+from ccf.merkletree import MerkleTree
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+SIGNATURE_TX_TABLE_NAME: str = "public:ccf.internal.signatures"
+"""KV table carrying the classical ECDSA signature over the Merkle root."""
+
+COSE_SIGNATURE_TX_TABLE_NAME: str = "public:ccf.internal.cose_signatures"
+"""KV table carrying the COSE Sign1 signature over the Merkle root."""
+
+SIGNATURE_TABLE_NAMES: frozenset[str] = frozenset(
+    {SIGNATURE_TX_TABLE_NAME, COSE_SIGNATURE_TX_TABLE_NAME}
+)
+"""All KV table names that carry a ledger-transaction signature."""
+
+
+def is_signature_transaction(tables: Container[str]) -> bool:
+    """Return ``True`` if ``tables`` contains any signature table.
+
+    ``tables`` is any object supporting ``in`` over table names. Typical
+    callers pass the dict returned by
+    ``transaction.get_public_domain().get_tables()``.
+    """
+    return any(name in tables for name in SIGNATURE_TABLE_NAMES)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class InvalidRootException(Exception):
+    """MerkleTree root doesn't match with the root reported in the signature's table"""
+
+
+class InvalidRootSignatureException(Exception):
+    """Signature of the MerkleRoot doesn't match with the signature that's reported in the signature's table"""
+
+
+class InvalidRootCoseSignatureException(Exception):
+    """COSE signature of the MerkleRoot doesn't pass COSE verification"""
+
+
+class UntrustedNodeException(Exception):
+    """The signing node wasn't part of the network when it issued a signature."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@functools.lru_cache(maxsize=64)
+def spki_from_cert(cert: bytes) -> bytes:
+    """Return the DER-encoded SubjectPublicKeyInfo for a PEM certificate."""
+    cert_obj = load_pem_x509_certificate(cert)
+    return cert_obj.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parsers: pure tx -> structured data, no validator state
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ClassicalSignaturePayload:
+    """A single classical-signature entry parsed from a signature transaction.
+
+    Every field is derived from the per-tx contents of
+    :data:`SIGNATURE_TX_TABLE_NAME`; nothing here depends on validator state.
+    """
+
+    seqno: int
+    view: int
+    signing_node: str
+    root: bytes
+    signature: bytes
+    embedded_cert: Optional[bytes]
+    """PEM bytes of the signing node's certificate as embedded in the
+    signature entry (``"cert"`` field), or ``None`` if absent."""
+
+
+def parse_classical_signatures(
+    tables: Mapping[str, Any],
+) -> List[ClassicalSignaturePayload]:
+    """Return all classical signature payloads in this tx.
+
+    A signature transaction may contain multiple classical signature entries
+    (e.g. one per signing node during a reconfiguration window); each becomes
+    a :class:`ClassicalSignaturePayload`. Returns ``[]`` when the table is
+    absent.
+    """
+    signature_table = tables.get(SIGNATURE_TX_TABLE_NAME)
+    if signature_table is None:
+        return []
+
+    payloads: List[ClassicalSignaturePayload] = []
+    for _, raw in signature_table.items():
+        sig = json.loads(raw)
+        embedded_cert = sig["cert"].encode("utf-8") if "cert" in sig else None
+        payloads.append(
+            ClassicalSignaturePayload(
+                seqno=sig["seqno"],
+                view=sig["view"],
+                signing_node=sig["node"],
+                root=bytes.fromhex(sig["root"]),
+                signature=base64.b64decode(sig["sig"]),
+                embedded_cert=embedded_cert,
+            )
+        )
+    return payloads
+
+
+def parse_cose_signature(tables: Mapping[str, Any]) -> Optional[bytes]:
+    """Return the COSE Sign1 bytes from this tx, or ``None`` if absent.
+
+    Strips the JSON-string + base64 wrapper used in the KV table and returns
+    the raw COSE Sign1 bytes ready for :func:`verify_cose_root_signature`.
+    """
+    cose_table = tables.get(COSE_SIGNATURE_TX_TABLE_NAME)
+    if cose_table is None:
+        return None
+    # Deferred to break the import cycle: ccf.ledger imports from this module
+    # but owns the generic KV constant.
+    from ccf.ledger import WELL_KNOWN_SINGLETON_TABLE_KEY
+
+    raw = cose_table.get(WELL_KNOWN_SINGLETON_TABLE_KEY)
+    if raw is None:
+        return None
+    return base64.b64decode(json.loads(raw))
+
+
+# ---------------------------------------------------------------------------
+# Primitive verifiers: pure crypto / comparison, take direct inputs
+# ---------------------------------------------------------------------------
+
+
+def verify_root_signature(node_cert: bytes, root: bytes, signature: bytes) -> None:
+    """Verify a classical ECDSA signature over a (prehashed) Merkle root.
+
+    Raises :class:`InvalidRootSignatureException` if verification fails.
+    """
+    try:
+        cert = load_pem_x509_certificate(node_cert)
+        pub_key = cert.public_key()
+
+        assert isinstance(pub_key, ec.EllipticCurvePublicKey)
+        pub_key.verify(
+            signature,
+            root,
+            ec.ECDSA(utils.Prehashed(hashes.SHA256())),
+        )
+    except InvalidSignature as exc:
+        raise InvalidRootSignatureException(
+            "Signature verification failed:"
+            + f"\nCertificate: {node_cert.decode()}"
+            + f"\nSignature: {base64.b64encode(signature).decode()}"
+            + f"\nRoot: {root.hex()}"
+        ) from exc
+
+
+def verify_cose_root_signature(
+    service_cert: str, root: bytes, cose_sign1: bytes
+) -> None:
+    """Verify a COSE Sign1 signature over a Merkle root against the service cert.
+
+    Raises :class:`InvalidRootCoseSignatureException` if verification fails.
+    """
+    try:
+        ccf.cose.verify_cose_sign1_with_cert(
+            certificate=service_cert.encode("ascii"),
+            cose_sign1=cose_sign1,
+            use_key=True,
+            payload=root,
+        )
+    except Exception as exc:
+        raise InvalidRootCoseSignatureException(
+            "Signature verification failed:"
+            + f"\nCertificate: {service_cert}"
+            + f"\nRoot: {root!r}"
+        ) from exc
+
+
+def verify_merkle_root(merkle_tree: MerkleTree, existing_root: bytes) -> None:
+    """Raise :class:`InvalidRootException` if the tree's root differs from ``existing_root``."""
+    root = merkle_tree.get_merkle_root()
+    if root != existing_root:
+        raise InvalidRootException(
+            f"\nComputed root: {root.hex()} \nExisting root from ledger: {existing_root.hex()}"
+        )

--- a/python/src/ccf/signatures.py
+++ b/python/src/ccf/signatures.py
@@ -31,6 +31,9 @@ SIGNATURE_TABLE_NAMES: frozenset[str] = frozenset(
 )
 """All KV table names that carry a ledger-transaction signature."""
 
+WELL_KNOWN_SINGLETON_TABLE_KEY: bytes = bytes(bytearray(8))
+"""Key used by CCF to record entries in single-row KV tables."""
+
 
 def is_signature_transaction(tables: Container[str]) -> bool:
     """Return ``True`` if ``tables`` contains any signature table.
@@ -141,10 +144,6 @@ def parse_cose_signature(tables: Mapping[str, Any]) -> Optional[bytes]:
     cose_table = tables.get(COSE_SIGNATURE_TX_TABLE_NAME)
     if cose_table is None:
         return None
-    # Deferred to break the import cycle: ccf.ledger imports from this module
-    # but owns the generic KV constant.
-    from ccf.ledger import WELL_KNOWN_SINGLETON_TABLE_KEY
-
     raw = cose_table.get(WELL_KNOWN_SINGLETON_TABLE_KEY)
     if raw is None:
         return None

--- a/python/src/ccf/split_ledger.py
+++ b/python/src/ccf/split_ledger.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 import ccf.ledger
+import ccf.signatures
 import sys
 import argparse
 import os
@@ -106,10 +107,7 @@ def run(args_):
         entry_seqno = public_entry.get_seqno()
 
         if looking_for_following_signature:
-            if (
-                ccf.ledger.SIGNATURE_TX_TABLE_NAME in public_entry.get_tables()
-                or ccf.ledger.COSE_SIGNATURE_TX_TABLE_NAME in public_entry.get_tables()
-            ):
+            if ccf.signatures.is_signature_transaction(public_entry.get_tables()):
                 next_signature_seqno = entry_seqno
                 break
             else:
@@ -125,9 +123,7 @@ def run(args_):
 
         if entry_seqno == args.seqno:
             if (
-                ccf.ledger.SIGNATURE_TX_TABLE_NAME not in public_entry.get_tables()
-                and ccf.ledger.COSE_SIGNATURE_TX_TABLE_NAME
-                not in public_entry.get_tables()
+                not ccf.signatures.is_signature_transaction(public_entry.get_tables())
                 and not args.allow_non_signature
             ):
                 looking_for_following_signature = True

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -1928,12 +1928,12 @@ def run_cose_only_mode_upgrade(args):
                 if seqno <= start_seqno:
                     continue
 
-                assert ccf.ledger.SIGNATURE_TX_TABLE_NAME not in tables, (
+                assert ccf.signatures.SIGNATURE_TX_TABLE_NAME not in tables, (
                     f"Found traditional (non-COSE) signature at seqno {seqno}, "
                     f"expected COSE-only after seqno {start_seqno}"
                 )
 
-                if ccf.ledger.COSE_SIGNATURE_TX_TABLE_NAME in tables:
+                if ccf.signatures.COSE_SIGNATURE_TX_TABLE_NAME in tables:
                     cose_sig_count += 1
 
         assert (

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -2952,6 +2952,26 @@ def run_merkle_verification_level(args):
     """Test MERKLE verification level on isolated chunks and full ledgers"""
     LOG.info("Testing MERKLE verification level")
 
+    def validate(path, level):
+        validator = ccf.ledger.LedgerValidator(verification_level=level)
+        ledger = ccf.ledger.Ledger([path], committed_only=False, contiguous_suffix=True)
+        for chunk in ledger:
+            for tx in chunk:
+                validator.add_transaction(tx)
+        return validator
+
+    def assert_modes_agree(path):
+        full = validate(path, ccf.ledger.VerificationLevel.FULL)
+        merkle = validate(path, ccf.ledger.VerificationLevel.MERKLE)
+        assert full.last_verified_txid() == merkle.last_verified_txid(), (
+            f"MERKLE last_verified {merkle.last_verified_txid()} "
+            f"!= FULL last_verified {full.last_verified_txid()} for {path}"
+        )
+        assert full.signature_count == merkle.signature_count, (
+            f"MERKLE signature_count {merkle.signature_count} "
+            f"!= FULL signature_count {full.signature_count} for {path}"
+        )
+
     # Test 1: MERKLE verification on full ledger
     for testdata_dir in os.scandir(args.historical_testdata):
         if not testdata_dir.is_dir():
@@ -2967,6 +2987,10 @@ def run_merkle_verification_level(args):
             print_mode=ccf.read_ledger.PrintMode.Quiet,
             verification_level=ccf.ledger.VerificationLevel.MERKLE,
         )
+        # Cross-check that MERKLE reached the same last_verified TxID and
+        # walked over the same signature count as FULL. Catches silent
+        # no-ops in the MERKLE-only path (e.g. on COSE-only sig TXs).
+        assert_modes_agree(testdata_path)
 
     # Test 2: MERKLE verification on isolated chunks
     # Find chunks with multiple signatures to test the "trust first signature" logic

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -11,6 +11,7 @@ import infra.e2e_args
 import infra.network
 import infra.platform_detection
 import ccf.ledger
+import ccf.signatures
 from ccf.tx_id import TxID
 import base64
 import suite.test_requirements as reqs
@@ -138,7 +139,7 @@ def find_ledger_chunk_for_seqno(ledger, seqno):
             if (
                 pd.get_seqno() >= seqno
                 and next_signature is None
-                and ccf.ledger.SIGNATURE_TX_TABLE_NAME in tables
+                and ccf.signatures.is_signature_transaction(tables)
             ):
                 next_signature = pd.get_seqno()
         if first <= seqno and seqno <= last:
@@ -945,10 +946,7 @@ def split_all_ledger_files_in_dir(input_dir, output_dir):
         for transaction in ledger_chunk:
             public_domain = transaction.get_public_domain()
             tables = public_domain.get_tables().keys()
-            if (
-                ccf.ledger.SIGNATURE_TX_TABLE_NAME in tables
-                or ccf.ledger.COSE_SIGNATURE_TX_TABLE_NAME in tables
-            ):
+            if ccf.signatures.is_signature_transaction(tables):
                 sig_seqnos.append(public_domain.get_seqno())
 
         if len(sig_seqnos) <= 1:

--- a/tests/governance_history.py
+++ b/tests/governance_history.py
@@ -4,6 +4,7 @@
 import infra.network
 import infra.crypto
 import ccf.ledger
+import ccf.signatures
 import infra.doc
 from infra.proposal import ProposalState
 import http
@@ -109,30 +110,29 @@ def check_signatures(ledger):
     for chunk in ledger:
         for tr in chunk:
             tables = tr.get_public_domain().get_tables()
-            if not ccf.ledger.is_signature_transaction(tables):
+            if not ccf.signatures.is_signature_transaction(tables):
                 continue
 
             gcm_view = tr.gcm_header.view
             gcm_seqno = tr.gcm_header.seqno
             sig_txid = TxID(gcm_view, gcm_seqno)
 
-            classical_table = tables.get(ccf.ledger.SIGNATURE_TX_TABLE_NAME)
-            if classical_table is not None:
-                payloads = ccf.ledger.parse_classical_signatures(tables)
-                assert len(payloads) == 1, payloads
-                (payload,) = payloads
+            raw_table = tables.get(ccf.signatures.SIGNATURE_TX_TABLE_NAME)
+            if raw_table is not None:
+                payload = ccf.signatures.parse_raw_signature_from_tx(tables)
+                assert payload is not None, raw_table
                 assert payload.view == gcm_view, (payload, gcm_view)
                 assert payload.seqno == gcm_seqno, (payload, gcm_seqno)
-                raw_entries = list(classical_table.items())
+                raw_entries = list(raw_table.items())
                 assert len(raw_entries) == 1, raw_entries
                 raw_sig = json.loads(raw_entries[0][1])
                 assert raw_sig["commit_view"] == 0, raw_sig
                 assert raw_sig["commit_seqno"] == 0, raw_sig
 
-            if ccf.ledger.COSE_SIGNATURE_TX_TABLE_NAME in tables:
-                cose_sign1 = ccf.ledger.parse_cose_signature(tables)
+            if ccf.signatures.COSE_SIGNATURE_TX_TABLE_NAME in tables:
+                cose_sign1 = ccf.signatures.parse_cose_signature_from_tx(tables)
                 assert cose_sign1 is not None, tables[
-                    ccf.ledger.COSE_SIGNATURE_TX_TABLE_NAME
+                    ccf.signatures.COSE_SIGNATURE_TX_TABLE_NAME
                 ]
                 msg = cwt.COSEMessage.loads(cose_sign1)
                 assert msg.type == cwt.COSETypes.SIGN1, msg

--- a/tests/governance_history.py
+++ b/tests/governance_history.py
@@ -109,33 +109,65 @@ def check_signatures(ledger):
     for chunk in ledger:
         for tr in chunk:
             tables = tr.get_public_domain().get_tables()
-            signatures_table_name = "public:ccf.internal.signatures"
-            if signatures_table_name in tables:
-                signatures_table = tables[signatures_table_name]
-                signatures = list(signatures_table.items())
-                assert len(signatures) == 1, signatures
-                signature_raw = signatures[0][1]
-                signature = json.loads(signature_raw)
-                # commit_view and commit_seqno fields are unsigned, deprecated, and set to 0
-                assert signature["commit_view"] == 0, signature
-                assert signature["commit_seqno"] == 0, signature
-                # view and seqno fields are unsigned, and always match the txID contained in the GcmHeader
-                assert tr.gcm_header.view == signature["view"]
-                assert tr.gcm_header.seqno == signature["seqno"]
+            if not ccf.ledger.is_signature_transaction(tables):
+                continue
 
-                sig_txid = TxID(tr.gcm_header.view, tr.gcm_header.seqno)
+            gcm_view = tr.gcm_header.view
+            gcm_seqno = tr.gcm_header.seqno
+            sig_txid = TxID(gcm_view, gcm_seqno)
 
-                # Adjacent signatures only occur on a view change
-                if prev_sig_txid is not None:
-                    if prev_sig_txid.seqno + 1 == sig_txid.seqno:
-                        # Reduced from assert while investigating cause
-                        # https://github.com/microsoft/CCF/issues/5078
-                        if sig_txid.view <= prev_sig_txid.view:
-                            LOG.error(
-                                f"Adjacent signatures at {prev_sig_txid} and {sig_txid}"
-                            )
+            classical_table = tables.get(ccf.ledger.SIGNATURE_TX_TABLE_NAME)
+            if classical_table is not None:
+                payloads = ccf.ledger.parse_classical_signatures(tables)
+                assert len(payloads) == 1, payloads
+                (payload,) = payloads
+                assert payload.view == gcm_view, (payload, gcm_view)
+                assert payload.seqno == gcm_seqno, (payload, gcm_seqno)
+                raw_entries = list(classical_table.items())
+                assert len(raw_entries) == 1, raw_entries
+                raw_sig = json.loads(raw_entries[0][1])
+                assert raw_sig["commit_view"] == 0, raw_sig
+                assert raw_sig["commit_seqno"] == 0, raw_sig
 
-                prev_sig_txid = sig_txid
+            if ccf.ledger.COSE_SIGNATURE_TX_TABLE_NAME in tables:
+                cose_sign1 = ccf.ledger.parse_cose_signature(tables)
+                assert cose_sign1 is not None, tables[
+                    ccf.ledger.COSE_SIGNATURE_TX_TABLE_NAME
+                ]
+                msg = cwt.COSEMessage.loads(cose_sign1)
+                assert msg.type == cwt.COSETypes.SIGN1, msg
+                assert msg.payload is None, msg
+                phdr = msg.protected
+
+                KID = 4
+                kid = phdr.get(KID)
+                assert isinstance(kid, bytes) and len(kid) > 0, phdr
+
+                VDS = 395
+                CCF_LEDGER_SHA256 = 2
+                assert phdr[VDS] == CCF_LEDGER_SHA256, phdr
+
+                CWT_CLAIMS = 15
+                IAT, ISS, SUB = 6, 1, 2
+                cwt_claims = phdr[CWT_CLAIMS]
+                for label in (IAT, ISS, SUB):
+                    assert label in cwt_claims, (label, cwt_claims)
+
+                cose_txid = TxID.from_str(phdr["ccf.v1"]["txid"])
+                assert cose_txid.view == gcm_view, (cose_txid, gcm_view)
+                assert cose_txid.seqno == gcm_seqno, (cose_txid, gcm_seqno)
+
+            # Adjacent signatures only occur on a view change
+            if prev_sig_txid is not None:
+                if prev_sig_txid.seqno + 1 == sig_txid.seqno:
+                    # Reduced from assert while investigating cause
+                    # https://github.com/microsoft/CCF/issues/5078
+                    if sig_txid.view <= prev_sig_txid.view:
+                        LOG.error(
+                            f"Adjacent signatures at {prev_sig_txid} and {sig_txid}"
+                        )
+
+            prev_sig_txid = sig_txid
 
 
 def check_all_tables_are_documented(table_names_in_ledger, doc_path):

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -729,7 +729,7 @@ def test_retiring_nodes_emit_at_most_one_signature(network, args):
                         continue
                     info = json.loads(info_)
                     if info["status"] == "Retired":
-                        retiring_nodes.add(nid)
+                        retiring_nodes.add(nid.decode())
 
             if ccf.signatures.SIGNATURE_TX_TABLE_NAME in tables:
                 sig = ccf.signatures.parse_raw_signature_from_tx(tables)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -731,13 +731,12 @@ def test_retiring_nodes_emit_at_most_one_signature(network, args):
                         retiring_nodes.add(nid)
 
             if ccf.ledger.SIGNATURE_TX_TABLE_NAME in tables:
-                sigs = tables[ccf.ledger.SIGNATURE_TX_TABLE_NAME]
-                assert len(sigs) == 1, sigs.keys()
-                (sig_,) = sigs.values()
-                sig = json.loads(sig_)
+                classical = ccf.ledger.parse_classical_signatures(tables)
+                assert len(classical) == 1, classical
+                (sig,) = classical
                 assert (
-                    sig["node"] not in retired_nodes
-                ), f"Unexpected signature from {sig['node']}"
+                    sig.signing_node not in retired_nodes
+                ), f"Unexpected signature from {sig.signing_node}"
                 retired_nodes |= retiring_nodes
                 retiring_nodes = set()
 

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -14,6 +14,7 @@ from copy import deepcopy
 import os
 import time
 import ccf.ledger
+import ccf.signatures
 import json
 import infra.crypto
 from datetime import datetime
@@ -730,10 +731,9 @@ def test_retiring_nodes_emit_at_most_one_signature(network, args):
                     if info["status"] == "Retired":
                         retiring_nodes.add(nid)
 
-            if ccf.ledger.SIGNATURE_TX_TABLE_NAME in tables:
-                classical = ccf.ledger.parse_classical_signatures(tables)
-                assert len(classical) == 1, classical
-                (sig,) = classical
+            if ccf.signatures.SIGNATURE_TX_TABLE_NAME in tables:
+                sig = ccf.signatures.parse_raw_signature_from_tx(tables)
+                assert sig is not None, tables
                 assert (
                     sig.signing_node not in retired_nodes
                 ), f"Unexpected signature from {sig.signing_node}"

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -1093,7 +1093,7 @@ def find_recovery_tx_seqno(node):
             if ccf.ledger.SERVICE_INFO_TABLE_NAME in tables:
                 service_status = json.loads(
                     tables[ccf.ledger.SERVICE_INFO_TABLE_NAME][
-                        ccf.ledger.WELL_KNOWN_SINGLETON_TABLE_KEY
+                        ccf.signatures.WELL_KNOWN_SINGLETON_TABLE_KEY
                     ]
                 )["status"]
                 if service_status == "Open":
@@ -1207,7 +1207,7 @@ def run(args):
             if ccf.ledger.SERVICE_INFO_TABLE_NAME in tables:
                 service_status = json.loads(
                     tables[ccf.ledger.SERVICE_INFO_TABLE_NAME][
-                        ccf.ledger.WELL_KNOWN_SINGLETON_TABLE_KEY
+                        ccf.signatures.WELL_KNOWN_SINGLETON_TABLE_KEY
                     ]
                 )["status"]
                 if service_status == "Opening" or service_status == "Recovering":

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -9,6 +9,7 @@ import infra.checker
 import infra.crypto
 import suite.test_requirements as reqs
 import ccf.ledger
+import ccf.signatures
 import os
 import subprocess
 import json
@@ -1048,7 +1049,7 @@ def run_corrupted_ledger(args):
             LOG.info("Finding first sig to corrupt")
             for chunk, tx in all_txs(ledger, verbose):
                 tables = tx.get_public_domain().get_tables()
-                if ccf.ledger.SIGNATURE_TX_TABLE_NAME in tables:
+                if ccf.signatures.is_signature_transaction(tables):
                     return chunk.filename(), get_middle_tx_offset(tx)
             return None, None
 
@@ -1276,7 +1277,9 @@ def test_incomplete_ledger_recovery(network, args):
         _, last_seqno = ledger.get_latest_public_state()
         last_tx = ledger.get_transaction(last_seqno)
 
-        if "ccf.internal.signatures" in last_tx.get_raw_tx().decode(errors="ignore"):
+        if ccf.signatures.is_signature_transaction(
+            last_tx.get_public_domain().get_tables()
+        ):
             LOG.info(
                 f"Found signature in last tx {last_tx.get_tx_digest()}, not a suitable candidate for this test"
             )


### PR DESCRIPTION
Motto: consolidate signature verification in one place, and benefit from it greatly when introducing PQC COSE signatures in the future.

I still plan to keep a split for verifying classical/cose, but for cose we'll extend the table itself in the future and will iterate over multiple cose signatures instead, and will try to get rid of classical signatures somewhere in the future. 