### PR TITLE
Fix node certificate synchronization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -793,6 +793,11 @@ if(BUILD_TESTS)
     )
     target_link_libraries(ledger_secrets_test PRIVATE ccf_kv)
 
+    add_unit_test(
+      node_client_test
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/node/test/node_client.cpp
+    )
+
     add_unit_test(js_test ${CMAKE_CURRENT_SOURCE_DIR}/src/js/test/js.cpp)
     target_link_libraries(
       js_test

--- a/src/node/http_node_client.h
+++ b/src/node/http_node_client.h
@@ -14,10 +14,13 @@ namespace ccf
     HTTPNodeClient(
       std::shared_ptr<ccf::RPCMap> rpc_map,
       ccf::crypto::ECKeyPairPtr node_sign_kp,
-      const ccf::crypto::Pem& self_signed_node_cert_,
-      const std::optional<ccf::crypto::Pem>& endorsed_node_cert_) :
+      ccf::crypto::Pem self_signed_node_cert_,
+      std::optional<ccf::crypto::Pem> endorsed_node_cert_) :
       NodeClient(
-        rpc_map, node_sign_kp, self_signed_node_cert_, endorsed_node_cert_)
+        std::move(rpc_map),
+        std::move(node_sign_kp),
+        std::move(self_signed_node_cert_),
+        std::move(endorsed_node_cert_))
     {}
 
     ~HTTPNodeClient() override = default;

--- a/src/node/node_client.h
+++ b/src/node/node_client.h
@@ -14,19 +14,19 @@ namespace ccf
   protected:
     std::shared_ptr<ccf::RPCMap> rpc_map;
     ccf::crypto::ECKeyPairPtr node_sign_kp;
-    const ccf::crypto::Pem& self_signed_node_cert;
-    const std::optional<ccf::crypto::Pem>& endorsed_node_cert = std::nullopt;
+    const ccf::crypto::Pem self_signed_node_cert;
+    const std::optional<ccf::crypto::Pem> endorsed_node_cert;
 
   public:
     NodeClient(
       std::shared_ptr<ccf::RPCMap> rpc_map_,
       ccf::crypto::ECKeyPairPtr node_sign_kp_,
-      const ccf::crypto::Pem& self_signed_node_cert_,
-      const std::optional<ccf::crypto::Pem>& endorsed_node_cert_) :
+      ccf::crypto::Pem self_signed_node_cert_,
+      std::optional<ccf::crypto::Pem> endorsed_node_cert_) :
       rpc_map(std::move(rpc_map_)),
       node_sign_kp(std::move(node_sign_kp_)),
-      self_signed_node_cert(self_signed_node_cert_),
-      endorsed_node_cert(endorsed_node_cert_)
+      self_signed_node_cert(std::move(self_signed_node_cert_)),
+      endorsed_node_cert(std::move(endorsed_node_cert_))
     {}
 
     virtual ~NodeClient() = default;

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -412,6 +412,7 @@ namespace ccf
     std::shared_ptr<ccf::crypto::ECKeyPair_OpenSSL> node_sign_kp;
     NodeId self;
     std::shared_ptr<ccf::crypto::RSAKeyPair> node_encrypt_kp;
+    pal::Mutex node_certificates_lock;
     ccf::crypto::Pem self_signed_node_cert;
     std::optional<ccf::crypto::Pem> endorsed_node_cert = std::nullopt;
     QuoteInfo quote_info;
@@ -1143,14 +1144,18 @@ namespace ccf
       subject_alt_names = get_subject_alternative_names();
 
       js::register_class_ids();
-      self_signed_node_cert = create_self_signed_cert(
+      const auto new_self_signed_node_cert = create_self_signed_cert(
         node_sign_kp,
         config.node_certificate.subject_name,
         subject_alt_names,
         config.startup_host_time,
         config.node_certificate.initial_validity_days);
+      {
+        std::lock_guard<pal::Mutex> cert_guard(node_certificates_lock);
+        self_signed_node_cert = new_self_signed_node_cert;
+      }
 
-      accept_node_tls_connections();
+      accept_node_tls_connections(new_self_signed_node_cert);
 
       // Signatures are only emitted on a timer once the public ledger has been
       // recovered
@@ -1175,7 +1180,7 @@ namespace ccf
           history->set_service_signing_identity(
             network.identity->get_key_pair(), config.cose_signatures);
 
-          setup_consensus(false, endorsed_node_cert);
+          setup_consensus(false);
 
           // Become the primary and force replication
           consensus->force_become_primary();
@@ -1185,14 +1190,14 @@ namespace ccf
           initiate_quote_generation();
 
           LOG_INFO_FMT("Created new node {}", self);
-          return {self_signed_node_cert, network.identity->cert};
+          return {new_self_signed_node_cert, network.identity->cert};
         }
         case StartType::Join:
         {
           initiate_quote_generation();
 
           LOG_INFO_FMT("Created join node {}", self);
-          return {self_signed_node_cert, {}};
+          return {new_self_signed_node_cert, {}};
         }
         case StartType::Recover:
         {
@@ -1215,7 +1220,7 @@ namespace ccf
           initiate_quote_generation();
 
           LOG_INFO_FMT("Created recovery node {}", self);
-          return {self_signed_node_cert, network.identity->cert};
+          return {new_self_signed_node_cert, network.identity->cert};
         }
         default:
         {
@@ -1320,10 +1325,9 @@ namespace ccf
       curl_handle.set_opt(CURLOPT_TIMEOUT, 60L);
 
       const auto client_key_pem = node_sign_kp->private_key_pem();
+      const auto self_signed_cert = get_self_signed_certificate();
       curl_handle.set_blob_opt(
-        CURLOPT_SSLCERT_BLOB,
-        self_signed_node_cert.data(),
-        self_signed_node_cert.size());
+        CURLOPT_SSLCERT_BLOB, self_signed_cert.data(), self_signed_cert.size());
       curl_handle.set_opt(CURLOPT_SSLCERTTYPE, "PEM");
       curl_handle.set_blob_opt(
         CURLOPT_SSLKEY_BLOB, client_key_pem.data(), client_key_pem.size());
@@ -1828,7 +1832,7 @@ namespace ccf
         consensus,
         rpc_map,
         node_sign_kp,
-        self_signed_node_cert,
+        get_self_signed_certificate(),
         config.jwt.key_refresh_max_response_size);
       jwt_key_auto_refresh->start();
 
@@ -2809,7 +2813,7 @@ namespace ccf
 
     ccf::crypto::Pem get_self_signed_certificate() override
     {
-      std::lock_guard<pal::Mutex> guard(lock);
+      std::lock_guard<pal::Mutex> guard(node_certificates_lock);
       return self_signed_node_cert;
     }
 
@@ -2878,30 +2882,21 @@ namespace ccf
       return sans;
     }
 
-    void accept_node_tls_connections()
+    void accept_node_tls_connections(const ccf::crypto::Pem& self_signed_cert)
     {
       // Accept TLS connections, presenting self-signed (i.e. non-endorsed)
       // node certificate.
       rpcsessions->set_node_cert(
-        self_signed_node_cert, node_sign_kp->private_key_pem());
+        self_signed_cert, node_sign_kp->private_key_pem());
       LOG_INFO_FMT("Node TLS connections now accepted");
     }
 
-    void accept_network_tls_connections()
+    void accept_network_tls_connections(const ccf::crypto::Pem& endorsed_cert)
     {
       // Accept TLS connections, presenting node certificate signed by network
       // certificate
-      CCF_ASSERT_FMT(
-        endorsed_node_cert.has_value(),
-        "Node certificate should be endorsed before accepting endorsed "
-        "client "
-        "connections");
-      if (auto cert_opt = endorsed_node_cert; cert_opt.has_value())
-      {
-        const auto& endorsed_cert = cert_opt.value();
-        rpcsessions->set_network_cert(
-          endorsed_cert, node_sign_kp->private_key_pem());
-      }
+      rpcsessions->set_network_cert(
+        endorsed_cert, node_sign_kp->private_key_pem());
       LOG_INFO_FMT("Network TLS connections now accepted");
     }
 
@@ -2926,20 +2921,13 @@ namespace ccf
       open_frontend(ActorsType::users);
     }
 
-    bool is_member_frontend_open_unsafe()
+    bool is_member_frontend_open() override
     {
       return find_frontend(ActorsType::members)->is_open();
     }
 
-    bool is_member_frontend_open() override
-    {
-      std::lock_guard<pal::Mutex> guard(lock);
-      return is_member_frontend_open_unsafe();
-    }
-
     bool is_user_frontend_open() override
     {
-      std::lock_guard<pal::Mutex> guard(lock);
       return find_frontend(ActorsType::users)->is_open();
     }
 
@@ -3039,8 +3027,9 @@ namespace ccf
 
     bool send_create_request(const std::vector<uint8_t>& packed)
     {
+      const auto self_signed_cert = get_self_signed_certificate();
       auto node_session = std::make_shared<SessionContext>(
-        InvalidSessionId, self_signed_node_cert.raw());
+        InvalidSessionId, self_signed_cert.raw());
       auto ctx = make_rpc_context(node_session, packed);
 
       std::shared_ptr<ccf::RpcHandler> search =
@@ -3267,21 +3256,26 @@ namespace ccf
                   "Could not find endorsed node certificate for {}", self));
               }
 
-              std::lock_guard<pal::Mutex> guard(lock);
+              const auto new_endorsed_node_cert = endorsed_certificate.value();
+              std::optional<ccf::crypto::Pem> previous_endorsed_node_cert;
+              {
+                std::lock_guard<pal::Mutex> cert_guard(node_certificates_lock);
+                previous_endorsed_node_cert = endorsed_node_cert;
+                endorsed_node_cert = new_endorsed_node_cert;
+              }
 
-              if (endorsed_node_cert.has_value())
+              if (previous_endorsed_node_cert.has_value())
               {
                 LOG_INFO_FMT(
                   "[local] Previous endorsed node cert was:\n{}",
-                  endorsed_node_cert->str());
+                  previous_endorsed_node_cert->str());
               }
 
-              endorsed_node_cert = endorsed_certificate.value();
               LOG_INFO_FMT(
-                "[local] Under lock, setting endorsed node cert to:\n{}",
-                endorsed_node_cert->str());
-              history->set_endorsed_certificate(endorsed_node_cert.value());
-              n2n_channels->set_endorsed_node_cert(endorsed_node_cert.value());
+                "[local] Setting endorsed node cert to:\n{}",
+                new_endorsed_node_cert.str());
+              history->set_endorsed_certificate(new_endorsed_node_cert);
+              n2n_channels->set_endorsed_node_cert(new_endorsed_node_cert);
             }
 
             return {nullptr};
@@ -3317,12 +3311,12 @@ namespace ccf
                   "Could not find endorsed node certificate for {}", self));
               }
 
-              std::lock_guard<pal::Mutex> guard(lock);
+              const auto new_endorsed_node_cert = endorsed_certificate.value();
 
               LOG_INFO_FMT("[global] Accepting network connections");
-              accept_network_tls_connections();
+              accept_network_tls_connections(new_endorsed_node_cert);
 
-              if (is_member_frontend_open_unsafe())
+              if (is_member_frontend_open())
               {
                 // Also, automatically refresh self-signed node certificate,
                 // using the same validity period as the endorsed certificate.
@@ -3331,30 +3325,43 @@ namespace ccf
                 // for the initial addition of the node (the self-signed
                 // certificate is output to disk then).
                 auto [valid_from, valid_to] =
-                  ccf::crypto::make_verifier(endorsed_node_cert.value())
+                  ccf::crypto::make_verifier(new_endorsed_node_cert)
                     ->validity_period();
                 LOG_INFO_FMT(
                   "[global] Member frontend is open, so refreshing self-signed "
                   "node cert");
-                LOG_INFO_FMT(
-                  "[global] Previously:\n{}", self_signed_node_cert.str());
-                self_signed_node_cert = create_self_signed_cert(
+                const auto new_self_signed_node_cert = create_self_signed_cert(
                   node_sign_kp,
                   config.node_certificate.subject_name,
                   subject_alt_names,
                   valid_from,
                   valid_to);
-                LOG_INFO_FMT("[global] Now:\n{}", self_signed_node_cert.str());
+
+                ccf::crypto::Pem previous_self_signed_node_cert;
+                {
+                  std::lock_guard<pal::Mutex> cert_guard(
+                    node_certificates_lock);
+                  previous_self_signed_node_cert = self_signed_node_cert;
+                  self_signed_node_cert = new_self_signed_node_cert;
+                }
+
+                LOG_INFO_FMT(
+                  "[global] Previously:\n{}",
+                  previous_self_signed_node_cert.str());
+                LOG_INFO_FMT(
+                  "[global] Now:\n{}", new_self_signed_node_cert.str());
 
                 LOG_INFO_FMT("[global] Accepting node connections");
-                accept_node_tls_connections();
+                accept_node_tls_connections(new_self_signed_node_cert);
               }
               else
               {
+                const auto current_self_signed_node_cert =
+                  get_self_signed_certificate();
                 LOG_INFO_FMT("[global] Member frontend is NOT open");
                 LOG_INFO_FMT(
                   "[global] Self-signed node cert remains:\n{}",
-                  self_signed_node_cert.str());
+                  current_self_signed_node_cert.str());
               }
 
               LOG_INFO_FMT("[global] Opening members frontend");
@@ -3516,7 +3523,10 @@ namespace ccf
       auto shared_state = std::make_shared<aft::State>(self);
 
       auto node_client = std::make_shared<HTTPNodeClient>(
-        rpc_map, node_sign_kp, self_signed_node_cert, endorsed_node_cert);
+        rpc_map,
+        node_sign_kp,
+        get_self_signed_certificate(),
+        endorsed_node_certificate_);
 
       consensus = std::make_shared<RaftType>(
         consensus_config,

--- a/src/node/recovery_decision_protocol.cpp
+++ b/src/node/recovery_decision_protocol.cpp
@@ -429,13 +429,8 @@ namespace ccf
         // Send a timeout to the internal handlers
         curl::UniqueCURL curl_handle;
 
-        crypto::Pem cert;
-        crypto::Pem privkey_pem;
-        {
-          std::lock_guard<pal::Mutex> guard(node_state->lock);
-          cert = node_state->self_signed_node_cert;
-          privkey_pem = node_state->node_sign_kp->private_key_pem();
-        }
+        const auto cert = node_state->get_self_signed_certificate();
+        const auto privkey_pem = node_state->node_sign_kp->private_key_pem();
 
         curl_handle.set_opt(CURLOPT_SSL_VERIFYHOST, 0L);
         curl_handle.set_opt(CURLOPT_SSL_VERIFYPEER, 0L);
@@ -596,6 +591,9 @@ namespace ccf
     request.info = get_node_info(tx);
     request.txid = get_last_recovered_signed_txid();
     nlohmann::json request_json = request;
+    const auto self_signed_node_cert =
+      node_state->get_self_signed_certificate();
+    const auto node_private_key = node_state->node_sign_kp->private_key_pem();
 
     for (auto& target : config.expected_locations)
     {
@@ -604,8 +602,8 @@ namespace ccf
         request_json,
         target_address,
         "gossip",
-        node_state->self_signed_node_cert,
-        node_state->node_sign_kp->private_key_pem());
+        self_signed_node_cert,
+        node_private_key);
     }
   }
 
@@ -619,14 +617,15 @@ namespace ccf
 
     recovery_decision_protocol::TaggedWithNodeInfo request{
       .info = get_node_info(tx)};
-
     nlohmann::json request_json = request;
+    const auto self_signed_node_cert =
+      node_state->get_self_signed_certificate();
 
     dispatch_authenticated_message(
       request_json,
       node_info.location.address,
       "vote",
-      node_state->self_signed_node_cert,
+      self_signed_node_cert,
       node_state->node_sign_kp->private_key_pem());
   }
 
@@ -676,6 +675,9 @@ namespace ccf
     LOG_TRACE_FMT("Sending recovery-decision-protocol iamopen");
 
     nlohmann::json request_json = get_iamopen_request(tx);
+    const auto self_signed_node_cert =
+      node_state->get_self_signed_certificate();
+    const auto node_private_key = node_state->node_sign_kp->private_key_pem();
 
     for (auto& target : config.expected_locations)
     {
@@ -688,8 +690,8 @@ namespace ccf
         request_json,
         target.address,
         "iamopen",
-        node_state->self_signed_node_cert,
-        node_state->node_sign_kp->private_key_pem());
+        self_signed_node_cert,
+        node_private_key);
     }
   }
 

--- a/src/node/test/node_client.cpp
+++ b/src/node/test/node_client.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+
+#include "node/node_client.h"
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+namespace
+{
+  class TestNodeClient : public ccf::NodeClient
+  {
+  public:
+    using ccf::NodeClient::NodeClient;
+
+    bool make_request([[maybe_unused]] ::http::Request& request) override
+    {
+      return true;
+    }
+
+    const ccf::crypto::Pem& get_self_signed_node_cert() const
+    {
+      return self_signed_node_cert;
+    }
+
+    const std::optional<ccf::crypto::Pem>& get_endorsed_node_cert() const
+    {
+      return endorsed_node_cert;
+    }
+  };
+}
+
+TEST_CASE("NodeClient owns certificate snapshots")
+{
+  ccf::crypto::Pem self_signed_node_cert(
+    "-----BEGIN CERTIFICATE-----\nself\n-----END CERTIFICATE-----");
+  std::optional<ccf::crypto::Pem> endorsed_node_cert(ccf::crypto::Pem(
+    "-----BEGIN CERTIFICATE-----\nendorsed\n-----END CERTIFICATE-----"));
+  const auto initial_self_signed_node_cert = self_signed_node_cert;
+  const auto initial_endorsed_node_cert = endorsed_node_cert.value();
+
+  TestNodeClient node_client(
+    nullptr, nullptr, self_signed_node_cert, endorsed_node_cert);
+
+  self_signed_node_cert = ccf::crypto::Pem(
+    "-----BEGIN CERTIFICATE-----\nnew self\n-----END CERTIFICATE-----");
+  endorsed_node_cert = ccf::crypto::Pem(
+    "-----BEGIN CERTIFICATE-----\nnew endorsed\n-----END CERTIFICATE-----");
+
+  CHECK(
+    node_client.get_self_signed_node_cert() == initial_self_signed_node_cert);
+  REQUIRE(node_client.get_endorsed_node_cert().has_value());
+  CHECK(
+    node_client.get_endorsed_node_cert().value() == initial_endorsed_node_cert);
+}


### PR DESCRIPTION
## Summary

- protect mutable node certificates with a dedicated mutex and use stable copies outside its lock scope
- make `NodeClient` own immutable certificate snapshots instead of references into `NodeState`
- update recovery-decision-protocol readers and add focused ownership coverage

## Issue #8123 coverage

This PR resolves **Still Applicable item 3, certificate state lock ordering and ownership**:

- certificate KV hooks no longer take the broad `NodeState::lock`
- both mutable node certificate fields are protected by a dedicated mutex
- certificate lock scopes cover only snapshot publication and never span TLS, history, node-to-node channel, frontend, or RPC work
- asynchronous `NodeClient` users retain immutable certificate snapshots rather than references that can race renewal

This PR does not resolve items 4-6 or the remaining AFT startup question.

## Testing

- Clang 18 Debug builds: `node_client_test`, `ccf`, `logging`
- `build-local/tests.sh -R '^node_client_test$'`
- focused three-node certificate renewal rollback/re-election partition scenario
- TSAN build and the same focused unit and partition scenario
- rebased onto #8127, then rebuilt `node_client_test` and `ccf` and reran the focused unit test
- C++/CMake formatting, include, copyright, ASCII, and diff checks

Partially addresses #8123