### PR TITLE
Add Werror to ccfcrypto

### DIFF
--- a/cmake/crypto.cmake
+++ b/cmake/crypto.cmake
@@ -34,6 +34,11 @@ find_library(CRYPTO_LIBRARY crypto)
 find_library(TLS_LIBRARY ssl)
 
 add_library(ccfcrypto STATIC ${CCFCRYPTO_SRC})
+add_warning_checks(ccfcrypto)
+target_compile_options(
+  ccfcrypto
+  PRIVATE $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-vla-cxx-extension>
+)
 add_san(ccfcrypto)
 add_hardening(ccfcrypto)
 add_tidy(ccfcrypto)

--- a/src/crypto/openssl/ec_key_pair.cpp
+++ b/src/crypto/openssl/ec_key_pair.cpp
@@ -433,14 +433,14 @@ namespace ccf::crypto
     int extension_count = sk_X509_EXTENSION_num(exts);
     if (extension_count > 0)
     {
-      for (size_t i = 0; i < extension_count; i++)
+      for (int i = 0; i < extension_count; i++)
       {
-        X509_EXTENSION* ext = sk_X509_EXTENSION_value(exts, i);
-        ASN1_OBJECT* obj = X509_EXTENSION_get_object(ext);
+        X509_EXTENSION* csr_ext = sk_X509_EXTENSION_value(exts, i);
+        ASN1_OBJECT* obj = X509_EXTENSION_get_object(csr_ext);
         auto nid = OBJ_obj2nid(obj);
         if (nid == NID_subject_alt_name)
         {
-          OpenSSL::CHECK1(X509_add_ext(crt, ext, -1));
+          OpenSSL::CHECK1(X509_add_ext(crt, csr_ext, -1));
         }
       }
     }
@@ -507,14 +507,16 @@ namespace ccf::crypto
   JsonWebKeyECPrivate ECKeyPair_OpenSSL::private_key_jwk(
     const std::optional<std::string>& kid) const
   {
-    JsonWebKeyECPrivate jwk = {ECPublicKey_OpenSSL::public_key_jwk(kid)};
+    JsonWebKeyECPrivate jwk;
+    static_cast<JsonWebKeyECPublic&>(jwk) =
+      ECPublicKey_OpenSSL::public_key_jwk(kid);
 
     // As per https://www.openssl.org/docs/man1.0.2/man3/BN_num_bytes.html, size
     // should not be calculated with BN_num_bytes(d)!
     // Use ceiling division so curves whose bit-size is not a multiple of 8
     // (e.g. P-521 with 521 bits) get the full 66-byte buffer rather than a
     // truncated 65-byte one.
-    size_t size = (EVP_PKEY_bits(key) + CHAR_BIT - 1) / CHAR_BIT;
+    int size = (EVP_PKEY_bits(key) + CHAR_BIT - 1) / CHAR_BIT;
     std::vector<uint8_t> bytes(size);
     Unique_BIGNUM d;
     BIGNUM* bn_d = nullptr;

--- a/src/crypto/openssl/ec_public_key.cpp
+++ b/src/crypto/openssl/ec_public_key.cpp
@@ -173,7 +173,8 @@ namespace ccf::crypto
         return NID_X9_62_prime256v1;
       case CurveID::SECP521R1:
         return NID_secp521r1;
-      default:
+      case CurveID::CURVE25519:
+      case CurveID::X25519:
         throw std::logic_error(
           fmt::format("unsupported OpenSSL CurveID {}", gid));
     }

--- a/src/crypto/openssl/eddsa_key_pair.cpp
+++ b/src/crypto/openssl/eddsa_key_pair.cpp
@@ -109,8 +109,9 @@ namespace ccf::crypto
   JsonWebKeyEdDSAPrivate EdDSAKeyPair_OpenSSL::private_key_jwk_eddsa(
     const std::optional<std::string>& kid) const
   {
-    JsonWebKeyEdDSAPrivate jwk = {
-      EdDSAPublicKey_OpenSSL::public_key_jwk_eddsa(kid)};
+    JsonWebKeyEdDSAPrivate jwk;
+    static_cast<JsonWebKeyEdDSAPublic&>(jwk) =
+      EdDSAPublicKey_OpenSSL::public_key_jwk_eddsa(kid);
 
     std::vector<uint8_t> raw_priv(EVP_PKEY_size(key));
     size_t raw_priv_len = raw_priv.size();

--- a/src/crypto/openssl/eddsa_public_key.cpp
+++ b/src/crypto/openssl/eddsa_public_key.cpp
@@ -95,7 +95,10 @@ namespace ccf::crypto
         return EVP_PKEY_ED25519;
       case CurveID::X25519:
         return EVP_PKEY_X25519;
-      default:
+      case CurveID::NONE:
+      case CurveID::SECP384R1:
+      case CurveID::SECP256R1:
+      case CurveID::SECP521R1:
         throw std::logic_error(
           fmt::format("unsupported OpenSSL CurveID {}", gid));
     }

--- a/src/crypto/openssl/rsa_key_pair.cpp
+++ b/src/crypto/openssl/rsa_key_pair.cpp
@@ -188,7 +188,9 @@ namespace ccf::crypto
   JsonWebKeyRSAPrivate RSAKeyPair_OpenSSL::private_key_jwk(
     const std::optional<std::string>& kid) const
   {
-    JsonWebKeyRSAPrivate jwk = {RSAPublicKey_OpenSSL::public_key_jwk(kid)};
+    JsonWebKeyRSAPrivate jwk;
+    static_cast<JsonWebKeyRSAPublic&>(jwk) =
+      RSAPublicKey_OpenSSL::public_key_jwk(kid);
 
     Unique_BIGNUM d;
     Unique_BIGNUM p;

--- a/src/crypto/openssl/symmetric_key.cpp
+++ b/src/crypto/openssl/symmetric_key.cpp
@@ -134,7 +134,7 @@ namespace ccf::crypto
         ctx, plaintext.data(), &plain_outl, cipher.data(), cipher.size()));
 
       // As we use no padding, we expect the input and output lengths to match.
-      assert(plain_outl == cipher.size());
+      assert(static_cast<size_t>(plain_outl) == cipher.size());
     }
 
     void* tag_ptr = const_cast<void*>(static_cast<const void*>(tag));

--- a/src/crypto/openssl/verifier.cpp
+++ b/src/crypto/openssl/verifier.cpp
@@ -131,15 +131,20 @@ namespace ccf::crypto
     for (const auto& pem : chain)
     {
       Unique_BIO certbio(*pem);
-      Unique_X509 cert(certbio, true);
-      if (cert == nullptr)
+      Unique_X509 chain_cert(certbio, true);
+      if (chain_cert == nullptr)
       {
         LOG_DEBUG_FMT("Failed to load certificate from PEM: {}", pem->str());
         return false;
       }
 
-      CHECKPOSITIVE(sk_X509_push(chain_stack, cert));
-      CHECK1(X509_up_ref(cert));
+      auto* chain_cert_ptr = chain_cert.release();
+      const auto rc = sk_X509_push(chain_stack, chain_cert_ptr);
+      if (rc <= 0)
+      {
+        X509_free(chain_cert_ptr);
+        CHECKPOSITIVE(rc);
+      }
     }
 
     // Allow to use intermediate CAs as trust anchors

--- a/src/crypto/openssl/verifier.cpp
+++ b/src/crypto/openssl/verifier.cpp
@@ -138,13 +138,8 @@ namespace ccf::crypto
         return false;
       }
 
-      auto* chain_cert_ptr = chain_cert.release();
-      const auto rc = sk_X509_push(chain_stack, chain_cert_ptr);
-      if (rc <= 0)
-      {
-        X509_free(chain_cert_ptr);
-        CHECKPOSITIVE(rc);
-      }
+      CHECKPOSITIVE(sk_X509_push(chain_stack, chain_cert));
+      (void)chain_cert.release();
     }
 
     // Allow to use intermediate CAs as trust anchors

--- a/src/crypto/symmetric_key.cpp
+++ b/src/crypto/symmetric_key.cpp
@@ -13,9 +13,9 @@
 namespace ccf::crypto
 {
   /// GcmHeader implementation
-  GcmHeader::GcmHeader(size_t iv_size)
+  GcmHeader::GcmHeader(size_t iv_size_)
   {
-    iv.resize(iv_size);
+    iv.resize(iv_size_);
   }
 
   void GcmHeader::set_iv(const uint8_t* data, size_t size)


### PR DESCRIPTION
Adds `add_warning_checks(ccfcrypto)` and fixes the following warning categories:

| Warning | Files | Fix |
|---|---|---|
| `-Wvla-cxx-extension` | `cmake/crypto.cmake` | Disables the Clang VLA diagnostic for `ccfcrypto`, preserving existing stack buffers. |
| `-Wshadow` | `src/crypto/openssl/ec_key_pair.cpp`, `src/crypto/openssl/verifier.cpp`, `src/crypto/symmetric_key.cpp` | Renamed shadowing locals/parameters. |
| `-Wmissing-field-initializers` | `src/crypto/openssl/ec_key_pair.cpp`, `src/crypto/openssl/eddsa_key_pair.cpp`, `src/crypto/openssl/rsa_key_pair.cpp` | Default-construct private JWK structs and assign the public base explicitly. |
| `-Wsign-compare` | `src/crypto/openssl/ec_key_pair.cpp`, `src/crypto/openssl/symmetric_key.cpp` | Uses matching integer types for OpenSSL-sized values and casts active Debug assertions. |
| `-Wswitch-enum` | `src/crypto/openssl/ec_public_key.cpp`, `src/crypto/openssl/eddsa_public_key.cpp` | Explicitly handles unsupported curve enum values. |

While fixing `-Wshadow` in `verifier.cpp`, review spotted unsafe X509 ownership, so the code now transfers ownership to the stack instead of pushing then incrementing the refcount.
