### PR TITLE
Update changelog instructions for clarity and accuracy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,7 +65,7 @@ sphinx-build --fail-on-warning -b html doc doc/html
 - All tests in `ci.yml` must pass before a PR can be merged. Consider which are likely to be affected by your changes and run those locally before pushing.
 - Take particular care with any changes that may affect compatibility with older releases, and ensure these are tested, via the `lts_compatibility` test with `LONG_TESTS=1` enabled.
 - Take particular care with changes to the consensus and crypto code, as these are critical for security and correctness. Ensure you have a thorough understanding of the existing code and the implications of your changes before proceeding.
-- Any changes to user-facing APIs or behaviour must be documented in `CHANGELOG.md` (Keep a Changelog format, under the current `[Unreleased]` or dev version, in `Added`/`Changed`/`Fixed`/`Removed` sections). When adding a new version to `CHANGELOG.md`, be sure to update `python/pyproject.toml` to match.
+- Any changes to user-facing APIs or behaviour must be documented in `CHANGELOG.md` in Keep a Changelog format, under a concrete version and in an `Added`, `Changed`, `Fixed`, `Removed`, or similarly named section. Follow `.github/instructions/changelog.instructions.md` to select the correct release section and keep `python/pyproject.toml` in sync.
 
 ### C++
 

--- a/.github/instructions/changelog.instructions.md
+++ b/.github/instructions/changelog.instructions.md
@@ -3,11 +3,25 @@ applyTo:
   - "CHANGELOG.md"
 ---
 
-# Code review – CHANGELOG entries
+# CHANGELOG entries
 
-When reviewing changes to `CHANGELOG.md`, always verify that every new or modified entry includes a reference to the pull request that introduced the change, in the form `(#1234)` at the end of the entry (matching the existing convention).
+These instructions apply both when writing and when reviewing changes to `CHANGELOG.md`.
 
-Flag any added or modified bullet under an `Added`, `Changed`, `Fixed`, `Removed`, or similarly-named section that does not include such a `(#<number>)` reference, and ask the author to add the corresponding PR number. This applies to entries under both top-level version sections (e.g. `[Unreleased]`) and nested subsections (e.g. `### Developer API` → `#### C++` → `##### Added`).
+## Selecting the release section
+
+Before adding an entry, determine the latest published CCF release from the repository's releases or `ccf-<version>` tags. Do not infer release status from the contents of `CHANGELOG.md` alone.
+
+- Every entry must be placed under a concrete Semantic Versioning release section.
+- If the first release section in `CHANGELOG.md` is newer than the latest published release, treat it as the next release and add the entry to the appropriate existing subsection.
+- If the first release section has already been published, create a new section above it by incrementing the patch component of the latest published release. Add the matching link definition using the existing `https://github.com/microsoft/CCF/releases/tag/ccf-<version>` convention.
+- Whenever a new release section is created, update `project.version` in `python/pyproject.toml` to the same version. The first version in `CHANGELOG.md` and `project.version` must always match.
+- When reviewing a changelog addition, verify the release status, section selection, and version synchronisation above.
+
+## Pull request references
+
+Every new or modified entry must include a reference to the pull request that introduced the change, in the form `(#1234)` at the end of the entry, matching the existing convention.
+
+When reviewing, flag any added or modified bullet under an `Added`, `Changed`, `Fixed`, `Removed`, or similarly named section that does not include such a `(#<number>)` reference, and ask the author to add the corresponding PR number. This applies to entries directly under top-level version sections and in nested subsections such as `Developer API` / `C++` / `Added`.
 
 Do not flag:
 

--- a/.github/instructions/changelog.instructions.md
+++ b/.github/instructions/changelog.instructions.md
@@ -19,7 +19,7 @@ Before adding an entry, determine the latest published CCF release from the repo
 
 ## Pull request references
 
-Every new or modified entry must include a reference to the pull request that introduced the change, in the form `(#1234)` at the end of the entry, matching the existing convention.
+Every new or modified entry must include a reference to the pull request that introduced the change and to the relevant issues(s) that the PR closes, in the form `(#1234)` at the end of the entry, matching the existing convention.
 
 When reviewing, flag any added or modified bullet under an `Added`, `Changed`, `Fixed`, `Removed`, or similarly named section that does not include such a `(#<number>)` reference, and ask the author to add the corresponding PR number. This applies to entries directly under top-level version sections and in nested subsections such as `Developer API` / `C++` / `Added`.
 

--- a/.github/instructions/changelog.instructions.md
+++ b/.github/instructions/changelog.instructions.md
@@ -9,7 +9,7 @@ These instructions apply both when writing and when reviewing changes to `CHANGE
 
 ## Selecting the release section
 
-Before adding an entry, determine the latest published CCF release from the repository's releases or `ccf-<version>` tags. Do not infer release status from the contents of `CHANGELOG.md` alone.
+Before adding an entry, determine the latest published CCF release from the git `ccf-<version>` tags or github.com/microsoft/CCF releases. Do not infer release status from the contents of `CHANGELOG.md` alone.
 
 - Every entry must be placed under a concrete Semantic Versioning release section.
 - If the first release section in `CHANGELOG.md` is newer than the latest published release, treat it as the next release and add the entry to the appropriate existing subsection.


### PR DESCRIPTION
This pull request updates the changelog instructions to ensure clarity and compliance with repository standards. Key changes include:

- Expanded the applicability of the instructions to both code-writing and reviewing agents.
- Removed all references to the invalid `[Unreleased]` tag.
- Specified that agents must determine the latest published release from existing releases or `ccf-*` tags.
- Required entries to use a concrete Semantic Version.
- Mandated reuse of an existing next-release section when present and the addition of a patch-version section if the top section is already published.
- Ensured that the version in `python/pyproject.toml` matches the first changelog version.
- Cleaned up conflicting guidance in `copilot-instructions.md`.

No changelog or version bump was made as this change does not add a new entry. The existing versions remain synchronized at `7.0.12`.