### PR TITLE
Use Microsoft npm proxy in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ permissions: read-all
 jobs:
   vmss-virtual-a:
     name: "VMSS Virtual A" # CI Checks, Clang Tidy, Python package tests, Doc build, Unit tests, e2e (bucket_a)
+    env:
+      NPM_CONFIG_REGISTRY: https://packagefeedproxy.microsoft.io/npm/
     runs-on:
       [
         self-hosted,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,12 @@ concurrency:
 
 permissions: read-all
 
+env:
+  NPM_CONFIG_REGISTRY: https://packagefeedproxy.microsoft.io/npm/
+
 jobs:
   vmss-virtual-a:
     name: "VMSS Virtual A" # CI Checks, Clang Tidy, Python package tests, Doc build, Unit tests, e2e (bucket_a)
-    env:
-      NPM_CONFIG_REGISTRY: https://packagefeedproxy.microsoft.io/npm/
     runs-on:
       [
         self-hosted,


### PR DESCRIPTION
## Summary

- configure the self-hosted `vmss-virtual-a` CI job to use `https://packagefeedproxy.microsoft.io/npm/`
- cover the indirect `ci-checks.sh` -> `prettier-checks.sh` -> `npm install` path
- leave release packaging unchanged because `npm version` and `npm pack` do not download dependencies
- preserve the GitHub-hosted npm publishing workflow's explicit `https://registry.npmjs.org` configuration

## Validation

- installed Prettier and its TypeSpec plugin through the Microsoft npm proxy
- ran Prettier against `.github/workflows/ci.yml`
- ran the repository ASCII check
- audited all npm/npx references in `.github/workflows` and all repository `npm install` call sites