### PR TITLE
Limit logging historical range pages to 500 seqnos

### DIFF
--- a/samples/apps/logging/js/src/logging.js
+++ b/samples/apps/logging/js/src/logging.js
@@ -212,9 +212,11 @@ function get_historical_range_impl(request, isPrivate, nextLinkPrefix) {
     };
   }
 
-  const max_seqno_per_page = 2000;
+  // Historical range setup is synchronous, so keep pages small enough to
+  // avoid delaying consensus processing.
+  const max_seqnos_per_page = 500;
   const range_begin = from_seqno;
-  const range_end = Math.min(to_seqno, range_begin + max_seqno_per_page);
+  const range_end = Math.min(to_seqno, range_begin + max_seqnos_per_page - 1);
 
   // Compute a deterministic handle for the range request.
   // Note: Instead of ccf.digest, an equivalent of std::hash should be used.
@@ -272,7 +274,7 @@ function get_historical_range_impl(request, isPrivate, nextLinkPrefix) {
     const next_page_start = range_end + 1;
     const next_page_end = Math.min(
       to_seqno,
-      next_page_start + max_seqno_per_page,
+      next_page_start + max_seqnos_per_page - 1,
     );
     const next_page_handle = makeHandle(
       next_page_start,
@@ -283,6 +285,7 @@ function get_historical_range_impl(request, isPrivate, nextLinkPrefix) {
       next_page_handle,
       next_page_start,
       next_page_end,
+      expiry_seconds,
     );
 
     // NB: This path tells the caller to continue to ask until the end of


### PR DESCRIPTION
## Summary

- Reduce the logging sample's historical range page size from 2,000 to exactly 500 sequence numbers.
- Correct the inclusive page boundary calculation.
- Pass the expiry duration when prefetching the next page.

## Rationale

The [`Long e2e - Debug` job](https://github.com/microsoft/CCF/actions/runs/29363027457/job/87187643662?pr=8002) failed in `e2e_logging` after historical JavaScript range requests took 4,298-4,376 ms, exceeding the 4,000 ms Raft election timeout. The delayed consensus processing caused repeated elections and eventually a `SessionConsistencyLost` response.

A request covering 967 sequence numbers took 3,251 ms in the same run, so a 1,000-entry page would leave little headroom. Limiting pages to 500 bounds the synchronous historical-range setup while preserving complete results through `@nextLink` pagination.

## Validation

- Ran the Debug `e2e_logging` test with the updated bundle.
- Confirmed pagination at sequence numbers 1-500 and 501-1000.
- The longest historical range request in the validated JavaScript run was 864 ms.
- Ran Prettier, copyright, and ASCII checks.
