### PR TITLE
Use node APIs for live ledger reads

### DIFF
--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -162,16 +162,16 @@ def test_forced_ledger_chunk(network, args):
 
     # Check that there is indeed a ledger chunk that ends at the
     # first signature after proposal.completed_seqno
-    ledger = primary.get_ledger_chunk_from_api(proposal.completed_seqno)
-    chunk, _, last, next_signature = find_ledger_chunk_for_seqno(
-        ledger, proposal.completed_seqno
-    )
-    LOG.info(
-        f"Found ledger chunk {chunk.filename()} with chunking proposal @{proposal.completed_seqno} and signature @{next_signature}"
-    )
-    assert chunk.is_complete and chunk.is_committed()
-    assert last == next_signature
-    assert next_signature - proposal.completed_seqno < args.sig_tx_interval
+    with primary.get_ledger_chunk_from_api(proposal.completed_seqno) as ledger:
+        chunk, _, last, next_signature = find_ledger_chunk_for_seqno(
+            ledger, proposal.completed_seqno
+        )
+        LOG.info(
+            f"Found ledger chunk {chunk.filename()} with chunking proposal @{proposal.completed_seqno} and signature @{next_signature}"
+        )
+        assert chunk.is_complete and chunk.is_committed()
+        assert last == next_signature
+        assert next_signature - proposal.completed_seqno < args.sig_tx_interval
     return network
 
 

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -160,11 +160,9 @@ def test_forced_ledger_chunk(network, args):
     # Issue some more transactions
     network.txs.issue(network, number_txs=5)
 
-    ledger_dirs = primary.remote.ledger_paths()
-
     # Check that there is indeed a ledger chunk that ends at the
     # first signature after proposal.completed_seqno
-    ledger = ccf.ledger.Ledger(ledger_dirs, contiguous_suffix=True)
+    ledger = primary.get_ledger_from_api(proposal.completed_seqno)
     chunk, _, last, next_signature = find_ledger_chunk_for_seqno(
         ledger, proposal.completed_seqno
     )

--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -162,7 +162,7 @@ def test_forced_ledger_chunk(network, args):
 
     # Check that there is indeed a ledger chunk that ends at the
     # first signature after proposal.completed_seqno
-    ledger = primary.get_ledger_from_api(proposal.completed_seqno)
+    ledger = primary.get_ledger_chunk_from_api(proposal.completed_seqno)
     chunk, _, last, next_signature = find_ledger_chunk_for_seqno(
         ledger, proposal.completed_seqno
     )

--- a/tests/governance_history.py
+++ b/tests/governance_history.py
@@ -207,8 +207,8 @@ def remove_prefix(s, prefix):
 def test_tables_doc(network, args):
     primary, _ = network.find_primary()
     target_seqno = network.create_and_wait_for_ledger_chunk(primary)
-    ledger = primary.get_ledger_from_api(target_seqno)
-    table_names_in_ledger = ledger.get_latest_public_state()[0].keys()
+    public_state, _ = primary.get_public_state_from_api(target_seqno)
+    table_names_in_ledger = public_state.keys()
     check_all_tables_are_documented(
         table_names_in_ledger, "../doc/audit/builtin_maps.rst"
     )

--- a/tests/governance_history.py
+++ b/tests/governance_history.py
@@ -206,8 +206,8 @@ def remove_prefix(s, prefix):
 @reqs.description("Check tables are documented")
 def test_tables_doc(network, args):
     primary, _ = network.find_primary()
-    ledger_directories = primary.remote.ledger_paths()
-    ledger = ccf.ledger.Ledger(ledger_directories, contiguous_suffix=True)
+    target_seqno = network.create_and_wait_for_ledger_chunk(primary)
+    ledger = primary.get_ledger_from_api(target_seqno)
     table_names_in_ledger = ledger.get_latest_public_state()[0].keys()
     check_all_tables_are_documented(
         table_names_in_ledger, "../doc/audit/builtin_maps.rst"
@@ -218,10 +218,9 @@ def test_tables_doc(network, args):
 @reqs.description("Test that all nodes' ledgers can be read")
 def test_ledger_is_readable(network, args):
     primary, backups = network.find_nodes()
+    target_seqno = network.create_and_wait_for_ledger_chunk(primary)
     for node in (primary, *backups):
-        ledger_dirs = node.remote.ledger_paths()
-        LOG.info(f"Reading ledger from {ledger_dirs}")
-        ledger = ccf.ledger.Ledger(ledger_dirs, contiguous_suffix=True)
+        ledger = node.get_ledger_from_api(target_seqno, local_only=True)
         for chunk in ledger:
             for _ in chunk:
                 pass
@@ -236,13 +235,12 @@ def test_read_ledger_utility(network, args):
     format_rule = [(".*records.*", {"key": fmt_str, "value": fmt_str})]
 
     network.txs.issue(network, number_txs=args.snapshot_tx_interval)
-    network.get_latest_ledger_public_state()
+    target_seqno = network.create_and_wait_for_ledger_chunk()
 
     primary, backups = network.find_nodes()
     for node in (primary, *backups):
-        ledger_dirs = node.remote.ledger_paths()
         assert ccf.read_ledger.run(
-            paths=ledger_dirs,
+            paths=node.download_ledger(target_seqno, local_only=True),
             print_mode=ccf.read_ledger.PrintMode.Contents,
             tables_format_rules=format_rule,
         )
@@ -274,7 +272,6 @@ def run(args):
 
         network.consortium.set_authenticate_session(args.authenticate_session)
 
-        ledger_directories = primary.remote.ledger_paths()
         LOG.info("Add new member proposal (implicit vote)")
         (
             new_member_proposal,
@@ -323,10 +320,9 @@ def run(args):
             (new_member_proposal.proposal_id, member.service_id, "withdraw")
         )
 
-        # Force ledger flush of all transactions so far
-        network.get_latest_ledger_public_state()
+        target_seqno = network.create_and_wait_for_ledger_chunk(primary)
 
-        ledger = ccf.ledger.Ledger(ledger_directories, contiguous_suffix=True)
+        ledger = primary.get_ledger_from_api(target_seqno)
         check_operations(ledger, governance_operations)
         check_signatures(ledger)
 

--- a/tests/governance_history.py
+++ b/tests/governance_history.py
@@ -220,10 +220,10 @@ def test_ledger_is_readable(network, args):
     primary, backups = network.find_nodes()
     target_seqno = network.create_and_wait_for_ledger_chunk(primary)
     for node in (primary, *backups):
-        ledger = node.get_ledger_from_api(target_seqno, local_only=True)
-        for chunk in ledger:
-            for _ in chunk:
-                pass
+        with node.get_ledger_from_api(target_seqno, local_only=True) as ledger:
+            for chunk in ledger:
+                for _ in chunk:
+                    pass
     return network
 
 
@@ -239,11 +239,12 @@ def test_read_ledger_utility(network, args):
 
     primary, backups = network.find_nodes()
     for node in (primary, *backups):
-        assert ccf.read_ledger.run(
-            paths=node.download_ledger(target_seqno, local_only=True),
-            print_mode=ccf.read_ledger.PrintMode.Contents,
-            tables_format_rules=format_rule,
-        )
+        with node.download_ledger(target_seqno, local_only=True) as ledger_paths:
+            assert ccf.read_ledger.run(
+                paths=ledger_paths,
+                print_mode=ccf.read_ledger.PrintMode.Contents,
+                tables_format_rules=format_rule,
+            )
 
     snapshot_dir = network.get_committed_snapshots(primary)
     assert ccf.read_ledger.run(
@@ -322,9 +323,9 @@ def run(args):
 
         target_seqno = network.create_and_wait_for_ledger_chunk(primary)
 
-        ledger = primary.get_ledger_from_api(target_seqno)
-        check_operations(ledger, governance_operations)
-        check_signatures(ledger)
+        with primary.get_ledger_from_api(target_seqno) as ledger:
+            check_operations(ledger, governance_operations)
+            check_signatures(ledger)
 
         test_ledger_is_readable(network, args)
         test_read_ledger_utility(network, args)

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -2256,31 +2256,17 @@ class Network:
 
         return target_seqno
 
-    def _get_ledger_public_view_at(self, node, call, seqno, timeout):
-        target_seqno = self.create_and_wait_for_ledger_chunk(
-            node=node,
-            timeout=timeout,
-        )
-        if self._supports_operator_feature(node, "LedgerChunkRead"):
-            return call(
-                node.get_ledger_from_api(target_seqno, timeout=timeout),
-                seqno,
-            )
-
-        return call(None, seqno)
-
     def get_ledger_public_state_at(self, seqno, timeout=5):
         primary, _ = self.find_primary()
-        return self._get_ledger_public_view_at(
-            primary,
-            lambda ledger, s: (
-                ledger.get_transaction(s).get_public_domain().get_tables()
-                if ledger is not None
-                else primary.get_ledger_public_tables_at(s)
-            ),
-            seqno,
-            timeout,
+        self.create_and_wait_for_ledger_chunk(
+            node=primary,
+            timeout=timeout,
         )
+        if self._supports_operator_feature(primary, "LedgerChunkRead"):
+            ledger = primary.get_ledger_chunk_from_api(seqno, timeout=timeout)
+            return ledger.get_transaction(seqno).get_public_domain().get_tables()
+
+        return primary.get_ledger_public_tables_at(seqno)
 
     def get_latest_ledger_public_state(self, timeout=5):
         primary, _ = self.find_primary()
@@ -2288,16 +2274,19 @@ class Network:
             resp = nc.get("/node/commit")
             body = resp.body.json()
             tx_id = TxID.from_str(body["transaction_id"])
-        return self._get_ledger_public_view_at(
-            primary,
-            lambda ledger, s: (
-                ledger.get_latest_public_state()
-                if ledger is not None
-                else primary.get_ledger_public_state_at(s)
-            ),
-            tx_id.seqno,
-            timeout,
+        target_seqno = self.create_and_wait_for_ledger_chunk(
+            node=primary,
+            timeout=timeout,
         )
+        if self._supports_operator_feature(
+            primary, "LedgerChunkRead"
+        ) and self._supports_operator_feature(primary, "SnapshotRead"):
+            return primary.get_public_state_from_api(
+                target_seqno,
+                timeout=timeout,
+            )
+
+        return primary.get_ledger_public_state_at(tx_id.seqno)
 
     @functools.cached_property
     def cert_path(self):

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -2218,23 +2218,68 @@ class Network:
 
         return node.get_committed_snapshots(wait_for_snapshots_to_be_committed)
 
-    def _get_ledger_public_view_at(self, node, call, seqno, timeout):
-        end_time = time.time() + timeout
-        self.consortium.force_ledger_chunk(node)
-        while time.time() < end_time:
-            try:
-                return call(seqno)
-            except Exception as ex:
-                LOG.info(f"Exception: {ex}")
-                time.sleep(0.1)
-        raise TimeoutError(
-            f"Could not read transaction at seqno {seqno} from ledger {node.remote.ledger_paths()} after {timeout}s"
+    @staticmethod
+    def _supports_operator_feature(node, feature):
+        file_serving_interface = node.host.rpc_interfaces.get(
+            infra.interfaces.FILE_SERVING_RPC_INTERFACE
         )
+        if file_serving_interface is None:
+            return False
+        operator_features = file_serving_interface.enabled_operator_features
+        return operator_features is None or feature in operator_features
+
+    def create_and_wait_for_ledger_chunk(self, node=None, timeout=5):
+        if node is None:
+            node, _ = self.find_primary()
+
+        if self._supports_operator_feature(node, "SnapshotCreate"):
+            target_seqno = node.trigger_snapshot().seqno
+        else:
+            proposal = self.consortium.force_ledger_chunk(node)
+            target_seqno = proposal.completed_seqno
+
+        if self._supports_operator_feature(node, "LedgerChunkRead"):
+            node.wait_for_ledger_chunk(target_seqno, timeout=timeout)
+        else:
+            end_time = time.time() + timeout
+            while time.time() < end_time:
+                try:
+                    node.get_ledger_public_tables_at(target_seqno)
+                    break
+                except (AssertionError, ccf.ledger.UnknownTransaction):
+                    time.sleep(0.1)
+            else:
+                raise TimeoutError(
+                    f"Could not read transaction at seqno {target_seqno} from "
+                    f"ledger {node.remote.ledger_paths()} after {timeout}s"
+                )
+
+        return target_seqno
+
+    def _get_ledger_public_view_at(self, node, call, seqno, timeout):
+        target_seqno = self.create_and_wait_for_ledger_chunk(
+            node=node,
+            timeout=timeout,
+        )
+        if self._supports_operator_feature(node, "LedgerChunkRead"):
+            return call(
+                node.get_ledger_from_api(target_seqno, timeout=timeout),
+                seqno,
+            )
+
+        return call(None, seqno)
 
     def get_ledger_public_state_at(self, seqno, timeout=5):
         primary, _ = self.find_primary()
         return self._get_ledger_public_view_at(
-            primary, primary.get_ledger_public_tables_at, seqno, timeout
+            primary,
+            lambda ledger, s: (
+                ledger.get_transaction(s).get_public_domain().get_tables()
+                if ledger is not None
+                else primary.get_ledger_public_tables_at(s)
+            ),
+            seqno,
+            timeout,
         )
 
     def get_latest_ledger_public_state(self, timeout=5):
@@ -2244,7 +2289,14 @@ class Network:
             body = resp.body.json()
             tx_id = TxID.from_str(body["transaction_id"])
         return self._get_ledger_public_view_at(
-            primary, primary.get_ledger_public_state_at, tx_id.seqno, timeout
+            primary,
+            lambda ledger, s: (
+                ledger.get_latest_public_state()
+                if ledger is not None
+                else primary.get_ledger_public_state_at(s)
+            ),
+            tx_id.seqno,
+            timeout,
         )
 
     @functools.cached_property

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -2263,8 +2263,8 @@ class Network:
             timeout=timeout,
         )
         if self._supports_operator_feature(primary, "LedgerChunkRead"):
-            ledger = primary.get_ledger_chunk_from_api(seqno, timeout=timeout)
-            return ledger.get_transaction(seqno).get_public_domain().get_tables()
+            with primary.get_ledger_chunk_from_api(seqno, timeout=timeout) as ledger:
+                return ledger.get_transaction(seqno).get_public_domain().get_tables()
 
         return primary.get_ledger_public_tables_at(seqno)
 

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -2226,7 +2226,7 @@ class Network:
         if file_serving_interface is None:
             return False
         operator_features = file_serving_interface.enabled_operator_features
-        return operator_features is None or feature in operator_features
+        return operator_features is not None and feature in operator_features
 
     def create_and_wait_for_ledger_chunk(self, node=None, timeout=5):
         if node is None:

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -212,11 +212,11 @@ class Node:
                     host=rpc_interface.host, port=node_port
                 )
 
-            # The ledger chunk download API is only supported from
-            # 7.0.0-dev10 onwards.
+            # These helpers use the underscored ledger chunk endpoint, which is
+            # only supported from 7.0.0-dev13 onwards.
             if (
                 self.version is not None
-                and Version(strip_version(self.version)) <= Version("7.0.0-dev9")
+                and Version(strip_version(self.version)) <= Version("7.0.0-dev12")
                 and rpc_interface.enabled_operator_features
                 and "LedgerChunkRead" in rpc_interface.enabled_operator_features
             ):

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -603,17 +603,14 @@ class Node:
             f"node {self.local_node_id} after {timeout}s"
         )
 
-    def download_ledger(
+    def _download_ledger(
         self,
+        ledger_dir,
         target_seqno,
         timeout=5,
         local_only=False,
         start_seqno=None,
     ):
-        ledger_dir = tempfile.mkdtemp(
-            prefix=f"{self.local_node_id}.ledger.downloaded.",
-            dir=self.common_dir,
-        )
         ledger_paths = []
 
         def save_chunk(response, requested_seqno):
@@ -713,6 +710,27 @@ class Node:
 
         return ledger_paths
 
+    @contextmanager
+    def download_ledger(
+        self,
+        target_seqno,
+        timeout=5,
+        local_only=False,
+        start_seqno=None,
+    ):
+        with tempfile.TemporaryDirectory(
+            prefix=f"{self.local_node_id}.ledger.downloaded.",
+            dir=self.common_dir,
+        ) as ledger_dir:
+            yield self._download_ledger(
+                ledger_dir,
+                target_seqno,
+                timeout=timeout,
+                local_only=local_only,
+                start_seqno=start_seqno,
+            )
+
+    @contextmanager
     def get_ledger_from_api(
         self,
         target_seqno,
@@ -722,28 +740,24 @@ class Node:
         **kwargs,
     ):
         kwargs.setdefault("committed_only", True)
-        return ccf.ledger.Ledger(
-            self.download_ledger(
-                target_seqno,
-                timeout=timeout,
-                local_only=local_only,
-                start_seqno=start_seqno,
-            ),
-            **kwargs,
-        )
+        with self.download_ledger(
+            target_seqno,
+            timeout=timeout,
+            local_only=local_only,
+            start_seqno=start_seqno,
+        ) as ledger_paths:
+            yield ccf.ledger.Ledger(ledger_paths, **kwargs)
 
+    @contextmanager
     def get_ledger_chunk_from_api(self, seqno, timeout=5):
-        return self.get_ledger_from_api(
+        with self.get_ledger_from_api(
             seqno,
             timeout=timeout,
             start_seqno=seqno,
-        )
+        ) as ledger:
+            yield ledger
 
-    def get_public_state_from_api(self, target_seqno, timeout=5):
-        snapshot_dir = tempfile.mkdtemp(
-            prefix=f"{self.local_node_id}.snapshot.downloaded.",
-            dir=self.common_dir,
-        )
+    def _download_snapshot(self, snapshot_dir, timeout):
         end_time = time.time() + timeout
         with self.client(
             interface_name=infra.interfaces.FILE_SERVING_RPC_INTERFACE
@@ -752,16 +766,17 @@ class Node:
                 r = c.get("/node/snapshot", allow_redirects=True)
                 if r.status_code == http.HTTPStatus.OK:
                     break
-                if time.time() >= end_time:
-                    raise RuntimeError(
-                        f"Unexpected response while downloading latest snapshot: {r}"
-                    )
                 if (
                     r.status_code != http.HTTPStatus.NOT_FOUND
                     and r.status_code < http.HTTPStatus.INTERNAL_SERVER_ERROR
                 ):
                     raise RuntimeError(
                         f"Unexpected response while downloading latest snapshot: {r}"
+                    )
+                if time.time() >= end_time:
+                    raise TimeoutError(
+                        f"Could not download latest snapshot from node "
+                        f"{self.local_node_id} after {timeout}s; last response: {r}"
                     )
                 time.sleep(0.1)
 
@@ -770,31 +785,40 @@ class Node:
             with open(snapshot_path, "wb") as snapshot_file:
                 snapshot_file.write(r.body.data())
 
-        with ccf.ledger.Snapshot(snapshot_path) as snapshot:
-            public_domain = snapshot.get_public_domain()
-            public_tables = public_domain.get_tables()
-            latest_seqno = public_domain.get_seqno()
+        return snapshot_path
+
+    def get_public_state_from_api(self, target_seqno, timeout=5):
+        with tempfile.TemporaryDirectory(
+            prefix=f"{self.local_node_id}.snapshot.downloaded.",
+            dir=self.common_dir,
+        ) as snapshot_dir:
+            snapshot_path = self._download_snapshot(snapshot_dir, timeout)
+            with ccf.ledger.Snapshot(snapshot_path) as snapshot:
+                public_domain = snapshot.get_public_domain()
+                public_tables = public_domain.get_tables()
+                latest_seqno = public_domain.get_seqno()
 
         if latest_seqno >= target_seqno:
             return public_tables, latest_seqno
 
-        for transaction in self.get_ledger_from_api(
+        with self.get_ledger_from_api(
             target_seqno,
             timeout=timeout,
             local_only=False,
             start_seqno=latest_seqno + 1,
             committed_only=True,
-        ).transactions():
-            public_domain = transaction.get_public_domain()
-            if public_domain.get_seqno() <= latest_seqno:
-                continue
-            latest_seqno = public_domain.get_seqno()
-            for table_name, records in public_domain.get_tables().items():
-                table = public_tables.setdefault(table_name, {})
-                table.update(records)
-                public_tables[table_name] = {
-                    key: value for key, value in table.items() if value is not None
-                }
+        ) as ledger:
+            for transaction in ledger.transactions():
+                public_domain = transaction.get_public_domain()
+                if public_domain.get_seqno() <= latest_seqno:
+                    continue
+                latest_seqno = public_domain.get_seqno()
+                for table_name, records in public_domain.get_tables().items():
+                    table = public_tables.setdefault(table_name, {})
+                    table.update(records)
+                    public_tables[table_name] = {
+                        key: value for key, value in table.items() if value is not None
+                    }
 
         return public_tables, latest_seqno
 

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -10,7 +10,9 @@ import os
 import re
 import socket
 import ssl
+import tempfile
 import time
+import urllib.parse
 from contextlib import closing, contextmanager
 from datetime import datetime, timedelta, timezone
 from enum import Enum, auto
@@ -210,10 +212,11 @@ class Node:
                     host=rpc_interface.host, port=node_port
                 )
 
-            # LedgerChunkRead operator feature is only supported from 7.0.0-dev7 onwards
+            # The ledger chunk download API is only supported from
+            # 7.0.0-dev10 onwards.
             if (
                 self.version is not None
-                and Version(strip_version(self.version)) <= Version("7.0.0-dev6")
+                and Version(strip_version(self.version)) <= Version("7.0.0-dev9")
                 and rpc_interface.enabled_operator_features
                 and "LedgerChunkRead" in rpc_interface.enabled_operator_features
             ):
@@ -548,15 +551,135 @@ class Node:
         raise TimeoutError(f"Node {self.local_node_id} failed to join the network")
 
     def get_ledger_public_tables_at(self, seqno):
+        if not self.is_stopped():
+            LOG.warning(
+                "Parsing ledger files directly from live node {}",
+                self.local_node_id,
+            )
         ledger = ccf.ledger.Ledger(self.remote.ledger_paths())
         assert ledger.last_committed_chunk_range[1] >= seqno
         tx = ledger.get_transaction(seqno)
         return tx.get_public_domain().get_tables()
 
     def get_ledger_public_state_at(self, seqno):
+        if not self.is_stopped():
+            LOG.warning(
+                "Parsing ledger files directly from live node {}",
+                self.local_node_id,
+            )
         ledger = ccf.ledger.Ledger(self.remote.ledger_paths())
         assert ledger.last_committed_chunk_range[1] >= seqno
         return ledger.get_latest_public_state()
+
+    def wait_for_ledger_chunk(self, seqno, timeout=5):
+        end_time = time.time() + timeout
+        with self.client(
+            interface_name=infra.interfaces.FILE_SERVING_RPC_INTERFACE
+        ) as c:
+            while time.time() < end_time:
+                r = c.head(
+                    f"/node/ledger_chunk?since={seqno}",
+                    allow_redirects=True,
+                )
+                if r.status_code == http.HTTPStatus.OK:
+                    chunk_name = os.path.basename(
+                        r.headers["x-ms-ccf-ledger-chunk-name"]
+                    )
+                    start_seqno, end_seqno = ccf.ledger.range_from_filename(chunk_name)
+                    assert (
+                        end_seqno is not None and start_seqno <= seqno <= end_seqno
+                    ), f"Ledger chunk {chunk_name} does not cover seqno {seqno}"
+                    return chunk_name
+
+                if r.status_code != http.HTTPStatus.NOT_FOUND:
+                    raise RuntimeError(
+                        f"Unexpected response while waiting for ledger chunk "
+                        f"covering seqno {seqno}: {r}"
+                    )
+                time.sleep(0.1)
+
+        raise TimeoutError(
+            f"Could not download ledger chunk covering seqno {seqno} from "
+            f"node {self.local_node_id} after {timeout}s"
+        )
+
+    def download_ledger(self, target_seqno, timeout=5, local_only=False):
+        ledger_dir = tempfile.mkdtemp(
+            prefix=f"{self.local_node_id}.ledger.downloaded.",
+            dir=self.common_dir,
+        )
+        ledger_paths = []
+        if local_only:
+            with self.client() as c:
+                r = c.get("/node/state")
+                assert r.status_code == http.HTTPStatus.OK, r
+                next_seqno = max(1, r.body.json()["startup_seqno"] + 1)
+        else:
+            next_seqno = 1
+        end_time = time.time() + timeout
+
+        with self.client(
+            interface_name=infra.interfaces.FILE_SERVING_RPC_INTERFACE
+        ) as c:
+            while next_seqno <= target_seqno:
+                r = c.get(
+                    f"/node/ledger_chunk?since={next_seqno}",
+                    allow_redirects=not local_only,
+                )
+                if local_only and r.status_code == http.HTTPStatus.PERMANENT_REDIRECT:
+                    chunk_url = urllib.parse.urlparse(r.headers["Location"])
+                    if chunk_url.query:
+                        if time.time() >= end_time:
+                            raise TimeoutError(
+                                f"Could not download local ledger through seqno "
+                                f"{target_seqno} from node {self.local_node_id} "
+                                f"after {timeout}s"
+                            )
+                        time.sleep(0.1)
+                        continue
+                    r = c.get(chunk_url.path, allow_redirects=False)
+
+                if r.status_code == http.HTTPStatus.NOT_FOUND:
+                    if time.time() >= end_time:
+                        raise TimeoutError(
+                            f"Could not download ledger through seqno "
+                            f"{target_seqno} from node {self.local_node_id} "
+                            f"after {timeout}s"
+                        )
+                    time.sleep(0.1)
+                    continue
+
+                if r.status_code != http.HTTPStatus.OK:
+                    raise RuntimeError(
+                        f"Unexpected response while downloading ledger chunk "
+                        f"covering seqno {next_seqno}: {r}"
+                    )
+
+                chunk_name = os.path.basename(r.headers["x-ms-ccf-ledger-chunk-name"])
+                start_seqno, end_seqno = ccf.ledger.range_from_filename(chunk_name)
+                assert (
+                    end_seqno is not None and start_seqno <= next_seqno <= end_seqno
+                ), f"Ledger chunk {chunk_name} does not cover seqno {next_seqno}"
+
+                chunk_path = os.path.join(ledger_dir, chunk_name)
+                with open(chunk_path, "wb") as chunk_file:
+                    chunk_file.write(r.body.data())
+                ledger_paths.append(chunk_path)
+                next_seqno = end_seqno + 1
+                end_time = time.time() + timeout
+
+        return ledger_paths
+
+    def get_ledger_from_api(self, target_seqno, timeout=5, local_only=False, **kwargs):
+        kwargs.setdefault("committed_only", True)
+        return ccf.ledger.Ledger(
+            self.download_ledger(
+                target_seqno,
+                timeout=timeout,
+                local_only=local_only,
+            ),
+            **kwargs,
+        )
 
     def get_main_ledger_dir(self):
         """
@@ -568,6 +691,11 @@ class Node:
         """
         Triage committed and un-committed (i.e. current) ledger files
         """
+        if not self.is_stopped():
+            LOG.warning(
+                "Copying ledger files directly from live node {}",
+                self.local_node_id,
+            )
         main_ledger_dir, read_only_ledger_dirs = self.remote.get_ledger(
             f"{self.local_node_id}.ledger"
         )

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -603,13 +603,37 @@ class Node:
             f"node {self.local_node_id} after {timeout}s"
         )
 
-    def download_ledger(self, target_seqno, timeout=5, local_only=False):
+    def download_ledger(
+        self,
+        target_seqno,
+        timeout=5,
+        local_only=False,
+        start_seqno=None,
+    ):
         ledger_dir = tempfile.mkdtemp(
             prefix=f"{self.local_node_id}.ledger.downloaded.",
             dir=self.common_dir,
         )
         ledger_paths = []
-        if local_only:
+
+        def save_chunk(response, requested_seqno):
+            chunk_name = os.path.basename(
+                response.headers["x-ms-ccf-ledger-chunk-name"]
+            )
+            start_seqno, end_seqno = ccf.ledger.range_from_filename(chunk_name)
+            assert (
+                end_seqno is not None and start_seqno <= requested_seqno <= end_seqno
+            ), f"Ledger chunk {chunk_name} does not cover seqno {requested_seqno}"
+
+            chunk_path = os.path.join(ledger_dir, chunk_name)
+            with open(chunk_path, "wb") as chunk_file:
+                chunk_file.write(response.body.data())
+            ledger_paths.append(chunk_path)
+            return end_seqno
+
+        if start_seqno is not None:
+            next_seqno = start_seqno
+        elif local_only:
             with self.client() as c:
                 r = c.get("/node/state")
                 assert r.status_code == http.HTTPStatus.OK, r
@@ -640,6 +664,20 @@ class Node:
                     r = c.get(chunk_url.path, allow_redirects=False)
 
                 if r.status_code == http.HTTPStatus.NOT_FOUND:
+                    if (
+                        not local_only
+                        and not ledger_paths
+                        and start_seqno is None
+                        and next_seqno < target_seqno
+                    ):
+                        r = c.get(
+                            f"/node/ledger_chunk?since={target_seqno}",
+                            allow_redirects=True,
+                        )
+                        if r.status_code == http.HTTPStatus.OK:
+                            save_chunk(r, target_seqno)
+                            return ledger_paths
+
                     if time.time() >= end_time:
                         raise TimeoutError(
                             f"Could not download ledger through seqno "
@@ -655,31 +693,96 @@ class Node:
                         f"covering seqno {next_seqno}: {r}"
                     )
 
-                chunk_name = os.path.basename(r.headers["x-ms-ccf-ledger-chunk-name"])
-                start_seqno, end_seqno = ccf.ledger.range_from_filename(chunk_name)
-                assert (
-                    end_seqno is not None and start_seqno <= next_seqno <= end_seqno
-                ), f"Ledger chunk {chunk_name} does not cover seqno {next_seqno}"
-
-                chunk_path = os.path.join(ledger_dir, chunk_name)
-                with open(chunk_path, "wb") as chunk_file:
-                    chunk_file.write(r.body.data())
-                ledger_paths.append(chunk_path)
+                end_seqno = save_chunk(r, next_seqno)
                 next_seqno = end_seqno + 1
                 end_time = time.time() + timeout
 
         return ledger_paths
 
-    def get_ledger_from_api(self, target_seqno, timeout=5, local_only=False, **kwargs):
+    def get_ledger_from_api(
+        self,
+        target_seqno,
+        timeout=5,
+        local_only=False,
+        start_seqno=None,
+        **kwargs,
+    ):
         kwargs.setdefault("committed_only", True)
         return ccf.ledger.Ledger(
             self.download_ledger(
                 target_seqno,
                 timeout=timeout,
                 local_only=local_only,
+                start_seqno=start_seqno,
             ),
             **kwargs,
         )
+
+    def get_ledger_chunk_from_api(self, seqno, timeout=5):
+        return self.get_ledger_from_api(
+            seqno,
+            timeout=timeout,
+            start_seqno=seqno,
+        )
+
+    def get_public_state_from_api(self, target_seqno, timeout=5):
+        snapshot_dir = tempfile.mkdtemp(
+            prefix=f"{self.local_node_id}.snapshot.downloaded.",
+            dir=self.common_dir,
+        )
+        end_time = time.time() + timeout
+        with self.client(
+            interface_name=infra.interfaces.FILE_SERVING_RPC_INTERFACE
+        ) as c:
+            while True:
+                r = c.get("/node/snapshot", allow_redirects=True)
+                if r.status_code == http.HTTPStatus.OK:
+                    break
+                if time.time() >= end_time:
+                    raise RuntimeError(
+                        f"Unexpected response while downloading latest snapshot: {r}"
+                    )
+                if (
+                    r.status_code != http.HTTPStatus.NOT_FOUND
+                    and r.status_code < http.HTTPStatus.INTERNAL_SERVER_ERROR
+                ):
+                    raise RuntimeError(
+                        f"Unexpected response while downloading latest snapshot: {r}"
+                    )
+                time.sleep(0.1)
+
+            snapshot_name = os.path.basename(r.headers["x-ms-ccf-snapshot-name"])
+            snapshot_path = os.path.join(snapshot_dir, snapshot_name)
+            with open(snapshot_path, "wb") as snapshot_file:
+                snapshot_file.write(r.body.data())
+
+        with ccf.ledger.Snapshot(snapshot_path) as snapshot:
+            public_domain = snapshot.get_public_domain()
+            public_tables = public_domain.get_tables()
+            latest_seqno = public_domain.get_seqno()
+
+        if latest_seqno >= target_seqno:
+            return public_tables, latest_seqno
+
+        for transaction in self.get_ledger_from_api(
+            target_seqno,
+            timeout=timeout,
+            local_only=False,
+            start_seqno=latest_seqno + 1,
+            committed_only=True,
+        ).transactions():
+            public_domain = transaction.get_public_domain()
+            if public_domain.get_seqno() <= latest_seqno:
+                continue
+            latest_seqno = public_domain.get_seqno()
+            for table_name, records in public_domain.get_tables().items():
+                table = public_tables.setdefault(table_name, {})
+                table.update(records)
+                public_tables[table_name] = {
+                    key: value for key, value in table.items() if value is not None
+                }
+
+        return public_tables, latest_seqno
 
     def get_main_ledger_dir(self):
         """

--- a/tests/infra/node.py
+++ b/tests/infra/node.py
@@ -645,12 +645,29 @@ class Node:
         with self.client(
             interface_name=infra.interfaces.FILE_SERVING_RPC_INTERFACE
         ) as c:
+
+            def get_chunk(seqno, allow_redirects):
+                try:
+                    return c.get(
+                        f"/node/ledger_chunk?since={seqno}",
+                        allow_redirects=allow_redirects,
+                    )
+                except (
+                    infra.clients.CCFConnectionException,
+                    infra.clients.CCFIOException,
+                ):
+                    # A node which does not hold a chunk redirects to another
+                    # node, which may since have been retired and stopped.
+                    # Treat that as the chunk being unavailable.
+                    return None
+
             while next_seqno <= target_seqno:
-                r = c.get(
-                    f"/node/ledger_chunk?since={next_seqno}",
-                    allow_redirects=not local_only,
-                )
-                if local_only and r.status_code == http.HTTPStatus.PERMANENT_REDIRECT:
+                r = get_chunk(next_seqno, not local_only)
+                if (
+                    local_only
+                    and r is not None
+                    and r.status_code == http.HTTPStatus.PERMANENT_REDIRECT
+                ):
                     chunk_url = urllib.parse.urlparse(r.headers["Location"])
                     if chunk_url.query:
                         if time.time() >= end_time:
@@ -663,18 +680,15 @@ class Node:
                         continue
                     r = c.get(chunk_url.path, allow_redirects=False)
 
-                if r.status_code == http.HTTPStatus.NOT_FOUND:
+                if r is None or r.status_code == http.HTTPStatus.NOT_FOUND:
                     if (
                         not local_only
                         and not ledger_paths
                         and start_seqno is None
                         and next_seqno < target_seqno
                     ):
-                        r = c.get(
-                            f"/node/ledger_chunk?since={target_seqno}",
-                            allow_redirects=True,
-                        )
-                        if r.status_code == http.HTTPStatus.OK:
+                        r = get_chunk(target_seqno, True)
+                        if r is not None and r.status_code == http.HTTPStatus.OK:
                             save_chunk(r, target_seqno)
                             return ledger_paths
 

--- a/tests/jwt_test.py
+++ b/tests/jwt_test.py
@@ -805,25 +805,24 @@ def test_jwt_key_auto_refresh_entries(network, args):
         target_seqno = network.create_and_wait_for_ledger_chunk(primary)
         # Check that despite refreshing JWTs multiple times, only a single
         # transaction was created for this kid.
-        ledger = primary.get_ledger_from_api(target_seqno)
-
-        last_key_refresh = None
-        for chunk in ledger:
-            for tx in chunk:
-                txid = TxID(tx.gcm_header.view, tx.gcm_header.seqno)
-                tables = tx.get_public_domain().get_tables()
-                if "public:ccf.gov.jwt.public_signing_keys_metadata_v2" in tables:
-                    pub_keys = tables[
-                        "public:ccf.gov.jwt.public_signing_keys_metadata_v2"
-                    ]
-                    if kid.encode() in pub_keys:
-                        if last_key_refresh is None:
-                            LOG.info(f"Refresh found for kid: {kid} at {txid}")
-                            last_key_refresh = txid
-                        else:
-                            assert (
-                                last_key_refresh == txid
-                            ), "Duplicate JWT refresh transaction"
+        with primary.get_ledger_from_api(target_seqno) as ledger:
+            last_key_refresh = None
+            for chunk in ledger:
+                for tx in chunk:
+                    txid = TxID(tx.gcm_header.view, tx.gcm_header.seqno)
+                    tables = tx.get_public_domain().get_tables()
+                    if "public:ccf.gov.jwt.public_signing_keys_metadata_v2" in tables:
+                        pub_keys = tables[
+                            "public:ccf.gov.jwt.public_signing_keys_metadata_v2"
+                        ]
+                        if kid.encode() in pub_keys:
+                            if last_key_refresh is None:
+                                LOG.info(f"Refresh found for kid: {kid} at {txid}")
+                                last_key_refresh = txid
+                            else:
+                                assert (
+                                    last_key_refresh == txid
+                                ), "Duplicate JWT refresh transaction"
         assert last_key_refresh, "Missing JWT refresh transaction"
 
     return network

--- a/tests/jwt_test.py
+++ b/tests/jwt_test.py
@@ -8,7 +8,6 @@ import time
 from contextlib import contextmanager
 
 import ca_certs
-import ccf.ledger
 import infra.clients
 import infra.crypto
 import infra.e2e_args
@@ -803,12 +802,10 @@ def test_jwt_key_auto_refresh_entries(network, args):
             timeout=max(5, args.jwt_key_refresh_interval_s * 5),
         )
 
-        # Force chunking
-        network.get_latest_ledger_public_state()
+        target_seqno = network.create_and_wait_for_ledger_chunk(primary)
         # Check that despite refreshing JWTs multiple times, only a single
         # transaction was created for this kid.
-        ledger_directories = primary.remote.ledger_paths()
-        ledger = ccf.ledger.Ledger(ledger_directories, contiguous_suffix=True)
+        ledger = primary.get_ledger_from_api(target_seqno)
 
         last_key_refresh = None
         for chunk in ledger:

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -4,7 +4,6 @@ import datetime
 import json
 import os
 import shutil
-import time
 
 import ccf.ledger
 import infra.crypto
@@ -18,7 +17,6 @@ import infra.platform_detection
 import infra.proc
 import infra.utils
 import suite.test_requirements as reqs
-from ccf.tx_id import TxID
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from e2e_logging import test_random_receipts
@@ -192,24 +190,8 @@ def test_new_service(
     if test_jwt_cleanup:
 
         def get_fresh_public_state():
-            with primary.client() as c:
-                r = c.get("/node/commit")
-                target_seqno = TxID.from_str(r.body.json()["transaction_id"]).seqno
-            network.consortium.force_ledger_chunk(primary)
-            for _ in range(10):
-                ledger = ccf.ledger.Ledger(
-                    primary.remote.ledger_paths(),
-                    committed_only=True,
-                    contiguous_suffix=True,
-                )
-                public_state, last_seqno = ledger.get_latest_public_state()
-                if last_seqno >= target_seqno:
-                    return public_state
-
-                time.sleep(0.1)
-            assert (
-                False
-            ), f"Failed to up-to-date ledger state, seqno needed: {target_seqno}, last seqno: {last_seqno}"
+            public_state, _ = network.get_latest_ledger_public_state()
+            return public_state
 
         def table_has_entries(table_name, public_state):
             rows = public_state.get(table_name, None)
@@ -548,7 +530,7 @@ def run_code_upgrade_from(
                 to_version,
                 expected_subject_name=service_subject_name,
             )
-            network.get_latest_ledger_public_state()
+            network.create_and_wait_for_ledger_chunk()
 
 
 @reqs.description("Run live compatibility with latest LTS")

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -886,9 +886,8 @@ def test_join_straddling_primary_replacement(network, args):
 def test_retired_nodes_stop_signing_after_retired_committed(network, args):
     primary, _ = network.find_primary()
 
-    # Force ledger flush of all transactions so far
-    network.get_latest_ledger_public_state()
-    ledger = ccf.ledger.Ledger(primary.remote.ledger_paths(), contiguous_suffix=True)
+    target_seqno = network.create_and_wait_for_ledger_chunk(primary)
+    ledger = primary.get_ledger_from_api(target_seqno)
 
     # True once a subsequent signature has committed the retired_committed tx
     # itself: rc is then globally committed and the node's retired_committed
@@ -970,13 +969,17 @@ def test_add_node_with_read_only_ledger(network, args):
 
 @reqs.description("Confirm ledger contains expected entries")
 def test_ledger_invariants(network, args):
-    # Force ledger flush of all transactions so far
-    network.get_latest_ledger_public_state()
+    target_seqno = network.create_and_wait_for_ledger_chunk()
 
     for node in network.nodes:
         LOG.info(f"Examining ledger on node {node.local_node_id}")
-        ledger_directories = node.remote.ledger_paths()
-        ledger = ccf.ledger.Ledger(ledger_directories, contiguous_suffix=True)
+        if node.is_stopped():
+            ledger = ccf.ledger.Ledger(
+                node.remote.ledger_paths(),
+                contiguous_suffix=True,
+            )
+        else:
+            ledger = node.get_ledger_from_api(target_seqno, local_only=True)
         check_signatures(ledger)
 
     return network
@@ -986,8 +989,7 @@ def test_ledger_invariants(network, args):
 def test_joining_nodes_snapshot_ledger_offset(network, args):
     primary, _ = network.find_primary()
 
-    network.consortium.force_ledger_chunk(primary)
-    network.get_latest_ledger_public_state()
+    network.create_and_wait_for_ledger_chunk(primary)
 
     network.txs.issue(network, number_txs=5, send_private=False, send_public=True)
     network.txs.issue(network, number_txs=5, send_private=False, send_public=True)
@@ -1029,15 +1031,9 @@ def test_joining_nodes_snapshot_ledger_offset(network, args):
         rest_txid,
     )
 
-    # flush ledger to disk from commit index
-    network.get_latest_ledger_public_state()
-    # Only use the committed ledger files flushed from above
-    _, committed_ledger_dirs = primary.get_ledger()
-    ledger = ccf.ledger.Ledger(
-        committed_ledger_dirs,
-        committed_only=True,
-        contiguous_suffix=True,
-    )
+    target_seqno = network.create_and_wait_for_ledger_chunk(primary)
+    downloaded_ledger = primary.download_ledger(target_seqno)
+    ledger = ccf.ledger.Ledger(downloaded_ledger)
 
     snapshot_chunk_start = None
     snapshot_chunk_entries = None
@@ -1109,13 +1105,10 @@ def test_joining_nodes_snapshot_ledger_offset(network, args):
         os.makedirs(current_dir)
         os.makedirs(prefix_dir)
 
-        for source_dir in committed_ledger_dirs:
-            for f in os.listdir(source_dir):
-                if not f.endswith(ccf.ledger.COMMITTED_FILE_SUFFIX):
-                    continue
-                _, range_end = ccf.ledger.range_from_filename(f)
-                if range_end is not None and range_end < snapshot_chunk_start:
-                    copy(os.path.join(source_dir, f), prefix_dir)
+        for source_path in downloaded_ledger:
+            _, range_end = ccf.ledger.range_from_filename(source_path)
+            if range_end is not None and range_end < snapshot_chunk_start:
+                copy(source_path, prefix_dir)
 
         for entries, end_seqno, complete in chunks_to_write:
             infra.utils.write_ledger_chunk(current_dir, entries, end_seqno, complete)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -1060,6 +1060,12 @@ def test_joining_nodes_snapshot_ledger_offset(network, args):
     snapshot_chunk_start = None
     snapshot_chunk_entries = None
     post_snapshot_entries = []
+    base_dir = os.path.join(network.common_dir, "joining_nodes_snapshot_ledger_offset")
+    rmtree(base_dir, ignore_errors=True)
+    os.makedirs(base_dir)
+    prefix_source_dir = os.path.join(base_dir, "ledger.prefix")
+    os.makedirs(prefix_source_dir)
+    prefix_ledger_paths = []
     with primary.download_ledger(target_seqno, local_only=True) as ledger_paths:
         ledger = ccf.ledger.Ledger(ledger_paths)
         for chunk in ledger:
@@ -1084,6 +1090,14 @@ def test_joining_nodes_snapshot_ledger_offset(network, args):
                 if snapshot_seqno < seqno <= rest_txid.seqno
             )
 
+        assert (
+            snapshot_chunk_start is not None
+        ), f"Could not find ledger chunk ending at snapshot seqno {snapshot_seqno}"
+        for source_path in ledger_paths:
+            _, range_end = ccf.ledger.range_from_filename(source_path)
+            if range_end is not None and range_end < snapshot_chunk_start:
+                prefix_ledger_paths.append(copy(source_path, prefix_source_dir))
+
     assert (
         snapshot_chunk_start is not None
     ), f"Could not find ledger chunk ending at snapshot seqno {snapshot_seqno}"
@@ -1100,10 +1114,6 @@ def test_joining_nodes_snapshot_ledger_offset(network, args):
         post_snapshot_entries
     ), f"Expected ledger entries after snapshot {snapshot_seqno}"
     assert post_snapshot_entries[0][0] == snapshot_seqno + 1, post_snapshot_entries[0]
-
-    base_dir = os.path.join(network.common_dir, "joining_nodes_snapshot_ledger_offset")
-    rmtree(base_dir, ignore_errors=True)
-    os.makedirs(base_dir)
 
     variants = [
         (
@@ -1129,10 +1139,8 @@ def test_joining_nodes_snapshot_ledger_offset(network, args):
         os.makedirs(current_dir)
         os.makedirs(prefix_dir)
 
-        for source_path in downloaded_ledger:
-            _, range_end = ccf.ledger.range_from_filename(source_path)
-            if range_end is not None and range_end < snapshot_chunk_start:
-                copy(source_path, prefix_dir)
+        for source_path in prefix_ledger_paths:
+            copy(source_path, prefix_dir)
 
         for entries, end_seqno, complete in chunks_to_write:
             infra.utils.write_ledger_chunk(current_dir, entries, end_seqno, complete)

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -1051,7 +1051,10 @@ def test_joining_nodes_snapshot_ledger_offset(network, args):
     )
 
     target_seqno = network.create_and_wait_for_ledger_chunk(primary)
-    downloaded_ledger = primary.download_ledger(target_seqno)
+    # Only read the range this node replicated itself. Asking for earlier
+    # seqnos would be redirected to other nodes, which may since have been
+    # retired and stopped.
+    downloaded_ledger = primary.download_ledger(target_seqno, local_only=True)
     ledger = ccf.ledger.Ledger(downloaded_ledger)
 
     snapshot_chunk_start = None

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -888,7 +888,10 @@ def test_retired_nodes_stop_signing_after_retired_committed(network, args):
     primary, _ = network.find_primary()
 
     target_seqno = network.create_and_wait_for_ledger_chunk(primary)
-    ledger = primary.get_ledger_from_api(target_seqno)
+    # Only read the range this node replicated itself. Asking for earlier
+    # seqnos would be redirected to other nodes, which may since have been
+    # retired and stopped.
+    ledger = primary.get_ledger_from_api(target_seqno, local_only=True)
 
     # True once a subsequent signature has committed the retired_committed tx
     # itself: rc is then globally committed and the node's retired_committed

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -14,6 +14,7 @@ from shutil import copy, rmtree
 
 import ccf.ledger
 import ccf.signatures
+import infra.clients
 import infra.crypto
 import infra.e2e_args
 import infra.logging_app as app
@@ -979,7 +980,22 @@ def test_ledger_invariants(network, args):
                 contiguous_suffix=True,
             )
         else:
-            ledger = node.get_ledger_from_api(target_seqno, local_only=True)
+            try:
+                ledger = node.get_ledger_from_api(target_seqno, local_only=True)
+            except (
+                infra.clients.CCFConnectionException,
+                infra.clients.CCFIOException,
+                TimeoutError,
+            ):
+                LOG.warning(
+                    "Node {} is no longer reachable; reading its ledger files "
+                    "directly",
+                    node.local_node_id,
+                )
+                ledger = ccf.ledger.Ledger(
+                    node.remote.ledger_paths(),
+                    contiguous_suffix=True,
+                )
         check_signatures(ledger)
 
     return network

--- a/tests/reconfiguration.py
+++ b/tests/reconfiguration.py
@@ -8,6 +8,7 @@ import random
 import re
 import tempfile
 import time
+from contextlib import ExitStack
 from copy import deepcopy
 from datetime import datetime, timezone
 from shutil import copy, rmtree
@@ -891,50 +892,49 @@ def test_retired_nodes_stop_signing_after_retired_committed(network, args):
     # Only read the range this node replicated itself. Asking for earlier
     # seqnos would be redirected to other nodes, which may since have been
     # retired and stopped.
-    ledger = primary.get_ledger_from_api(target_seqno, local_only=True)
-
     # True once a subsequent signature has committed the retired_committed tx
     # itself: rc is then globally committed and the node's retired_committed
     # hook must have fired, so any further signature from that node is a
     # violation. Presence in this dict means rc has been observed for the node.
     rc_globally_committed: dict[str, bool] = {}
 
-    for chunk in ledger:
-        for tr in chunk:
-            tables = tr.get_public_domain().get_tables()
+    with primary.get_ledger_from_api(target_seqno, local_only=True) as ledger:
+        for chunk in ledger:
+            for tr in chunk:
+                tables = tr.get_public_domain().get_tables()
 
-            if ccf.ledger.NODES_TABLE_NAME in tables:
-                for nid_bytes, info_ in tables[ccf.ledger.NODES_TABLE_NAME].items():
-                    if info_ is None:
-                        continue
-                    info = json.loads(info_)
-                    nid = nid_bytes.decode()
-                    if (
-                        info.get("retired_committed")
-                        and nid not in rc_globally_committed
-                    ):
-                        rc_globally_committed[nid] = False
+                if ccf.ledger.NODES_TABLE_NAME in tables:
+                    for nid_bytes, info_ in tables[ccf.ledger.NODES_TABLE_NAME].items():
+                        if info_ is None:
+                            continue
+                        info = json.loads(info_)
+                        nid = nid_bytes.decode()
+                        if (
+                            info.get("retired_committed")
+                            and nid not in rc_globally_committed
+                        ):
+                            rc_globally_committed[nid] = False
 
-            if ccf.signatures.SIGNATURE_TX_TABLE_NAME in tables:
-                sig = ccf.signatures.parse_raw_signature_from_tx(tables)
-                assert sig is not None, tables
-                signing_node = sig.signing_node
-                sig_seqno = sig.seqno
+                if ccf.signatures.SIGNATURE_TX_TABLE_NAME in tables:
+                    sig = ccf.signatures.parse_raw_signature_from_tx(tables)
+                    assert sig is not None, tables
+                    signing_node = sig.signing_node
+                    sig_seqno = sig.seqno
 
-                # Check BEFORE marking. A node may legally emit exactly one
-                # signature past its rc tx (the chain-closer that commits it).
-                # Once that chain-closer has been seen, the node's
-                # retired_committed hook must have fired, so any further
-                # signature from that node is a violation.
-                assert not rc_globally_committed.get(signing_node, False), (
-                    f"Node {signing_node} signed at seqno {sig_seqno} after "
-                    f"its retired_committed was already globally committed"
-                )
+                    # Check BEFORE marking. A node may legally emit exactly one
+                    # signature past its rc tx (the chain-closer that commits it).
+                    # Once that chain-closer has been seen, the node's
+                    # retired_committed hook must have fired, so any further
+                    # signature from that node is a violation.
+                    assert not rc_globally_committed.get(signing_node, False), (
+                        f"Node {signing_node} signed at seqno {sig_seqno} after "
+                        f"its retired_committed was already globally committed"
+                    )
 
-                # Ledger iteration is seqno-ordered, so any tracked rc was
-                # written at a lower seqno than this sig; the sig commits it.
-                for nid in rc_globally_committed:
-                    rc_globally_committed[nid] = True
+                    # Ledger iteration is seqno-ordered, so any tracked rc was
+                    # written at a lower seqno than this sig; the sig commits it.
+                    for nid in rc_globally_committed:
+                        rc_globally_committed[nid] = True
 
     LOG.info(
         "{} nodes had retired_committed observed throughout test",
@@ -977,29 +977,32 @@ def test_ledger_invariants(network, args):
 
     for node in network.nodes:
         LOG.info(f"Examining ledger on node {node.local_node_id}")
-        if node.is_stopped():
-            ledger = ccf.ledger.Ledger(
-                node.remote.ledger_paths(),
-                contiguous_suffix=True,
-            )
-        else:
-            try:
-                ledger = node.get_ledger_from_api(target_seqno, local_only=True)
-            except (
-                infra.clients.CCFConnectionException,
-                infra.clients.CCFIOException,
-                TimeoutError,
-            ):
-                LOG.warning(
-                    "Node {} is no longer reachable; reading its ledger files "
-                    "directly",
-                    node.local_node_id,
-                )
+        with ExitStack() as stack:
+            if node.is_stopped():
                 ledger = ccf.ledger.Ledger(
                     node.remote.ledger_paths(),
                     contiguous_suffix=True,
                 )
-        check_signatures(ledger)
+            else:
+                try:
+                    ledger = stack.enter_context(
+                        node.get_ledger_from_api(target_seqno, local_only=True)
+                    )
+                except (
+                    infra.clients.CCFConnectionException,
+                    infra.clients.CCFIOException,
+                    TimeoutError,
+                ):
+                    LOG.warning(
+                        "Node {} is no longer reachable; reading its ledger files "
+                        "directly",
+                        node.local_node_id,
+                    )
+                    ledger = ccf.ledger.Ledger(
+                        node.remote.ledger_paths(),
+                        contiguous_suffix=True,
+                    )
+            check_signatures(ledger)
 
     return network
 
@@ -1054,33 +1057,32 @@ def test_joining_nodes_snapshot_ledger_offset(network, args):
     # Only read the range this node replicated itself. Asking for earlier
     # seqnos would be redirected to other nodes, which may since have been
     # retired and stopped.
-    downloaded_ledger = primary.download_ledger(target_seqno, local_only=True)
-    ledger = ccf.ledger.Ledger(downloaded_ledger)
-
     snapshot_chunk_start = None
     snapshot_chunk_entries = None
     post_snapshot_entries = []
-    for chunk in ledger:
-        entries = [
-            (tx.get_public_domain().get_seqno(), tx.get_raw_tx()) for tx in chunk
-        ]
-        if not entries:
-            continue
+    with primary.download_ledger(target_seqno, local_only=True) as ledger_paths:
+        ledger = ccf.ledger.Ledger(ledger_paths)
+        for chunk in ledger:
+            entries = [
+                (tx.get_public_domain().get_seqno(), tx.get_raw_tx()) for tx in chunk
+            ]
+            if not entries:
+                continue
 
-        chunk_start = entries[0][0]
-        chunk_end = entries[-1][0]
-        if chunk_start <= snapshot_seqno <= chunk_end:
-            snapshot_chunk_start = chunk_start
-            snapshot_chunk_entries = entries
-            assert (
-                chunk_end == snapshot_seqno
-            ), f"Expected snapshot seqno {snapshot_seqno} at chunk boundary, got chunk {chunk_start}-{chunk_end}"
+            chunk_start = entries[0][0]
+            chunk_end = entries[-1][0]
+            if chunk_start <= snapshot_seqno <= chunk_end:
+                snapshot_chunk_start = chunk_start
+                snapshot_chunk_entries = entries
+                assert (
+                    chunk_end == snapshot_seqno
+                ), f"Expected snapshot seqno {snapshot_seqno} at chunk boundary, got chunk {chunk_start}-{chunk_end}"
 
-        post_snapshot_entries.extend(
-            (seqno, raw_tx)
-            for seqno, raw_tx in entries
-            if snapshot_seqno < seqno <= rest_txid.seqno
-        )
+            post_snapshot_entries.extend(
+                (seqno, raw_tx)
+                for seqno, raw_tx in entries
+                if snapshot_seqno < seqno <= rest_txid.seqno
+            )
 
     assert (
         snapshot_chunk_start is not None

--- a/tests/recovery.py
+++ b/tests/recovery.py
@@ -2361,8 +2361,7 @@ def run_recover_snapshot_ledger_offset(args):
         network.start_and_open(args)
         primary, _ = network.find_primary()
 
-        network.consortium.force_ledger_chunk(primary)
-        network.get_latest_ledger_public_state()
+        network.create_and_wait_for_ledger_chunk(primary)
 
         network.txs.issue(network, number_txs=5, send_private=False, send_public=True)
         network.txs.issue(network, number_txs=5, send_private=False, send_public=True)
@@ -2400,7 +2399,7 @@ def run_recover_snapshot_ledger_offset(args):
         rest_txid = network.txs.issue(
             network, number_txs=5, send_private=False, send_public=True
         )
-        network.get_latest_ledger_public_state()
+        network.create_and_wait_for_ledger_chunk(primary)
 
         assert snapshot_trigger_txid.seqno < snapshot_seqno < rest_txid.seqno, (
             snapshot_trigger_txid,


### PR DESCRIPTION
## Summary

This replaces #8047, and is what we want to do instead.

Rather than reducing and warning about direct reads of a live node's ledger files, this uses the node's own APIs to fetch ledger chunks and snapshots over HTTP. That preserves the principle of **the node as the single reader/writer of its files**: tests no longer reach into a running node's ledger directory behind its back, so there is no race against the node's own writes, and no need to reason about which files are safe to read at any given moment.

## Approach

- Trigger ledger chunk boundaries through `POST /node/snapshot:create` rather than governance.
- Wait for and download committed chunks through `GET`/`HEAD /node/ledger_chunk?since=...` rather than racing live ledger files.
- Read public state through `GET /node/snapshot`, falling back to ledger chunks for anything after the snapshot.
- Retain compatibility fallbacks for older nodes which do not expose these operator APIs.
- Warn when tests still read or copy ledger files directly from a live node.

Where a test only needs the history a node replicated itself, it asks for exactly that range (`local_only=True`). Requesting earlier seqnos would be redirected to another node, which may since have been retired and stopped.

## CI

CI was re-run 5 times on `bd10486` to confirm the reconfiguration flakiness is gone. All 5 attempts passed both workflows - 40 job runs, no failures.

| Attempt | Continuous Integration | Continuous Integration AL4 |
| --- | --- | --- |
| [1](https://github.com/microsoft/CCF/actions/runs/31741887328/attempts/2) | [✅](https://github.com/microsoft/CCF/actions/runs/31741887328/attempts/2) | [✅](https://github.com/microsoft/CCF/actions/runs/31741887379/attempts/2) |
| [2](https://github.com/microsoft/CCF/actions/runs/31741887328/attempts/3) | [✅](https://github.com/microsoft/CCF/actions/runs/31741887328/attempts/3) | [✅](https://github.com/microsoft/CCF/actions/runs/31741887379/attempts/3) |
| [3](https://github.com/microsoft/CCF/actions/runs/31741887328/attempts/4) | [✅](https://github.com/microsoft/CCF/actions/runs/31741887328/attempts/4) | [✅](https://github.com/microsoft/CCF/actions/runs/31741887379/attempts/4) |
| [4](https://github.com/microsoft/CCF/actions/runs/31741887328/attempts/5) | [✅](https://github.com/microsoft/CCF/actions/runs/31741887328/attempts/5) | [✅](https://github.com/microsoft/CCF/actions/runs/31741887379/attempts/5) |
| [5](https://github.com/microsoft/CCF/actions/runs/31741887328/attempts/6) | [✅](https://github.com/microsoft/CCF/actions/runs/31741887328/attempts/6) | [✅](https://github.com/microsoft/CCF/actions/runs/31741887379/attempts/6) |