### PR TITLE
Stabilize npm cache key hashing

### DIFF
--- a/.github/actions/install-ci-dependencies/action.yml
+++ b/.github/actions/install-ci-dependencies/action.yml
@@ -110,15 +110,24 @@ runs:
         restore-keys: |
           azure-linux-${{ steps.configure.outputs.package-manager }}-python-packages-${{ runner.arch }}-${{ hashFiles('scripts/install_uv.sh', 'python/pyproject.toml', inputs.python-requirements) }}-
           azure-linux-${{ steps.configure.outputs.package-manager }}-python-packages-${{ runner.arch }}-
+    # Cache inputs are re-evaluated during post-job cleanup, after tests have
+    # modified the workspace, so snapshot the hash before running them.
+    - name: Compute npm package cache key
+      id: npm_cache_key
+      shell: bash
+      env:
+        INPUT_HASH: ${{ hashFiles('**/package.json', 'scripts/prettier-checks.sh') }}
+      run: echo "hash=$INPUT_HASH" >> "$GITHUB_OUTPUT"
+
     - name: Restore npm package cache
       continue-on-error: true
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: /github/home/.npm
-        key: azure-linux-npm-packages-${{ runner.arch }}-${{ hashFiles('**/package.json', 'scripts/prettier-checks.sh') }}-${{ github.job }}-${{ steps.configure.outputs.cache-week }}
+        key: azure-linux-npm-packages-${{ runner.arch }}-${{ steps.npm_cache_key.outputs.hash }}-${{ github.job }}-${{ steps.configure.outputs.cache-week }}
         restore-keys: |
-          azure-linux-npm-packages-${{ runner.arch }}-${{ hashFiles('**/package.json', 'scripts/prettier-checks.sh') }}-${{ github.job }}-
-          azure-linux-npm-packages-${{ runner.arch }}-${{ hashFiles('**/package.json', 'scripts/prettier-checks.sh') }}-
+          azure-linux-npm-packages-${{ runner.arch }}-${{ steps.npm_cache_key.outputs.hash }}-${{ github.job }}-
+          azure-linux-npm-packages-${{ runner.arch }}-${{ steps.npm_cache_key.outputs.hash }}-
           azure-linux-npm-packages-${{ runner.arch }}-
 
     - name: Install dependencies


### PR DESCRIPTION
## Summary

- compute the npm cache input hash once before build and test steps
- reuse the stable step output in cache keys and restore keys
- avoid rescanning the test-mutated workspace during `actions/cache` post-job cleanup

## Context

VMSS Virtual B completed successfully but emitted a failure annotation when `hashFiles('**/package.json', 'scripts/prettier-checks.sh')` was re-evaluated during cache cleanup.

## Validation

- `scripts/prettier-checks.sh -f`
- `scripts/ascii-checks.sh`