### PR TITLE
Add and use `ccf::nonstd::strerror`

### DIFF
--- a/include/ccf/ds/nonstd.h
+++ b/include/ccf/ds/nonstd.h
@@ -5,6 +5,7 @@
 #include <array>
 #include <cctype>
 #include <chrono>
+#include <cstring>
 #include <ctime>
 #include <regex>
 #include <string>
@@ -217,6 +218,58 @@ namespace ccf::nonstd
   static inline CloseFdGuard make_close_fd_guard(int* fd)
   {
     return {fd, close_fd};
+  }
+
+#if !defined(__STDC_LIB_EXT1__)
+  namespace detail
+  {
+    // POSIX specifies two incompatible variants of strerror_r, distinguished
+    // only by their return type. Overload on that return type so that the
+    // correct variant is selected at compile time.
+
+    // XSI-compliant variant: int strerror_r(int, char*, size_t). Returns 0 on
+    // success and writes the message into the supplied buffer.
+    static inline std::string strerror_r_result(int rc, const char* buf)
+    {
+      if (rc != 0)
+      {
+        return "Unknown error";
+      }
+      return buf;
+    }
+
+    // GNU variant: char* strerror_r(int, char*, size_t). Returns a pointer to
+    // the message, which may point to a static string rather than the supplied
+    // buffer.
+    static inline std::string strerror_r_result(
+      const char* msg, const char* /* buf */)
+    {
+      return msg;
+    }
+  }
+#endif
+
+  /** A thread-safe replacement for std::strerror.
+   *
+   * The C strerror (and std::strerror) may return a pointer to a statically
+   * allocated buffer which can be overwritten by a concurrent call from another
+   * thread, so clang-tidy flags it as concurrency-mt-unsafe. This wrapper uses
+   * the platform's safe equivalent - the C11 Annex K strerror_s/strerrorlen_s
+   * where available, or POSIX strerror_r otherwise - and returns an owning
+   * std::string.
+   */
+  static inline std::string strerror(int errnum)
+  {
+#if defined(__STDC_LIB_EXT1__)
+    const size_t len = ::strerrorlen_s(errnum);
+    std::string result(len, '\0');
+    ::strerror_s(result.data(), result.size() + 1, errnum);
+    return result;
+#else
+    std::array<char, 256> buf{};
+    return detail::strerror_r_result(
+      ::strerror_r(errnum, buf.data(), buf.size()), buf.data());
+#endif
   }
 
   // A custom clock type for handling certificate validity periods, which are

--- a/include/ccf/ds/nonstd.h
+++ b/include/ccf/ds/nonstd.h
@@ -262,8 +262,13 @@ namespace ccf::nonstd
   {
 #if defined(__STDC_LIB_EXT1__)
     const size_t len = ::strerrorlen_s(errnum);
-    std::string result(len, '\0');
-    ::strerror_s(result.data(), result.size() + 1, errnum);
+    std::string result(len + 1, '\0');
+    const errno_t rc = ::strerror_s(result.data(), result.size(), errnum);
+    if (rc != 0)
+    {
+      return "Unknown error";
+    }
+    result.resize(std::strlen(result.c_str()));
     return result;
 #else
     std::array<char, 256> buf{};

--- a/include/ccf/pal/snp_ioctl6.h
+++ b/include/ccf/pal/snp_ioctl6.h
@@ -244,7 +244,7 @@ namespace ccf::pal::snp::ioctl6
         const auto msg = fmt::format(
           "Failed to issue ioctl SEV_SNP_GUEST_MSG_REPORT: {} fw_error: {} "
           "vmm_error: {}",
-          strerror(errno), // NOLINT(concurrency-mt-unsafe)
+          nonstd::strerror(errno),
           payload.exit_info.errors.fw,
           payload.exit_info.errors.vmm);
         throw std::logic_error(msg);
@@ -303,7 +303,7 @@ namespace ccf::pal::snp::ioctl6
         const auto msg = fmt::format(
           "Failed to issue ioctl SEV_SNP_GUEST_MSG_DERIVED_KEY: {} fw_error: "
           "{} vmm_error: {}",
-          strerror(errno), // NOLINT(concurrency-mt-unsafe)
+          nonstd::strerror(errno),
           payload.exit_info.errors.fw,
           payload.exit_info.errors.vmm);
         throw std::logic_error(msg);

--- a/src/ds/files.h
+++ b/src/ds/files.h
@@ -2,6 +2,8 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
+#include "ccf/ds/nonstd.h"
+
 #include <cerrno>
 #include <cstddef>
 #include <cstdio>
@@ -170,7 +172,7 @@ namespace files
       throw std::logic_error(fmt::format(
         "Failed to open file {} for writing: {}",
         file.string(),
-        std::strerror(errno))); // NOLINT(concurrency-mt-unsafe)
+        ccf::nonstd::strerror(errno)));
     }
 
     errno = 0;
@@ -194,7 +196,7 @@ namespace files
       throw std::logic_error(fmt::format(
         "Failed to write to file {}: {}",
         file.string(),
-        std::strerror(errno))); // NOLINT(concurrency-mt-unsafe)
+        ccf::nonstd::strerror(errno)));
     }
   }
 

--- a/src/ds/system.h
+++ b/src/ds/system.h
@@ -22,7 +22,7 @@ namespace ccf::ds::system
     FILE* pipe = popen(cmd.c_str(), "r");
     if (!pipe)
     {
-      LOG_FAIL_FMT("Error opening pipe: {}", strerror(errno));
+      LOG_FAIL_FMT("Error opening pipe: {}", ccf::nonstd::strerror(errno));
       return std::nullopt;
     }
 

--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -140,7 +140,7 @@ namespace asynchost
         throw std::logic_error(fmt::format(
           "Unable to open ledger file {}: {}",
           file_path,
-          std::strerror(errno))); // NOLINT(concurrency-mt-unsafe)
+          ccf::nonstd::strerror(errno)));
       }
 
       // Header reserved for the offset to the position table
@@ -176,7 +176,7 @@ namespace asynchost
         throw std::logic_error(fmt::format(
           "Unable to open ledger file {}: {}",
           file_path,
-          std::strerror(errno))); // NOLINT(concurrency-mt-unsafe)
+          ccf::nonstd::strerror(errno)));
       }
 
       // First, get full size of file
@@ -406,7 +406,7 @@ namespace asynchost
           {
             throw std::logic_error(fmt::format(
               "Failed to flush entry to ledger: {}",
-              std::strerror(errno))); // NOLINT(concurrency-mt-unsafe)
+              ccf::nonstd::strerror(errno)));
           }
         }
       }
@@ -571,7 +571,7 @@ namespace asynchost
         {
           throw std::logic_error(fmt::format(
             "Failed to flush ledger file: {}",
-            std::strerror(errno))); // NOLINT(concurrency-mt-unsafe)
+            ccf::nonstd::strerror(errno)));
         }
       }
 
@@ -582,7 +582,7 @@ namespace asynchost
         {
           throw std::logic_error(fmt::format(
             "Failed to truncate ledger: {}",
-            std::strerror(errno))); // NOLINT(concurrency-mt-unsafe)
+            ccf::nonstd::strerror(errno)));
         }
       }
 
@@ -652,7 +652,7 @@ namespace asynchost
         {
           throw std::logic_error(fmt::format(
             "Failed to flush ledger file: {}",
-            std::strerror(errno))); // NOLINT(concurrency-mt-unsafe)
+            ccf::nonstd::strerror(errno)));
         }
       }
 
@@ -711,7 +711,7 @@ namespace asynchost
         {
           throw std::logic_error(fmt::format(
             "Failed to flush ledger file: {}",
-            std::strerror(errno))); // NOLINT(concurrency-mt-unsafe)
+            ccf::nonstd::strerror(errno)));
         }
       }
 

--- a/src/host/ledger.h
+++ b/src/host/ledger.h
@@ -570,8 +570,7 @@ namespace asynchost
         if (fflush(file) != 0)
         {
           throw std::logic_error(fmt::format(
-            "Failed to flush ledger file: {}",
-            ccf::nonstd::strerror(errno)));
+            "Failed to flush ledger file: {}", ccf::nonstd::strerror(errno)));
         }
       }
 
@@ -581,8 +580,7 @@ namespace asynchost
         if (ftruncate(fileno(file), total_len) != 0)
         {
           throw std::logic_error(fmt::format(
-            "Failed to truncate ledger: {}",
-            ccf::nonstd::strerror(errno)));
+            "Failed to truncate ledger: {}", ccf::nonstd::strerror(errno)));
         }
       }
 
@@ -651,8 +649,7 @@ namespace asynchost
         if (fflush(file) != 0)
         {
           throw std::logic_error(fmt::format(
-            "Failed to flush ledger file: {}",
-            ccf::nonstd::strerror(errno)));
+            "Failed to flush ledger file: {}", ccf::nonstd::strerror(errno)));
         }
       }
 
@@ -710,8 +707,7 @@ namespace asynchost
         if (fsync(fileno(file)) != 0)
         {
           throw std::logic_error(fmt::format(
-            "Failed to flush ledger file: {}",
-            ccf::nonstd::strerror(errno)));
+            "Failed to flush ledger file: {}", ccf::nonstd::strerror(errno)));
         }
       }
 

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -418,8 +418,7 @@ namespace asynchost
         if ((sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) == -1)
         {
           LOG_FAIL_FMT(
-            "socket creation failed: {}",
-            ccf::nonstd::strerror(errno));
+            "socket creation failed: {}", ccf::nonstd::strerror(errno));
           return false;
         }
 

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "before_io.h"
+#include "ccf/ds/nonstd.h"
 #include "ccf/pal/locking.h"
 #include "dns.h"
 #include "ds/internal_logger.h"
@@ -418,7 +419,7 @@ namespace asynchost
         {
           LOG_FAIL_FMT(
             "socket creation failed: {}",
-            std::strerror(errno)); // NOLINT(concurrency-mt-unsafe)
+            ccf::nonstd::strerror(errno));
           return false;
         }
 
@@ -431,7 +432,7 @@ namespace asynchost
           {
             LOG_FAIL_FMT(
               "Failed to set socket option (TCP_USER_TIMEOUT): {}",
-              std::strerror(errno)); // NOLINT(concurrency-mt-unsafe)
+              ccf::nonstd::strerror(errno));
             return false;
           }
         }

--- a/src/snapshots/snapshot_manager.h
+++ b/src/snapshots/snapshot_manager.h
@@ -96,9 +96,8 @@ namespace snapshots
     if (rc == -1) \
     { \
       throw std::runtime_error( \
-        fmt::format(/* NOLINTNEXTLINE(concurrency-mt-unsafe) */ \
-                    "Error ({}) writing snapshot {} in " #x, \
-                    strerror(errno), \
+        fmt::format("Error ({}) writing snapshot {} in " #x, \
+                    ccf::nonstd::strerror(errno), \
                     name)); \
     } \
   } while (0)

--- a/src/snapshots/snapshot_manager.h
+++ b/src/snapshots/snapshot_manager.h
@@ -95,10 +95,10 @@ namespace snapshots
     auto rc = x; \
     if (rc == -1) \
     { \
-      throw std::runtime_error( \
-        fmt::format("Error ({}) writing snapshot {} in " #x, \
-                    ccf::nonstd::strerror(errno), \
-                    name)); \
+      throw std::runtime_error(fmt::format( \
+        "Error ({}) writing snapshot {} in " #x, \
+        ccf::nonstd::strerror(errno), \
+        name)); \
     } \
   } while (0)
 

--- a/src/tls/test/main.cpp
+++ b/src/tls/test/main.cpp
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 #include "ccf/crypto/ec_key_pair.h"
 #include "ccf/crypto/verifier.h"
+#include "ccf/ds/nonstd.h"
 #include "crypto/certs.h"
 #include "ds/internal_logger.h"
 #include "tcp/msg_types.h"
@@ -40,7 +41,7 @@ public:
     if (socketpair(PF_LOCAL, SOCK_STREAM, 0, pfd) == -1)
     {
       throw runtime_error(
-        "Failed to create socketpair: " + string(strerror(errno)));
+        "Failed to create socketpair: " + string(ccf::nonstd::strerror(errno)));
     }
   }
   ~TestPipe()
@@ -53,7 +54,7 @@ public:
   {
     int rc = write(pfd[id], buf, len);
     if (rc == -1)
-      LOG_FAIL_FMT("Error while reading: {}", std::strerror(errno));
+      LOG_FAIL_FMT("Error while reading: {}", ccf::nonstd::strerror(errno));
     return rc;
   }
 
@@ -61,7 +62,7 @@ public:
   {
     int rc = read(pfd[id], buf, len);
     if (rc == -1)
-      LOG_FAIL_FMT("Error while reading: {}", std::strerror(errno));
+      LOG_FAIL_FMT("Error while reading: {}", ccf::nonstd::strerror(errno));
     return rc;
   }
 };


### PR DESCRIPTION
We have `strerror(errno), // NOLINT(concurrency-mt-unsafe)` throughout the repo. In 2026, surely there's a better alternative?

> `strerror_s( char *buf, rsize_t bufsz, errno_t errnum ); ... (2)	(since C11)`

Cool!

> As with all bounds-checked functions, strerror_s and strerrorlen_s are only guaranteed to be available if __STDC_LIB_EXT1__ is defined by the implementation and if the user defines __STDC_WANT_LIB_EXT1__ to the integer constant 1 before including [<string.h>](https://en.cppreference.com/c/header/string).

Oh. Uhhh, weird, but that must be a bit of historic nonsense, right?

> Annex K is not available here; strerror_r (GNU variant) is what's present.

Oh. Ok. But this `Annex K` thing is the right thing to do going _forward_, surely?

> https://open-std.org/jtc1/sc22/wg14/www/docs/n1967.htm
> Submission Date: September 25, 2015
> The design of the Bounds checking interfaces, though well-intentioned, suffers from far too many problems to correct. Using the APIs has been seen to lead to worse quality, less secure software than relying on established approaches or modern technologies. More effective and less intrusive approaches have become commonplace and are often preferred by users and security experts alike.
> Therefore, we propose that Annex K be either removed from the next revision of the C standard, or deprecated and then removed.

Hahahahahahaha.

Still, the robot tried _so hard_ on this one, so let's give it a look.