### PR TITLE
Show recent branch runs in benchmark radar

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,7 +14,7 @@ File: `bencher.yml`
 
 ## Bencher A/B
 
-Builds and runs CCF performance tests on the PR branch, then renders radar charts comparing up to five recent branch runs against the recent trend on `main`. Two nested shaded bands show the shared seven-run-half-life EWMA baseline +/- 1 and +/- 2 standard deviations of the latest `main` runs. Both branch and `main` histories are restored from cumulative perf artifacts, and the branch lines progress from the faintest oldest run to the strongest latest run. Triggered on PRs that have the label `bench-ab`.
+Builds and runs CCF performance tests on the PR branch, then renders radar charts comparing up to five recent branch runs against the recent trend on `main`. Two nested shaded blue bands show the shared seven-run-half-life EWMA baseline +/- 1 and +/- 2 standard deviations of the latest `main` runs. Both branch and `main` histories are restored from cumulative perf artifacts, and the orange branch lines progress from the faintest oldest run to the strongest latest run. Triggered on PRs that have the label `bench-ab`.
 
 File: `bencher-ab.yml`
 3rd party dependencies: None

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,7 +14,7 @@ File: `bencher.yml`
 
 ## Bencher A/B
 
-Builds and runs CCF performance tests on the PR branch, then renders radar charts comparing the branch's latest run against the recent trend on `main`. Two nested shaded bands show the shared seven-run-half-life EWMA baseline +/- 1 and +/- 2 standard deviations of the latest `main` runs (restored from their perf artifacts), and the highlighted line is the branch. Triggered on PRs that have the label `bench-ab`.
+Builds and runs CCF performance tests on the PR branch, then renders radar charts comparing up to five recent branch runs against the recent trend on `main`. Two nested shaded bands show the shared seven-run-half-life EWMA baseline +/- 1 and +/- 2 standard deviations of the latest `main` runs. Both branch and `main` histories are restored from cumulative perf artifacts, and the branch lines progress from the faintest oldest run to the strongest latest run. Triggered on PRs that have the label `bench-ab`.
 
 File: `bencher-ab.yml`
 3rd party dependencies: None

--- a/.github/workflows/bencher-ab.yml
+++ b/.github/workflows/bencher-ab.yml
@@ -13,6 +13,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   benchmark_pr:
     name: Benchmark PR
@@ -23,6 +27,8 @@ jobs:
         "JobId=bab_benchmark_pr-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}",
       ]
     if: ${{ (github.event.action == 'labeled' && github.event.label.name == 'bench-ab') || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'bench-ab')) }}
+    env:
+      BRANCH_PERF_ARTIFACT: perf-bench-virtual-pr-${{ github.event.pull_request.number }}
     container:
       image: mcr.microsoft.com/azurelinux/base/core:3.0
       options: --user root
@@ -77,10 +83,40 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Restore recent branch perf results
+        run: |
+          set -exo pipefail
+          mkdir -p branch_perf
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          run_ids=$(gh api "repos/${{ github.repository }}/actions/artifacts?name=${BRANCH_PERF_ARTIFACT}&per_page=100" \
+            --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | reverse | .[0:20] | .[].workflow_run.id')
+          for run_id in $run_ids; do
+            if gh run download "$run_id" --name "$BRANCH_PERF_ARTIFACT" --dir branch_artifact; then
+              find branch_artifact -name '*.json' -exec cp {} branch_perf/ \;
+              break
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Collect branch perf results
+        run: |
+          set -exo pipefail
+          jobid="${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"
+          cp build/bencher.json "branch_perf/${jobid}.json"
+          (cd branch_perf && ls -1 | sort -t- -k1,1n -k2,2n -k3,3n | head -n -5 | xargs -r rm -f)
+
+      - name: Upload branch perf results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ env.BRANCH_PERF_ARTIFACT }}
+          path: branch_perf
+          if-no-files-found: error
+
       - name: Summarise A/B comparison against main
         run: |
           set -exo pipefail
-          python3 scripts/perf_compare_radar.py main_perf build/bencher.json \
+          python3 scripts/perf_compare_radar.py main_perf branch_perf \
             --branch-label "#${{ github.event.pull_request.number }}" \
             | tee benchmark-ab-summary.md >> "$GITHUB_STEP_SUMMARY"
 

--- a/scripts/perf_compare_radar.py
+++ b/scripts/perf_compare_radar.py
@@ -65,6 +65,7 @@ RADAR_CONFIG = {
 _CANVAS = "var(--color-canvas-default,var(--bgColor-default,#fff))"
 _BLUE = "#62B5E5"
 _BRANCH_ORANGE = "#F97316"
+_OLDEST_BRANCH_OPACITY = 0.3
 _BAND_1SIGMA = f"color-mix(in srgb, {_BLUE} 40%, {_CANVAS})"
 _BAND_2SIGMA = f"color-mix(in srgb, {_BLUE} 13%, {_CANVAS})"
 RADAR_THEME_CSS = (
@@ -278,7 +279,8 @@ def branch_curve_css(curve_count: int) -> list[str]:
     for index in range(curve_count):
         is_latest = index == curve_count - 1
         width = "1.75" if is_latest else "1.5"
-        opacity = 1.0 if curve_count == 1 else 0.5 + (0.5 * index / (curve_count - 1))
+        age_fraction = (curve_count - index - 1) / max(curve_count - 1, 1)
+        opacity = _OLDEST_BRANCH_OPACITY**age_fraction
         css.append(
             f".radarCurve-{index + 4}{{stroke-width:{width}px!important;"
             f"stroke-opacity:{opacity:.2f}!important}}"

--- a/scripts/perf_compare_radar.py
+++ b/scripts/perf_compare_radar.py
@@ -66,6 +66,7 @@ _CANVAS = "var(--color-canvas-default,var(--bgColor-default,#fff))"
 _BLUE = "#62B5E5"
 _BRANCH_ORANGE = "#F97316"
 _BRANCH_OPACITY_BY_AGE = (1.0, 0.5, 0.4, 0.3, 0.2)
+MAX_BRANCH_RUNS = len(_BRANCH_OPACITY_BY_AGE)
 _BAND_1SIGMA = f"color-mix(in srgb, {_BLUE} 40%, {_CANVAS})"
 _BAND_2SIGMA = f"color-mix(in srgb, {_BLUE} 13%, {_CANVAS})"
 RADAR_THEME_CSS = (
@@ -548,7 +549,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    branch_runs = load_runs(args.branch_directory)
+    branch_runs = load_runs(args.branch_directory)[-MAX_BRANCH_RUNS:]
     if not branch_runs:
         print(
             f"_No benchmark data found for the branch in "

--- a/scripts/perf_compare_radar.py
+++ b/scripts/perf_compare_radar.py
@@ -277,8 +277,8 @@ def branch_curve_css(curve_count: int) -> list[str]:
     css: list[str] = []
     for index in range(curve_count):
         is_latest = index == curve_count - 1
-        width = "2.5" if is_latest else "1.25"
-        opacity = 1.0 if curve_count == 1 else 0.2 + (0.8 * index / (curve_count - 1))
+        width = "1.75" if is_latest else "1.5"
+        opacity = 1.0 if curve_count == 1 else 0.5 + (0.5 * index / (curve_count - 1))
         css.append(
             f".radarCurve-{index + 4}{{stroke-width:{width}px!important;"
             f"stroke-opacity:{opacity:.2f}!important}}"

--- a/scripts/perf_compare_radar.py
+++ b/scripts/perf_compare_radar.py
@@ -1,13 +1,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-"""Render Mermaid radar charts comparing a branch's benchmark run against the
+"""Render Mermaid radar charts comparing a branch's benchmark runs against the
 recent trend on ``main``.
 
 For each metric, benchmarks form the radar axes. Two nested shaded bands show the
 EWMA baseline +/- 1 and +/- 2 standard deviations of the most recent ``main``
-runs, and the highlighted curve is the branch's latest run. Values are normalized
-per benchmark so that 100 is the ``main`` EWMA baseline.
+runs. Up to five branch curves run from the oldest and faintest to the latest and
+strongest. Values are normalized per benchmark so that 100 is the ``main`` EWMA
+baseline.
 """
 
 import os
@@ -59,8 +60,8 @@ RADAR_CONFIG = {
 # fill is the blue tint mixed over the canvas colour, so it stays theme-adaptive
 # while remaining opaque. Opaque fills let the darker 1 std dev ring paint
 # cleanly on top of the lighter 2 std dev ring, and a final canvas-coloured
-# polygon punches out the centre below -2 std dev. The last curve is the branch
-# line, drawn on top of both bands.
+# polygon punches out the centre below -2 std dev. Branch curves are drawn on top
+# of both bands.
 _CANVAS = "var(--color-canvas-default,var(--bgColor-default,#fff))"
 _BLUE = "#62B5E5"
 _BAND_1SIGMA = f"color-mix(in srgb, {_BLUE} 40%, {_CANVAS})"
@@ -70,7 +71,6 @@ RADAR_THEME_CSS = (
     f".radarCurve-1{{fill:{_BAND_1SIGMA}!important;fill-opacity:1!important;stroke:none!important;stroke-width:0!important}}",
     f".radarCurve-2{{fill:{_BAND_2SIGMA}!important;fill-opacity:1!important;stroke:none!important;stroke-width:0!important}}",
     f".radarCurve-3{{fill:{_CANVAS}!important;fill-opacity:1!important;stroke:none!important;stroke-width:0!important}}",
-    ".radarCurve-4{stroke-width:2px!important}",
     ".radarAxisLabel,.radarTitle{fill:var(--color-fg-default,var(--fgColor-default,#111827))!important;color:var(--color-fg-default,var(--fgColor-default,#111827))!important}",
 )
 
@@ -89,7 +89,7 @@ def jobid_sort_key(name: str) -> tuple[int, object]:
         return (1, name)
 
 
-def list_trend_files(directory: str) -> list[str]:
+def list_perf_files(directory: str) -> list[str]:
     """Return perf files in the directory, ordered chronologically (oldest first)."""
     if not os.path.isdir(directory):
         return []
@@ -111,15 +111,15 @@ def load_json(path: str) -> PerfData | None:
     return data if isinstance(data, dict) else None
 
 
-def load_trend(directory: str) -> list[PerfData]:
-    """Load all main runs in chronological order (oldest first)."""
-    files = list_trend_files(directory)
-    trend: list[PerfData] = []
+def load_runs(directory: str) -> list[PerfData]:
+    """Load all perf runs in chronological order (oldest first)."""
+    files = list_perf_files(directory)
+    runs: list[PerfData] = []
     for name in files:
         data = load_json(os.path.join(directory, name))
         if data is not None:
-            trend.append(data)
-    return trend
+            runs.append(data)
+    return runs
 
 
 def metric_value(data: PerfData, benchmark: str, metric: str) -> float | None:
@@ -271,26 +271,44 @@ def render_radar_curve(curve_id: str, label: str, values: list[float]) -> str:
     return f"  curve {curve_id}[{mermaid_label(label)}]{{{rendered_values}}}"
 
 
+def branch_curve_css(curve_count: int) -> list[str]:
+    """Style branch curves from the faintest oldest run to the strongest latest."""
+    css: list[str] = []
+    for index in range(curve_count):
+        is_latest = index == curve_count - 1
+        width = "2.5" if is_latest else "1.25"
+        opacity = (
+            "1" if is_latest else f"{0.2 + (0.5 * index / max(curve_count - 1, 1)):.2f}"
+        )
+        css.append(
+            f".radarCurve-{index + 4}{{stroke-width:{width}px!important;"
+            f"stroke-opacity:{opacity}!important}}"
+        )
+    return css
+
+
 def render_mermaid_radar_chart(
     trend: list[PerfData],
-    branch_data: PerfData,
+    branch_runs: list[PerfData],
     benchmarks: list[str],
     metric: str,
     unit: str,
     branch_label: str,
 ) -> str:
-    """Render one Mermaid radar chart comparing the branch run with the main trend."""
+    """Render one radar chart comparing the branch runs with the main trend."""
     higher_better = metric in HIGHER_IS_BETTER
+    latest_branch = branch_runs[-1]
     axes: list[str] = []
     axis_colors: list[str] = []
-    branch_values: list[float] = []
+    branch_curve_values: list[list[float]] = [[] for _ in branch_runs]
+    branch_curve_complete = [True] * len(branch_runs)
     low_values: list[float] = []
     high_values: list[float] = []
     low2_values: list[float] = []
     high2_values: list[float] = []
 
     for index, benchmark in enumerate(benchmarks):
-        branch_value = metric_value(branch_data, benchmark, metric)
+        branch_value = metric_value(latest_branch, benchmark, metric)
         if branch_value is None:
             continue
 
@@ -313,10 +331,17 @@ def render_mermaid_radar_chart(
         axes.append(
             f"b{index}[{mermaid_label(axis_label(benchmark, branch_value, branch_percent, unit, within_noise))}]"
         )
-        branch_values.append(branch_percent)
         axis_colors.append(
             axis_label_color(branch_percent, higher_better, within_noise)
         )
+        for run_index, branch_data in enumerate(branch_runs):
+            historical_value = metric_value(branch_data, benchmark, metric)
+            if historical_value is None:
+                branch_curve_complete[run_index] = False
+                continue
+            branch_curve_values[run_index].append(
+                normalized_percent(historical_value, baseline)
+            )
         low_values.append(max(0.0, normalized_percent(baseline - sigma, baseline)))
         high_values.append(normalized_percent(baseline + sigma, baseline))
         low2_values.append(max(0.0, normalized_percent(baseline - 2 * sigma, baseline)))
@@ -328,10 +353,21 @@ def render_mermaid_radar_chart(
             "run and the recent main runs._\n"
         )
 
+    rendered_branch_curves = [
+        (run_index, values)
+        for run_index, (values, complete) in enumerate(
+            zip(branch_curve_values, branch_curve_complete)
+        )
+        if complete
+    ]
+
     # Zoom the radial scale to the data instead of starting at 0, so the rings
     # fill the chart rather than hugging the outer edge. The margin keeps the
     # innermost ring off the centre and the outermost ring inside the frame.
-    data_values = branch_values + low_values + high_values + low2_values + high2_values
+    data_values = [
+        value for _, curve_values in rendered_branch_curves for value in curve_values
+    ]
+    data_values += low_values + high_values + low2_values + high2_values
     data_low = min(data_values)
     data_high = max(data_values)
     pad = max((data_high - data_low) * ZOOM_PAD_FACTOR, ZOOM_MIN_PAD)
@@ -355,13 +391,14 @@ def render_mermaid_radar_chart(
         "  theme: base",
         "  themeCSS: |",
         *[f"    {line}" for line in RADAR_THEME_CSS],
+        *[f"    {line}" for line in branch_curve_css(len(rendered_branch_curves))],
         *[f"    {line}" for line in label_color_css],
         "  themeVariables:",
-        '    cScale0: "#62B5E5"',
-        '    cScale1: "#62B5E5"',
-        '    cScale2: "#62B5E5"',
-        '    cScale3: "#62B5E5"',
-        '    cScale4: "#008FD3"',
+        *[f'    cScale{index}: "#62B5E5"' for index in range(4)],
+        *[
+            f'    cScale{index}: "#008FD3"'
+            for index in range(4, 4 + len(rendered_branch_curves))
+        ],
         "    radar:",
         '      axisColor: "#9CA3AF"',
         '      graticuleColor: "#E5E7EB"',
@@ -378,7 +415,21 @@ def render_mermaid_radar_chart(
             render_radar_curve("stddev1_high", "main EWMA + 1 std dev", high_values),
             render_radar_curve("stddev1_low", "main EWMA - 1 std dev", low_values),
             render_radar_curve("stddev2_low", "main EWMA - 2 std dev", low2_values),
-            render_radar_curve("branch", branch_label, branch_values),
+        ]
+    )
+    for run_index, values in rendered_branch_curves:
+        runs_earlier = len(branch_runs) - run_index - 1
+        curve_label = (
+            branch_label
+            if runs_earlier == 0
+            else (
+                f"{branch_label} ({runs_earlier} "
+                f"{'run' if runs_earlier == 1 else 'runs'} earlier)"
+            )
+        )
+        lines.append(render_radar_curve(f"branch_{run_index}", curve_label, values))
+    lines.extend(
+        [
             "  graticule polygon",
             f"  max {chart_max}",
             *([f"  min {chart_min}"] if chart_min > 0 else []),
@@ -393,14 +444,14 @@ def render_mermaid_radar_chart(
 
 def render_metric_group(
     trend: list[PerfData],
-    branch_data: PerfData,
+    branch_runs: list[PerfData],
     branch_label: str,
     metric: str,
     title: str,
     unit: str,
 ) -> str:
     """Render a radar chart for benchmarks that report the given metric."""
-    benchmarks = benchmarks_with_metric([branch_data, *trend], metric)
+    benchmarks = benchmarks_with_metric([branch_runs[-1], *trend], metric)
     lines = [f"## {title} ({unit})", ""]
     if not benchmarks:
         lines.append(f"_No benchmarks with a `{metric}` metric found._")
@@ -409,39 +460,48 @@ def render_metric_group(
 
     lines.append(
         render_mermaid_radar_chart(
-            trend, branch_data, benchmarks, metric, unit, branch_label
+            trend, branch_runs, benchmarks, metric, unit, branch_label
         )
     )
     return "\n".join(lines)
 
 
 def render_comparison(
-    trend: list[PerfData], branch_data: PerfData, branch_label: str
+    trend: list[PerfData], branch_runs: list[PerfData], branch_label: str
 ) -> str:
-    """Render all metric groups comparing the branch run with the main trend."""
+    """Render all metric groups comparing the branch runs with the main trend."""
+    branch_curve_description = (
+        "The blue line is this branch's latest run"
+        if len(branch_runs) == 1
+        else (
+            f"The {len(branch_runs)} blue branch lines run from the oldest "
+            "(faintest) to the latest (darkest and thickest)"
+        )
+    )
+    branch_run_noun = "run" if len(branch_runs) == 1 else "runs"
     lines = [
         "<details>",
         "<summary>Description</summary>",
         "",
         (
-            f"_Comparing this branch ({branch_label}) against the trend of the "
-            f"last {len(trend)} `main` runs._"
+            f"_Comparing {len(branch_runs)} available {branch_run_noun} from this branch "
+            f"({branch_label}) against the trend of the last {len(trend)} `main` runs._"
         ),
         "",
         (
             "_Each chart plots every benchmark as an axis, with values normalized so "
             f"100 is the EWMA baseline of recent `main` runs, using a "
-            f"{EWMA_HALF_LIFE}-run half-life. The blue line is this branch's latest "
-            "run; the darker blue band is the main baseline +/- 1 std dev and the "
+            f"{EWMA_HALF_LIFE}-run half-life. {branch_curve_description}; the darker "
+            "blue band is the main baseline +/- 1 std dev and the "
             "lighter blue band around it is +/- 2 std dev._"
         ),
         "",
         (
-            "_Axis labels show this branch's value and its difference from the main "
-            "EWMA baseline, where 0% is on the baseline. They are coloured green "
-            "where this branch improves on the baseline, red where it regresses, "
-            "and grey where the difference is within one std dev of the baseline "
-            "(within noise). "
+            "_Axis labels show the latest branch value and its difference from the "
+            "main EWMA baseline, where 0% is on the baseline. They are coloured "
+            "green where the latest run improves on the baseline, red where it "
+            "regresses, and grey where the difference is within one std dev of the "
+            "baseline (within noise). "
             "Higher is better for throughput and rate, lower for latency and memory._"
         ),
         "",
@@ -460,7 +520,7 @@ def render_comparison(
         lines.append("")
     for metric, title, unit in METRIC_GROUPS:
         lines.append(
-            render_metric_group(trend, branch_data, branch_label, metric, title, unit)
+            render_metric_group(trend, branch_runs, branch_label, metric, title, unit)
         )
     return "\n".join(lines)
 
@@ -468,7 +528,7 @@ def render_comparison(
 def main() -> None:
     parser = argparse.ArgumentParser(
         description=(
-            "Render radar charts comparing a branch benchmark run against the "
+            "Render radar charts comparing recent branch benchmark runs against the "
             "recent trend on main, as markdown for a job summary."
         )
     )
@@ -477,8 +537,8 @@ def main() -> None:
         help="Directory containing the recent main perf data files.",
     )
     parser.add_argument(
-        "branch_file",
-        help="Path to the branch bencher.json file.",
+        "branch_directory",
+        help="Directory containing the recent branch perf data files.",
     )
     parser.add_argument(
         "--branch-label",
@@ -487,13 +547,16 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    branch_data = load_json(args.branch_file)
-    if branch_data is None:
-        print(f"_No benchmark data found for the branch at `{args.branch_file}`._")
+    branch_runs = load_runs(args.branch_directory)
+    if not branch_runs:
+        print(
+            f"_No benchmark data found for the branch in "
+            f"`{args.branch_directory}`._"
+        )
         return
 
-    trend = load_trend(args.main_directory)
-    print(render_comparison(trend, branch_data, args.branch_label))
+    trend = load_runs(args.main_directory)
+    print(render_comparison(trend, branch_runs, args.branch_label))
 
 
 if __name__ == "__main__":

--- a/scripts/perf_compare_radar.py
+++ b/scripts/perf_compare_radar.py
@@ -65,7 +65,7 @@ RADAR_CONFIG = {
 _CANVAS = "var(--color-canvas-default,var(--bgColor-default,#fff))"
 _BLUE = "#62B5E5"
 _BRANCH_ORANGE = "#F97316"
-_OLDEST_BRANCH_OPACITY = 0.3
+_BRANCH_OPACITY_BY_AGE = (1.0, 0.5, 0.4, 0.3, 0.2)
 _BAND_1SIGMA = f"color-mix(in srgb, {_BLUE} 40%, {_CANVAS})"
 _BAND_2SIGMA = f"color-mix(in srgb, {_BLUE} 13%, {_CANVAS})"
 RADAR_THEME_CSS = (
@@ -279,8 +279,8 @@ def branch_curve_css(curve_count: int) -> list[str]:
     for index in range(curve_count):
         is_latest = index == curve_count - 1
         width = "1.75" if is_latest else "1.5"
-        age_fraction = (curve_count - index - 1) / max(curve_count - 1, 1)
-        opacity = _OLDEST_BRANCH_OPACITY**age_fraction
+        age = curve_count - index - 1
+        opacity = _BRANCH_OPACITY_BY_AGE[min(age, len(_BRANCH_OPACITY_BY_AGE) - 1)]
         css.append(
             f".radarCurve-{index + 4}{{stroke-width:{width}px!important;"
             f"stroke-opacity:{opacity:.2f}!important}}"

--- a/scripts/perf_compare_radar.py
+++ b/scripts/perf_compare_radar.py
@@ -64,6 +64,7 @@ RADAR_CONFIG = {
 # of both bands.
 _CANVAS = "var(--color-canvas-default,var(--bgColor-default,#fff))"
 _BLUE = "#62B5E5"
+_BRANCH_ORANGE = "#F97316"
 _BAND_1SIGMA = f"color-mix(in srgb, {_BLUE} 40%, {_CANVAS})"
 _BAND_2SIGMA = f"color-mix(in srgb, {_BLUE} 13%, {_CANVAS})"
 RADAR_THEME_CSS = (
@@ -277,12 +278,10 @@ def branch_curve_css(curve_count: int) -> list[str]:
     for index in range(curve_count):
         is_latest = index == curve_count - 1
         width = "2.5" if is_latest else "1.25"
-        opacity = (
-            "1" if is_latest else f"{0.2 + (0.5 * index / max(curve_count - 1, 1)):.2f}"
-        )
+        opacity = 1.0 if curve_count == 1 else 0.2 + (0.8 * index / (curve_count - 1))
         css.append(
             f".radarCurve-{index + 4}{{stroke-width:{width}px!important;"
-            f"stroke-opacity:{opacity}!important}}"
+            f"stroke-opacity:{opacity:.2f}!important}}"
         )
     return css
 
@@ -396,7 +395,7 @@ def render_mermaid_radar_chart(
         "  themeVariables:",
         *[f'    cScale{index}: "#62B5E5"' for index in range(4)],
         *[
-            f'    cScale{index}: "#008FD3"'
+            f'    cScale{index}: "{_BRANCH_ORANGE}"'
             for index in range(4, 4 + len(rendered_branch_curves))
         ],
         "    radar:",
@@ -471,10 +470,10 @@ def render_comparison(
 ) -> str:
     """Render all metric groups comparing the branch runs with the main trend."""
     branch_curve_description = (
-        "The blue line is this branch's latest run"
+        "The orange line is this branch's latest run"
         if len(branch_runs) == 1
         else (
-            f"The {len(branch_runs)} blue branch lines run from the oldest "
+            f"The {len(branch_runs)} orange branch lines run from the oldest "
             "(faintest) to the latest (darkest and thickest)"
         )
     )


### PR DESCRIPTION
## Summary

- retain the newest five Benchmark A/B results in a cumulative artifact scoped to the pull request
- serialize Benchmark A/B runs per PR so concurrent workflow updates cannot lose branch history
- restore both the 30-run `main` baseline and the retained branch history before rendering each summary
- draw branch runs in orange at 20%, 30%, 40%, 50%, and 100% opacity from oldest to newest, with a slightly thicker latest curve
- keep axis values, deltas, and improvement/regression colours based on the latest branch run
- document the cumulative branch artifact and multi-run radar behavior

## Validation

- rendered synthetic one-run and five-run summaries from retained benchmark data
- completed five successive Benchmark A/B runs to exercise artifact creation, restoration, accumulation, and five-result retention
- confirmed the latest PR summary contains five orange curves per radar with the expected opacity sequence
- ran Black, Prettier, YAML parsing, and diff checks