### PR TITLE
Guard reserved signature side effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- A signature transaction decided whether to end a ledger chunk, and recorded that decision on the chunker, outside the version lock. A rollback landing in that window discarded the signature but left the chunk marker behind. The decision and the record are now made atomically, and skipped when the signature's view or rollback epoch no longer holds (#8246).
 - A transaction's `force_ledger_chunk` and `snapshot_at_next_signature` flags are no longer applied once a concurrent view change has discarded the transaction's writes, which previously left a chunk boundary, or an armed snapshot, for a transaction no longer present in the ledger. The forced chunk is also attached to the transaction's own version rather than whichever version the store had reached (#8245).
 - A rollback whose target is at or beyond the store's own version no longer moves ledger chunk metadata forward past it, which previously left a permanent offset skewing later chunk boundaries (#8244).
 - Ledger chunk metadata and snapshot scheduling are no longer restored by a transaction whose writes a concurrent view change has already discarded. Both are now updated under the same lock as the rollback, and skipped when the transaction's rollback epoch or view no longer holds (#8243).

--- a/src/kv/committable_tx.h
+++ b/src/kv/committable_tx.h
@@ -557,20 +557,25 @@ namespace ccf::kv
 
       // This is a signature and, if the ledger chunking or snapshot flags are
       // enabled, we want the host to create a chunk when it sees this entry.
-      // version_lock held by Store::commit
-      if (pimpl->store->should_create_ledger_chunk_unsafe(version))
+      // Deciding this and recording the chunk must be atomic with respect to
+      // rollback, so that a signature a rollback discards leaves no marker
+      // behind.
+      const auto should_create_chunk = pimpl->store->prepare_reserved_tx(
+        version, pimpl->commit_view, rollback_count);
+      if (!should_create_chunk.has_value())
+      {
+        committed = true;
+        return {
+          CommitResult::FAIL_NO_REPLICATE, {}, ccf::empty_claims(), {}, {}};
+      }
+
+      if (should_create_chunk.value())
       {
         entry_flags |= EntryFlags::FORCE_LEDGER_CHUNK_AFTER;
         LOG_DEBUG_FMT(
           "Ending ledger chunk with signature at {}.{}",
           pimpl->commit_view,
           version);
-
-        auto chunker = pimpl->store->get_chunker();
-        if (chunker)
-        {
-          chunker->produced_chunk_at(version);
-        }
       }
 
       committed = true;

--- a/src/kv/committable_tx.h
+++ b/src/kv/committable_tx.h
@@ -560,8 +560,9 @@ namespace ccf::kv
       // Deciding this and recording the chunk must be atomic with respect to
       // rollback, so that a signature a rollback discards leaves no marker
       // behind.
-      const auto should_create_chunk = pimpl->store->prepare_reserved_tx(
-        version, pimpl->commit_view, rollback_count);
+      const auto should_create_chunk =
+        pimpl->store->should_create_ledger_chunk_for_reserved_tx(
+          version, pimpl->commit_view, rollback_count);
       if (!should_create_chunk.has_value())
       {
         committed = true;

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -750,7 +750,7 @@ namespace ccf::kv
       Version expected_rollback_count,
       bool force_ledger_chunk,
       bool snapshot_at_next_signature) = 0;
-    virtual std::optional<bool> prepare_reserved_tx(
+    virtual std::optional<bool> should_create_ledger_chunk_for_reserved_tx(
       Version version, Term expected_term, Version expected_rollback_count) = 0;
 
     virtual std::unique_ptr<AbstractSnapshot> snapshot_unsafe_maps(

--- a/src/kv/kv_types.h
+++ b/src/kv/kv_types.h
@@ -750,6 +750,8 @@ namespace ccf::kv
       Version expected_rollback_count,
       bool force_ledger_chunk,
       bool snapshot_at_next_signature) = 0;
+    virtual std::optional<bool> prepare_reserved_tx(
+      Version version, Term expected_term, Version expected_rollback_count) = 0;
 
     virtual std::unique_ptr<AbstractSnapshot> snapshot_unsafe_maps(
       Version v) = 0;

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -1150,6 +1150,28 @@ namespace ccf::kv
       return false;
     }
 
+    std::optional<bool> prepare_reserved_tx(
+      Version version,
+      Term expected_term,
+      Version expected_rollback_count) override
+    {
+      std::lock_guard<ccf::pal::Mutex> vguard(version_lock);
+      if (
+        term_of_next_version != expected_term ||
+        rollback_count != expected_rollback_count)
+      {
+        return std::nullopt;
+      }
+
+      const auto should_create_chunk =
+        should_create_ledger_chunk_unsafe(version);
+      if (should_create_chunk && chunker)
+      {
+        chunker->produced_chunk_at(version);
+      }
+      return should_create_chunk;
+    }
+
     bool should_create_ledger_chunk(Version version) override
     {
       std::lock_guard<ccf::ds::Mutex> vguard(version_lock);

--- a/src/kv/store.h
+++ b/src/kv/store.h
@@ -1150,12 +1150,12 @@ namespace ccf::kv
       return false;
     }
 
-    std::optional<bool> prepare_reserved_tx(
+    std::optional<bool> should_create_ledger_chunk_for_reserved_tx(
       Version version,
       Term expected_term,
       Version expected_rollback_count) override
     {
-      std::lock_guard<ccf::pal::Mutex> vguard(version_lock);
+      std::lock_guard<ccf::ds::Mutex> vguard(version_lock);
       if (
         term_of_next_version != expected_term ||
         rollback_count != expected_rollback_count)

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -3507,7 +3507,7 @@ public:
 
   bool has_chunk_end_at(ccf::kv::Version v)
   {
-    ccf::pal::MutexGuard guard(chunker_lock);
+    ccf::ds::MutexGuard guard(chunker_lock);
     return chunk_ends.contains(v);
   }
 };
@@ -3753,8 +3753,10 @@ TEST_CASE("Reserved signature side effects are not applied after a rollback")
     store.rollback({initial_term, reserved.seqno - 1}, initial_term + 1);
     REQUIRE(store.check_rollback_count(1));
 
-    CHECK_FALSE(
-      store.prepare_reserved_tx(reserved.seqno, reserved.view, 0).has_value());
+    CHECK_FALSE(store
+                  .should_create_ledger_chunk_for_reserved_tx(
+                    reserved.seqno, reserved.view, 0)
+                  .has_value());
     CHECK_FALSE(chunker->has_chunk_end_at(reserved.seqno));
   }
 
@@ -3775,7 +3777,9 @@ TEST_CASE("Reserved signature side effects are not applied after a rollback")
     REQUIRE(store.flag_enabled(
       ccf::kv::AbstractStore::StoreFlag::SNAPSHOT_AT_NEXT_SIGNATURE));
 
-    CHECK_FALSE(store.prepare_reserved_tx(superseded.seqno, superseded.view, 1)
+    CHECK_FALSE(store
+                  .should_create_ledger_chunk_for_reserved_tx(
+                    superseded.seqno, superseded.view, 1)
                   .has_value());
     CHECK_FALSE(chunker->has_chunk_end_at(superseded.seqno));
   }
@@ -3790,7 +3794,8 @@ TEST_CASE("Reserved signature side effects are not applied after a rollback")
       ccf::kv::AbstractStore::StoreFlag::SNAPSHOT_AT_NEXT_SIGNATURE);
 
     const auto should_create_chunk =
-      store.prepare_reserved_tx(replacement.seqno, replacement.view, 1);
+      store.should_create_ledger_chunk_for_reserved_tx(
+        replacement.seqno, replacement.view, 1);
     REQUIRE(should_create_chunk.has_value());
     CHECK(should_create_chunk.value());
     CHECK(chunker->has_chunk_end_at(replacement.seqno));

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -3504,6 +3504,12 @@ public:
     ccf::ds::MutexGuard guard(chunker_lock);
     return current_tx_version;
   }
+
+  bool has_chunk_end_at(ccf::kv::Version v)
+  {
+    ccf::pal::MutexGuard guard(chunker_lock);
+    return chunk_ends.contains(v);
+  }
 };
 
 // A PendingTx which rolls the store back while Store::commit() is midway
@@ -3712,6 +3718,82 @@ TEST_CASE("Rollback-sensitive transaction flags are not restored")
     INFO("The chunk is requested at the transaction's own version");
     CHECK(chunker->is_chunk_end_requested(replacement.seqno));
     CHECK_FALSE(chunker->is_chunk_end_requested(replacement.seqno - 1));
+  }
+}
+
+TEST_CASE("Reserved signature side effects are not applied after a rollback")
+{
+  ccf::kv::Store store;
+  store.set_encryptor(std::make_shared<ccf::kv::NullTxEncryptor>());
+  auto consensus = std::make_shared<ccf::kv::test::PrimaryStubConsensus>();
+  store.set_consensus(consensus);
+  auto chunker = std::make_shared<InspectableChunker>();
+  store.set_chunker(chunker);
+
+  constexpr ccf::kv::Term initial_term = 2;
+  store.initialise_term(initial_term);
+  MapTypes::StringString map("public:map");
+
+  for (const auto* value : {"first", "second"})
+  {
+    auto tx = store.create_tx();
+    tx.rw(map)->put("key", value);
+    REQUIRE(tx.commit() == ccf::kv::CommitResult::SUCCESS);
+  }
+
+  const auto reserved = store.current_txid();
+  REQUIRE(store.check_rollback_count(0));
+
+  INFO("A signature a rollback discarded records no chunk end");
+  {
+    // A signature ends a chunk when a snapshot is due, which is what the
+    // reserved transaction records once it decides to replicate.
+    store.set_flag(
+      ccf::kv::AbstractStore::StoreFlag::SNAPSHOT_AT_NEXT_SIGNATURE);
+    store.rollback({initial_term, reserved.seqno - 1}, initial_term + 1);
+    REQUIRE(store.check_rollback_count(1));
+
+    CHECK_FALSE(
+      store.prepare_reserved_tx(reserved.seqno, reserved.view, 0).has_value());
+    CHECK_FALSE(chunker->has_chunk_end_at(reserved.seqno));
+  }
+
+  INFO("A signature whose view has moved on records no chunk end");
+  {
+    auto tx = store.create_tx();
+    tx.rw(map)->put("key", "next");
+    REQUIRE(tx.commit() == ccf::kv::CommitResult::SUCCESS);
+    const auto superseded = store.current_txid();
+    store.set_flag(
+      ccf::kv::AbstractStore::StoreFlag::SNAPSHOT_AT_NEXT_SIGNATURE);
+
+    // A rollback which discards nothing locally, but moves the view on, so
+    // consensus will refuse to replicate this signature. The snapshot flag
+    // survives, so without the view check the chunk end would be recorded.
+    store.rollback(superseded, superseded.view + 1);
+    REQUIRE(store.check_rollback_count(1));
+    REQUIRE(store.flag_enabled(
+      ccf::kv::AbstractStore::StoreFlag::SNAPSHOT_AT_NEXT_SIGNATURE));
+
+    CHECK_FALSE(store.prepare_reserved_tx(superseded.seqno, superseded.view, 1)
+                  .has_value());
+    CHECK_FALSE(chunker->has_chunk_end_at(superseded.seqno));
+  }
+
+  INFO("A signature still in its own epoch records its chunk end");
+  {
+    auto tx = store.create_tx();
+    tx.rw(map)->put("key", "replacement");
+    REQUIRE(tx.commit() == ccf::kv::CommitResult::SUCCESS);
+    const auto replacement = store.current_txid();
+    store.set_flag(
+      ccf::kv::AbstractStore::StoreFlag::SNAPSHOT_AT_NEXT_SIGNATURE);
+
+    const auto should_create_chunk =
+      store.prepare_reserved_tx(replacement.seqno, replacement.view, 1);
+    REQUIRE(should_create_chunk.has_value());
+    CHECK(should_create_chunk.value());
+    CHECK(chunker->has_chunk_end_at(replacement.seqno));
   }
 }
 


### PR DESCRIPTION
Last of a stack of small fixes for a family of key-value store races found by an interleaving-exploration harness. Stacked on #8245.

### The problem

`CommittableTx::commit_reserved()` decided whether a signature should end a ledger chunk, and recorded that decision on the chunker, in two steps:

```cpp
// version_lock held by Store::commit
if (pimpl->store->should_create_ledger_chunk_unsafe(version))
{
  entry_flags |= EntryFlags::FORCE_LEDGER_CHUNK_AFTER;
  auto chunker = pimpl->store->get_chunker();
  if (chunker) { chunker->produced_chunk_at(version); }
}
```

That comment is wrong, and has been for some time. `Store::commit()` releases `version_lock` before it calls `pending_tx->call()`, which is what reaches this code - so the `_unsafe` read runs with no lock at all, and a rollback can land between the read and `produced_chunk_at`.

Two consequences:

- **A stale chunk marker.** The signature is discarded, but `chunk_ends` keeps an entry at its version. `LedgerChunker::get_unchunked_size` measures from the most recent chunk end, so every later chunk boundary is measured from an entry that is not in the ledger.
- **A torn decision.** The chunk flag on the entry and the chunker's record of it can disagree, because nothing holds them together.

`Store::commit()` already anticipates this shape of failure - it handles `FAIL_NO_REPLICATE` from `pending_tx->call()` with the comment *"A pending tx may fail here if rollback invalidated a reserved signature tx after it was dequeued from pending_txs"* - but `commit_reserved()` only produced it for a map-level conflict, never for its own side effects.

### The fix

`Store::prepare_reserved_tx` takes `version_lock` once and does the whole thing atomically: validate the signature's view and rollback epoch, decide, and record. If the epoch no longer holds it returns `nullopt` and `commit_reserved()` returns `FAIL_NO_REPLICATE` - the path `Store::commit()` was already written to expect.

The stale comment is replaced with one that says what actually holds.

### Why this is minimal

- One new store method, one call site; the decision logic itself is unchanged.
- No new locks. `version_lock` is *not* held here, so taking it is safe - and the existing order `commit_lock` -> `version_lock` -> `chunker_lock` is preserved, with `LedgerChunker` still a leaf.
- Cost is one lock acquisition per signature, which is not the write path.

### Test

`Reserved signature side effects are not applied after a rollback` in `kv_test` calls `Store::prepare_reserved_tx` directly - single-threaded, no harness - covering all three cases:

1. a truncating rollback (new rollback epoch) is refused;
2. a **non-truncating** rollback that only moves the view is refused. This case matters: it discards nothing locally, so the snapshot flag survives and the pre-fix code would happily record a chunk end for a signature consensus is about to reject;
3. a signature still in its own epoch records its chunk end.

Mutation-verified: disabling the guard leaves exactly the stale `chunk_ends` marker described above.

Labelled `run-long-test`.

---

### Review stack

These five PRs come from one investigation and are stacked; review and merge in order.

| PR | Change |
| --- | --- |
| #8242 | Reject stale-view writes before local commit |
| #8243 | Order chunk metadata and snapshot scheduling with rollback |
| #8244 | Stop a rollback moving chunk metadata forward |
| #8245 | Guard rollback-sensitive transaction flags |
| #8246 | Guard reserved signature side effects |

All were found by an interleaving-exploration harness built over the real KV, consensus and history stack (draft #8238). The harness itself is deliberately **not** included here; these PRs carry only the fixes and the single-threaded regression tests that pin them.
