### PR TITLE
Harden Loguru markup handling in test clients

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1020,6 +1020,18 @@ if(BUILD_TESTS)
     set_property(TEST csr_test APPEND PROPERTY LABELS unit_test)
 
     add_test(
+      NAME client_logging_test
+      COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/tests/infra/client_logging_test.py
+    )
+    set_property(TEST client_logging_test APPEND PROPERTY LABELS unit)
+    set_property(
+      TEST client_logging_test
+      APPEND
+      PROPERTY
+        ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}/tests:$ENV{PYTHONPATH}"
+    )
+
+    add_test(
       NAME versionifier_test
       COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/python/src/ccf/_versionifier.py
     )

--- a/tests/infra/client_logging_test.py
+++ b/tests/infra/client_logging_test.py
@@ -1,0 +1,127 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+import io
+import unittest
+
+import httpx
+from loguru import logger as LOG
+
+from infra.clients import (
+    CCFClient,
+    Request,
+    RequestsResponseBody,
+    Response,
+    escape_loguru_tags,
+)
+from infra.log_capture import flush_info
+
+
+class StubClient:
+    def __init__(self, response):
+        self.response = response
+
+    def request(self, request, timeout, cose_header_parameters_override):
+        return self.response
+
+
+class ClientLoggingTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        LOG.remove()
+
+    def capture(self, callback):
+        output = io.StringIO()
+        handler_id = LOG.add(output, format="{message}", colorize=False)
+        try:
+            callback()
+        finally:
+            LOG.remove(handler_id)
+        return output.getvalue().rstrip("\n")
+
+    def render(self, message):
+        return self.capture(lambda: flush_info([message]))
+
+    @staticmethod
+    def response(status_code=200, body="body", headers=None):
+        headers = headers or {}
+        httpx_response = httpx.Response(status_code, headers=headers, text=body)
+        return Response(
+            status_code=status_code,
+            body=RequestsResponseBody(httpx_response),
+            seqno=None,
+            view=None,
+            headers=headers,
+        )
+
+    def test_escapes_loguru_tags_after_backslashes(self):
+        for backslash_count in range(5):
+            with self.subTest(backslash_count=backslash_count):
+                message = ("\\" * backslash_count) + "<invalid>"
+                self.assertEqual(self.render(escape_loguru_tags(message)), message)
+
+    def test_escapes_dynamic_request_text(self):
+        headers = {"x": r"\<invalid>"}
+        cases = (
+            (Request(r"/\<invalid>", None, "GET", {}), r"GET /\<invalid>"),
+            (
+                Request("/endpoint", None, "GET", headers),
+                f"GET /endpoint {headers}",
+            ),
+            (
+                Request("/endpoint", r"\<invalid>", "POST", {}),
+                r"POST /endpoint \<invalid>",
+            ),
+        )
+
+        for request, expected in cases:
+            with self.subTest(request=request):
+                self.assertEqual(self.render(str(request)), expected)
+
+        for backslash_count in range(5):
+            with self.subTest(backslash_count=backslash_count):
+                path = "/trailing" + ("\\" * backslash_count)
+                self.assertEqual(
+                    self.render(str(Request(path, None, "GET", {}))),
+                    f"GET {path}",
+                )
+
+    def test_escapes_dynamic_response_text(self):
+        self.assertEqual(
+            self.render(str(self.response(body=r"\<invalid>"))),
+            r"200 \<invalid>",
+        )
+
+        for backslash_count in range(5):
+            body = "trailing" + ("\\" * backslash_count)
+            with self.subTest(body=body):
+                self.assertEqual(
+                    self.render(str(self.response(body=body))), f"200 {body}"
+                )
+
+        location = r"/\<invalid>"
+        response = self.response(
+            status_code=307,
+            headers={"location": location},
+        )
+        self.assertEqual(
+            self.render(str(response)),
+            f"307 [Redirect to -> {location}] body",
+        )
+
+    def test_escapes_client_description(self):
+        response = self.response()
+        client = CCFClient.__new__(CCFClient)
+        client.description = r"client \<invalid>"
+        client.client_impl = StubClient(response)
+
+        rendered = self.capture(lambda: client._call("/endpoint", http_verb="GET"))
+
+        self.assertEqual(
+            rendered,
+            "client \\<invalid> GET /endpoint\n200 body",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/infra/client_logging_test.py
+++ b/tests/infra/client_logging_test.py
@@ -112,15 +112,19 @@ class ClientLoggingTest(unittest.TestCase):
     def test_escapes_client_description(self):
         response = self.response()
         client = CCFClient.__new__(CCFClient)
-        client.description = r"client \<invalid>"
         client.client_impl = StubClient(response)
 
-        rendered = self.capture(lambda: client._call("/endpoint", http_verb="GET"))
+        for description in (r"client \<invalid>", "client\\", 42):
+            with self.subTest(description=description):
+                client.description = description
+                rendered = self.capture(
+                    lambda: client._call("/endpoint", http_verb="GET")
+                )
 
-        self.assertEqual(
-            rendered,
-            "client \\<invalid> GET /endpoint\n200 body",
-        )
+                self.assertEqual(
+                    rendered,
+                    f"{description} GET /endpoint\n200 body",
+                )
 
 
 if __name__ == "__main__":

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -1111,7 +1111,7 @@ class CCFClient:
             headers = {}
 
         r = Request(path, body, http_verb, headers)
-        flush_info([f"{escape_loguru_tags(self.description)} {r}"], log_capture, 3)
+        flush_info([f"{escape_loguru_tags(str(self.description))} {r}"], log_capture, 3)
 
         response = self.client_impl.request(r, timeout, cose_header_parameters_override)
         flush_info([str(response)], log_capture, 3)

--- a/tests/infra/clients.py
+++ b/tests/infra/clients.py
@@ -119,11 +119,21 @@ class HttpSig(httpx.Auth):
         yield request
 
 
-loguru_tag_regex = re.compile(r"\\?</?((?:[fb]g\s)?[^<>\s]*)>")
+loguru_tag_regex = re.compile(r"(\\*)(</?(?:[fb]g\s)?[^<>\s]*>)")
 
 
 def escape_loguru_tags(s):
-    return loguru_tag_regex.sub(lambda match: f"\\{match[0]}", s)
+    # Loguru consumes pairs of backslashes and escapes markup after an odd count.
+    return loguru_tag_regex.sub(
+        lambda match: f"{match.group(1) * 2}\\{match.group(2)}", s
+    )
+
+
+def _escape_loguru_markup_text(s):
+    escaped = escape_loguru_tags(s)
+    # Generated closing tags must follow an even number of backslashes.
+    trailing_backslashes = len(escaped) - len(escaped.rstrip("\\"))
+    return escaped + ("\\" * trailing_backslashes)
 
 
 def truncate(string: str, max_len: int = 256):
@@ -156,9 +166,14 @@ class Request:
     headers: dict
 
     def __str__(self):
-        string = f"<cyan>{self.http_verb}</> <green>{self.path}</>"
+        http_verb = _escape_loguru_markup_text(self.http_verb)
+        path = _escape_loguru_markup_text(self.path)
+        string = f"<cyan>{http_verb}</> <green>{path}</>"
         if self.headers:
-            string += f" <blue>{truncate(str(self.headers), max_len=25)}</>"
+            headers = _escape_loguru_markup_text(
+                truncate(str(self.headers), max_len=25)
+            )
+            string += f" <blue>{headers}</>"
         if self.body is not None:
             if (
                 "content-type" in self.headers
@@ -278,16 +293,14 @@ class Response:
         ):
             body_s = f"<binary: {len(self.body)} bytes>"
         else:
-            body_s = escape_loguru_tags(truncate(str(self.body)))
-
-        # Body can't end with a \, or it will escape the loguru closing tag
-        if len(body_s) > 0 and body_s[-1] == "\\":
-            body_s += " "
+            body_s = truncate(str(self.body))
+        body_s = _escape_loguru_markup_text(body_s)
 
         return (
             f"<{status_color}>{self.status_code}</> "
             + (
-                f"<yellow>[Redirect to -> {self.headers.get('location')}]</> "
+                "<yellow>[Redirect to -> "
+                f"{_escape_loguru_markup_text(str(self.headers.get('location')))}]</> "
                 if redirect
                 else ""
             )
@@ -1098,7 +1111,7 @@ class CCFClient:
             headers = {}
 
         r = Request(path, body, http_verb, headers)
-        flush_info([f"{self.description} {r}"], log_capture, 3)
+        flush_info([f"{escape_loguru_tags(self.description)} {r}"], log_capture, 3)
 
         response = self.client_impl.request(r, timeout, cose_header_parameters_override)
         flush_info([str(response)], log_capture, 3)


### PR DESCRIPTION
## Summary
- preserve arbitrary existing backslashes when escaping tag-like text for Loguru
- safely embed dynamic request paths, headers, redirect locations, response bodies, and client descriptions in colored log messages
- add a focused unit test that exercises the real `flush_info(colors=True)` path

## Examples of previously unsafe input

| Surface | Example input | Previous behavior |
| --- | --- | --- |
| Escaped body text | `\<invalid>` | The old helper added one backslash, producing an even count before `<invalid>`, so Loguru parsed the unknown tag and raised `ValueError`. |
| Request path or redirect `Location` | `/records/<invalid>` | The value was interpolated directly into colored markup, so Loguru parsed `<invalid>` instead of logging it literally. |
| Request header or client description | `<red>spoofed</>` | Valid Loguru markup supplied by dynamic data was interpreted, changing the rendered log rather than preserving the input text. |
| Path or response body ending in a backslash | `trailing\` | The final backslash could escape the generated `</>` closing tag; the response workaround avoided the parse issue by adding a visible trailing space. |

The hardened paths render each example literally, including the original number of backslashes.

## Context

This is defense-in-depth logging hardening split out from #8077. It intentionally does **not** add COSE, CBOR, or other binary media-type classification or response-body suppression; that minimal COSE-specific behavior remains in #8077.

The broader markup issue was revealed while investigating the failed GitHub Actions job: https://github.com/microsoft/CCF/actions/runs/29526537129/job/87716300085

## Testing
- `tests/infra/client_logging_test.py`
- Black and Ruff on the changed Python files
- Gersemi on `CMakeLists.txt`