### PR TITLE
Replace bencher with a GHA job summary

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -112,6 +112,13 @@ jobs:
         shell: bash
         if: success() || failure()
 
+      - name: "Summarise perf data files"
+        run: &perf_summary |
+          set -ex
+          python3 scripts/perf_summary.py perf >> "$GITHUB_STEP_SUMMARY"
+        shell: bash
+        if: success() || failure()
+
       - name: "Upload logs"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -201,6 +208,11 @@ jobs:
           jobid="${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"
           mkdir -p perf
           cp build/bencher.json "perf/${jobid}.json"
+        shell: bash
+        if: success() || failure()
+
+      - name: "Summarise perf data files"
+        run: *perf_summary
         shell: bash
         if: success() || failure()
 

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -149,6 +149,10 @@ jobs:
         "JobId=bench_snp-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}",
       ]
     steps:
+      - name: "Install gh"
+        shell: bash
+        run: tdnf -y install gh
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -227,4 +227,3 @@ jobs:
           path: perf
           if-no-files-found: ignore
         if: success() || failure()
-

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -69,6 +69,26 @@ jobs:
           python3 tests/infra/platform_detection.py virtual
         shell: bash
 
+      - name: "Restore previous perf results"
+        run: &restore_perf |
+          set -ex
+          slug="${GITHUB_REF_NAME//\//-}"
+          echo "BRANCH_SLUG=${slug}" >> "$GITHUB_ENV"
+          name="${ARTIFACT_PREFIX}-${slug}"
+          mkdir -p perf
+          run_id=$(gh api "repos/${{ github.repository }}/actions/artifacts?name=${name}&per_page=100" \
+            --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last | .workflow_run.id // empty')
+          if [ -n "$run_id" ]; then
+            gh run download "$run_id" --name "$name" --dir prev_artifact
+            if [ -d prev_artifact/perf ]; then
+              cp -r prev_artifact/perf/. perf/
+            fi
+          fi
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_PREFIX: logs-bench-virtual
+
       - name: Build and run virtual perf tests
         run: |
           git config --global --add safe.directory /__w/CCF/CCF
@@ -85,11 +105,21 @@ jobs:
           PYTHONPATH=../tests python convert_pico_to_bencher.py
         shell: bash
 
+      - name: "Collect perf results"
+        run: |
+          set -ex
+          jobid="${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"
+          mkdir -p perf
+          cp build/bencher.json "perf/${jobid}.json"
+        shell: bash
+        if: success() || failure()
+
       - name: "Upload logs"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: logs-bench-virtual
+          name: logs-bench-virtual-${{ env.BRANCH_SLUG }}
           path: |
+            perf
             build/workspace/*/*.config.json
             build/workspace/*/out
             build/workspace/*/err
@@ -133,6 +163,13 @@ jobs:
           python3 tests/infra/platform_detection.py snp
         shell: bash
 
+      - name: "Restore previous perf results"
+        run: *restore_perf
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_PREFIX: logs-bench-snp
+
       - name: Build and run SNP perf tests
         run: |
           git config --global --add safe.directory /__w/CCF/CCF
@@ -149,11 +186,21 @@ jobs:
           PYTHONPATH=../tests python convert_pico_to_bencher.py
         shell: bash
 
+      - name: "Collect perf results"
+        run: |
+          set -ex
+          jobid="${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"
+          mkdir -p perf
+          cp build/bencher.json "perf/${jobid}.json"
+        shell: bash
+        if: success() || failure()
+
       - name: "Upload logs"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: logs-bench-snp
+          name: logs-bench-snp-${{ env.BRANCH_SLUG }}
           path: |
+            perf
             dmesg.log
             build/workspace/*/*.config.json
             build/workspace/*/out

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -6,9 +6,14 @@ on:
   push:
     branches:
       - main
+      - perf_track
   workflow_dispatch:
 
 permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   benchmark_virtual:

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -80,14 +80,12 @@ jobs:
             --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last | .workflow_run.id // empty')
           if [ -n "$run_id" ]; then
             gh run download "$run_id" --name "$name" --dir prev_artifact
-            if [ -d prev_artifact/perf ]; then
-              cp -r prev_artifact/perf/. perf/
-            fi
+            find prev_artifact -name '*.json' -exec cp {} perf/ \;
           fi
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          ARTIFACT_PREFIX: logs-bench-virtual
+          ARTIFACT_PREFIX: perf-bench-virtual
 
       - name: Build and run virtual perf tests
         run: |
@@ -119,12 +117,19 @@ jobs:
         with:
           name: logs-bench-virtual-${{ env.BRANCH_SLUG }}
           path: |
-            perf
             build/workspace/*/*.config.json
             build/workspace/*/out
             build/workspace/*/err
             build/workspace/*/*.ledger/*
             build/workspace/*/stack_trace
+          if-no-files-found: ignore
+        if: success() || failure()
+
+      - name: "Upload perf data"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: perf-bench-virtual-${{ env.BRANCH_SLUG }}
+          path: perf
           if-no-files-found: ignore
         if: success() || failure()
 
@@ -172,7 +177,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          ARTIFACT_PREFIX: logs-bench-snp
+          ARTIFACT_PREFIX: perf-bench-snp
 
       - name: Build and run SNP perf tests
         run: |
@@ -204,13 +209,20 @@ jobs:
         with:
           name: logs-bench-snp-${{ env.BRANCH_SLUG }}
           path: |
-            perf
             dmesg.log
             build/workspace/*/*.config.json
             build/workspace/*/out
             build/workspace/*/err
             build/workspace/*/*.ledger/*
             build/workspace/*/stack_trace
+          if-no-files-found: ignore
+        if: success() || failure()
+
+      - name: "Upload perf data"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: perf-bench-snp-${{ env.BRANCH_SLUG }}
+          path: perf
           if-no-files-found: ignore
         if: success() || failure()
 

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -143,18 +143,6 @@ jobs:
           if-no-files-found: ignore
         if: success() || failure()
 
-      - uses: bencherdev/bencher@50fb1e138651a46d2fb704fab1adab38c181552e # v0.6.6
-      - name: Track base branch benchmarks with Bencher
-        run: &bencher_run |
-          bencher run \
-          --project ccf \
-          --token '${{ secrets.BENCHER_API_TOKEN }}' \
-          --branch main \
-          --testbed "${CCF_PLATFORM_SLUG}-${CCF_CPUID}-${CCF_CORES}cores-${CCF_MEM_GB}g" \
-          --adapter json \
-          --err \
-          --file build/bencher.json
-
   benchmark_snp:
     name: Benchmark SNP
     runs-on:
@@ -241,6 +229,3 @@ jobs:
           if-no-files-found: ignore
         if: success() || failure()
 
-      - uses: bencherdev/bencher@50fb1e138651a46d2fb704fab1adab38c181552e # v0.6.6
-      - name: Track base branch benchmarks with Bencher
-        run: *bencher_run

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -77,12 +77,14 @@ jobs:
           name="${ARTIFACT_PREFIX}-${slug}"
           mkdir -p perf
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          run_id=$(gh api "repos/${{ github.repository }}/actions/artifacts?name=${name}&per_page=100" \
-            --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last | .workflow_run.id // empty')
-          if [ -n "$run_id" ]; then
-            gh run download "$run_id" --name "$name" --dir prev_artifact
-            find prev_artifact -name '*.json' -exec cp {} perf/ \;
-          fi
+          run_ids=$(gh api "repos/${{ github.repository }}/actions/artifacts?name=${name}&per_page=100" \
+            --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | reverse | .[0:20] | .[].workflow_run.id')
+          for run_id in $run_ids; do
+            if gh run download "$run_id" --name "$name" --dir prev_artifact; then
+              find prev_artifact -name '*.json' -exec cp {} perf/ \;
+              break
+            fi
+          done
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - perf_track
   workflow_dispatch:
 
 permissions: read-all

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           gpg --import /etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY
           tdnf -y update
-          tdnf -y install ca-certificates git
+          tdnf -y install ca-certificates git gh
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -76,6 +76,7 @@ jobs:
           echo "BRANCH_SLUG=${slug}" >> "$GITHUB_ENV"
           name="${ARTIFACT_PREFIX}-${slug}"
           mkdir -p perf
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           run_id=$(gh api "repos/${{ github.repository }}/actions/artifacts?name=${name}&per_page=100" \
             --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last | .workflow_run.id // empty')
           if [ -n "$run_id" ]; then

--- a/scripts/compare_bencher_ab.py
+++ b/scripts/compare_bencher_ab.py
@@ -6,6 +6,8 @@ import sys
 import argparse
 from typing import Dict
 
+METADATA_KEY = "__metadata"
+
 
 def load_bencher_file(filepath: str) -> Dict:
     """Load a bencher.json file"""
@@ -24,6 +26,8 @@ def extract_metrics(data: Dict) -> Dict[str, float]:
     """Extract metrics from bencher data into a flat dictionary"""
     metrics = {}
     for test_name, test_data in data.items():
+        if test_name == METADATA_KEY:
+            continue
         for metric_type, metric_data in test_data.items():
             key = f"{test_name} - {metric_type}"
             if isinstance(metric_data, dict) and "value" in metric_data:

--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -134,10 +134,7 @@ def render_mermaid_xychart(
     """Render a Mermaid xychart-beta line chart for a single benchmark metric."""
     labels = ", ".join(f'"{label}"' for label, _, _, _ in series)
     values = ", ".join(f"{value}" for _, _, _, value in series)
-    links = ", ".join(
-        f"[{label}]({commit or run})" if commit or run else label
-        for label, run, commit, _ in series
-    )
+    links = ", ".join(run_links(label, run, commit) for label, run, commit, _ in series)
     lines = [
         f"### {benchmark}",
         "",
@@ -153,6 +150,17 @@ def render_mermaid_xychart(
         "",
     ]
     return "\n".join(lines)
+
+
+def run_links(label: str, run: Optional[str], commit: Optional[str]) -> str:
+    """Markdown links for a chart point's Actions run and commit."""
+    if run and commit:
+        return f"[{label}]({run}) ([commit]({commit}))"
+    if run:
+        return f"[{label}]({run})"
+    if commit:
+        return f"{label} ([commit]({commit}))"
+    return label
 
 
 def render_metric_charts(loaded: List[PerfRun], metric: str, unit: str) -> str:

--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -6,6 +6,7 @@ import sys
 import json
 import argparse
 import html
+import statistics
 from typing import List, Optional, Tuple
 
 # Metric groups to chart over time. A chart is produced for every benchmark that
@@ -18,6 +19,7 @@ METRIC_GROUPS = [
 ]
 CHART_MAX_POINTS = 30
 CHART_COLUMNS = 3
+EWMA_ALPHA = 0.3
 DEFAULT_REPOSITORY = "microsoft/CCF"
 METADATA_KEY = "__metadata"
 
@@ -131,6 +133,19 @@ def benchmarks_with_metric(loaded: List[PerfRun], metric: str) -> List[str]:
     return sorted(names)
 
 
+def ewma(values: List[float], alpha: float = EWMA_ALPHA) -> float:
+    """Return the exponentially weighted moving average of the values."""
+    average = values[0]
+    for value in values[1:]:
+        average = alpha * value + (1 - alpha) * average
+    return average
+
+
+def repeated_values(value: float, count: int) -> str:
+    """Render a constant series for every chart category."""
+    return ", ".join(f"{value:.2f}" for _ in range(count))
+
+
 def render_mermaid_xychart(
     series: List[Tuple[str, Optional[str], Optional[str], float]],
     benchmark: str,
@@ -142,6 +157,9 @@ def render_mermaid_xychart(
     labels = ", ".join(f'"{label}"' for label, _, _, _ in ordered_series)
     raw_values = [value for _, _, _, value in ordered_series]
     values = ", ".join(f"{value:.2f}" for value in raw_values)
+    chronological_values = [value for _, _, _, value in series]
+    baseline = ewma(chronological_values)
+    sigma = statistics.pstdev(chronological_values) if len(chronological_values) > 1 else 0
     lines = [
         f"<h4>{html.escape(benchmark)}</h4>",
         "",
@@ -161,12 +179,15 @@ def render_mermaid_xychart(
         "            showTitle: false",
         "    themeVariables:",
         "        xyChart:",
-        "            plotColorPalette: \"#107C10\"",
+        "            plotColorPalette: \"#003E7E, #62B5E5, #C7E9FB, #C7E9FB\"",
         "---",
         "xychart horizontal",
         f"    x-axis [{labels}]",
         f'    y-axis "{metric} ({unit})"',
         f"    line [{values}]",
+        f"    line [{repeated_values(baseline, len(raw_values))}]",
+        f"    line [{repeated_values(baseline - sigma, len(raw_values))}]",
+        f"    line [{repeated_values(baseline + sigma, len(raw_values))}]",
         "```",
         "",
     ]
@@ -243,7 +264,13 @@ def render_metric_group(
 
 def render_perf_summary(loaded: List[PerfRun]) -> str:
     """Render all perf metric groups as markdown."""
-    lines = ["# Performance summary", "", render_runs_table(loaded)]
+    lines = [
+        "# Performance summary",
+        "",
+        "_Each chart shows run values, an EWMA baseline, and +/-1 sigma reference lines._",
+        "",
+        render_runs_table(loaded),
+    ]
     for metric, title, unit in METRIC_GROUPS:
         lines.append(render_metric_group(loaded, metric, title, unit))
     return "\n".join(lines)

--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -68,9 +68,7 @@ def run_url(name: str) -> Optional[str]:
     if not parts or not parts[0].isdigit():
         return None
 
-    server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com").rstrip(
-        "/"
-    )
+    server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com").rstrip("/")
     repository = os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPOSITORY)
     return f"{server_url}/{repository}/actions/runs/{parts[0]}"
 
@@ -105,9 +103,7 @@ def load_perf_data(directory: str, files: List[str]) -> List[PerfRun]:
             metadata = data.get(METADATA_KEY, {})
             if not isinstance(metadata, dict):
                 metadata = {}
-            loaded.append(
-                (run_label(name), run_url(name), commit_url(metadata), data)
-            )
+            loaded.append((run_label(name), run_url(name), commit_url(metadata), data))
     return loaded
 
 
@@ -162,9 +158,7 @@ def render_mermaid_xychart(
     chronological_values = [value for _, value in series]
     baseline = ewma(chronological_values)
     sigma = (
-        statistics.pstdev(chronological_values)
-        if len(chronological_values) > 1
-        else 0
+        statistics.pstdev(chronological_values) if len(chronological_values) > 1 else 0
     )
     lines = [
         f"<h4>{html.escape(benchmark)}</h4>",
@@ -185,7 +179,7 @@ def render_mermaid_xychart(
         "            showTitle: false",
         "    themeVariables:",
         "        xyChart:",
-        "            plotColorPalette: \"#003E7E, #62B5E5, #C7E9FB, #C7E9FB\"",
+        '            plotColorPalette: "#003E7E, #62B5E5, #C7E9FB, #C7E9FB"',
         "---",
         "xychart horizontal",
         f"    x-axis [{labels}]",

--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -1,0 +1,64 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+import os
+import sys
+import argparse
+from datetime import datetime, timezone
+from typing import List
+
+
+def list_perf_files(directory: str) -> List[str]:
+    """Return the sorted list of file names available in the perf directory."""
+    if not os.path.isdir(directory):
+        return []
+    return sorted(
+        name
+        for name in os.listdir(directory)
+        if os.path.isfile(os.path.join(directory, name))
+    )
+
+
+def render_markdown_table(directory: str, files: List[str]) -> str:
+    """Render a markdown table listing the files available in the directory."""
+    lines = [f"## Perf data files in `{directory}`", ""]
+
+    if not files:
+        lines.append("_No perf data files found._")
+        lines.append("")
+        return "\n".join(lines)
+
+    lines.append("| File | Size (bytes) | Modified (UTC) |")
+    lines.append("| --- | --- | --- |")
+    for name in files:
+        path = os.path.join(directory, name)
+        size = os.path.getsize(path)
+        modified = datetime.fromtimestamp(
+            os.path.getmtime(path), tz=timezone.utc
+        ).strftime("%Y-%m-%d %H:%M:%S")
+        lines.append(f"| {name} | {size} | {modified} |")
+
+    lines.append("")
+    lines.append(f"Total: {len(files)} file(s)")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="List the files in a perf directory as a markdown table."
+    )
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        default="perf",
+        help="Directory containing the perf data files (default: perf)",
+    )
+    args = parser.parse_args()
+
+    files = list_perf_files(args.directory)
+    print(render_markdown_table(args.directory, files))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -5,13 +5,19 @@ import os
 import sys
 import json
 import argparse
+import html
 from typing import List, Optional, Tuple
 
-# Metric to chart over time, with its unit, and how many recent runs to include.
-# A chart is produced for every benchmark that reports this metric.
-CHART_METRIC = "throughput"
-CHART_METRIC_UNIT = "tx/s"
-CHART_MAX_POINTS = 10
+# Metric groups to chart over time. A chart is produced for every benchmark that
+# reports each metric.
+METRIC_GROUPS = [
+    ("throughput", "Throughput", "tx/s"),
+    ("latency", "Latency", "ms"),
+    ("memory", "Memory", "bytes"),
+    ("rate", "Rate", "ops/s"),
+]
+CHART_MAX_POINTS = 30
+CHART_COLUMNS = 3
 DEFAULT_REPOSITORY = "microsoft/CCF"
 METADATA_KEY = "__metadata"
 
@@ -134,36 +140,64 @@ def render_mermaid_xychart(
     """Render a Mermaid xychart line chart for a single benchmark metric."""
     ordered_series = list(reversed(series))
     labels = ", ".join(f'"{label}"' for label, _, _, _ in ordered_series)
-    values = ", ".join(f"{value}" for _, _, _, value in ordered_series)
-    links = ", ".join(
-        run_links(label, run, commit) for label, run, commit, _ in ordered_series
-    )
+    raw_values = [value for _, _, _, value in ordered_series]
+    values = ", ".join(f"{value:.2f}" for value in raw_values)
     lines = [
-        f"### {benchmark}",
+        f"<h4>{html.escape(benchmark)}</h4>",
         "",
         "```mermaid",
         "---",
         "config:",
         "    xyChart:",
-        "        showDataLabel: true",
-        "        titleFontSize: 14",
+        "        width: 300",
+        "        height: 320",
+        "        showTitle: false",
         "        xAxis:",
         "            labelFontSize: 10",
         "            titleFontSize: 12",
         "        yAxis:",
-        "            labelFontSize: 10",
+        "            labelFontSize: 8",
         "            titleFontSize: 12",
+        "            showTitle: false",
+        "    themeVariables:",
+        "        xyChart:",
+        "            plotColorPalette: \"#107C10\"",
         "---",
         "xychart horizontal",
-        f'    title "{benchmark} {metric}"',
-        f'    x-axis "run" [{labels}]',
+        f"    x-axis [{labels}]",
         f'    y-axis "{metric} ({unit})"',
         f"    line [{values}]",
         "```",
         "",
-        f"Runs: {links}",
-        "",
     ]
+    return "\n".join(lines)
+
+
+def render_chart_table(
+    loaded: List[PerfRun], benchmarks: List[str], metric: str, unit: str
+) -> str:
+    """Render benchmark charts in a three-column table."""
+    lines = ['<table width="100%">']
+    for index, benchmark in enumerate(benchmarks):
+        if index % CHART_COLUMNS == 0:
+            lines.append("<tr>")
+        lines.append('<td valign="top" width="33%">')
+        series = [
+            (label, run, commit, value)
+            for label, run, commit, data in loaded
+            if (value := metric_value(data, benchmark, metric)) is not None
+        ]
+        lines.append(render_mermaid_xychart(series, benchmark, metric, unit))
+        lines.append("</td>")
+        if index % CHART_COLUMNS == CHART_COLUMNS - 1:
+            lines.append("</tr>")
+    remaining = len(benchmarks) % CHART_COLUMNS
+    if remaining:
+        for _ in range(CHART_COLUMNS - remaining):
+            lines.append('<td valign="top" width="33%"></td>')
+        lines.append("</tr>")
+    lines.append("</table>")
+    lines.append("")
     return "\n".join(lines)
 
 
@@ -178,22 +212,40 @@ def run_links(label: str, run: Optional[str], commit: Optional[str]) -> str:
     return label
 
 
-def render_metric_charts(loaded: List[PerfRun], metric: str, unit: str) -> str:
+def render_runs_table(loaded: List[PerfRun]) -> str:
+    """Render a compact table of run labels, Actions runs, and commits."""
+    lines = ["### Runs", "", "| Run | Actions | Commit |", "| --- | --- | --- |"]
+    for label, run, commit, data in reversed(loaded):
+        metadata = data.get(METADATA_KEY, {})
+        commit_sha = metadata.get("commit") if isinstance(metadata, dict) else None
+        short_commit = commit_sha[:8] if isinstance(commit_sha, str) else ""
+        run_link = f"[run]({run})" if run else ""
+        commit_link = f"[{short_commit}]({commit})" if commit and short_commit else ""
+        lines.append(f"| {label} | {run_link} | {commit_link} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_metric_group(
+    loaded: List[PerfRun], metric: str, title: str, unit: str
+) -> str:
     """Render one chart per benchmark that reports the given metric."""
     benchmarks = benchmarks_with_metric(loaded, metric)
-    lines = [f"## {metric.capitalize()} per benchmark ({unit})", ""]
+    lines = [f"## {title} ({unit})", ""]
     if not benchmarks:
         lines.append(f"_No benchmarks with a `{metric}` metric found._")
         lines.append("")
         return "\n".join(lines)
 
-    for benchmark in benchmarks:
-        series = [
-            (label, run, commit, value)
-            for label, run, commit, data in loaded
-            if (value := metric_value(data, benchmark, metric)) is not None
-        ]
-        lines.append(render_mermaid_xychart(series, benchmark, metric, unit))
+    lines.append(render_chart_table(loaded, benchmarks, metric, unit))
+    return "\n".join(lines)
+
+
+def render_perf_summary(loaded: List[PerfRun]) -> str:
+    """Render all perf metric groups as markdown."""
+    lines = ["# Performance summary", "", render_runs_table(loaded)]
+    for metric, title, unit in METRIC_GROUPS:
+        lines.append(render_metric_group(loaded, metric, title, unit))
     return "\n".join(lines)
 
 
@@ -213,7 +265,7 @@ def main() -> None:
 
     recent = files[-CHART_MAX_POINTS:]
     loaded = load_perf_data(args.directory, recent)
-    print(render_metric_charts(loaded, CHART_METRIC, CHART_METRIC_UNIT))
+    print(render_perf_summary(loaded))
 
 
 if __name__ == "__main__":

--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -12,7 +12,7 @@ from typing import List, Optional, Tuple
 # A chart is produced for every benchmark that reports this metric.
 CHART_METRIC = "throughput"
 CHART_METRIC_UNIT = "tx/s"
-CHART_MAX_POINTS = 10
+CHART_MAX_POINTS = 30
 
 
 def jobid_sort_key(name: str) -> Tuple[int, object]:

--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -18,12 +18,14 @@ METRIC_GROUPS = [
     ("rate", "Rate", "ops/s"),
 ]
 CHART_MAX_POINTS = 30
-CHART_COLUMNS = 3
+CHART_COLUMNS = 4
+CHART_CELL_WIDTH = f"{100 // CHART_COLUMNS}%"
 EWMA_ALPHA = 0.3
 DEFAULT_REPOSITORY = "microsoft/CCF"
 METADATA_KEY = "__metadata"
 
 PerfRun = Tuple[str, Optional[str], Optional[str], dict]
+ChartSeries = List[Tuple[str, float]]
 
 
 def jobid_sort_key(name: str) -> Tuple[int, object]:
@@ -147,19 +149,23 @@ def repeated_values(value: float, count: int) -> str:
 
 
 def render_mermaid_xychart(
-    series: List[Tuple[str, Optional[str], Optional[str], float]],
+    series: ChartSeries,
     benchmark: str,
     metric: str,
     unit: str,
 ) -> str:
     """Render a Mermaid xychart line chart for a single benchmark metric."""
     ordered_series = list(reversed(series))
-    labels = ", ".join(f'"{label}"' for label, _, _, _ in ordered_series)
-    raw_values = [value for _, _, _, value in ordered_series]
+    labels = ", ".join(f'"{label}"' for label, _ in ordered_series)
+    raw_values = [value for _, value in ordered_series]
     values = ", ".join(f"{value:.2f}" for value in raw_values)
-    chronological_values = [value for _, _, _, value in series]
+    chronological_values = [value for _, value in series]
     baseline = ewma(chronological_values)
-    sigma = statistics.pstdev(chronological_values) if len(chronological_values) > 1 else 0
+    sigma = (
+        statistics.pstdev(chronological_values)
+        if len(chronological_values) > 1
+        else 0
+    )
     lines = [
         f"<h4>{html.escape(benchmark)}</h4>",
         "",
@@ -167,7 +173,7 @@ def render_mermaid_xychart(
         "---",
         "config:",
         "    xyChart:",
-        "        width: 300",
+        "        width: 220",
         "        height: 320",
         "        showTitle: false",
         "        xAxis:",
@@ -202,10 +208,10 @@ def render_chart_table(
     for index, benchmark in enumerate(benchmarks):
         if index % CHART_COLUMNS == 0:
             lines.append("<tr>")
-        lines.append('<td valign="top" width="33%">')
+        lines.append(f'<td valign="top" width="{CHART_CELL_WIDTH}">')
         series = [
-            (label, run, commit, value)
-            for label, run, commit, data in loaded
+            (label, value)
+            for label, _, _, data in loaded
             if (value := metric_value(data, benchmark, metric)) is not None
         ]
         lines.append(render_mermaid_xychart(series, benchmark, metric, unit))
@@ -215,22 +221,11 @@ def render_chart_table(
     remaining = len(benchmarks) % CHART_COLUMNS
     if remaining:
         for _ in range(CHART_COLUMNS - remaining):
-            lines.append('<td valign="top" width="33%"></td>')
+            lines.append(f'<td valign="top" width="{CHART_CELL_WIDTH}"></td>')
         lines.append("</tr>")
     lines.append("</table>")
     lines.append("")
     return "\n".join(lines)
-
-
-def run_links(label: str, run: Optional[str], commit: Optional[str]) -> str:
-    """Markdown links for a chart point's Actions run and commit."""
-    if run and commit:
-        return f"[{label}]({run}) ([commit]({commit}))"
-    if run:
-        return f"[{label}]({run})"
-    if commit:
-        return f"{label} ([commit]({commit}))"
-    return label
 
 
 def render_runs_table(loaded: List[PerfRun]) -> str:

--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -13,8 +13,9 @@ CHART_METRIC = "throughput"
 CHART_METRIC_UNIT = "tx/s"
 CHART_MAX_POINTS = 10
 DEFAULT_REPOSITORY = "microsoft/CCF"
+METADATA_KEY = "__metadata"
 
-PerfRun = Tuple[str, Optional[str], dict]
+PerfRun = Tuple[str, Optional[str], Optional[str], dict]
 
 
 def jobid_sort_key(name: str) -> Tuple[int, object]:
@@ -64,8 +65,25 @@ def run_url(name: str) -> Optional[str]:
     return f"{server_url}/{repository}/actions/runs/{parts[0]}"
 
 
+def commit_url(metadata: dict) -> Optional[str]:
+    """GitHub commit URL from perf metadata, when available."""
+    commit = metadata.get("commit")
+    if not isinstance(commit, str) or not commit:
+        return None
+
+    server_url = metadata.get("server_url") or os.environ.get(
+        "GITHUB_SERVER_URL", "https://github.com"
+    )
+    repository = metadata.get("repository") or os.environ.get(
+        "GITHUB_REPOSITORY", DEFAULT_REPOSITORY
+    )
+    if not isinstance(server_url, str) or not isinstance(repository, str):
+        return None
+    return f"{server_url.rstrip('/')}/{repository}/commit/{commit}"
+
+
 def load_perf_data(directory: str, files: List[str]) -> List[PerfRun]:
-    """Load (label, run_url, data) for each readable JSON perf file."""
+    """Load (label, run_url, commit_url, data) for each readable perf file."""
     loaded: List[PerfRun] = []
     for name in files:
         try:
@@ -74,7 +92,12 @@ def load_perf_data(directory: str, files: List[str]) -> List[PerfRun]:
         except (OSError, json.JSONDecodeError):
             continue
         if isinstance(data, dict):
-            loaded.append((run_label(name), run_url(name), data))
+            metadata = data.get(METADATA_KEY, {})
+            if not isinstance(metadata, dict):
+                metadata = {}
+            loaded.append(
+                (run_label(name), run_url(name), commit_url(metadata), data)
+            )
     return loaded
 
 
@@ -93,24 +116,27 @@ def metric_value(data: dict, benchmark: str, metric: str) -> Optional[float]:
 def benchmarks_with_metric(loaded: List[PerfRun], metric: str) -> List[str]:
     """Sorted names of benchmarks that report the given metric in any run."""
     names = set()
-    for _, _, data in loaded:
+    for _, _, _, data in loaded:
         for benchmark in data:
+            if benchmark == METADATA_KEY:
+                continue
             if metric_value(data, benchmark, metric) is not None:
                 names.add(benchmark)
     return sorted(names)
 
 
 def render_mermaid_xychart(
-    series: List[Tuple[str, Optional[str], float]],
+    series: List[Tuple[str, Optional[str], Optional[str], float]],
     benchmark: str,
     metric: str,
     unit: str,
 ) -> str:
     """Render a Mermaid xychart-beta line chart for a single benchmark metric."""
-    labels = ", ".join(f'"{label}"' for label, _, _ in series)
-    values = ", ".join(f"{value}" for _, _, value in series)
+    labels = ", ".join(f'"{label}"' for label, _, _, _ in series)
+    values = ", ".join(f"{value}" for _, _, _, value in series)
     links = ", ".join(
-        f"[{label}]({url})" if url else label for label, url, _ in series
+        f"[{label}]({commit or run})" if commit or run else label
+        for label, run, commit, _ in series
     )
     lines = [
         f"### {benchmark}",
@@ -140,8 +166,8 @@ def render_metric_charts(loaded: List[PerfRun], metric: str, unit: str) -> str:
 
     for benchmark in benchmarks:
         series = [
-            (label, url, value)
-            for label, url, data in loaded
+            (label, run, commit, value)
+            for label, run, commit, data in loaded
             if (value := metric_value(data, benchmark, metric)) is not None
         ]
         lines.append(render_mermaid_xychart(series, benchmark, metric, unit))

--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -12,7 +12,7 @@ from typing import List, Optional, Tuple
 # A chart is produced for every benchmark that reports this metric.
 CHART_METRIC = "throughput"
 CHART_METRIC_UNIT = "tx/s"
-CHART_MAX_POINTS = 30
+CHART_MAX_POINTS = 10
 
 
 def jobid_sort_key(name: str) -> Tuple[int, object]:

--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -6,12 +6,12 @@ import sys
 import json
 import argparse
 from datetime import datetime, timezone
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
-# Benchmark metric to chart over time. Start with a single series for now; this
-# can be extended to cover more benchmarks or metrics later.
-CHART_BENCHMARK = "Basic"
+# Metric to chart over time, with its unit, and how many recent runs to include.
+# A chart is produced for every benchmark that reports this metric.
 CHART_METRIC = "throughput"
+CHART_METRIC_UNIT = "tx/s"
 CHART_MAX_POINTS = 10
 
 
@@ -73,49 +73,79 @@ def run_label(name: str) -> str:
     return parts[1] if len(parts) >= 2 else stem
 
 
-def extract_metric_series(
-    directory: str, files: List[str], benchmark: str, metric: str
-) -> List[Tuple[str, float]]:
-    """Extract (label, value) points for a benchmark metric from the given files."""
-    series: List[Tuple[str, float]] = []
+def load_perf_data(directory: str, files: List[str]) -> List[Tuple[str, dict]]:
+    """Load (label, data) for each readable JSON perf file, preserving order."""
+    loaded: List[Tuple[str, dict]] = []
     for name in files:
         try:
             with open(os.path.join(directory, name), "r") as f:
                 data = json.load(f)
         except (OSError, json.JSONDecodeError):
             continue
-        if not isinstance(data, dict):
-            continue
-        value = data.get(benchmark, {}).get(metric, {}).get("value")
-        if isinstance(value, (int, float)):
-            series.append((run_label(name), value))
-    return series
+        if isinstance(data, dict):
+            loaded.append((run_label(name), data))
+    return loaded
+
+
+def metric_value(data: dict, benchmark: str, metric: str) -> Optional[float]:
+    """Return the numeric value of a benchmark metric, or None if absent."""
+    metrics = data.get(benchmark)
+    if not isinstance(metrics, dict):
+        return None
+    entry = metrics.get(metric)
+    if not isinstance(entry, dict):
+        return None
+    value = entry.get("value")
+    return value if isinstance(value, (int, float)) else None
+
+
+def benchmarks_with_metric(loaded: List[Tuple[str, dict]], metric: str) -> List[str]:
+    """Sorted names of benchmarks that report the given metric in any run."""
+    names = set()
+    for _, data in loaded:
+        for benchmark in data:
+            if metric_value(data, benchmark, metric) is not None:
+                names.add(benchmark)
+    return sorted(names)
 
 
 def render_mermaid_xychart(
-    series: List[Tuple[str, float]], benchmark: str, metric: str
+    series: List[Tuple[str, float]], benchmark: str, metric: str, unit: str
 ) -> str:
-    """Render a Mermaid xychart-beta line chart of a metric over time."""
-    if not series:
-        return (
-            f"## `{benchmark}` {metric}\n\n"
-            f"_No `{metric}` data found for benchmark `{benchmark}`._\n"
-        )
-
+    """Render a Mermaid xychart-beta line chart for a single benchmark metric."""
     labels = ", ".join(f'"{label}"' for label, _ in series)
     values = ", ".join(f"{value}" for _, value in series)
     lines = [
-        f"## `{benchmark}` {metric} over the last {len(series)} run(s)",
+        f"### {benchmark}",
         "",
         "```mermaid",
         "xychart-beta",
         f'    title "{benchmark} {metric}"',
         f'    x-axis "run" [{labels}]',
-        f'    y-axis "{metric}"',
+        f'    y-axis "{metric} ({unit})"',
         f"    line [{values}]",
         "```",
         "",
     ]
+    return "\n".join(lines)
+
+
+def render_metric_charts(loaded: List[Tuple[str, dict]], metric: str, unit: str) -> str:
+    """Render one chart per benchmark that reports the given metric."""
+    benchmarks = benchmarks_with_metric(loaded, metric)
+    lines = [f"## {metric.capitalize()} per benchmark ({unit})", ""]
+    if not benchmarks:
+        lines.append(f"_No benchmarks with a `{metric}` metric found._")
+        lines.append("")
+        return "\n".join(lines)
+
+    for benchmark in benchmarks:
+        series = [
+            (label, value)
+            for label, data in loaded
+            if (value := metric_value(data, benchmark, metric)) is not None
+        ]
+        lines.append(render_mermaid_xychart(series, benchmark, metric, unit))
     return "\n".join(lines)
 
 
@@ -135,10 +165,8 @@ def main() -> None:
     print(render_markdown_table(args.directory, files))
 
     recent = files[-CHART_MAX_POINTS:]
-    series = extract_metric_series(
-        args.directory, recent, CHART_BENCHMARK, CHART_METRIC
-    )
-    print(render_mermaid_xychart(series, CHART_BENCHMARK, CHART_METRIC))
+    loaded = load_perf_data(args.directory, recent)
+    print(render_metric_charts(loaded, CHART_METRIC, CHART_METRIC_UNIT))
 
 
 if __name__ == "__main__":

--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -203,8 +203,7 @@ def render_mermaid_xychart(
 def render_chart_table(
     loaded: List[PerfRun], benchmarks: List[str], metric: str, unit: str
 ) -> str:
-    """Render benchmark charts in a three-column table."""
-    lines = ['<table width="100%">']
+    """Render benchmark charts in a four-column table."""
     for index, benchmark in enumerate(benchmarks):
         if index % CHART_COLUMNS == 0:
             lines.append("<tr>")

--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -131,15 +131,30 @@ def render_mermaid_xychart(
     metric: str,
     unit: str,
 ) -> str:
-    """Render a Mermaid xychart-beta line chart for a single benchmark metric."""
-    labels = ", ".join(f'"{label}"' for label, _, _, _ in series)
-    values = ", ".join(f"{value}" for _, _, _, value in series)
-    links = ", ".join(run_links(label, run, commit) for label, run, commit, _ in series)
+    """Render a Mermaid xychart line chart for a single benchmark metric."""
+    ordered_series = list(reversed(series))
+    labels = ", ".join(f'"{label}"' for label, _, _, _ in ordered_series)
+    values = ", ".join(f"{value}" for _, _, _, value in ordered_series)
+    links = ", ".join(
+        run_links(label, run, commit) for label, run, commit, _ in ordered_series
+    )
     lines = [
         f"### {benchmark}",
         "",
         "```mermaid",
-        "xychart-beta",
+        "---",
+        "config:",
+        "    xyChart:",
+        "        showDataLabel: true",
+        "        titleFontSize: 14",
+        "        xAxis:",
+        "            labelFontSize: 10",
+        "            titleFontSize: 12",
+        "        yAxis:",
+        "            labelFontSize: 10",
+        "            titleFontSize: 12",
+        "---",
+        "xychart horizontal",
         f'    title "{benchmark} {metric}"',
         f'    x-axis "run" [{labels}]',
         f'    y-axis "{metric} ({unit})"',

--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -5,7 +5,6 @@ import os
 import sys
 import json
 import argparse
-from datetime import datetime, timezone
 from typing import List, Optional, Tuple
 
 # Metric to chart over time, with its unit, and how many recent runs to include.
@@ -13,6 +12,9 @@ from typing import List, Optional, Tuple
 CHART_METRIC = "throughput"
 CHART_METRIC_UNIT = "tx/s"
 CHART_MAX_POINTS = 10
+DEFAULT_REPOSITORY = "microsoft/CCF"
+
+PerfRun = Tuple[str, Optional[str], dict]
 
 
 def jobid_sort_key(name: str) -> Tuple[int, object]:
@@ -41,31 +43,6 @@ def list_perf_files(directory: str) -> List[str]:
     return sorted(files, key=jobid_sort_key)
 
 
-def render_markdown_table(directory: str, files: List[str]) -> str:
-    """Render a markdown table listing the files available in the directory."""
-    lines = [f"## Perf data files in `{directory}`", ""]
-
-    if not files:
-        lines.append("_No perf data files found._")
-        lines.append("")
-        return "\n".join(lines)
-
-    lines.append("| File | Size (bytes) | Modified (UTC) |")
-    lines.append("| --- | --- | --- |")
-    for name in files:
-        path = os.path.join(directory, name)
-        size = os.path.getsize(path)
-        modified = datetime.fromtimestamp(
-            os.path.getmtime(path), tz=timezone.utc
-        ).strftime("%Y-%m-%d %H:%M:%S")
-        lines.append(f"| {name} | {size} | {modified} |")
-
-    lines.append("")
-    lines.append(f"Total: {len(files)} file(s)")
-    lines.append("")
-    return "\n".join(lines)
-
-
 def run_label(name: str) -> str:
     """Short x-axis label for a perf file: the run number when available."""
     stem = name[:-5] if name.endswith(".json") else name
@@ -73,9 +50,23 @@ def run_label(name: str) -> str:
     return parts[1] if len(parts) >= 2 else stem
 
 
-def load_perf_data(directory: str, files: List[str]) -> List[Tuple[str, dict]]:
-    """Load (label, data) for each readable JSON perf file, preserving order."""
-    loaded: List[Tuple[str, dict]] = []
+def run_url(name: str) -> Optional[str]:
+    """GitHub Actions URL for a perf file, when the run id can be parsed."""
+    stem = name[:-5] if name.endswith(".json") else name
+    parts = stem.split("-")
+    if not parts or not parts[0].isdigit():
+        return None
+
+    server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com").rstrip(
+        "/"
+    )
+    repository = os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPOSITORY)
+    return f"{server_url}/{repository}/actions/runs/{parts[0]}"
+
+
+def load_perf_data(directory: str, files: List[str]) -> List[PerfRun]:
+    """Load (label, run_url, data) for each readable JSON perf file."""
+    loaded: List[PerfRun] = []
     for name in files:
         try:
             with open(os.path.join(directory, name), "r") as f:
@@ -83,7 +74,7 @@ def load_perf_data(directory: str, files: List[str]) -> List[Tuple[str, dict]]:
         except (OSError, json.JSONDecodeError):
             continue
         if isinstance(data, dict):
-            loaded.append((run_label(name), data))
+            loaded.append((run_label(name), run_url(name), data))
     return loaded
 
 
@@ -99,10 +90,10 @@ def metric_value(data: dict, benchmark: str, metric: str) -> Optional[float]:
     return value if isinstance(value, (int, float)) else None
 
 
-def benchmarks_with_metric(loaded: List[Tuple[str, dict]], metric: str) -> List[str]:
+def benchmarks_with_metric(loaded: List[PerfRun], metric: str) -> List[str]:
     """Sorted names of benchmarks that report the given metric in any run."""
     names = set()
-    for _, data in loaded:
+    for _, _, data in loaded:
         for benchmark in data:
             if metric_value(data, benchmark, metric) is not None:
                 names.add(benchmark)
@@ -110,11 +101,17 @@ def benchmarks_with_metric(loaded: List[Tuple[str, dict]], metric: str) -> List[
 
 
 def render_mermaid_xychart(
-    series: List[Tuple[str, float]], benchmark: str, metric: str, unit: str
+    series: List[Tuple[str, Optional[str], float]],
+    benchmark: str,
+    metric: str,
+    unit: str,
 ) -> str:
     """Render a Mermaid xychart-beta line chart for a single benchmark metric."""
-    labels = ", ".join(f'"{label}"' for label, _ in series)
-    values = ", ".join(f"{value}" for _, value in series)
+    labels = ", ".join(f'"{label}"' for label, _, _ in series)
+    values = ", ".join(f"{value}" for _, _, value in series)
+    links = ", ".join(
+        f"[{label}]({url})" if url else label for label, url, _ in series
+    )
     lines = [
         f"### {benchmark}",
         "",
@@ -126,11 +123,13 @@ def render_mermaid_xychart(
         f"    line [{values}]",
         "```",
         "",
+        f"Runs: {links}",
+        "",
     ]
     return "\n".join(lines)
 
 
-def render_metric_charts(loaded: List[Tuple[str, dict]], metric: str, unit: str) -> str:
+def render_metric_charts(loaded: List[PerfRun], metric: str, unit: str) -> str:
     """Render one chart per benchmark that reports the given metric."""
     benchmarks = benchmarks_with_metric(loaded, metric)
     lines = [f"## {metric.capitalize()} per benchmark ({unit})", ""]
@@ -141,8 +140,8 @@ def render_metric_charts(loaded: List[Tuple[str, dict]], metric: str, unit: str)
 
     for benchmark in benchmarks:
         series = [
-            (label, value)
-            for label, data in loaded
+            (label, url, value)
+            for label, url, data in loaded
             if (value := metric_value(data, benchmark, metric)) is not None
         ]
         lines.append(render_mermaid_xychart(series, benchmark, metric, unit))
@@ -162,7 +161,6 @@ def main() -> None:
     args = parser.parse_args()
 
     files = list_perf_files(args.directory)
-    print(render_markdown_table(args.directory, files))
 
     recent = files[-CHART_MAX_POINTS:]
     loaded = load_perf_data(args.directory, recent)

--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -3,20 +3,42 @@
 
 import os
 import sys
+import json
 import argparse
 from datetime import datetime, timezone
-from typing import List
+from typing import List, Tuple
+
+# Benchmark metric to chart over time. Start with a single series for now; this
+# can be extended to cover more benchmarks or metrics later.
+CHART_BENCHMARK = "Basic"
+CHART_METRIC = "throughput"
+CHART_MAX_POINTS = 10
+
+
+def jobid_sort_key(name: str) -> Tuple[int, object]:
+    """Order perf files chronologically by their numeric job id.
+
+    File names have the form ``<run_id>-<run_number>-<run_attempt>.json`` where
+    each component increases over time, so ordering by the integer components
+    gives chronological order. Falls back to the name for unexpected formats.
+    """
+    stem = name[:-5] if name.endswith(".json") else name
+    try:
+        return (0, tuple(int(part) for part in stem.split("-")))
+    except ValueError:
+        return (1, name)
 
 
 def list_perf_files(directory: str) -> List[str]:
-    """Return the sorted list of file names available in the perf directory."""
+    """Return perf files in the directory, ordered chronologically (oldest first)."""
     if not os.path.isdir(directory):
         return []
-    return sorted(
+    files = [
         name
         for name in os.listdir(directory)
         if os.path.isfile(os.path.join(directory, name))
-    )
+    ]
+    return sorted(files, key=jobid_sort_key)
 
 
 def render_markdown_table(directory: str, files: List[str]) -> str:
@@ -44,9 +66,62 @@ def render_markdown_table(directory: str, files: List[str]) -> str:
     return "\n".join(lines)
 
 
+def run_label(name: str) -> str:
+    """Short x-axis label for a perf file: the run number when available."""
+    stem = name[:-5] if name.endswith(".json") else name
+    parts = stem.split("-")
+    return parts[1] if len(parts) >= 2 else stem
+
+
+def extract_metric_series(
+    directory: str, files: List[str], benchmark: str, metric: str
+) -> List[Tuple[str, float]]:
+    """Extract (label, value) points for a benchmark metric from the given files."""
+    series: List[Tuple[str, float]] = []
+    for name in files:
+        try:
+            with open(os.path.join(directory, name), "r") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        value = data.get(benchmark, {}).get(metric, {}).get("value")
+        if isinstance(value, (int, float)):
+            series.append((run_label(name), value))
+    return series
+
+
+def render_mermaid_xychart(
+    series: List[Tuple[str, float]], benchmark: str, metric: str
+) -> str:
+    """Render a Mermaid xychart-beta line chart of a metric over time."""
+    if not series:
+        return (
+            f"## `{benchmark}` {metric}\n\n"
+            f"_No `{metric}` data found for benchmark `{benchmark}`._\n"
+        )
+
+    labels = ", ".join(f'"{label}"' for label, _ in series)
+    values = ", ".join(f"{value}" for _, value in series)
+    lines = [
+        f"## `{benchmark}` {metric} over the last {len(series)} run(s)",
+        "",
+        "```mermaid",
+        "xychart-beta",
+        f'    title "{benchmark} {metric}"',
+        f'    x-axis "run" [{labels}]',
+        f'    y-axis "{metric}"',
+        f"    line [{values}]",
+        "```",
+        "",
+    ]
+    return "\n".join(lines)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="List the files in a perf directory as a markdown table."
+        description="Summarise perf data files as markdown for a job summary."
     )
     parser.add_argument(
         "directory",
@@ -58,6 +133,12 @@ def main() -> None:
 
     files = list_perf_files(args.directory)
     print(render_markdown_table(args.directory, files))
+
+    recent = files[-CHART_MAX_POINTS:]
+    series = extract_metric_series(
+        args.directory, recent, CHART_BENCHMARK, CHART_METRIC
+    )
+    print(render_mermaid_xychart(series, CHART_BENCHMARK, CHART_METRIC))
 
 
 if __name__ == "__main__":

--- a/tests/infra/bencher.py
+++ b/tests/infra/bencher.py
@@ -4,11 +4,13 @@
 import os
 import json
 import dataclasses
+import subprocess
 from typing import Optional, Union
 
 from loguru import logger as LOG
 
 BENCHER_FILE = "bencher.json"
+METADATA_KEY = "__metadata"
 
 # See https://bencher.dev/docs/reference/bencher-metric-format/
 
@@ -72,11 +74,49 @@ class Rate:
         self.rate = Value(value, high_value, low_value)
 
 
+def get_commit() -> Optional[str]:
+    commit = os.environ.get("GITHUB_SHA")
+    if commit:
+        return commit
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+    return result.stdout.strip() or None
+
+
+def get_metadata() -> dict:
+    metadata = {
+        "commit": get_commit(),
+        "repository": os.environ.get("GITHUB_REPOSITORY"),
+        "server_url": os.environ.get("GITHUB_SERVER_URL"),
+        "run_id": os.environ.get("GITHUB_RUN_ID"),
+        "run_number": os.environ.get("GITHUB_RUN_NUMBER"),
+        "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+    }
+    return {key: value for key, value in metadata.items() if value}
+
+
 class Bencher:
     def __init__(self):
         if not os.path.isfile(BENCHER_FILE):
             with open(BENCHER_FILE, "w+") as bf:
                 json.dump({}, bf)
+
+        metadata = get_metadata()
+        if metadata:
+            with open(BENCHER_FILE, "r") as bf:
+                data = json.load(bf)
+            data[METADATA_KEY] = metadata
+            with open(BENCHER_FILE, "w") as bf:
+                json.dump(data, bf, indent=4)
 
     def set_memory(self, key: str, proc_stats: dict):
         LOG.info(


### PR DESCRIPTION
This PR replaces the Bencher-based benchmark tracking in `.github/workflows/bencher.yml` with GitHub Actions artifact history and job-summary charts for both virtual and SNP benchmark jobs.

It:
- removes the Bencher action and `bencher run` upload path from the benchmark workflow
- restores recent perf JSON artifacts for the current branch before each benchmark run
- collects the current `build/bencher.json` into a per-run perf JSON file and uploads it separately from logs
- splits benchmark logs and perf data into branch-scoped artifacts for virtual and SNP jobs
- installs `gh` where needed so the workflow can query and download previous artifacts
- serializes benchmark workflow runs per ref with workflow concurrency
- removes the temporary `perf_track` push trigger so the workflow only runs on `main`, schedule, or manual dispatch

The PR also adds `scripts/perf_summary.py`, which renders GitHub Step Summary output from the restored perf JSON files. The summary includes a run table with Actions and commit links, plus Mermaid xycharts for throughput, latency, memory, and rate metrics. Each chart shows recent run values, an EWMA baseline, and +/-1 sigma reference lines.

Preview: https://github.com/microsoft/CCF/actions/runs/28103533380 shows what the generated job summary looks like.

Finally, `tests/infra/bencher.py` now writes GitHub run and commit metadata into generated Bencher JSON files so the summary script can link perf results back to their source run and commit.

The PR otherwise preserves the bencher format so far, we may start to diverge from it in later PRs.