### PR TITLE
Reduce flakiness in JWT initial-refresh test (post-failover timeout)

### DIFF
--- a/tests/jwt_test.py
+++ b/tests/jwt_test.py
@@ -833,7 +833,7 @@ def test_jwt_key_auto_refresh_entries(network, args):
 
 
 @reqs.description("JWT with auto_refresh enabled, initial refresh")
-def test_jwt_key_initial_refresh(network, args):
+def test_jwt_key_initial_refresh(network, args, timeout_s=15):
     primary, _ = network.find_nodes()
 
     ca_cert_bundle_name = "jwt"
@@ -877,7 +877,7 @@ def test_jwt_key_initial_refresh(network, args):
         # load.
         with_timeout(
             lambda: check_kv_jwt_key_matches(args, network, kid, issuer.key_pub_pem),
-            timeout=15,
+            timeout=timeout_s,
         )
 
         LOG.info("Check that JWT refresh endpoint has no failures")
@@ -1073,7 +1073,7 @@ def run_manual(args):
         primary, _ = network.find_primary()
         primary.stop()
         network.wait_for_new_primary(primary)
-        test_jwt_key_initial_refresh(network, args)
+        test_jwt_key_initial_refresh(network, args, timeout_s=30)
         test_jwt_key_auto_refresh_connection_failure(network, args)
         test_jwt_key_auto_refresh_tls_failure(network, args)
         test_jwt_key_auto_refresh_invalid_metadata_issuer(network, args)

--- a/tests/jwt_test.py
+++ b/tests/jwt_test.py
@@ -629,7 +629,7 @@ def test_jwt_key_auto_refresh_response_size_limit(network, args):
                 lambda: check_kv_jwt_key_matches(
                     args, network, kid, issuer.key_pub_pem
                 ),
-                timeout=5,
+                timeout=15,
             )
         finally:
             network.consortium.remove_jwt_issuer(primary, issuer.name)

--- a/tests/jwt_test.py
+++ b/tests/jwt_test.py
@@ -871,9 +871,13 @@ def test_jwt_key_initial_refresh(network, args):
         LOG.info("Check that keys got refreshed")
         # Auto-refresh interval has been set to a large value so that it doesn't happen within the timeout.
         # This is testing the one-off refresh after adding a new issuer.
+        # The timeout is generous because this check also runs straight after a
+        # primary failover, where the newly-elected primary must restart the
+        # refresh and re-fetch the keys, which can take several seconds under CI
+        # load.
         with_timeout(
             lambda: check_kv_jwt_key_matches(args, network, kid, issuer.key_pub_pem),
-            timeout=5,
+            timeout=15,
         )
 
         LOG.info("Check that JWT refresh endpoint has no failures")


### PR DESCRIPTION
## Problem

`test_jwt_key_initial_refresh` (the JWT "manual" scenario, part of the `programmability_and_jwt` / bucket_c e2e test) intermittently fails with:

```
AssertionError: assert kid in latest_jwt_signing_keys
RuntimeError: ['Failure in manual: AssertionError()']
```

Observed failing job: [VMSS Virtual C - `programmability_and_jwt`](https://github.com/microsoft/CCF/actions/runs/28668826918/job/85027090362) (from run [28668826918](https://github.com/microsoft/CCF/actions/runs/28668826918)).

## Root cause

The test waits for the one-off JWKS refresh with a flat `timeout=5`. It runs the check twice: once on the initial primary (fast, ~0.6s in the failing run) and again immediately after a deliberate primary failover ("initial refresh also works on backups").

On the newly-elected primary the refresh has to be (re)started and the keys re-fetched over TLS from the local OpenID server and applied via governance - a cold start that can occasionally exceed 5s under CI load. In the observed failure the `manual` scenario logged **no node error** (the refresh succeeds, just late); it simply had not populated the key within 5s when the assertion fired. It is plausibly more variable now that JWK fetching was migrated to the new curl-based client (#8005), and this test has a history of flakiness (#7543).

## Fix

Raise the timeout for this specific check from 5s to 15s, matching the intent of the sibling auto-refresh check which already uses a scaled timeout (`max(5, args.jwt_key_refresh_interval_s * 5)`).

Test-only change; no product code or user-facing behaviour is affected, so no CHANGELOG entry.
