### PR TITLE
Fix committed RW real-time response indexing

### DIFF
--- a/tla/consistency/ExternalHistoryInvars.tla
+++ b/tla/consistency/ExternalHistoryInvars.tla
@@ -230,7 +230,7 @@ CommittedRwResponses ==
 CommittedRwOrderedRealTimeInv == 
     \A i \in RwTxResponseCommittedEventIndexes :
         \A j \in RwTxRequestCommittedEventIndexes :
-            \A k \in RoTxResponseCommittedEventIndexes :
+            \A k \in RwTxResponseCommittedEventIndexes :
                 /\ history[k].tx = history[j].tx
                 /\ i < j 
                 => TxIDStrictlyLessThan(history[i].tx_id, history[k].tx_id)


### PR DESCRIPTION
CommittedRwOrderedRealTimeInv compares three history events:

- i is a committed read-write response that occurred first.
- j is a later committed read-write request.
- k is the committed read-write response matching j.

k was incorrectly selected from RoTxResponseCommittedEventIndexes. Because request transaction values are unique, a read-only response cannot match the committed read-write request j, so history[k].tx = history[j].tx could not hold and the implication was vacuously true. In the no-read model, the read-only response set is empty. Ranging k over RwTxResponseCommittedEventIndexes selects the intended matching response and makes the real-time ordering check effective.

TLC checks passed with no errors:

- python3 ./tlc.py mc consistency/MCMultiNode.tla
- python3 ./tlc.py mc consistency/MCMultiNodeReads.tla

This defect was noticed while examining #8134. This PR is intentionally independent and contains none of #8134 invariant-relaxation work, including no change to CommittedRwOrderedSerializableInv.