### PR TITLE
Harden npm proxy retries in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ permissions: read-all
 
 env:
   NPM_CONFIG_REGISTRY: https://packagefeedproxy.microsoft.io/npm/
-  # Rewrite npmjs lockfile URLs through the proxy without changing the proxy's
-  # own Azure Artifacts download URLs.
-  NPM_CONFIG_REPLACE_REGISTRY_HOST: npmjs
   # Add bounded retries for transient runner-to-package-storage route failures.
   NPM_CONFIG_FETCH_RETRIES: "5"
   NPM_CONFIG_FETCH_RETRY_FACTOR: "2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,15 @@ permissions: read-all
 
 env:
   NPM_CONFIG_REGISTRY: https://packagefeedproxy.microsoft.io/npm/
+  # Rewrite npmjs lockfile URLs through the proxy without changing the proxy's
+  # own Azure Artifacts download URLs.
+  NPM_CONFIG_REPLACE_REGISTRY_HOST: npmjs
+  # Add bounded retries for transient runner-to-package-storage route failures.
+  NPM_CONFIG_FETCH_RETRIES: "5"
+  NPM_CONFIG_FETCH_RETRY_FACTOR: "2"
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "5000"
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "30000"
+  NPM_CONFIG_FETCH_TIMEOUT: "60000"
 
 jobs:
   vmss-virtual-a:


### PR DESCRIPTION
## Summary

- retry npm package fetches five times with bounded exponential backoff
- cap individual fetches at 60 seconds so stalled requests do not consume an entire end-to-end test timeout
- continue using the Microsoft npm proxy as the workflow-wide registry

## Context

This follows [the VMSS Virtual C failure](https://github.com/microsoft/CCF/actions/runs/32481185608/job/96767696803?pr=8180), where npm received a proxy-served blob URL and then hit `ENETUNREACH`. The failed install caused `modules_test` to fail and left `tsc` unavailable for the subsequent `auth` test.

There is no npmjs fallback to disable: `NPM_CONFIG_REGISTRY` already makes the Microsoft proxy authoritative. This change therefore stays focused on making transient package-storage route failures less likely to fail CI.

## Validation

- installed and ran Prettier through the Microsoft npm proxy with the new retry settings
- checked `.github/workflows/ci.yml` with Prettier
- checked the workflow for non-ASCII content