### PR TITLE
Check IAT claims in didx509

### DIFF
--- a/doc/operations/code_upgrade.rst
+++ b/doc/operations/code_upgrade.rst
@@ -200,7 +200,7 @@ Instead of explicitly trusting host data values, members can set a **code update
 
     CCF currently only supports **self-issued** transparent statements: the service itself acts as the transparency service, issuing receipts over signed statements registered on its own ledger.
 
-The policy receives an array of transparent statements and must return ``true`` to accept or a string describing the rejection reason. Any other return value is treated as an error. Structural validation (non-empty fields, receipt signature verification, claims digest binding) is performed by CCF before the policy runs; the policy only needs to compare values.
+The policy receives an array of transparent statements and must return ``true`` to accept or a string describing the rejection reason. Any other return value is treated as an error. Structural validation (non-empty fields, statement and receipt signature verification, statement ``iat`` validation against the ``x5chain`` certificate validity period when present, and claims digest binding) is performed by CCF before the policy runs; the policy only needs to compare values.
 
 Policy Input Schema
 ~~~~~~~~~~~~~~~~~~~

--- a/include/ccf/crypto/openssl/openssl_wrappers.h
+++ b/include/ccf/crypto/openssl/openssl_wrappers.h
@@ -8,6 +8,7 @@
 
 #include "ccf/ds/x509_time_fmt.h"
 
+#include <algorithm>
 #include <chrono>
 #include <fmt/format.h>
 #include <memory>
@@ -21,6 +22,7 @@
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
+#include <optional>
 
 namespace ccf::crypto::OpenSSL
 {
@@ -271,6 +273,64 @@ namespace ccf::crypto::OpenSSL
       Unique_SSL_OBJECT(cert, X509_free, check_null)
     {}
   };
+
+  struct X509ValidityPeriod
+  {
+    ccf::nonstd::SystemClock::time_point not_before;
+    ccf::nonstd::SystemClock::time_point not_after;
+  };
+
+  /**
+   * Extract the inclusive validity period common to every certificate in a
+   * DER-encoded chain.
+   *
+   * @return The common validity period, or std::nullopt if the chain is empty
+   * or its certificate validity periods do not overlap.
+   */
+  inline std::optional<X509ValidityPeriod>
+  get_x509_chain_common_validity_period(
+    const std::vector<std::vector<uint8_t>>& certificate_chain)
+  {
+    std::optional<X509ValidityPeriod> common_validity_period;
+
+    for (const auto& certificate : certificate_chain)
+    {
+      Unique_BIO certificate_bio(certificate);
+      Unique_X509 x509(certificate_bio, false, true);
+
+      std::tm not_before{};
+      std::tm not_after{};
+      CHECK1(ASN1_TIME_to_tm(X509_get0_notBefore(x509), &not_before));
+      CHECK1(ASN1_TIME_to_tm(X509_get0_notAfter(x509), &not_after));
+
+      const X509ValidityPeriod certificate_validity_period{
+        ccf::nonstd::SystemClock::from_time_t(timegm(&not_before)),
+        ccf::nonstd::SystemClock::from_time_t(timegm(&not_after))};
+
+      if (!common_validity_period.has_value())
+      {
+        common_validity_period = certificate_validity_period;
+      }
+      else
+      {
+        common_validity_period->not_before = std::max(
+          common_validity_period->not_before,
+          certificate_validity_period.not_before);
+        common_validity_period->not_after = std::min(
+          common_validity_period->not_after,
+          certificate_validity_period.not_after);
+      }
+    }
+
+    if (
+      common_validity_period.has_value() &&
+      common_validity_period->not_before > common_validity_period->not_after)
+    {
+      return std::nullopt;
+    }
+
+    return common_validity_period;
+  }
 
   struct Unique_X509_STORE
     : public Unique_SSL_OBJECT<X509_STORE, X509_STORE_new, X509_STORE_free>

--- a/src/crypto/cbor.h
+++ b/src/crypto/cbor.h
@@ -18,6 +18,9 @@ namespace ccf::cbor
 {
   namespace tag
   {
+    // https://www.rfc-editor.org/rfc/rfc8949.html#section-3.4.2
+    static constexpr int64_t EPOCH_DATE_TIME = 1;
+
     // https://www.rfc-editor.org/rfc/rfc8152.html#section-2
     static constexpr int64_t COSE_SIGN_1 = 18;
   }

--- a/src/crypto/test/crypto.cpp
+++ b/src/crypto/test/crypto.cpp
@@ -976,6 +976,50 @@ TEST_CASE("x509 time")
   }
 }
 
+TEST_CASE("X509 chain common validity period")
+{
+  const auto make_certificate =
+    [](const std::string& not_before, const std::string& not_after) {
+      auto key_pair =
+        ccf::crypto::make_ec_key_pair(ccf::crypto::CurveID::SECP384R1);
+      return ccf::crypto::cert_pem_to_der(
+        key_pair->self_sign("CN=test", not_before, not_after));
+    };
+
+  const auto first = make_certificate("20240101000000Z", "20241231235959Z");
+  const auto second = make_certificate("20240601000000Z", "20250601235959Z");
+
+  const auto common_validity_period =
+    ccf::crypto::OpenSSL::get_x509_chain_common_validity_period(
+      {first, second});
+  REQUIRE(common_validity_period.has_value());
+  REQUIRE(
+    ccf::ds::to_x509_time_string(common_validity_period->not_before) ==
+    "20240601000000Z");
+  REQUIRE(
+    ccf::ds::to_x509_time_string(common_validity_period->not_after) ==
+    "20241231235959Z");
+
+  const auto touching = make_certificate("20241231235959Z", "20260101000000Z");
+  const auto touching_common_validity_period =
+    ccf::crypto::OpenSSL::get_x509_chain_common_validity_period(
+      {first, touching});
+  REQUIRE(touching_common_validity_period.has_value());
+  REQUIRE(
+    touching_common_validity_period->not_before ==
+    touching_common_validity_period->not_after);
+  REQUIRE(
+    ccf::ds::to_x509_time_string(touching_common_validity_period->not_before) ==
+    "20241231235959Z");
+
+  const auto disjoint = make_certificate("20250101000000Z", "20260101000000Z");
+  REQUIRE_FALSE(ccf::crypto::OpenSSL::get_x509_chain_common_validity_period(
+                  {first, disjoint})
+                  .has_value());
+  REQUIRE_FALSE(ccf::crypto::OpenSSL::get_x509_chain_common_validity_period({})
+                  .has_value());
+}
+
 TEST_CASE("hmac")
 {
   std::vector<uint8_t> key(32, 0);

--- a/src/node/cose_common.h
+++ b/src/node/cose_common.h
@@ -127,7 +127,10 @@ namespace ccf::cose
     }
     catch (const CBORDecodeError& err)
     {
-      std::ignore = err; // optional field
+      if (err.error_code() != Error::KEY_NOT_FOUND)
+      {
+        throw;
+      }
     }
   }
 

--- a/src/node/cose_common.h
+++ b/src/node/cose_common.h
@@ -3,15 +3,19 @@
 
 #pragma once
 
+#include "ccf/crypto/openssl/openssl_wrappers.h"
 #include "ccf/ds/hex.h"
+#include "ccf/ds/x509_time_fmt.h"
 #include "ccf/receipt.h"
 
+#include <chrono>
 #include <crypto/cbor.h>
 #include <crypto/cose.h>
 #include <crypto/cose_utils.h>
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <variant>
 
 namespace ccf::cose
@@ -79,8 +83,20 @@ namespace ccf::cose
 
     try
     {
-      claims.iat = cwt_claims->map_at(make_signed(ccf::cwt::header::iana::IAT))
-                     ->as_signed();
+      const auto& iat =
+        cwt_claims->map_at(make_signed(ccf::cwt::header::iana::IAT));
+      try
+      {
+        claims.iat = iat->as_signed();
+      }
+      catch (const CBORDecodeError&)
+      {
+        // CWT NumericDate values MUST omit CBOR tags:
+        // https://www.rfc-editor.org/rfc/rfc8392.html#section-5
+        // This non-conforming fallback accepts CBOR tag 1 for UVM
+        // endorsement compatibility.
+        claims.iat = iat->tag_at(ccf::cbor::tag::EPOCH_DATE_TIME)->as_signed();
+      }
     }
     catch (const CBORDecodeError& err)
     {
@@ -112,6 +128,45 @@ namespace ccf::cose
     catch (const CBORDecodeError& err)
     {
       std::ignore = err; // optional field
+    }
+  }
+
+  static void validate_cwt_iat_against_x5chain(
+    const CwtClaims& claims,
+    const std::vector<std::vector<uint8_t>>& x5chain,
+    std::string_view context)
+  {
+    if (!claims.iat.has_value())
+    {
+      return;
+    }
+
+    if (x5chain.empty())
+    {
+      throw COSEDecodeError(
+        fmt::format("No certificates in {} x5chain", context));
+    }
+
+    const auto common_validity_period =
+      ccf::crypto::OpenSSL::get_x509_chain_common_validity_period(x5chain);
+    if (!common_validity_period.has_value())
+    {
+      throw COSEDecodeError(fmt::format(
+        "Certificates in {} x5chain have no common validity period", context));
+    }
+
+    const auto iat = ccf::nonstd::SystemClock::time_point{
+      std::chrono::seconds{claims.iat.value()}};
+    if (
+      iat < common_validity_period->not_before ||
+      iat > common_validity_period->not_after)
+    {
+      throw COSEDecodeError(fmt::format(
+        "CWT iat {} in {} is outside x5chain common validity period [{}, {}]",
+        claims.iat.value(),
+        context,
+        ccf::ds::to_x509_time_string(common_validity_period->not_before),
+        ccf::ds::to_x509_time_string(common_validity_period->not_after)));
     }
   }
 

--- a/src/node/quote.cpp
+++ b/src/node/quote.cpp
@@ -367,6 +367,9 @@ namespace ccf
         throw std::logic_error("No CWT issuer in transparent statement");
       }
 
+      cose::validate_cwt_iat_against_x5chain(
+        h.cwt, h.x5chain, "code transparent statement");
+
       auto pubk = resolve_pubkey_from_x5chain_and_issuer(h.x5chain, h.cwt.iss);
       auto verifier = ccf::crypto::make_cose_verifier_from_key(pubk);
 

--- a/src/node/test/endorsements.cpp
+++ b/src/node/test/endorsements.cpp
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 License.
 
 #include "ccf/pal/measurement.h"
+#include "crypto/cbor.h"
 #include "crypto/openssl/hash.h"
 #include "ds/files.h"
 #include "node/uvm_endorsements.h"
@@ -177,6 +178,30 @@ TEST_CASE("Check Test endorsement for UVM 0.2.10")
   REQUIRE(endorsements.did == ccf::default_uvm_roots_of_trust[0].did);
   REQUIRE(endorsements.feed == ccf::default_uvm_roots_of_trust[0].feed);
   REQUIRE(endorsements.svn == "104");
+
+  auto parsed = ccf::cbor::parse(endorsement);
+  const auto& cose_sign1 = parsed->tag_at(ccf::cbor::tag::COSE_SIGN_1);
+  const auto& protected_header_raw = cose_sign1->array_at(0);
+  auto protected_header = ccf::cbor::parse(protected_header_raw->as_bytes());
+  const auto& cwt_claims = protected_header->map_at(
+    ccf::cbor::make_signed(ccf::cose::header::iana::CWT_CLAIMS));
+  const auto& iat =
+    cwt_claims->map_at(ccf::cbor::make_signed(ccf::cwt::header::iana::IAT));
+  iat->value = ccf::cbor::Tagged{
+    ccf::cbor::tag::EPOCH_DATE_TIME, ccf::cbor::make_signed(0)};
+
+  auto protected_header_bytes = ccf::cbor::serialize(protected_header);
+  protected_header_raw->value = ccf::cbor::Bytes{protected_header_bytes};
+  auto invalid_iat_endorsement = ccf::cbor::serialize(parsed);
+
+  REQUIRE_THROWS_WITH_AS(
+    ccf::verify_uvm_endorsements_against_roots_of_trust(
+      invalid_iat_endorsement,
+      uvm_measurement,
+      ccf::default_uvm_roots_of_trust),
+    "CWT iat 0 in UVM endorsements is outside x5chain common validity period "
+    "[20250515185703Z, 20260515185703Z]",
+    ccf::cose::COSEDecodeError);
 }
 
 TEST_CASE("Check UVM roots of trust matching")

--- a/src/node/uvm_endorsements.cpp
+++ b/src/node/uvm_endorsements.cpp
@@ -168,48 +168,21 @@ namespace ccf
             "Parse x5chain ({}) in protected header in UVM endorsements",
             header::iana::X5CHAIN));
 
-        const ccf::cbor::Value& cwt_claims = ccf::cbor::rethrow_with_msg(
-          [&]() -> const ccf::cbor::Value& {
-            return parsed_phdr->map_at(
-              ccf::cbor::make_signed(ccf::cose::header::iana::CWT_CLAIMS));
-          },
-          fmt::format(
-            "Parse CWT claims ({}) in protected header in UVM endorsements",
-            ccf::cose::header::iana::CWT_CLAIMS));
+        CwtClaims cwt_claims;
+        decode_cwt_claims(parsed_phdr, cwt_claims);
+        result.iss = cwt_claims.iss;
+        result.feed = cwt_claims.sub;
 
-        result.iss = ccf::cbor::rethrow_with_msg(
-          [&]() {
-            return std::string(
-              cwt_claims
-                ->map_at(ccf::cbor::make_signed(ccf::cwt::header::iana::ISS))
-                ->as_string());
-          },
-          fmt::format(
-            "Parse iss ({}) in CWT claims in UVM endorsements",
-            ccf::cwt::header::iana::ISS));
+        if (!cwt_claims.svn.has_value())
+        {
+          throw ccf::cbor::CBORDecodeError(
+            ccf::cbor::Error::KEY_NOT_FOUND, "No CWT svn in UVM endorsements");
+        }
 
-        result.feed = ccf::cbor::rethrow_with_msg(
-          [&]() {
-            return std::string(
-              cwt_claims
-                ->map_at(ccf::cbor::make_signed(ccf::cwt::header::iana::SUB))
-                ->as_string());
-          },
-          fmt::format(
-            "Parse sub ({}) in CWT claims in UVM endorsements",
-            ccf::cwt::header::iana::SUB));
+        validate_cwt_iat_against_x5chain(
+          cwt_claims, result.x5_chain, "UVM endorsements");
 
-        uint64_t svn = ccf::cbor::rethrow_with_msg(
-          [&]() {
-            return cwt_claims
-              ->map_at(ccf::cbor::make_string(ccf::cwt::header::custom::SVN))
-              ->as_signed();
-          },
-          fmt::format(
-            "Parse svn ({}) in CWT claims in UVM endorsements",
-            ccf::cwt::header::custom::SVN));
-
-        return {result, std::to_string(svn)};
+        return {result, std::to_string(cwt_claims.svn.value())};
       }
 
       std::span<const uint8_t> verify_uvm_endorsements_signature(

--- a/tests/code_update.py
+++ b/tests/code_update.py
@@ -668,6 +668,32 @@ def test_add_node_via_code_policy(network, args):
         payload=bytes.fromhex(host_data), sub="Some feed", svn=500, eku="2.999"
     )
     transparent_statement = register_signed_statement(primary, signed_statement)
+
+    # --- Statement IAT is outside the signing certificate validity period ---
+    invalid_iat_statement, invalid_iat_issuer = create_signed_statement(
+        payload=bytes.fromhex(host_data),
+        sub="Some feed",
+        svn=500,
+        eku="2.999",
+        iat=1,
+    )
+    invalid_iat_transparent_statement = register_signed_statement(
+        primary, invalid_iat_statement
+    )
+    invalid_iat_joiner_args = prepare_joiner_with_statement(
+        args, network, invalid_iat_transparent_statement
+    )
+    network.consortium.set_node_join_policy(
+        primary,
+        make_node_join_policy(
+            invalid_iat_issuer,
+            min_svn=500,
+            receipt_issuer=receipt_issuer,
+            receipt_subject=receipt_subject,
+        ),
+    )
+    assert_node_join_fails(network, invalid_iat_joiner_args)
+
     joiner_args = prepare_joiner_with_statement(args, network, transparent_statement)
 
     # --- Policy 1: SVN too low (requires >= 501, statement has 500) ---

--- a/tests/infra/crypto.py
+++ b/tests/infra/crypto.py
@@ -397,7 +397,12 @@ def datetime_to_X509time(datetime: datetime):
 
 
 def create_signed_statement(
-    payload: bytes, sub: str, svn: int, eku: str, ca_identity=None
+    payload: bytes,
+    sub: str,
+    svn: int,
+    eku: str,
+    ca_identity=None,
+    iat: int | None = None,
 ) -> tuple:
     """
     Create a COSE_Sign1 signed statement with x5chain and CWT claims.
@@ -513,11 +518,15 @@ def create_signed_statement(
 
     # Build COSE_Sign1 protected headers
 
+    cwt_claims = {1: issuer, 2: sub, "svn": svn}
+    if iat is not None:
+        cwt_claims[6] = iat
+
     phdr = {
         1: -7,  # alg: ES256
         3: "application/octet-stream",  # content_type
         33: [leaf_der, ca_der],  # x5chain
-        15: {1: issuer, 2: sub, "svn": svn},  # CWT claims
+        15: cwt_claims,
     }
 
     leaf_key_pem = leaf_key.private_bytes(


### PR DESCRIPTION
Use IAT claim for didx509 checking at the moment of issuing, as in the common validity overlapping period of the chain has to match the signing time.

Up to discussions for changing only to **leaf** validity.

Also pushed to the `microsoft/CCF` remote, so feel free to close on this when I'm away.