### PR TITLE
Bump request attempt timeout for invalid.azure.com

### DIFF
--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -3329,8 +3329,9 @@ def run_error_message_on_failure_to_read_aci_sec_context(args):
         args_copy.snp_endorsements_file = "/a/fake/path"
         failed = False
         try:
+            # 4 retries after 3s timeout, 3s backoff between retries = 27 seconds
             network.join_node(
-                new_node, args.package, args_copy, timeout=20, from_snapshot=False
+                new_node, args.package, args_copy, timeout=60, from_snapshot=False
             )
         except infra.network.CollateralFetchTimeout:
             LOG.info(


### PR DESCRIPTION
We have an snp test which has an incorrect timeout for when it asserts that it fails to start when there is no security context and no snp endorsement servers.

In this case we expect the requests to invalid.azure.com to take 27s to complete (3s per request timeout + 3s between attempts, for 5 requests total, 4 retries).
The request side is generally quick, as it gets a nack from the DNS servers, making it only 12s long, but that isn't guaranteed.

https://github.com/microsoft/CCF/actions/runs/32263722374/job/96103228560

Is a case where we got the pessimismal behaviour.