### PR TITLE
Fix Long Test with IPv6

### DIFF
--- a/tests/infra/service_load.py
+++ b/tests/infra/service_load.py
@@ -9,6 +9,7 @@ import pandas as pd
 from shutil import copyfileobj
 from enum import Enum, auto
 import infra.concurrency
+import infra.interfaces
 import random
 from contextlib import contextmanager
 
@@ -50,7 +51,9 @@ class LoadStrategy(Enum):
 
 
 def make_target_host(target_node):
-    return f"https://{target_node.get_public_rpc_host()}:{target_node.get_public_rpc_port()}"
+    return "https://" + infra.interfaces.make_address(
+        target_node.get_public_rpc_host(), target_node.get_public_rpc_port()
+    )
 
 
 class LoadClient:


### PR DESCRIPTION
 The Debug and Release failures were the same issue: `recovery_test` timed out in the new  `recovery_ipv6` subtest.

 `recovery_ipv6` started correctly, opened an IPv6 network on `::1`, then entered the `--with-load`  phase before recovery. It started Locust with an invalid IPv6 URL:

 ```text
 https://::1:<port>
 ```

 IPv6 literals in URLs must be bracketed:

 ```text
 https://[::1]:<port>
 ```

 Because the load target URL was malformed, Locust did not drive traffic as expected. The test waited  for committed seqnos to advance before beginning recovery, but they never advanced enough, so  `recovery_test` hit the CTest timeout.

 ## Root cause

 `tests/infra/service_load.py` built load target URLs manually:

 ```py
 f"https://{host}:{port}"
 ```

 That works for IPv4, but not IPv6.

 ## Fix

 Use the existing bracket-aware helper:

 ```py
 "https://" + infra.interfaces.make_address(host, port)
 ```

 This preserves IPv4 output and correctly formats IPv6 as `[::1]:port`.

 ## Validation

 Focused IPv6 recovery test now passes:

 ```bash
 CR_FILTER=recovery_ipv6 ./tests.sh --output-on-failure --timeout 600 -R '^recovery_test$'
 ```

 Result:

 ```text
 100% tests passed, 0 tests failed out of 1
 ```