### PR TITLE
Fix bencher?

### DIFF
--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -198,6 +198,7 @@ def render_chart_table(
     loaded: List[PerfRun], benchmarks: List[str], metric: str, unit: str
 ) -> str:
     """Render benchmark charts in a four-column table."""
+    lines = ['<table width="100%">']
     for index, benchmark in enumerate(benchmarks):
         if index % CHART_COLUMNS == 0:
             lines.append("<tr>")


### PR DESCRIPTION
 ## Diagnostics

 Root cause: the new local summary script was broken on  `main`.

 `bencher.yml` now runs:

 ```sh
 python3 scripts/perf_summary.py perf >>  "$GITHUB_STEP_SUMMARY"
 ```

 In failed run `28363105292`, both `Benchmark Virtual` and  `Benchmark SNP` completed the benchmark work, then failed  in `Summarise perf data files` with:

 ```text
 NameError: name 'lines' is not defined
 scripts/perf_summary.py, line 203, in render_chart_table
 ```

 Current `scripts/perf_summary.py` had  `render_chart_table()` calling `lines.append(...)` without  defining `lines` first.

 ## Why the introducing PR was green

 The green preview run `28103533380` was on `perf_track` at  commit `08988b5c`, where `render_chart_table()` still had:

 ```py
 lines = ['<table width="100%">']
 ```

 That initializer was removed later in PR #7969 by commit  `59ea16b` (`Potential fix for pull request finding`). After  that, the temporary `perf_track` trigger was removed, and  the PR checks did not actually run `bencher.yml`; the check  list shows `Benchmark Main` was skipped.

 So the PR looked green, but the final code path was first  exercised by the post-merge `main` push, which immediately  failed.

 ## Fix

 Restore the missing `lines` initializer in  `render_chart_table()`.