### PR TITLE
Add verify_uvm_attestation_and_endorsements to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,6 +230,12 @@ jobs:
           name: logging
           path: build_against_install/logging
 
+      - name: "Upload SNP Canary"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: verify_uvm_attestation_and_endorsements
+          path: build/verify_uvm_attestation_and_endorsements
+
       - name: "Upload .rpm Package"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -482,6 +488,10 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: logging
+      - name: Download SNP Canary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: verify_uvm_attestation_and_endorsements
       - name: Download Reproducibility Metadata
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -492,7 +502,7 @@ jobs:
           set -ex
           CCF_VERSION=${{ github.ref_name }}
           CCF_VERSION=${CCF_VERSION#ccf-}
-          gh release create --title $CCF_VERSION --draft --notes-file rel-notes.md ${{ github.ref_name }} pkg/* wheel/*.whl tstgz/*.tgz sbom/* tls_report.html compatibility_report.json repro/* logging ./reproduce/start_container_and_reproduce_rpm.sh
+          gh release create --title $CCF_VERSION --draft --notes-file rel-notes.md ${{ github.ref_name }} pkg/* wheel/*.whl tstgz/*.tgz sbom/* tls_report.html compatibility_report.json repro/* logging verify_uvm_attestation_and_endorsements ./reproduce/start_container_and_reproduce_rpm.sh
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [7.0.4]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.4
 
+### Added
+
+- Added `verify_uvm_attestation_and_endorsements` as a release artifact alongside the logging sample app (#7920).
+
 ### Changed
 
 - JSON parsing can now reject inputs whose object/array nesting depth exceeds a certain value, defaulting to 64 levels and overridable per call site via `ccf::parse_json_safe`'s `max_depth` parameter (#7896).

--- a/src/pal/test/verify_uvm_attestation_and_endorsements.cpp
+++ b/src/pal/test/verify_uvm_attestation_and_endorsements.cpp
@@ -132,10 +132,28 @@ ccf::QuoteVerificationResult validate_join_policy(
     return ccf::QuoteVerificationResult::Failed;
   }
 
-  ccf::verify_uvm_endorsements_against_roots_of_trust(
-    quote_info.uvm_endorsements.value(),
-    measurement,
-    ccf::default_uvm_roots_of_trust);
+  if (quote_info.uvm_endorsements.has_value())
+  {
+    try
+    {
+      ccf::verify_uvm_endorsements_against_roots_of_trust(
+        quote_info.uvm_endorsements.value(),
+        measurement,
+        ccf::default_uvm_roots_of_trust);
+    }
+    catch (const std::exception& e)
+    {
+      LOG_FAIL_FMT(
+        "Failed to verify UVM endorsements against default roots of trust: {}",
+        e.what());
+      return ccf::QuoteVerificationResult::FailedUVMEndorsementsNotFound;
+    }
+  }
+  else
+  {
+    LOG_INFO_FMT(
+      "No UVM endorsements provided, skipping root of trust validation");
+  }
 
   auto rc = ccf::verify_quoted_node_public_key(expected_pubk_der, quoted_hash);
 
@@ -259,7 +277,7 @@ int main(int argc, char** argv)
       },
       {});
   }
-  catch (const std::invalid_argument& e)
+  catch (const std::exception& e)
   {
     LOG_FAIL_FMT("Error: {}", e.what());
     return 2;


### PR DESCRIPTION
Add the verify_uvm_attestation_and_endorsements to release pipeline to make it easier for CCF consumers to ensure compatibility.