### PR TITLE
Stabilize certificate rollback partition test

### DIFF
--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -459,7 +459,7 @@ def test_rolled_back_node_certificate(network, args):
             rollback_tx,
             timeout=network.election_duration * 4,
         )
-    network.wait_for_node_commit_sync()
+    network.wait_for_node_commit_sync(timeout=network.election_duration * 4)
     assert get_stored_certificate(renewed_node) == original_cert
 
     with new_primary.client() as c:


### PR DESCRIPTION
## Summary

Use the test network's election-derived timeout while waiting for commit levels to converge after healing the partition in `test_rolled_back_node_certificate`.

This is deliberately scoped to this call site. The generic 3-second default remains unchanged for tests that do not intentionally tear down node-to-node connectivity.

## Why

The first attempt of [CI run 31189649906](https://github.com/microsoft/CCF/actions/runs/31189649906/attempts/1) failed after the certificate-renewal partition was removed:

- node 0 rolled back its conflicting view-6 suffix and stored the view-7 suffix through `7.96`;
- node 0 reported `7.94` committed while nodes 1 and 3 reported `7.96` for the full 3-second `wait_for_node_commit_sync()` default;
- the network's configured election timeout was 4 seconds;
- just after that 3-second wait failed, node 0 reopened node-to-node connections, started view 8, and became leader with `7.96` in its log.

Deleting the iptables rules and reaching primary unanimity do not guarantee that node-to-node transport has recovered immediately. This is the same class of timing behaviour described in #7687 and handled elsewhere by #7601.

The preceding `wait_for_commit()` in this test already uses `network.election_duration * 4`. Applying the same bound to commit synchronization gives transport reconnection and any resulting election time to complete, without adding an unbounded wait or weakening assertions.

[Attempt 2](https://github.com/microsoft/CCF/actions/runs/31189649906/attempts/2) passed unchanged, including the partitions step, confirming that the original failure was intermittent rather than a deterministic consensus regression.

## Validation

- `scripts/ci-checks.sh`
- `cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build`
- `./tests.sh --timeout 360 --output-on-failure -L partitions -C partitions` (passed in a user network namespace with `NET_ADMIN`)