### PR TITLE
Fix snapshot ledger chunk race

### DIFF
--- a/tests/e2e_operations.py
+++ b/tests/e2e_operations.py
@@ -235,6 +235,16 @@ def test_forced_snapshot(network, args):
     )
     find_snapshot_after_seqno(snapshots_dir, hwm_pre_proposal)
 
+    # Do not issue another transaction after this call. The snapshot request
+    # must make all preceding transactions available in a committed chunk even
+    # when the network is otherwise idle.
+    target_seqno = network.create_and_wait_for_ledger_chunk(primary)
+    with primary.get_ledger_chunk_from_api(target_seqno) as ledger:
+        chunk, first, last, _ = find_ledger_chunk_for_seqno(ledger, target_seqno)
+        assert chunk is not None
+        assert chunk.is_complete and chunk.is_committed()
+        assert first <= target_seqno <= last
+
     return network
 
 

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -2229,11 +2229,17 @@ class Network:
         return operator_features is not None and feature in operator_features
 
     def create_and_wait_for_ledger_chunk(self, node=None, timeout=5):
+        """Create a chunk boundary and return a seqno in the committed chunk."""
         if node is None:
             node, _ = self.find_primary()
 
         if self._supports_operator_feature(node, "SnapshotCreate"):
-            target_seqno = node.trigger_snapshot().seqno
+            snapshot_txid = node.trigger_snapshot()
+            # A signature whose seqno was reserved before this request may consume
+            # the snapshot flag after the request commits. In that case the chunk
+            # ends immediately before the request; otherwise it ends at a later
+            # signature. The preceding seqno is covered in either ordering.
+            target_seqno = snapshot_txid.seqno - 1
         else:
             proposal = self.consortium.force_ledger_chunk(node)
             target_seqno = proposal.completed_seqno

--- a/tests/infra/network.py
+++ b/tests/infra/network.py
@@ -2239,7 +2239,9 @@ class Network:
             # the snapshot flag after the request commits. In that case the chunk
             # ends immediately before the request; otherwise it ends at a later
             # signature. The preceding seqno is covered in either ordering.
-            target_seqno = snapshot_txid.seqno - 1
+            target_seqno = snapshot_txid.seqno
+            if target_seqno > 1:
+                target_seqno -= 1
         else:
             proposal = self.consortium.force_ledger_chunk(node)
             target_seqno = proposal.completed_seqno


### PR DESCRIPTION
## Summary

- wait for the transaction immediately preceding a snapshot request when creating a committed ledger chunk
- handle the race where an already-reserved signature consumes the snapshot flag and closes the chunk before the request transaction
- cover an otherwise-idle network so the helper does not depend on unrelated follow-up writes

This fixes the `programmability_and_jwt` failure in [ACI SNP Genoa job 97390067769](https://github.com/microsoft/CCF/actions/runs/32713600107/job/97390067769?pr=8175), where `/node/snapshot:create` returned seqno 312 but the snapshot signature committed `ledger_305-311`, leaving seqno 312 in the next open chunk until the test timed out.

## Validation

- Python formatting and lint checks
- Python bytecode compilation
- ASCII check
- Debug build of the logging test application

The targeted e2e runner could not execute locally because CCF aborted during TCP startup in the local WSL environment, before test execution.