### PR TITLE
Fix performance chart ordering

### DIFF
--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -209,9 +209,8 @@ def repeated_values(value: float, count: int) -> str:
 
 def render_mermaid_xychart(series: ChartSeries, metric: str, unit: str) -> str:
     """Render a Mermaid xychart line chart for a single benchmark metric."""
-    ordered_series = list(reversed(series))
-    labels = ", ".join(json.dumps(label) for label, _ in ordered_series)
-    raw_values = [value for _, value in ordered_series]
+    labels = ", ".join(json.dumps(label) for label, _ in series)
+    raw_values = [value for _, value in series]
     values = ", ".join(f"{value:.2f}" for value in raw_values)
     chronological_values = [value for _, value in series]
     baseline = ewma(chronological_values)

--- a/scripts/perf_summary.py
+++ b/scripts/perf_summary.py
@@ -212,11 +212,8 @@ def render_mermaid_xychart(series: ChartSeries, metric: str, unit: str) -> str:
     labels = ", ".join(json.dumps(label) for label, _ in series)
     raw_values = [value for _, value in series]
     values = ", ".join(f"{value:.2f}" for value in raw_values)
-    chronological_values = [value for _, value in series]
-    baseline = ewma(chronological_values)
-    sigma = (
-        statistics.pstdev(chronological_values) if len(chronological_values) > 1 else 0
-    )
+    baseline = ewma(raw_values)
+    sigma = statistics.pstdev(raw_values) if len(raw_values) > 1 else 0
     lines = [
         "```mermaid",
         "---",


### PR DESCRIPTION
## Summary
- preserve chronological perf run order when rendering Mermaid charts
- plot oldest runs on the left and newest runs on the right

## Testing
- rendered a synthetic three-point series and verified label and value ordering
- `python -m py_compile scripts/perf_summary.py`
- `python -m black --check scripts/perf_summary.py`