### PR TITLE
Hold the map set while committing a reserved transaction

### DIFF
--- a/src/kv/committable_tx.h
+++ b/src/kv/committable_tx.h
@@ -458,6 +458,17 @@ namespace ccf::kv
 
       std::vector<ConsensusHookPtr> hooks;
       bool track_deletes_on_missing_keys = false;
+
+      // A reserved transaction can create maps too - the first signature
+      // creates the signature tables. As in commit(), hold the map set while
+      // applying, so that add_dynamic_map() does not mutate it underneath a
+      // concurrent reader.
+      const bool maps_created = !pimpl->created_maps.empty();
+      if (maps_created)
+      {
+        this->pimpl->store->lock_map_set();
+      }
+
       auto c = apply_changes(
         all_changes,
         [this](bool) { return std::make_tuple(version, version - 1); },
@@ -466,6 +477,12 @@ namespace ccf::kv
         version,
         track_deletes_on_missing_keys,
         rollback_count);
+
+      if (maps_created)
+      {
+        this->pimpl->store->unlock_map_set();
+      }
+
       success = c.has_value();
 
       if (!success)

--- a/src/kv/committable_tx.h
+++ b/src/kv/committable_tx.h
@@ -28,6 +28,35 @@ namespace ccf::kv
     };
 
   protected:
+    class MapSetLockGuard
+    {
+    private:
+      AbstractStore& store;
+      const bool locked;
+
+    public:
+      MapSetLockGuard(AbstractStore& store_, bool should_lock) :
+        store(store_),
+        locked(should_lock)
+      {
+        if (locked)
+        {
+          store.lock_map_set();
+        }
+      }
+
+      ~MapSetLockGuard()
+      {
+        if (locked)
+        {
+          store.unlock_map_set();
+        }
+      }
+
+      MapSetLockGuard(const MapSetLockGuard&) = delete;
+      MapSetLockGuard& operator=(const MapSetLockGuard&) = delete;
+    };
+
     bool committed = false;
     bool success = false;
 
@@ -206,31 +235,26 @@ namespace ccf::kv
       // If this transaction creates any maps, ensure that commit gets a
       // consistent snapshot of the existing map set
       const bool maps_created = !pimpl->created_maps.empty();
-      if (maps_created)
-      {
-        this->pimpl->store->lock_map_set();
-      }
 
       ccf::kv::ConsensusHookPtrs hooks;
 
       std::optional<Version> new_maps_conflict_version = std::nullopt;
 
       bool track_deletes_on_missing_keys = false;
-      auto c = apply_changes(
-        all_changes,
-        version_resolver == nullptr ?
-          [&](bool has_new_map) {
-            return pimpl->store->next_version(has_new_map);
-          } :
-          version_resolver,
-        hooks,
-        pimpl->created_maps,
-        new_maps_conflict_version,
-        track_deletes_on_missing_keys);
-
-      if (maps_created)
+      std::optional<Version> c;
       {
-        this->pimpl->store->unlock_map_set();
+        MapSetLockGuard map_set_guard(*pimpl->store, maps_created);
+        c = apply_changes(
+          all_changes,
+          version_resolver == nullptr ?
+            [&](bool has_new_map) {
+              return pimpl->store->next_version(has_new_map);
+            } :
+            version_resolver,
+          hooks,
+          pimpl->created_maps,
+          new_maps_conflict_version,
+          track_deletes_on_missing_keys);
       }
 
       success = c.has_value();
@@ -464,23 +488,18 @@ namespace ccf::kv
       // applying, so that add_dynamic_map() does not mutate it underneath a
       // concurrent reader.
       const bool maps_created = !pimpl->created_maps.empty();
-      if (maps_created)
-      {
-        this->pimpl->store->lock_map_set();
-      }
 
-      auto c = apply_changes(
-        all_changes,
-        [this](bool) { return std::make_tuple(version, version - 1); },
-        hooks,
-        pimpl->created_maps,
-        version,
-        track_deletes_on_missing_keys,
-        rollback_count);
-
-      if (maps_created)
+      std::optional<Version> c;
       {
-        this->pimpl->store->unlock_map_set();
+        MapSetLockGuard map_set_guard(*pimpl->store, maps_created);
+        c = apply_changes(
+          all_changes,
+          [this](bool) { return std::make_tuple(version, version - 1); },
+          hooks,
+          pimpl->created_maps,
+          version,
+          track_deletes_on_missing_keys,
+          rollback_count);
       }
 
       success = c.has_value();

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -18,9 +18,11 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 #include <doctest/doctest.h>
 #undef FAIL
+#include <atomic>
 #include <random>
 #include <set>
 #include <string>
+#include <thread>
 #include <vector>
 
 struct MapTypes
@@ -3356,6 +3358,73 @@ TEST_CASE("Range")
     REQUIRE(std_range == kv_range);
     REQUIRE(kv_range.at(existing_key) == well_known_value);
   }
+}
+
+// Reproduces the race between a reserved transaction creating a map (which
+// writes to the Store's map set) and a concurrent reader looking one up. The
+// write happens in Store::add_dynamic_map via commit_reserved; the read holds
+// maps_lock via Store::get_map. Only ThreadSanitizer can observe the failure,
+// so this asserts nothing about interleaving - it exists to give TSAN both
+// accesses concurrently.
+TEST_CASE("Reserved transaction map creation is serialised with lookups")
+{
+  ccf::kv::Store store;
+  store.set_encryptor(std::make_shared<ccf::kv::NullTxEncryptor>());
+
+  {
+    auto tx = store.create_tx();
+    tx.rw<MapTypes::StringString>("public:existing")->put("k", "v");
+    REQUIRE(tx.commit() == ccf::kv::CommitResult::SUCCESS);
+  }
+
+  std::atomic<bool> stop{false};
+  std::vector<std::thread> readers;
+  readers.reserve(4);
+  for (size_t r = 0; r < 4; ++r)
+  {
+    readers.emplace_back([&store, &stop]() {
+      size_t n = 0;
+      while (!stop.load(std::memory_order_relaxed))
+      {
+        // Takes maps_lock and searches the map set. Looks up names in the
+        // range being inserted, so the search path traverses the nodes
+        // add_dynamic_map is writing. Deliberately avoids current_version(),
+        // so this contends only on maps_lock.
+        (void)store.get_map(1, fmt::format("public:reserved_{}", n % 2000));
+        n++;
+      }
+    });
+  }
+
+  constexpr size_t reserved_txs = 2000;
+  for (size_t i = 0; i < reserved_txs; ++i)
+  {
+    // Each reserved transaction writes to a map that does not exist yet, so
+    // committing it adds to the Store's map set. Nothing else here may take
+    // maps_lock, or it would order the write against the readers and hide the
+    // race being reproduced.
+    auto tx = store.create_reserved_tx(store.next_txid());
+    tx.rw<MapTypes::StringString>(fmt::format("public:reserved_{}", i))
+      ->put("k", "v");
+    const auto [result, data, claims, commit_evidence, hooks] =
+      tx.commit_reserved();
+    REQUIRE(result == ccf::kv::CommitResult::SUCCESS);
+  }
+
+  stop.store(true);
+  for (auto& reader : readers)
+  {
+    reader.join();
+  }
+
+  // Confirm the writes really did extend the map set, so this exercises
+  // Store::add_dynamic_map rather than silently doing nothing.
+  REQUIRE(
+    store.get_map(store.current_version(), "public:reserved_0") != nullptr);
+  REQUIRE(
+    store.get_map(
+      store.current_version(),
+      fmt::format("public:reserved_{}", reserved_txs - 1)) != nullptr);
 }
 
 TEST_CASE("Ledger entry chunk request")

--- a/src/kv/test/kv_test.cpp
+++ b/src/kv/test/kv_test.cpp
@@ -18,9 +18,9 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 #include <doctest/doctest.h>
 #undef FAIL
-#include <atomic>
 #include <random>
 #include <set>
+#include <stop_token>
 #include <string>
 #include <thread>
 #include <vector>
@@ -1538,7 +1538,7 @@ TEST_CASE("foreach_key")
     auto tx = kv_store.create_tx();
     auto handle = tx.rw(map);
     REQUIRE_NOTHROW(handle->foreach_key([](const std::string& k) {
-      REQUIRE(k.find('k') != std::string::npos);
+      REQUIRE(k.contains('k'));
       return true;
     }));
 
@@ -1575,7 +1575,7 @@ TEST_CASE("foreach_value")
     auto tx = kv_store.create_tx();
     auto handle = tx.rw(map);
     REQUIRE_NOTHROW(handle->foreach_value([](const std::string& v) {
-      REQUIRE(v.find('v') != std::string::npos);
+      REQUIRE(v.contains('v'));
       return true;
     }));
 
@@ -3377,14 +3377,15 @@ TEST_CASE("Reserved transaction map creation is serialised with lookups")
     REQUIRE(tx.commit() == ccf::kv::CommitResult::SUCCESS);
   }
 
-  std::atomic<bool> stop{false};
-  std::vector<std::thread> readers;
+  // Ensure every exit path, including a failed REQUIRE, stops and joins
+  // readers.
+  std::vector<std::jthread> readers;
   readers.reserve(4);
   for (size_t r = 0; r < 4; ++r)
   {
-    readers.emplace_back([&store, &stop]() {
+    readers.emplace_back([&store](std::stop_token stop_token) {
       size_t n = 0;
-      while (!stop.load(std::memory_order_relaxed))
+      while (!stop_token.stop_requested())
       {
         // Takes maps_lock and searches the map set. Looks up names in the
         // range being inserted, so the search path traverses the nodes
@@ -3411,11 +3412,11 @@ TEST_CASE("Reserved transaction map creation is serialised with lookups")
     REQUIRE(result == ccf::kv::CommitResult::SUCCESS);
   }
 
-  stop.store(true);
   for (auto& reader : readers)
   {
-    reader.join();
+    reader.request_stop();
   }
+  readers.clear();
 
   // Confirm the writes really did extend the map set, so this exercises
   // Store::add_dynamic_map rather than silently doing nothing.


### PR DESCRIPTION
Closes #8250.

Independent of the other open concurrency work - based on `main`, touches no file that #8242..#8246 or #8249 touch.

### The race

`CommittableTx::commit()` brackets `apply_changes` with the map set lock when the transaction creates maps:

```cpp
const bool maps_created = !pimpl->created_maps.empty();
if (maps_created)
{
  this->pimpl->store->lock_map_set();
}
... apply_changes(...) ...
if (maps_created)
{
  this->pimpl->store->unlock_map_set();
}
```

`ReservedTx::commit_reserved()` applies changes the same way, through the same `apply_changes`, but never took that lock.

That matters because a reserved transaction **does** create maps - the first signature creates the signature tables. So `Store::add_dynamic_map()` reaches

```cpp
maps[map_name] = std::make_pair(v, map);
```

with no lock held, while another thread is inside `Store::get_map()` holding `maps_lock` and searching the same `std::map`. ThreadSanitizer reports it as a race in `Store::get_map_internal`:

```
Read of size 8 by thread T3 (mutexes: write M0):
  #7 ccf::kv::Store::get_map_internal        src/kv/store.h:314
  #8 ccf::kv::Store::get_map                 src/kv/store.h:302
  #9 ccf::kv::BaseTx::get_map_and_change_set_by_name
 #12 ccf::NodeStateAccessor::get_current_service_identity()

Previous write of size 8 by thread T4:
  #9 ccf::kv::Store::add_dynamic_map         src/kv/store.h:356
 #10 ccf::kv::apply_changes                  src/kv/apply_changes.h:131
 #11 ccf::kv::ReservedTx::commit_reserved()  src/kv/committable_tx.h:461
 #13 ccf::kv::Store::commit                  src/kv/store.h:1051
 #14 ccf::HashedTxHistory::emit_signature()
```

Note the reader is correctly synchronised. It is the writer that is not.

### The fix

Do in `commit_reserved()` what `commit()` already does.

The lock has to be taken by the caller rather than inside `add_dynamic_map()`: `commit()` already holds it by the time it gets there, and `ccf::pal::Mutex` is not recursive, so locking inside would deadlock the existing path.

### Lock ordering

`Store::commit()` holds `commit_lock` when it reaches `commit_reserved()` via `pending_tx->call()`, so this adds a `commit_lock -> maps_lock` edge. There is no reverse edge: `commit_lock` is acquired in exactly one place (the top of `Store::commit`), and `commit()` releases the map set before it calls `Store::commit()`. The other `maps_lock` holders (compact, rollback, snapshot, clone) never call `Store::commit()`.

### Testing

`Reserved transaction map creation is serialised with lookups` in `kv_test` reproduces the race directly: four reader threads calling `Store::get_map()` while the main thread commits reserved transactions that each create a map.

**Verified by reproduction, not just by inspection:**

- Without the fix, under TSAN, it reports exactly the CI signature:
  ```
  SUMMARY: ThreadSanitizer: data race src/kv/store.h:314:26 in ccf::kv::Store::get_map_internal
  ```
- With the fix, clean across repeated runs.
- The whole of `kv_test` is clean under TSAN (36084 assertions).

Two details the test depends on, both commented in place: the readers look up names in the range being inserted, so their search path traverses the nodes being written (looking up an unrelated key mostly misses them and the race does not surface); and nothing in the writer loop may take `maps_lock`, since that would order the write against the readers and hide it.

Runs in ~1.9s normally, ~11.7s under TSAN.

No CHANGELOG entry: no user-facing API or behaviour change.

Labelled `run-long-test`.
