### PR TITLE
Run AL4 CI daily on main instead of on PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,6 +41,13 @@ Main continuous integration job. Builds CCF for all target platforms, runs unit,
 File: `ci.yml`
 3rd party dependencies: None
 
+# Continuous Integration AL4
+
+Builds CCF on Azure Linux 4 and runs unit and end to end tests, to track readiness for the move from Azure Linux 3, which `ci.yml` builds against. Runs daily on `main` on week days, and manually. It deliberately does not run on PRs, to keep PR feedback fast and limit pool usage.
+
+File: `ci-al4.yml`
+3rd party dependencies: None
+
 # Coverage
 
 Builds CCF with coverage enabled, runs unit and end to end tests, and uploads HTML coverage reports. Triggered on every commit on `main`, twice daily on week days, and manually.

--- a/.github/workflows/ci-al4.yml
+++ b/.github/workflows/ci-al4.yml
@@ -3,7 +3,6 @@ name: Continuous Integration AL4
 on:
   schedule:
     - cron: "0 0 * * 1-5"
-  pull_request:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Stops the Azure Linux 4 CI workflow (`ci-al4.yml`) from running on every pull request. It now runs only on its existing weekday schedule, which executes against `main`, plus manual `workflow_dispatch`.

`ci-al4.yml` builds Debug and runs unit tests and all three e2e buckets on the Azure Linux 4 base image, largely duplicating `ci.yml` (Azure Linux 3) coverage. On PRs that meant a full extra build plus e2e run per push, for a signal that is really about base-image readiness rather than the change under review. A daily run on `main` catches AL4-specific breakage just as well, at a fraction of the pool usage.

## Changes

- `.github/workflows/ci-al4.yml`: removed the `pull_request` trigger. `schedule` (`0 0 * * 1-5`) and `workflow_dispatch` are unchanged.
- `.github/workflows/README.md`: added a section for the workflow, which previously had no entry, describing its role and its triggers.

## Notes

- The `concurrency` block is left as-is: for scheduled runs `github.ref` is `refs/heads/main`, so `cancel-in-progress` evaluates to `false`, and it still cancels superseded manual dispatches on other branches.
- If `AL4 VMSS Virtual A/B/C` are configured as required status checks in branch protection, they will need to be removed there, since they will no longer report on PRs.
- No `CHANGELOG.md` entry: this is CI configuration only, with no user-facing API or behaviour change.