### PR TITLE
Add Werror to other targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -948,6 +948,7 @@ if(BUILD_TESTS)
       src/node/test/merkle_mem.cpp
       ${CCF_DIR}/src/enclave/thread_local.cpp
     )
+    add_warning_checks(merkle_mem)
     target_link_libraries(
       merkle_mem
       PRIVATE ${CMAKE_THREAD_LIBS_INIT} ccfcrypto

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -59,6 +59,7 @@ function(add_fuzz_test name)
   target_link_options(${name} PRIVATE -fsanitize=fuzzer)
   target_include_directories(${name} PRIVATE src ${CCFCRYPTO_INC})
   target_link_libraries(${name} PRIVATE -pthread)
+  add_warning_checks(${name})
   add_san(${name})
   # UBSan's vptr check fires inside libstdc++'s
   # std::_Sp_counted_ptr_inplace<T,A,_Lp>::_Sp_counted_ptr_inplace ctor
@@ -88,6 +89,7 @@ function(add_test_bin name)
   )
   enable_coverage(${name})
   target_link_libraries(${name} PRIVATE ccfcrypto)
+  add_warning_checks(${name})
   add_san(${name})
 endfunction()
 

--- a/src/clients/rpc_tls_client.h
+++ b/src/clients/rpc_tls_client.h
@@ -191,8 +191,6 @@ namespace client
       }
       else if (http::status_success(resp.status))
       {
-        const auto& content_type =
-          resp.headers.find(ccf::http::headers::CONTENT_TYPE);
         return nlohmann::json::parse(resp.body);
       }
       else

--- a/src/http/test/curl_test.cpp
+++ b/src/http/test/curl_test.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Synchronous")
   Data data = {.foo = "alpha", .bar = "beta"};
   size_t response_count = 0;
   constexpr size_t sync_number_requests = 10;
-  for (int i = 0; i < sync_number_requests; ++i)
+  for (size_t i = 0; i < sync_number_requests; ++i)
   {
     data.iter = i;
     std::string url = fmt::format("http://{}/{}", server_address, i);
@@ -91,7 +91,7 @@ TEST_CASE("CurlmLibuvContext")
     thread_local std::uniform_int_distribution<> uniform_dist(1, max_delay_ms);
     auto* response_count_ptr = reinterpret_cast<size_t*>(req->data);
     Data data = {.foo = "alpha", .bar = "beta"};
-    for (int i = 0; i < number_requests; ++i)
+    for (size_t i = 0; i < number_requests; ++i)
     {
       auto delay = uniform_dist(gen);
       std::this_thread::sleep_for(std::chrono::milliseconds(delay));
@@ -156,7 +156,7 @@ TEST_CASE("CurlmLibuvContext slow")
     auto* response_count_ptr = reinterpret_cast<size_t*>(req->data);
     (void)req;
     Data data = {.foo = "alpha", .bar = "beta"};
-    for (int i = 0; i < slow_number_requests; ++i)
+    for (size_t i = 0; i < slow_number_requests; ++i)
     {
       auto delay = uniform_dist(gen);
       std::this_thread::sleep_for(std::chrono::milliseconds(delay));
@@ -223,7 +223,7 @@ TEST_CASE("CurlmLibuvContext timeouts")
     (void)req;
 
     Data data = {.foo = "alpha", .bar = "beta"};
-    for (int i = 0; i < number_requests; ++i)
+    for (size_t i = 0; i < number_requests; ++i)
     {
       auto delay = uniform_dist(gen);
       std::this_thread::sleep_for(std::chrono::milliseconds(delay));
@@ -298,7 +298,7 @@ TEST_CASE("CurlmLibuvContext multiple init")
     (void)req;
 
     Data data = {.foo = "alpha", .bar = "beta"};
-    for (int i = 0; i < number_requests; ++i)
+    for (size_t i = 0; i < number_requests; ++i)
     {
       auto delay = uniform_dist(gen);
       std::this_thread::sleep_for(std::chrono::milliseconds(delay));
@@ -350,7 +350,7 @@ TEST_CASE("CurlmLibuvContext multiple init")
     }
   };
 
-  for (int i = 0; i < number_iterations; ++i)
+  for (size_t i = 0; i < number_iterations; ++i)
   {
     ccf::curl::CurlmLibuvContextSingleton singleton(uv_default_loop());
 

--- a/src/pal/test/verify_attestation.cpp
+++ b/src/pal/test/verify_attestation.cpp
@@ -112,8 +112,6 @@ int main(int argc, char** argv)
   run_loop();
   LOG_INFO_FMT("Successfully fetched endorsements from AMD");
 
-  const auto* attestation_unverified =
-    reinterpret_cast<const ccf::pal::snp::Attestation*>(quote.quote.data());
   ccf::pal::PlatformAttestationMeasurement m = {};
   ccf::pal::PlatformAttestationReportData rd = {};
   ccf::pal::verify_quote(quote, m, rd);

--- a/tests/perf-system/submitter/CMakeLists.txt
+++ b/tests/perf-system/submitter/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(
   ${CCF_DIR}/src/enclave/thread_local.cpp
 )
 
+add_warning_checks(submit)
 target_link_libraries(submit PRIVATE http_parser ccfcrypto arrow parquet)
 
 install(TARGETS submit DESTINATION bin)

--- a/tests/perf-system/submitter/submit.cpp
+++ b/tests/perf-system/submitter/submit.cpp
@@ -21,6 +21,7 @@
 #include <parquet/arrow/writer.h>
 #include <signal.h>
 #include <time.h>
+#include <utility>
 
 
 using namespace std;
@@ -320,7 +321,9 @@ int main(int argc, char** argv)
         connection->write({request.data(), request.size()});
         if (
           connection->bytes_available() or
-          ridx - read_reqs >= args.max_inflight_requests)
+          (args.max_inflight_requests >= 0 &&
+           ridx - read_reqs >=
+             static_cast<size_t>(args.max_inflight_requests)))
         {
           responses[read_reqs] = connection->read_response();
           clock_gettime(CLOCK_REALTIME, &end[read_reqs]);


### PR DESCRIPTION
Adds warnings-as-errors coverage for several small/standalone target groups, with only the minimal warning fixes needed for those targets to build cleanly.

| Target / wrapper | CMake change | Required warning fixes |
|---|---|---|
| `add_fuzz_test()` | Adds `add_warning_checks(${name})` in `cmake/common.cmake`. | None. |
| `add_test_bin()` | Adds `add_warning_checks(${name})` in `cmake/common.cmake`. | `curl_test.cpp`: fixes `-Wsign-compare` by using `size_t` loop counters. `verify_attestation.cpp`: removes unused `attestation_unverified`. |
| `merkle_mem` | Adds `add_warning_checks(merkle_mem)` in `CMakeLists.txt`. | None. |
| `submit` | Adds `add_warning_checks(submit)` in `tests/perf-system/submitter/CMakeLists.txt`. | `rpc_tls_client.h`: removes unused `content_type`. `submit.cpp`: fixes signed/unsigned comparison while preserving negative `max_inflight_requests` as unlimited pipelining. |

| Warning | Files | Fix |
|---|---|---|
| `-Wsign-compare` | `src/http/test/curl_test.cpp`, `tests/perf-system/submitter/submit.cpp` | Uses matching unsigned loop counters or a non-negative guard before casting. |
| `-Wunused-variable` | `src/pal/test/verify_attestation.cpp`, `src/clients/rpc_tls_client.h` | Removes unused variables. |
