### PR TITLE
Relax PEM comparison for priv/pub converted keys

### DIFF
--- a/js/ccf-app/test/polyfill.test.ts
+++ b/js/ccf-app/test/polyfill.test.ts
@@ -606,14 +606,20 @@ describe("polyfill", function () {
           assert.equal(jwk.kty, "EC");
           assert.notExists(jwk.kid);
           const pem = ccf.crypto.jwkToPem(jwk);
-          assert.equal(pem, pair.privateKey);
+          assert.deepEqual(
+            crypto.createPrivateKey(pem).export({ format: "jwk" }),
+            crypto.createPrivateKey(pair.privateKey).export({ format: "jwk" }),
+          );
         }
         {
           const jwk = ccf.crypto.pemToJwk(pair.privateKey, my_kid);
           assert.equal(jwk.kty, "EC");
           assert.equal(jwk.kid, my_kid);
           const pem = ccf.crypto.jwkToPem(jwk);
-          assert.equal(pem, pair.privateKey);
+          assert.deepEqual(
+            crypto.createPrivateKey(pem).export({ format: "jwk" }),
+            crypto.createPrivateKey(pair.privateKey).export({ format: "jwk" }),
+          );
         }
       }
     });


### PR DESCRIPTION
Permanent CI failures with newer node-js.

New API contains both pub and priv parts after conversion, and they used not to, test is quite strict about this.

```
The two PEMs in the CI diff are both PKCS#8-wrapped ECPrivateKey (RFC 5915):

 ECPrivateKey ::= SEQUENCE {
   version    INTEGER (1),
   privateKey OCTET STRING,           -- scalar d
   parameters [0] OPTIONAL,           -- omitted (curve is in outer AlgID)
   publicKey  [1] BIT STRING OPTIONAL -- ← THE DIFFERENCE
 }

 - Expected (MEECAQAw…, 67 B) — short: no publicKey [1]. Produced by generateKeyPairSync('ec', {pkcs8/pem}) at polyfill.ts:244.
 - Actual (MIGHAgEA…, 138 B) — long: same d, plus [1] BIT STRING = 04||X||Y. Produced by createPrivateKey({format:'jwk'}).export({pkcs8/pem}) at polyfill.ts:573.

Same key, two valid encodings. The "extra" bytes are the public point — recomputable from d.

Why they diverge: in OpenSSL 3 the EC PKCS#8 encoder emits publicKey [1] whenever the EVP_PKEY has the public point set. generateKeyPairSync doesn't set it (so: short); the JWK loader sets it from x/y (so: long). OpenSSL 1.1.1 stripped it in both paths, hiding the issue.

Why the test breaks: assert.equal(jwkToPem(pemToJwk(pk)), pk) compares PEM bytes. PKCS#8 isn't canonical for EC keys, so this assertion was over-specified from day one — it only "worked" because the old OpenSSL erased the difference. Nothing in CCF changed; the runtime did.

Both failing CTest jobs (modules_test, programmability_and_jwt) call build_npm_app() → npm test in js/ccf-app/, so both inherit the same single Mocha failure.
```