### PR TITLE
Finish mutex lock-order cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -939,6 +939,7 @@ if(BUILD_TESTS)
       ${CCF_DIR}/src/node/quote.cpp
       ${CCF_DIR}/src/node/uvm_endorsements.cpp
       ${CCF_DIR}/src/node/recovery_decision_protocol.cpp
+      DETECT_DEADLOCKS
     )
     target_link_libraries(
       frontend_test
@@ -1252,6 +1253,7 @@ if(BUILD_TESTS)
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/governance.py
     CONSTITUTION ${CONSTITUTION_ARGS}
     BUCKET bucket_c
+    DETECT_DEADLOCKS
     ADDITIONAL_ARGS
       --initial-operator-count
       1
@@ -1290,6 +1292,7 @@ if(BUILD_TESTS)
     NAME e2e_logging
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/e2e_logging.py
     BUCKET bucket_c
+    DETECT_DEADLOCKS
     ADDITIONAL_ARGS --js-app-bundle ${CMAKE_SOURCE_DIR}/samples/apps/logging/js
   )
 
@@ -1345,6 +1348,7 @@ if(BUILD_TESTS)
     NAME partitions
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/partitions_test.py
     LABEL partitions
+    DETECT_DEADLOCKS
     CONFIGURATIONS partitions
   )
 

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -126,7 +126,7 @@ function(add_e2e_test)
   cmake_parse_arguments(
     PARSE_ARGV 0
     PARSED_ARGS
-    ""
+    "DETECT_DEADLOCKS"
     "NAME;PYTHON_SCRIPT;LABEL;CURL_CLIENT;BUCKET"
     "CONSTITUTION;ADDITIONAL_ARGS;CONFIGURATIONS"
   )
@@ -190,7 +190,11 @@ function(add_e2e_test)
       )
     endif()
 
-    add_san_test_properties(${PARSED_ARGS_NAME})
+    set(SAN_TEST_ARGS "")
+    if(PARSED_ARGS_DETECT_DEADLOCKS)
+      set(SAN_TEST_ARGS DETECT_DEADLOCKS)
+    endif()
+    add_san_test_properties(${PARSED_ARGS_NAME} ${SAN_TEST_ARGS})
 
     if(COVERAGE)
       set_property(

--- a/cmake/gersemi_definitions.cmake
+++ b/cmake/gersemi_definitions.cmake
@@ -23,7 +23,7 @@ function(add_e2e_test)
   cmake_parse_arguments(
     PARSE_ARGV 0
     PARSED_ARGS
-    ""
+    "DETECT_DEADLOCKS"
     "NAME;PYTHON_SCRIPT;LABEL;CURL_CLIENT;BUCKET"
     "CONSTITUTION;ADDITIONAL_ARGS;CONFIGURATIONS"
   )

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -2970,9 +2970,13 @@ namespace ccf
       find_frontend(actor)->open();
     }
 
-    void open_user_frontend()
+    void open_frontend_async(ActorsType actor)
     {
-      open_frontend(ActorsType::users);
+      // Global hooks may run while KV locks are held. Defer frontend
+      // initialisation so its internal locks are acquired after the hook
+      // returns. RpcFrontend::open() is idempotent.
+      ccf::tasks::add_task(
+        ccf::tasks::make_basic_task([this, actor]() { open_frontend(actor); }));
     }
 
     bool is_member_frontend_open() override
@@ -3419,7 +3423,7 @@ namespace ccf
               }
 
               LOG_INFO_FMT("[global] Opening members frontend");
-              open_frontend(ActorsType::members);
+              open_frontend_async(ActorsType::members);
             }
           }));
 
@@ -3457,7 +3461,7 @@ namespace ccf
             network.identity->set_certificate(w->cert);
             if (w->status == ServiceStatus::OPEN)
             {
-              open_user_frontend();
+              open_frontend_async(ActorsType::users);
 
               RINGBUFFER_WRITE_MESSAGE(::consensus::ledger_open, to_host);
               LOG_INFO_FMT("Service open at seqno {}", hook_version);

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -1159,7 +1159,10 @@ namespace ccf
 
     void tick(std::chrono::milliseconds elapsed) override
     {
-      endpoints.tick(elapsed);
+      if (is_open_.load(std::memory_order_acquire))
+      {
+        endpoints.tick(elapsed);
+      }
     }
   };
 }

--- a/src/node/rpc/frontend.h
+++ b/src/node/rpc/frontend.h
@@ -42,7 +42,7 @@ namespace ccf
 
   private:
     ccf::pal::Mutex open_lock;
-    bool is_open_ = false;
+    std::atomic<bool> is_open_{false};
 
     std::atomic<ccf::kv::Consensus*> consensus{nullptr};
     std::shared_ptr<AbstractForwarder> cmd_forwarder;
@@ -1078,11 +1078,11 @@ namespace ccf
     void open() override
     {
       std::lock_guard<ccf::pal::Mutex> mguard(open_lock);
-      if (!is_open_)
+      if (!is_open_.load(std::memory_order_relaxed))
       {
         LOG_INFO_FMT("Opening frontend");
-        is_open_ = true;
         endpoints.init_handlers();
+        is_open_.store(true, std::memory_order_release);
       }
     }
 
@@ -1097,8 +1097,7 @@ namespace ccf
 
     bool is_open() override
     {
-      std::lock_guard<ccf::pal::Mutex> mguard(open_lock);
-      return is_open_;
+      return is_open_.load(std::memory_order_acquire);
     }
 
     void set_root_on_proposals(

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -487,6 +487,32 @@ public:
   }
 };
 
+class BlockingUserEndpointRegistry : public UserEndpointRegistry
+{
+  std::latch& init_started;
+  std::latch& continue_init;
+
+public:
+  std::atomic<size_t> init_count{0};
+
+  BlockingUserEndpointRegistry(
+    ccf::AbstractNodeContext& context,
+    std::latch& init_started_,
+    std::latch& continue_init_) :
+    UserEndpointRegistry(context),
+    init_started(init_started_),
+    continue_init(continue_init_)
+  {}
+
+  void init_handlers() override
+  {
+    ++init_count;
+    init_started.count_down();
+    continue_init.wait();
+    UserEndpointRegistry::init_handlers();
+  }
+};
+
 void publish_frontend_state(RpcHandler& frontend, NetworkState& network)
 {
   const auto consensus = network.tables->get_consensus();
@@ -514,6 +540,29 @@ void prepare_callers(NetworkState& network)
   member_id = InternalTablesAccess::add_member(tx, member_cert);
   invalid_member_id = InternalTablesAccess::add_member(tx, invalid_caller);
   CHECK(tx.commit() == ccf::kv::CommitResult::SUCCESS);
+}
+
+TEST_CASE("Frontend opens atomically")
+{
+  NetworkState network;
+  prepare_callers(network);
+  ccf::StubNodeContext context;
+  std::latch init_started(1);
+  std::latch continue_init(1);
+  BlockingUserEndpointRegistry registry(context, init_started, continue_init);
+  RpcFrontend frontend(*network.tables, registry, context);
+
+  REQUIRE_FALSE(frontend.is_open());
+
+  std::thread opener([&frontend]() { frontend.open(); });
+  init_started.wait();
+  CHECK_FALSE(frontend.is_open());
+  continue_init.count_down();
+  opener.join();
+
+  REQUIRE(frontend.is_open());
+  frontend.open();
+  REQUIRE(registry.init_count.load() == 1);
 }
 
 TEST_CASE("Frontend state publication is thread-safe")

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -494,6 +494,7 @@ class BlockingUserEndpointRegistry : public UserEndpointRegistry
 
 public:
   std::atomic<size_t> init_count{0};
+  std::atomic<size_t> tick_count{0};
 
   BlockingUserEndpointRegistry(
     ccf::AbstractNodeContext& context,
@@ -510,6 +511,11 @@ public:
     init_started.count_down();
     continue_init.wait();
     UserEndpointRegistry::init_handlers();
+  }
+
+  void tick(std::chrono::milliseconds) override
+  {
+    ++tick_count;
   }
 };
 
@@ -557,12 +563,16 @@ TEST_CASE("Frontend opens atomically")
   std::thread opener([&frontend]() { frontend.open(); });
   init_started.wait();
   CHECK_FALSE(frontend.is_open());
+  frontend.tick(std::chrono::milliseconds(1));
+  CHECK(registry.tick_count.load() == 0);
   continue_init.count_down();
   opener.join();
 
   REQUIRE(frontend.is_open());
+  frontend.tick(std::chrono::milliseconds(1));
   frontend.open();
   REQUIRE(registry.init_count.load() == 1);
+  REQUIRE(registry.tick_count.load() == 1);
 }
 
 TEST_CASE("Frontend state publication is thread-safe")

--- a/tsan_env_suppressions
+++ b/tsan_env_suppressions
@@ -4,10 +4,6 @@
 # Awkward usages of '*' in this file like '/ds/*ring_buffer.h' are necessary to handle the cases where tsan thinks
 # src/ds/ring_buffer.h as src/ds/test/../ring_buffer.h for example
 
-# For partitions_test
-deadlock:*/store.h
-deadlock:*/untyped_map.h
-
 # Race between closedir and epoll_ctl.
 race:closedir
 race:epoll_ctl


### PR DESCRIPTION
## Summary

- defer member and user frontend initialization until after their KV global hooks return, while keeping the node frontend synchronous
- publish frontend readiness atomically after handler initialization so hook-side readiness checks do not take `open_lock`
- add focused atomic-open regression coverage
- enable suppression-free TSAN deadlock detection for the frontend, governance, logging, and partition tests
- remove the broad `store.h` and `untyped_map.h` deadlock suppressions

## Why

The endorsed-certificate and service global hooks could call `RpcFrontend::open()` while KV locks were held. `open()` takes `open_lock` and initializes endpoint handlers, extending the hook-side lock chain. The endorsed-certificate hook also queried frontend readiness by taking the same mutex.

The hooks now enqueue idempotent frontend initialization on the task system. `RpcFrontend::open()` retains its mutex for one-time initialization and release-publishes readiness only after `init_handlers()` completes; readers acquire-load readiness without taking that mutex.

The node frontend remains synchronous because boot and in-process node RPC tasks depend on it being available immediately.

## TSAN exit criteria

`DETECT_DEADLOCKS` is now available to e2e tests and is applied to the focused startup/governance/partition coverage as well as `frontend_test`. These tests run with deadlock detection enabled, halt on the first report, and do not load repository-wide suppressions.

The long TSAN workflow will determine whether AFT startup still reports a lock-order inversion. If it does, this PR will add the two-phase startup change described in #8123 before the suppressions remain removed.

## Testing

- TSAN build: `frontend_test`, `js_generic`, and `logging`
- suppression-free TSAN: `frontend_test` and `ledger_secrets_test`
- C++ and CMake formatting
- include, copyright, and ASCII checks
- suppression-free e2e startup and governance runs reached the deferred member-frontend path locally, but could not complete because WSL rejected test TCP listeners; long TSAN CI is requested for authoritative e2e and partition coverage

Closes #8123