### PR TITLE
Fix doc build failure under sphinx-multiversion

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -222,6 +222,7 @@ smv_outputdir_format = "{ref.name}"
 
 assert re.match(smv_branch_whitelist, "main")
 assert not re.match(smv_branch_whitelist, "release/not-a-version")
+assert not re.match(smv_branch_whitelist, "release/2.x")
 assert re.match(smv_branch_whitelist, "release/7.x")
 assert re.match(smv_branch_whitelist, "release/100.x")
 assert not re.match(smv_branch_whitelist, "release/7.x_feature")

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -358,10 +358,12 @@ def typedoc_role(
         element_path = ".".join(element_path)
         typedoc_path += f"/{kind_name}/{element_path}.html{url_hash}"
 
-    # construct final url relative to current page
-    source = pathlib.Path(inliner.document.attributes["source"]).resolve()
-    rel_source = source.relative_to(pathlib.Path(__file__).parent.resolve())
-    levels = len(rel_source.parent.parts)
+    # construct final url relative to current page. Use the Sphinx docname
+    # (always relative to the source root) rather than the filesystem path, so
+    # this works under sphinx-multiversion where sources live in a temporary
+    # checkout that differs from the conf.py location.
+    docname = inliner.document.settings.env.docname
+    levels = docname.count("/")
     refuri = "../" * levels + typedoc_path
 
     # build docutils node


### PR DESCRIPTION
## Problem

The doc build ([doc.yml](https://github.com/microsoft/CCF/actions/workflows/doc.yml)) has been failing since #8081 was merged, with:

```
ValueError: '/tmp/tmp3tmolv4m/.../doc/build_apps/crypto.rst' is not in the subpath of '/__w/CCF/CCF/doc'
```

## Cause

#8081 rewrote the URL-depth calculation in `typedoc_role` (`doc/conf.py`) to compute the source path `relative_to` `conf.py`'s `__file__`:

```python
source = pathlib.Path(inliner.document.attributes["source"]).resolve()
rel_source = source.relative_to(pathlib.Path(__file__).parent.resolve())
levels = len(rel_source.parent.parts)
```

Under `sphinx-multiversion`, source RSTs are checked out into a temporary directory (`/tmp/.../doc/...`) while Sphinx is pointed (via `-c`) at the `conf.py` in `/__w/CCF/CCF/doc`. These two paths share no common root, so `relative_to()` raises `ValueError` and aborts the whole build.

## Fix

Compute the page depth from Sphinx's `docname`, which is always relative to the source root regardless of where the files physically live:

```python
docname = inliner.document.settings.env.docname
levels = docname.count("/")
```

This restores the pre-#8081 behaviour (e.g. `build_apps/crypto` -> `levels = 1`) and works in both single-version and multiversion builds.

## Notes

I was unable to run the Sphinx build locally (no Python interpreter available on the dev machine), so please rely on CI to confirm the doc build passes.