### PR TITLE
Use Microsoft PyPI proxy in CI

### DIFF
--- a/.github/workflows/bencher-ab.yml
+++ b/.github/workflows/bencher-ab.yml
@@ -13,6 +13,9 @@ on:
 
 permissions: read-all
 
+env:
+  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: false
@@ -29,7 +32,6 @@ jobs:
     if: ${{ (github.event.action == 'labeled' && github.event.label.name == 'bench-ab') || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'bench-ab')) }}
     env:
       BRANCH_PERF_ARTIFACT: perf-bench-virtual-pr-${{ github.event.pull_request.number }}
-      PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
     container:
       image: mcr.microsoft.com/azurelinux/base/core:3.0
       options: --user root

--- a/.github/workflows/bencher-ab.yml
+++ b/.github/workflows/bencher-ab.yml
@@ -29,6 +29,7 @@ jobs:
     if: ${{ (github.event.action == 'labeled' && github.event.label.name == 'bench-ab') || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'bench-ab')) }}
     env:
       BRANCH_PERF_ARTIFACT: perf-bench-virtual-pr-${{ github.event.pull_request.number }}
+      PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
     container:
       image: mcr.microsoft.com/azurelinux/base/core:3.0
       options: --user root

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -10,6 +10,9 @@ on:
 
 permissions: read-all
 
+env:
+  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   queue: max

--- a/.github/workflows/ci-al4.yml
+++ b/.github/workflows/ci-al4.yml
@@ -12,6 +12,9 @@ concurrency:
 
 permissions: read-all
 
+env:
+  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
+
 jobs:
   vmss-virtual-a:
     name: "AL4 VMSS Virtual A" # Debug build, unit tests, e2e (bucket_a)

--- a/.github/workflows/ci-verification.yml
+++ b/.github/workflows/ci-verification.yml
@@ -193,6 +193,8 @@ jobs:
     container:
       image: mcr.microsoft.com/azurelinux/base/core:3.0
       options: --user root --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE
+    env:
+      PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
 
     steps:
       - name: "Checkout dependencies"

--- a/.github/workflows/ci-verification.yml
+++ b/.github/workflows/ci-verification.yml
@@ -17,6 +17,9 @@ concurrency:
 
 permissions: read-all
 
+env:
+  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
+
 jobs:
   model-checking-consistency:
     name: Model Checking - Consistency
@@ -193,8 +196,6 @@ jobs:
     container:
       image: mcr.microsoft.com/azurelinux/base/core:3.0
       options: --user root --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE
-    env:
-      PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
 
     steps:
       - name: "Checkout dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
 
 permissions: read-all
 
+env:
+  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
+
 jobs:
   vmss-virtual-a:
     name: "VMSS Virtual A" # CI Checks, Clang Tidy, Python package tests, Doc build, Unit tests, e2e (bucket_a)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,9 @@ concurrency:
 
 permissions: read-all
 
+env:
+  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,7 @@ permissions: read-all
 # scripts/coverage_summary.py, so that the two stay in sync from a single place.
 env:
   COVERAGE_HISTORY_POINTS: "9"
+  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
 
 jobs:
   coverage_virtual:

--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -17,6 +17,9 @@ concurrency:
 
 permissions: read-all
 
+env:
+  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
+
 jobs:
   long-asan:
     if: &check_trigger_conditions ${{ (github.event.action == 'labeled' && github.event.label.name == 'run-long-test') || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-long-test')) || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions: read-all
 
 env:
   IMAGE: mcr.microsoft.com/azurelinux/base/core:3.0
+  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
 
 jobs:
   make_sbom:
@@ -105,8 +106,6 @@ jobs:
     container:
       image: ${{ needs.image_digest.outputs.image_digest }}
       options: "--user root --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0 --sysctl net.ipv6.conf.lo.disable_ipv6=0"
-    env:
-      PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
 
     steps:
       - name: "Set SOURCE_DATE_EPOCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,8 @@ jobs:
     container:
       image: ${{ needs.image_digest.outputs.image_digest }}
       options: "--user root --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0 --sysctl net.ipv6.conf.lo.disable_ipv6=0"
+    env:
+      PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
 
     steps:
       - name: "Set SOURCE_DATE_EPOCH"


### PR DESCRIPTION
## Summary

- configure eligible self-hosted CI jobs to use the Microsoft PyPI feed proxy
- apply the setting at workflow or job scope so direct and script-invoked pip installs inherit it
- avoid applying the authenticated proxy to public GitHub-hosted runners

## Validation

- Continuous Integration passed on VMSS Virtual A/B/C and ACI SNP Milan/Genoa
- Continuous Integration AL4 passed on VMSS Virtual A/B/C
- CodeQL and Trace Validation passed
- pip logs list only `https://packagefeedproxy.microsoft.io/pypi/simple/` as the active index