### PR TITLE
Order chunk metadata and snapshot scheduling with rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- If the view changed while a transaction was committing, the transaction could apply its writes to the local key-value store and then fail to replicate, leaving state that never reached consensus. The transaction's view is now validated atomically with the allocation of its version, so it is rejected before any map is modified, and `ccf::kv::CommitResult::FAIL_NO_REPLICATE` no longer implies a locally applied write (#8242).
+- Ledger chunk metadata and snapshot scheduling are no longer restored by a transaction whose writes a concurrent view change has already discarded. Both are now updated under the same lock as the rollback, and skipped when the transaction's rollback epoch or view no longer holds (#8243).
+- A transaction whose view changed while it was committing could apply its writes to the local key-value store and then fail to replicate, leaving state that never reached consensus. The transaction's view is now validated atomically with the allocation of its version, so it is rejected before any map is modified, and `ccf::kv::CommitResult::FAIL_NO_REPLICATE` no longer implies a locally applied write (#8242).
 
 ### Changed
 

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -659,16 +659,6 @@ namespace ccf::kv
       // at the specified version.
       // No transactions can be prepared or committed during rollback.
 
-      if (snapshotter)
-      {
-        snapshotter->rollback(tx_id.seqno);
-      }
-
-      if (chunker)
-      {
-        chunker->rolled_back_to(tx_id.seqno);
-      }
-
       std::lock_guard<ccf::ds::Mutex> mguard(maps_lock);
 
       {
@@ -696,6 +686,16 @@ namespace ccf::kv
 
         if (tx_id.seqno >= version)
         {
+          if (snapshotter)
+          {
+            snapshotter->rollback(tx_id.seqno);
+          }
+          if (chunker)
+          {
+            // Keep this ordered with append_entry_size() below, so a commit
+            // cannot restore chunk metadata after this rollback.
+            chunker->rolled_back_to(tx_id.seqno);
+          }
           return;
         }
 
@@ -707,6 +707,16 @@ namespace ccf::kv
         unset_flag_unsafe(StoreFlag::SNAPSHOT_AT_NEXT_SIGNATURE);
         rollback_count++;
         pending_txs.clear();
+        if (snapshotter)
+        {
+          snapshotter->rollback(tx_id.seqno);
+        }
+        if (chunker)
+        {
+          // Keep this ordered with append_entry_size() below, so a commit
+          // cannot restore chunk metadata after this rollback.
+          chunker->rolled_back_to(tx_id.seqno);
+        }
         auto e = get_encryptor();
         if (e)
         {
@@ -1083,7 +1093,18 @@ namespace ccf::kv
 
         if (chunker)
         {
-          chunker->append_entry_size(data_shared->size());
+          std::lock_guard<ccf::ds::Mutex> vguard(version_lock);
+          // A rollback can only discard this batch's writes by truncating,
+          // which requires its target to be below `version` and therefore
+          // increments rollback_count. A rollback that does not truncate
+          // leaves the writes intact, but may still move the term on, which
+          // consensus will reject - so both are checked here.
+          if (
+            previous_rollback_count == rollback_count &&
+            replication_view == term_of_next_version)
+          {
+            chunker->append_entry_size(data_shared->size());
+          }
         }
 
         LOG_DEBUG_FMT(

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -3494,6 +3494,108 @@ TEST_CASE("Reserved transaction map creation is serialised with lookups")
       fmt::format("public:reserved_{}", reserved_txs - 1)) != nullptr);
 }
 
+// Exposes the version the chunker has recorded entries up to, which is the
+// state a rollback and a concurrent commit can disagree about.
+class InspectableChunker : public ccf::kv::LedgerChunker
+{
+public:
+  ccf::kv::Version current_version()
+  {
+    ccf::ds::MutexGuard guard(chunker_lock);
+    return current_tx_version;
+  }
+};
+
+// A PendingTx which rolls the store back while Store::commit() is midway
+// through the batch it belongs to. Store::commit() calls this after releasing
+// version_lock, so it reproduces a rollback landing between a batch being
+// assembled and its chunk metadata being recorded, without needing threads.
+class RollingBackPendingTx : public ccf::kv::PendingTx
+{
+  ccf::TxID txid;
+  ccf::kv::Store& store;
+  MapTypes::StringString& table;
+  ccf::TxID rollback_to;
+  ccf::kv::Term rollback_term;
+
+public:
+  RollingBackPendingTx(
+    ccf::TxID txid_,
+    ccf::kv::Store& store_,
+    MapTypes::StringString& table_,
+    ccf::TxID rollback_to_,
+    ccf::kv::Term rollback_term_) :
+    txid(txid_),
+    store(store_),
+    table(table_),
+    rollback_to(rollback_to_),
+    rollback_term(rollback_term_)
+  {}
+
+  ccf::kv::PendingTxInfo call() override
+  {
+    auto tx = store.create_reserved_tx(txid);
+    tx.rw(table)->put("key", "value");
+    auto info = tx.commit_reserved();
+    store.rollback(rollback_to, rollback_term);
+    return info;
+  }
+};
+
+TEST_CASE("Chunk metadata is not restored by a batch a rollback discarded")
+{
+  ccf::kv::Store store;
+  store.set_encryptor(std::make_shared<ccf::kv::NullTxEncryptor>());
+  auto consensus = std::make_shared<ccf::kv::test::PrimaryStubConsensus>();
+  store.set_consensus(consensus);
+  auto chunker = std::make_shared<InspectableChunker>();
+  store.set_chunker(chunker);
+
+  constexpr ccf::kv::Term initial_term = 2;
+  store.initialise_term(initial_term);
+  MapTypes::StringString map("public:map");
+
+  INFO("Commit an ordinary transaction to establish a baseline");
+  {
+    auto tx = store.create_tx();
+    tx.rw(map)->put("key", "initial");
+    REQUIRE(tx.commit() == ccf::kv::CommitResult::SUCCESS);
+  }
+
+  const auto baseline_txid = store.current_txid();
+  REQUIRE(chunker->current_version() == baseline_txid.seqno);
+
+  INFO(
+    "A batch whose writes are discarded by a rollback must not leave chunk "
+    "metadata behind");
+  {
+    const auto reserved = store.next_txid();
+    REQUIRE(reserved.seqno == baseline_txid.seqno + 1);
+
+    // The rollback target is below the reserved version, so it truncates and
+    // moves the rollback epoch on - exactly what a real election would do.
+    store.commit(
+      reserved,
+      std::make_unique<RollingBackPendingTx>(
+        reserved, store, map, baseline_txid, initial_term + 1),
+      false);
+  }
+
+  CHECK(store.current_txid() == baseline_txid);
+  CHECK(chunker->current_version() == baseline_txid.seqno);
+
+  INFO(
+    "The next transaction is chunked against its own version, with no "
+    "accumulated offset from the discarded batch");
+  {
+    auto tx = store.create_tx();
+    tx.rw(map)->put("key", "fresh");
+    REQUIRE(tx.commit() == ccf::kv::CommitResult::SUCCESS);
+  }
+
+  CHECK(chunker->current_version() == store.current_version());
+}
+
 TEST_CASE("Ledger entry chunk request")
 {
   ccf::kv::Store store;


### PR DESCRIPTION
> Stacked on #8242. Review the top commit only; the base PR must merge first.

## Why this is necessary

`LedgerChunker` decides where ledger chunks end, and `Snapshotter` decides where snapshots are taken. Both accumulate state that outlives the transaction which contributes to it, and both are reset by `Store::rollback()` when a view change discards uncommitted work.

Neither was ordered against the commit path. `Store::commit()` appended an entry''s size to the chunker *after* releasing `version_lock`, so this interleaving was possible:

1. a batch is assembled and its entries applied;
2. a view change rolls the store back, clearing chunk metadata above the rollback point;
3. the batch resumes and appends its size anyway.

The chunker is now permanently one entry ahead of the store. Its counter is independent of the store''s version, so the offset never self-corrects: every subsequent entry is recorded against the wrong version, `get_unchunked_size()` sums the wrong range, and chunk boundaries drift from what the ledger actually contains. `Snapshotter::rollback()` had the same shape, able to interleave with a commit recording a committable index.

## What changes

Both are updated under `version_lock`, the same lock the rollback takes, and the append is skipped when the batch''s rollback epoch or view no longer holds.

The two conditions are complementary rather than redundant, which is worth stating because it is not obvious:

- a rollback can only **discard** a batch''s writes by truncating, which requires its target below `version` and therefore increments `rollback_count`;
- a rollback that does **not** truncate leaves the writes intact, but may still move the view on, which consensus will reject.

This invariant is recorded as a comment at the check, so a future change to rollback semantics cannot silently invalidate it.

## Why this is minimal

Only the ordering changes. No new locks are introduced and no state is added: the epoch and view compared were already captured by `Store::commit()` for its existing `last_replicated` guard.

Moving the chunker and snapshotter calls inside the existing `version_lock` section is what makes them atomic with respect to `rollback_count`, which is the property the check depends on. Leaving them outside and adding a separate lock would reintroduce the same window.

## Performance

This is the one change in the stack with a cost on the commit path: one `version_lock` acquire/release per entry in a batch. The lock is short and usually uncontended, but it scales with batch size. If it shows up in benchmarks the check can be hoisted out of the loop, since the epoch cannot change mid-loop without the whole batch failing anyway.

Lock ordering is unchanged in shape: `commit_lock -> version_lock -> chunker_lock`. `commit_lock` is only ever taken at the top of `Store::commit()`, before `version_lock`, and `LedgerChunker` is a leaf that holds no store reference, so no cycle is introduced.

## Testing

`kv_test` gains "Chunk metadata is not restored by a batch a rollback discarded". It drives the race deterministically and without threads, using a `PendingTx` that performs the rollback inline - `Store::commit()` invokes it in exactly the window concerned.

Verified that the test fails without the fix (the chunker ends one entry ahead of the store) and passes with it.

Labelled `run-long-test`.

---

### Review stack

These five PRs come from one investigation and are stacked; review and merge in order.

| PR | Change |
| --- | --- |
| #8242 | Reject stale-view writes before local commit |
| #8243 | Order chunk metadata and snapshot scheduling with rollback |
| #8244 | Stop a rollback moving chunk metadata forward |
| #8245 | Guard rollback-sensitive transaction flags |
| #8246 | Guard reserved signature side effects |

All were found by an interleaving-exploration harness built over the real KV, consensus and history stack (draft #8238). The harness itself is deliberately **not** included here; these PRs carry only the fixes and the single-threaded regression tests that pin them.
