### PR TITLE
start_in_recovery(..., from_network=

### DIFF
--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -471,6 +471,7 @@ class Network:
         ledger_dir=None,
         read_only_ledger_dirs=None,
         snapshots_dir=None,
+        per_node_recovery_dirs=None,
         **kwargs,
     ):
         self.args = args
@@ -492,6 +493,26 @@ class Network:
         for i, node in enumerate(self.nodes):
             forwarded_args_with_overrides = forwarded_args.copy()
             forwarded_args_with_overrides.update(self.per_node_args_override.get(i, {}))
+            # When recovering from a whole network, each node is seeded from its own
+            # source node's disk (see start_in_recovery's from_network path); otherwise
+            # every node shares the single passed-in ledger/snapshot set.
+            if per_node_recovery_dirs is not None:
+                # per-node seeding (from_network) and the single passed-in
+                # ledger/snapshot set are mutually exclusive.
+                assert (
+                    ledger_dir is None
+                    and not read_only_ledger_dirs
+                    and snapshots_dir is None
+                ), "per_node_recovery_dirs cannot be combined with ledger_dir/read_only_ledger_dirs/snapshots_dir"
+                node_ledger_dir = per_node_recovery_dirs[i]["ledger_dir"]
+                node_read_only_ledger_dirs = per_node_recovery_dirs[i][
+                    "read_only_ledger_dirs"
+                ]
+                node_snapshots_dir = per_node_recovery_dirs[i]["snapshots_dir"]
+            else:
+                node_ledger_dir = ledger_dir
+                node_read_only_ledger_dirs = read_only_ledger_dirs
+                node_snapshots_dir = snapshots_dir
             try:
                 if i == 0:
                     if not recovery:
@@ -500,7 +521,7 @@ class Network:
                             workspace=args.workspace,
                             label=args.label,
                             common_dir=self.common_dir,
-                            ledger_dir=ledger_dir,
+                            ledger_dir=node_ledger_dir,
                             members_info=self.consortium.get_members_info(),
                             **forwarded_args_with_overrides,
                             **kwargs,
@@ -511,9 +532,9 @@ class Network:
                             "workspace": args.workspace,
                             "label": args.label,
                             "common_dir": self.common_dir,
-                            "ledger_dir": ledger_dir,
-                            "read_only_ledger_dirs": read_only_ledger_dirs,
-                            "snapshots_dir": snapshots_dir,
+                            "ledger_dir": node_ledger_dir,
+                            "read_only_ledger_dirs": node_read_only_ledger_dirs,
+                            "snapshots_dir": node_snapshots_dir,
                         }
                         # If a kwarg is passed in override automatically set variants
                         node_kwargs = (
@@ -532,10 +553,10 @@ class Network:
                         args.package,
                         args,
                         recovery=recovery,
-                        ledger_dir=ledger_dir,
-                        from_snapshot=snapshots_dir is not None,
-                        read_only_ledger_dirs=read_only_ledger_dirs,
-                        snapshots_dir=snapshots_dir,
+                        ledger_dir=node_ledger_dir,
+                        from_snapshot=node_snapshots_dir is not None,
+                        read_only_ledger_dirs=node_read_only_ledger_dirs,
+                        snapshots_dir=node_snapshots_dir,
                         **forwarded_args_with_overrides,
                         **kwargs,
                     )
@@ -702,6 +723,43 @@ class Network:
         self.start(args, **kwargs)
         self.open(args)
 
+    def _recovery_dirs_from_network(self, from_network):
+        """
+        Build per-node recovery seed directories from a previous Network.
+
+        Mirrors the per-node seeding of start_in_recovery_decision_protocol: each new
+        node is seeded from one of the previous network's nodes, selected round-robin
+        (new node i <- from_network.nodes[i % len]). Depending on the relative node
+        counts, some source ledgers are reused across several new nodes and some are
+        dropped entirely. Seeding from a node that is behind the others is a supported
+        case (e.g. when a fresher node's disk is not yet available for recovery), so no
+        "freshest node" selection is attempted here.
+        """
+        source_nodes = from_network.nodes
+        if not source_nodes:
+            raise ValueError("from_network has no nodes to recover from")
+
+        # Gather each distinct source node's ledger and committed snapshots once. Both
+        # getters are filesystem copies that work whether or not the source node is
+        # still running, so this is safe after the previous network has been stopped.
+        seeds = {}
+        per_node_recovery_dirs = {}
+        for i in range(len(self.nodes)):
+            source = source_nodes[i % len(source_nodes)]
+            if source not in seeds:
+                ledger_dir, committed_ledger_dirs = source.get_ledger()
+                snapshots_dir = source.get_committed_snapshots()
+                if not os.listdir(snapshots_dir):
+                    snapshots_dir = None
+                seeds[source] = (ledger_dir, committed_ledger_dirs, snapshots_dir)
+            ledger_dir, committed_ledger_dirs, snapshots_dir = seeds[source]
+            per_node_recovery_dirs[i] = {
+                "ledger_dir": ledger_dir,
+                "read_only_ledger_dirs": committed_ledger_dirs,
+                "snapshots_dir": snapshots_dir,
+            }
+        return per_node_recovery_dirs
+
     def start_in_recovery(
         self,
         args,
@@ -710,6 +768,7 @@ class Network:
         snapshots_dir=None,
         common_dir=None,
         set_authenticate_session=None,
+        from_network=None,
         **kwargs,
     ):
         """
@@ -718,6 +777,10 @@ class Network:
         :param ledger_dir: ledger directory to recover from.
         :param snapshots_dir: snapshot directory to recover from.
         :param common_dir: common directory containing member and user keys and certs.
+        :param from_network: recover from a whole previous Network rather than a single
+            ledger/snapshot set. Each new node is seeded from one of the previous
+            network's nodes (round-robin), node 0 is recovered and the others join it.
+            Mutually exclusive with ledger_dir/committed_ledger_dirs/snapshots_dir.
         """
         self.common_dir = (
             common_dir
@@ -726,12 +789,22 @@ class Network:
         )
         committed_ledger_dirs = committed_ledger_dirs or []
 
+        per_node_recovery_dirs = None
+        if from_network is not None:
+            if ledger_dir is not None or committed_ledger_dirs or snapshots_dir:
+                raise ValueError(
+                    "from_network is mutually exclusive with "
+                    "ledger_dir/committed_ledger_dirs/snapshots_dir"
+                )
+            per_node_recovery_dirs = self._recovery_dirs_from_network(from_network)
+
         primary = self._start_all_nodes(
             args,
             recovery=True,
             ledger_dir=ledger_dir,
             read_only_ledger_dirs=committed_ledger_dirs,
             snapshots_dir=snapshots_dir,
+            per_node_recovery_dirs=per_node_recovery_dirs,
             **kwargs,
         )
 

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -1692,6 +1692,90 @@ def run_recover_via_added_recovery_owner(args):
         return network
 
 
+@reqs.description("Recover a service by seeding from the whole previous network")
+def test_recover_service_from_network(network, args):
+    """
+    Seed the recovered network from the whole previous network - each node from its
+    own disk, selected round-robin - rather than from a single ledger and snapshot
+    set, then recover node 0 and have the other nodes join it. This mirrors a
+    production disaster recovery where every node has its own persistent disk.
+
+    Nodes are stopped one by one, so the first-stopped node (which round-robin maps to
+    the recovery node, node 0) has the least fresh state while the later-stopped nodes
+    keep committing and end up ahead. With such divergent per-node snapshots, recovery
+    currently fails to start: a joining node seeded from a fresher node holds a
+    snapshot ahead of the recovery node's recovery point (or a snapshot with no
+    counterpart in the recovered service), and cannot join. The exact failure mode
+    varies with the divergence, so this test only asserts that recovery fails to
+    start; it must be updated once that divergence is handled.
+    """
+    network.save_service_identity(args)
+    old_primary, _ = network.find_primary()
+
+    # Issue transactions and force a committed snapshot so at least one node is seeded
+    # with a snapshot, then stop nodes one by one so their committed ledgers and
+    # snapshots diverge.
+    network.txs.issue(network, number_txs=10)
+    network.get_committed_snapshots(old_primary)
+
+    for node in network.get_joined_nodes():
+        time.sleep(args.election_timeout_ms / 1000)
+        node.stop()
+
+    recovered_network = infra.network.Network(
+        args.nodes,
+        args.binary_dir,
+        args.debug_nodes,
+        existing_network=network,
+    )
+
+    # Recovery from the diverged network is currently expected to fail to start, as a
+    # joining node cannot start from a snapshot that diverges from the recovery node's
+    # recovery point.
+    exception = None
+    try:
+        recovered_network.start_in_recovery(args, from_network=network)
+    except TimeoutError as ex:
+        exception = ex
+
+    recovered_network.ignoring_shutdown_errors = True
+    # The nodes are deliberately seeded from divergent disks, so skip the
+    # cross-node ledger/snapshot consistency invariants on shutdown.
+    recovered_network.stop_all_nodes(
+        skip_verification=True,
+        check_file_invariants=False,
+        skip_verify_chunking=True,
+    )
+
+    if exception is None:
+        raise ValueError(
+            "Recovery from a diverged network was expected to fail to start "
+            "(a joining node should fail to join)"
+        )
+
+    return network
+
+
+def run_recover_service_from_network(args):
+    """
+    Recover a service by seeding the recovered network from the whole previous
+    network (each node from its own disk) rather than from a single ledger and
+    snapshot set, more closely matching a production disaster recovery where every
+    node has its own persistent disk.
+    """
+    txs = app.LoggingTxs("user0")
+    with infra.network.network(
+        args.nodes,
+        args.binary_dir,
+        args.debug_nodes,
+        pdb=args.pdb,
+        txs=txs,
+    ) as network:
+        network.start_and_open(args)
+        network = test_recover_service_from_network(network, args)
+        return network
+
+
 def run_recovery_after_cose_upgrade(args):
     """Start Dual, upgrade to COSE-only via node replacement, then recover
     with allow-dual-joiners. Then live-upgrade the recovered network to strict
@@ -2681,6 +2765,15 @@ checked. Note that the key for each logging message is unique (per table).
         run_recover_via_added_recovery_owner,
         package="samples/apps/logging/logging",
         nodes=infra.e2e_args.min_nodes(cr.args, f=0),  # 1 node suffices for recovery
+    )
+
+    cr.add(
+        "recovery_from_network",
+        run_recover_service_from_network,
+        package="samples/apps/logging/logging",
+        nodes=infra.e2e_args.min_nodes(cr.args, f=1),
+        ledger_chunk_bytes="50KB",
+        snapshot_tx_interval=30,
     )
 
     cr.add(


### PR DESCRIPTION
Currently when we start in recovery we pass a ledger and snapshot directory.
We then:
- start a node in recovery using those
- start the followers in join using those ledger and snapshot directories

This means we are not testing divergent snapshots in our CI currently.
This PR somewhat addresses that by providing a `from_network` argument to start_in_recovery which maps each node in the recovery network to a node in the original network via round-robin and then recovers using that.

Two issues its highlighted, but I haven't yet dug into
- The snapshot identity issue
- Joining from a snapshot from a divergent history (I think we morally support this as we definitely support this for the ledger)

_Why does the test currently fail as it is doing nothing?_
If the network was stable when it was stopped, I'd expect the recovery to be fine, but I think its because we immediately after opening shut down the network.