### PR TITLE
Leader completeness property fix

### DIFF
--- a/.github/workflows/ci-verification.yml
+++ b/.github/workflows/ci-verification.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "tla/**"
       - "src/consensus/**"
+      - "tests/raft_scenarios/**"
       - ".github/workflows/ci-verification.yml"
   workflow_dispatch:
 

--- a/tests/raft_scenarios/indirect_commit_stale_leader
+++ b/tests/raft_scenarios/indirect_commit_stale_leader
@@ -1,0 +1,83 @@
+pre_vote_enabled,false
+# Reproduce a stale-leader shape where an entry from an old term is only
+# committed indirectly by a later leader's signature.
+#
+# Node 0 appends e2/s2 locally in term 2. Node 1 then wins term 3 with node 2,
+# and appends a conflicting e3/s3 at the same indexes, but does not replicate it.
+# Node 0 wins term 4 with node 2, keeps its committable e2/s2 suffix, appends
+# e4/s4, and commits through the term-4 signature.
+
+start_node,0
+assert_detail,0,leadership_state,Leader
+emit_signature,2
+
+assert_detail,0,leadership_state,Leader
+assert_commit_idx,0,2
+
+trust_nodes,2,1,2
+emit_signature,2
+
+dispatch_all
+periodic_all,10
+dispatch_all
+periodic_all,10
+dispatch_all
+assert_commit_idx,0,4
+assert_state_sync
+
+# Node 0 locally appends and signs a term-2 client entry at indexes 5 and 6,
+# but does not replicate it.
+replicate,2,e2
+emit_signature,2
+assert_last_txid,0,2.6
+
+# Node 1 times out and wins term 3 with node 2. Node 0 observes the newer-term
+# vote request and steps down, but Node 1 only needs node 2's vote to win.
+periodic_one,1,110
+dispatch_single,1,0
+dispatch_single,1,2
+dispatch_single,0,1
+dispatch_single,2,1
+assert_detail,0,leadership_state,Follower
+assert_detail,1,leadership_state,Leader
+
+# Node 1 appends and signs a conflicting term-3 entry at indexes 5 and 6, but
+# keeps it local. Node 2 still has only the shared prefix committed to index 4.
+replicate,3,e3
+emit_signature,3
+assert_last_txid,1,3.6
+assert_commit_idx,1,4
+assert_commit_idx,2,4
+
+# Isolate stale leader Node 1. Node 0 can now win term 4 with Node 2 because
+# Node 0's committable suffix is at least as up-to-date as Node 2's prefix.
+disconnect_node,1
+periodic_one,0,110
+dispatch_single,0,2
+dispatch_single,2,0
+assert_detail,0,leadership_state,Leader
+assert_last_txid,0,2.6
+
+# Node 0 appends and signs in term 4, then brings Node 2 up to index 8. Committing
+# s4 at index 8 indirectly commits the earlier term-2 e2/s2 suffix at 5 and 6,
+# while stale leader Node 1 still has the conflicting e3/s3 suffix.
+replicate,4,e4
+emit_signature,4
+
+periodic_one,0,10
+dispatch_all
+periodic_one,0,10
+dispatch_all
+periodic_one,0,10
+dispatch_all
+periodic_one,0,10
+dispatch_all
+
+assert_commit_idx,0,8
+assert_commit_safety,0
+assert_last_txid,2,4.8
+assert_detail,1,leadership_state,Leader
+assert_last_txid,1,3.6
+
+summarise_logs_all
+state_all

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -494,20 +494,6 @@ Committable(i) ==
     THEN << >>
     ELSE SubSeq(log[i],1,MaxCommittableIndex(log[i]))
 
-\* The prefix of the log of server i that has been committed up to term x
-CommittedTermPrefix(i, x) ==
-    \* Only if log of i is non-empty, and if there exists an entry up to the term x
-    IF Len(log[i]) /= 0 /\ \E y \in DOMAIN log[i] : log[i][y].term <= x
-    THEN
-      \* then, we use the subsequence up to the maximum committed term of the leader
-      LET maxTermIndex ==
-          CHOOSE y \in DOMAIN log[i] :
-            /\ log[i][y].term <= x
-            /\ \A z \in DOMAIN log[i] : log[i][z].term <= x  => y >= z
-      IN SubSeq(log[i], 1, min(maxTermIndex, commitIndex[i]))
-    \* Otherwise the prefix is the empty tuple
-    ELSE << >>
-
 \* RetirementIndexLog is the index at which node i is first removed from node_log, 0 otherwise
 RetirementIndexLog(node_log, i) ==
     LET 
@@ -1486,14 +1472,13 @@ DebugMoreUpToDateCorrectInv ==
             /\ UpToDateCheck(i, j)
             => IsPrefix(Committed(j), log[i])
 
-\* The committed entries in every log are a prefix of the
-\* leader's log up to the leader's term (since a next Leader may already be
-\* elected without the old leader stepping down yet)
+\* The entries locally known to be committed by any server are a prefix of
+\* every leader's log in higher-numbered terms.
 LeaderCompletenessInv ==
     \A i \in Servers :
         leadershipState[i] = Leader =>
         \A j \in Servers : i /= j =>
-            IsPrefix(CommittedTermPrefix(j, currentTerm[i]),log[i])
+            (currentTerm[i] > currentTerm[j] => IsPrefix(Committed(j), log[i]))
 
 \* In CCF, only signature messages should ever be committed
 SignatureInv ==


### PR DESCRIPTION
Turns out that the leader completeness property fails for a 3 node network.

Consider the following valid logs:
```
L4: [1.1, 2.2, *4.3]
L3: [*1.1, 3.2]
B4: [1.1, 2.2, (4.3)]
```
So two nodes which believe themselves to be leaders. and 4.3 and 1.1 known committed.

The problem is how to express in TLA: `If a prefix is committed in a given term, all future leaders will have that prefix`
And the answer we chose previous was: 
```
CommittedPrefixTerm(id, term) == log[id][1..min(commit_idx[id], term)]
\A i,j in Servers: leadershipState[i] = Leader => IsPrefix(CommittedPrefixTerm(j, currentTerm[i]), log[i])
```
Or in plain english: For every pair of nodes, the prefix of the node capped at the leader's term and the commit index, is on that leader.

In the example we have a network where 2.2 is committed in term 4 and hence is checked against 3.2 and fails.

There are two fixes, we can either explicitly track when a prefix is committed.
Or we can have the following property:
```
 LeaderCompletenessInv ==
   \A i \in Servers :
     leadershipState[i] = Leader =>
       \A j \in Servers : i /= j =>
         currentTerm[i] > currentTerm[j] =>
           IsPrefix(Committed(j), log[i])
```
ie that we take two nodes, if one is a leader for a higher term, we require that the leader has the committed prefix of the other one.

Thanks to @granular-storage for [finding this](https://github.com/granular-storage/RaftFix).
Closes #7968 