### PR TITLE
Unwind the ark signature algorithm pinning

### DIFF
--- a/include/ccf/pal/attestation_sev_snp.h
+++ b/include/ccf/pal/attestation_sev_snp.h
@@ -87,8 +87,7 @@ pRb21iI1NlNCfOGUPIhVpWECAwEAAQ==
     {ProductName::Milan,
      {amd_milan_root_signing_public_key,
       "CN=ARK-Milan,O=Advanced Micro Devices,ST=CA,L=Santa Clara,C=US,"
-      "OU=Engineering"
-      }},
+      "OU=Engineering"}},
     {ProductName::Genoa,
      {amd_genoa_root_signing_public_key,
       "CN=ARK-Genoa,O=Advanced Micro Devices,ST=CA,L=Santa Clara,C=US,"

--- a/include/ccf/pal/attestation_sev_snp.h
+++ b/include/ccf/pal/attestation_sev_snp.h
@@ -81,25 +81,22 @@ pRb21iI1NlNCfOGUPIhVpWECAwEAAQ==
   {
     const char* public_key;
     const char* issuer;
-    const char* signature_algorithm;
   };
 
   inline const std::map<ProductName, AmdRootSigningKey> amd_root_signing_keys{
     {ProductName::Milan,
      {amd_milan_root_signing_public_key,
       "CN=ARK-Milan,O=Advanced Micro Devices,ST=CA,L=Santa Clara,C=US,"
-      "OU=Engineering",
-      "rsassaPss"}},
+      "OU=Engineering"
+      }},
     {ProductName::Genoa,
      {amd_genoa_root_signing_public_key,
       "CN=ARK-Genoa,O=Advanced Micro Devices,ST=CA,L=Santa Clara,C=US,"
-      "OU=Engineering",
-      "rsassaPss"}},
+      "OU=Engineering"}},
     {ProductName::Turin,
      {amd_turin_root_signing_public_key,
       "CN=ARK-Turin,O=Advanced Micro Devices,ST=CA,L=Santa Clara,C=US,"
-      "OU=Engineering",
-      "rsassaPss"}},
+      "OU=Engineering"}},
   };
 
 #pragma pack(push, 1)

--- a/src/pal/attestation.cpp
+++ b/src/pal/attestation.cpp
@@ -56,41 +56,6 @@ namespace ccf::pal
       return name;
     }
 
-    void verify_ark_certificate_matches_pinned_metadata(
-      const crypto::Pem& ark_cert,
-      snp::ProductName product_family,
-      const snp::AmdRootSigningKey& expected_ark)
-    {
-      ccf::crypto::OpenSSL::Unique_BIO mem_bio(ark_cert);
-      ccf::crypto::OpenSSL::Unique_X509 x509(
-        mem_bio, true, true /* check_null */);
-
-      const auto issuer =
-        x509_name_to_rfc2253_string(X509_get_issuer_name(x509));
-      if (issuer != expected_ark.issuer)
-      {
-        throw std::logic_error(fmt::format(
-          "SEV-SNP: The root of trust issuer for this attestation was not "
-          "the expected one for {}: {} != {}",
-          product_family,
-          issuer,
-          expected_ark.issuer));
-      }
-
-      const auto signature_algorithm =
-        signature_algorithm_name(X509_get_signature_nid(x509));
-      if (signature_algorithm != expected_ark.signature_algorithm)
-      {
-        throw std::logic_error(fmt::format(
-          "SEV-SNP: The root of trust signature algorithm for this "
-          "attestation was not the expected one for {}: {} != {}",
-          product_family,
-          signature_algorithm,
-          expected_ark.signature_algorithm));
-      }
-    }
-  }
-
   void verify_virtual_attestation_report(
     const QuoteInfo& quote_info,
     PlatformAttestationMeasurement& measurement,
@@ -351,8 +316,19 @@ namespace ccf::pal
         expected_ark.public_key));
     }
 
-    verify_ark_certificate_matches_pinned_metadata(
-      ark_cert, product_family, expected_ark);
+    ccf::crypto::OpenSSL::Unique_BIO mem_bio(ark_cert);
+    ccf::crypto::OpenSSL::Unique_X509 x509(
+      mem_bio, true, true /* check_null */);
+    const auto issuer = x509_name_to_rfc2253_string(X509_get_issuer_name(x509));
+    if (issuer != expected_ark.issuer)
+    {
+      throw std::logic_error(fmt::format(
+        "SEV-SNP: The root of trust issuer for this attestation was not "
+        "the expected one for {}: {} != {}",
+        product_family,
+        issuer,
+        expected_ark.issuer));
+    }
 
     if (!ark_verifier->verify_certificate({&ark_cert}))
     {

--- a/src/pal/attestation.cpp
+++ b/src/pal/attestation.cpp
@@ -55,6 +55,7 @@ namespace ccf::pal
       }
       return name;
     }
+  }
 
   void verify_virtual_attestation_report(
     const QuoteInfo& quote_info,

--- a/src/pal/attestation.cpp
+++ b/src/pal/attestation.cpp
@@ -45,16 +45,6 @@ namespace ccf::pal
 
       return {bptr->data, bptr->length};
     }
-
-    std::string signature_algorithm_name(int nid)
-    {
-      const auto* name = OBJ_nid2ln(nid);
-      if (name == nullptr)
-      {
-        return fmt::format("nid {}", nid);
-      }
-      return name;
-    }
   }
 
   void verify_virtual_attestation_report(

--- a/src/pal/test/snp_attestation_validation.cpp
+++ b/src/pal/test/snp_attestation_validation.cpp
@@ -229,23 +229,6 @@ TEST_CASE("ARK with unexpected issuer fails")
     std::logic_error);
 }
 
-TEST_CASE("ARK with unexpected signature algorithm fails")
-{
-  auto quote_info =
-    milan_quote_info_with_ark(ark_with_sha384_rsa_signature_algorithm());
-
-  ccf::pal::PlatformAttestationMeasurement measurement;
-  ccf::pal::PlatformAttestationReportData report_data;
-
-  CHECK_THROWS_WITH_AS(
-    ccf::pal::verify_snp_attestation_report(
-      quote_info, measurement, report_data),
-    doctest::Contains(
-      "SEV-SNP: The root of trust signature algorithm for this attestation "
-      "was not the expected one"),
-    std::logic_error);
-}
-
 TEST_CASE("Parsing of Tcb versions from strings")
 {
   const auto milan_tcb_version_raw =


### PR DESCRIPTION
In #7934 we pinned the algorithm for the ark public key. Except we actually pinned the signature algorithm for the ARK.
We already pin the key algorithm as we take the DER encoding of the public key: [bytes + algorithm] and sha256 that.
So this unwinds the extra constraint on the signature algorithm that was unnecessary.