### PR TITLE
Post benchmark summary links on pull requests

### DIFF
--- a/.github/workflows/bencher-ab.yml
+++ b/.github/workflows/bencher-ab.yml
@@ -83,3 +83,37 @@ jobs:
           python3 scripts/perf_compare_radar.py main_perf build/bencher.json \
             --branch-label "#${{ github.event.pull_request.number }}" \
             >> "$GITHUB_STEP_SUMMARY"
+
+  post_summary_link:
+    name: Post performance summary link
+    needs: benchmark_pr
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Create or update PR comment
+        shell: bash
+        run: |
+          set -euo pipefail
+          marker="<!-- benchmark-ab-summary -->"
+          summary_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          body=$(printf '%s\n\n## Benchmark A/B results\n\n[View the performance summary for run #%s, attempt %s](%s)\n' \
+            "$marker" "$GITHUB_RUN_NUMBER" "$GITHUB_RUN_ATTEMPT" "$summary_url")
+          comment_ids=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${marker}\"))) | .id")
+          comment_id=${comment_ids%%$'\n'*}
+
+          if [[ -n "$comment_id" ]]; then
+            gh api --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
+              -f body="$body" > /dev/null
+          else
+            gh api --method POST \
+              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -f body="$body" > /dev/null
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/bencher-ab.yml
+++ b/.github/workflows/bencher-ab.yml
@@ -79,27 +79,41 @@ jobs:
 
       - name: Summarise A/B comparison against main
         run: |
-          set -ex
+          set -exo pipefail
           python3 scripts/perf_compare_radar.py main_perf build/bencher.json \
             --branch-label "#${{ github.event.pull_request.number }}" \
-            >> "$GITHUB_STEP_SUMMARY"
+            | tee benchmark-ab-summary.md >> "$GITHUB_STEP_SUMMARY"
 
-  post_summary_link:
-    name: Post performance summary link
+      - name: Upload A/B comparison summary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: benchmark-ab-summary
+          path: benchmark-ab-summary.md
+          if-no-files-found: error
+          retention-days: 1
+
+  post_summary:
+    name: Post performance summary
     needs: benchmark_pr
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
+      - name: Download A/B comparison summary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: benchmark-ab-summary
+
       - name: Create or update PR comment
         shell: bash
         run: |
           set -euo pipefail
           marker="<!-- benchmark-ab-summary -->"
-          summary_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          body=$(printf '%s\n\n## Benchmark A/B results\n\n[View the performance summary for run #%s, attempt %s](%s)\n' \
-            "$marker" "$GITHUB_RUN_NUMBER" "$GITHUB_RUN_ATTEMPT" "$summary_url")
+          {
+            printf '%s\n\n' "$marker"
+            cat benchmark-ab-summary.md
+          } > benchmark-ab-comment.md
           comment_ids=$(gh api --paginate \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
             --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${marker}\"))) | .id")
@@ -108,11 +122,11 @@ jobs:
           if [[ -n "$comment_id" ]]; then
             gh api --method PATCH \
               "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
-              -f body="$body" > /dev/null
+              -F body=@benchmark-ab-comment.md > /dev/null
           else
             gh api --method POST \
               "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-              -f body="$body" > /dev/null
+              -F body=@benchmark-ab-comment.md > /dev/null
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/perf_compare_radar.py
+++ b/scripts/perf_compare_radar.py
@@ -420,7 +420,8 @@ def render_comparison(
 ) -> str:
     """Render all metric groups comparing the branch run with the main trend."""
     lines = [
-        "# Benchmark A/B",
+        "<details>",
+        "<summary>Description</summary>",
         "",
         (
             f"_Comparing this branch ({branch_label}) against the trend of the "
@@ -443,6 +444,8 @@ def render_comparison(
             "(within noise). "
             "Higher is better for throughput and rate, lower for latency and memory._"
         ),
+        "",
+        "</details>",
         "",
     ]
     if not trend:

--- a/scripts/perf_compare_radar.py
+++ b/scripts/perf_compare_radar.py
@@ -49,7 +49,7 @@ RADAR_CONFIG = {
     "height": 620,
     "marginTop": 90,
     "marginRight": 220,
-    "marginBottom": 120,
+    "marginBottom": 60,
     "marginLeft": 220,
     "axisLabelFactor": 1.12,
     "curveTension": 0.08,


### PR DESCRIPTION
## Summary

- publish the full Benchmark A/B performance summary directly in the pull request
- update a single marked `github-actions[bot]` comment in place on subsequent runs
- transfer the generated Markdown between isolated jobs through a short-lived artifact
- keep benchmark execution read-only and grant `pull-requests: write` only to the comment job
- skip comment publication for fork pull requests

## Testing

- exercised shell syntax and both comment creation and update paths with a mocked `gh api`
- verified the live workflow can create its marked PR comment with the scoped token
- checked the workflow diff for whitespace and non-ASCII content