### PR TITLE
Avoid shared CDDL file in recovery tests

### DIFF
--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -81,7 +81,7 @@ def query_endorsements_chain(node, txid):
     return response
 
 
-def verify_endorsements_chain(primary, endorsements, pubkey):
+def verify_endorsements_chain(primary, endorsements, pubkey, *, temp_dir):
     for endorsement in endorsements:
         phdr, _, payload = verify_cose_sign1_with_key(pubkey, endorsement)
 
@@ -98,18 +98,23 @@ def verify_endorsements_chain(primary, endorsements, pubkey):
         last_five_minutes = 5 * 60
         assert time.time() - phdr[CWT_KEY][IAT_CWT_LABEL] < last_five_minutes, phdr
 
-        endorsement_filename = "prev_service_identity_endorsement.cose"
-        with open(endorsement_filename, "wb") as f:
-            f.write(endorsement)
-        subprocess.run(
-            [
-                "cddl",
-                "../cddl/ccf-cose-endorsement-service-identity.cddl",
-                "v",
-                endorsement_filename,
-            ],
-            check=True,
-        )
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=temp_dir,
+            prefix="prev_service_identity_endorsement_",
+            suffix=".cose",
+        ) as endorsement_file:
+            endorsement_file.write(endorsement)
+            endorsement_file.flush()
+            subprocess.run(
+                [
+                    "cddl",
+                    "../cddl/ccf-cose-endorsement-service-identity.cddl",
+                    "v",
+                    endorsement_file.name,
+                ],
+                check=True,
+            )
 
         next_key_bytes = payload
         pubkey = infra.crypto.pub_key_der_to_pem(next_key_bytes).encode("ascii")
@@ -863,6 +868,7 @@ def test_recover_service_with_wrong_identity(network, args):
                     serialization.Encoding.PEM,
                     serialization.PublicFormat.SubjectPublicKeyInfo,
                 ),
+                temp_dir=recovered_network.common_dir,
             )
 
         for tx in txids[1:4]:
@@ -879,6 +885,7 @@ def test_recover_service_with_wrong_identity(network, args):
                     serialization.Encoding.PEM,
                     serialization.PublicFormat.SubjectPublicKeyInfo,
                 ),
+                temp_dir=recovered_network.common_dir,
             )
 
         for tx in txids[4:]:


### PR DESCRIPTION
## Summary

- write service-identity endorsement validation inputs into each recovery test's workspace-local common directory
- use unique temporary filenames so concurrent `recovery` and `recovery_ipv6` threads cannot overwrite the same file
- clean temporary files automatically after CDDL validation

## Failure evidence

- Workflow run: https://github.com/microsoft/CCF/actions/runs/29419566411
- Failing job: https://github.com/microsoft/CCF/actions/runs/29419566411/job/87366249402?pr=8066
- Both concurrent recovery variants failed at the same timestamp with `extra bytes follow after a deserialized object`, while using the same `prev_service_identity_endorsement.cose` path.

## Testing

- `CR_FILTER="recovery|recovery_ipv6" ./tests.sh --timeout 360 --output-on-failure -R "^recovery_test$"`
- Python formatting, linting, typing, copyright, ASCII, and diff checks
