### PR TITLE
Add Werror to picobench targets

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -268,6 +268,11 @@ function(add_picobench name)
   )
 
   add_san(${name})
+  add_warning_checks(${name})
+  target_compile_options(
+    ${name}
+    PRIVATE $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-vla-cxx-extension>
+  )
 
   # -Wall -Werror catches a number of warnings in picobench
   target_include_directories(${name} SYSTEM PRIVATE 3rdparty/test)

--- a/src/ds/test/hash_bench.cpp
+++ b/src/ds/test/hash_bench.cpp
@@ -22,7 +22,7 @@ static void hash(picobench::state& s)
   s.start_timer();
   for (size_t i = 0; i < 1000; ++i)
   {
-    volatile auto n = hasher(v);
+    [[maybe_unused]] volatile auto n = hasher(v);
     s.stop_timer();
   }
 }

--- a/src/ds/test/json_bench.cpp
+++ b/src/ds/test/json_bench.cpp
@@ -192,7 +192,7 @@ static void conv(picobench::state& s)
   clobber_memory();
   picobench::scope scope(s);
 
-  for (size_t i = 0; i < s.iterations(); ++i)
+  for (int i = 0; i < s.iterations(); ++i)
   {
     nlohmann::json j = entries[i];
     const auto b = j.get<T>();
@@ -209,7 +209,7 @@ void valmacro(picobench::state& s)
   clobber_memory();
   picobench::scope scope(s);
 
-  for (size_t i = 0; i < s.iterations(); ++i)
+  for (int i = 0; i < s.iterations(); ++i)
   {
     const auto b = entries[i].get<T>();
     do_not_optimize(b);

--- a/src/ds/test/logger_bench.cpp
+++ b/src/ds/test/logger_bench.cpp
@@ -55,7 +55,7 @@ static void log_accepted(picobench::state& s)
   {
     picobench::scope scope(s);
 
-    for (size_t i = 0; i < s.iterations(); ++i)
+    for (int i = 0; i < s.iterations(); ++i)
     {
       CCF_LOG_OUT(DEBUG, "") << "test " << i << std::endl;
     }
@@ -73,7 +73,7 @@ static void log_accepted_fmt(picobench::state& s)
   {
     picobench::scope scope(s);
 
-    for (size_t i = 0; i < s.iterations(); ++i)
+    for (int i = 0; i < s.iterations(); ++i)
     {
       LOG_DEBUG_FMT("test {}", i);
     }
@@ -91,7 +91,7 @@ static void log_rejected(picobench::state& s)
   {
     picobench::scope scope(s);
 
-    for (size_t i = 0; i < s.iterations(); ++i)
+    for (int i = 0; i < s.iterations(); ++i)
     {
       CCF_LOG_OUT(DEBUG, "") << "test " << i << std::endl;
     }
@@ -109,7 +109,7 @@ static void log_rejected_fmt(picobench::state& s)
   {
     picobench::scope scope(s);
 
-    for (size_t i = 0; i < s.iterations(); ++i)
+    for (int i = 0; i < s.iterations(); ++i)
     {
       LOG_DEBUG_FMT("test {}", i);
     }

--- a/src/ds/test/map_bench.cpp
+++ b/src/ds/test/map_bench.cpp
@@ -166,7 +166,7 @@ static void benchmark_foreach(picobench::state& s)
     }
     else
     {
-      for (auto const& e : map)
+      for ([[maybe_unused]] auto const& e : map)
       {
         count++;
       }

--- a/src/kv/test/kv_bench.cpp
+++ b/src/kv/test/kv_bench.cpp
@@ -142,7 +142,7 @@ static void commit_latency(picobench::state& s)
     auto tx = kv_store.create_tx();
     auto tx0 = tx.rw<MapType>(map0);
     auto tx1 = tx.rw<MapType>(map1);
-    for (int iTx = 0; iTx < S; iTx++)
+    for (size_t iTx = 0; iTx < S; iTx++)
     {
       const auto key = gen_key(i, std::to_string(iTx));
       const auto value = gen_value(i);
@@ -176,7 +176,7 @@ static void ser_snap(picobench::state& s)
   for (int i = 0; i < s.iterations(); i++)
   {
     auto handle = tx.rw<MapType>(fmt::format("map{}", i));
-    for (int j = 0; j < KEY_COUNT; j++)
+    for (size_t j = 0; j < KEY_COUNT; j++)
     {
       const auto key = gen_key(j);
       const auto value = gen_value(j);
@@ -216,7 +216,7 @@ static void des_snap(picobench::state& s)
   for (int i = 0; i < s.iterations(); i++)
   {
     auto handle = tx.rw<MapType>(fmt::format("map{}", i));
-    for (int j = 0; j < KEY_COUNT; j++)
+    for (size_t j = 0; j < KEY_COUNT; j++)
     {
       const auto key = gen_key(j);
       const auto value = gen_value(j);

--- a/src/node/test/history_bench.cpp
+++ b/src/node/test/history_bench.cpp
@@ -35,7 +35,7 @@ static void hash_only(picobench::state& s)
   ::srand(42);
 
   std::vector<std::vector<uint8_t>> txs;
-  for (size_t i = 0; i < s.iterations(); i++)
+  for (int i = 0; i < s.iterations(); i++)
   {
     std::vector<uint8_t> tx;
     for (size_t j = 0; j < S; j++)
@@ -76,7 +76,7 @@ static void append(picobench::state& s)
   store.set_history(history);
 
   std::vector<std::vector<uint8_t>> txs;
-  for (size_t i = 0; i < s.iterations(); i++)
+  for (int i = 0; i < s.iterations(); i++)
   {
     std::vector<uint8_t> tx;
     for (size_t j = 0; j < S; j++)
@@ -115,7 +115,7 @@ static void append_compact(picobench::state& s)
   store.set_history(history);
 
   std::vector<std::vector<uint8_t>> txs;
-  for (size_t i = 0; i < s.iterations(); i++)
+  for (int i = 0; i < s.iterations(); i++)
   {
     std::vector<uint8_t> tx;
     for (size_t j = 0; j < S; j++)

--- a/src/node/test/merkle_bench.cpp
+++ b/src/node/test/merkle_bench.cpp
@@ -29,7 +29,7 @@ static void append_retract(picobench::state& s)
   vector<ccf::crypto::Sha256Hash> hashes;
   std::random_device r;
 
-  for (size_t i = 0; i < s.iterations(); ++i)
+  for (int i = 0; i < s.iterations(); ++i)
   {
     ccf::crypto::Sha256Hash h;
     for (size_t j = 0; j < ccf::crypto::Sha256Hash::SIZE; j++)
@@ -62,7 +62,7 @@ static void append_flush(picobench::state& s)
   vector<ccf::crypto::Sha256Hash> hashes;
   std::random_device r;
 
-  for (size_t i = 0; i < s.iterations(); ++i)
+  for (int i = 0; i < s.iterations(); ++i)
   {
     ccf::crypto::Sha256Hash h;
     for (size_t j = 0; j < ccf::crypto::Sha256Hash::SIZE; j++)
@@ -92,7 +92,7 @@ static void append_get_proof_verify(picobench::state& s)
   vector<ccf::crypto::Sha256Hash> hashes;
   std::random_device r;
 
-  for (size_t i = 0; i < s.iterations(); ++i)
+  for (int i = 0; i < s.iterations(); ++i)
   {
     ccf::crypto::Sha256Hash h;
     for (size_t j = 0; j < ccf::crypto::Sha256Hash::SIZE; j++)
@@ -124,7 +124,7 @@ static void append_get_proof_verify_v(picobench::state& s)
   vector<ccf::crypto::Sha256Hash> hashes;
   std::random_device r;
 
-  for (size_t i = 0; i < s.iterations(); ++i)
+  for (int i = 0; i < s.iterations(); ++i)
   {
     ccf::crypto::Sha256Hash h;
     for (size_t j = 0; j < ccf::crypto::Sha256Hash::SIZE; j++)
@@ -156,7 +156,7 @@ static void serialise_deserialise(picobench::state& s)
   ccf::MerkleTreeHistory t;
   std::random_device r;
 
-  for (size_t i = 0; i < s.iterations(); ++i)
+  for (int i = 0; i < s.iterations(); ++i)
   {
     ccf::crypto::Sha256Hash h;
     for (size_t j = 0; j < ccf::crypto::Sha256Hash::SIZE; j++)
@@ -175,7 +175,7 @@ static void serialised_size(picobench::state& s)
   ccf::MerkleTreeHistory t;
   std::random_device r;
 
-  for (size_t i = 0; i < s.iterations(); ++i)
+  for (int i = 0; i < s.iterations(); ++i)
   {
     ccf::crypto::Sha256Hash h;
     for (size_t j = 0; j < ccf::crypto::Sha256Hash::SIZE; j++)

--- a/src/tasks/test/bench/contention_bench.cpp
+++ b/src/tasks/test/bench/contention_bench.cpp
@@ -25,10 +25,10 @@ void enqueue_many(picobench::state& s, size_t thread_count, size_t task_count)
 {
   s.start_timer();
   std::vector<std::thread> threads;
-  for (auto i = 0; i < thread_count; ++i)
+  for (size_t i = 0; i < thread_count; ++i)
   {
     threads.emplace_back([task_count]() {
-      for (auto j = 0; j < task_count; ++j)
+      for (size_t j = 0; j < task_count; ++j)
       {
         ccf::tasks::add_task(std::make_shared<NopTask>());
         std::this_thread::yield();
@@ -70,7 +70,7 @@ struct IncTask : public ccf::tasks::BaseTask
 void dequeue_many(picobench::state& s, size_t thread_count, size_t task_count)
 {
   std::atomic<size_t> tasks_done = 0;
-  for (auto j = 0; j < task_count; ++j)
+  for (size_t j = 0; j < task_count; ++j)
   {
     ccf::tasks::add_task(std::make_shared<IncTask>(tasks_done));
     std::this_thread::yield();
@@ -78,7 +78,7 @@ void dequeue_many(picobench::state& s, size_t thread_count, size_t task_count)
 
   s.start_timer();
   std::vector<std::thread> threads;
-  for (auto i = 0; i < thread_count; ++i)
+  for (size_t i = 0; i < thread_count; ++i)
   {
     threads.emplace_back([task_count, &tasks_done]() {
       while (tasks_done.load() < task_count)

--- a/src/tasks/test/bench/merge_sort.h
+++ b/src/tasks/test/bench/merge_sort.h
@@ -5,6 +5,7 @@
 #include "tasks/task_system.h"
 
 #include <span>
+#include <utility>
 
 struct MergeSortTask : public ccf::tasks::BaseTask,
                        public std::enable_shared_from_this<MergeSortTask>
@@ -28,8 +29,8 @@ struct MergeSortTask : public ccf::tasks::BaseTask,
     std::shared_ptr<MergeSortTask> p = nullptr) :
     begin(b),
     end(e),
-    parent(p),
-    stop_signal(ss)
+    stop_signal(ss),
+    parent(p)
   {}
 
   void merge()
@@ -52,7 +53,7 @@ struct MergeSortTask : public ccf::tasks::BaseTask,
   void do_task_implementation() override
   {
     const auto dist = std::distance(begin, end);
-    if (dist >= sort_threshold)
+    if (std::cmp_greater_equal(dist, sort_threshold))
     {
       sub_tasks.store(2);
 

--- a/src/tasks/test/bench/sleep_bench.cpp
+++ b/src/tasks/test/bench/sleep_bench.cpp
@@ -42,7 +42,7 @@ void sleep_with_many_workers(
 {
   std::atomic<bool> stop_signal{false};
 
-  for (auto i = 0; i < num_sleeps; ++i)
+  for (size_t i = 0; i < num_sleeps; ++i)
   {
     ccf::tasks::add_task(ccf::tasks::make_basic_task(
       []() { SleepImpl::sleep_for(std::chrono::milliseconds(1)); }));


### PR DESCRIPTION
Adds `add_warning_checks(${name})` to `add_picobench()` and fixes the warnings exposed in benchmark targets.

| Warning | Files | Fix |
|---|---|---|
| `-Wsign-compare` | `src/ds/test/json_bench.cpp`, `src/ds/test/logger_bench.cpp`, `src/kv/test/kv_bench.cpp`, `src/node/test/history_bench.cpp`, `src/node/test/merkle_bench.cpp`, `src/tasks/test/bench/contention_bench.cpp`, `src/tasks/test/bench/sleep_bench.cpp`, `src/tasks/test/bench/merge_sort.h` | Uses matching loop-counter types or `std::cmp_greater_equal`. |
| `-Wunused-variable` | `src/ds/test/hash_bench.cpp`, `src/ds/test/map_bench.cpp` | Marks intentionally unused benchmark values as `[[maybe_unused]]`. |
| `-Wreorder-ctor` | `src/tasks/test/bench/merge_sort.h` | Reorders constructor initializers to match member declaration order. |
| `-Wvla-cxx-extension` | `cmake/common.cmake` | Disables the Clang VLA diagnostic for picobench targets, preserving existing stack buffers. |
