### PR TITLE
Stabilize forced partition elections

### DIFF
--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -1178,12 +1178,10 @@ def force_become_primary(network, args, target_node):
         # target becomes primary and emits signature
         # target replicates signature
         # then we can remove the partition
-        rules = network.partitioner.isolate_node(primary, target_node)
-        target_node.wait_for_leadership_state(
-            0, "Leader", timeout=2 * args.election_timeout_ms / 1000
-        )
-        network.wait_for_node_commit_sync(nodes=backups)
-        rules.drop()
+        timeout = 4 * network.observed_election_duration
+        with network.partitioner.isolate_node(primary, target_node):
+            target_node.wait_for_leadership_state(0, "Leader", timeout=timeout)
+            network.wait_for_node_commit_sync(nodes=backups, timeout=timeout)
         # Wait for the old primary to observe the new one
         network.wait_for_new_primary_in({target_node}, nodes=[primary])
         network.wait_for_primary_unanimity()


### PR DESCRIPTION
## Summary

- Allow forced primary elections to wait through four observed election periods.
- Apply the same bound while waiting for the new primary's signature to replicate.
- Always remove the temporary partition when the election wait exits.

## Why

The [`VMSS Virtual C` failure](https://github.com/microsoft/CCF/actions/runs/32477661804/job/96757281321?pr=8196) healed the certificate-renewal partition at `11:53:28.006`, observed primary unanimity and matching commit levels, and then isolated the current primary from the target node roughly 0.4 seconds later.

The target needed the remaining backup's vote, but that follower-to-follower node channel had not recovered from the previous iptables partition. The target repeatedly became a pre-vote candidate without receiving a vote response, then hit the existing 8-second bound.

Commit synchronization proves that nodes agree on replicated state; it does not prove that every pairwise node transport is immediately usable. This is the same class of delayed transport recovery previously addressed in #8132.

Waiting for four observed election periods makes the desired outcome itself the readiness probe and permits multiple pre-vote and reconnection attempts. It does not add delay to successful runs because both waits return immediately when their conditions are met, remains bounded, and does not weaken any assertion. Using the partition as a context manager also prevents leaked iptables rules if either wait fails.

## Testing

- `uvx black --check tests/partitions_test.py`
- `uvx ruff check tests/partitions_test.py`