### PR TITLE
#2 Make previous identity endorsement fetching robust to the ledger gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - JSON parsing can now reject inputs whose object/array nesting depth exceeds a certain value, defaulting to 64 levels and overridable per call site via `ccf::parse_json_safe`'s `max_depth` parameter (#7896).
-- `NetworkIdentitySubsystem` retries when walking the previous-identity endorsement chain are now bounded by a new optional `identity_history_fetch` node startup config (`max_attempts`, `retry_interval`). On exhaustion the subsystem transitions to a new terminal `FetchStatus::Partial`: the validated suffix of the chain is still served, but historical receipts for seqnos below it fail with an error. The chain-extension retry interval, previously hardcoded, now also follows `retry_interval` (#7922).
+- `NetworkIdentitySubsystem` retries when walking the previous-identity endorsement chain are now bounded by a new optional `identity_history_fetch` node startup config (`max_attempts`, `retry_interval`). On exhaustion the subsystem transitions to a new terminal `FetchStatus::Partial`: the validated suffix of the chain is still served, but historical receipts for seqnos below it fail with an error. Both the chain-extension retries and the pre-bootstrap waits (for the node to join the network, for the service-create txid, and for the first endorsement entry) now poll at `retry_interval` (default `100ms`); the pre-bootstrap polling interval was previously hardcoded to `1s` (#7922).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - JSON parsing can now reject inputs whose object/array nesting depth exceeds a certain value, defaulting to 64 levels and overridable per call site via `ccf::parse_json_safe`'s `max_depth` parameter (#7896).
+- `NetworkIdentitySubsystem` retries are now bounded by a new optional `identity_history_fetch` node config (`max_attempts`, `retry_interval`); on exhaustion the subsystem settles in a new terminal `FetchStatus::Partial`; validated suffix is served, historical receipts below it return an error instead of looping at HTTP 202 (#7913).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - JSON parsing can now reject inputs whose object/array nesting depth exceeds a certain value, defaulting to 64 levels and overridable per call site via `ccf::parse_json_safe`'s `max_depth` parameter (#7896).
-- `NetworkIdentitySubsystem` retries are now bounded by a new optional `identity_history_fetch` node config (`max_attempts`, `retry_interval`); on exhaustion the subsystem settles in a new terminal `FetchStatus::Partial`; validated suffix is served, historical receipts below it return an error instead of looping at HTTP 202 (#7913).
+- `NetworkIdentitySubsystem` retries when walking the previous-identity endorsement chain are now bounded by a new optional `identity_history_fetch` node startup config (`max_attempts`, `retry_interval`). On exhaustion the subsystem transitions to a new terminal `FetchStatus::Partial`: the validated suffix of the chain is still served, but historical receipts for seqnos below it fail with an error. The chain-extension retry interval, previously hardcoded, now also follows `retry_interval` (#7922).
 
 ### Deprecated
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -772,6 +772,15 @@ if(BUILD_TESTS)
       PRIVATE http_parser ccf_kv ccf_endpoints ccf_tasks
     )
     add_unit_test(
+      network_identity_subsystem_test
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/node/test/network_identity_subsystem.cpp
+    )
+    target_link_libraries(
+      network_identity_subsystem_test
+      PRIVATE ccf_kv ccf_endpoints ccf_tasks
+    )
+
+    add_unit_test(
       indexing_test
       ${CMAKE_CURRENT_SOURCE_DIR}/src/indexing/test/indexing.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/src/indexing/test/lfs.cpp

--- a/doc/host_config_schema/host_config.json
+++ b/doc/host_config_schema/host_config.json
@@ -569,6 +569,24 @@
       "description": "This section includes configuration for periodic cleanup of old files (snapshots, ledger chunks)",
       "additionalProperties": false
     },
+    "identity_history_fetch": {
+      "type": "object",
+      "properties": {
+        "max_attempts": {
+          "type": "integer",
+          "default": 60,
+          "description": "Maximum number of fetch attempts before giving up",
+          "minimum": 1
+        },
+        "retry_interval": {
+          "type": "string",
+          "default": "1000ms",
+          "description": "Delay between retry attempts"
+        }
+      },
+      "description": "Configuration for the network identity endorsement chain fetch",
+      "additionalProperties": false
+    },
     "logging": {
       "type": "object",
       "properties": {

--- a/doc/host_config_schema/host_config.json
+++ b/doc/host_config_schema/host_config.json
@@ -574,13 +574,13 @@
       "properties": {
         "max_attempts": {
           "type": "integer",
-          "default": 60,
+          "default": 100,
           "description": "Maximum number of fetch attempts before giving up",
           "minimum": 1
         },
         "retry_interval": {
           "type": "string",
-          "default": "1000ms",
+          "default": "100ms",
           "description": "Delay between retry attempts"
         }
       },

--- a/include/ccf/network_identity_interface.h
+++ b/include/ccf/network_identity_interface.h
@@ -26,7 +26,11 @@ namespace ccf
   {
     Retry, ///< Fetching should be retried
     Done, ///< Fetching completed successfully
-    Failed ///< Fetching failed
+    Failed, ///< Fetching failed
+    Partial ///< Fetching completed but only a validated suffix of the
+            ///< chain is available (e.g. ledger chunks were missing).
+            ///< Terminal state: the subsystem will not attempt to
+            ///< extend the chain.
   };
 
   /// Map from sequence number to EC public key, representing the trusted

--- a/include/ccf/network_identity_interface.h
+++ b/include/ccf/network_identity_interface.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace ccf
@@ -32,6 +33,22 @@ namespace ccf
             ///< Terminal state: the subsystem will not attempt to
             ///< extend the chain.
   };
+
+  inline std::string_view to_string(FetchStatus status)
+  {
+    switch (status)
+    {
+      case FetchStatus::Retry:
+        return "Retry";
+      case FetchStatus::Done:
+        return "Done";
+      case FetchStatus::Failed:
+        return "Failed";
+      case FetchStatus::Partial:
+        return "Partial";
+    }
+    return "Unknown";
+  }
 
   /// Map from sequence number to EC public key, representing the trusted
   /// network identity keys over the history of the service.

--- a/include/ccf/node/startup_config.h
+++ b/include/ccf/node/startup_config.h
@@ -129,8 +129,8 @@ namespace ccf
 
     struct IdentityHistoryFetch
     {
-      size_t max_attempts = 60;
-      ccf::ds::TimeString retry_interval = {"1000ms"};
+      size_t max_attempts = 100;
+      ccf::ds::TimeString retry_interval = {"100ms"};
 
       bool operator==(const IdentityHistoryFetch&) const = default;
     };

--- a/include/ccf/node/startup_config.h
+++ b/include/ccf/node/startup_config.h
@@ -126,6 +126,15 @@ namespace ccf
       bool operator==(const FilesCleanup&) const = default;
     };
     FilesCleanup files_cleanup = {};
+
+    struct IdentityHistoryFetch
+    {
+      size_t max_attempts = 60;
+      ccf::ds::TimeString retry_interval = {"1000ms"};
+
+      bool operator==(const IdentityHistoryFetch&) const = default;
+    };
+    IdentityHistoryFetch identity_history_fetch = {};
   };
 
   struct RecoveryDecisionProtocolConfig

--- a/src/common/configuration.h
+++ b/src/common/configuration.h
@@ -122,6 +122,11 @@ namespace ccf
     max_committed_ledger_chunks,
     interval);
 
+  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(CCFConfig::IdentityHistoryFetch);
+  DECLARE_JSON_REQUIRED_FIELDS(CCFConfig::IdentityHistoryFetch);
+  DECLARE_JSON_OPTIONAL_FIELDS(
+    CCFConfig::IdentityHistoryFetch, max_attempts, retry_interval);
+
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(CCFConfig);
   DECLARE_JSON_REQUIRED_FIELDS(CCFConfig, network);
   DECLARE_JSON_OPTIONAL_FIELDS(
@@ -136,7 +141,8 @@ namespace ccf
     snapshots,
     files_cleanup,
     node_to_node_message_limit,
-    historical_cache_soft_limit);
+    historical_cache_soft_limit,
+    identity_history_fetch);
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(RecoveryDecisionProtocolConfig);
   DECLARE_JSON_REQUIRED_FIELDS(

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -27,6 +27,7 @@
 #include "node/rpc/gov_effects.h"
 #include "node/rpc/ledger_subsystem.h"
 #include "node/rpc/member_frontend.h"
+#include "node/rpc/network_identity_accessors_impl.h"
 #include "node/rpc/network_identity_subsystem.h"
 #include "node/rpc/node_frontend.h"
 #include "node/rpc/node_operation.h"
@@ -132,7 +133,11 @@ namespace ccf
 
       context->install_subsystem(
         std::make_shared<ccf::NetworkIdentitySubsystem>(
-          *node, network.identity, historical_state_cache));
+          std::make_shared<ccf::NodeStateAccessor>(*node),
+          std::make_shared<ccf::HistoricalStateAccessor>(
+            historical_state_cache),
+          network.identity,
+          std::make_shared<ccf::TaskSchedulerImpl>()));
 
       context->install_subsystem(
         std::make_shared<ccf::NodeConfigurationSubsystem>(*node));

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -203,6 +203,18 @@ namespace ccf
       historical_state_cache->set_soft_cache_limit(
         ccf_config_.historical_cache_soft_limit);
 
+      auto network_identity_subsystem =
+        context->get_subsystem<ccf::NetworkIdentitySubsystem>();
+      if (network_identity_subsystem == nullptr)
+      {
+        LOG_FAIL_FMT(
+          "NetworkIdentitySubsystem is not installed; cannot start "
+          "network identity fetching");
+        return CreateNodeStatus::InternalError;
+      }
+      network_identity_subsystem->start_with_config(
+        ccf_config_.identity_history_fetch);
+
       // If we haven't heard from a node for multiple elections, then cleanup
       // their node-to-node channel
       const auto idle_timeout =

--- a/src/enclave/enclave.h
+++ b/src/enclave/enclave.h
@@ -212,8 +212,16 @@ namespace ccf
           "network identity fetching");
         return CreateNodeStatus::InternalError;
       }
-      network_identity_subsystem->start_with_config(
-        ccf_config_.identity_history_fetch);
+      try
+      {
+        network_identity_subsystem->start_with_config(
+          ccf_config_.identity_history_fetch);
+      }
+      catch (const std::exception& e)
+      {
+        LOG_FAIL_FMT("Failed to start network identity fetching: {}", e.what());
+        return CreateNodeStatus::InternalError;
+      }
 
       // If we haven't heard from a node for multiple elections, then cleanup
       // their node-to-node channel

--- a/src/node/historical_queries_utils.cpp
+++ b/src/node/historical_queries_utils.cpp
@@ -235,7 +235,10 @@ namespace ccf
       }
       if (fetching != FetchStatus::Done && fetching != FetchStatus::Partial)
       {
-        throw std::logic_error("Unexpected endorsements fetching status");
+        throw std::runtime_error(fmt::format(
+          "Unexpected endorsements fetching status: expected Done or Partial; "
+          "got {}",
+          ccf::to_string(fetching)));
       }
 
       auto cose_endorsements =
@@ -246,8 +249,8 @@ namespace ccf
         // Cannot tell whether this seqno was ever endorsed.
         throw std::runtime_error(fmt::format(
           "Cannot determine the service identity endorsement chain "
-          "for the receipt at seqno {}",
-          state->transaction_id.seqno));
+          "for the receipt at {}",
+          state->transaction_id.to_str()));
       }
       state->receipt->cose_endorsements = cose_endorsements;
       return true;

--- a/src/node/historical_queries_utils.cpp
+++ b/src/node/historical_queries_utils.cpp
@@ -233,7 +233,7 @@ namespace ccf
           "cannot be fetched",
           state->transaction_id.seqno));
       }
-      if (fetching != FetchStatus::Done)
+      if (fetching != FetchStatus::Done && fetching != FetchStatus::Partial)
       {
         throw std::logic_error("Unexpected endorsements fetching status");
       }
@@ -241,6 +241,14 @@ namespace ccf
       auto cose_endorsements =
         network_identity_subsystem->get_cose_endorsements_chain(
           state->transaction_id.seqno);
+      if (!cose_endorsements.has_value())
+      {
+        // Cannot tell whether this seqno was ever endorsed.
+        throw std::runtime_error(fmt::format(
+          "Cannot determine the service identity endorsement chain "
+          "for the receipt at seqno {}",
+          state->transaction_id.seqno));
+      }
       state->receipt->cose_endorsements = cose_endorsements;
       return true;
     }

--- a/src/node/rpc/network_identity_accessors.h
+++ b/src/node/rpc/network_identity_accessors.h
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ccf/tx_id.h"
+#include "service/tables/previous_service_identity.h"
+#include "tasks/task_system.h"
+
+#include <chrono>
+#include <functional>
+#include <optional>
+
+namespace ccf
+{
+  struct INodeStateAccessor
+  {
+    virtual ~INodeStateAccessor() = default;
+
+    [[nodiscard]] virtual bool is_part_of_network() const = 0;
+
+    // Current service's create-txid, or nullopt if not yet available.
+    virtual std::optional<TxID> read_current_service_from() = 0;
+
+    // Topmost previous-identity endorsement entry, or nullopt if none.
+    virtual std::optional<CoseEndorsement> read_topmost_endorsement() = 0;
+  };
+
+  struct IHistoricalStateAccessor
+  {
+    virtual ~IHistoricalStateAccessor() = default;
+
+    // Endorsement entry at the given historical kv version, or nullopt
+    // if the historical state is not yet loaded. Implementations may
+    // throw on hard errors.
+    virtual std::optional<CoseEndorsement> get_endorsement_at(SeqNo) = 0;
+  };
+
+  struct TaskScheduler
+  {
+    virtual ~TaskScheduler() = default;
+
+    virtual void add_task(std::function<void()> fn) = 0;
+
+    virtual void add_delayed_task(
+      std::function<void()> fn, std::chrono::milliseconds delay) = 0;
+  };
+}

--- a/src/node/rpc/network_identity_accessors.h
+++ b/src/node/rpc/network_identity_accessors.h
@@ -4,7 +4,6 @@
 
 #include "ccf/tx_id.h"
 #include "service/tables/previous_service_identity.h"
-#include "tasks/task_system.h"
 
 #include <chrono>
 #include <functional>
@@ -19,10 +18,11 @@ namespace ccf
     [[nodiscard]] virtual bool is_part_of_network() const = 0;
 
     // Current service's create-txid, or nullopt if not yet available.
-    virtual std::optional<TxID> read_current_service_from() = 0;
+    virtual std::optional<TxID> get_current_service_txid() = 0;
 
-    // Topmost previous-identity endorsement entry, or nullopt if none.
-    virtual std::optional<CoseEndorsement> read_topmost_endorsement() = 0;
+    // Current previous-identity endorsement entry in the live KV, or
+    // nullopt if none has been written yet.
+    virtual std::optional<CoseEndorsement> get_current_endorsement() = 0;
   };
 
   struct IHistoricalStateAccessor
@@ -38,8 +38,6 @@ namespace ccf
   struct TaskScheduler
   {
     virtual ~TaskScheduler() = default;
-
-    virtual void add_task(std::function<void()> fn) = 0;
 
     virtual void add_delayed_task(
       std::function<void()> fn, std::chrono::milliseconds delay) = 0;

--- a/src/node/rpc/network_identity_accessors_impl.h
+++ b/src/node/rpc/network_identity_accessors_impl.h
@@ -6,7 +6,6 @@
 #include "node/historical_queries.h"
 #include "node/rpc/network_identity_accessors.h"
 #include "node/rpc/node_interface.h"
-#include "service/internal_tables_access.h"
 #include "tasks/basic_task.h"
 #include "tasks/task_system.h"
 
@@ -31,7 +30,7 @@ namespace ccf
       return node_state.is_part_of_network();
     }
 
-    std::optional<TxID> read_current_service_from() override
+    std::optional<TxID> get_current_service_txid() override
     {
       auto store = node_state.get_store();
       auto tx = store->create_read_only_tx();
@@ -56,7 +55,7 @@ namespace ccf
       return service_info->current_service_create_txid;
     }
 
-    std::optional<CoseEndorsement> read_topmost_endorsement() override
+    std::optional<CoseEndorsement> get_current_endorsement() override
     {
       auto store = node_state.get_store();
       auto tx = store->create_read_only_tx();
@@ -115,11 +114,6 @@ namespace ccf
   class TaskSchedulerImpl : public TaskScheduler
   {
   public:
-    void add_task(std::function<void()> fn) override
-    {
-      ccf::tasks::add_task(ccf::tasks::make_basic_task(std::move(fn)));
-    }
-
     void add_delayed_task(
       std::function<void()> fn, std::chrono::milliseconds delay) override
     {

--- a/src/node/rpc/network_identity_accessors_impl.h
+++ b/src/node/rpc/network_identity_accessors_impl.h
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ccf/service/tables/service.h"
+#include "node/historical_queries.h"
+#include "node/rpc/network_identity_accessors.h"
+#include "node/rpc/node_interface.h"
+#include "service/internal_tables_access.h"
+#include "tasks/basic_task.h"
+#include "tasks/task_system.h"
+
+#include <fmt/format.h>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+namespace ccf
+{
+  class NodeStateAccessor : public INodeStateAccessor
+  {
+  protected:
+    AbstractNodeState& node_state;
+
+  public:
+    NodeStateAccessor(AbstractNodeState& node_state_) : node_state(node_state_)
+    {}
+
+    [[nodiscard]] bool is_part_of_network() const override
+    {
+      return node_state.is_part_of_network();
+    }
+
+    std::optional<TxID> read_current_service_from() override
+    {
+      auto store = node_state.get_store();
+      auto tx = store->create_read_only_tx();
+      auto* service_info_handle =
+        tx.template ro<ccf::Service>(ccf::Tables::SERVICE);
+      auto service_info = service_info_handle->get();
+      if (
+        !service_info || !service_info->current_service_create_txid.has_value())
+      {
+        return std::nullopt;
+      }
+      if (service_info->status != ServiceStatus::OPEN)
+      {
+        // It can happen that node advances its internal state machine to
+        // part-of-network, but the service opening tx has not been
+        // replicated yet. This will cause the first fetched endorsement
+        // to be obsolete, but waiting for ServiceStatus::OPEN is
+        // sufficient, as it's supposed to arrive in the same TX that
+        // the previous identity endorsement.
+        return std::nullopt;
+      }
+      return service_info->current_service_create_txid;
+    }
+
+    std::optional<CoseEndorsement> read_topmost_endorsement() override
+    {
+      auto store = node_state.get_store();
+      auto tx = store->create_read_only_tx();
+      return tx
+        .template ro<ccf::PreviousServiceIdentityEndorsement>(
+          ccf::Tables::PREVIOUS_SERVICE_IDENTITY_ENDORSEMENT)
+        ->get();
+    }
+  };
+
+  class HistoricalStateAccessor : public IHistoricalStateAccessor
+  {
+  protected:
+    std::shared_ptr<historical::StateCacheImpl> historical_cache;
+
+  public:
+    HistoricalStateAccessor(
+      std::shared_ptr<historical::StateCacheImpl> historical_cache_) :
+      historical_cache(std::move(historical_cache_))
+    {}
+
+    std::optional<CoseEndorsement> get_endorsement_at(SeqNo seq) override
+    {
+      auto state = historical_cache->get_state_at(
+        ccf::historical::CompoundHandle{
+          ccf::historical::RequestNamespace::System, seq},
+        seq);
+      if (!state)
+      {
+        return std::nullopt;
+      }
+      if (!state->store)
+      {
+        throw std::runtime_error(fmt::format(
+          "Historical state with seqno {} is loaded but its store is "
+          "missing",
+          seq));
+      }
+      auto htx = state->store->create_read_only_tx();
+      auto endorsement =
+        htx
+          .template ro<ccf::PreviousServiceIdentityEndorsement>(
+            ccf::Tables::PREVIOUS_SERVICE_IDENTITY_ENDORSEMENT)
+          ->get();
+      if (!endorsement.has_value())
+      {
+        throw std::runtime_error(fmt::format(
+          "COSE endorsement entry for seqno {} is missing from its "
+          "historical state",
+          seq));
+      }
+      return endorsement;
+    }
+  };
+
+  class TaskSchedulerImpl : public TaskScheduler
+  {
+  public:
+    void add_task(std::function<void()> fn) override
+    {
+      ccf::tasks::add_task(ccf::tasks::make_basic_task(std::move(fn)));
+    }
+
+    void add_delayed_task(
+      std::function<void()> fn, std::chrono::milliseconds delay) override
+    {
+      auto task = ccf::tasks::make_basic_task(std::move(fn));
+      ccf::tasks::add_delayed_task(task, delay);
+    }
+  };
+}

--- a/src/node/rpc/network_identity_chain_helpers.h
+++ b/src/node/rpc/network_identity_chain_helpers.h
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ccf/network_identity_interface.h"
+#include "ccf/tx_id.h"
+#include "consensus/aft/raft_types.h"
+#include "service/tables/previous_service_identity.h"
+
+#include <fmt/format.h>
+#include <stdexcept>
+
+namespace ccf
+{
+  inline bool is_self_endorsement(const ccf::CoseEndorsement& endorsement)
+  {
+    return !endorsement.previous_version.has_value();
+  }
+
+  inline bool is_ill_formed(const ccf::CoseEndorsement& endorsement)
+  {
+    return endorsement.endorsement_epoch_end.has_value() &&
+      endorsement.endorsement_epoch_end->seqno <
+      endorsement.endorsement_epoch_begin.seqno;
+  }
+
+  inline void verify_endorsements_connected(
+    const ccf::CoseEndorsement& newer, const ccf::CoseEndorsement& older)
+  {
+    if (!older.endorsement_epoch_end.has_value())
+    {
+      throw std::logic_error(fmt::format(
+        "COSE endorsement chain integrity is violated, previous endorsement "
+        "from {} does not have an epoch end",
+        older.endorsement_epoch_begin.to_str()));
+    }
+
+    if (
+      newer.endorsement_epoch_begin.view - aft::starting_view_change !=
+        older.endorsement_epoch_end->view ||
+      newer.endorsement_epoch_begin.seqno - 1 !=
+        older.endorsement_epoch_end->seqno)
+    {
+      throw std::logic_error(fmt::format(
+        "COSE endorsement chain integrity is violated, previous endorsement "
+        "epoch end {} is not chained with newer endorsement epoch begin {}",
+        older.endorsement_epoch_end->to_str(),
+        newer.endorsement_epoch_begin.to_str()));
+    }
+  }
+
+  // Verify the newest endorsement immediately precedes the current service.
+  inline void validate_chain_front_connection(
+    const ccf::CoseEndorsement& newest, const ccf::TxID& current_service_from)
+  {
+    if (!newest.endorsement_epoch_end.has_value())
+    {
+      throw std::logic_error(fmt::format(
+        "The last fetched endorsement at {} has no epoch end",
+        newest.endorsement_epoch_begin.seqno));
+    }
+    if (
+      current_service_from.view - aft::starting_view_change !=
+        newest.endorsement_epoch_end->view ||
+      current_service_from.seqno - 1 != newest.endorsement_epoch_end->seqno)
+    {
+      throw std::logic_error(fmt::format(
+        "COSE endorsement chain integrity is violated, the current service "
+        "start at {} is not chained with previous endorsement ending at {}",
+        current_service_from.to_str(),
+        newest.endorsement_epoch_end->to_str()));
+    }
+  }
+}

--- a/src/node/rpc/network_identity_chain_helpers.h
+++ b/src/node/rpc/network_identity_chain_helpers.h
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
-#include "ccf/network_identity_interface.h"
 #include "ccf/tx_id.h"
 #include "consensus/aft/raft_types.h"
 #include "service/tables/previous_service_identity.h"
@@ -17,7 +16,8 @@ namespace ccf
     return !endorsement.previous_version.has_value();
   }
 
-  inline bool is_ill_formed(const ccf::CoseEndorsement& endorsement)
+  inline bool has_ill_formed_epoch_range(
+    const ccf::CoseEndorsement& endorsement)
   {
     return endorsement.endorsement_epoch_end.has_value() &&
       endorsement.endorsement_epoch_end->seqno <
@@ -57,7 +57,7 @@ namespace ccf
     {
       throw std::logic_error(fmt::format(
         "The last fetched endorsement at {} has no epoch end",
-        newest.endorsement_epoch_begin.seqno));
+        newest.endorsement_epoch_begin.to_str()));
     }
     if (
       current_service_from.view - aft::starting_view_change !=

--- a/src/node/rpc/network_identity_subsystem.h
+++ b/src/node/rpc/network_identity_subsystem.h
@@ -2,16 +2,14 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ccf/crypto/cose_verifier.h"
 #include "ccf/network_identity_interface.h"
 #include "ccf/node/startup_config.h"
-#include "ccf/service/tables/service.h"
-#include "node/historical_queries.h"
+#include "crypto/cose.h"
+#include "ds/internal_logger.h"
 #include "node/identity.h"
 #include "node/rpc/network_identity_accessors.h"
-#include "node/rpc/network_identity_accessors_impl.h"
 #include "node/rpc/network_identity_chain_helpers.h"
-#include "node/rpc/node_interface.h"
-#include "service/internal_tables_access.h"
 
 #include <atomic>
 #include <chrono>
@@ -80,37 +78,28 @@ namespace ccf
     const std::unique_ptr<NetworkIdentity>& network_identity;
     std::shared_ptr<TaskScheduler> scheduler;
 
-    // Retry budget. Initialised to defaults at construction and
-    // frozen by start_with_config(). Atomic so the scheduler thread
-    // can read these safely once a retry has been scheduled.
-    std::atomic<size_t> max_attempts{
-      CCFConfig::IdentityHistoryFetch{}.max_attempts};
-    std::atomic<int64_t> retry_interval_ms{static_cast<int64_t>(
+    // Retry budget. Set once by start_with_config(); thereafter only
+    // read by the scheduler thread. Happens-before from the writing
+    // thread is established by the task scheduler when fetch_first()
+    // is submitted.
+    size_t max_attempts{CCFConfig::IdentityHistoryFetch{}.max_attempts};
+    int64_t retry_interval_ms{static_cast<int64_t>(
       CCFConfig::IdentityHistoryFetch{}.retry_interval.count_ms())};
     // Single-shot guard: start_with_config() must be called exactly
     // once over the lifetime of the subsystem.
-    std::atomic<bool> started{false};
+    bool started{false};
 
     std::map<SeqNo, CoseEndorsement> endorsements;
     std::map<SeqNo, ccf::crypto::ECPublicKeyPtr> trusted_keys;
     std::optional<TxID> current_service_from;
     SeqNo earliest_endorsed_seq{0};
+    // Atomic: written by the scheduler thread when fetching settles,
+    // read by RPC threads on every reader call.
     std::atomic<FetchStatus> fetch_status{FetchStatus::Retry};
     bool has_predecessors{false};
     size_t fetch_attempts{0};
 
   public:
-    NetworkIdentitySubsystem(
-      AbstractNodeState& node_state_,
-      const std::unique_ptr<NetworkIdentity>& network_identity_,
-      std::shared_ptr<ccf::historical::StateCacheImpl> historical_cache_) :
-      NetworkIdentitySubsystem(
-        std::make_shared<NodeStateAccessor>(node_state_),
-        std::make_shared<HistoricalStateAccessor>(std::move(historical_cache_)),
-        network_identity_,
-        std::make_shared<TaskSchedulerImpl>())
-    {}
-
     NetworkIdentitySubsystem(
       std::shared_ptr<INodeStateAccessor> node_state_accessor_,
       std::shared_ptr<IHistoricalStateAccessor> historical_state_accessor_,
@@ -132,15 +121,16 @@ namespace ccf
     // argument uses the default-constructed config.
     void start_with_config(const CCFConfig::IdentityHistoryFetch& config = {})
     {
-      if (started.exchange(true))
+      if (started)
       {
         throw std::logic_error(
           "NetworkIdentitySubsystem::start_with_config called more than "
           "once");
       }
-      max_attempts.store(config.max_attempts);
-      retry_interval_ms.store(
-        static_cast<int64_t>(config.retry_interval.count_ms()));
+      started = true;
+      max_attempts = config.max_attempts;
+      retry_interval_ms =
+        static_cast<int64_t>(config.retry_interval.count_ms());
       fetch_first();
     }
 
@@ -257,16 +247,16 @@ namespace ccf
     [[nodiscard]] bool schedule_retry(std::function<void()> fn)
     {
       ++fetch_attempts;
-      if (fetch_attempts >= max_attempts.load())
+      if (fetch_attempts >= max_attempts)
       {
         return false;
       }
       scheduler->add_delayed_task(
-        std::move(fn), std::chrono::milliseconds(retry_interval_ms.load()));
+        std::move(fn), std::chrono::milliseconds(retry_interval_ms));
       return true;
     }
 
-    void fail_fetching(const std::string& err = "")
+    [[noreturn]] void fail_fetching(const std::string& err = "")
     {
       if (!err.empty())
       {
@@ -286,6 +276,7 @@ namespace ccf
       if (!current_service_from.has_value())
       {
         // No current_service_from: settle without building a chain.
+        log_terminal_status(target_status);
         fetch_status.store(target_status);
         return;
       }
@@ -327,11 +318,30 @@ namespace ccf
         fail_fetching(e.what());
       }
 
+      log_terminal_status(target_status);
       fetch_status.store(target_status);
+    }
+
+    static void log_terminal_status(FetchStatus status)
+    {
+      if (status == FetchStatus::Partial)
+      {
+        LOG_FAIL_FMT(
+          "Network identity fetching settled at Partial: only the validated "
+          "suffix of the endorsement chain is available");
+      }
+      else
+      {
+        LOG_INFO_FMT("Network identity fetching settled at Done");
+      }
     }
 
     void fetch_first()
     {
+      // Pre-bootstrap waits are unbounded: KV reads can legitimately
+      // block for arbitrary durations (e.g. waiting for service open
+      // during recovery). The budget only applies to historical reads
+      // in fetch_next_at.
       if (!node_state_accessor->is_part_of_network())
       {
         LOG_INFO_FMT(
@@ -339,13 +349,13 @@ namespace ccf
           "yet");
         scheduler->add_delayed_task(
           [this]() { this->fetch_first(); },
-          std::chrono::milliseconds(retry_interval_ms.load()));
+          std::chrono::milliseconds(retry_interval_ms));
         return;
       }
 
       if (!current_service_from.has_value())
       {
-        auto cs = node_state_accessor->read_current_service_from();
+        auto cs = node_state_accessor->get_current_service_txid();
         if (!cs.has_value())
         {
           LOG_INFO_FMT(
@@ -353,13 +363,13 @@ namespace ccf
             "txid is not yet available or service is not yet open");
           scheduler->add_delayed_task(
             [this]() { this->fetch_first(); },
-            std::chrono::milliseconds(retry_interval_ms.load()));
+            std::chrono::milliseconds(retry_interval_ms));
           return;
         }
         current_service_from = cs;
       }
 
-      auto endorsement = node_state_accessor->read_topmost_endorsement();
+      auto endorsement = node_state_accessor->get_current_endorsement();
       if (!endorsement.has_value())
       {
         LOG_INFO_FMT(
@@ -367,12 +377,12 @@ namespace ccf
           "service identity endorsement yet");
         scheduler->add_delayed_task(
           [this]() { this->fetch_first(); },
-          std::chrono::milliseconds(retry_interval_ms.load()));
+          std::chrono::milliseconds(retry_interval_ms));
         return;
       }
 
-      // Successful read of the topmost entry: fresh budget for the
-      // chain walk below.
+      // Current endorsement found: fresh budget for the chain walk
+      // below.
       fetch_attempts = 0;
 
       if (is_self_endorsement(endorsement.value()))
@@ -382,10 +392,10 @@ namespace ccf
           endorsement->endorsement_epoch_begin.seqno)
         {
           fail_fetching(fmt::format(
-            "The first fetched endorsement is a self-endorsement with seqno "
-            "{} which is different from current_service_create_txid {}",
-            endorsement->endorsement_epoch_begin.seqno,
-            current_service_from->seqno));
+            "The first fetched endorsement is a self-endorsement at {} "
+            "which is different from current_service_create_txid {}",
+            endorsement->endorsement_epoch_begin.to_str(),
+            current_service_from->to_str()));
         }
 
         LOG_INFO_FMT(
@@ -405,7 +415,7 @@ namespace ccf
 
     void process_endorsement(const ccf::CoseEndorsement& endorsement)
     {
-      if (is_ill_formed(endorsement))
+      if (has_ill_formed_epoch_range(endorsement))
       {
         // For double-sealed cases, which could have happened in the past.
         // Skip intentionally if a predecessor exists; the next link's
@@ -429,13 +439,14 @@ namespace ccf
       }
 
       const auto from = endorsement.endorsement_epoch_begin.seqno;
+      const auto from_str = endorsement.endorsement_epoch_begin.to_str();
       if (is_self_endorsement(endorsement))
       {
         if (endorsements.find(from) == endorsements.end())
         {
           fail_fetching(fmt::format(
-            "Fetched self-endorsement with seqno {} which has not been seen",
-            from));
+            "Fetched self-endorsement at {} which has not been seen",
+            from_str));
         }
         LOG_INFO_FMT("Got self-endorsement at {}, stopping fetching", from);
         complete_fetching(FetchStatus::Done);
@@ -445,25 +456,23 @@ namespace ccf
       if (from >= earliest_endorsed_seq)
       {
         fail_fetching(fmt::format(
-          "Fetched service endorsement with seqno {} which is greater than "
-          "the earliest known in the chain {}",
-          from,
+          "Fetched service endorsement at {} which is greater than the "
+          "earliest known seqno in the chain {}",
+          from_str,
           earliest_endorsed_seq));
       }
 
       if (!endorsement.endorsement_epoch_end.has_value())
       {
         fail_fetching(
-          fmt::format("Fetched endorsement at {} has no epoch end", from));
-        return; // to silence clang-tidy unchecked optional
+          fmt::format("Fetched endorsement at {} has no epoch end", from_str));
       }
 
       earliest_endorsed_seq = from;
       if (endorsements.find(from) != endorsements.end())
       {
         fail_fetching(fmt::format(
-          "Fetched service endorsement with seqno {} which already exists",
-          from));
+          "Fetched service endorsement at {} which already exists", from_str));
       }
 
       LOG_INFO_FMT(
@@ -524,7 +533,7 @@ namespace ccf
           throw std::logic_error(fmt::format(
             "Endorsement from {} to {} over public key {} doesn't chain with "
             "the previous endorsement with key {}",
-            endorsement.endorsement_epoch_begin.seqno,
+            endorsement.endorsement_epoch_begin.to_str(),
             format_epoch(endorsement.endorsement_epoch_end),
             ccf::ds::to_hex(endorsed_key),
             ccf::ds::to_hex(previous_key_der)));
@@ -577,7 +586,7 @@ namespace ccf
         {
           LOG_FAIL_FMT(
             "Exhausted retry budget fetching previous-identity endorsement "
-            "at seqno {}; settling at Partial with the validated suffix",
+            "at seqno {}",
             seq);
           complete_fetching(FetchStatus::Partial);
         }

--- a/src/node/rpc/network_identity_subsystem.h
+++ b/src/node/rpc/network_identity_subsystem.h
@@ -167,7 +167,7 @@ namespace ccf
       // suffix were ever endorsed; signal absence via nullopt.
       if (
         status == FetchStatus::Partial && seqno < current_service_from->seqno &&
-        (!has_predecessors || seqno < earliest_endorsed_seq))
+        seqno < earliest_endorsed_seq)
       {
         return std::nullopt;
       }
@@ -241,7 +241,7 @@ namespace ccf
       return trusted_keys;
     }
 
-  private:
+  protected:
     // Returns true if a retry was scheduled. Returns false if the
     // budget is exhausted.
     [[nodiscard]] bool schedule_retry(std::function<void()> fn)
@@ -275,42 +275,26 @@ namespace ccf
     {
       if (!current_service_from.has_value())
       {
-        // No current_service_from: settle without building a chain.
-        log_terminal_status(target_status);
-        fetch_status.store(target_status);
-        return;
+        // Invariant: every complete_fetching call site is downstream of
+        // current_service_from being set. Reaching this branch means a
+        // caller violated that contract.
+        fail_fetching("Unset current_service_from when completing fetching");
       }
 
-      if (!endorsements.empty())
+      try
       {
-        auto next = endorsements.begin();
-        auto prev = next++;
-        try
+        if (!endorsements.empty())
         {
+          auto next = endorsements.begin();
+          auto prev = next++;
           while (next != endorsements.end())
           {
             verify_endorsements_connected(next->second, prev->second);
             ++prev;
             ++next;
           }
-        }
-        catch (const std::exception& e)
-        {
-          fail_fetching(e.what());
-        }
-
-        try
-        {
           validate_chain_front_connection(prev->second, *current_service_from);
         }
-        catch (const std::exception& e)
-        {
-          fail_fetching(e.what());
-        }
-      }
-
-      try
-      {
         build_trusted_key_chain();
       }
       catch (const std::exception& e)
@@ -318,22 +302,14 @@ namespace ccf
         fail_fetching(e.what());
       }
 
-      log_terminal_status(target_status);
+      log_status(target_status);
       fetch_status.store(target_status);
     }
 
-    static void log_terminal_status(FetchStatus status)
+    static void log_status(FetchStatus status)
     {
-      if (status == FetchStatus::Partial)
-      {
-        LOG_FAIL_FMT(
-          "Network identity fetching settled at Partial: only the validated "
-          "suffix of the endorsement chain is available");
-      }
-      else
-      {
-        LOG_INFO_FMT("Network identity fetching settled at Done");
-      }
+      LOG_INFO_FMT(
+        "Network identity fetching settled at {}", ccf::to_string(status));
     }
 
     void fetch_first()
@@ -380,10 +356,6 @@ namespace ccf
           std::chrono::milliseconds(retry_interval_ms));
         return;
       }
-
-      // Current endorsement found: fresh budget for the chain walk
-      // below.
-      fetch_attempts = 0;
 
       if (is_self_endorsement(endorsement.value()))
       {

--- a/src/node/rpc/network_identity_subsystem.h
+++ b/src/node/rpc/network_identity_subsystem.h
@@ -3,34 +3,27 @@
 #pragma once
 
 #include "ccf/network_identity_interface.h"
+#include "ccf/node/startup_config.h"
 #include "ccf/service/tables/service.h"
 #include "node/historical_queries.h"
 #include "node/identity.h"
+#include "node/rpc/network_identity_accessors.h"
+#include "node/rpc/network_identity_accessors_impl.h"
+#include "node/rpc/network_identity_chain_helpers.h"
 #include "node/rpc/node_interface.h"
 #include "service/internal_tables_access.h"
 
 #include <atomic>
+#include <chrono>
 
 namespace ccf
 {
-  static std::string format_epoch(const std::optional<ccf::TxID>& epoch_end)
+  inline std::string format_epoch(const std::optional<ccf::TxID>& epoch_end)
   {
     return epoch_end.has_value() ? epoch_end->to_str() : "null";
   }
 
-  static bool is_self_endorsement(const ccf::CoseEndorsement& endorsement)
-  {
-    return !endorsement.previous_version.has_value();
-  }
-
-  static bool is_ill_formed(const ccf::CoseEndorsement& endorsement)
-  {
-    return endorsement.endorsement_epoch_end.has_value() &&
-      endorsement.endorsement_epoch_end->seqno <
-      endorsement.endorsement_epoch_begin.seqno;
-  }
-
-  static void validate_fetched_endorsement(
+  inline void validate_fetched_endorsement(
     const ccf::CoseEndorsement& endorsement)
   {
     LOG_INFO_FMT(
@@ -79,53 +72,75 @@ namespace ccf
     }
   }
 
-  static void validate_chain_integrity(
-    const ccf::CoseEndorsement& newer, const ccf::CoseEndorsement& older)
-  {
-    if (!older.endorsement_epoch_end.has_value())
-    {
-      throw std::logic_error(fmt::format(
-        "COSE endorsement chain integrity is violated, previous endorsement "
-        "from {} does not have an epoch end",
-        older.endorsement_epoch_begin.to_str()));
-    }
-
-    if (
-      newer.endorsement_epoch_begin.view - aft::starting_view_change !=
-        older.endorsement_epoch_end->view ||
-      newer.endorsement_epoch_begin.seqno - 1 !=
-        older.endorsement_epoch_end->seqno)
-    {
-      throw std::logic_error(fmt::format(
-        "COSE endorsement chain integrity is violated, previous endorsement "
-        "epoch end {} is not chained with newer endorsement epoch begin {}",
-        older.endorsement_epoch_end->to_str(),
-        newer.endorsement_epoch_begin.to_str()));
-    }
-  }
-
   class NetworkIdentitySubsystem : public NetworkIdentitySubsystemInterface
   {
   protected:
-    AbstractNodeState& node_state;
+    std::shared_ptr<INodeStateAccessor> node_state_accessor;
+    std::shared_ptr<IHistoricalStateAccessor> historical_state_accessor;
     const std::unique_ptr<NetworkIdentity>& network_identity;
-    std::shared_ptr<historical::StateCacheImpl> historical_cache;
+    std::shared_ptr<TaskScheduler> scheduler;
+
+    // Retry budget. Initialised to defaults at construction and
+    // frozen by start_with_config(). Atomic so the scheduler thread
+    // can read these safely once a retry has been scheduled.
+    std::atomic<size_t> max_attempts{
+      CCFConfig::IdentityHistoryFetch{}.max_attempts};
+    std::atomic<int64_t> retry_interval_ms{static_cast<int64_t>(
+      CCFConfig::IdentityHistoryFetch{}.retry_interval.count_ms())};
+    // Single-shot guard: start_with_config() must be called exactly
+    // once over the lifetime of the subsystem.
+    std::atomic<bool> started{false};
+
     std::map<SeqNo, CoseEndorsement> endorsements;
     std::map<SeqNo, ccf::crypto::ECPublicKeyPtr> trusted_keys;
     std::optional<TxID> current_service_from;
     SeqNo earliest_endorsed_seq{0};
     std::atomic<FetchStatus> fetch_status{FetchStatus::Retry};
     bool has_predecessors{false};
+    size_t fetch_attempts{0};
 
   public:
     NetworkIdentitySubsystem(
       AbstractNodeState& node_state_,
       const std::unique_ptr<NetworkIdentity>& network_identity_,
       std::shared_ptr<ccf::historical::StateCacheImpl> historical_cache_) :
-      node_state(node_state_),
+      NetworkIdentitySubsystem(
+        std::make_shared<NodeStateAccessor>(node_state_),
+        std::make_shared<HistoricalStateAccessor>(std::move(historical_cache_)),
+        network_identity_,
+        std::make_shared<TaskSchedulerImpl>())
+    {}
+
+    NetworkIdentitySubsystem(
+      std::shared_ptr<INodeStateAccessor> node_state_accessor_,
+      std::shared_ptr<IHistoricalStateAccessor> historical_state_accessor_,
+      const std::unique_ptr<NetworkIdentity>& network_identity_,
+      std::shared_ptr<TaskScheduler> scheduler_) :
+      node_state_accessor(std::move(node_state_accessor_)),
+      historical_state_accessor(std::move(historical_state_accessor_)),
       network_identity(network_identity_),
-      historical_cache(std::move(historical_cache_))
+      scheduler(std::move(scheduler_))
     {
+      // Note: bootstrap does not start until start_with_config() is
+      // called. Until then the subsystem stays in Retry and readers
+      // throw IdentityHistoryNotFetched.
+    }
+
+    // Apply the retry-budget configuration and kick off the initial
+    // bootstrap. Must be called exactly once over the subsystem's
+    // lifetime; subsequent calls throw std::logic_error. The default
+    // argument uses the default-constructed config.
+    void start_with_config(const CCFConfig::IdentityHistoryFetch& config = {})
+    {
+      if (started.exchange(true))
+      {
+        throw std::logic_error(
+          "NetworkIdentitySubsystem::start_with_config called more than "
+          "once");
+      }
+      max_attempts.store(config.max_attempts);
+      retry_interval_ms.store(
+        static_cast<int64_t>(config.retry_interval.count_ms()));
       fetch_first();
     }
 
@@ -142,7 +157,8 @@ namespace ccf
     [[nodiscard]] std::optional<CoseEndorsementsChain>
     get_cose_endorsements_chain(ccf::SeqNo seqno) const override
     {
-      if (fetch_status.load() != FetchStatus::Done)
+      const auto status = fetch_status.load();
+      if (status != FetchStatus::Done && status != FetchStatus::Partial)
       {
         throw IdentityHistoryNotFetched(fmt::format(
           "COSE endorsements chain requested for seqno {} but identity "
@@ -154,6 +170,15 @@ namespace ccf
       {
         LOG_FAIL_FMT(
           "Unset current_service_from when fetching endorsements chain");
+        return std::nullopt;
+      }
+
+      // In Partial we cannot tell whether seqnos below the validated
+      // suffix were ever endorsed; signal absence via nullopt.
+      if (
+        status == FetchStatus::Partial && seqno < current_service_from->seqno &&
+        (!has_predecessors || seqno < earliest_endorsed_seq))
+      {
         return std::nullopt;
       }
 
@@ -169,7 +194,7 @@ namespace ccf
           "No endorsements found for seqno {}, earliest endorsed is {}",
           seqno,
           earliest_endorsed_seq);
-        return {};
+        return CoseEndorsementsChain{};
       }
 
       CoseEndorsementsChain result;
@@ -184,7 +209,8 @@ namespace ccf
     [[nodiscard]] ccf::crypto::ECPublicKeyPtr get_trusted_identity_for(
       ccf::SeqNo seqno) const override
     {
-      if (fetch_status.load() != FetchStatus::Done)
+      const auto status = fetch_status.load();
+      if (status != FetchStatus::Done && status != FetchStatus::Partial)
       {
         throw IdentityHistoryNotFetched(fmt::format(
           "Trusted key requested for seqno {} but identity history "
@@ -215,7 +241,8 @@ namespace ccf
 
     [[nodiscard]] TrustedKeys get_trusted_keys() const override
     {
-      if (fetch_status.load() != FetchStatus::Done)
+      const auto status = fetch_status.load();
+      if (status != FetchStatus::Done && status != FetchStatus::Partial)
       {
         throw IdentityHistoryNotFetched(
           "Trusted keys requested but identity history fetching has not "
@@ -225,13 +252,18 @@ namespace ccf
     }
 
   private:
-    void retry_first_fetch()
+    // Returns true if a retry was scheduled. Returns false if the
+    // budget is exhausted.
+    [[nodiscard]] bool schedule_retry(std::function<void()> fn)
     {
-      using namespace std::chrono_literals;
-      static constexpr auto retry_after = 1s;
-      ccf::tasks::add_delayed_task(
-        ccf::tasks::make_basic_task([this]() { this->fetch_first(); }),
-        retry_after);
+      ++fetch_attempts;
+      if (fetch_attempts >= max_attempts.load())
+      {
+        return false;
+      }
+      scheduler->add_delayed_task(
+        std::move(fn), std::chrono::milliseconds(retry_interval_ms.load()));
+      return true;
     }
 
     void fail_fetching(const std::string& err = "")
@@ -242,20 +274,20 @@ namespace ccf
       }
       fetch_status.store(FetchStatus::Failed);
 
-      // The caller may want to re-capture this, but by default it's supposed to
-      // fail the node startup early. This is purely reading, so there's no risk
-      // of corruption, but the endorsement chain is essential for the node to
-      // produce receipts for the past epochs, which is a must-have
-      // functionality.
+      // The caller may want to re-capture this, but by default it is
+      // supposed to fail the node startup early. The endorsement chain
+      // is essential for the node to produce receipts for past epochs,
+      // which is a must-have functionality.
       throw std::runtime_error("Failed fetching network identity: " + err);
     }
 
-    void complete_fetching()
+    void complete_fetching(FetchStatus target_status)
     {
       if (!current_service_from.has_value())
       {
-        fail_fetching("Unset current_service_from when completing fetching");
-        return; // to silence clang-tidy unchecked optional
+        // No current_service_from: settle without building a chain.
+        fetch_status.store(target_status);
+        return;
       }
 
       if (!endorsements.empty())
@@ -266,7 +298,7 @@ namespace ccf
         {
           while (next != endorsements.end())
           {
-            validate_chain_integrity(next->second, prev->second);
+            verify_endorsements_connected(next->second, prev->second);
             ++prev;
             ++next;
           }
@@ -276,26 +308,13 @@ namespace ccf
           fail_fetching(e.what());
         }
 
-        const auto& last = prev->second;
-        if (!last.endorsement_epoch_end.has_value())
+        try
         {
-          fail_fetching(fmt::format(
-            "The last fetched endorsement at {} has no epoch end",
-            last.endorsement_epoch_begin.seqno));
-          return; // to silence clang-tidy unchecked optional
+          validate_chain_front_connection(prev->second, *current_service_from);
         }
-
-        if (
-          current_service_from->view - aft::starting_view_change !=
-            last.endorsement_epoch_end->view ||
-          current_service_from->seqno - 1 != last.endorsement_epoch_end->seqno)
+        catch (const std::exception& e)
         {
-          fail_fetching(fmt::format(
-            "COSE endorsement chain integrity is violated, the current "
-            "service start at {} is not chained with previous endorsement "
-            "ending at {}",
-            current_service_from->to_str(),
-            last.endorsement_epoch_end->to_str()));
+          fail_fetching(e.what());
         }
       }
 
@@ -308,68 +327,53 @@ namespace ccf
         fail_fetching(e.what());
       }
 
-      fetch_status.store(FetchStatus::Done);
+      fetch_status.store(target_status);
     }
 
     void fetch_first()
     {
-      if (!node_state.is_part_of_network())
+      if (!node_state_accessor->is_part_of_network())
       {
         LOG_INFO_FMT(
           "Retry fetching network identity as node is not part of the network "
           "yet");
-        retry_first_fetch();
+        scheduler->add_delayed_task(
+          [this]() { this->fetch_first(); },
+          std::chrono::milliseconds(retry_interval_ms.load()));
         return;
       }
-
-      auto store = node_state.get_store();
-      auto tx = store->create_read_only_tx();
 
       if (!current_service_from.has_value())
       {
-        auto* service_info_handle =
-          tx.template ro<ccf::Service>(ccf::Tables::SERVICE);
-        auto service_info = service_info_handle->get();
-        if (
-          !service_info ||
-          !service_info->current_service_create_txid.has_value())
+        auto cs = node_state_accessor->read_current_service_from();
+        if (!cs.has_value())
         {
           LOG_INFO_FMT(
-            "Retrying fetching network identity as current service create txid "
-            "is not yet available");
-          retry_first_fetch();
+            "Retrying fetching network identity as current service create "
+            "txid is not yet available or service is not yet open");
+          scheduler->add_delayed_task(
+            [this]() { this->fetch_first(); },
+            std::chrono::milliseconds(retry_interval_ms.load()));
           return;
         }
-
-        if (service_info->status != ServiceStatus::OPEN)
-        {
-          // It can happen that node advances its internal state machine to
-          // part-of-network, but the service opening tx has not been replicated
-          // yet. This will cause the first fetched endorsement to be obsolete,
-          // but waiting for ServiceStatus::OPEN is sufficient, as it's supposed
-          // to arrive in the same TX that the previous identity endorsement.
-          LOG_INFO_FMT(
-            "Retrying fetching network identity as service is not yet open");
-          retry_first_fetch();
-          return;
-        }
-
-        current_service_from = service_info->current_service_create_txid;
+        current_service_from = cs;
       }
 
-      auto* previous_identity_endorsement =
-        tx.ro<ccf::PreviousServiceIdentityEndorsement>(
-          ccf::Tables::PREVIOUS_SERVICE_IDENTITY_ENDORSEMENT);
-
-      auto endorsement = previous_identity_endorsement->get();
+      auto endorsement = node_state_accessor->read_topmost_endorsement();
       if (!endorsement.has_value())
       {
         LOG_INFO_FMT(
-          "Retrying fetching network identity as there is no previous service "
-          "identity endorsement yet");
-        retry_first_fetch();
+          "Retrying fetching network identity as there is no previous "
+          "service identity endorsement yet");
+        scheduler->add_delayed_task(
+          [this]() { this->fetch_first(); },
+          std::chrono::milliseconds(retry_interval_ms.load()));
         return;
       }
+
+      // Successful read of the topmost entry: fresh budget for the
+      // chain walk below.
+      fetch_attempts = 0;
 
       if (is_self_endorsement(endorsement.value()))
       {
@@ -378,8 +382,8 @@ namespace ccf
           endorsement->endorsement_epoch_begin.seqno)
         {
           fail_fetching(fmt::format(
-            "The first fetched endorsement is a self-endorsement with seqno {} "
-            "which is different from current_service_create_txid {}",
+            "The first fetched endorsement is a self-endorsement with seqno "
+            "{} which is different from current_service_create_txid {}",
             endorsement->endorsement_epoch_begin.seqno,
             current_service_from->seqno));
         }
@@ -390,7 +394,7 @@ namespace ccf
           current_service_from->seqno);
 
         has_predecessors = false;
-        complete_fetching();
+        complete_fetching(FetchStatus::Done);
         return;
       }
 
@@ -403,10 +407,10 @@ namespace ccf
     {
       if (is_ill_formed(endorsement))
       {
-        // For double-sealed cases, which could have happened in the past. We
-        // mark with failed logs, but skip intentionally if there are other
-        // endorsements that follow. The overall chain integrity will be checked
-        // at the end and will fail anyway if it's not intact.
+        // For double-sealed cases, which could have happened in the past.
+        // Skip intentionally if a predecessor exists; the next link's
+        // chain-integrity check will fail-hard if the resulting chain is
+        // inconsistent.
         if (endorsement.previous_version.has_value())
         {
           LOG_INFO_FMT(
@@ -434,7 +438,7 @@ namespace ccf
             from));
         }
         LOG_INFO_FMT("Got self-endorsement at {}, stopping fetching", from);
-        complete_fetching();
+        complete_fetching(FetchStatus::Done);
         return;
       }
 
@@ -474,7 +478,7 @@ namespace ccf
         return;
       }
 
-      complete_fetching();
+      complete_fetching(FetchStatus::Done);
     }
 
     void build_trusted_key_chain()
@@ -495,8 +499,8 @@ namespace ccf
         if (!verifier->verify(endorsement.endorsement, endorsed_key))
         {
           throw std::logic_error(fmt::format(
-            "COSE endorsement chain integrity is violated, endorsement from {} "
-            "to {} failed signature verification",
+            "COSE endorsement chain integrity is violated, endorsement from "
+            "{} to {} failed signature verification",
             endorsement.endorsement_epoch_begin.to_str(),
             format_epoch(endorsement.endorsement_epoch_end)));
         }
@@ -557,34 +561,31 @@ namespace ccf
 
     void fetch_next_at(ccf::SeqNo seq)
     {
-      auto state = historical_cache->get_state_at(
-        ccf::historical::CompoundHandle{
-          ccf::historical::RequestNamespace::System, seq},
-        seq);
-      if (!state)
+      std::optional<CoseEndorsement> endorsement;
+      try
       {
-        retry_fetch_next(seq);
-        return;
+        endorsement = historical_state_accessor->get_endorsement_at(seq);
       }
-
-      if (!state->store)
+      catch (const std::exception& e)
       {
-        fail_fetching(fmt::format(
-          "Fetched historical state with seqno {} with missing store", seq));
+        fail_fetching(e.what());
       }
-      auto htx = state->store->create_read_only_tx();
-      const auto endorsement =
-        htx
-          .template ro<ccf::PreviousServiceIdentityEndorsement>(
-            ccf::Tables::PREVIOUS_SERVICE_IDENTITY_ENDORSEMENT)
-          ->get();
 
       if (!endorsement.has_value())
       {
-        fail_fetching(
-          fmt::format("Fetched COSE endorsement for {} is invalid", seq));
-        return; // to silence clang-tidy unchecked optional
+        if (!schedule_retry([this, seq]() { this->fetch_next_at(seq); }))
+        {
+          LOG_FAIL_FMT(
+            "Exhausted retry budget fetching previous-identity endorsement "
+            "at seqno {}; settling at Partial with the validated suffix",
+            seq);
+          complete_fetching(FetchStatus::Partial);
+        }
+        return;
       }
+
+      // Successful fetch: reset attempt counter.
+      fetch_attempts = 0;
 
       try
       {
@@ -596,16 +597,6 @@ namespace ccf
       }
 
       process_endorsement(endorsement.value());
-    }
-
-    void retry_fetch_next(ccf::SeqNo seq)
-    {
-      using namespace std::chrono_literals;
-      static constexpr auto retry_after = 100ms;
-      ccf::tasks::add_delayed_task(
-        ccf::tasks::make_basic_task(
-          [this, seq]() { this->fetch_next_at(seq); }),
-        retry_after);
     }
   };
 }

--- a/src/node/test/network_identity_subsystem.cpp
+++ b/src/node/test/network_identity_subsystem.cpp
@@ -88,7 +88,13 @@ namespace
       auto it = entries.find(seq);
       if (it == entries.end())
       {
-        return std::nullopt;
+        // Mirror production: HistoricalStateAccessor throws when the
+        // entry is missing from a loaded historical state (as opposed
+        // to nullopt, which means "state not yet loaded"). Reaching
+        // here from a test is a test-author bug -- surface it loudly
+        // rather than silently dropping the subsystem into Retry.
+        throw std::runtime_error(fmt::format(
+          "MockHistoricalStateAccessor: no entry for seqno {}", seq));
       }
       return it->second;
     }
@@ -843,4 +849,47 @@ TEST_CASE("Chain walk exhausts retries on missing chunk and settles in Partial")
   // succeeded (topmost + current-service).
   REQUIRE_FALSE(sub->get_cose_endorsements_chain(50).has_value());
   REQUIRE(sub->get_trusted_keys().size() == 2);
+}
+
+// White-box invariant test: locks the contract that complete_fetching
+// must be called only after current_service_from has been populated.
+// Reaching that branch indicates a programmer error in a future
+// refactor; we want a hard fail (matching the pre-PR fail_fetching
+// behaviour) rather than a silent settle that leaves the subsystem
+// usable-but-empty in a state that should be unreachable.
+namespace
+{
+  class ExposedSubsystem : public ccf::NetworkIdentitySubsystem
+  {
+  public:
+    using ccf::NetworkIdentitySubsystem::complete_fetching;
+    using ccf::NetworkIdentitySubsystem::NetworkIdentitySubsystem;
+  };
+}
+
+TEST_CASE(
+  "complete_fetching with unset current_service_from is a hard invariant "
+  "violation (Failed, not silent settle)")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 1});
+  f.use_identity_key(cb.current_key_pair());
+
+  // Construct directly without start_with_config so we can drive
+  // complete_fetching with a fresh subsystem whose current_service_from
+  // is still nullopt.
+  ExposedSubsystem sub(f.node_state, f.historical, f.identity, f.scheduler);
+
+  REQUIRE(sub.endorsements_fetching_status() == ccf::FetchStatus::Retry);
+
+  // Both target statuses must trip the invariant: Done and Partial
+  // alike are illegitimate outcomes when the chain root is unknown.
+  for (auto target : {ccf::FetchStatus::Done, ccf::FetchStatus::Partial})
+  {
+    REQUIRE_THROWS_AS(sub.complete_fetching(target), std::runtime_error);
+    // Settles in Failed (set by fail_fetching), not in the requested
+    // target_status.
+    REQUIRE(sub.endorsements_fetching_status() == ccf::FetchStatus::Failed);
+  }
 }

--- a/src/node/test/network_identity_subsystem.cpp
+++ b/src/node/test/network_identity_subsystem.cpp
@@ -1,0 +1,883 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+
+#include "node/rpc/network_identity_subsystem.h"
+
+#include "cose/cose_rs_ffi.h"
+#include "crypto/openssl/ec_key_pair.h"
+#include "node/rpc/network_identity_accessors.h"
+#include "node/rpc/network_identity_chain_helpers.h"
+#include "tasks/basic_task.h"
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <atomic>
+#include <chrono>
+#include <deque>
+#include <doctest/doctest.h>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+  // Build a synthetic CoseEndorsement covering range [begin_view:begin_seqno,
+  // end_view:end_seqno]. Signature/key payloads are left empty: only the
+  // range fields are exercised by the pure-helper validators tested here.
+  ccf::CoseEndorsement make_range_endorsement(
+    ccf::View begin_view,
+    ccf::SeqNo begin_seqno,
+    ccf::View end_view,
+    ccf::SeqNo end_seqno,
+    std::optional<ccf::kv::Version> previous_version = ccf::kv::Version{
+      1} /* default: not self-endorsement */)
+  {
+    ccf::CoseEndorsement e;
+    e.endorsement_epoch_begin = ccf::TxID{begin_view, begin_seqno};
+    e.endorsement_epoch_end = ccf::TxID{end_view, end_seqno};
+    e.previous_version = previous_version;
+    return e;
+  }
+
+  ccf::CoseEndorsement make_self_endorsement(
+    ccf::View begin_view, ccf::SeqNo begin_seqno)
+  {
+    ccf::CoseEndorsement e;
+    e.endorsement_epoch_begin = ccf::TxID{begin_view, begin_seqno};
+    // Self-endorsements have neither epoch_end nor previous_version
+    e.endorsement_epoch_end = std::nullopt;
+    e.previous_version = std::nullopt;
+    return e;
+  }
+
+  // Test scaffolding -----------------------------------------------------
+
+  // Mocks -- in-memory canned responses. `unavailable` lets tests
+  // simulate "ledger chunk is not yet loadable" by making
+  // get_endorsement_at(seq) return nullopt.
+  class MockNodeStateAccessor : public ccf::INodeStateAccessor
+  {
+  public:
+    bool part_of_network = true;
+    std::optional<ccf::TxID> current_service_from;
+    std::optional<ccf::CoseEndorsement> topmost;
+
+    [[nodiscard]] bool is_part_of_network() const override
+    {
+      return part_of_network;
+    }
+    std::optional<ccf::TxID> read_current_service_from() override
+    {
+      return current_service_from;
+    }
+    std::optional<ccf::CoseEndorsement> read_topmost_endorsement() override
+    {
+      return topmost;
+    }
+  };
+
+  class MockHistoricalStateAccessor : public ccf::IHistoricalStateAccessor
+  {
+  public:
+    std::map<ccf::SeqNo, ccf::CoseEndorsement> entries;
+    std::set<ccf::SeqNo> unavailable;
+
+    std::optional<ccf::CoseEndorsement> get_endorsement_at(
+      ccf::SeqNo seq) override
+    {
+      if (unavailable.contains(seq))
+      {
+        return std::nullopt;
+      }
+      auto it = entries.find(seq);
+      if (it == entries.end())
+      {
+        return std::nullopt;
+      }
+      return it->second;
+    }
+  };
+
+  // Fake TaskScheduler -- queues delayed tasks for tests to fire
+  // deterministically.
+  class FakeTaskScheduler : public ccf::TaskScheduler
+  {
+  public:
+    std::mutex mtx;
+    std::deque<std::function<void()>> immediate;
+    std::deque<std::function<void()>> delayed;
+
+    void add_task(std::function<void()> fn) override
+    {
+      std::lock_guard<std::mutex> g(mtx);
+      immediate.push_back(std::move(fn));
+    }
+
+    void add_delayed_task(
+      std::function<void()> fn, std::chrono::milliseconds /* delay */) override
+    {
+      std::lock_guard<std::mutex> g(mtx);
+      delayed.push_back(std::move(fn));
+    }
+
+    [[nodiscard]] size_t pending_immediate_count()
+    {
+      std::lock_guard<std::mutex> g(mtx);
+      return immediate.size();
+    }
+
+    [[nodiscard]] size_t pending_delayed_count()
+    {
+      std::lock_guard<std::mutex> g(mtx);
+      return delayed.size();
+    }
+
+    // Drain all immediate tasks, calling each. May push new ones.
+    void run_immediate()
+    {
+      while (true)
+      {
+        std::function<void()> fn;
+        {
+          std::lock_guard<std::mutex> g(mtx);
+          if (immediate.empty())
+          {
+            return;
+          }
+          fn = std::move(immediate.front());
+          immediate.pop_front();
+        }
+        fn();
+      }
+    }
+
+    // Fire all delayed tasks and drain any immediate tasks they enqueue.
+    // Returns the number of delayed tasks fired.
+    size_t fire_delayed_once()
+    {
+      std::deque<std::function<void()>> batch;
+      {
+        std::lock_guard<std::mutex> g(mtx);
+        batch = std::move(delayed);
+        delayed.clear();
+      }
+      size_t ran = 0;
+      for (auto& fn : batch)
+      {
+        fn();
+        ++ran;
+      }
+      run_immediate();
+      return ran;
+    }
+
+    // Loop firing immediate + delayed until both are empty.
+    void run_to_completion(size_t safety_cap = 100)
+    {
+      run_immediate();
+      while (pending_delayed_count() > 0 && safety_cap-- > 0)
+      {
+        fire_delayed_once();
+      }
+    }
+  };
+
+  // ChainBuilder -- mints real COSE-signed endorsements via the same
+  // cose-rs path production uses. Layout mirrors production:
+  //
+  //   * Service S_0 self-endorses, producing entry e_0. e_0 has no
+  //     epoch_end and no previous_version. Its epoch_begin is the create
+  //     TxID of S_0.
+  //   * Each subsequent service S_i (i>=1) creates entry e_i whose
+  //     endorsing_key is S_i's public key and whose COSE payload is
+  //     S_{i-1}'s public key. e_i.epoch_begin equals the previous entry's
+  //     epoch_begin if the previous is a self-endorsement, else
+  //     next_tx_if_recovery(prev.epoch_end). e_i.epoch_end is one txid
+  //     before S_i's create TxID. e_i.previous_version is the kv::Version
+  //     at which e_{i-1} was written.
+  //   * In production, e_N (the topmost) is what
+  //     `read_topmost_endorsement` returns. e_0..e_{N-1} are what
+  //     `get_endorsement_at(write_version)` returns. The current
+  //     service's public key (in DER) must match e_N's signing key.
+  //
+  // For Test purposes we ignore the "previous_root" semantics -- the
+  // subsystem doesn't validate it.
+  class ChainBuilder
+  {
+  public:
+    std::vector<std::shared_ptr<ccf::crypto::ECKeyPair_OpenSSL>> service_keys;
+    std::vector<ccf::CoseEndorsement> entries;
+    std::vector<ccf::kv::Version> write_versions;
+    ccf::kv::Version next_write_version = 1;
+
+    // Add the deepest service in the chain, self-endorsing.
+    ChainBuilder& add_self(ccf::TxID begin)
+    {
+      auto kp = std::make_shared<ccf::crypto::ECKeyPair_OpenSSL>(
+        ccf::crypto::CurveID::SECP384R1);
+      ccf::CoseEndorsement e;
+      e.endorsement_epoch_begin = begin;
+      e.endorsing_key = kp->public_key_der();
+      e.endorsement = sign(*kp, begin, std::nullopt, {}, kp->public_key_der());
+      service_keys.push_back(kp);
+      entries.push_back(e);
+      write_versions.push_back(next_write_version++);
+      return *this;
+    }
+
+    // Add the next service in the chain, endorsing the prior service's
+    // key. `begin` and `end` define this entry's epoch range.
+    ChainBuilder& add_next(ccf::TxID begin, ccf::TxID end)
+    {
+      REQUIRE(!service_keys.empty());
+      auto kp = std::make_shared<ccf::crypto::ECKeyPair_OpenSSL>(
+        ccf::crypto::CurveID::SECP384R1);
+      const auto& prev_kp = service_keys.back();
+      ccf::CoseEndorsement e;
+      e.endorsement_epoch_begin = begin;
+      e.endorsement_epoch_end = end;
+      e.previous_version = write_versions.back();
+      e.endorsing_key = kp->public_key_der();
+      e.endorsement = sign(
+        *kp,
+        begin,
+        end,
+        std::vector<uint8_t>{0xaa, 0xbb, 0xcc, 0xdd},
+        prev_kp->public_key_der());
+      service_keys.push_back(kp);
+      entries.push_back(e);
+      write_versions.push_back(next_write_version++);
+      return *this;
+    }
+
+    // The current service's public key (DER) -- matches the most-recent
+    // entry's signing key.
+    [[nodiscard]] std::vector<uint8_t> current_pkey_der() const
+    {
+      REQUIRE(!service_keys.empty());
+      return service_keys.back()->public_key_der();
+    }
+
+    [[nodiscard]] std::shared_ptr<ccf::crypto::ECKeyPair_OpenSSL>
+    current_key_pair() const
+    {
+      REQUIRE(!service_keys.empty());
+      return service_keys.back();
+    }
+
+    // TxID at which the current service was created. Synthesised by
+    // applying the recovery (view, seqno) increment to the most-recent
+    // entry's epoch_end. The subsystem checks the resulting TxID against
+    // the last entry's epoch_end via validate_chain_front_connection.
+    [[nodiscard]] ccf::TxID synthesised_current_service_from() const
+    {
+      REQUIRE(!entries.empty());
+      const auto& last = entries.back();
+      REQUIRE(last.endorsement_epoch_end.has_value());
+      return ccf::TxID{
+        last.endorsement_epoch_end->view + aft::starting_view_change,
+        last.endorsement_epoch_end->seqno + 1};
+    }
+
+    // For sources: pop the topmost entry off (it lives in
+    // read_topmost_endorsement, not in `historical`).
+    ccf::CoseEndorsement topmost_entry() const
+    {
+      REQUIRE(!entries.empty());
+      return entries.back();
+    }
+    std::map<ccf::SeqNo, ccf::CoseEndorsement> historical_entries() const
+    {
+      std::map<ccf::SeqNo, ccf::CoseEndorsement> m;
+      // All but the topmost.
+      for (size_t i = 0; i + 1 < entries.size(); ++i)
+      {
+        m.emplace(write_versions[i], entries[i]);
+      }
+      return m;
+    }
+
+  private:
+    static std::vector<uint8_t> sign(
+      ccf::crypto::ECKeyPair_OpenSSL& key,
+      const ccf::TxID& begin,
+      const std::optional<ccf::TxID>& end,
+      const std::vector<uint8_t>& previous_root,
+      const std::vector<uint8_t>& payload)
+    {
+      const auto begin_str = begin.to_str();
+      const auto end_str = end.has_value() ? end->to_str() : std::string{};
+      auto priv_der = key.private_key_der();
+      CoseBuffer key_err;
+      auto cose_key =
+        CoseKey::from_private(priv_der.data(), priv_der.size(), key_err);
+      REQUIRE(cose_key.is_set());
+
+      CoseBuffer out;
+      CoseBuffer sign_err;
+      auto rc = cose_sign_endorsement(
+        cose_key,
+        /*iat=*/1700000000,
+        reinterpret_cast<const uint8_t*>(begin_str.data()),
+        begin_str.size(),
+        end.has_value() ? reinterpret_cast<const uint8_t*>(end_str.data()) :
+                          nullptr,
+        end.has_value() ? end_str.size() : 0,
+        previous_root.data(),
+        previous_root.size(),
+        payload.data(),
+        payload.size(),
+        out,
+        sign_err);
+      REQUIRE(rc == 0);
+      REQUIRE(out.is_set());
+      return out.to_vector();
+    }
+  };
+
+  // Fixture that owns the mocks, scheduler, and identity so tests can
+  // build a subsystem with one call.
+  struct SubsystemFixture
+  {
+    std::shared_ptr<MockNodeStateAccessor> node_state =
+      std::make_shared<MockNodeStateAccessor>();
+    std::shared_ptr<MockHistoricalStateAccessor> historical =
+      std::make_shared<MockHistoricalStateAccessor>();
+    std::shared_ptr<FakeTaskScheduler> scheduler =
+      std::make_shared<FakeTaskScheduler>();
+    std::unique_ptr<ccf::NetworkIdentity> identity;
+
+    SubsystemFixture()
+    {
+      identity = std::make_unique<ccf::NetworkIdentity>(
+        "CN=Test Service",
+        ccf::crypto::CurveID::SECP384R1,
+        "20240101000000Z",
+        365);
+    }
+
+    // Replace the identity's key pair so its public key matches the chain
+    // tail. Tests must do this BEFORE constructing the subsystem.
+    void use_identity_key(
+      const std::shared_ptr<ccf::crypto::ECKeyPair_OpenSSL>& kp)
+    {
+      identity->priv_key = kp->private_key_pem();
+    }
+
+    // Small, deterministic retry budget so budget-exhaustion tests
+    // do not have to spin a large number of fake delays. Tests that
+    // care about specific budget values should pass an explicit
+    // config.
+    static ccf::CCFConfig::IdentityHistoryFetch default_config()
+    {
+      ccf::CCFConfig::IdentityHistoryFetch c;
+      c.max_attempts = 30;
+      c.retry_interval = ccf::ds::TimeString{"1000ms"};
+      return c;
+    }
+
+    std::unique_ptr<ccf::NetworkIdentitySubsystem> make_subsystem(
+      const ccf::CCFConfig::IdentityHistoryFetch& config = default_config())
+    {
+      auto sub = std::make_unique<ccf::NetworkIdentitySubsystem>(
+        node_state, historical, identity, scheduler);
+      sub->start_with_config(config);
+      return sub;
+    }
+  };
+
+  // Populate the mocks from `cb` to model a chain of length N already
+  // committed to the ledger and topmost in the current store.
+  void wire_chain(
+    SubsystemFixture& f,
+    const ChainBuilder& cb,
+    std::optional<ccf::TxID> current_service_from = std::nullopt)
+  {
+    f.node_state->current_service_from =
+      current_service_from.value_or(cb.synthesised_current_service_from());
+    f.node_state->topmost = cb.topmost_entry();
+    f.historical->entries = cb.historical_entries();
+  }
+}
+
+TEST_CASE("is_self_endorsement detects absence of previous_version")
+{
+  REQUIRE(ccf::is_self_endorsement(make_self_endorsement(2, 10)));
+  REQUIRE_FALSE(ccf::is_self_endorsement(make_range_endorsement(3, 11, 3, 20)));
+}
+
+TEST_CASE("is_ill_formed detects inverted range")
+{
+  REQUIRE(ccf::is_ill_formed(make_range_endorsement(3, 20, 3, 10)));
+  REQUIRE_FALSE(ccf::is_ill_formed(make_range_endorsement(3, 10, 3, 20)));
+  // Self-endorsement has no epoch_end, so it is never ill-formed
+  REQUIRE_FALSE(ccf::is_ill_formed(make_self_endorsement(2, 10)));
+}
+
+TEST_CASE("verify_endorsements_connected accepts adjacent endorsements")
+{
+  // older covers [v=2, 10..20]; newer starts at v=3, seqno=21.
+  // The view rule is: newer.begin.view - aft::starting_view_change ==
+  // older.end.view, and newer.begin.seqno - 1 == older.end.seqno.
+  auto older = make_range_endorsement(2, 10, 2, 20);
+  auto newer = make_range_endorsement(2 + aft::starting_view_change, 21, 3, 30);
+
+  REQUIRE_NOTHROW(ccf::verify_endorsements_connected(newer, older));
+}
+
+TEST_CASE("verify_endorsements_connected rejects view discontinuity")
+{
+  auto older = make_range_endorsement(2, 10, 2, 20);
+  // newer.begin.view should be 2 + starting_view_change; use a wrong value
+  auto newer =
+    make_range_endorsement(2 + aft::starting_view_change + 1, 21, 3, 30);
+
+  REQUIRE_THROWS_AS(
+    ccf::verify_endorsements_connected(newer, older), std::logic_error);
+}
+
+TEST_CASE("verify_endorsements_connected rejects seqno gap")
+{
+  auto older = make_range_endorsement(2, 10, 2, 20);
+  // seqno gap: newer.begin.seqno should be 21
+  auto newer = make_range_endorsement(2 + aft::starting_view_change, 22, 3, 30);
+
+  REQUIRE_THROWS_AS(
+    ccf::verify_endorsements_connected(newer, older), std::logic_error);
+}
+
+TEST_CASE("verify_endorsements_connected rejects older with no epoch_end")
+{
+  ccf::CoseEndorsement older = make_range_endorsement(2, 10, 2, 20);
+  older.endorsement_epoch_end = std::nullopt;
+  auto newer = make_range_endorsement(2 + aft::starting_view_change, 21, 3, 30);
+
+  REQUIRE_THROWS_AS(
+    ccf::verify_endorsements_connected(newer, older), std::logic_error);
+}
+
+TEST_CASE(
+  "validate_chain_front_connection requires current_service_from to "
+  "immediately follow the endorsement")
+{
+  ccf::CoseEndorsement e = make_range_endorsement(2, 10, 2, 20);
+
+  // current_service_from must have view = 2 + starting_view_change and
+  // seqno = 21 to be adjacent.
+  ccf::TxID good{2 + aft::starting_view_change, 21};
+  REQUIRE_NOTHROW(ccf::validate_chain_front_connection(e, good));
+
+  ccf::TxID bad_seqno{2 + aft::starting_view_change, 22};
+  REQUIRE_THROWS_AS(
+    ccf::validate_chain_front_connection(e, bad_seqno), std::logic_error);
+
+  ccf::TxID bad_view{3 + aft::starting_view_change, 21};
+  REQUIRE_THROWS_AS(
+    ccf::validate_chain_front_connection(e, bad_view), std::logic_error);
+}
+
+TEST_CASE(
+  "validate_chain_front_connection rejects endorsement with no epoch_end")
+{
+  ccf::CoseEndorsement bad = make_range_endorsement(2, 10, 2, 20);
+  bad.endorsement_epoch_end = std::nullopt;
+
+  ccf::TxID after{2 + aft::starting_view_change, 21};
+  REQUIRE_THROWS_AS(
+    ccf::validate_chain_front_connection(bad, after), std::logic_error);
+}
+
+// ------------------------------------------------------------------------
+// State-machine tests using Mock{NodeState,HistoricalState}Accessor +
+// FakeTaskScheduler + ChainBuilder. Each test wires a synthetic ledger,
+// constructs the subsystem, drives the scheduler, and asserts on the
+// public state.
+// ------------------------------------------------------------------------
+
+TEST_CASE(
+  "Constructor leaves subsystem in Retry until start_with_config is called")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 100});
+  f.use_identity_key(cb.current_key_pair());
+  f.node_state->current_service_from = {2, 100};
+  f.node_state->topmost = cb.topmost_entry();
+
+  // Construct WITHOUT calling start_with_config.
+  auto sub = std::make_unique<ccf::NetworkIdentitySubsystem>(
+    f.node_state, f.historical, f.identity, f.scheduler);
+
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Retry);
+  REQUIRE(f.scheduler->pending_immediate_count() == 0);
+  REQUIRE(f.scheduler->pending_delayed_count() == 0);
+  REQUIRE_THROWS_AS(sub->get_trusted_keys(), ccf::IdentityHistoryNotFetched);
+
+  // Calling start_with_config bootstraps the subsystem.
+  sub->start_with_config();
+  f.scheduler->run_to_completion();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Done);
+
+  // A second start_with_config must throw.
+  REQUIRE_THROWS_AS(sub->start_with_config(), std::logic_error);
+}
+
+TEST_CASE("Bootstrap with self-only chain transitions immediately to Done")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 100});
+  f.use_identity_key(cb.current_key_pair());
+  // Self-only: topmost IS the self-endorsement, current_service_from
+  // matches its epoch_begin.
+  f.node_state->current_service_from = {2, 100};
+  f.node_state->topmost = cb.topmost_entry();
+
+  auto sub = f.make_subsystem();
+  f.scheduler->run_to_completion();
+
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Done);
+  auto keys = sub->get_trusted_keys();
+  REQUIRE(keys.size() == 1);
+  // Current-epoch seqno: empty chain (short-circuited by the
+  // seqno >= current_service_from branch).
+  REQUIRE(sub->get_cose_endorsements_chain(100)->empty());
+  // Older seqno: Done + !has_predecessors -> empty chain (pre-history,
+  // no historical endorsements will ever cover it).
+  REQUIRE(sub->get_cose_endorsements_chain(50)->empty());
+}
+
+TEST_CASE("Bootstrap with N-link chain reaches Done with full key map")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 1}).add_next({2, 1}, {4, 200}).add_next({6, 201}, {6, 400});
+
+  f.use_identity_key(cb.current_key_pair());
+  wire_chain(f, cb);
+
+  auto sub = f.make_subsystem();
+  f.scheduler->run_to_completion();
+
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Done);
+  REQUIRE(sub->get_trusted_keys().size() == 3);
+}
+
+// ------------------------------------------------------------------------
+// Extended coverage: bootstrap waiting cases, Failed transitions, reader
+// semantics, retry budgets.
+// ------------------------------------------------------------------------
+
+TEST_CASE("Bootstrap waits for is_part_of_network then proceeds")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 1});
+  f.use_identity_key(cb.current_key_pair());
+  f.node_state->current_service_from = ccf::TxID{2, 1};
+  f.node_state->topmost = cb.topmost_entry();
+  f.node_state->part_of_network = false;
+
+  auto sub = f.make_subsystem();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Retry);
+  // A delayed retry should have been scheduled.
+  REQUIRE(f.scheduler->pending_delayed_count() == 1);
+
+  // Fire it: still not part of network -> another retry queued.
+  f.scheduler->fire_delayed_once();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Retry);
+  REQUIRE(f.scheduler->pending_delayed_count() == 1);
+
+  // Become ready; next firing should bootstrap to Done.
+  f.node_state->part_of_network = true;
+  f.scheduler->fire_delayed_once();
+  f.scheduler->run_to_completion();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Done);
+}
+
+// While bootstrap is in flight the subsystem is in Retry, and the
+// readers must throw IdentityHistoryNotFetched (the original public
+// contract preserved across this change).
+TEST_CASE("Readers throw IdentityHistoryNotFetched while subsystem is in Retry")
+{
+  SubsystemFixture f;
+  f.node_state->part_of_network = false;
+  auto sub = f.make_subsystem();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Retry);
+
+  REQUIRE_THROWS_AS(
+    sub->get_cose_endorsements_chain(0), ccf::IdentityHistoryNotFetched);
+  REQUIRE_THROWS_AS(
+    sub->get_cose_endorsements_chain(123), ccf::IdentityHistoryNotFetched);
+  REQUIRE_THROWS_AS(
+    sub->get_trusted_identity_for(0), ccf::IdentityHistoryNotFetched);
+  REQUIRE_THROWS_AS(
+    sub->get_trusted_identity_for(999), ccf::IdentityHistoryNotFetched);
+  REQUIRE_THROWS_AS(sub->get_trusted_keys(), ccf::IdentityHistoryNotFetched);
+}
+
+TEST_CASE("Bootstrap waits for current_service_from then proceeds")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 1});
+  f.use_identity_key(cb.current_key_pair());
+  // part_of_network=true (default) but no current_service_from yet
+  f.node_state->topmost = cb.topmost_entry();
+
+  auto sub = f.make_subsystem();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Retry);
+  REQUIRE(f.scheduler->pending_delayed_count() == 1);
+
+  f.node_state->current_service_from = ccf::TxID{2, 1};
+  f.scheduler->fire_delayed_once();
+  f.scheduler->run_to_completion();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Done);
+}
+
+TEST_CASE("Bootstrap waits for topmost endorsement entry then proceeds")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 1});
+  f.use_identity_key(cb.current_key_pair());
+  f.node_state->current_service_from = ccf::TxID{2, 1};
+  // topmost is unset
+
+  auto sub = f.make_subsystem();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Retry);
+  REQUIRE(f.scheduler->pending_delayed_count() == 1);
+
+  f.node_state->topmost = cb.topmost_entry();
+  f.scheduler->fire_delayed_once();
+  f.scheduler->run_to_completion();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Done);
+}
+
+TEST_CASE("Failed: bad signature on topmost detected during bootstrap")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 1}).add_next({2, 1}, {4, 200});
+  f.use_identity_key(cb.current_key_pair());
+  wire_chain(f, cb);
+
+  // Tamper the topmost's signature: build_trusted_key_chain in
+  // complete_fetching(Done) catches it and Failed escapes the ctor.
+  REQUIRE(f.node_state->topmost.has_value());
+  f.node_state->topmost->endorsement.back() ^= 0xFF;
+
+  REQUIRE_THROWS_AS({ auto sub = f.make_subsystem(); }, std::exception);
+}
+
+TEST_CASE(
+  "Failed: historical endorsement COSE header range disagrees with table "
+  "fields -> Failed during bootstrap")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 1}).add_next({2, 1}, {4, 200}).add_next({6, 201}, {6, 400});
+  f.use_identity_key(cb.current_key_pair());
+  wire_chain(f, cb);
+
+  // Tamper a HISTORICAL entry's table-side epoch_end so it disagrees
+  // with the signed COSE header range. validate_fetched_endorsement
+  // runs only on historically-fetched links (not the topmost) and
+  // catches the mismatch.
+  auto mid_wv = cb.write_versions.at(1);
+  f.historical->entries.at(mid_wv).endorsement_epoch_end = ccf::TxID{99, 99999};
+
+  REQUIRE_THROWS_AS({ auto sub = f.make_subsystem(); }, std::exception);
+}
+
+TEST_CASE("Failed: chain link broken (wrong endorsing_key) during bootstrap")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 1}).add_next({2, 1}, {4, 200}).add_next({6, 201}, {6, 400});
+  f.use_identity_key(cb.current_key_pair());
+  wire_chain(f, cb);
+
+  // Replace the middle entry's endorsing_key with a stranger; the
+  // actual signature was made with the original key, so verification
+  // fails. Throw escapes the constructor.
+  auto mid_wv = cb.write_versions.at(1);
+  auto stranger = std::make_shared<ccf::crypto::ECKeyPair_OpenSSL>(
+    ccf::crypto::CurveID::SECP384R1);
+  f.historical->entries.at(mid_wv).endorsing_key = stranger->public_key_der();
+
+  REQUIRE_THROWS_AS({ auto sub = f.make_subsystem(); }, std::exception);
+}
+
+TEST_CASE(
+  "Failed: self-endorsement at unexpected seqno detected during bootstrap")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 1});
+  f.use_identity_key(cb.current_key_pair());
+  // Advertise current_service_from at a different seqno than the
+  // self-endorsement's epoch_begin.
+  f.node_state->current_service_from = ccf::TxID{2, 99};
+  f.node_state->topmost = cb.topmost_entry();
+
+  REQUIRE_THROWS_AS({ auto sub = f.make_subsystem(); }, std::exception);
+}
+
+TEST_CASE("Reader: empty chain for current-epoch seqno in Done")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 1}).add_next({2, 1}, {4, 200});
+  f.use_identity_key(cb.current_key_pair());
+  wire_chain(f, cb);
+  auto sub = f.make_subsystem();
+  f.scheduler->run_to_completion();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Done);
+  // current_service_from = synthesised = view 6, seqno 201
+  auto chain = sub->get_cose_endorsements_chain(500);
+  REQUIRE(chain.has_value());
+  REQUIRE(chain->empty());
+}
+
+TEST_CASE("Reader: empty chain for pre-history seqno in Done")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 100}).add_next({2, 100}, {4, 500});
+  f.use_identity_key(cb.current_key_pair());
+  wire_chain(f, cb);
+  auto sub = f.make_subsystem();
+  f.scheduler->run_to_completion();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Done);
+  auto chain = sub->get_cose_endorsements_chain(50);
+  REQUIRE(chain.has_value());
+  REQUIRE(chain->empty());
+}
+
+TEST_CASE("Reader: nullopt for uncovered seqno in Partial")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  // Pick a self-endorsement at seqno 100 so the topmost ends up with
+  // earliest_endorsed_seq = 100 and a query at seqno 50 is genuinely
+  // below the partial chain.
+  cb.add_self({2, 100}).add_next({2, 100}, {4, 200});
+  f.use_identity_key(cb.current_key_pair());
+  wire_chain(f, cb);
+  f.historical->unavailable.insert(cb.write_versions.at(0));
+
+  auto sub = f.make_subsystem();
+  for (int i = 0; i < 30; ++i)
+  {
+    f.scheduler->fire_delayed_once();
+  }
+  f.scheduler->run_to_completion();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Partial);
+
+  // earliest_endorsed_seq is the topmost's begin.seqno = 100.
+  // A request strictly below that returns nullopt (we have no chain
+  // for it; the caller fails the receipt request).
+  REQUIRE_FALSE(sub->get_cose_endorsements_chain(50).has_value());
+  // A request inside the topmost epoch returns a non-empty chain.
+  auto chain = sub->get_cose_endorsements_chain(150);
+  REQUIRE(chain.has_value());
+  REQUIRE(chain->size() == 1);
+}
+
+TEST_CASE("Reader: get_trusted_identity_for boundary semantics")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 1}).add_next({2, 1}, {4, 200}).add_next({6, 201}, {6, 400});
+  f.use_identity_key(cb.current_key_pair());
+  wire_chain(f, cb);
+  auto sub = f.make_subsystem();
+  f.scheduler->run_to_completion();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Done);
+
+  // trusted_keys are at seqnos {1, 201, 401}
+  // Below the earliest -> nullptr
+  REQUIRE(sub->get_trusted_identity_for(0) == nullptr);
+  // Exact boundary returns the key at that seqno
+  REQUIRE(sub->get_trusted_identity_for(1) != nullptr);
+  // Between boundaries: returns the most-recent <= seqno
+  REQUIRE(sub->get_trusted_identity_for(100) != nullptr);
+  REQUIRE(sub->get_trusted_identity_for(200) != nullptr);
+  REQUIRE(sub->get_trusted_identity_for(201) != nullptr);
+  // Far above last boundary -> returns the most-recent (current)
+  REQUIRE(sub->get_trusted_identity_for(1000000) != nullptr);
+}
+
+TEST_CASE("Reader: get_trusted_keys returns partial map in Partial")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 1})
+    .add_next({2, 1}, {4, 200})
+    .add_next({6, 201}, {6, 400})
+    .add_next({8, 401}, {8, 600});
+  f.use_identity_key(cb.current_key_pair());
+  wire_chain(f, cb);
+  // Make all but the topmost unavailable.
+  f.historical->unavailable = {
+    cb.write_versions.at(0), cb.write_versions.at(1), cb.write_versions.at(2)};
+
+  auto sub = f.make_subsystem();
+  for (int i = 0; i < 30; ++i)
+  {
+    f.scheduler->fire_delayed_once();
+  }
+  f.scheduler->run_to_completion();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Partial);
+  // Topmost + current-service: the only two keys whose endorsements
+  // were validated.
+  REQUIRE(sub->get_trusted_keys().size() == 2);
+}
+
+TEST_CASE("Done is terminal: no tasks queued after reaching Done")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  cb.add_self({2, 1}).add_next({2, 1}, {4, 200});
+  f.use_identity_key(cb.current_key_pair());
+  wire_chain(f, cb);
+
+  auto sub = f.make_subsystem();
+  f.scheduler->run_to_completion();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Done);
+  REQUIRE(f.scheduler->pending_delayed_count() == 0);
+}
+
+TEST_CASE("Chain walk exhausts retries on missing chunk and settles in Partial")
+{
+  SubsystemFixture f;
+  ChainBuilder cb;
+  // Topmost begins at seqno 100 so a request at seqno 50 is genuinely
+  // below the validated suffix.
+  cb.add_self({2, 100}).add_next({2, 100}, {4, 200});
+  f.use_identity_key(cb.current_key_pair());
+  wire_chain(f, cb);
+  // Predecessor chunk is missing during chain walk.
+  f.historical->unavailable.insert(cb.write_versions.at(0));
+
+  auto sub = f.make_subsystem();
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Retry);
+
+  // Drain delayed retries until the budget exhausts. schedule_retry
+  // exits without queueing the next retry once the configured cap is
+  // reached, so the loop terminates.
+  int fired = 0;
+  while (f.scheduler->pending_delayed_count() > 0)
+  {
+    f.scheduler->fire_delayed_once();
+    ++fired;
+  }
+  REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Partial);
+  REQUIRE(fired > 0);
+
+  // Readers in Partial: chain reader returns nullopt for the missing
+  // seqno (below validated suffix); trusted_keys is the suffix that
+  // succeeded (topmost + current-service).
+  REQUIRE_FALSE(sub->get_cose_endorsements_chain(50).has_value());
+  REQUIRE(sub->get_trusted_keys().size() == 2);
+}

--- a/src/node/test/network_identity_subsystem.cpp
+++ b/src/node/test/network_identity_subsystem.cpp
@@ -7,14 +7,11 @@
 #include "crypto/openssl/ec_key_pair.h"
 #include "node/rpc/network_identity_accessors.h"
 #include "node/rpc/network_identity_chain_helpers.h"
-#include "tasks/basic_task.h"
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include <atomic>
 #include <chrono>
 #include <deque>
 #include <doctest/doctest.h>
-#include <thread>
 
 using namespace std::chrono_literals;
 
@@ -65,11 +62,11 @@ namespace
     {
       return part_of_network;
     }
-    std::optional<ccf::TxID> read_current_service_from() override
+    std::optional<ccf::TxID> get_current_service_txid() override
     {
       return current_service_from;
     }
-    std::optional<ccf::CoseEndorsement> read_topmost_endorsement() override
+    std::optional<ccf::CoseEndorsement> get_current_endorsement() override
     {
       return topmost;
     }
@@ -103,14 +100,7 @@ namespace
   {
   public:
     std::mutex mtx;
-    std::deque<std::function<void()>> immediate;
     std::deque<std::function<void()>> delayed;
-
-    void add_task(std::function<void()> fn) override
-    {
-      std::lock_guard<std::mutex> g(mtx);
-      immediate.push_back(std::move(fn));
-    }
 
     void add_delayed_task(
       std::function<void()> fn, std::chrono::milliseconds /* delay */) override
@@ -119,39 +109,13 @@ namespace
       delayed.push_back(std::move(fn));
     }
 
-    [[nodiscard]] size_t pending_immediate_count()
-    {
-      std::lock_guard<std::mutex> g(mtx);
-      return immediate.size();
-    }
-
     [[nodiscard]] size_t pending_delayed_count()
     {
       std::lock_guard<std::mutex> g(mtx);
       return delayed.size();
     }
 
-    // Drain all immediate tasks, calling each. May push new ones.
-    void run_immediate()
-    {
-      while (true)
-      {
-        std::function<void()> fn;
-        {
-          std::lock_guard<std::mutex> g(mtx);
-          if (immediate.empty())
-          {
-            return;
-          }
-          fn = std::move(immediate.front());
-          immediate.pop_front();
-        }
-        fn();
-      }
-    }
-
-    // Fire all delayed tasks and drain any immediate tasks they enqueue.
-    // Returns the number of delayed tasks fired.
+    // Fire all currently queued delayed tasks. Returns the number fired.
     size_t fire_delayed_once()
     {
       std::deque<std::function<void()>> batch;
@@ -166,14 +130,12 @@ namespace
         fn();
         ++ran;
       }
-      run_immediate();
       return ran;
     }
 
-    // Loop firing immediate + delayed until both are empty.
+    // Loop firing delayed tasks until the queue is empty.
     void run_to_completion(size_t safety_cap = 100)
     {
-      run_immediate();
       while (pending_delayed_count() > 0 && safety_cap-- > 0)
       {
         fire_delayed_once();
@@ -194,8 +156,8 @@ namespace
   //     next_tx_if_recovery(prev.epoch_end). e_i.epoch_end is one txid
   //     before S_i's create TxID. e_i.previous_version is the kv::Version
   //     at which e_{i-1} was written.
-  //   * In production, e_N (the topmost) is what
-  //     `read_topmost_endorsement` returns. e_0..e_{N-1} are what
+  //   * In production, e_N (the current KV entry) is what
+  //     `get_current_endorsement` returns. e_0..e_{N-1} are what
   //     `get_endorsement_at(write_version)` returns. The current
   //     service's public key (in DER) must match e_N's signing key.
   //
@@ -278,8 +240,8 @@ namespace
         last.endorsement_epoch_end->seqno + 1};
     }
 
-    // For sources: pop the topmost entry off (it lives in
-    // read_topmost_endorsement, not in `historical`).
+    // For sources: pop the latest entry off (it lives in
+    // get_current_endorsement, not in `historical`).
     ccf::CoseEndorsement topmost_entry() const
     {
       REQUIRE(!entries.empty());
@@ -405,12 +367,14 @@ TEST_CASE("is_self_endorsement detects absence of previous_version")
   REQUIRE_FALSE(ccf::is_self_endorsement(make_range_endorsement(3, 11, 3, 20)));
 }
 
-TEST_CASE("is_ill_formed detects inverted range")
+TEST_CASE("has_ill_formed_epoch_range detects inverted range")
 {
-  REQUIRE(ccf::is_ill_formed(make_range_endorsement(3, 20, 3, 10)));
-  REQUIRE_FALSE(ccf::is_ill_formed(make_range_endorsement(3, 10, 3, 20)));
+  REQUIRE(
+    ccf::has_ill_formed_epoch_range(make_range_endorsement(3, 20, 3, 10)));
+  REQUIRE_FALSE(
+    ccf::has_ill_formed_epoch_range(make_range_endorsement(3, 10, 3, 20)));
   // Self-endorsement has no epoch_end, so it is never ill-formed
-  REQUIRE_FALSE(ccf::is_ill_formed(make_self_endorsement(2, 10)));
+  REQUIRE_FALSE(ccf::has_ill_formed_epoch_range(make_self_endorsement(2, 10)));
 }
 
 TEST_CASE("verify_endorsements_connected accepts adjacent endorsements")
@@ -508,7 +472,6 @@ TEST_CASE(
     f.node_state, f.historical, f.identity, f.scheduler);
 
   REQUIRE(sub->endorsements_fetching_status() == ccf::FetchStatus::Retry);
-  REQUIRE(f.scheduler->pending_immediate_count() == 0);
   REQUIRE(f.scheduler->pending_delayed_count() == 0);
   REQUIRE_THROWS_AS(sub->get_trusted_keys(), ccf::IdentityHistoryNotFetched);
 

--- a/tests/config.jinja
+++ b/tests/config.jinja
@@ -117,7 +117,11 @@
     "max_msg_size": "{{ max_msg_size_bytes }}",
     "max_fragment_size": "256KB"
   },
-  "ignore_first_sigterm": {{ ignore_first_sigterm|tojson }}{% if sealing_recovery_location %},
+  "ignore_first_sigterm": {{ ignore_first_sigterm|tojson }}{% if identity_history_fetch_max_attempts or identity_history_fetch_retry_interval %},
+  "identity_history_fetch": {
+    {% if identity_history_fetch_max_attempts %}"max_attempts": {{ identity_history_fetch_max_attempts }}{% endif %}{% if identity_history_fetch_max_attempts and identity_history_fetch_retry_interval %},
+    {% endif %}{% if identity_history_fetch_retry_interval %}"retry_interval": "{{ identity_history_fetch_retry_interval }}"{% endif %}
+  }{% endif %}{% if sealing_recovery_location %},
   "sealing_recovery": {
     "location": {
       "name": "{{ sealing_recovery_location.name }}",

--- a/tests/infra/remote.py
+++ b/tests/infra/remote.py
@@ -341,6 +341,8 @@ class CCFRemote(object):
         backup_snapshot_fetch_retry_interval=None,
         backup_snapshot_fetch_target_rpc_interface=None,
         backup_snapshot_fetch_max_size=None,
+        identity_history_fetch_max_attempts=None,
+        identity_history_fetch_retry_interval=None,
         host_data_transparent_statement_path=None,
         **kwargs,
     ):
@@ -544,6 +546,8 @@ class CCFRemote(object):
                 backup_snapshot_fetch_target_rpc_interface=backup_snapshot_fetch_target_rpc_interface
                 or infra.interfaces.FILE_SERVING_RPC_INTERFACE,
                 backup_snapshot_fetch_max_size=backup_snapshot_fetch_max_size,
+                identity_history_fetch_max_attempts=identity_history_fetch_max_attempts,
+                identity_history_fetch_retry_interval=identity_history_fetch_retry_interval,
                 host_data_transparent_statement_path=host_data_transparent_statement_path,
                 **kwargs,
             )

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -2020,6 +2020,172 @@ def run_recover_snapshot_ledger_offset(args):
                 )
 
 
+def _find_endorsement_write_chunks(committed_ledger_dirs):
+    """Return [(seqno, chunk_path), ...] for every write to the previous
+    service identity endorsement table across the committed ledger
+    directories, sorted by seqno. Used by the partial-chain e2e test to
+    locate a chunk whose removal will break the chain walk."""
+    endorsement_table = "public:ccf.internal.previous_service_identity_endorsement"
+    writes = []
+    for ledger_dir in committed_ledger_dirs:
+        for filename in os.listdir(ledger_dir):
+            if not ccf.ledger.is_ledger_chunk_committed(filename):
+                continue
+            chunk_path = os.path.join(ledger_dir, filename)
+            chunk = ccf.ledger.LedgerChunk(chunk_path)
+            for transaction in chunk:
+                public_domain = transaction.get_public_domain()
+                tables = public_domain.get_tables()
+                if endorsement_table in tables:
+                    writes.append((public_domain.get_seqno(), chunk_path))
+    writes.sort(key=lambda w: w[0])
+    return writes
+
+
+@reqs.description(
+    "Network identity subsystem settles in Partial when a previous-identity "
+    "endorsement ledger chunk is missing"
+)
+def run_recovery_partial_when_ledger_gap(args):
+    """Builds a chain over 2 recoveries (S1 -> S2 -> S3), stops the
+    network, moves out the ledger chunk that contains the S2-era
+    endorsement write, and recovers once more (-> S4). With the
+    missing chunk the endorsement chain walk cannot complete; we
+    configure the subsystem with a small retry budget so it settles
+    in Partial quickly. We assert:
+
+      * the subsystem reaches Partial (not Done, not Failed);
+      * the validated suffix is available via the trusted_keys
+        endpoint.
+
+    No "restore the chunk and re-fetch" step: Partial is terminal."""
+    txs = app.LoggingTxs("user0")
+
+    with infra.network.network(
+        args.nodes,
+        args.binary_dir,
+        args.debug_nodes,
+        pdb=args.pdb,
+        txs=txs,
+    ) as network:
+        network.start_and_open(args)
+
+        # A couple of transactions in the first epoch so the recovery
+        # chain has non-trivial content to walk.
+        network.txs.issue(network, number_txs=2)
+
+        # First recovery -> S2.
+        network = test_recover_service(network, args)
+        network.txs.issue(network, number_txs=2)
+
+        # Second recovery -> S3.
+        network = test_recover_service(network, args)
+        network.txs.issue(network, number_txs=2)
+
+        primary, _ = network.find_primary()
+
+        snapshots_dir = network.get_committed_snapshots(primary)
+        network.save_service_identity(args)
+        network.stop_all_nodes()
+        current_ledger_dir, committed_ledger_dirs = primary.get_ledger()
+
+        # Move out the chunk containing the S2-era endorsement write
+        # (the second-oldest write to the endorsement table). The third
+        # recovery's chain walk fetches this from a historical ledger
+        # chunk; removing it forces the Partial path.
+        writes = _find_endorsement_write_chunks(committed_ledger_dirs)
+        LOG.info(f"Endorsement-table writes across committed ledger: {writes}")
+        assert len(writes) >= 3, (
+            "Expected at least 3 endorsement writes (one per service open "
+            "across S1, S2, S3) in the committed ledger, got: "
+            f"{writes}"
+        )
+        target_seqno, target_chunk = writes[1]
+        other_writes_in_target_chunk = [
+            seq
+            for seq, chunk in writes
+            if chunk == target_chunk and seq != target_seqno
+        ]
+        assert not other_writes_in_target_chunk, (
+            f"Chunk {target_chunk} contains additional endorsement writes "
+            f"at seqnos {other_writes_in_target_chunk}; the test cannot "
+            "deterministically isolate the chain link to break."
+        )
+
+        backup_dir = tempfile.mkdtemp(prefix="ccf_missing_chunk_")
+        moved_chunk_path = os.path.join(backup_dir, os.path.basename(target_chunk))
+        LOG.info(
+            f"Moving chunk {target_chunk} (containing endorsement write at "
+            f"seqno {target_seqno}) to {moved_chunk_path}"
+        )
+        shutil.move(target_chunk, moved_chunk_path)
+
+        # Third recovery (S4) with the missing chunk. The
+        # identity-history retry budget is shrunk so the test does
+        # not have to wait long for the chain walk to exhaust.
+        recovered_network = infra.network.Network(
+            args.nodes,
+            args.binary_dir,
+            args.debug_nodes,
+            existing_network=network,
+            txs=txs,
+        )
+        with infra.network.close_on_error(recovered_network):
+            recovered_network.start_in_recovery(
+                args,
+                ledger_dir=current_ledger_dir,
+                committed_ledger_dirs=committed_ledger_dirs,
+                snapshots_dir=snapshots_dir,
+                identity_history_fetch_max_attempts=5,
+                identity_history_fetch_retry_interval="200ms",
+            )
+            recovered_network.recover(args)
+
+            primary, _ = recovered_network.find_primary()
+
+            # Poll /log/public/trusted_keys. While the subsystem is in
+            # Retry the endpoint returns 5xx (the underlying
+            # get_trusted_keys() throws IdentityHistoryNotFetched).
+            # Once the bounded retries settle in Partial (a few seconds
+            # under the small test budget), the endpoint returns 200
+            # with whatever validated suffix was built.
+            LOG.info(
+                "Polling /log/public/trusted_keys until subsystem settles "
+                "out of Retry"
+            )
+            deadline = time.time() + 30
+            settled_response = None
+            while time.time() < deadline:
+                with primary.client() as cli:
+                    r = cli.get("/log/public/trusted_keys")
+                if r.status_code == http.HTTPStatus.OK:
+                    settled_response = r
+                    break
+                time.sleep(0.5)
+
+            assert settled_response is not None, (
+                "trusted_keys never returned 200 within 30s; subsystem "
+                "stayed in Retry beyond the configured retry budget."
+            )
+
+            partial_keys = settled_response.body.json()["keys"]
+            LOG.info(f"trusted_keys count while in Partial: {len(partial_keys)}")
+            # Current-service key (from the live identity) + the key
+            # endorsed by the topmost endorsement.
+            assert len(partial_keys) >= 2, (
+                f"Expected at least 2 trusted keys, got {len(partial_keys)}: "
+                f"{partial_keys}"
+            )
+
+            shutil.rmtree(backup_dir, ignore_errors=True)
+
+            LOG.success(
+                f"Subsystem settled in Partial with {len(partial_keys)} "
+                "validated trusted keys; the missing ledger chunk did "
+                "not block node startup."
+            )
+
+
 if __name__ == "__main__":
 
     def add(parser):
@@ -2158,6 +2324,15 @@ checked. Note that the key for each logging message is unique (per table).
         nodes=infra.e2e_args.min_nodes(cr.args, f=1),
         ledger_chunk_bytes="50MB",
         snapshot_tx_interval=50,
+    )
+
+    cr.add(
+        "recovery_partial_when_ledger_gap",
+        run_recovery_partial_when_ledger_gap,
+        package="samples/apps/logging/logging",
+        nodes=infra.e2e_args.min_nodes(cr.args, f=1),
+        ledger_chunk_bytes="50KB",
+        snapshot_tx_interval=30,
     )
 
     cr.run()

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -2113,77 +2113,78 @@ def run_recovery_partial_when_ledger_gap(args):
         )
 
         backup_dir = tempfile.mkdtemp(prefix="ccf_missing_chunk_")
-        moved_chunk_path = os.path.join(backup_dir, os.path.basename(target_chunk))
-        LOG.info(
-            f"Moving chunk {target_chunk} (containing endorsement write at "
-            f"seqno {target_seqno}) to {moved_chunk_path}"
-        )
-        shutil.move(target_chunk, moved_chunk_path)
-
-        # Third recovery (S4) with the missing chunk. The
-        # identity-history retry budget is shrunk so the test does
-        # not have to wait long for the chain walk to exhaust.
-        recovered_network = infra.network.Network(
-            args.nodes,
-            args.binary_dir,
-            args.debug_nodes,
-            existing_network=network,
-            txs=txs,
-        )
-        with infra.network.close_on_error(recovered_network):
-            recovered_network.start_in_recovery(
-                args,
-                ledger_dir=current_ledger_dir,
-                committed_ledger_dirs=committed_ledger_dirs,
-                snapshots_dir=snapshots_dir,
-                identity_history_fetch_max_attempts=5,
-                identity_history_fetch_retry_interval="200ms",
-            )
-            recovered_network.recover(args)
-
-            primary, _ = recovered_network.find_primary()
-
-            # Poll /log/public/trusted_keys. While the subsystem is in
-            # Retry the endpoint returns 5xx (the underlying
-            # get_trusted_keys() throws IdentityHistoryNotFetched).
-            # Once the bounded retries settle in Partial (a few seconds
-            # under the small test budget), the endpoint returns 200
-            # with whatever validated suffix was built.
+        try:
+            moved_chunk_path = os.path.join(backup_dir, os.path.basename(target_chunk))
             LOG.info(
-                "Polling /log/public/trusted_keys until subsystem settles "
-                "out of Retry"
+                f"Moving chunk {target_chunk} (containing endorsement write at "
+                f"seqno {target_seqno}) to {moved_chunk_path}"
             )
-            deadline = time.time() + 30
-            settled_response = None
-            while time.time() < deadline:
-                with primary.client() as cli:
-                    r = cli.get("/log/public/trusted_keys")
-                if r.status_code == http.HTTPStatus.OK:
-                    settled_response = r
-                    break
-                time.sleep(0.5)
+            shutil.move(target_chunk, moved_chunk_path)
 
-            assert settled_response is not None, (
-                "trusted_keys never returned 200 within 30s; subsystem "
-                "stayed in Retry beyond the configured retry budget."
+            # Third recovery (S4) with the missing chunk. The
+            # identity-history retry budget is shrunk so the test does
+            # not have to wait long for the chain walk to exhaust.
+            recovered_network = infra.network.Network(
+                args.nodes,
+                args.binary_dir,
+                args.debug_nodes,
+                existing_network=network,
+                txs=txs,
             )
+            with infra.network.close_on_error(recovered_network):
+                recovered_network.start_in_recovery(
+                    args,
+                    ledger_dir=current_ledger_dir,
+                    committed_ledger_dirs=committed_ledger_dirs,
+                    snapshots_dir=snapshots_dir,
+                    identity_history_fetch_max_attempts=5,
+                    identity_history_fetch_retry_interval="200ms",
+                )
+                recovered_network.recover(args)
 
-            partial_keys = settled_response.body.json()["keys"]
-            LOG.info(f"trusted_keys count while in Partial: {len(partial_keys)}")
-            # Current-service key (from the live identity) + the key
-            # endorsed by the topmost endorsement.
-            assert len(partial_keys) >= 2, (
-                f"Expected at least 2 trusted keys, got {len(partial_keys)}: "
-                f"{partial_keys}"
-            )
+                primary, _ = recovered_network.find_primary()
 
+                # Poll /log/public/trusted_keys. While the subsystem is in
+                # Retry the endpoint returns 5xx (the underlying
+                # get_trusted_keys() throws IdentityHistoryNotFetched).
+                # Once the bounded retries settle in Partial (a few seconds
+                # under the small test budget), the endpoint returns 200
+                # with whatever validated suffix was built.
+                LOG.info(
+                    "Polling /log/public/trusted_keys until subsystem settles "
+                    "out of Retry"
+                )
+                deadline = time.time() + 30
+                settled_response = None
+                while time.time() < deadline:
+                    with primary.client() as cli:
+                        r = cli.get("/log/public/trusted_keys")
+                    if r.status_code == http.HTTPStatus.OK:
+                        settled_response = r
+                        break
+                    time.sleep(0.5)
+
+                assert settled_response is not None, (
+                    "trusted_keys never returned 200 within 30s; subsystem "
+                    "stayed in Retry beyond the configured retry budget."
+                )
+
+                partial_keys = settled_response.body.json()["keys"]
+                LOG.info(f"trusted_keys count while in Partial: {len(partial_keys)}")
+                # Current-service key (from the live identity) + the key
+                # endorsed by the topmost endorsement.
+                assert len(partial_keys) >= 2, (
+                    f"Expected at least 2 trusted keys, got {len(partial_keys)}: "
+                    f"{partial_keys}"
+                )
+
+                LOG.success(
+                    f"Subsystem settled in Partial with {len(partial_keys)} "
+                    "validated trusted keys; the missing ledger chunk did "
+                    "not block node startup."
+                )
+        finally:
             shutil.rmtree(backup_dir, ignore_errors=True)
-
-            LOG.success(
-                f"Subsystem settled in Partial with {len(partial_keys)} "
-                "validated trusted keys; the missing ledger chunk did "
-                "not block node startup."
-            )
 
 
 if __name__ == "__main__":

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -28,6 +28,7 @@ import ccf.tx_id
 import tempfile
 import http
 import base64
+import hashlib
 import shutil
 from cryptography.x509 import load_pem_x509_certificate
 from cryptography.hazmat.backends import default_backend
@@ -2070,17 +2071,32 @@ def run_recovery_partial_when_ledger_gap(args):
     ) as network:
         network.start_and_open(args)
 
-        # A couple of transactions in the first epoch so the recovery
-        # chain has non-trivial content to walk.
+        # S1 is live. Capture an S1-era txid (after the issue) so we
+        # can later prove a receipt for it cannot be served in
+        # Partial mode.
         network.txs.issue(network, number_txs=2)
+        _, msg = network.txs.get_last_tx(priv=True)
+        s1_era_txid = ccf.tx_id.TxID(msg["view"], msg["seqno"])
 
         # First recovery -> S2.
         network = test_recover_service(network, args)
+        # S2 is live: capture its cert and an S2-era txid.
+        primary, _ = network.find_primary()
+        with primary.client() as cli:
+            s2_cert_pem = cli.get("/node/network").body.json()["service_certificate"]
         network.txs.issue(network, number_txs=2)
+        _, msg = network.txs.get_last_tx(priv=True)
+        s2_era_txid = ccf.tx_id.TxID(msg["view"], msg["seqno"])
 
         # Second recovery -> S3.
         network = test_recover_service(network, args)
+        # S3 is live: capture its cert and an S3-era txid.
+        primary, _ = network.find_primary()
+        with primary.client() as cli:
+            s3_cert_pem = cli.get("/node/network").body.json()["service_certificate"]
         network.txs.issue(network, number_txs=2)
+        _, msg = network.txs.get_last_tx(priv=True)
+        s3_era_txid = ccf.tx_id.TxID(msg["view"], msg["seqno"])
 
         primary, _ = network.find_primary()
 
@@ -2089,16 +2105,29 @@ def run_recovery_partial_when_ledger_gap(args):
         network.stop_all_nodes()
         current_ledger_dir, committed_ledger_dirs = primary.get_ledger()
 
-        # Move out the chunk containing the S2-era endorsement write
-        # (the second-oldest write to the endorsement table). The third
-        # recovery's chain walk fetches this from a historical ledger
-        # chunk; removing it forces the Partial path.
+        # The committed ledger captured before the final recovery
+        # contains 3 endorsement-table writes:
+        #   writes[0]: self-endorsement of S1 (written when S1 first
+        #              opened; no previous service to endorse).
+        #   writes[1]: e_S1 (written by S2's recovery, endorses S1).
+        #   writes[2]: e_S2 (written by S3's recovery, endorses S2).
+        # We move out the chunk containing writes[1] (e_S1's write)
+        # to break the chain walk for S4 at the S1 link: S4's
+        # recovery bootstraps from a snapshot taken later than the
+        # missing chunk and proceeds normally; the chain walk then
+        # successfully fetches e_S2 historically but fails to fetch
+        # e_S1 from the moved chunk and settles in Partial. The
+        # validated suffix is then exactly three trusted keys -- S2
+        # endorsed by e_S2, S3 endorsed by e_S3 (the fresh entry S4
+        # just wrote), and S4 itself -- and a historical receipt for
+        # any S1-era seqno must return an error from the historical
+        # adapter (seqno below the validated suffix).
         writes = _find_endorsement_write_chunks(committed_ledger_dirs)
         LOG.info(f"Endorsement-table writes across committed ledger: {writes}")
-        assert len(writes) >= 3, (
-            "Expected at least 3 endorsement writes (one per service open "
-            "across S1, S2, S3) in the committed ledger, got: "
-            f"{writes}"
+        assert len(writes) == 3, (
+            "Expected exactly 3 endorsement writes (self-endorsement "
+            "of S1 + one per recovery across S2, S3) in the committed "
+            f"ledger, got: {writes}"
         )
         target_seqno, target_chunk = writes[1]
         other_writes_in_target_chunk = [
@@ -2144,6 +2173,16 @@ def run_recovery_partial_when_ledger_gap(args):
 
                 primary, _ = recovered_network.find_primary()
 
+                # S4 is live. Capture its cert and an S4-era txid for
+                # the receipt assertions below.
+                with primary.client() as cli:
+                    s4_cert_pem = cli.get("/node/network").body.json()[
+                        "service_certificate"
+                    ]
+                recovered_network.txs.issue(recovered_network, number_txs=2)
+                _, msg = recovered_network.txs.get_last_tx(priv=True)
+                s4_era_txid = ccf.tx_id.TxID(msg["view"], msg["seqno"])
+
                 # Poll /log/public/trusted_keys. While the subsystem is in
                 # Retry the endpoint returns 5xx (the underlying
                 # get_trusted_keys() throws IdentityHistoryNotFetched).
@@ -2171,17 +2210,87 @@ def run_recovery_partial_when_ledger_gap(args):
 
                 partial_keys = settled_response.body.json()["keys"]
                 LOG.info(f"trusted_keys count while in Partial: {len(partial_keys)}")
-                # Current-service key (from the live identity) + the key
-                # endorsed by the topmost endorsement.
-                assert len(partial_keys) >= 2, (
-                    f"Expected at least 2 trusted keys, got {len(partial_keys)}: "
-                    f"{partial_keys}"
+
+                # Expected validated suffix: S2, S3, S4. S1's key is
+                # NOT reachable because e_S1's ledger chunk was moved
+                # out, so the chain walk fails on the S2 -> S1 hop
+                # and settles in Partial.
+                def kid_for_cert_pem(cert_pem):
+                    cert = load_pem_x509_certificate(
+                        (
+                            cert_pem.encode("ascii")
+                            if isinstance(cert_pem, str)
+                            else cert_pem
+                        ),
+                        default_backend(),
+                    )
+                    pk_der = cert.public_key().public_bytes(
+                        serialization.Encoding.DER,
+                        serialization.PublicFormat.SubjectPublicKeyInfo,
+                    )
+                    return hashlib.sha256(pk_der).hexdigest()
+
+                expected_kids = {
+                    kid_for_cert_pem(s2_cert_pem),
+                    kid_for_cert_pem(s3_cert_pem),
+                    kid_for_cert_pem(s4_cert_pem),
+                }
+                got_kids = {k["kid"] for k in partial_keys}
+                assert got_kids == expected_kids, (
+                    f"trusted_keys mismatch in Partial.\n"
+                    f"  expected (S2 + S3 + S4): "
+                    f"{sorted(expected_kids)}\n"
+                    f"  got: {sorted(got_kids)}"
+                )
+
+                # User-visible Partial-vs-Done discriminator. A
+                # receipt for an S2/S3/S4-era seqno must be served
+                # successfully (the chain reader returns a valid sub-
+                # chain or an empty chain for current-service
+                # seqnos), but a receipt for an S1-era seqno must
+                # fail because the historical adapter cannot
+                # determine the endorsement chain for any seqno below
+                # the validated suffix.
+                def poll_receipt(txid, timeout=10):
+                    deadline = time.time() + timeout
+                    rc = None
+                    while time.time() < deadline:
+                        with primary.client() as cli:
+                            rc = cli.get(f"/node/receipt/cose?transaction_id={txid}")
+                        if rc.status_code != http.HTTPStatus.ACCEPTED:
+                            return rc
+                        time.sleep(0.2)
+                    return rc
+
+                for label, txid in (
+                    ("S2", s2_era_txid),
+                    ("S3", s3_era_txid),
+                    ("S4", s4_era_txid),
+                ):
+                    rc = poll_receipt(txid)
+                    assert rc.status_code == http.HTTPStatus.OK, (
+                        f"Receipt fetch for {label}-era {txid} failed: "
+                        f"{rc.status_code} {rc.body!r}"
+                    )
+                    LOG.info(f"Receipt for {label}-era {txid} -> 200 OK")
+
+                rc_s1 = poll_receipt(s1_era_txid)
+                assert rc_s1.status_code != http.HTTPStatus.OK, (
+                    f"Receipt fetch for S1-era {s1_era_txid} unexpectedly "
+                    f"succeeded; subsystem appears to be in Done, not "
+                    f"Partial. Response: {rc_s1.status_code} {rc_s1.body!r}"
+                )
+                LOG.info(
+                    f"Receipt for S1-era {s1_era_txid} -> {rc_s1.status_code} "
+                    "as expected (seqno below validated suffix)"
                 )
 
                 LOG.success(
-                    f"Subsystem settled in Partial with {len(partial_keys)} "
-                    "validated trusted keys; the missing ledger chunk did "
-                    "not block node startup."
+                    "Subsystem settled in Partial with exactly three "
+                    "validated trusted keys (S2 + S3 + S4); receipts "
+                    "serve for S2/S3/S4 seqnos and fail for S1 seqnos; "
+                    "the missing ledger chunk did not block node "
+                    "startup."
                 )
         finally:
             shutil.rmtree(backup_dir, ignore_errors=True)


### PR DESCRIPTION
Simplified version of #7913.

Settle network identity subsystem in `Partial` when previous-identity endorsements cannot be fetched

Missing previous-identity endorsement ledger chunks no longer block node startup. After a bounded number of chain-walk retries the subsystem settles in a new terminal `Partial` state, serves the validated suffix, and lets callers decide what to do.

```
                          Retry                    (initial; readers throw)
                            |
                            | start_with_config()
                            v
                +-----------+-----------+
                |           |           |
                v           v           v
              Done       Partial      Failed       (all three terminal)
```

- **New public API**: `FetchStatus::Partial` appended; `NetworkIdentitySubsystem::start_with_config(config = {})` is a single-shot bootstrap trigger (calls beyond the first throw `std::logic_error`).
- **Reader contract**: `Done` and `Partial` both serve. In `Partial`, `get_cose_endorsements_chain(seqno)` returns `nullopt` for seqnos below the validated suffix (we cannot tell whether they were ever endorsed).
- **Bounded chain-walk retries**: stops after `identity_history_fetch.max_attempts` at `identity_history_fetch.retry_interval`; on exhaustion the subsystem settles in `Partial`. Pre-bootstrap waits remain unbounded.
- **New optional node config**: `identity_history_fetch.{max_attempts, retry_interval}` (defaults 100 / `100ms`).
- **Caller update** (`historical_queries_utils.cpp`): treats `Partial` like `Done`; a `nullopt` chain becomes an explicit error rather than an unverifiable empty chain.
- **Unit tests** (26 cases): helpers, bootstrap happy / waiting paths, `Failed` transitions on data corruption, reader contract, `start_with_config` single-shot guard, bounded retry exhaustion to `Partial`.
- **e2e** (`recovery_partial_when_ledger_gap`): recovery with a moved ledger chunk and a small retry budget; asserts `Partial` and that the validated trusted-key suffix is exposed.