### PR TITLE
Make curl request bodies rewindable

### DIFF
--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -258,7 +258,10 @@ namespace ccf::curl
         return 0;
       }
       const auto bytes_to_copy = std::min(data->unsent.size(), size * nitems);
-      memcpy(ptr, data->unsent.data(), bytes_to_copy);
+      if (bytes_to_copy > 0)
+      {
+        memcpy(ptr, data->unsent.data(), bytes_to_copy);
+      }
       data->unsent = data->unsent.subspan(bytes_to_copy);
       return bytes_to_copy;
     }

--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -226,7 +226,7 @@ namespace ccf::curl
     size_t read_offset = 0;
 
   public:
-    RequestBody(std::vector<uint8_t>& buffer) : buffer(buffer) {}
+    RequestBody(const std::vector<uint8_t>& buffer_) : buffer(buffer_) {}
 
     RequestBody(std::vector<uint8_t>&& buffer_) : buffer(std::move(buffer_)) {}
 

--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -266,6 +266,48 @@ namespace ccf::curl
       return bytes_to_copy;
     }
 
+    bool seek(curl_off_t offset, int origin)
+    {
+      const auto end = static_cast<curl_off_t>(buffer.size());
+      if (end < 0 || static_cast<size_t>(end) != buffer.size())
+      {
+        return false;
+      }
+
+      const auto current =
+        static_cast<curl_off_t>(buffer.size() - unsent.size());
+      curl_off_t position = 0;
+      switch (origin)
+      {
+        case SEEK_SET:
+          if (offset < 0 || offset > end)
+          {
+            return false;
+          }
+          position = offset;
+          break;
+        case SEEK_CUR:
+          if (offset < -current || offset > end - current)
+          {
+            return false;
+          }
+          position = current + offset;
+          break;
+        case SEEK_END:
+          if (offset < -end || offset > 0)
+          {
+            return false;
+          }
+          position = end + offset;
+          break;
+        default:
+          return false;
+      }
+
+      rewind(static_cast<size_t>(position));
+      return true;
+    }
+
     static int seek_data(RequestBody* data, curl_off_t offset, int origin)
     {
       if (data == nullptr)
@@ -274,48 +316,8 @@ namespace ccf::curl
         return CURL_SEEKFUNC_FAIL;
       }
 
-      const auto end = static_cast<curl_off_t>(data->buffer.size());
-      if (end < 0 || static_cast<size_t>(end) != data->buffer.size())
-      {
-        return CURL_SEEKFUNC_FAIL;
-      }
-
-      const auto current = static_cast<curl_off_t>(data->sent_size());
-      curl_off_t position = 0;
-      switch (origin)
-      {
-        case SEEK_SET:
-          if (offset < 0 || offset > end)
-          {
-            return CURL_SEEKFUNC_CANTSEEK;
-          }
-          position = offset;
-          break;
-        case SEEK_CUR:
-          if (offset < -current || offset > end - current)
-          {
-            return CURL_SEEKFUNC_CANTSEEK;
-          }
-          position = current + offset;
-          break;
-        case SEEK_END:
-          if (offset < -end || offset > 0)
-          {
-            return CURL_SEEKFUNC_CANTSEEK;
-          }
-          position = end + offset;
-          break;
-        default:
-          return CURL_SEEKFUNC_CANTSEEK;
-      }
-
-      data->rewind(static_cast<size_t>(position));
-      return CURL_SEEKFUNC_OK;
-    }
-
-    [[nodiscard]] size_t sent_size() const
-    {
-      return buffer.size() - unsent.size();
+      return data->seek(offset, origin) ? CURL_SEEKFUNC_OK :
+                                          CURL_SEEKFUNC_CANTSEEK;
     }
 
     [[nodiscard]] size_t size() const

--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -223,25 +223,18 @@ namespace ccf::curl
   class RequestBody
   {
     std::vector<uint8_t> buffer;
-    std::span<const uint8_t> unsent;
+    size_t read_offset = 0;
 
   public:
-    RequestBody(std::vector<uint8_t>& buffer) : buffer(buffer)
-    {
-      unsent = std::span<const uint8_t>(buffer.data(), buffer.size());
-    }
+    RequestBody(std::vector<uint8_t>& buffer) : buffer(buffer) {}
 
-    RequestBody(std::vector<uint8_t>&& buffer_) : buffer(std::move(buffer_))
-    {
-      unsent = std::span<const uint8_t>(buffer.data(), buffer.size());
-    }
+    RequestBody(std::vector<uint8_t>&& buffer_) : buffer(std::move(buffer_)) {}
 
     RequestBody(nlohmann::json json)
     {
       auto json_str = json.dump();
       buffer = std::vector<uint8_t>(
         json_str.begin(), json_str.end()); // Convert to vector of bytes
-      unsent = std::span<const uint8_t>(buffer.data(), buffer.size());
     }
 
     static size_t send_data(
@@ -252,15 +245,57 @@ namespace ccf::curl
         LOG_FAIL_FMT("send_data called with null userdata");
         return 0;
       }
-      auto bytes_to_copy = std::min(data->unsent.size(), size * nitems);
-      memcpy(ptr, data->unsent.data(), bytes_to_copy);
-      data->unsent = data->unsent.subspan(bytes_to_copy);
+      const auto bytes_to_copy =
+        std::min(data->buffer.size() - data->read_offset, size * nitems);
+      if (bytes_to_copy > 0)
+      {
+        memcpy(ptr, data->buffer.data() + data->read_offset, bytes_to_copy);
+      }
+      data->read_offset += bytes_to_copy;
       return bytes_to_copy;
+    }
+
+    static int seek_data(RequestBody* data, curl_off_t offset, int origin)
+    {
+      if (data == nullptr)
+      {
+        LOG_FAIL_FMT("seek_data called with null userdata");
+        return CURL_SEEKFUNC_FAIL;
+      }
+
+      const auto end = static_cast<curl_off_t>(data->buffer.size());
+      if (end < 0 || static_cast<size_t>(end) != data->buffer.size())
+      {
+        return CURL_SEEKFUNC_FAIL;
+      }
+
+      curl_off_t base = 0;
+      switch (origin)
+      {
+        case SEEK_SET:
+          break;
+        case SEEK_CUR:
+          base = static_cast<curl_off_t>(data->read_offset);
+          break;
+        case SEEK_END:
+          base = end;
+          break;
+        default:
+          return CURL_SEEKFUNC_CANTSEEK;
+      }
+
+      if ((offset < 0 && offset < -base) || (offset > 0 && offset > end - base))
+      {
+        return CURL_SEEKFUNC_CANTSEEK;
+      }
+
+      data->read_offset = static_cast<size_t>(base + offset);
+      return CURL_SEEKFUNC_OK;
     }
 
     [[nodiscard]] size_t size() const
     {
-      return unsent.size();
+      return buffer.size();
     }
 
     void attach_to_curl(CURL* curl)
@@ -272,6 +307,8 @@ namespace ccf::curl
       }
       CHECK_CURL_EASY_SETOPT(curl, CURLOPT_READDATA, this);
       CHECK_CURL_EASY_SETOPT(curl, CURLOPT_READFUNCTION, send_data);
+      CHECK_CURL_EASY_SETOPT(curl, CURLOPT_SEEKDATA, this);
+      CHECK_CURL_EASY_SETOPT(curl, CURLOPT_SEEKFUNCTION, seek_data);
       // The body size is declared by the caller in a method-specific way
       // (CURLOPT_POSTFIELDSIZE_LARGE for POST, CURLOPT_INFILESIZE_LARGE for a
       // PUT upload), so it is intentionally not set here.

--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -258,10 +258,7 @@ namespace ccf::curl
         return 0;
       }
       const auto bytes_to_copy = std::min(data->unsent.size(), size * nitems);
-      if (bytes_to_copy > 0)
-      {
-        memcpy(ptr, data->unsent.data(), bytes_to_copy);
-      }
+      memcpy(ptr, data->unsent.data(), bytes_to_copy);
       data->unsent = data->unsent.subspan(bytes_to_copy);
       return bytes_to_copy;
     }

--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -292,14 +292,15 @@ namespace ccf::curl
       return true;
     }
 
-    static int seek_data(RequestBody* data, curl_off_t offset, int origin)
+    static int seek_data(void* userdata, curl_off_t offset, int origin)
     {
-      if (data == nullptr)
+      if (userdata == nullptr)
       {
         LOG_FAIL_FMT("seek_data called with null userdata");
         return CURL_SEEKFUNC_FAIL;
       }
 
+      auto* data = static_cast<RequestBody*>(userdata);
       return data->seek(offset, origin) ? CURL_SEEKFUNC_OK :
                                           CURL_SEEKFUNC_CANTSEEK;
     }

--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -223,18 +223,30 @@ namespace ccf::curl
   class RequestBody
   {
     std::vector<uint8_t> buffer;
-    size_t read_offset = 0;
+    std::span<const uint8_t> unsent;
+
+    void rewind(size_t offset = 0)
+    {
+      unsent = std::span<const uint8_t>(buffer).subspan(offset);
+    }
 
   public:
-    RequestBody(const std::vector<uint8_t>& buffer_) : buffer(buffer_) {}
+    RequestBody(const std::vector<uint8_t>& buffer_) :
+      buffer(buffer_),
+      unsent(buffer)
+    {}
 
-    RequestBody(std::vector<uint8_t>&& buffer_) : buffer(std::move(buffer_)) {}
+    RequestBody(std::vector<uint8_t>&& buffer_) :
+      buffer(std::move(buffer_)),
+      unsent(buffer)
+    {}
 
     RequestBody(nlohmann::json json)
     {
       auto json_str = json.dump();
       buffer = std::vector<uint8_t>(
         json_str.begin(), json_str.end()); // Convert to vector of bytes
+      rewind();
     }
 
     static size_t send_data(
@@ -245,13 +257,12 @@ namespace ccf::curl
         LOG_FAIL_FMT("send_data called with null userdata");
         return 0;
       }
-      const auto bytes_to_copy =
-        std::min(data->buffer.size() - data->read_offset, size * nitems);
+      const auto bytes_to_copy = std::min(data->unsent.size(), size * nitems);
       if (bytes_to_copy > 0)
       {
-        memcpy(ptr, data->buffer.data() + data->read_offset, bytes_to_copy);
+        memcpy(ptr, data->unsent.data(), bytes_to_copy);
       }
-      data->read_offset += bytes_to_copy;
+      data->unsent = data->unsent.subspan(bytes_to_copy);
       return bytes_to_copy;
     }
 
@@ -263,39 +274,26 @@ namespace ccf::curl
         return CURL_SEEKFUNC_FAIL;
       }
 
-      const auto end = static_cast<curl_off_t>(data->buffer.size());
-      if (end < 0 || static_cast<size_t>(end) != data->buffer.size())
-      {
-        return CURL_SEEKFUNC_FAIL;
-      }
-
-      curl_off_t base = 0;
-      switch (origin)
-      {
-        case SEEK_SET:
-          break;
-        case SEEK_CUR:
-          base = static_cast<curl_off_t>(data->read_offset);
-          break;
-        case SEEK_END:
-          base = end;
-          break;
-        default:
-          return CURL_SEEKFUNC_CANTSEEK;
-      }
-
-      if ((offset < 0 && offset < -base) || (offset > 0 && offset > end - base))
+      if (origin != SEEK_SET || offset < 0)
       {
         return CURL_SEEKFUNC_CANTSEEK;
       }
 
-      data->read_offset = static_cast<size_t>(base + offset);
+      const auto position = static_cast<size_t>(offset);
+      if (
+        static_cast<curl_off_t>(position) != offset ||
+        position > data->buffer.size())
+      {
+        return CURL_SEEKFUNC_CANTSEEK;
+      }
+
+      data->rewind(position);
       return CURL_SEEKFUNC_OK;
     }
 
     [[nodiscard]] size_t size() const
     {
-      return buffer.size();
+      return unsent.size();
     }
 
     void attach_to_curl(CURL* curl)

--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -274,44 +274,48 @@ namespace ccf::curl
         return CURL_SEEKFUNC_FAIL;
       }
 
-      size_t base = 0;
+      const auto end = static_cast<curl_off_t>(data->buffer.size());
+      if (end < 0 || static_cast<size_t>(end) != data->buffer.size())
+      {
+        return CURL_SEEKFUNC_FAIL;
+      }
+
+      const auto current = static_cast<curl_off_t>(data->sent_size());
+      curl_off_t position = 0;
       switch (origin)
       {
         case SEEK_SET:
+          if (offset < 0 || offset > end)
+          {
+            return CURL_SEEKFUNC_CANTSEEK;
+          }
+          position = offset;
           break;
         case SEEK_CUR:
-          base = data->buffer.size() - data->unsent.size();
+          if (offset < -current || offset > end - current)
+          {
+            return CURL_SEEKFUNC_CANTSEEK;
+          }
+          position = current + offset;
           break;
         case SEEK_END:
-          base = data->buffer.size();
+          if (offset < -end || offset > 0)
+          {
+            return CURL_SEEKFUNC_CANTSEEK;
+          }
+          position = end + offset;
           break;
         default:
           return CURL_SEEKFUNC_CANTSEEK;
       }
 
-      size_t position = 0;
-      if (offset < 0)
-      {
-        const auto distance = static_cast<std::uintmax_t>(-(offset + 1)) + 1;
-        if (distance > base)
-        {
-          return CURL_SEEKFUNC_CANTSEEK;
-        }
-        position = base - static_cast<size_t>(distance);
-      }
-      else
-      {
-        const auto distance = static_cast<std::uintmax_t>(offset);
-        const auto remaining = data->buffer.size() - base;
-        if (distance > remaining)
-        {
-          return CURL_SEEKFUNC_CANTSEEK;
-        }
-        position = base + static_cast<size_t>(distance);
-      }
-
-      data->rewind(position);
+      data->rewind(static_cast<size_t>(position));
       return CURL_SEEKFUNC_OK;
+    }
+
+    [[nodiscard]] size_t sent_size() const
+    {
+      return buffer.size() - unsent.size();
     }
 
     [[nodiscard]] size_t size() const

--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -225,18 +225,6 @@ namespace ccf::curl
     std::vector<uint8_t> buffer;
     std::span<const uint8_t> unsent;
 
-    [[nodiscard]] bool is_offset_in_bounds(curl_off_t offset) const
-    {
-      if (offset < 0)
-      {
-        return false;
-      }
-
-      const auto position = static_cast<size_t>(offset);
-      return static_cast<curl_off_t>(position) == offset &&
-        position <= buffer.size();
-    }
-
     void rewind(size_t offset = 0)
     {
       unsent = std::span<const uint8_t>(buffer).subspan(offset);
@@ -280,42 +268,30 @@ namespace ccf::curl
 
     bool seek(curl_off_t offset, int origin)
     {
-      const auto end = static_cast<curl_off_t>(buffer.size());
-      if (end < 0 || static_cast<size_t>(end) != buffer.size())
-      {
-        return false;
-      }
-
-      const auto current =
-        static_cast<curl_off_t>(buffer.size() - unsent.size());
-      curl_off_t position = 0;
+      size_t base = 0;
       switch (origin)
       {
         case SEEK_SET:
-          position = offset;
           break;
         case SEEK_CUR:
-          if (__builtin_add_overflow(current, offset, &position))
-          {
-            return false;
-          }
+          base = buffer.size() - unsent.size();
           break;
         case SEEK_END:
-          if (__builtin_add_overflow(end, offset, &position))
-          {
-            return false;
-          }
+          base = buffer.size();
           break;
         default:
           return false;
       }
 
-      if (!is_offset_in_bounds(position))
+      size_t position = 0;
+      if (
+        __builtin_add_overflow(base, offset, &position) ||
+        position > buffer.size())
       {
         return false;
       }
 
-      rewind(static_cast<size_t>(position));
+      rewind(position);
       return true;
     }
 

--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -225,6 +225,18 @@ namespace ccf::curl
     std::vector<uint8_t> buffer;
     std::span<const uint8_t> unsent;
 
+    [[nodiscard]] bool is_offset_in_bounds(curl_off_t offset) const
+    {
+      if (offset < 0)
+      {
+        return false;
+      }
+
+      const auto position = static_cast<size_t>(offset);
+      return static_cast<curl_off_t>(position) == offset &&
+        position <= buffer.size();
+    }
+
     void rewind(size_t offset = 0)
     {
       unsent = std::span<const uint8_t>(buffer).subspan(offset);
@@ -280,28 +292,27 @@ namespace ccf::curl
       switch (origin)
       {
         case SEEK_SET:
-          if (offset < 0 || offset > end)
-          {
-            return false;
-          }
           position = offset;
           break;
         case SEEK_CUR:
-          if (offset < -current || offset > end - current)
+          if (__builtin_add_overflow(current, offset, &position))
           {
             return false;
           }
-          position = current + offset;
           break;
         case SEEK_END:
-          if (offset < -end || offset > 0)
+          if (__builtin_add_overflow(end, offset, &position))
           {
             return false;
           }
-          position = end + offset;
           break;
         default:
           return false;
+      }
+
+      if (!is_offset_in_bounds(position))
+      {
+        return false;
       }
 
       rewind(static_cast<size_t>(position));

--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -274,17 +274,40 @@ namespace ccf::curl
         return CURL_SEEKFUNC_FAIL;
       }
 
-      if (origin != SEEK_SET || offset < 0)
+      size_t base = 0;
+      switch (origin)
       {
-        return CURL_SEEKFUNC_CANTSEEK;
+        case SEEK_SET:
+          break;
+        case SEEK_CUR:
+          base = data->buffer.size() - data->unsent.size();
+          break;
+        case SEEK_END:
+          base = data->buffer.size();
+          break;
+        default:
+          return CURL_SEEKFUNC_CANTSEEK;
       }
 
-      const auto position = static_cast<size_t>(offset);
-      if (
-        static_cast<curl_off_t>(position) != offset ||
-        position > data->buffer.size())
+      size_t position = 0;
+      if (offset < 0)
       {
-        return CURL_SEEKFUNC_CANTSEEK;
+        const auto distance = static_cast<std::uintmax_t>(-(offset + 1)) + 1;
+        if (distance > base)
+        {
+          return CURL_SEEKFUNC_CANTSEEK;
+        }
+        position = base - static_cast<size_t>(distance);
+      }
+      else
+      {
+        const auto distance = static_cast<std::uintmax_t>(offset);
+        const auto remaining = data->buffer.size() - base;
+        if (distance > remaining)
+        {
+          return CURL_SEEKFUNC_CANTSEEK;
+        }
+        position = base + static_cast<size_t>(distance);
       }
 
       data->rewind(position);

--- a/src/http/test/curl_test.cpp
+++ b/src/http/test/curl_test.cpp
@@ -83,7 +83,7 @@ TEST_CASE("is_transient_transport_error classifies curl errors")
 TEST_CASE("RequestBody supports replay")
 {
   const std::vector<uint8_t> expected = {1, 2, 3, 4};
-  auto data = expected;
+  const auto data = expected;
   ccf::curl::RequestBody body(data);
 
   std::vector<char> partial(2);

--- a/src/http/test/curl_test.cpp
+++ b/src/http/test/curl_test.cpp
@@ -115,12 +115,32 @@ TEST_CASE("RequestBody supports replay")
       return static_cast<uint8_t>(lhs) == rhs;
     }));
 
+  REQUIRE(body.seek(2, SEEK_SET));
+  REQUIRE_FALSE(body.seek(std::numeric_limits<curl_off_t>::max(), SEEK_CUR));
+  char after_failed_seek = 0;
+  REQUIRE(
+    ccf::curl::RequestBody::send_data(&after_failed_seek, 1, 1, &body) == 1);
+  REQUIRE(static_cast<uint8_t>(after_failed_seek) == expected[2]);
+
   REQUIRE_FALSE(body.seek(-1, SEEK_SET));
   REQUIRE_FALSE(body.seek(expected.size() + 1, SEEK_SET));
+  REQUIRE(body.seek(0, SEEK_END));
   REQUIRE_FALSE(body.seek(1, SEEK_CUR));
   REQUIRE_FALSE(
     body.seek(-static_cast<curl_off_t>(expected.size()) - 1, SEEK_END));
-  REQUIRE_FALSE(body.seek(std::numeric_limits<curl_off_t>::max(), SEEK_CUR));
+}
+
+TEST_CASE("RequestBody supports empty bodies")
+{
+  ccf::curl::RequestBody body(std::vector<uint8_t>{});
+
+  REQUIRE(body.size() == 0);
+  REQUIRE(body.seek(0, SEEK_SET));
+  REQUIRE(body.seek(0, SEEK_CUR));
+  REQUIRE(body.seek(0, SEEK_END));
+
+  char unused = 0;
+  REQUIRE(ccf::curl::RequestBody::send_data(&unused, 1, 1, &body) == 0);
 }
 
 TEST_CASE("ResponseHeaders rejects oversized headers")

--- a/src/http/test/curl_test.cpp
+++ b/src/http/test/curl_test.cpp
@@ -85,6 +85,7 @@ TEST_CASE("RequestBody supports replay")
   const std::vector<uint8_t> expected = {1, 2, 3, 4};
   const auto data = expected;
   ccf::curl::RequestBody body(data);
+  REQUIRE(body.sent_size() == 0);
 
   std::vector<char> partial(2);
   REQUIRE(
@@ -92,21 +93,25 @@ TEST_CASE("RequestBody supports replay")
       partial.data(), 1, partial.size(), &body) == partial.size());
   REQUIRE(static_cast<uint8_t>(partial[0]) == expected[0]);
   REQUIRE(static_cast<uint8_t>(partial[1]) == expected[1]);
+  REQUIRE(body.sent_size() == partial.size());
 
   REQUIRE(
     ccf::curl::RequestBody::seek_data(&body, -1, SEEK_CUR) == CURL_SEEKFUNC_OK);
+  REQUIRE(body.sent_size() == 1);
   char current = 0;
   REQUIRE(ccf::curl::RequestBody::send_data(&current, 1, 1, &body) == 1);
   REQUIRE(static_cast<uint8_t>(current) == expected[1]);
 
   REQUIRE(
     ccf::curl::RequestBody::seek_data(&body, -1, SEEK_END) == CURL_SEEKFUNC_OK);
+  REQUIRE(body.sent_size() == expected.size() - 1);
   char last = 0;
   REQUIRE(ccf::curl::RequestBody::send_data(&last, 1, 1, &body) == 1);
   REQUIRE(static_cast<uint8_t>(last) == expected.back());
 
   REQUIRE(
     ccf::curl::RequestBody::seek_data(&body, 0, SEEK_SET) == CURL_SEEKFUNC_OK);
+  REQUIRE(body.sent_size() == 0);
 
   std::vector<char> replayed(expected.size());
   REQUIRE(

--- a/src/http/test/curl_test.cpp
+++ b/src/http/test/curl_test.cpp
@@ -94,6 +94,18 @@ TEST_CASE("RequestBody supports replay")
   REQUIRE(static_cast<uint8_t>(partial[1]) == expected[1]);
 
   REQUIRE(
+    ccf::curl::RequestBody::seek_data(&body, -1, SEEK_CUR) == CURL_SEEKFUNC_OK);
+  char current = 0;
+  REQUIRE(ccf::curl::RequestBody::send_data(&current, 1, 1, &body) == 1);
+  REQUIRE(static_cast<uint8_t>(current) == expected[1]);
+
+  REQUIRE(
+    ccf::curl::RequestBody::seek_data(&body, -1, SEEK_END) == CURL_SEEKFUNC_OK);
+  char last = 0;
+  REQUIRE(ccf::curl::RequestBody::send_data(&last, 1, 1, &body) == 1);
+  REQUIRE(static_cast<uint8_t>(last) == expected.back());
+
+  REQUIRE(
     ccf::curl::RequestBody::seek_data(&body, 0, SEEK_SET) == CURL_SEEKFUNC_OK);
 
   std::vector<char> replayed(expected.size());
@@ -109,7 +121,11 @@ TEST_CASE("RequestBody supports replay")
     ccf::curl::RequestBody::seek_data(&body, expected.size() + 1, SEEK_SET) ==
     CURL_SEEKFUNC_CANTSEEK);
   REQUIRE(
-    ccf::curl::RequestBody::seek_data(&body, 0, SEEK_CUR) ==
+    ccf::curl::RequestBody::seek_data(&body, 1, SEEK_CUR) ==
+    CURL_SEEKFUNC_CANTSEEK);
+  REQUIRE(
+    ccf::curl::RequestBody::seek_data(
+      &body, -static_cast<curl_off_t>(expected.size()) - 1, SEEK_END) ==
     CURL_SEEKFUNC_CANTSEEK);
 }
 

--- a/src/http/test/curl_test.cpp
+++ b/src/http/test/curl_test.cpp
@@ -85,7 +85,6 @@ TEST_CASE("RequestBody supports replay")
   const std::vector<uint8_t> expected = {1, 2, 3, 4};
   const auto data = expected;
   ccf::curl::RequestBody body(data);
-  REQUIRE(body.sent_size() == 0);
 
   std::vector<char> partial(2);
   REQUIRE(
@@ -93,25 +92,18 @@ TEST_CASE("RequestBody supports replay")
       partial.data(), 1, partial.size(), &body) == partial.size());
   REQUIRE(static_cast<uint8_t>(partial[0]) == expected[0]);
   REQUIRE(static_cast<uint8_t>(partial[1]) == expected[1]);
-  REQUIRE(body.sent_size() == partial.size());
 
-  REQUIRE(
-    ccf::curl::RequestBody::seek_data(&body, -1, SEEK_CUR) == CURL_SEEKFUNC_OK);
-  REQUIRE(body.sent_size() == 1);
+  REQUIRE(body.seek(-1, SEEK_CUR));
   char current = 0;
   REQUIRE(ccf::curl::RequestBody::send_data(&current, 1, 1, &body) == 1);
   REQUIRE(static_cast<uint8_t>(current) == expected[1]);
 
-  REQUIRE(
-    ccf::curl::RequestBody::seek_data(&body, -1, SEEK_END) == CURL_SEEKFUNC_OK);
-  REQUIRE(body.sent_size() == expected.size() - 1);
+  REQUIRE(body.seek(-1, SEEK_END));
   char last = 0;
   REQUIRE(ccf::curl::RequestBody::send_data(&last, 1, 1, &body) == 1);
   REQUIRE(static_cast<uint8_t>(last) == expected.back());
 
-  REQUIRE(
-    ccf::curl::RequestBody::seek_data(&body, 0, SEEK_SET) == CURL_SEEKFUNC_OK);
-  REQUIRE(body.sent_size() == 0);
+  REQUIRE(body.seek(0, SEEK_SET));
 
   std::vector<char> replayed(expected.size());
   REQUIRE(
@@ -122,16 +114,10 @@ TEST_CASE("RequestBody supports replay")
       return static_cast<uint8_t>(lhs) == rhs;
     }));
 
-  REQUIRE(
-    ccf::curl::RequestBody::seek_data(&body, expected.size() + 1, SEEK_SET) ==
-    CURL_SEEKFUNC_CANTSEEK);
-  REQUIRE(
-    ccf::curl::RequestBody::seek_data(&body, 1, SEEK_CUR) ==
-    CURL_SEEKFUNC_CANTSEEK);
-  REQUIRE(
-    ccf::curl::RequestBody::seek_data(
-      &body, -static_cast<curl_off_t>(expected.size()) - 1, SEEK_END) ==
-    CURL_SEEKFUNC_CANTSEEK);
+  REQUIRE_FALSE(body.seek(expected.size() + 1, SEEK_SET));
+  REQUIRE_FALSE(body.seek(1, SEEK_CUR));
+  REQUIRE_FALSE(
+    body.seek(-static_cast<curl_off_t>(expected.size()) - 1, SEEK_END));
 }
 
 TEST_CASE("ResponseHeaders rejects oversized headers")

--- a/src/http/test/curl_test.cpp
+++ b/src/http/test/curl_test.cpp
@@ -115,6 +115,7 @@ TEST_CASE("RequestBody supports replay")
       return static_cast<uint8_t>(lhs) == rhs;
     }));
 
+  REQUIRE_FALSE(body.seek(-1, SEEK_SET));
   REQUIRE_FALSE(body.seek(expected.size() + 1, SEEK_SET));
   REQUIRE_FALSE(body.seek(1, SEEK_CUR));
   REQUIRE_FALSE(

--- a/src/http/test/curl_test.cpp
+++ b/src/http/test/curl_test.cpp
@@ -10,6 +10,7 @@
 #include <curl/header.h>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <llhttp/llhttp.h>
 #include <memory>
 #include <nlohmann/json.hpp>
@@ -118,6 +119,7 @@ TEST_CASE("RequestBody supports replay")
   REQUIRE_FALSE(body.seek(1, SEEK_CUR));
   REQUIRE_FALSE(
     body.seek(-static_cast<curl_off_t>(expected.size()) - 1, SEEK_END));
+  REQUIRE_FALSE(body.seek(std::numeric_limits<curl_off_t>::max(), SEEK_CUR));
 }
 
 TEST_CASE("ResponseHeaders rejects oversized headers")

--- a/src/http/test/curl_test.cpp
+++ b/src/http/test/curl_test.cpp
@@ -106,7 +106,10 @@ TEST_CASE("RequestBody supports replay")
     }));
 
   REQUIRE(
-    ccf::curl::RequestBody::seek_data(&body, 1, SEEK_END) ==
+    ccf::curl::RequestBody::seek_data(&body, expected.size() + 1, SEEK_SET) ==
+    CURL_SEEKFUNC_CANTSEEK);
+  REQUIRE(
+    ccf::curl::RequestBody::seek_data(&body, 0, SEEK_CUR) ==
     CURL_SEEKFUNC_CANTSEEK);
 }
 

--- a/src/http/test/curl_test.cpp
+++ b/src/http/test/curl_test.cpp
@@ -128,6 +128,15 @@ TEST_CASE("RequestBody supports replay")
   REQUIRE_FALSE(body.seek(1, SEEK_CUR));
   REQUIRE_FALSE(
     body.seek(-static_cast<curl_off_t>(expected.size()) - 1, SEEK_END));
+
+  REQUIRE(
+    ccf::curl::RequestBody::seek_data(&body, 0, SEEK_SET) == CURL_SEEKFUNC_OK);
+  REQUIRE(
+    ccf::curl::RequestBody::seek_data(&body, expected.size() + 1, SEEK_SET) ==
+    CURL_SEEKFUNC_CANTSEEK);
+  REQUIRE(
+    ccf::curl::RequestBody::seek_data(nullptr, 0, SEEK_SET) ==
+    CURL_SEEKFUNC_FAIL);
 }
 
 TEST_CASE("RequestBody supports empty bodies")

--- a/src/http/test/curl_test.cpp
+++ b/src/http/test/curl_test.cpp
@@ -80,6 +80,36 @@ TEST_CASE("is_transient_transport_error classifies curl errors")
   }
 }
 
+TEST_CASE("RequestBody supports replay")
+{
+  const std::vector<uint8_t> expected = {1, 2, 3, 4};
+  auto data = expected;
+  ccf::curl::RequestBody body(data);
+
+  std::vector<char> partial(2);
+  REQUIRE(
+    ccf::curl::RequestBody::send_data(
+      partial.data(), 1, partial.size(), &body) == partial.size());
+  REQUIRE(static_cast<uint8_t>(partial[0]) == expected[0]);
+  REQUIRE(static_cast<uint8_t>(partial[1]) == expected[1]);
+
+  REQUIRE(
+    ccf::curl::RequestBody::seek_data(&body, 0, SEEK_SET) == CURL_SEEKFUNC_OK);
+
+  std::vector<char> replayed(expected.size());
+  REQUIRE(
+    ccf::curl::RequestBody::send_data(
+      replayed.data(), 1, replayed.size(), &body) == replayed.size());
+  REQUIRE(std::equal(
+    replayed.begin(), replayed.end(), expected.begin(), [](char lhs, auto rhs) {
+      return static_cast<uint8_t>(lhs) == rhs;
+    }));
+
+  REQUIRE(
+    ccf::curl::RequestBody::seek_data(&body, 1, SEEK_END) ==
+    CURL_SEEKFUNC_CANTSEEK);
+}
+
 TEST_CASE("ResponseHeaders rejects oversized headers")
 {
   ccf::curl::ResponseHeaders headers;
@@ -267,6 +297,54 @@ TEST_CASE("Synchronous POST echoes body")
 
   const auto parsed = nlohmann::json::parse(response_body);
   REQUIRE(parsed.at("metadata").at("method") == "POST");
+  REQUIRE(parsed.at("body") == sent_body);
+}
+
+TEST_CASE("Synchronous POST replays body after redirect")
+{
+  const std::string sent_body = R"({"message":"replay"})";
+  std::vector<uint8_t> body_bytes(sent_body.begin(), sent_body.end());
+  auto body = std::make_unique<ccf::curl::RequestBody>(std::move(body_bytes));
+
+  auto headers = ccf::curl::UniqueSlist();
+  headers.append("Content-Type", "application/json");
+
+  auto curl_handle = ccf::curl::UniqueCURL();
+  curl_handle.set_opt(CURLOPT_FOLLOWLOCATION, 1L);
+  std::string url = fmt::format("http://{}/redirect", server_address);
+
+  CURLcode curl_code = CURLE_FAILED_INIT;
+  long status_code = 0;
+  std::string response_body;
+
+  auto response = [&curl_code, &status_code, &response_body](
+                    std::unique_ptr<ccf::curl::CurlRequest>&& request,
+                    CURLcode curl_response,
+                    long status) {
+    curl_code = curl_response;
+    status_code = status;
+    auto* rb = request->get_response_body();
+    response_body = std::string(rb->buffer.begin(), rb->buffer.end());
+  };
+
+  auto request = std::make_unique<ccf::curl::CurlRequest>(
+    std::move(curl_handle),
+    HTTP_POST,
+    std::move(url),
+    std::move(headers),
+    std::move(body),
+    std::make_unique<ccf::curl::ResponseBody>(SIZE_MAX),
+    response);
+
+  ccf::curl::CurlRequest::synchronous_perform(std::move(request));
+
+  constexpr long HTTP_SUCCESS = 200;
+  REQUIRE(curl_code == CURLE_OK);
+  REQUIRE(status_code == HTTP_SUCCESS);
+
+  const auto parsed = nlohmann::json::parse(response_body);
+  REQUIRE(parsed.at("metadata").at("method") == "POST");
+  REQUIRE(parsed.at("metadata").at("path") == "/redirected");
   REQUIRE(parsed.at("body") == sent_body);
 }
 

--- a/tests/e2e_curl.py
+++ b/tests/e2e_curl.py
@@ -41,6 +41,10 @@ async def echo_handler(request):
     return web.json_response(response_data)
 
 
+async def redirect_handler(_request):
+    raise web.HTTPTemporaryRedirect("/redirected")
+
+
 def make_self_signed_cert(san_dns):
     key = ec.generate_private_key(ec.SECP256R1())
     name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, san_dns)])
@@ -70,6 +74,7 @@ def make_self_signed_cert(san_dns):
 
 async def main():
     app = web.Application()
+    app.router.add_route("*", "/redirect", redirect_handler)
     app.router.add_route("*", "/{path:.*}", echo_handler)
 
     runner = web.AppRunner(app)


### PR DESCRIPTION
## Summary

Make `ccf::curl::RequestBody` seekable so libcurl can replay POST and PUT request bodies when it needs to resend a transfer.

This registers `CURLOPT_SEEKFUNCTION` and `CURLOPT_SEEKDATA`, retains the existing `unsent` span, and rewinds it with a bounded subspan of the body buffer. Direct and end-to-end tests cover the replay path.

## Issue

This was first spotted in an intermittent [`AL4 VMSS Virtual B` CI failure](https://github.com/microsoft/CCF/actions/runs/29091622532/job/86358079856) while investigating #7977. That PR's original formatting failure was fixed, but the subsequent CI run exposed an unrelated failure in `nodes_test` during the reconfiguration suite.

`test_add_node_invalid_validity_period` intentionally creates a pending node and then submits a governance proposal with a certificate validity period above the configured maximum. Governance correctly rejects the proposal, leaving the node pending and periodically retrying `POST /node/join`.

During suite shutdown, that pending node attempted another join while its target was being stopped. Libcurl had consumed the POST body and then attempted to resend the transfer. The current `RequestBody` installs `CURLOPT_READFUNCTION`, but provides no seek callback and represents progress by destructively advancing an `unsent` span. It therefore cannot return to the start of the body.

Libcurl reported:

```text
Send failed since rewinding of the data stream failed (65)
```

This is `CURLE_SEND_FAIL_REWIND`. The join client treated it as a non-transient transport failure, sent a fatal error to the host, and aborted the pending node. The test itself had completed successfully, but shutdown then failed with:

```text
NetworkShutdownError('Fatal error found during node shutdown')
```

The failure is timing-dependent: only the AL4 Virtual B shard happened to exercise the resend while the target was shutting down. The underlying problem applies generally to any curl POST or PUT using `RequestBody` when libcurl needs to replay the upload, including connection retries, redirects that preserve the method, and authentication retries.

## Fix

- Keep the existing `unsent` span so request-body reads remain intrinsically bounded by the span.
- Encapsulate `SEEK_SET`, `SEEK_CUR`, and `SEEK_END` resolution in `RequestBody::seek()`. The origin switch only computes an absolute position (using overflow-checked additions for relative origins), `is_offset_in_bounds()` validates it once against the buffer, and the validated position rebuilds the `unsent` span. Keep `seek_data()` as a thin libcurl callback adapter.
- Reject unsupported origins and seeks outside `[0, body.size()]`.
- Register the callback with `CURLOPT_SEEKFUNCTION` and the `RequestBody` instance with `CURLOPT_SEEKDATA`.
- Avoid dereferencing the body buffer for zero-length reads.

## Tests

- Added a focused unit test that partially consumes a body, rewinds it, and verifies the exact bytes can be read again. It also checks rejection of an out-of-range seek.
- Added a 307 redirect endpoint to `e2e_curl.py` and an integration test that follows the redirect with a POST. HTTP 307 requires preserving the method and body, forcing libcurl to invoke the seek callback and resend the complete payload.

Validation performed:

```text
curl_test: 14/14 test cases passed, 329/329 assertions passed
C++ formatting: passed
Python formatting: passed
Python lint: passed
git diff --check: passed
```