### PR TITLE
Preserve votes when term does not change

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -2282,8 +2282,11 @@ namespace aft
     {
       RAFT_DEBUG_FMT("Becoming aware of new term {}", term);
 
+      if (state->current_view != term)
+      {
+        voted_for.reset();
+      }
       state->current_view = term;
-      voted_for.reset();
       reset_votes_for_me();
       become_follower();
       is_new_follower = true;

--- a/tests/raft_scenarios/pre_vote_double_leader
+++ b/tests/raft_scenarios/pre_vote_double_leader
@@ -1,0 +1,125 @@
+# Reproduce a same-term election-safety violation involving pre-vote.
+#
+# Nodes 1 and 2 become candidates in term 3. Node 1 wins with votes from
+# nodes 0 and 3, while node 2 receives a vote from node 4. Node 3 then times
+# out into PreVoteCandidate without changing its vote for node 1. An unmatched
+# AppendEntries from node 1 makes node 3 step down and clears that vote. Node 3
+# grants node 2's delayed vote request, so both nodes 1 and 2 become leaders in
+# term 3.
+pre_vote_enabled,true
+
+start_node,0
+emit_signature,2
+
+trust_nodes,2,1,2,3,4
+emit_signature,2
+
+# Bring every node to the same committed prefix.
+periodic_all,10
+dispatch_all
+periodic_all,10
+dispatch_all
+periodic_all,10
+dispatch_all
+assert_state_sync
+assert_commit_idx,0,4
+
+# Give future leader node 1 a longer committable suffix. Its first heartbeat
+# will refer to index 5, which node 3 does not have.
+emit_signature,2
+periodic_one,0,10
+dispatch_single,0,1
+assert_last_txid,1,2.5
+assert_last_txid,2,2.4
+assert_last_txid,3,2.4
+
+# Remove the other replication messages and node 1's response.
+drop_pending,0
+drop_pending,1
+
+# Nodes 1 and 2 start pre-vote rounds in term 2.
+periodic_one,1,100
+periodic_one,2,100
+assert_detail,1,leadership_state,PreVoteCandidate
+assert_detail,2,leadership_state,PreVoteCandidate
+assert_detail,1,current_view,2
+assert_detail,2,current_view,2
+
+# Collect two pre-votes for each node, but retain no other pre-vote requests.
+dispatch_single,1,0
+dispatch_single,1,3
+dispatch_single,2,3
+dispatch_single,2,4
+drop_pending_to,1,2
+drop_pending_to,1,4
+drop_pending_to,2,0
+drop_pending_to,2,1
+
+# Deliver the pre-vote responses. Both nodes become candidates in term 3.
+dispatch_single,0,1
+dispatch_single,3,2
+dispatch_single,3,1
+dispatch_single,4,2
+assert_detail,1,leadership_state,Candidate
+assert_detail,2,leadership_state,Candidate
+assert_detail,1,current_view,3
+assert_detail,2,current_view,3
+
+# Keep requests for node 1 to win votes from nodes 0 and 3. Keep node 2's
+# request to node 4 and its delayed request to node 3.
+drop_pending_to,1,2
+drop_pending_to,1,4
+drop_pending_to,2,0
+drop_pending_to,2,1
+
+dispatch_single,1,0
+dispatch_single,1,3
+dispatch_single,2,4
+dispatch_single,4,2
+dispatch_single,0,1
+dispatch_single,3,1
+assert_detail,1,leadership_state,Leader
+assert_detail,1,current_view,3
+assert_detail,2,leadership_state,Candidate
+
+# Retain only node 1's unmatched AppendEntries to node 3.
+drop_pending_to,1,0
+drop_pending_to,1,2
+drop_pending_to,1,4
+
+# Node 3 keeps its term-3 vote for node 1 when it becomes a pre-vote
+# candidate. Drop its speculative pre-vote requests.
+periodic_one,3,100
+assert_detail,3,leadership_state,PreVoteCandidate
+assert_detail,3,current_view,3
+drop_pending,3
+
+# Node 1's unmatched AppendEntries makes node 3 a follower without teaching it
+# the leader. The same-term transition clears node 3's vote for node 1.
+dispatch_single,1,3
+assert_detail,3,leadership_state,Follower
+assert_detail,3,current_view,3
+assert_last_txid,3,2.4
+drop_pending,3
+
+# Node 3 grants node 2's delayed request. Node 2 now has votes from itself,
+# node 4, and node 3, so it becomes another leader in term 3.
+dispatch_single,2,3
+dispatch_single,3,2
+assert_detail,1,leadership_state,Leader
+assert_detail,2,leadership_state,Leader
+assert_detail,1,current_view,3
+assert_detail,2,current_view,3
+
+# Preserve a path back to liveness for the scenario driver. With all pending
+# messages dropped, node 1 fails CheckQuorum and steps down, leaving node 2 to
+# converge the network after the safety violation has been recorded.
+drop_pending,0
+drop_pending,1
+drop_pending,2
+drop_pending,3
+drop_pending,4
+periodic_one,1,100
+assert_detail,1,leadership_state,Follower
+assert_detail,2,leadership_state,Leader
+loop_until_sync

--- a/tests/raft_scenarios/pre_vote_double_leader
+++ b/tests/raft_scenarios/pre_vote_double_leader
@@ -1,10 +1,12 @@
-# Reproduce a same-term election-safety violation involving pre-vote.
+# Regression test for a previous same-term election-safety violation involving
+# pre-vote.
 #
 # Nodes 0 and 2 become candidates in term 3. Node 0 wins with node 1's vote.
 # Node 1 then times out into PreVoteCandidate without changing its vote for
-# node 0. An unmatched AppendEntries from node 0 makes node 1 step down and
-# clears that vote. Node 1 grants node 2's delayed vote request, so both nodes
-# 0 and 2 become leaders in term 3.
+# node 0. Previously, an unmatched AppendEntries from node 0 made node 1 step
+# down and cleared that vote, so node 1 granted node 2's delayed vote request
+# and both nodes became leaders in term 3. This test asserts that same-term
+# step-down now preserves node 1's vote, so node 2 remains a candidate.
 pre_vote_enabled,true
 
 start_node,0
@@ -75,29 +77,28 @@ assert_detail,1,current_view,3
 drop_pending,1
 
 # Node 0's unmatched AppendEntries makes node 1 a follower without teaching it
-# the leader. The same-term transition clears node 1's vote for node 0.
+# the leader. The same-term transition preserves node 1's vote for node 0.
 dispatch_single,0,1
 assert_detail,1,leadership_state,Follower
 assert_detail,1,current_view,3
 assert_last_txid,1,2.4
 drop_pending,1
 
-# Node 1 grants node 2's delayed request. Node 2 now has votes from itself and
-# node 1, so it becomes another leader in term 3.
+# Node 1 rejects node 2's delayed request because it already voted for node 0.
+# Node 2 remains a candidate, preventing a second leader in term 3.
 dispatch_single,2,1
 dispatch_single,1,2
 assert_detail,0,leadership_state,Leader
-assert_detail,2,leadership_state,Leader
+# Before same-term step-down preserved voted_for, node 1 granted this vote and
+# this assertion expected node 2 to have become a second leader in term 3.
+assert_detail,2,leadership_state,Candidate
 assert_detail,0,current_view,3
 assert_detail,2,current_view,3
 
 # Preserve a path back to liveness for the scenario driver. With all pending
-# messages dropped, node 2 fails CheckQuorum and steps down, leaving node 0 to
-# converge the network after the safety violation has been recorded.
+# messages dropped, node 0 can converge the network after proving the second
+# election was rejected.
 drop_pending,0
 drop_pending,1
 drop_pending,2
-periodic_one,2,100
-assert_detail,2,leadership_state,Follower
-assert_detail,0,leadership_state,Leader
 loop_until_sync

--- a/tests/raft_scenarios/pre_vote_double_leader
+++ b/tests/raft_scenarios/pre_vote_double_leader
@@ -1,17 +1,16 @@
 # Reproduce a same-term election-safety violation involving pre-vote.
 #
-# Nodes 1 and 2 become candidates in term 3. Node 1 wins with votes from
-# nodes 0 and 3, while node 2 receives a vote from node 4. Node 3 then times
-# out into PreVoteCandidate without changing its vote for node 1. An unmatched
-# AppendEntries from node 1 makes node 3 step down and clears that vote. Node 3
-# grants node 2's delayed vote request, so both nodes 1 and 2 become leaders in
-# term 3.
+# Nodes 0 and 2 become candidates in term 3. Node 0 wins with node 1's vote.
+# Node 1 then times out into PreVoteCandidate without changing its vote for
+# node 0. An unmatched AppendEntries from node 0 makes node 1 step down and
+# clears that vote. Node 1 grants node 2's delayed vote request, so both nodes
+# 0 and 2 become leaders in term 3.
 pre_vote_enabled,true
 
 start_node,0
 emit_signature,2
 
-trust_nodes,2,1,2,3,4
+trust_nodes,2,1,2
 emit_signature,2
 
 # Bring every node to the same committed prefix.
@@ -24,102 +23,81 @@ dispatch_all
 assert_state_sync
 assert_commit_idx,0,4
 
-# Give future leader node 1 a longer committable suffix. Its first heartbeat
-# will refer to index 5, which node 3 does not have.
+# Give future leader node 0 a longer committable suffix. Its first heartbeat
+# will refer to index 5, which node 1 does not have.
 emit_signature,2
-periodic_one,0,10
-dispatch_single,0,1
-assert_last_txid,1,2.5
+assert_last_txid,0,2.5
+assert_last_txid,1,2.4
 assert_last_txid,2,2.4
-assert_last_txid,3,2.4
-
-# Remove the other replication messages and node 1's response.
 drop_pending,0
-drop_pending,1
 
-# Nodes 1 and 2 start pre-vote rounds in term 2.
-periodic_one,1,100
+# Node 0 first fails CheckQuorum. Nodes 0 and 2 then start pre-vote rounds in
+# term 2.
+periodic_one,0,100
+assert_detail,0,leadership_state,Follower
+drop_pending,0
+periodic_one,0,100
 periodic_one,2,100
-assert_detail,1,leadership_state,PreVoteCandidate
+assert_detail,0,leadership_state,PreVoteCandidate
 assert_detail,2,leadership_state,PreVoteCandidate
-assert_detail,1,current_view,2
+assert_detail,0,current_view,2
 assert_detail,2,current_view,2
 
-# Collect two pre-votes for each node, but retain no other pre-vote requests.
-dispatch_single,1,0
-dispatch_single,1,3
-dispatch_single,2,3
-dispatch_single,2,4
-drop_pending_to,1,2
-drop_pending_to,1,4
+# Short-log node 1 grants a pre-vote to both prospective candidates.
+drop_pending_to,0,2
 drop_pending_to,2,0
-drop_pending_to,2,1
-
-# Deliver the pre-vote responses. Both nodes become candidates in term 3.
 dispatch_single,0,1
-dispatch_single,3,2
-dispatch_single,3,1
-dispatch_single,4,2
-assert_detail,1,leadership_state,Candidate
+dispatch_single,2,1
+dispatch_single,1,0
+dispatch_single,1,2
+assert_detail,0,leadership_state,Candidate
 assert_detail,2,leadership_state,Candidate
-assert_detail,1,current_view,3
+assert_detail,0,current_view,3
 assert_detail,2,current_view,3
 
-# Keep requests for node 1 to win votes from nodes 0 and 3. Keep node 2's
-# request to node 4 and its delayed request to node 3.
-drop_pending_to,1,2
-drop_pending_to,1,4
+# Node 1 votes for node 0, electing it. Keep node 2's request delayed.
+drop_pending_to,0,2
 drop_pending_to,2,0
-drop_pending_to,2,1
-
-dispatch_single,1,0
-dispatch_single,1,3
-dispatch_single,2,4
-dispatch_single,4,2
 dispatch_single,0,1
-dispatch_single,3,1
-assert_detail,1,leadership_state,Leader
-assert_detail,1,current_view,3
+dispatch_single,1,0
+assert_detail,0,leadership_state,Leader
+assert_detail,0,current_view,3
 assert_detail,2,leadership_state,Candidate
 
-# Retain only node 1's unmatched AppendEntries to node 3.
-drop_pending_to,1,0
-drop_pending_to,1,2
-drop_pending_to,1,4
+# Retain only node 0's unmatched AppendEntries to node 1.
+drop_pending_to,0,2
 
-# Node 3 keeps its term-3 vote for node 1 when it becomes a pre-vote
+# Node 1 keeps its term-3 vote for node 0 when it becomes a pre-vote
 # candidate. Drop its speculative pre-vote requests.
-periodic_one,3,100
-assert_detail,3,leadership_state,PreVoteCandidate
-assert_detail,3,current_view,3
-drop_pending,3
-
-# Node 1's unmatched AppendEntries makes node 3 a follower without teaching it
-# the leader. The same-term transition clears node 3's vote for node 1.
-dispatch_single,1,3
-assert_detail,3,leadership_state,Follower
-assert_detail,3,current_view,3
-assert_last_txid,3,2.4
-drop_pending,3
-
-# Node 3 grants node 2's delayed request. Node 2 now has votes from itself,
-# node 4, and node 3, so it becomes another leader in term 3.
-dispatch_single,2,3
-dispatch_single,3,2
-assert_detail,1,leadership_state,Leader
-assert_detail,2,leadership_state,Leader
+periodic_one,1,100
+assert_detail,1,leadership_state,PreVoteCandidate
 assert_detail,1,current_view,3
+drop_pending,1
+
+# Node 0's unmatched AppendEntries makes node 1 a follower without teaching it
+# the leader. The same-term transition clears node 1's vote for node 0.
+dispatch_single,0,1
+assert_detail,1,leadership_state,Follower
+assert_detail,1,current_view,3
+assert_last_txid,1,2.4
+drop_pending,1
+
+# Node 1 grants node 2's delayed request. Node 2 now has votes from itself and
+# node 1, so it becomes another leader in term 3.
+dispatch_single,2,1
+dispatch_single,1,2
+assert_detail,0,leadership_state,Leader
+assert_detail,2,leadership_state,Leader
+assert_detail,0,current_view,3
 assert_detail,2,current_view,3
 
 # Preserve a path back to liveness for the scenario driver. With all pending
-# messages dropped, node 1 fails CheckQuorum and steps down, leaving node 2 to
+# messages dropped, node 2 fails CheckQuorum and steps down, leaving node 0 to
 # converge the network after the safety violation has been recorded.
 drop_pending,0
 drop_pending,1
 drop_pending,2
-drop_pending,3
-drop_pending,4
-periodic_one,1,100
-assert_detail,1,leadership_state,Follower
-assert_detail,2,leadership_state,Leader
+periodic_one,2,100
+assert_detail,2,leadership_state,Follower
+assert_detail,0,leadership_state,Leader
 loop_until_sync


### PR DESCRIPTION
## Summary

- fix same-term step-down so `voted_for` is only cleared when the observed term actually changes
- add a deterministic three-node Raft scenario covering the pre-vote double-leader path
- assert that the delayed second election is rejected, then converge the network for driver liveness

## Why this fixes the violation

Pre-vote does not write `voted_for`, but it preserves any regular vote already cast in the current term. Previously, a same-term unmatched AppendEntries called `become_aware_of_new_term()` and erased that regular vote even though the term had not changed. This let the same node vote for two different candidates in term 3. Same term is not a new term, so the vote is now preserved; higher-term handling still clears it.

## Validation

- old two-leader assertion goes red with `Candidate != Leader` and `already voted for n[0]`
- fixed scenario passed 20/20 repeated runs
- all Raft scenarios passed
- fixed scenario trace validation passed
- `scripts/ci-checks.sh` passed