### PR TITLE
Cache caller certificate digests per session

### DIFF
--- a/include/ccf/rpc_context.h
+++ b/include/ccf/rpc_context.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ccf/claims_digest.h"
+#include "ccf/crypto/sha256_hash.h"
 #include "ccf/endpoint_context.h"
 #include "ccf/frame_format.h"
 #include "ccf/http_consts.h"
@@ -25,7 +26,8 @@ namespace ccf
     size_t client_session_id = InvalidSessionId;
 
     // Contains DER encoding of original caller
-    std::vector<uint8_t> caller_cert;
+    const std::vector<uint8_t> caller_cert;
+    const std::string caller_cert_sha256;
     bool is_forwarding = false;
 
     // Only set for RPC sessions (i.e. non-forwarded and non-internal)
@@ -45,6 +47,7 @@ namespace ccf
       const std::optional<ListenInterfaceID>& interface_id_ = std::nullopt) :
       client_session_id(client_session_id_),
       caller_cert(caller_cert_),
+      caller_cert_sha256(crypto::Sha256Hash(caller_cert).hex_str()),
       interface_id(interface_id_)
     {}
 

--- a/src/endpoints/authentication/cert_auth.cpp
+++ b/src/endpoints/authentication/cert_auth.cpp
@@ -109,7 +109,8 @@ namespace ccf
     const std::shared_ptr<ccf::RpcContext>& ctx,
     std::string& error_reason)
   {
-    const auto& caller_cert = ctx->get_session_context()->caller_cert;
+    const auto& session = ctx->get_session_context();
+    const auto& caller_cert = session->caller_cert;
     if (caller_cert.empty())
     {
       error_reason = "No caller user certificate";
@@ -122,7 +123,7 @@ namespace ccf
       return nullptr;
     }
 
-    auto caller_id = ccf::crypto::Sha256Hash(caller_cert).hex_str();
+    const auto& caller_id = session->caller_cert_sha256;
 
     auto* user_certs = tx.ro<UserCerts>(Tables::USER_CERTS);
     if (user_certs->has(caller_id))
@@ -147,14 +148,15 @@ namespace ccf
     const std::shared_ptr<ccf::RpcContext>& ctx,
     std::string& error_reason)
   {
-    const auto& caller_cert = ctx->get_session_context()->caller_cert;
+    const auto& session = ctx->get_session_context();
+    const auto& caller_cert = session->caller_cert;
     if (caller_cert.empty())
     {
       error_reason = "No caller member certificate";
       return nullptr;
     }
 
-    auto caller_id = ccf::crypto::Sha256Hash(caller_cert).hex_str();
+    const auto& caller_id = session->caller_cert_sha256;
 
     auto* member_certs = tx.ro<MemberCerts>(Tables::MEMBER_CERTS);
     if (member_certs->has(caller_id))

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -24,6 +24,7 @@
 #include <doctest/doctest.h>
 #include <iostream>
 #include <string>
+#include <type_traits>
 
 using namespace ccf;
 using namespace std;
@@ -459,6 +460,10 @@ auto member_session =
 auto anonymous_session =
   make_shared<ccf::SessionContext>(ccf::InvalidSessionId, anonymous_caller_der);
 
+static_assert(
+  std::is_const_v<decltype(user_session->caller_cert)>,
+  "Session caller certificates must remain immutable");
+
 UserId user_id;
 
 MemberId member_id;
@@ -501,6 +506,13 @@ TEST_CASE("SignedReq to and from json")
 
 TEST_CASE("process with caller")
 {
+  CHECK(
+    user_session->caller_cert_sha256 ==
+    ccf::crypto::Sha256Hash(user_caller_der).hex_str());
+  CHECK(
+    anonymous_session->caller_cert_sha256 ==
+    ccf::crypto::Sha256Hash(anonymous_caller_der).hex_str());
+
   NetworkState network;
   prepare_callers(network);
   TestUserFrontend frontend(*network.tables);


### PR DESCRIPTION
Cache the SHA-256 digest of each immutable caller certificate in `SessionContext`, avoiding repeated certificate hashing and hex encoding during user and member authentication. Authentication still consults governance tables on every request, preserving revocation behavior, and the empty certificate remains the sole anonymous-session indicator.

Validation:
- `cmake --build build --target frontend_test basic`
- `./tests.sh -VV -R '^frontend_test$'` (19 test cases, 1,678 assertions)
- C++ formatting, public include, copyright, ASCII, and diff checks