### PR TITLE
[release/6.x] Cherry pick: pypi changes (#7348, ##7897, #7880, #7893, #7932)

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -32,4 +32,4 @@ jobs:
           python3 -m venv env
           source ./env/bin/activate
           pip install twine
-          twine upload -u __token__ -p ${{ secrets.PYPI_TOKEN }} *.whl
+          twine upload -u __token__ -p ${{ secrets.PYPI_TOKEN }} --skip-existing *.whl

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Get release number from git tag (release) or latest (branch)
         run: |

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Get release number from git tag (release) or latest (branch)
         run: |

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: read
       id-token: write
 
     steps:
@@ -24,10 +25,14 @@ jobs:
 
       - name: Fetch PyPi Package from release
         run: |
+          set -euo pipefail
           mkdir -p dist
           cd dist
-          RELEASE_WHEEL_URL=$(curl -s  https://api.github.com/repos/microsoft/ccf/releases/tags/ccf-${{steps.tref.outputs.version}} | jq -r '.assets[] | select(.name|test("ccf-.*.whl")) | .browser_download_url')
-          wget ${RELEASE_WHEEL_URL}
+          RELEASE_WHEEL_URL=$(
+            curl -fsS "https://api.github.com/repos/microsoft/ccf/releases/tags/ccf-${{ steps.tref.outputs.version }}" |
+              jq -r '[.assets[] | select(.name | test("^ccf-.*\\.whl$")) | .browser_download_url] | if length == 1 then .[0] else error("expected exactly one CCF wheel asset, found \(length)") end'
+          )
+          wget "${RELEASE_WHEEL_URL}"
 
       - name: Publish PyPi Package to https://pypi.org/project/ccf/
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -10,6 +10,9 @@ jobs:
   build_and_publish:
     name: "Publish ccf package to PyPi"
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v6
@@ -21,15 +24,12 @@ jobs:
 
       - name: Fetch PyPi Package from release
         run: |
-          cd python
+          mkdir -p dist
+          cd dist
           RELEASE_WHEEL_URL=$(curl -s  https://api.github.com/repos/microsoft/ccf/releases/tags/ccf-${{steps.tref.outputs.version}} | jq -r '.assets[] | select(.name|test("ccf-.*.whl")) | .browser_download_url')
           wget ${RELEASE_WHEEL_URL}
 
       - name: Publish PyPi Package to https://pypi.org/project/ccf/
-        run: |
-          set -ex
-          cd python
-          python3 -m venv env
-          source ./env/bin/activate
-          pip install twine
-          twine upload -u __token__ -p ${{ secrets.PYPI_TOKEN }} --skip-existing *.whl
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true


### PR DESCRIPTION
This backports the following PRs's changes to pypi.

- #7348 - Tighten GHA permissions
- #7879 - Switch PyPI publish workflow to OIDC trusted publishing
- #7880 - Pin GitHub Actions by SHA and add 5-day Dependabot cooldown
- #7893 - Address PyPI workflow review comments
- #7932 - Bump actions/checkout from 6.0.2 to 6.0.3

Diff against main's pypi,yml:
```
cjen1-msft@DESKTOP-TN51J3I ~/C/.w/release-6.x (backport-pypi)> git diff .github/workflows/pypi.yml ~/CCF/.github/workflows/pypi.yml
cjen1-msft@DESKTOP-TN51J3I ~/C/.w/release-6.x (backport-pypi)>
```