### PR TITLE
Fix LTS governance API compatibility

### DIFF
--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -799,6 +799,7 @@ def run_ledger_compatibility_since_first(
 if __name__ == "__main__":
 
     def add(parser):
+        parser.set_defaults(gov_api_version=infra.clients.API_VERSION_01)
         parser.add_argument("--check-ledger-compatibility", action="store_true")
         parser.add_argument(
             "--compatibility-report-file", type=str, default="compatibility_report.json"


### PR DESCRIPTION
## Summary

- use the frozen `2024-07-01` governance API by default in the LTS compatibility test
- keep the global test default on `latest` so current-version coverage is unchanged
- allow recovery against CCF releases that predate the `latest` alias

Fixes the failure in [Coverage Virtual](https://github.com/microsoft/CCF/actions/runs/32389138604/job/96490769885).

## Validation

- Python formatting (Black)
- Python linting (Ruff)
- Python syntax compilation
- ASCII check