### PR TITLE
Make blocking performance test measure throughput

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1468,6 +1468,60 @@ if(BUILD_TESTS)
       "1,write,3000000,primary"
   )
 
+  set(BLOCKING_PERF_CLIENT_COUNT 320 CACHE STRING "Blocking perf client count")
+  set(
+    BLOCKING_PERF_CLIENTS_PER_PROCESS
+    32
+    CACHE STRING
+    "Blocking perf logical clients per process"
+  )
+  set(
+    BLOCKING_PERF_ITERATIONS
+    2000
+    CACHE STRING
+    "Blocking perf iterations per client"
+  )
+  set(
+    BLOCKING_PERF_SIG_TX_INTERVAL
+    5000
+    CACHE STRING
+    "Blocking perf signature transaction interval"
+  )
+  set(
+    BLOCKING_PERF_SIG_MS_INTERVAL
+    2
+    CACHE STRING
+    "Blocking perf signature time interval"
+  )
+  set(
+    BLOCKING_PERF_NODE_CPU_AFFINITY
+    ""
+    CACHE STRING
+    "Blocking perf node CPU list"
+  )
+  set(
+    BLOCKING_PERF_CLIENT_CPU_AFFINITY
+    ""
+    CACHE STRING
+    "Blocking perf client CPU list"
+  )
+
+  set(BLOCKING_PERF_AFFINITY_ARGS)
+  if(BLOCKING_PERF_NODE_CPU_AFFINITY)
+    list(
+      APPEND BLOCKING_PERF_AFFINITY_ARGS
+      --node-cpu-affinity
+      ${BLOCKING_PERF_NODE_CPU_AFFINITY}
+    )
+  endif()
+  if(BLOCKING_PERF_CLIENT_CPU_AFFINITY)
+    list(
+      APPEND BLOCKING_PERF_AFFINITY_ARGS
+      --client-cpu-affinity
+      ${BLOCKING_PERF_CLIENT_CPU_AFFINITY}
+    )
+  endif()
+
   add_piccolo_test(
     NAME pi_basic_blocking
     PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/infra/basicperf.py
@@ -1477,9 +1531,16 @@ if(BUILD_TESTS)
       --package
       "samples/apps/basic/basic"
       --client-def
-      "128,blocking_write,100,primary"
+      "${BLOCKING_PERF_CLIENT_COUNT},blocking_write,${BLOCKING_PERF_ITERATIONS},primary"
+      --clients-per-process
+      ${BLOCKING_PERF_CLIENTS_PER_PROCESS}
       --max-writes-ahead
       0
+      --sig-tx-interval
+      ${BLOCKING_PERF_SIG_TX_INTERVAL}
+      --sig-ms-interval
+      ${BLOCKING_PERF_SIG_MS_INTERVAL}
+      ${BLOCKING_PERF_AFFINITY_ARGS}
   )
 
   add_piccolo_test(

--- a/src/http/curl.h
+++ b/src/http/curl.h
@@ -630,10 +630,7 @@ namespace ccf::curl
 
       response_headers.attach_to_curl(curl_handle);
 
-      if (headers.get() != nullptr)
-      {
-        CHECK_CURL_EASY_SETOPT(curl_handle, CURLOPT_HTTPHEADER, headers.get());
-      }
+      CHECK_CURL_EASY_SETOPT(curl_handle, CURLOPT_HTTPHEADER, headers.get());
     }
 
     static void handle_response(
@@ -690,6 +687,11 @@ namespace ccf::curl
     [[nodiscard]] UniqueCURL& get_easy_handle_ptr()
     {
       return curl_handle;
+    }
+
+    [[nodiscard]] UniqueCURL take_easy_handle()
+    {
+      return std::move(curl_handle);
     }
 
     [[nodiscard]] RESTVerb get_method() const
@@ -1276,6 +1278,25 @@ namespace ccf::curl
       {
         safe_abort_request(std::move(request_to_abort), "attach_request");
       }
+    }
+
+    void set_connection_limits(long maximum_connections)
+    {
+      CHECK_CURL_MULTI(
+        curl_multi_setopt,
+        curl_request_curlm,
+        CURLMOPT_MAXCONNECTS,
+        maximum_connections);
+      CHECK_CURL_MULTI(
+        curl_multi_setopt,
+        curl_request_curlm,
+        CURLMOPT_MAX_HOST_CONNECTIONS,
+        maximum_connections);
+      CHECK_CURL_MULTI(
+        curl_multi_setopt,
+        curl_request_curlm,
+        CURLMOPT_MAX_TOTAL_CONNECTIONS,
+        maximum_connections);
     }
 
   private:

--- a/src/http/test/curl_test.cpp
+++ b/src/http/test/curl_test.cpp
@@ -246,6 +246,68 @@ TEST_CASE("CurlmLibuvContext aborts queued requests on close")
   REQUIRE(observed_status_code == 0);
 }
 
+TEST_CASE("Reused easy handles clear absent header lists")
+{
+  const std::string url = fmt::format("http://{}/reused", server_address);
+  std::optional<ccf::curl::UniqueCURL> reused_handle;
+  long first_local_port = 0;
+
+  auto stale_headers = ccf::curl::UniqueSlist();
+  stale_headers.append("X-Stale-Header", "must-not-be-reused");
+  auto first_response = [&reused_handle, &first_local_port](
+                          std::unique_ptr<ccf::curl::CurlRequest>&& request,
+                          CURLcode curl_response,
+                          long status_code) {
+    REQUIRE(curl_response == CURLE_OK);
+    REQUIRE(status_code == 200);
+    CHECK_CURL_EASY_GETINFO(
+      request->get_easy_handle(), CURLINFO_LOCAL_PORT, &first_local_port);
+    reused_handle.emplace(request->take_easy_handle());
+  };
+
+  auto first_request = std::make_unique<ccf::curl::CurlRequest>(
+    ccf::curl::UniqueCURL(),
+    HTTP_GET,
+    url,
+    std::move(stale_headers),
+    nullptr,
+    std::make_unique<ccf::curl::ResponseBody>(SIZE_MAX),
+    std::move(first_response));
+  ccf::curl::CurlRequest::synchronous_perform(std::move(first_request));
+  REQUIRE(reused_handle.has_value());
+
+  long second_local_port = 0;
+  std::string response_body;
+  auto second_response = [&second_local_port, &response_body](
+                           std::unique_ptr<ccf::curl::CurlRequest>&& request,
+                           CURLcode curl_response,
+                           long status_code) {
+    REQUIRE(curl_response == CURLE_OK);
+    REQUIRE(status_code == 200);
+    CHECK_CURL_EASY_GETINFO(
+      request->get_easy_handle(), CURLINFO_LOCAL_PORT, &second_local_port);
+    const auto* body = request->get_response_body();
+    response_body.assign(body->buffer.begin(), body->buffer.end());
+  };
+
+  auto second_request = std::make_unique<ccf::curl::CurlRequest>(
+    std::move(reused_handle.value()),
+    HTTP_GET,
+    url,
+    ccf::curl::UniqueSlist(),
+    nullptr,
+    std::make_unique<ccf::curl::ResponseBody>(SIZE_MAX),
+    std::move(second_response));
+  ccf::curl::CurlRequest::synchronous_perform(std::move(second_request));
+
+  REQUIRE(first_local_port == second_local_port);
+  const auto parsed = nlohmann::json::parse(response_body);
+  for (const auto& header : parsed.at("headers"))
+  {
+    REQUIRE(header.at(0) != "X-Stale-Header");
+  }
+}
+
 TEST_CASE("Synchronous")
 {
   Data data = {.foo = "alpha", .bar = "beta"};

--- a/tests/e2e_curl.py
+++ b/tests/e2e_curl.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 from datetime import UTC, datetime, timedelta
 
+import polars as pl
 from aiohttp import web
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
@@ -81,6 +82,57 @@ def write_tls_files(cert_path, cert_pem, key_path, key_pem):
         key_file.write(key_pem)
 
 
+async def test_submitter_callback_failure(addr, cert_path, key_path, temp_dir):
+    workload_path = os.path.join(temp_dir, "submitter_workload.parquet")
+    pl.DataFrame(
+        {
+            "messageID": ["first", "second"],
+            "sessionID": ["session", "session"],
+            "request": [
+                b"GET /first HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+                b"DELETE /second HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+            ],
+        }
+    ).write_parquet(workload_path, compression="uncompressed")
+
+    process = await asyncio.create_subprocess_exec(
+        "./submit",
+        "--cert",
+        cert_path,
+        "--key",
+        key_path,
+        "--cacert",
+        cert_path,
+        "--server-address",
+        addr,
+        "--max-writes-ahead",
+        "0",
+        "--send-filepath",
+        os.path.join(temp_dir, "submitter_send.parquet"),
+        "--response-filepath",
+        os.path.join(temp_dir, "submitter_response.parquet"),
+        "--generator-filepath",
+        workload_path,
+        "--pid-file-path",
+        os.path.join(temp_dir, "submitter.pid"),
+        "--multi-session",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=10)
+    except TimeoutError:
+        process.kill()
+        await process.wait()
+        raise AssertionError("Submitter hung after callback failure")
+
+    output = (stdout + stderr).decode()
+    if process.returncode == 0:
+        raise AssertionError(f"Submitter unexpectedly succeeded:\n{output}")
+    if "Unsupported HTTP method: DELETE" not in output:
+        raise AssertionError(f"Submitter did not surface callback failure:\n{output}")
+
+
 async def main():
     app = web.Application()
     app.router.add_route("*", "/redirect", redirect_handler)
@@ -140,7 +192,10 @@ async def main():
         cmd = "./curl_test"
         process = await asyncio.create_subprocess_shell(cmd, env=env)
         await process.wait()
-        sys.exit(process.returncode)
+        if process.returncode != 0:
+            sys.exit(process.returncode)
+
+        await test_submitter_callback_failure(tls_addr, cert_path, key_path, tls_dir)
 
 
 if __name__ == "__main__":

--- a/tests/infra/basicperf.py
+++ b/tests/infra/basicperf.py
@@ -24,6 +24,33 @@ import infra.proc
 import infra.remote_client
 
 
+def parse_cpu_affinity(value: str) -> set[int]:
+    cpus = set()
+    for item in value.split(","):
+        bounds = [int(bound) for bound in item.split("-", maxsplit=1)]
+        if len(bounds) == 1:
+            cpus.add(bounds[0])
+        else:
+            if bounds[0] > bounds[1]:
+                raise ValueError(f"CPU affinity range must be ascending: {item}")
+            cpus.update(range(bounds[0], bounds[1] + 1))
+    if not cpus:
+        raise ValueError("CPU affinity cannot be empty")
+    return cpus
+
+
+def set_process_affinity(pid: int, value: str):
+    cpus = parse_cpu_affinity(value)
+    unavailable = cpus - os.sched_getaffinity(0)
+    if unavailable:
+        raise ValueError(f"CPUs are unavailable to this process: {unavailable}")
+    for task_id in os.listdir(f"/proc/{pid}/task"):
+        try:
+            os.sched_setaffinity(int(task_id), cpus)
+        except ProcessLookupError:
+            pass
+
+
 def configure_remote_client(args, client_id, client_host, common_dir):
     client_host = infra.net.expand_localhost()
 
@@ -272,6 +299,14 @@ def replace_primary(network, host, old_primary, snapshots_dir, statistics):
 def run(args):
     hosts = args.nodes or infra.e2e_args.nodes(args, 1)
 
+    if args.clients_per_process <= 0:
+        raise ValueError("--clients-per-process must be positive")
+    if args.stop_primary_after_s and args.clients_per_process != 1:
+        raise ValueError(
+            "Failover tests require --clients-per-process=1 because the "
+            "multi-session submitter does not support failover"
+        )
+
     if args.stop_primary_after_s:
         assert (
             len(hosts) > 1
@@ -289,6 +324,12 @@ def run(args):
                     network.per_node_args_override[i] = {"election_timeout_ms": 15000}
         network.start_and_open(args)
 
+        if args.node_cpu_affinity:
+            for node in network.nodes:
+                set_process_affinity(
+                    node.remote.remote.proc.pid, args.node_cpu_affinity
+                )
+
         primary, backups = network.find_nodes()
         additional_headers = {}
         if args.use_jwt:
@@ -299,9 +340,9 @@ def run(args):
 
         key_space = create_and_fill_key_space(args.key_space_size, primary)
 
-        clients = []
         client_idx = 0
-        requests_file_paths = []
+        pending_batches = {}
+        client_batches = []
         for client_def in args.client_def:
             count, gen, iterations, target = client_def.split(",")
             # The round robin index deliberately starts at 1, so that backups/any are
@@ -320,7 +361,14 @@ def run(args):
                 )
                 LOG.info(f"Writing generated requests to {path_to_requests_file}")
                 msgs.to_parquet_file(path_to_requests_file)
-                requests_file_paths.append(path_to_requests_file)
+                session_id = f"client_{client_idx}"
+                payloads = pl.read_parquet(path_to_requests_file).with_columns(
+                    pl.concat_str(
+                        [pl.lit(f"{session_id}:"), pl.col("messageID")]
+                    ).alias("messageID"),
+                    sessionID=pl.lit(session_id),
+                )
+                payloads.write_parquet(path_to_requests_file)
                 node = None
                 if target == "primary":
                     node = primary
@@ -332,40 +380,75 @@ def run(args):
                     rr_idx += 1
                 else:
                     raise NotImplementedError(f"Unknown target {target}")
-                remote_client = configure_remote_client(
-                    args, client_idx, "localhost", network.common_dir
+
+                batch_key = node.get_public_rpc_address()
+                batch = pending_batches.setdefault(batch_key, [])
+                batch.append(
+                    {
+                        "gen": gen,
+                        "iterations": iterations,
+                        "node": node,
+                        "path": path_to_requests_file,
+                        "target": target,
+                    }
                 )
-                cmd = [
-                    args.client,
-                    "--cert",
-                    "user0_cert.pem",
-                    "--key",
-                    "user0_privk.pem",
-                    "--cacert",
-                    os.path.basename(network.cert_path),
-                    f"--server-address={node.get_public_rpc_host()}:{node.get_public_rpc_port()}",
-                    "--max-writes-ahead",
-                    str(args.max_writes_ahead),
-                    "--send-filepath",
-                    "pi_requests.parquet",
-                    "--response-filepath",
-                    "pi_response.parquet",
-                    "--generator-filepath",
-                    os.path.abspath(path_to_requests_file),
-                    "--pid-file-path",
-                    "cmd.pid",
-                ]
-                # All clients talking to the primary are configured to fail over to the first backup,
-                # which is the only node whose election timeout has not been raised, to guarantee its
-                # election as the old primary becomes unavailable.
-                if args.stop_primary_after_s and target == "primary":
-                    cmd.append(
-                        f"--failover-server-address={backups[0].get_public_rpc_host()}:{backups[0].get_public_rpc_port()}"
-                    )
-                remote_client.setcmd(cmd)
-                remote_client.description = f"{gen} x {iterations} to {target} ({node.get_public_rpc_address()})"
-                clients.append(remote_client)
+                if len(batch) == args.clients_per_process:
+                    client_batches.append(batch)
+                    pending_batches[batch_key] = []
                 client_idx += 1
+
+        client_batches.extend(batch for batch in pending_batches.values() if batch)
+
+        clients = []
+        requests_file_paths = []
+        for process_idx, batch in enumerate(client_batches):
+            node = batch[0]["node"]
+            path_to_requests_file = os.path.join(
+                network.common_dir, f"pi_client_process{process_idx}_requests.parquet"
+            )
+            pl.concat(
+                [pl.read_parquet(client["path"]) for client in batch], rechunk=True
+            ).write_parquet(path_to_requests_file)
+            requests_file_paths.append(path_to_requests_file)
+
+            remote_client = configure_remote_client(
+                args, process_idx, "localhost", network.common_dir
+            )
+            cmd = [
+                args.client,
+                "--cert",
+                "user0_cert.pem",
+                "--key",
+                "user0_privk.pem",
+                "--cacert",
+                os.path.basename(network.cert_path),
+                f"--server-address={node.get_public_rpc_host()}:{node.get_public_rpc_port()}",
+                "--max-writes-ahead",
+                str(args.max_writes_ahead),
+                "--send-filepath",
+                "pi_requests.parquet",
+                "--response-filepath",
+                "pi_response.parquet",
+                "--generator-filepath",
+                os.path.abspath(path_to_requests_file),
+                "--pid-file-path",
+                "cmd.pid",
+            ]
+            if args.client_cpu_affinity:
+                cmd = ["taskset", "--cpu-list", args.client_cpu_affinity] + cmd
+            if len(batch) > 1:
+                cmd.append("--multi-session")
+            target = batch[0]["target"]
+            if args.stop_primary_after_s and target == "primary":
+                cmd.append(
+                    f"--failover-server-address={backups[0].get_public_rpc_host()}:{backups[0].get_public_rpc_port()}"
+                )
+            remote_client.setcmd(cmd)
+            remote_client.description = ", ".join(
+                f'{client["gen"]} x {client["iterations"]} to {client["target"]}'
+                for client in batch
+            )
+            clients.append(remote_client)
 
         if args.network_only:
             for remote_client in clients:
@@ -483,7 +566,7 @@ def run(args):
                         overall = payloads.join(sent, on="messageID")
                         overall = rcvd.join(overall, on="messageID")
                         overall = overall.with_columns(
-                            client=pl.lit(remote_client.name),
+                            client=pl.col("sessionID"),
                             requestSize=pl.col("request").map_elements(
                                 len, return_dtype=pl.Int64
                             ),
@@ -560,6 +643,16 @@ def run(args):
                 byte_output = (agg["responseSize"].sum() / duration_s) / (1024 * 1024)
                 statistics["average_request_output_mb/s"] = byte_output
                 print(f"Average request output: {byte_output:.2f} Mbytes/s")
+
+                latency_us = agg.select(
+                    pl.col("latency").dt.total_microseconds().alias("latency_us")
+                )["latency_us"]
+                for percentile in (50, 90, 99):
+                    value = latency_us.quantile(
+                        percentile / 100, interpolation="nearest"
+                    )
+                    statistics[f"latency_p{percentile}_us"] = value
+                    print(f"Latency p{percentile}: {value}us")
 
                 each_client = agg.partition_by("client")
                 latest_start = max(client["sendTime"].min() for client in each_client)
@@ -851,6 +944,20 @@ def cli_args():
         help="Client definitions, e.g. '3,write,1000,primary' starts 3 clients sending 1000 writes to the primary",
         action="append",
         required=True,
+    )
+    parser.add_argument(
+        "--clients-per-process",
+        help="Number of logical client sessions driven by each submitter process",
+        type=int,
+        default=1,
+    )
+    parser.add_argument(
+        "--node-cpu-affinity",
+        help="CPU list assigned to all local CCF node threads, for example 0-7",
+    )
+    parser.add_argument(
+        "--client-cpu-affinity",
+        help="CPU list assigned to local submitter processes, for example 8-31",
     )
     parser.add_argument(
         "--stop-primary-after-s", help="Stop primary after this many seconds", type=int

--- a/tests/perf-system/submitter/CMakeLists.txt
+++ b/tests/perf-system/submitter/CMakeLists.txt
@@ -8,6 +8,9 @@ add_executable(
 )
 
 add_warning_checks(submit)
-target_link_libraries(submit PRIVATE http_parser ccfcrypto arrow parquet)
+target_link_libraries(
+  submit
+  PRIVATE http_parser ccfcrypto arrow parquet curl uv
+)
 
 install(TARGETS submit DESTINATION bin)

--- a/tests/perf-system/submitter/handle_arguments.h
+++ b/tests/perf-system/submitter/handle_arguments.h
@@ -24,6 +24,7 @@ public:
   std::string generator_filepath;
   int max_inflight_requests = 0;
   std::string pid_file_path = "submit.pid";
+  bool multi_session = false;
 
   ArgumentParser(const std::string& default_label, CLI::App& app) :
     label(default_label)
@@ -60,7 +61,8 @@ public:
       .add_option(
         "--failover-server-address",
         failover_server_address,
-        "Specify failover address, in case connection to the main server address is lost.")
+        "Specify failover address, in case connection to the main server "
+        "address is lost.")
       ->capture_default_str();
     app
       .add_option(
@@ -99,5 +101,10 @@ public:
         pid_file_path,
         "Path to file where the pid of the submitter will be stored.")
       ->capture_default_str();
+    app.add_flag(
+      "--multi-session",
+      multi_session,
+      "Run each sessionID in the input as an independent asynchronous HTTP "
+      "session. This mode requires --max-writes-ahead=0.");
   }
 };

--- a/tests/perf-system/submitter/parquet_data.h
+++ b/tests/perf-system/submitter/parquet_data.h
@@ -12,6 +12,7 @@ public:
   ParquetData() {}
 
   std::vector<std::string> ids;
+  std::vector<std::string> session_ids;
   std::vector<std::vector<uint8_t>> request;
   std::vector<size_t> response_status_code;
   std::vector<std::string> response_headers;

--- a/tests/perf-system/submitter/submit.cpp
+++ b/tests/perf-system/submitter/submit.cpp
@@ -9,6 +9,8 @@
 #include "crypto/openssl/hash.h"
 #include "ds/files.h"
 #include "handle_arguments.h"
+#include "http/curl.h"
+#include "http/http_parser.h"
 #include "parquet_data.h"
 
 #include <CLI11/CLI11.hpp>
@@ -18,12 +20,17 @@
 #include <arrow/io/file.h>
 #include <arrow/table.h>
 #include <arrow/util/config.h>
+#include <cerrno>
+#include <deque>
+#include <exception>
+#include <map>
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
+#include <set>
 #include <signal.h>
+#include <system_error>
 #include <time.h>
 #include <utility>
-
 
 using namespace std;
 using namespace client;
@@ -31,6 +38,48 @@ using namespace client;
 ccf::crypto::Pem key = {};
 std::string key_id = "Invalid";
 std::shared_ptr<::tls::Cert> tls_cert = nullptr;
+
+std::string get_string_value(
+  const std::shared_ptr<arrow::Array>& values, int64_t row)
+{
+  if (
+    const auto strings = std::dynamic_pointer_cast<arrow::StringArray>(values))
+  {
+    return strings->GetString(row);
+  }
+  if (
+    const auto strings =
+      std::dynamic_pointer_cast<arrow::LargeStringArray>(values))
+  {
+    return strings->GetString(row);
+  }
+  throw std::logic_error(
+    fmt::format(
+      "Expected string or large_string array, found {}",
+      values->type()->name()));
+}
+
+std::vector<uint8_t> get_binary_value(
+  const std::shared_ptr<arrow::Array>& values, int64_t row)
+{
+  if (
+    const auto binaries = std::dynamic_pointer_cast<arrow::BinaryArray>(values))
+  {
+    const auto value = binaries->Value(row);
+    return {value.begin(), value.end()};
+  }
+  if (
+    const auto binaries =
+      std::dynamic_pointer_cast<arrow::LargeBinaryArray>(values))
+  {
+    const auto value = binaries->Value(row);
+    return {value.begin(), value.end()};
+  }
+  throw std::logic_error(
+    fmt::format(
+      "Expected binary or large_binary array, found {}",
+      values->type()->name()));
+}
 
 void read_parquet_file(string generator_filepath, ParquetData& data_handler)
 {
@@ -119,9 +168,10 @@ void read_parquet_file(string generator_filepath, ParquetData& data_handler)
     exit(1);
   }
 
-  auto message_id_values =
-    std::dynamic_pointer_cast<arrow::StringArray>(message_id_column->chunk(0));
-  if (message_id_values == nullptr)
+  auto message_id_values = message_id_column->chunk(0);
+  if (
+    message_id_values->type_id() != arrow::Type::STRING &&
+    message_id_values->type_id() != arrow::Type::LARGE_STRING)
   {
     LOG_FAIL_FMT(
       "The messageID column of input file could not be read as string array");
@@ -144,20 +194,46 @@ void read_parquet_file(string generator_filepath, ParquetData& data_handler)
     exit(1);
   }
 
-  auto request_values =
-    std::dynamic_pointer_cast<arrow::BinaryArray>(request_column->chunk(0));
-  if (request_values == nullptr)
+  auto request_values = request_column->chunk(0);
+  if (
+    request_values->type_id() != arrow::Type::BINARY &&
+    request_values->type_id() != arrow::Type::LARGE_BINARY)
   {
     LOG_FAIL_FMT(
       "The request column of input file could not be read as binary array");
     exit(1);
   }
 
+  std::shared_ptr<arrow::Array> session_id_values = nullptr;
+  const auto session_id_idx = schema->GetFieldIndex("sessionID");
+  if (session_id_idx != -1)
+  {
+    const auto& session_id_column = table->column(session_id_idx);
+    if (session_id_column->num_chunks() != 1)
+    {
+      LOG_FAIL_FMT(
+        "Expected a single sessionID chunk, found {}",
+        session_id_column->num_chunks());
+      exit(1);
+    }
+
+    session_id_values = session_id_column->chunk(0);
+    if (
+      session_id_values->type_id() != arrow::Type::STRING &&
+      session_id_values->type_id() != arrow::Type::LARGE_STRING)
+    {
+      LOG_FAIL_FMT("The sessionID column could not be read as a string array");
+      exit(1);
+    }
+  }
+
   for (int64_t row = 0; row < table->num_rows(); row++)
   {
-    data_handler.ids.push_back(message_id_values->GetString(row));
-    const auto request = request_values->Value(row);
-    data_handler.request.push_back({request.begin(), request.end()});
+    data_handler.ids.push_back(get_string_value(message_id_values, row));
+    data_handler.session_ids.push_back(
+      session_id_values == nullptr ? "0" :
+                                     get_string_value(session_id_values, row));
+    data_handler.request.push_back(get_binary_value(request_values, row));
   }
 }
 
@@ -223,8 +299,9 @@ void store_parquet_results(ArgumentParser args, ParquetData data_handler)
     std::shared_ptr<arrow::io::FileOutputStream> outfile;
     PARQUET_ASSIGN_OR_THROW(
       outfile, arrow::io::FileOutputStream::Open(args.send_filepath));
-    PARQUET_THROW_NOT_OK(parquet::arrow::WriteTable(
-      *table, arrow::default_memory_pool(), outfile));
+    PARQUET_THROW_NOT_OK(
+      parquet::arrow::WriteTable(
+        *table, arrow::default_memory_pool(), outfile));
   }
 
   // Write Response Parquet
@@ -273,12 +350,291 @@ void store_parquet_results(ArgumentParser args, ParquetData data_handler)
     std::shared_ptr<arrow::io::FileOutputStream> outfile;
     PARQUET_ASSIGN_OR_THROW(
       outfile, arrow::io::FileOutputStream::Open(args.response_filepath));
-    PARQUET_THROW_NOT_OK(parquet::arrow::WriteTable(
-      *table, arrow::default_memory_pool(), outfile));
+    PARQUET_THROW_NOT_OK(
+      parquet::arrow::WriteTable(
+        *table, arrow::default_memory_pool(), outfile));
   }
 
   LOG_INFO_FMT("Finished storing results");
 }
+
+int64_t get_timestamp_us()
+{
+  timespec timestamp;
+  if (clock_gettime(CLOCK_REALTIME, &timestamp) != 0)
+  {
+    throw std::system_error(
+      errno, std::generic_category(), "clock_gettime failed");
+  }
+  return timestamp.tv_sec * 1'000'000 + timestamp.tv_nsec / 1000;
+}
+
+class CurlGlobalCleanup
+{
+public:
+  ~CurlGlobalCleanup()
+  {
+    curl_global_cleanup();
+  }
+};
+
+class MultiSessionSubmitter
+{
+private:
+  ArgumentParser& args;
+  ParquetData& data;
+  std::vector<http::SimpleRequestProcessor::Request> requests;
+  std::map<std::string, std::deque<size_t>> pending;
+  std::vector<uint8_t> cert;
+  std::vector<uint8_t> private_key;
+  std::vector<uint8_t> ca;
+  uv_timer_t keepalive = {};
+  size_t completed = 0;
+  size_t in_flight = 0;
+  size_t peak_in_flight = 0;
+  std::set<long> local_ports;
+  std::exception_ptr terminal_error = nullptr;
+
+  void close_keepalive_if_finished()
+  {
+    if (
+      (terminal_error != nullptr && in_flight == 0) ||
+      completed == data.ids.size())
+    {
+      auto* keepalive_handle = reinterpret_cast<uv_handle_t*>(&keepalive);
+      if (!uv_is_closing(keepalive_handle))
+      {
+        uv_close(keepalive_handle, nullptr);
+      }
+    }
+  }
+
+  void submit_next(
+    const std::string& session_id,
+    ccf::curl::UniqueCURL&& curl_handle,
+    bool configure_connection)
+  {
+    auto& session_pending = pending.at(session_id);
+    if (session_pending.empty())
+    {
+      return;
+    }
+
+    const auto request_idx = session_pending.front();
+    session_pending.pop_front();
+    auto& parsed = requests[request_idx];
+
+    if (configure_connection)
+    {
+      curl_handle.set_opt(CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+      curl_handle.set_opt(CURLOPT_TCP_NODELAY, 1L);
+      curl_handle.set_opt(CURLOPT_NOSIGNAL, 1L);
+      curl_handle.set_opt(CURLOPT_SSL_VERIFYHOST, 2L);
+      curl_handle.set_opt(CURLOPT_SSL_VERIFYPEER, 1L);
+      curl_handle.set_blob_opt(CURLOPT_CAINFO_BLOB, ca.data(), ca.size());
+      curl_handle.set_blob_opt(CURLOPT_SSLCERT_BLOB, cert.data(), cert.size());
+      curl_handle.set_opt(CURLOPT_SSLCERTTYPE, "PEM");
+      curl_handle.set_blob_opt(
+        CURLOPT_SSLKEY_BLOB, private_key.data(), private_key.size());
+      curl_handle.set_opt(CURLOPT_SSLKEYTYPE, "PEM");
+    }
+
+    ccf::curl::UniqueSlist headers;
+    for (const auto& [name, value] : parsed.headers)
+    {
+      if (
+        name != ccf::http::headers::CONTENT_LENGTH && name != "host" &&
+        name != "transfer-encoding")
+      {
+        headers.append(name, value);
+      }
+    }
+
+    auto body = std::make_unique<ccf::curl::RequestBody>(parsed.body);
+    auto response = std::make_unique<ccf::curl::ResponseBody>(SIZE_MAX);
+    auto response_callback =
+      [this, session_id, request_idx](
+        std::unique_ptr<ccf::curl::CurlRequest>&& request,
+        CURLcode curl_response,
+        long status_code) {
+        in_flight--;
+        try
+        {
+          data.response_time[request_idx] = get_timestamp_us();
+          data.response_status_code[request_idx] =
+            curl_response == CURLE_OK ? status_code : 599;
+
+          std::string response_headers;
+          for (const auto& [name, value] : request->get_response_headers())
+          {
+            if (!response_headers.empty())
+            {
+              response_headers += "\n";
+            }
+            response_headers += fmt::format("{}: {}", name, value);
+          }
+          data.response_headers[request_idx] = std::move(response_headers);
+
+          long local_port = 0;
+          CHECK_CURL_EASY_GETINFO(
+            request->get_easy_handle(), CURLINFO_LOCAL_PORT, &local_port);
+          local_ports.insert(local_port);
+
+          if (curl_response == CURLE_OK)
+          {
+            data.response_body[request_idx] =
+              std::move(request->get_response_body()->buffer);
+          }
+          else
+          {
+            const auto error = std::string(curl_easy_strerror(curl_response));
+            data.response_body[request_idx] = {error.begin(), error.end()};
+          }
+
+          completed++;
+          if (terminal_error == nullptr)
+          {
+            auto next_handle = request->take_easy_handle();
+            submit_next(session_id, std::move(next_handle), false);
+          }
+        }
+        catch (...)
+        {
+          if (terminal_error == nullptr)
+          {
+            terminal_error = std::current_exception();
+          }
+        }
+
+        close_keepalive_if_finished();
+      };
+
+    auto request = std::make_unique<ccf::curl::CurlRequest>(
+      std::move(curl_handle),
+      ccf::RESTVerb(parsed.method),
+      fmt::format("https://{}{}", args.server_address, parsed.url),
+      std::move(headers),
+      std::move(body),
+      std::move(response),
+      std::move(response_callback));
+
+    data.send_time[request_idx] = get_timestamp_us();
+    in_flight++;
+    try
+    {
+      ccf::curl::CurlmLibuvContextSingleton::get_instance()->attach_request(
+        std::move(request));
+      peak_in_flight = std::max(peak_in_flight, in_flight);
+    }
+    catch (...)
+    {
+      in_flight--;
+      throw;
+    }
+  }
+
+public:
+  MultiSessionSubmitter(ArgumentParser& args_, ParquetData& data_) :
+    args(args_),
+    data(data_),
+    cert(files::slurp(args.cert)),
+    private_key(files::slurp(args.key)),
+    ca(files::slurp(args.rootCa))
+  {
+    requests.reserve(data.request.size());
+    for (const auto& encoded : data.request)
+    {
+      http::SimpleRequestProcessor processor;
+      http::RequestParser parser(processor);
+      parser.execute(encoded.data(), encoded.size());
+      if (processor.received.size() != 1)
+      {
+        throw std::logic_error(
+          fmt::format(
+            "Expected one request, parsed {}", processor.received.size()));
+      }
+      requests.push_back(std::move(processor.received.front()));
+    }
+
+    for (size_t idx = 0; idx < data.session_ids.size(); ++idx)
+    {
+      pending[data.session_ids[idx]].push_back(idx);
+    }
+
+    data.response_status_code.resize(data.ids.size());
+    data.response_headers.resize(data.ids.size());
+    data.response_body.resize(data.ids.size());
+    data.send_time.resize(data.ids.size());
+    data.response_time.resize(data.ids.size());
+  }
+
+  void run()
+  {
+    if (data.ids.empty())
+    {
+      return;
+    }
+
+    const auto curl_init_result = curl_global_init(CURL_GLOBAL_DEFAULT);
+    if (curl_init_result != CURLE_OK)
+    {
+      throw std::runtime_error(
+        fmt::format(
+          "Failed to initialise curl: {}",
+          curl_easy_strerror(curl_init_result)));
+    }
+    const CurlGlobalCleanup curl_cleanup;
+
+    {
+      auto* loop = uv_default_loop();
+      if (loop == nullptr)
+      {
+        throw std::runtime_error("Failed to initialise the default libuv loop");
+      }
+      ccf::curl::CurlmLibuvContextSingleton curl_context(loop);
+      ccf::curl::CurlmLibuvContextSingleton::get_instance()
+        ->set_connection_limits(pending.size());
+      CHECK_UV(uv_timer_init, loop, &keepalive);
+      CHECK_UV(uv_timer_start, &keepalive, [](uv_timer_t*) {}, 60'000, 60'000);
+
+      for (const auto& [session_id, _] : pending)
+      {
+        try
+        {
+          submit_next(session_id, ccf::curl::UniqueCURL(), true);
+        }
+        catch (...)
+        {
+          terminal_error = std::current_exception();
+          break;
+        }
+      }
+      close_keepalive_if_finished();
+
+      if (uv_run(loop, UV_RUN_DEFAULT) != 0)
+      {
+        throw std::runtime_error("libuv loop stopped with active handles");
+      }
+    }
+
+    if (terminal_error != nullptr)
+    {
+      std::rethrow_exception(terminal_error);
+    }
+
+    if (completed != data.ids.size())
+    {
+      throw std::runtime_error(
+        fmt::format("Completed {} of {} requests", completed, data.ids.size()));
+    }
+    LOG_INFO_FMT(
+      "Completed {} requests with peak {} in-flight transfers over {} local "
+      "TCP ports",
+      completed,
+      peak_in_flight,
+      local_ports.size());
+  }
+};
 
 int main(int argc, char** argv)
 {
@@ -290,6 +646,19 @@ int main(int argc, char** argv)
   CLI::App cli_app{"Perf Tool"};
   ArgumentParser args("Perf Tool", cli_app);
   CLI11_PARSE(cli_app, argc, argv);
+
+  if (args.multi_session)
+  {
+    if (args.max_inflight_requests != 0)
+    {
+      throw std::logic_error("--multi-session requires --max-writes-ahead=0");
+    }
+    if (!args.failover_server_address.empty())
+    {
+      throw std::logic_error(
+        "--multi-session does not support --failover-server-address");
+    }
+  }
 
   std::vector<std::string> args_str(argv, argv + argc);
   LOG_INFO_FMT("Running {}", fmt::join(args_str, " "));
@@ -307,6 +676,14 @@ int main(int argc, char** argv)
 
   // Write PID to disk
   files::dump(fmt::format("{}", ::getpid()), args.pid_file_path);
+
+  if (args.multi_session)
+  {
+    MultiSessionSubmitter submitter(args, data_handler);
+    submitter.run();
+    store_parquet_results(args, data_handler);
+    return 0;
+  }
 
   auto requests_size = data_handler.ids.size();
 
@@ -340,8 +717,7 @@ int main(int argc, char** argv)
         if (
           connection->bytes_available() or
           (args.max_inflight_requests >= 0 &&
-           ridx - read_reqs >=
-             static_cast<size_t>(args.max_inflight_requests)))
+           ridx - read_reqs >= static_cast<size_t>(args.max_inflight_requests)))
         {
           responses[read_reqs] = connection->read_response();
           clock_gettime(CLOCK_REALTIME, &end[read_reqs]);


### PR DESCRIPTION
## Summary

Update `pi_basic_blocking` from a basic load test that showed blocking responses could handle some concurrency into a useful measure of blocking transaction throughput.

The previous test launched one synchronous submitter process per logical client. With 128 processes, 100 requests per client, and a 100ms signature interval, it was dominated by signature cadence and client process overhead. Its roughly 1,200 tx/s result mostly confirmed that blocking requests completed under load rather than measuring the throughput the service can sustain with blocking enabled.

This change adds an event-driven, multi-session mode to the Piccolo submitter. Each process drives multiple independent logical sessions through libcurl-multi/libuv while preserving one blocking request in flight and one persistent HTTP/1.1 connection per session. This reduces the physical client count from hundreds of processes to a small number of event loops without reducing logical concurrency.

The updated blocking benchmark uses:

- 320 logical sessions across 10 submitter processes
- 2,000 blocking writes per session
- a 2ms signature interval
- explicit connection-pool sizing so all session connections remain persistent

On the development machine, the updated workload completed 640,000 requests without errors at approximately 27,500-29,000 tx/s, compared with an approximately 1,200 tx/s baseline.

## Additional changes

- Preserve the existing synchronous submitter path for pipelined and failover tests.
- Keep generated and result parquet schemas compatible while batching logical-session workloads into fewer processes.
- Report p50, p90, and p99 latency alongside throughput.
- Expose blocking workload, signature cadence, and optional CPU-affinity settings as CMake parameters.
- Validate unsupported multi-session option combinations and terminate cleanly if a queued request cannot be scheduled.

## Validation

- Built the `submit` and `curl_test` targets.
- Passed the extended `e2e_curl` fixture, including persistent-handle reuse and callback-failure regression coverage.
- Passed the optimized blocking performance workload and legacy synchronous submitter path during performance validation.
- Passed C++, Python, CMake, include, copyright, ASCII, and whitespace checks.