### PR TITLE
Remove redundant basic multithreaded benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1470,8 +1470,9 @@ if(BUILD_TESTS)
       "1,write,300000,primary"
   )
 
-  # Blocking commit benchmark driven by locust so that the number of
-  # concurrent clients can be varied.
+  # Blocking commit benchmark driven by locust. Its concurrent connections
+  # exercise every configured worker thread, so this also covers the
+  # multi-threaded basic workload.
   add_e2e_test(
     NAME pi_basic_blocking_locust
     PYTHON_SCRIPT ${CMAKE_SOURCE_DIR}/tests/basicperf_locust.py
@@ -1502,20 +1503,6 @@ if(BUILD_TESTS)
       20
       100
   )
-
-  if(WORKER_THREADS)
-    add_piccolo_test(
-      NAME pi_basic_mt
-      PYTHON_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/tests/infra/basicperf.py
-      CLIENT_BIN ./submit
-      PERF_LABEL "Basic Multi-Threaded"
-      ADDITIONAL_ARGS
-        --package
-        "samples/apps/basic/basic"
-        --client-def
-        "${WORKER_THREADS},write,2000000,primary"
-    )
-  endif()
 
   # JWT-authenticated blocking logging workload, driven by locust so that the
   # number of concurrent clients can be varied.


### PR DESCRIPTION
## Summary
- remove the Piccolo-backed `pi_basic_mt` performance test
- document that `pi_basic_blocking_locust` already exercises every configured worker thread

## Rationale
The benchmark workflows configure `WORKER_THREADS=2`, which is passed to `pi_basic_blocking_locust` through the common network test arguments. Its 320 concurrent Locust connections already cover the multi-threaded basic workload, so adding another blocking Locust replacement would duplicate coverage.

## Validation
- configured CMake with `BUILD_TESTS=ON` and `WORKER_THREADS=2`
- confirmed the generated CTest registration includes `pi_basic_blocking_locust` with `--worker-threads 2` and no `pi_basic_mt`
- formatted `CMakeLists.txt` with gersemi 0.27.0
- ran diff and ASCII integrity checks