### PR TITLE
Remove duplicate Piccolo blocking benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1458,20 +1458,6 @@ if(BUILD_TESTS)
   )
 
   add_piccolo_test(
-    NAME pi_basic_blocking
-    PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/infra/basicperf.py
-    CLIENT_BIN ./submit
-    PERF_LABEL "Basic Blocking"
-    ADDITIONAL_ARGS
-      --package
-      "samples/apps/basic/basic"
-      --client-def
-      "128,blocking_write,100,primary"
-      --max-writes-ahead
-      0
-  )
-
-  add_piccolo_test(
     NAME pi_basic_js
     PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/infra/basicperf.py
     CLIENT_BIN ./submit
@@ -1483,8 +1469,8 @@ if(BUILD_TESTS)
       "1,write,300000,primary"
   )
 
-  # Same workload as pi_basic_blocking, driven by locust rather than piccolo,
-  # so that the number of concurrent clients can be varied.
+  # Blocking commit benchmark driven by locust so that the number of
+  # concurrent clients can be varied.
   add_e2e_test(
     NAME pi_basic_blocking_locust
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/basicperf_locust.py

--- a/tests/basicperf_locust.py
+++ b/tests/basicperf_locust.py
@@ -5,10 +5,9 @@
 "Basic Blocking Locust" benchmark.
 
 Measures the throughput of blocking writes (PUT /records/blocking/{key}), which
-only return once the transaction has committed. This covers the same ground as
-the piccolo-driven "Basic Blocking" benchmark, but drives load with locust
-instead, so that the client count can be ramped up and the workload described
-in Python rather than in a pre-generated parquet file.
+only return once the transaction has committed. Locust lets the client count be
+ramped up and the workload be described in Python rather than in a pre-generated
+parquet file.
 
 The load itself is defined in infra/basicperf_locustfile.py. This script owns
 the network, runs locust against it, and converts locust's statistics into


### PR DESCRIPTION
## Summary

- Remove the Piccolo-backed `pi_basic_blocking` performance test.
- Keep `pi_basic_blocking_locust` as the blocking commit benchmark.
- Update the Locust benchmark documentation to remove the obsolete Piccolo comparison.

## Rationale

The Piccolo and Locust tests cover the same blocking commit behavior. The Locust benchmark supersedes the Piccolo version and additionally varies client concurrency and signature intervals, so retaining both duplicates coverage and adds unnecessary benchmark runtime.

## Checks

- CMake formatting (`gersemi`)
- Python formatting and linting (`black`, `ruff`)
- ASCII and diff integrity checks