### PR TITLE
Fix race condition between recovery seqno and merkle tree root

### DIFF
--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -1991,10 +1991,13 @@ namespace ccf
       recovery_store->set_history(recovery_history);
       recovery_store->set_encryptor(recovery_encryptor);
 
-      // Record real store version and root
-      recovery_v = network.tables->current_version();
+      // Record a consistent public store version and root. The store's current
+      // version can advance before its Merkle history is updated during commit,
+      // so these must be captured together from the history.
       auto* h = dynamic_cast<MerkleTxHistory*>(history.get());
-      recovery_root = h->get_replicated_state_root();
+      const auto& [txid, root, _] = h->get_replicated_state_txid_and_root();
+      recovery_v = txid.seqno;
+      recovery_root = root;
 
       if (startup_snapshot_info)
       {


### PR DESCRIPTION
If we had a tx commit between `network.tables->current_version` and `h->get_replicated_state_root` this will cause recovery to fail.

Specifically the version is used to record a hwm on private txs from before the recovery started, so once we have the relevant keys we can rematerialise the KV for that seqno and use that as the private state going forward.
However as a safety step we check the reconstructed root against the captured root to ensure we recovered correctly, and if these drift, then the node crashes.

This PR just synchronises these accesses.