### PR TITLE
Clarify pre-vote view wording

### DIFF
--- a/doc/architecture/consensus/index.rst
+++ b/doc/architecture/consensus/index.rst
@@ -242,7 +242,7 @@ If the ``PreVoteCandidate`` receives a quorum of positive pre-vote responses, it
 
         Note over Node 1: Leader for view 3
 
-The only state update in response to a pre-vote message is that if the node's view is older than the pre-vote message's view, it will update it.
+The only state update in response to a pre-vote message is that if the node's current view is older than the one carried by the pre-vote message, it will update it.
 This allows the pre-vote request to inform lagging nodes that a more recent view had a node succeed in its pre-vote, becoming a Candidate or a Leader.
 This can be viewed as piggybacking the view information from that previous Candidate or Leader, with the pre-vote request to the lagging node.
 


### PR DESCRIPTION
This clarifies a sentence in the consensus PreVote documentation where repeated use of "view" made the comparison awkward to read.

The change keeps the message examples using the actual `term` wire field, while describing the conceptual comparison as the node's current view versus the view carried by the pre-vote message.