### PR TITLE
Reorder clang-tidy executable names in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ endif()
 if(CLANG_TIDY)
   find_program(
     CLANG_TIDY_EXE
-    NAMES "clang-tidy" "clang-tidy-18" "clang-tidy-15"
+    NAMES "clang-tidy-18" "clang-tidy"
   )
   message(STATUS "Using clang-tidy from: ${CLANG_TIDY_EXE}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,10 +147,7 @@ endif()
 
 # Must happen before tools.cmake is included
 if(CLANG_TIDY)
-  find_program(
-    CLANG_TIDY_EXE
-    NAMES "clang-tidy-18" "clang-tidy"
-  )
+  find_program(CLANG_TIDY_EXE NAMES "clang-tidy-18" "clang-tidy" REQUIRED)
   message(STATUS "Using clang-tidy from: ${CLANG_TIDY_EXE}")
 endif()
 


### PR DESCRIPTION
15 is out, and we want to prioritise versioned if we come across it, and only fall back otherwise.