### PR TITLE
Stop a rollback moving chunk metadata forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- A rollback whose target is at or beyond the store's own version no longer moves ledger chunk metadata forward past it, which previously left a permanent offset skewing later chunk boundaries (#8244).
 - Ledger chunk metadata and snapshot scheduling are no longer restored by a transaction whose writes a concurrent view change has already discarded. Both are now updated under the same lock as the rollback, and skipped when the transaction's rollback epoch or view no longer holds (#8243).
 - A transaction whose view changed while it was committing could apply its writes to the local key-value store and then fail to replicate, leaving state that never reached consensus. The transaction's view is now validated atomically with the allocation of its version, so it is rejected before any map is modified, and `ccf::kv::CommitResult::FAIL_NO_REPLICATE` no longer implies a locally applied write (#8242).
 

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -692,9 +692,11 @@ namespace ccf::kv
           }
           if (chunker)
           {
-            // Keep this ordered with append_entry_size() below, so a commit
-            // cannot restore chunk metadata after this rollback.
-            chunker->rolled_back_to(tx_id.seqno);
+            // Nothing local is discarded here, but the chunker may still be
+            // behind `version` if an allocated entry has not reached
+            // append_entry_size() yet. Clamp so this can only ever move the
+            // chunker back, never forward past the Store.
+            chunker->rolled_back_to(std::min<Version>(tx_id.seqno, version));
           }
           return;
         }

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -692,10 +692,9 @@ namespace ccf::kv
           }
           if (chunker)
           {
-            // Nothing local is discarded here, but the chunker may still be
-            // behind `version` if an allocated entry has not reached
-            // append_entry_size() yet. Clamp so this can only ever move the
-            // chunker back, never forward past the Store.
+            // Nothing local is discarded here, but the rollback target may be
+            // at or beyond the Store's current version. Clamp so this cannot
+            // move chunk metadata forward past the Store.
             chunker->rolled_back_to(std::min<Version>(tx_id.seqno, version));
           }
           return;

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -3596,6 +3596,51 @@ TEST_CASE("Chunk metadata is not restored by a batch a rollback discarded")
   CHECK(chunker->current_version() == store.current_version());
 }
 
+TEST_CASE("A rollback never moves chunk metadata past the store's version")
+{
+  ccf::kv::Store store;
+  store.set_encryptor(std::make_shared<ccf::kv::NullTxEncryptor>());
+  auto consensus = std::make_shared<ccf::kv::test::PrimaryStubConsensus>();
+  store.set_consensus(consensus);
+  auto chunker = std::make_shared<InspectableChunker>();
+  store.set_chunker(chunker);
+
+  constexpr ccf::kv::Term initial_term = 2;
+  store.initialise_term(initial_term);
+  MapTypes::StringString map("public:map");
+
+  {
+    auto tx = store.create_tx();
+    tx.rw(map)->put("key", "initial");
+    REQUIRE(tx.commit() == ccf::kv::CommitResult::SUCCESS);
+  }
+
+  const auto version = store.current_version();
+  REQUIRE(chunker->current_version() == version);
+
+  SUBCASE("Rollback to the current version")
+  {
+    store.rollback(store.current_txid(), initial_term + 1);
+  }
+
+  SUBCASE("Rollback beyond the current version")
+  {
+    store.rollback({initial_term, version + 3}, initial_term + 1);
+  }
+
+  // Neither discards anything, so neither may move the chunker.
+  CHECK(store.current_version() == version);
+  CHECK(chunker->current_version() == version);
+
+  INFO("Later entries are still recorded against their own version");
+  {
+    auto tx = store.create_tx();
+    tx.rw(map)->put("key", "fresh");
+    REQUIRE(tx.commit() == ccf::kv::CommitResult::SUCCESS);
+  }
+  CHECK(chunker->current_version() == store.current_version());
+}
+
 TEST_CASE("Ledger entry chunk request")
 {
   ccf::kv::Store store;


### PR DESCRIPTION
> Stacked on #8243. Review the top commit only; the base PRs must merge first.

## Why this is necessary

`Store::rollback()` has two paths. If the target is below the store''s version it truncates; if the target is at or beyond it, nothing local is discarded and it returns early. Both paths reset the chunker to the rollback target.

For the truncating path that is right. For the early-return path it is not, because **the chunker is allowed to lag the store**. An entry is assigned a version by `next_version()` well before `Store::commit()` records its size, so at any moment the chunker can legitimately be behind. Resetting it to a target at or beyond the store''s version therefore moves it *forward*, past entries whose sizes were never recorded.

The chunker''s counter is independent of the store''s version and only ever advances, so the offset is permanent. Every subsequent entry is then recorded against the wrong version, `transaction_sizes` acquires a hole, and `get_unchunked_size()` silently under-counts - chunk boundaries drift from what the ledger contains, and `compacted_to()` can prune entries that were never accounted for.

A rollback to exactly the current version is routine: it is how a view change is communicated when there is nothing to truncate.

## What changes

Clamp the rollback target to the store''s own version, so a rollback can only ever move chunk metadata **back**:

```cpp
chunker->rolled_back_to(std::min<Version>(tx_id.seqno, version));
```

## Why this is minimal

One `std::min` on the non-truncating path. The truncating path is untouched - there the target is below `version` by construction, so the clamp would be a no-op.

The alternative, keeping the chunker eagerly in step with allocation rather than with commit, would mean recording sizes for entries that may never be replicated, which is the resurrection problem the previous PR in this stack fixes.

## Performance

None. One comparison on a path taken only during a view change.

## Testing

`kv_test` gains "A rollback never moves chunk metadata past the store''s version", covering both a rollback to exactly the current version and one beyond it, then asserting later entries are still recorded against their own version. Single-threaded and deterministic.

Verified that the test fails without the clamp - the chunker ends ahead of the store, and stays ahead - and passes with it.

Labelled `run-long-test`.

---

### Review stack

These five PRs come from one investigation and are stacked; review and merge in order.

| PR | Change |
| --- | --- |
| #8242 | Reject stale-view writes before local commit |
| #8243 | Order chunk metadata and snapshot scheduling with rollback |
| #8244 | Stop a rollback moving chunk metadata forward |
| #8245 | Guard rollback-sensitive transaction flags |
| #8246 | Guard reserved signature side effects |

All were found by an interleaving-exploration harness built over the real KV, consensus and history stack (draft #8238). The harness itself is deliberately **not** included here; these PRs carry only the fixes and the single-threaded regression tests that pin them.
