### PR TITLE
Fix encoding of empty CBOR byte and text strings

### DIFF
--- a/src/crypto/cbor.cpp
+++ b/src/crypto/cbor.cpp
@@ -266,13 +266,17 @@ namespace
     return cbor_nondet_mk_int64(v);
   }
 
+  // EverCBOR rejects null data pointers, which empty spans and string_views
+  // may hold. Never dereferenced, because the length is zero.
+  uint8_t empty_string_placeholder{0};
+
   cbor_raw to_raw_string(const String& v)
   {
     cbor_raw result;
-    if (!cbor_nondet_mk_text_string(
-          reinterpret_cast<uint8_t*>(const_cast<char*>(v.data())),
-          v.size(),
-          &result))
+    auto* data = v.empty() ?
+      &empty_string_placeholder :
+      reinterpret_cast<uint8_t*>(const_cast<char*>(v.data()));
+    if (!cbor_nondet_mk_text_string(data, v.size(), &result))
     {
       throw CBOREncodeError(
         Error::ENCODE_FAILED, fmt::format("Encoding text string {} failed", v));
@@ -283,8 +287,9 @@ namespace
   cbor_raw to_raw_bytes(const Bytes& v)
   {
     cbor_raw result;
-    if (!cbor_nondet_mk_byte_string(
-          const_cast<uint8_t*>(v.data()), v.size(), &result))
+    auto* data =
+      v.empty() ? &empty_string_placeholder : const_cast<uint8_t*>(v.data());
+    if (!cbor_nondet_mk_byte_string(data, v.size(), &result))
     {
       throw CBOREncodeError(
         Error::ENCODE_FAILED,

--- a/src/crypto/test/cbor.cpp
+++ b/src/crypto/test/cbor.cpp
@@ -1679,6 +1679,21 @@ TEST_CASE("CBOR: helper function make_string")
   REQUIRE(result == expected_repr);
 }
 
+TEST_CASE("CBOR: encode empty bytes and string with null data pointer")
+{
+  // Zero-length spans and string_views may hold a null data pointer.
+  const Bytes null_bytes{static_cast<const uint8_t*>(nullptr), 0};
+  REQUIRE_EQ(serialize(make_bytes(null_bytes)), ccf::ds::from_hex("40"));
+
+  const String null_string{};
+  REQUIRE(null_string.data() == nullptr);
+  REQUIRE_EQ(serialize(make_string(null_string)), ccf::ds::from_hex("60"));
+
+  // The common case: an empty vector, whose data() may be null.
+  const std::vector<uint8_t> empty_vec;
+  REQUIRE_EQ(serialize(make_bytes(empty_vec)), ccf::ds::from_hex("40"));
+}
+
 TEST_CASE("CBOR: error - invalid data")
 {
   auto cbor_bytes = ccf::ds::from_hex("18");


### PR DESCRIPTION

`to_raw_bytes` and `to_raw_string` pass the span/string_view data pointer straight to EverCBOR, which rejects null pointers. A default-constructed `std::vector` or `std::string` has a null `data()`, so serializing an empty byte or text string threw `CBOREncodeError` - even though `{valid_ptr, 0}` encodes `0x40` fine. The check is on the pointer, not the length.

`to_raw_array` and `to_raw_map` already work around this by passing a placeholder pointer for empty collections. This applies the same behavior to byte and text strings, so empty values encode consistently instead of throwing.

The existing "empty bytes" test missed it because it round-trips through `parse()`, which yields a non-null pointer into the input buffer. The new test builds the values directly.

