### PR TITLE
Hybrid (PQ) TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Asynchronous ledger reads (used to serve committed entry ranges to the enclave) no longer access the host `Ledger` object after it has been destroyed during shutdown. The `Ledger` now waits for any in-flight read workers to finish, and workers that have not yet started skip accessing it, fixing a potential use-after-free on shutdown (#8003).
 
+### Changed
+
+- TLS handshakes now prefer OpenSSL hybrid post-quantum key exchange groups when the linked OpenSSL version supports them, while retaining the existing P-521/P-384/P-256 groups as fallbacks (#0000).
+
 ## [7.0.10]
 
 [7.0.10]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- TLS handshakes now prefer OpenSSL hybrid post-quantum key exchange groups when the linked OpenSSL version supports them, while retaining the existing P-521/P-384/P-256 groups as fallbacks (#0000).
+- TLS handshakes now prefer OpenSSL hybrid post-quantum key exchange groups when the linked OpenSSL version supports them, while retaining the existing P-521/P-384/P-256 groups as fallbacks (#8097).
 
 ## [7.0.10]
 

--- a/src/tls/context.h
+++ b/src/tls/context.h
@@ -73,8 +73,12 @@ namespace ccf::tls
         "TLS_AES_128_GCM_SHA256";
       CHECK1(SSL_CTX_set_ciphersuites(cfg, ciphersuites));
 
-      // Restrict the curves to approved ones
-      CHECK1(SSL_CTX_set1_curves_list(cfg, "P-521:P-384:P-256"));
+      // Prefer hybrid post-quantum groups when available, while retaining the
+      // approved classical groups as fallbacks
+      CHECK1(SSL_CTX_set1_groups_list(
+        cfg,
+        "?X25519MLKEM768:?SecP256r1MLKEM768:?SecP384r1MLKEM1024:"
+        "P-521:P-384:P-256"));
 
       // Allow buffer to be relocated between WANT_WRITE retries, and do partial
       // writes if possible

--- a/src/tls/test/main.cpp
+++ b/src/tls/test/main.cpp
@@ -10,9 +10,11 @@
 #include "tls/server.h"
 #include "tls/tls.h"
 
+#include <algorithm>
 #include <chrono>
 #include <exception>
 #include <openssl/err.h>
+#include <openssl/objects.h>
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 #include <iostream>
@@ -349,6 +351,53 @@ std::string truncate_message(const uint8_t* msg, size_t len)
   return str;
 }
 
+void run_handshake(tls::Server& server, tls::Client& client)
+{
+  std::atomic<bool> keep_going = true;
+  std::optional<std::runtime_error> client_exception, server_exception;
+
+  thread client_thread([&client, &keep_going, &client_exception]() {
+    LOG_INFO_FMT("Client handshake");
+    try
+    {
+      if (handshake(&client, keep_going))
+        throw runtime_error("Client handshake error");
+    }
+    catch (std::runtime_error& ex)
+    {
+      keep_going = false;
+      client_exception = ex;
+    }
+  });
+
+  thread server_thread([&server, &keep_going, &server_exception]() {
+    LOG_INFO_FMT("Server handshake");
+    try
+    {
+      if (handshake(&server, keep_going))
+        throw runtime_error("Server handshake error");
+    }
+    catch (std::runtime_error& ex)
+    {
+      keep_going = false;
+      server_exception = ex;
+    }
+  });
+
+  client_thread.join();
+  server_thread.join();
+  LOG_INFO_FMT("Handshake completed");
+
+  if (client_exception)
+  {
+    throw *client_exception;
+  }
+  if (server_exception)
+  {
+    throw *server_exception;
+  }
+}
+
 /// Test runner, with various options for different kinds of tests.
 void run_test_case(
   const uint8_t* message,
@@ -369,52 +418,7 @@ void run_test_case(
   server.set_bio(&pipe, send<TestPipe::SERVER>, recv<TestPipe::SERVER>);
   client.set_bio(&pipe, send<TestPipe::CLIENT>, recv<TestPipe::CLIENT>);
 
-  std::atomic<bool> keep_going = true;
-  std::optional<std::runtime_error> client_exception, server_exception;
-
-  // Create a thread for the client handshake
-  thread client_thread([&client, &keep_going, &client_exception]() {
-    LOG_INFO_FMT("Client handshake");
-    try
-    {
-      if (handshake(&client, keep_going))
-        throw runtime_error("Client handshake error");
-    }
-    catch (std::runtime_error& ex)
-    {
-      keep_going = false;
-      client_exception = ex;
-    }
-  });
-
-  // Create a thread for the server handshake
-  thread server_thread([&server, &keep_going, &server_exception]() {
-    LOG_INFO_FMT("Server handshake");
-    try
-    {
-      if (handshake(&server, keep_going))
-        throw runtime_error("Server handshake error");
-    }
-    catch (std::runtime_error& ex)
-    {
-      keep_going = false;
-      server_exception = ex;
-    }
-  });
-
-  // Join threads
-  client_thread.join();
-  server_thread.join();
-  LOG_INFO_FMT("Handshake completed");
-
-  if (client_exception)
-  {
-    throw *client_exception;
-  }
-  if (server_exception)
-  {
-    throw *server_exception;
-  }
+  run_handshake(server, client);
 
   // The rest of the communication is deterministic and easy to simulate
   // so we take them out of the thread, to guarantee there will be bytes
@@ -476,7 +480,31 @@ public:
   {
     return SSL_get_verify_mode(get_ssl());
   }
+
+  std::string negotiated_group_name()
+  {
+    const auto nid = SSL_get_negotiated_group(get_ssl());
+    if (nid == NID_undef)
+    {
+      return {};
+    }
+
+    const auto* name = OBJ_nid2sn(nid);
+    return name == nullptr ? std::to_string(nid) : name;
+  }
 };
+
+bool openssl_supports_group(const char* group_name)
+{
+  ccf::crypto::OpenSSL::Unique_SSL_CTX ctx(TLS_client_method());
+  const auto rc = SSL_CTX_set1_groups_list(ctx, group_name);
+  if (rc != 1)
+  {
+    ERR_clear_error();
+  }
+
+  return rc == 1;
+}
 
 TEST_CASE("connection inherits verification mode from context")
 {
@@ -495,6 +523,41 @@ TEST_CASE("connection inherits verification mode from context")
   REQUIRE((request_only_client.verify_mode() & SSL_VERIFY_PEER) != 0);
   REQUIRE(
     (request_only_client.verify_mode() & SSL_VERIFY_FAIL_IF_NO_PEER_CERT) == 0);
+}
+
+TEST_CASE("handshake prefers hybrid post-quantum group when available")
+{
+  const std::vector<std::string> hybrid_groups = {
+    "X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM1024"};
+
+  bool supports_hybrid_group = false;
+  for (const auto& group : hybrid_groups)
+  {
+    supports_hybrid_group |= openssl_supports_group(group.c_str());
+  }
+
+  if (!supports_hybrid_group)
+  {
+    MESSAGE("OpenSSL does not support the hybrid post-quantum TLS groups");
+    return;
+  }
+
+  auto ca = get_ca();
+  tls::Server server(get_dummy_cert(ca, "server", false));
+  InspectableClient client(get_dummy_cert(ca, "client", false));
+
+  TestPipe pipe;
+  server.set_bio(&pipe, send<TestPipe::SERVER>, recv<TestPipe::SERVER>);
+  client.set_bio(&pipe, send<TestPipe::CLIENT>, recv<TestPipe::CLIENT>);
+
+  run_handshake(server, client);
+
+  const auto negotiated_group = client.negotiated_group_name();
+  INFO("Negotiated TLS group: " << negotiated_group);
+  REQUIRE(
+    std::find(
+      hybrid_groups.begin(), hybrid_groups.end(), negotiated_group) !=
+    hybrid_groups.end());
 }
 
 TEST_CASE("unverified handshake")

--- a/src/tls/test/main.cpp
+++ b/src/tls/test/main.cpp
@@ -555,8 +555,7 @@ TEST_CASE("handshake prefers hybrid post-quantum group when available")
   const auto negotiated_group = client.negotiated_group_name();
   INFO("Negotiated TLS group: " << negotiated_group);
   REQUIRE(
-    std::find(
-      hybrid_groups.begin(), hybrid_groups.end(), negotiated_group) !=
+    std::find(hybrid_groups.begin(), hybrid_groups.end(), negotiated_group) !=
     hybrid_groups.end());
 }
 

--- a/src/tls/test/main.cpp
+++ b/src/tls/test/main.cpp
@@ -14,7 +14,6 @@
 #include <chrono>
 #include <exception>
 #include <openssl/err.h>
-#include <openssl/objects.h>
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 #include <iostream>
@@ -483,14 +482,19 @@ public:
 
   std::string negotiated_group_name()
   {
-    const auto nid = SSL_get_negotiated_group(get_ssl());
-    if (nid == NID_undef)
+    const auto group_id = SSL_get_negotiated_group(get_ssl());
+    if (group_id == NID_undef)
     {
       return {};
     }
 
-    const auto* name = OBJ_nid2sn(nid);
-    return name == nullptr ? std::to_string(nid) : name;
+    const auto* group_name = SSL_group_to_name(get_ssl(), group_id);
+    if (group_name != nullptr)
+    {
+      return group_name;
+    }
+
+    return std::to_string(group_id);
   }
 };
 


### PR DESCRIPTION
While looking at alternatives to #8076, following @achamayou's proposed design:

> I think this is ideally moved to the code, where we detect if we crypto provider support PQC values, and extend the list in that case.

I spotted that `[SSL_CTX_set1_curves](https://docs.openssl.org/master/man3/SSL_CTX_set1_curves/)` has a `?` syntax that handles this detection automagically.

> If a group name is prefixed with the ? character, it will be ignored if an implementation is missing. Otherwise, listing an unknown group name will cause a failure to parse the list. Note that whether a group is known or not may depend on the OpenSSL version, how OpenSSL was compiled and/or which providers are loaded. Make sure you have the correct spelling of the group name and when in doubt prefix it with a ? to handle configurations in which it might nevertheless be unknown.

I think this is exactly what we want? And may even resolve #8061? But looking for input from @maxtropets.