### PR TITLE
Flush setup writes before SNP tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,6 +314,7 @@ jobs:
           ./tests.sh --timeout 360 -V -R '^ledger_bench$'
         shell: bash
         env:
+          CCF_TEST_SYNC_AFTER_SETUP: 1
           ELECTION_TIMEOUT_MS: 10000
 
       - name: "Capture dmesg"
@@ -399,6 +400,7 @@ jobs:
           ./tests.sh --timeout 360 -V -R '^ledger_bench$'
         shell: bash
         env:
+          CCF_TEST_SYNC_AFTER_SETUP: 1
           ELECTION_TIMEOUT_MS: 10000
 
       - name: "Capture dmesg"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -16,6 +16,13 @@ pip install -q -U -e ../python/
 pip install -q -U -r ../tests/requirements.txt
 echo "Python environment successfully setup"
 
+if [[ "${CCF_TEST_SYNC_AFTER_SETUP:-0}" == "1" ]]; then
+    echo "Flushing filesystem writeback after Python environment setup..."
+    sync_start=$SECONDS
+    sync
+    echo "Filesystem writeback completed in $((SECONDS - sync_start))s"
+fi
+
 # Export where the VENV has been set, so tests running
 # a sandbox.sh can inherit it rather create a new one
 VENV_DIR=$(realpath env)


### PR DESCRIPTION
## Summary

- Add an opt-in `CCF_TEST_SYNC_AFTER_SETUP` flush after the Python test environment is installed.
- Enable the flush for both ACI SNP Milan and Genoa jobs.
- Extract only the mitigation from #8211, without carrying over its diagnostic instrumentation.

## Why

The Milan investigation in #8211 found that Python environment setup accumulated roughly 600-900 MiB of dirty data. Linux's 30-second dirty-page expiry then started a large XFS writeback batch while CCF was running, causing independent CCF nodes and the same-filesystem canary to block together even though the scheduler heartbeat remained stable.

In the comparison runs from #8211, the baseline cohort had two failures in nine runs and reached an 8.477-second maximum CCF `fsync`. With an explicit post-setup `sync`, all ten runs passed, every `programmability_and_jwt` `fsync` stayed below 0.9 seconds, and the 7-9 second flush cost was paid before CCF started. Genoa runs the same Python setup and SNP test sequence, so both physical SNP workflows should drain setup writeback before launching CCF.

## Validation

- Prettier
- ShellCheck
- Copyright and ASCII checks