### PR TITLE
Remove Microsoft package feed proxies from CI

### DIFF
--- a/.github/workflows/bencher-ab.yml
+++ b/.github/workflows/bencher-ab.yml
@@ -13,9 +13,6 @@ on:
 
 permissions: read-all
 
-env:
-  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: false

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -10,9 +10,6 @@ on:
 
 permissions: read-all
 
-env:
-  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   queue: max

--- a/.github/workflows/ci-al4.yml
+++ b/.github/workflows/ci-al4.yml
@@ -12,9 +12,6 @@ concurrency:
 
 permissions: read-all
 
-env:
-  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
-
 jobs:
   vmss-virtual-a:
     name: "AL4 VMSS Virtual A" # Debug build, unit tests, e2e (bucket_a)

--- a/.github/workflows/ci-verification.yml
+++ b/.github/workflows/ci-verification.yml
@@ -10,9 +10,6 @@ concurrency:
 
 permissions: read-all
 
-env:
-  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
-
 jobs:
   model-checking-consistency:
     name: Model Checking - Consistency

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,12 @@ concurrency:
 permissions: read-all
 
 env:
-  NPM_CONFIG_REGISTRY: https://packagefeedproxy.microsoft.io/npm/
   # Add bounded retries for transient runner-to-package-storage route failures.
   NPM_CONFIG_FETCH_RETRIES: "5"
   NPM_CONFIG_FETCH_RETRY_FACTOR: "2"
   NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "5000"
   NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "30000"
   NPM_CONFIG_FETCH_TIMEOUT: "60000"
-  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
 
 jobs:
   vmss-virtual-a:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,9 +22,6 @@ concurrency:
 
 permissions: read-all
 
-env:
-  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
-
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,6 @@ permissions: read-all
 # scripts/coverage_summary.py, so that the two stay in sync from a single place.
 env:
   COVERAGE_HISTORY_POINTS: "9"
-  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
 
 jobs:
   coverage_virtual:

--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -17,9 +17,6 @@ concurrency:
 
 permissions: read-all
 
-env:
-  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
-
 jobs:
   long-asan:
     if: &check_trigger_conditions ${{ (github.event.action == 'labeled' && github.event.label.name == 'run-long-test') || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-long-test')) || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ permissions: read-all
 
 env:
   IMAGE: mcr.microsoft.com/azurelinux/base/core:3.0
-  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
 
 jobs:
   make_sbom:

--- a/.github/workflows/tla-shallow.yml
+++ b/.github/workflows/tla-shallow.yml
@@ -13,9 +13,6 @@ concurrency:
 
 permissions: read-all
 
-env:
-  PIP_INDEX_URL: https://packagefeedproxy.microsoft.io/pypi/simple/
-
 jobs:
   simulation:
     name: TLA Simulation


### PR DESCRIPTION
Removing overrides, as per guidance, and leveraging the pool environment instead.

The existing npm retry configuration remains unchanged.