### PR TITLE
Add NET_ADMIN capability to devcontainer for partitions tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,12 @@
     "dockerfile": "Dockerfile",
     "context": "."
   },
-  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+  "runArgs": [
+    "--cap-add=SYS_PTRACE",
+    "--cap-add=NET_ADMIN",
+    "--security-opt",
+    "seccomp=unconfined"
+  ],
   "hostRequirements": {
     "cpus": 16,
     "memory": "64gb",


### PR DESCRIPTION
## Description

The `partitions` test suite (`tests/partitions_test.py`) uses `python-iptables` to manipulate `iptables` rules in order to simulate network partitions between nodes. This requires the `NET_ADMIN` capability.

The devcontainer previously only granted `SYS_PTRACE`, so any attempt to run the partitions tests inside it failed with:

```
iptc.ip4tc.IPTCError: can't initialize filter: b'Permission denied (you must be root)'
```

even when running as root, since `NET_ADMIN` was excluded from the capability bounding set.

## Changes

- Add `--cap-add=NET_ADMIN` to `runArgs` in `.devcontainer/devcontainer.json`.

This is scoped to just the capability that's actually needed, rather than running the container fully `--privileged`.

Requires a container rebuild to take effect.