### PR TITLE
Sample: Align isOperator and CanOperatorPass checks

### DIFF
--- a/samples/constitutions/operator/resolve.js
+++ b/samples/constitutions/operator/resolve.js
@@ -37,7 +37,11 @@ function canOperatorPass(action) {
   // Additionally, operators can add or retire other operators.
   if (action.name === "set_member") {
     const memberData = action.args["member_data"];
-    if (memberData && memberData.is_operator) {
+    if (
+      memberData &&
+      memberData.is_operator &&
+      action.args["encryption_pub_key"] == null
+    ) {
       return true;
     }
   } else if (action.name === "remove_member") {


### PR DESCRIPTION
In the sample constitution it was possible for an operator to add a new operator with a recovery key.

Specifically `isOperator == !has_recovery_key && data.is_operator` while `canOperatorPass == data.is_operator`.

Thus an operator could add an operator who has a recovery key, which is fine for canOperatorPass, but is not an operator for membership counting reasons.
So an operator could use this to add N+1 'operator recovery members' and hence pass their own ballots.

This PR aligns these two constraints.

To clarify this just fixes up a sample, not anything which is released.