### PR TITLE
[DRAFT] UnitTest based tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1285,7 +1285,7 @@ if(BUILD_TESTS)
   if(BUILD_END_TO_END_TESTS)
     add_test(
       NAME e2e_unittests
-      COMMAND ${PYTHON} -m unittest discover -s ${CMAKE_SOURCE_DIR}/tests
+      COMMAND ${PYTHON} -m unittest discover -s ${CMAKE_SOURCE_DIR}/tests -v
     )
     set_property(
       TEST e2e_unittests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1282,6 +1282,27 @@ if(BUILD_TESTS)
   )
   set_tests_properties(schema_test PROPERTIES TIMEOUT 900)
 
+  if(BUILD_END_TO_END_TESTS)
+    add_test(
+      NAME e2e_unittests
+      COMMAND ${PYTHON} -m unittest discover -s ${CMAKE_SOURCE_DIR}/tests
+    )
+    set_property(
+      TEST e2e_unittests
+      APPEND
+      PROPERTY ENVIRONMENT "PYTHONPATH=${CCF_DIR}/tests:$ENV{PYTHONPATH}"
+    )
+    set_property(
+      TEST e2e_unittests
+      APPEND
+      PROPERTY ENVIRONMENT "CCF_TEST_CONFIG=${CMAKE_BINARY_DIR}/test_config.json"
+    )
+    set_property(TEST e2e_unittests APPEND PROPERTY LABELS e2e)
+    set_property(TEST e2e_unittests APPEND PROPERTY LABELS e2e_unittest)
+    set_property(TEST e2e_unittests APPEND PROPERTY LABELS bucket_a)
+    add_san_test_properties(e2e_unittests)
+  endif()
+
   add_e2e_test(
     NAME snp_platform_tests
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/amd_snp.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,22 +307,46 @@ set(
 )
 
 set(
-  CCF_NETWORK_TEST_DEFAULT_CONSTITUTION
-  --constitution
+  CCF_NETWORK_TEST_DEFAULT_CONSTITUTION_FILES
   ${CCF_DIR}/samples/constitutions/default/actions.js
-  --constitution
   ${CCF_DIR}/samples/constitutions/default/validate.js
-  --constitution
   ${CCF_DIR}/samples/constitutions/default/resolve.js
-  --constitution
   ${CCF_DIR}/samples/constitutions/default/apply.js
 )
+set(CCF_NETWORK_TEST_DEFAULT_CONSTITUTION "")
+foreach(CONSTITUTION_FILE IN LISTS CCF_NETWORK_TEST_DEFAULT_CONSTITUTION_FILES)
+  list(
+    APPEND CCF_NETWORK_TEST_DEFAULT_CONSTITUTION --constitution
+    ${CONSTITUTION_FILE}
+  )
+endforeach()
 set(
   CCF_NETWORK_TEST_ARGS
   --log-level
   ${TEST_LOGGING_LEVEL}
   --worker-threads
   ${WORKER_THREADS}
+)
+
+# For fast e2e runs, tick node faster than default value (except for
+# instrumented builds which may process ticks slower).
+if(SAN)
+  set(NODE_TICK_MS 10)
+else()
+  set(NODE_TICK_MS 1)
+endif()
+
+list(
+  TRANSFORM CCF_NETWORK_TEST_DEFAULT_CONSTITUTION_FILES
+  REPLACE "(.+)" "\"\\1\""
+  OUTPUT_VARIABLE QUOTED_DEFAULT_CONSTITUTION_FILES
+)
+list(JOIN QUOTED_DEFAULT_CONSTITUTION_FILES ", " DEFAULT_CONSTITUTION_JSON)
+set(DEFAULT_CONSTITUTION_JSON "[${DEFAULT_CONSTITUTION_JSON}]")
+configure_file(
+  ${CCF_DIR}/cmake/test_config.json.in
+  ${CMAKE_BINARY_DIR}/test_config.json
+  @ONLY
 )
 
 # SNIPPET_START: JS generic application

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -112,14 +112,6 @@ function(add_e2e_test)
   if(BUILD_END_TO_END_TESTS)
     set(PYTHON_WRAPPER ${PYTHON})
 
-    # For fast e2e runs, tick node faster than default value (except for
-    # instrumented builds which may process ticks slower).
-    if(SAN)
-      set(NODE_TICK_MS 10)
-    else()
-      set(NODE_TICK_MS 1)
-    endif()
-
     if(NOT PARSED_ARGS_PERF_LABEL)
       set(PARSED_ARGS_PERF_LABEL ${PARSED_ARGS_NAME})
     endif()

--- a/cmake/test_config.json.in
+++ b/cmake/test_config.json.in
@@ -1,0 +1,9 @@
+{
+  "binary_dir": "@CMAKE_BINARY_DIR@",
+  "log_level": "@TEST_LOGGING_LEVEL@",
+  "worker_threads": @WORKER_THREADS@,
+  "tick_ms": @NODE_TICK_MS@,
+  "default_constitution": @DEFAULT_CONSTITUTION_JSON@,
+  "historical_testdata": "@CMAKE_SOURCE_DIR@/tests/testdata",
+  "jinja_templates_path": "@CMAKE_SOURCE_DIR@/samples/templates"
+}

--- a/python/src/ccf/ledger.py
+++ b/python/src/ccf/ledger.py
@@ -399,7 +399,8 @@ class SimpleBuffer:
 
     @staticmethod
     def from_file(filename):
-        return SimpleBuffer(filename, open(filename, "rb").read())
+        with open(filename, "rb") as f:
+            return SimpleBuffer(filename, f.read())
 
 
 def _byte_read_safe(file: SimpleBuffer, num_of_bytes):

--- a/tests/ci-buckets.txt
+++ b/tests/ci-buckets.txt
@@ -15,6 +15,7 @@
 #   ./scripts/test-buckets-checks.sh -f
 
 bucket_a:
+  e2e_unittests
   lts_compatibility
 
 bucket_b:

--- a/tests/infra/e2e_args.py
+++ b/tests/infra/e2e_args.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 import argparse
+import json
 import os
 import infra.interfaces
 import infra.path
@@ -46,11 +47,26 @@ def default_platform():
     return "virtual"
 
 
+def _load_test_config():
+    config_path = os.getenv("CCF_TEST_CONFIG")
+    if config_path:
+        with open(config_path, encoding="utf-8") as f:
+            return json.load(f)
+
+    config_path = os.path.join(os.getcwd(), "test_config.json")
+    if os.path.isfile(config_path):
+        with open(config_path, encoding="utf-8") as f:
+            return json.load(f)
+
+    return None
+
+
 def cli_args(
     add=lambda x: None,
     parser=None,
     accept_unknown=False,
     ledger_chunk_bytes_override=None,
+    argv=None,
 ):
     LOG.remove()
     LOG.add(
@@ -400,10 +416,20 @@ def cli_args(
     )
     add(parser)
 
+    test_config = _load_test_config()
+    if test_config is not None:
+        config_defaults = {
+            k: v for k, v in test_config.items() if k != "default_constitution"
+        }
+        parser.set_defaults(**config_defaults)
+
     if accept_unknown:
-        args, unknown_args = parser.parse_known_args()
+        args, unknown_args = parser.parse_known_args(argv)
     else:
-        args = parser.parse_args()
+        args = parser.parse_args(argv)
+
+    if test_config is not None and not args.constitution:
+        args.constitution = test_config.get("default_constitution", [])
 
     args.binary_dir = os.path.abspath(args.binary_dir)
 

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -2279,7 +2279,6 @@ class NetworkTestCase(unittest.TestCase):
             cls.args.nodes,
             cls.args.binary_dir,
             cls.args.debug_nodes,
-            pdb=cls.args.pdb,
             **cls.network_kwargs(cls.args),
         )
         with infra.network.close_on_error(cls.network, pdb=cls.args.pdb):

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -6,6 +6,7 @@ import time
 
 from contextlib import contextmanager
 from enum import Enum, IntEnum, auto
+import unittest
 from infra.clients import flush_info, CCFConnectionException, CCFIOException
 import infra.crypto
 import infra.member
@@ -2229,3 +2230,74 @@ def network(
     )
     if init_partitioner:
         net.partitioner.cleanup()
+
+
+class NetworkTestCase(unittest.TestCase):
+    label = None
+    package = "samples/apps/logging/logging"
+    test_config_overrides = lambda args: {}
+    network_kwargs = lambda args: {}
+    start_and_open_kwargs = {}
+    failure_stop_kwargs = {
+        "skip_verification": True,
+        "accept_ledger_diff": True,
+        "skip_verify_chunking": True,
+    }
+    success_stop_kwargs = {
+        "skip_verification": False,
+        "accept_ledger_diff": False,
+        "skip_verify_chunking": False,
+    }
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if cls.label is None:
+            raise TypeError(f"{cls.__name__} must define a label")
+        if not isinstance(cls.label, str):
+            raise TypeError(f"{cls.__name__}.label must be a string")
+
+    @classmethod
+    def resolve_args_overrides(cls, args):
+        return cls.test_config_overrides(args)
+
+    @classmethod
+    def cleanup(cls):
+        if cls._failing_test_id is None:
+            cls.network.stop_all_nodes(**cls.success_stop_kwargs)
+        else:
+            cls.network.stop_all_nodes(**cls.failure_stop_kwargs)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.args = infra.e2e_args.cli_args(argv=[])
+        cls.args.label = cls.label
+        cls.args.package = cls.package
+        for name, value in cls.resolve_args_overrides(cls.args).items():
+            setattr(cls.args, name, value)
+
+        cls.network = infra.network.Network(
+            cls.args.nodes,
+            cls.args.binary_dir,
+            cls.args.debug_nodes,
+            pdb=cls.args.pdb,
+            **cls.network_kwargs(cls.args),
+        )
+        with infra.network.close_on_error(cls.network, pdb=cls.args.pdb):
+            cls.network.start_and_open(cls.args, **cls.start_and_open_kwargs)
+        cls._failing_test_id = None
+        cls.addClassCleanup(cls.cleanup)
+
+    # Record traces on exceptions
+    def _callTestMethod(self, method):
+        if type(self)._failing_test_id is not None:
+            raise unittest.SkipTest(
+                f"Skipping test due to previous failure: {type(self)._failing_test_id}"
+            )
+        try:
+            with infra.network.close_on_error(self.network, pdb=self.args.pdb):
+                return method()
+        except unittest.SkipTest:
+            raise
+        except BaseException:
+            type(self)._failing_test_id = self.id()
+            raise

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -2261,10 +2261,12 @@ class NetworkTestCase(unittest.TestCase):
         return cls.test_config_overrides(args)
 
     @classmethod
-    def cleanup(cls):
+    def _cleanup(cls):
         if cls._failing_test_id is None:
             cls.network.stop_all_nodes(**cls.success_stop_kwargs)
         else:
+            cls.network.txs = None
+            cls.network.log_stack_traces(timeout=10)
             cls.network.stop_all_nodes(**cls.failure_stop_kwargs)
 
     @classmethod
@@ -2286,7 +2288,7 @@ class NetworkTestCase(unittest.TestCase):
         with infra.network.close_on_error(cls.network, pdb=cls.args.pdb):
             cls.network.start_and_open(cls.args, **cls.start_and_open_kwargs)
         cls._failing_test_id = None
-        cls.addClassCleanup(cls.cleanup)
+        cls.addClassCleanup(cls._cleanup)
 
     # Record traces on exceptions
     def _callTestMethod(self, method):
@@ -2295,10 +2297,13 @@ class NetworkTestCase(unittest.TestCase):
                 f"Skipping test due to previous failure: {type(self)._failing_test_id}"
             )
         try:
-            with infra.network.close_on_error(self.network, pdb=self.args.pdb):
-                return method()
+            return method()
         except unittest.SkipTest:
             raise
-        except BaseException:
+        except Exception:
             type(self)._failing_test_id = self.id()
+            if self.args.pdb:
+                import pdb
+
+                pdb.post_mortem()
             raise

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -2272,6 +2272,8 @@ class NetworkTestCase(unittest.TestCase):
         cls.args = infra.e2e_args.cli_args(argv=[])
         cls.args.label = cls.label
         cls.args.package = cls.package
+        if not os.path.isabs(cls.args.package):
+            cls.args.package = os.path.join(cls.args.binary_dir, cls.args.package)
         for name, value in cls.resolve_args_overrides(cls.args).items():
             setattr(cls.args, name, value)
 

--- a/tests/test_e2e_operations.py
+++ b/tests/test_e2e_operations.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
 import infra.logging_app as app
 import infra
 from e2e_operations import (

--- a/tests/test_e2e_operations.py
+++ b/tests/test_e2e_operations.py
@@ -1,6 +1,6 @@
 import infra.logging_app as app
 import infra
-from tests.e2e_operations import (
+from e2e_operations import (
     test_backup_snapshot_fetch,
     test_backup_snapshot_fetch_max_size,
     test_error_message_on_failure_to_fetch_snapshot,
@@ -17,6 +17,9 @@ class BackupSnapshotDownload(infra.network.NetworkTestCase):
     }
     start_and_open_kwargs = {"backup_snapshot_fetch_enabled": True}
     network_kwargs = lambda _: {"txs": app.LoggingTxs("user0")}
+    success_stop_kwargs = {
+        "skip_verification": True,
+    }
 
     def test_backup_snapshot_fetch(self):
         test_backup_snapshot_fetch(self.network, self.args)

--- a/tests/test_e2e_operations.py
+++ b/tests/test_e2e_operations.py
@@ -1,0 +1,34 @@
+import infra.logging_app as app
+import infra
+from tests.e2e_operations import (
+    test_backup_snapshot_fetch,
+    test_backup_snapshot_fetch_max_size,
+    test_error_message_on_failure_to_fetch_snapshot,
+    test_join_idempotency_short_circuits_on_backup,
+    test_join_time_snapshot_fetch_failure,
+)
+
+
+class BackupSnapshotDownload(infra.network.NetworkTestCase):
+    label = "backup_snapshot_download"
+    test_config_overrides = lambda args: {
+        "snapshot_tx_interval": 30,
+        "nodes": infra.e2e_args.max_nodes(args, f=0),
+    }
+    start_and_open_kwargs = {"backup_snapshot_fetch_enabled": True}
+    network_kwargs = lambda _: {"txs": app.LoggingTxs("user0")}
+
+    def test_backup_snapshot_fetch(self):
+        test_backup_snapshot_fetch(self.network, self.args)
+
+    def test_backup_snapshot_fetch_max_size(self):
+        test_backup_snapshot_fetch_max_size(self.network, self.args)
+
+    def test_join_idempotency_short_circuits_on_backup(self):
+        test_join_idempotency_short_circuits_on_backup(self.network, self.args)
+
+    def test_join_time_snapshot_fetch_failure(self):
+        test_join_time_snapshot_fetch_failure(self.network, self.args)
+
+    def test_error_message_on_failure_to_fetch_snapshot(self):
+        test_error_message_on_failure_to_fetch_snapshot(self.network, self.args)


### PR DESCRIPTION
Several changes to make this work:
- Pass cli args as config file and path to that file as an environment variable.
- test files need to start with test_*

The atom in UnitTest is a TestCase.
So here I've mapped the suite to a single TestCase.
If down the line we still want to separate out different tests to different runners, we can do so by adding them to suites.

Selectors for single tests work:
```
   PYTHONPATH=tests:python/src \
   CCF_TEST_CONFIG=build/test_config.json \
   python -m unittest test_e2e_operations.BackupSnapshotDownload.test_backup_snapshot_fetch -v
```

I'm enthuastically open to suggestions and bikeshedding on this as it will be quite a large change and we need to ensure we are careful and correct in how we do it.

There is none of the reworks to the config, or deduplication or concurrent runners or anything like that, this is solely focused on showing how we could go about using unittest to improve the UX and improve the UX of our testing.
It does however pave the way to future improvements such as:
- Better config management
- Efficiency (deduplication and more concurrency)