### PR TITLE
Bound Copilot APT connection attempts

### DIFF
--- a/scripts/setup-ubuntu-ci-checks.sh
+++ b/scripts/setup-ubuntu-ci-checks.sh
@@ -29,9 +29,9 @@ fi
 install_packages_ubuntu() {
   log "Installing packages with apt (Ubuntu)"
   export DEBIAN_FRONTEND=noninteractive
-  $SUDO apt-get update
+  $SUDO apt-get -o Acquire::http::Timeout=5 -o Acquire::https::Timeout=5 -o Acquire::Retries=1 update
   # clang-format-18 matches the version pinned by scripts/check-format.sh.
-  $SUDO apt-get install -y --no-install-recommends \
+  $SUDO apt-get -o Acquire::http::Timeout=5 -o Acquire::https::Timeout=5 -o Acquire::Retries=1 install -y --no-install-recommends \
     ca-certificates \
     git \
     tar \


### PR DESCRIPTION
## Summary

- Set five-second HTTP and HTTPS connection/data timeouts for APT setup operations.
- Retry transient APT download failures once.

This prevents an unresponsive package mirror from consuming the Copilot reviewer's 20-minute runtime, as seen in https://github.com/microsoft/CCF/actions/runs/32226813113/job/95988041815, while retaining the dependency installation needed for formatting checks.