### PR TITLE
Prevent AL4 setup from masking failures

### DIFF
--- a/scripts/setup-ci-al4.sh
+++ b/scripts/setup-ci-al4.sh
@@ -17,6 +17,7 @@ retry() {
 
     local attempt=1
     local delay
+    local max_attempts=5
     local status
     while true; do
         # Calling a function from an if condition disables errexit within it,
@@ -33,8 +34,8 @@ retry() {
             return
         fi
 
-        if (( attempt == 3 )); then
-            echo "'$description' failed after 3 attempts"
+        if (( attempt == max_attempts )); then
+            echo "'$description' failed after $max_attempts attempts"
             return 1
         fi
 

--- a/scripts/setup-ci-al4.sh
+++ b/scripts/setup-ci-al4.sh
@@ -17,8 +17,19 @@ retry() {
 
     local attempt=1
     local delay
+    local status
     while true; do
-        if "$@"; then
+        # Calling a function from an if condition disables errexit within it,
+        # so a later successful command can mask an earlier failure.
+        set +e
+        (
+            set -e
+            "$@"
+        )
+        status=$?
+        set -e
+
+        if (( status == 0 )); then
             return
         fi
 


### PR DESCRIPTION
## Summary

- preserve failures from any command within an AL4 dependency installer
- run each retry attempt with errexit enabled before inspecting its status
- retry failed dependency installation up to five times

## Context

The AL4 CI runner timed out downloading a build dependency. A later successful install masked that failure, so the job continued without cmake.

Failed job: https://github.com/microsoft/CCF/actions/runs/32466914442/job/96731955694?pr=8193

## Validation

- Bash syntax check
- ShellCheck
- regression simulation confirming the masked failure is retried five times