### PR TITLE
Hybrid TLS secret exchange

### DIFF
--- a/.github/workflows/ci-al4.yml
+++ b/.github/workflows/ci-al4.yml
@@ -49,7 +49,7 @@ jobs:
           git config --global --add safe.directory /__w/CCF/CCF
           mkdir build
           cd build
-          cmake -GNinja -DCMAKE_BUILD_TYPE=Debug ..
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DTEST_HYBRID_TLS_GROUPS=ON ..
           ninja
         shell: bash
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Asynchronous ledger reads (used to serve committed entry ranges to the enclave) no longer access the host `Ledger` object after it has been destroyed during shutdown. The `Ledger` now waits for any in-flight read workers to finish, and workers that have not yet started skip accessing it, fixing a potential use-after-free on shutdown (#8003).
 
+### Changed
+
+- TLS handshakes now prefer hybrid post-quantum key exchange groups, in the order `SecP384r1MLKEM1024`, `SecP256r1MLKEM768`, `X25519MLKEM768`, when the linked crypto provider supports them. The `P-521`, `P-384` and `P-256` groups are retained as fallbacks (#8107).
+
 ## [7.0.10]
 
 [7.0.10]: https://github.com/microsoft/CCF/releases/tag/ccf-7.0.10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,12 @@ option(LONG_TESTS "Enable long end-to-end tests" OFF)
 option(USE_SNMALLOC "Link against snmalloc" ON)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/snmalloc.cmake)
 
+option(
+  TEST_HYBRID_TLS_GROUPS
+  "Assert that TLS handshakes negotiate a hybrid post-quantum group, which requires OpenSSL 3.5 or later"
+  OFF
+)
+
 option(CLANG_TIDY "Run clang-tidy on the codebase" OFF)
 
 option(
@@ -863,6 +869,10 @@ if(BUILD_TESTS)
 
     add_unit_test(tls_test ${CMAKE_CURRENT_SOURCE_DIR}/src/tls/test/main.cpp)
     target_link_libraries(tls_test PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+    target_compile_definitions(
+      tls_test
+      PRIVATE TEST_HYBRID_TLS_GROUPS=$<BOOL:${TEST_HYBRID_TLS_GROUPS}>
+    )
 
     add_unit_test(
       base64_test
@@ -1331,6 +1341,14 @@ if(BUILD_TESTS)
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/connections.py
     BUCKET bucket_c
   )
+
+  if(TEST_HYBRID_TLS_GROUPS)
+    add_e2e_test(
+      NAME tls_groups_test
+      PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/tls_groups.py
+      BUCKET bucket_a
+    )
+  endif()
 
   if(CLIENT_PROTOCOLS_TEST)
     add_e2e_test(

--- a/src/tls/context.h
+++ b/src/tls/context.h
@@ -73,8 +73,12 @@ namespace ccf::tls
         "TLS_AES_128_GCM_SHA256";
       CHECK1(SSL_CTX_set_ciphersuites(cfg, ciphersuites));
 
-      // Restrict the curves to approved ones
-      CHECK1(SSL_CTX_set1_curves_list(cfg, "P-521:P-384:P-256"));
+      // Prefer hybrid post-quantum groups when available, while retaining the
+      // approved classical groups as fallbacks
+      CHECK1(SSL_CTX_set1_groups_list(
+        cfg,
+        "?SecP384r1MLKEM1024:?SecP256r1MLKEM768:?X25519MLKEM768:"
+        "P-521:P-384:P-256"));
 
       // Allow buffer to be relocated between WANT_WRITE retries, and do partial
       // writes if possible

--- a/src/tls/test/main.cpp
+++ b/src/tls/test/main.cpp
@@ -10,6 +10,7 @@
 #include "tls/server.h"
 #include "tls/tls.h"
 
+#include <algorithm>
 #include <chrono>
 #include <exception>
 #include <openssl/err.h>
@@ -349,6 +350,53 @@ std::string truncate_message(const uint8_t* msg, size_t len)
   return str;
 }
 
+void run_handshake(tls::Server& server, tls::Client& client)
+{
+  std::atomic<bool> keep_going = true;
+  std::optional<std::runtime_error> client_exception, server_exception;
+
+  thread client_thread([&client, &keep_going, &client_exception]() {
+    LOG_INFO_FMT("Client handshake");
+    try
+    {
+      if (handshake(&client, keep_going))
+        throw runtime_error("Client handshake error");
+    }
+    catch (std::runtime_error& ex)
+    {
+      keep_going = false;
+      client_exception = ex;
+    }
+  });
+
+  thread server_thread([&server, &keep_going, &server_exception]() {
+    LOG_INFO_FMT("Server handshake");
+    try
+    {
+      if (handshake(&server, keep_going))
+        throw runtime_error("Server handshake error");
+    }
+    catch (std::runtime_error& ex)
+    {
+      keep_going = false;
+      server_exception = ex;
+    }
+  });
+
+  client_thread.join();
+  server_thread.join();
+  LOG_INFO_FMT("Handshake completed");
+
+  if (client_exception)
+  {
+    throw *client_exception;
+  }
+  if (server_exception)
+  {
+    throw *server_exception;
+  }
+}
+
 /// Test runner, with various options for different kinds of tests.
 void run_test_case(
   const uint8_t* message,
@@ -369,52 +417,7 @@ void run_test_case(
   server.set_bio(&pipe, send<TestPipe::SERVER>, recv<TestPipe::SERVER>);
   client.set_bio(&pipe, send<TestPipe::CLIENT>, recv<TestPipe::CLIENT>);
 
-  std::atomic<bool> keep_going = true;
-  std::optional<std::runtime_error> client_exception, server_exception;
-
-  // Create a thread for the client handshake
-  thread client_thread([&client, &keep_going, &client_exception]() {
-    LOG_INFO_FMT("Client handshake");
-    try
-    {
-      if (handshake(&client, keep_going))
-        throw runtime_error("Client handshake error");
-    }
-    catch (std::runtime_error& ex)
-    {
-      keep_going = false;
-      client_exception = ex;
-    }
-  });
-
-  // Create a thread for the server handshake
-  thread server_thread([&server, &keep_going, &server_exception]() {
-    LOG_INFO_FMT("Server handshake");
-    try
-    {
-      if (handshake(&server, keep_going))
-        throw runtime_error("Server handshake error");
-    }
-    catch (std::runtime_error& ex)
-    {
-      keep_going = false;
-      server_exception = ex;
-    }
-  });
-
-  // Join threads
-  client_thread.join();
-  server_thread.join();
-  LOG_INFO_FMT("Handshake completed");
-
-  if (client_exception)
-  {
-    throw *client_exception;
-  }
-  if (server_exception)
-  {
-    throw *server_exception;
-  }
+  run_handshake(server, client);
 
   // The rest of the communication is deterministic and easy to simulate
   // so we take them out of the thread, to guarantee there will be bytes
@@ -467,16 +470,97 @@ void run_test_case(
   server.close();
 }
 
+std::string negotiated_group_name(SSL* ssl)
+{
+  const auto group_id = SSL_get_negotiated_group(ssl);
+  if (group_id == NID_undef)
+  {
+    return {};
+  }
+
+  const auto* group_name = SSL_group_to_name(ssl, group_id);
+  if (group_name != nullptr)
+  {
+    return group_name;
+  }
+
+  return std::to_string(group_id);
+}
+
 class InspectableClient : public tls::Client
 {
 public:
   using tls::Client::Client;
 
+  InspectableClient(
+    std::shared_ptr<::tls::Cert> cert, const std::string& groups) :
+    tls::Client(std::move(cert))
+  {
+    REQUIRE(SSL_set1_groups_list(get_ssl(), groups.c_str()) == 1);
+  }
+
   int verify_mode()
   {
     return SSL_get_verify_mode(get_ssl());
   }
+
+  std::string negotiated_group()
+  {
+    return negotiated_group_name(get_ssl());
+  }
 };
+
+class InspectableServer : public tls::Server
+{
+public:
+  InspectableServer(
+    const std::shared_ptr<::tls::Cert>& cert, const std::string& groups) :
+    tls::Server(cert)
+  {
+    REQUIRE(SSL_set1_groups_list(get_ssl(), groups.c_str()) == 1);
+  }
+
+  std::string negotiated_group()
+  {
+    return negotiated_group_name(get_ssl());
+  }
+};
+
+#ifndef TEST_HYBRID_TLS_GROUPS
+#  define TEST_HYBRID_TLS_GROUPS 0
+#endif
+
+// Hybrid groups offered by src/tls/context.h, in the order they are offered
+constexpr auto secp384r1_mlkem1024 = "SecP384r1MLKEM1024";
+constexpr auto secp256r1_mlkem768 = "SecP256r1MLKEM768";
+constexpr auto x25519_mlkem768 = "X25519MLKEM768";
+
+// Classical groups offered by src/tls/context.h, in the same order
+constexpr auto classical_groups = "P-521:P-384:P-256";
+
+/// Handshakes a client offering client_groups against a server offering
+/// server_groups, and returns the group they agreed on. Throws if they cannot
+/// agree.
+std::string negotiate_group(
+  const std::string& client_groups, const std::string& server_groups)
+{
+  INFO("client groups: ", client_groups);
+  INFO("server groups: ", server_groups);
+
+  auto ca = get_ca();
+  InspectableServer server(get_dummy_cert(ca, "server", false), server_groups);
+  InspectableClient client(get_dummy_cert(ca, "client", false), client_groups);
+
+  TestPipe pipe;
+  server.set_bio(&pipe, send<TestPipe::SERVER>, recv<TestPipe::SERVER>);
+  client.set_bio(&pipe, send<TestPipe::CLIENT>, recv<TestPipe::CLIENT>);
+
+  run_handshake(server, client);
+
+  const auto group = client.negotiated_group();
+  REQUIRE(group == server.negotiated_group());
+  return group;
+}
 
 TEST_CASE("connection inherits verification mode from context")
 {
@@ -495,6 +579,113 @@ TEST_CASE("connection inherits verification mode from context")
   REQUIRE((request_only_client.verify_mode() & SSL_VERIFY_PEER) != 0);
   REQUIRE(
     (request_only_client.verify_mode() & SSL_VERIFY_FAIL_IF_NO_PEER_CERT) == 0);
+}
+
+TEST_CASE("group negotiation")
+{
+  SUBCASE("the first group offered by the client wins")
+  {
+    REQUIRE(
+      negotiate_group("P-384:P-256:P-521", "P-384:P-256:P-521") == "secp384r1");
+    REQUIRE(
+      negotiate_group("P-256:P-384:P-521", "P-256:P-384:P-521") == "secp256r1");
+  }
+
+  SUBCASE("the client order wins over the server order")
+  {
+    // In TLS 1.3 the server selects the group, and OpenSSL selects the first
+    // group the client offered that the server also supports. The server order
+    // is only a filter, so the client dictates the outcome.
+    REQUIRE(negotiate_group("P-256:P-521", "P-521:P-256") == "secp256r1");
+    REQUIRE(negotiate_group("P-521:P-256", "P-256:P-521") == "secp521r1");
+  }
+
+  SUBCASE("disjoint groups fail the handshake")
+  {
+    REQUIRE_THROWS_AS(
+      negotiate_group("P-521", "P-256"), const std::runtime_error&);
+  }
+}
+
+TEST_CASE(
+  "hybrid group negotiation" * doctest::skip(TEST_HYBRID_TLS_GROUPS == 0))
+{
+  const std::vector<std::string> hybrid_groups = {
+    secp384r1_mlkem1024, secp256r1_mlkem768, x25519_mlkem768};
+
+  SUBCASE("the configured groups negotiate the strongest hybrid group")
+  {
+    auto ca = get_ca();
+    tls::Server server(get_dummy_cert(ca, "server", false));
+    InspectableClient client(get_dummy_cert(ca, "client", false));
+
+    TestPipe pipe;
+    server.set_bio(&pipe, send<TestPipe::SERVER>, recv<TestPipe::SERVER>);
+    client.set_bio(&pipe, send<TestPipe::CLIENT>, recv<TestPipe::CLIENT>);
+
+    run_handshake(server, client);
+
+    REQUIRE(client.negotiated_group() == secp384r1_mlkem1024);
+  }
+
+  SUBCASE("disjoint hybrid groups with no classical fallback fail")
+  {
+    REQUIRE_THROWS_AS(
+      negotiate_group(secp384r1_mlkem1024, secp256r1_mlkem768),
+      const std::runtime_error&);
+  }
+
+  SUBCASE("disjoint hybrid groups fall back to the first shared classical one")
+  {
+    REQUIRE(
+      negotiate_group(
+        fmt::format("{}:{}", secp384r1_mlkem1024, classical_groups),
+        fmt::format("{}:{}", secp256r1_mlkem768, classical_groups)) ==
+      "secp521r1");
+  }
+
+  SUBCASE("disjoint hybrid and disjoint classical groups fail")
+  {
+    REQUIRE_THROWS_AS(
+      negotiate_group(
+        fmt::format("{}:P-521", secp384r1_mlkem1024),
+        fmt::format("{}:P-256", secp256r1_mlkem768)),
+      const std::runtime_error&);
+  }
+
+  SUBCASE("the client order decides which shared hybrid group is used")
+  {
+    // As for classical groups, the client's order is what matters
+    REQUIRE(
+      negotiate_group(
+        fmt::format("{}:{}", secp384r1_mlkem1024, secp256r1_mlkem768),
+        fmt::format("{}:{}", secp256r1_mlkem768, secp384r1_mlkem1024)) ==
+      secp384r1_mlkem1024);
+    REQUIRE(
+      negotiate_group(
+        fmt::format("{}:{}", secp256r1_mlkem768, secp384r1_mlkem1024),
+        fmt::format("{}:{}", secp384r1_mlkem1024, secp256r1_mlkem768)) ==
+      secp256r1_mlkem768);
+  }
+
+  SUBCASE("each hybrid group can be negotiated on its own")
+  {
+    for (const auto& group : hybrid_groups)
+    {
+      INFO("group: ", group);
+      REQUIRE(negotiate_group(group, group) == group);
+    }
+  }
+
+  SUBCASE("a shared hybrid group is preferred over classical fallbacks")
+  {
+    for (const auto& group : hybrid_groups)
+    {
+      INFO("group: ", group);
+      const auto groups = fmt::format("{}:{}", group, classical_groups);
+      REQUIRE(negotiate_group(groups, groups) == group);
+    }
+  }
 }
 
 TEST_CASE("unverified handshake")

--- a/tests/tls_groups.py
+++ b/tests/tls_groups.py
@@ -1,0 +1,99 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+import re
+import subprocess
+
+import infra.e2e_args
+import infra.network
+import suite.test_requirements as reqs
+from loguru import logger as LOG
+
+# Hybrid groups offered by src/tls/context.h, in the order they are offered
+HYBRID_GROUPS = ["SecP384r1MLKEM1024", "SecP256r1MLKEM768", "X25519MLKEM768"]
+
+# Weakest classical fallback, and the name OpenSSL reports for it
+WEAKEST_GROUP = "P-256"
+WEAKEST_GROUP_REPORTED = "prime256v1"
+
+# A group CCF does not offer
+UNSUPPORTED_GROUP = "X448"
+
+# s_client reports hybrid groups by name, and classical groups as a peer key
+NEGOTIATED_GROUP = re.compile(r"^Negotiated TLS1\.3 group: (\S+)$", re.MULTILINE)
+PEER_TEMP_KEY = re.compile(r"^Peer Temp Key: ECDH, ([^,]+),", re.MULTILINE)
+
+
+def negotiate_group(address, groups):
+    """
+    Handshakes with the node at address, offering only groups, and returns the
+    group they agreed on, or None if they could not agree.
+    """
+    completed = subprocess.run(
+        ["openssl", "s_client", "-connect", address, "-groups", groups],
+        input="",
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    output = completed.stdout + completed.stderr
+
+    match = NEGOTIATED_GROUP.search(output)
+    if match is not None and match.group(1) != "<NULL>":
+        return match.group(1)
+
+    match = PEER_TEMP_KEY.search(output)
+    if match is not None:
+        return match.group(1)
+
+    return None
+
+
+@reqs.description("Node negotiates hybrid post-quantum TLS groups")
+def test_tls_groups(network, args):
+    primary, _ = network.find_primary()
+    address = primary.get_public_rpc_address()
+
+    for group in HYBRID_GROUPS:
+        negotiated = negotiate_group(address, group)
+        LOG.info(f"Offered {group}, negotiated {negotiated}")
+        assert negotiated == group, f"Offered {group}, negotiated {negotiated}"
+
+    # The node offers HYBRID_GROUPS in that order, but the server order is only
+    # a filter: OpenSSL picks the first group the client offered that the
+    # server also supports, so the client order decides the outcome.
+    strongest, weakest = HYBRID_GROUPS[0], HYBRID_GROUPS[-1]
+    for first, second in ((weakest, strongest), (strongest, weakest)):
+        offered = f"{first}:{second}"
+        negotiated = negotiate_group(address, offered)
+        LOG.info(f"Offered {offered}, negotiated {negotiated}")
+        assert negotiated == first, f"Offered {offered}, negotiated {negotiated}"
+
+    negotiated = negotiate_group(address, WEAKEST_GROUP)
+    LOG.info(f"Offered {WEAKEST_GROUP}, negotiated {negotiated}")
+    assert (
+        negotiated == WEAKEST_GROUP_REPORTED
+    ), f"Offered {WEAKEST_GROUP}, negotiated {negotiated}"
+
+    negotiated = negotiate_group(address, UNSUPPORTED_GROUP)
+    LOG.info(f"Offered {UNSUPPORTED_GROUP}, negotiated {negotiated}")
+    assert (
+        negotiated is None
+    ), f"Offered {UNSUPPORTED_GROUP}, but negotiated {negotiated}"
+
+    return network
+
+
+def run(args):
+    with infra.network.network(
+        args.nodes, args.binary_dir, args.debug_nodes, pdb=args.pdb
+    ) as network:
+        network.start_and_open(args)
+        test_tls_groups(network, args)
+
+
+if __name__ == "__main__":
+    args = infra.e2e_args.cli_args()
+    args.package = "samples/apps/logging/logging"
+    args.nodes = infra.e2e_args.min_nodes(args, f=0)
+    run(args)


### PR DESCRIPTION
This supersedes #8097 (which in turn supersedes #8076).

Diff
- changed the offered order and clarified that in the changelog
- added more tests, in particular for mixed-up groups and client/server ordering
- made hybrid test mandatory to pass for Azure Linux 4 CI