### PR TITLE
Introduce identity type map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -884,6 +884,11 @@ if(BUILD_TESTS)
       ${CMAKE_CURRENT_SOURCE_DIR}/src/node/test/node_info_json.cpp
     )
 
+    add_unit_test(
+      identity_types_test
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/node/test/identity_types.cpp
+    )
+
     add_unit_test(tls_test ${CMAKE_CURRENT_SOURCE_DIR}/src/tls/test/main.cpp)
     target_link_libraries(tls_test PRIVATE ${CMAKE_THREAD_LIBS_INIT})
 

--- a/src/node/test/identity_types.cpp
+++ b/src/node/test/identity_types.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+
+#include "service/tables/identity_types.h"
+
+#include "ccf/kv/unit.h"
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <array>
+#include <cstdint>
+#include <doctest/doctest.h>
+#include <limits>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using IdentityTypeSerialiser =
+  ccf::kv::serialisers::BlitSerialiser<ccf::IdentityType>;
+
+static constexpr std::array<ccf::IdentityType, 2> IDENTITY_TYPES = {
+  ccf::IdentityType::EC384, ccf::IdentityType::MLDSA65};
+
+TEST_CASE("EC384 shares the serialised key of a single-Value table")
+{
+  // ServiceValue is a Map with a single entry, whose key is 8 null bytes. A
+  // table keyed by IdentityType is therefore serialised identically to a
+  // ServiceValue for as long as EC384 is its only entry.
+  REQUIRE(
+    IdentityTypeSerialiser::to_serialised(ccf::IdentityType::EC384) ==
+    ccf::kv::serialisers::ZeroBlitUnitCreator::get());
+
+  REQUIRE(
+    IdentityTypeSerialiser::to_serialised(ccf::IdentityType::MLDSA65) !=
+    ccf::kv::serialisers::ZeroBlitUnitCreator::get());
+}
+
+TEST_CASE("IdentityType serialisation round-trips")
+{
+  for (const auto identity_type : IDENTITY_TYPES)
+  {
+    const auto serialised =
+      IdentityTypeSerialiser::to_serialised(identity_type);
+    REQUIRE(serialised.size() == sizeof(uint64_t));
+    REQUIRE(
+      IdentityTypeSerialiser::from_serialised(serialised) == identity_type);
+  }
+}
+
+TEST_CASE("Unknown identity types are rejected")
+{
+  const auto unknown =
+    ccf::kv::serialisers::BlitSerialiser<uint64_t>::to_serialised(
+      std::numeric_limits<uint64_t>::max());
+  REQUIRE_THROWS_AS(
+    IdentityTypeSerialiser::from_serialised(unknown), std::logic_error);
+}
+
+TEST_CASE("IdentityType names are distinct and stable")
+{
+  // These names will appear in the ledger, so they must not change.
+  REQUIRE(nlohmann::json(ccf::IdentityType::EC384) == "EC384");
+  REQUIRE(nlohmann::json(ccf::IdentityType::MLDSA65) == "MLDSA65");
+
+  std::set<std::string> names;
+  for (const auto identity_type : IDENTITY_TYPES)
+  {
+    const nlohmann::json name = identity_type;
+    REQUIRE(names.insert(name.get<std::string>()).second);
+  }
+  REQUIRE(names.size() == IDENTITY_TYPES.size());
+}
+
+TEST_CASE("Identity round-trips through JSON")
+{
+  const ccf::Identity identity{
+    ccf::IdentityKind::RawX509Key, std::vector<uint8_t>{1, 2, 3, 4}};
+
+  const nlohmann::json j = identity;
+  REQUIRE(j["kind"] == "RawX509Key");
+
+  REQUIRE(j.get<ccf::Identity>() == identity);
+}
+
+TEST_CASE("Identities round-trips through JSON")
+{
+  const ccf::Identities identities{
+    {ccf::IdentityType::EC384,
+     {ccf::IdentityKind::RawX509Cert, std::vector<uint8_t>{1, 2}}},
+    {ccf::IdentityType::MLDSA65,
+     {ccf::IdentityKind::RawX509Key, std::vector<uint8_t>{3, 4}}}};
+
+  const nlohmann::json j = identities;
+  REQUIRE(j.get<ccf::Identities>() == identities);
+}

--- a/src/node/test/identity_types.cpp
+++ b/src/node/test/identity_types.cpp
@@ -19,19 +19,19 @@ using IdentityTypeSerialiser =
   ccf::kv::serialisers::BlitSerialiser<ccf::IdentityType>;
 
 static constexpr std::array<ccf::IdentityType, 2> IDENTITY_TYPES = {
-  ccf::IdentityType::ECDSA, ccf::IdentityType::MLDSA};
+  ccf::IdentityType::CLASSICAL, ccf::IdentityType::PQ};
 
-TEST_CASE("ECDSA shares the serialised key of a single-Value table")
+TEST_CASE("CLASSICAL shares the serialised key of a single-Value table")
 {
   // ServiceValue is a Map with a single entry, whose key is 8 null bytes. A
   // table keyed by IdentityType is therefore serialised identically to a
-  // ServiceValue for as long as ECDSA is its only entry.
+  // ServiceValue for as long as CLASSICAL is its only entry.
   REQUIRE(
-    IdentityTypeSerialiser::to_serialised(ccf::IdentityType::ECDSA) ==
+    IdentityTypeSerialiser::to_serialised(ccf::IdentityType::CLASSICAL) ==
     ccf::kv::serialisers::ZeroBlitUnitCreator::get());
 
   REQUIRE(
-    IdentityTypeSerialiser::to_serialised(ccf::IdentityType::MLDSA) !=
+    IdentityTypeSerialiser::to_serialised(ccf::IdentityType::PQ) !=
     ccf::kv::serialisers::ZeroBlitUnitCreator::get());
 }
 
@@ -59,8 +59,8 @@ TEST_CASE("Unknown identity types are rejected")
 TEST_CASE("IdentityType names are distinct and stable")
 {
   // These names will appear in the ledger, so they must not change.
-  REQUIRE(nlohmann::json(ccf::IdentityType::ECDSA) == "ECDSA");
-  REQUIRE(nlohmann::json(ccf::IdentityType::MLDSA) == "MLDSA");
+  REQUIRE(nlohmann::json(ccf::IdentityType::CLASSICAL) == "CLASSICAL");
+  REQUIRE(nlohmann::json(ccf::IdentityType::PQ) == "PQ");
 
   std::set<std::string> names;
   for (const auto identity_type : IDENTITY_TYPES)
@@ -85,9 +85,9 @@ TEST_CASE("Identity round-trips through JSON")
 TEST_CASE("Identities round-trips through JSON")
 {
   const ccf::Identities identities{
-    {ccf::IdentityType::ECDSA,
+    {ccf::IdentityType::CLASSICAL,
      {ccf::IdentityKind::X509_CERT_DER, std::vector<uint8_t>{1, 2}}},
-    {ccf::IdentityType::MLDSA,
+    {ccf::IdentityType::PQ,
      {ccf::IdentityKind::X509_SPKI_DER, std::vector<uint8_t>{3, 4}}}};
 
   const nlohmann::json j = identities;

--- a/src/node/test/identity_types.cpp
+++ b/src/node/test/identity_types.cpp
@@ -19,15 +19,15 @@ using IdentityTypeSerialiser =
   ccf::kv::serialisers::BlitSerialiser<ccf::IdentityType>;
 
 static constexpr std::array<ccf::IdentityType, 2> IDENTITY_TYPES = {
-  ccf::IdentityType::EC384, ccf::IdentityType::MLDSA65};
+  ccf::IdentityType::ES384, ccf::IdentityType::MLDSA65};
 
-TEST_CASE("EC384 shares the serialised key of a single-Value table")
+TEST_CASE("ES384 shares the serialised key of a single-Value table")
 {
   // ServiceValue is a Map with a single entry, whose key is 8 null bytes. A
   // table keyed by IdentityType is therefore serialised identically to a
-  // ServiceValue for as long as EC384 is its only entry.
+  // ServiceValue for as long as ES384 is its only entry.
   REQUIRE(
-    IdentityTypeSerialiser::to_serialised(ccf::IdentityType::EC384) ==
+    IdentityTypeSerialiser::to_serialised(ccf::IdentityType::ES384) ==
     ccf::kv::serialisers::ZeroBlitUnitCreator::get());
 
   REQUIRE(
@@ -59,7 +59,7 @@ TEST_CASE("Unknown identity types are rejected")
 TEST_CASE("IdentityType names are distinct and stable")
 {
   // These names will appear in the ledger, so they must not change.
-  REQUIRE(nlohmann::json(ccf::IdentityType::EC384) == "EC384");
+  REQUIRE(nlohmann::json(ccf::IdentityType::ES384) == "ES384");
   REQUIRE(nlohmann::json(ccf::IdentityType::MLDSA65) == "MLDSA65");
 
   std::set<std::string> names;
@@ -85,7 +85,7 @@ TEST_CASE("Identity round-trips through JSON")
 TEST_CASE("Identities round-trips through JSON")
 {
   const ccf::Identities identities{
-    {ccf::IdentityType::EC384,
+    {ccf::IdentityType::ES384,
      {ccf::IdentityKind::RawX509Cert, std::vector<uint8_t>{1, 2}}},
     {ccf::IdentityType::MLDSA65,
      {ccf::IdentityKind::RawX509Key, std::vector<uint8_t>{3, 4}}}};

--- a/src/node/test/identity_types.cpp
+++ b/src/node/test/identity_types.cpp
@@ -19,15 +19,15 @@ using IdentityTypeSerialiser =
   ccf::kv::serialisers::BlitSerialiser<ccf::IdentityType>;
 
 static constexpr std::array<ccf::IdentityType, 2> IDENTITY_TYPES = {
-  ccf::IdentityType::ES, ccf::IdentityType::MLDSA};
+  ccf::IdentityType::ECDSA, ccf::IdentityType::MLDSA};
 
-TEST_CASE("ES shares the serialised key of a single-Value table")
+TEST_CASE("ECDSA shares the serialised key of a single-Value table")
 {
   // ServiceValue is a Map with a single entry, whose key is 8 null bytes. A
   // table keyed by IdentityType is therefore serialised identically to a
-  // ServiceValue for as long as ES is its only entry.
+  // ServiceValue for as long as ECDSA is its only entry.
   REQUIRE(
-    IdentityTypeSerialiser::to_serialised(ccf::IdentityType::ES) ==
+    IdentityTypeSerialiser::to_serialised(ccf::IdentityType::ECDSA) ==
     ccf::kv::serialisers::ZeroBlitUnitCreator::get());
 
   REQUIRE(
@@ -59,7 +59,7 @@ TEST_CASE("Unknown identity types are rejected")
 TEST_CASE("IdentityType names are distinct and stable")
 {
   // These names will appear in the ledger, so they must not change.
-  REQUIRE(nlohmann::json(ccf::IdentityType::ES) == "ES");
+  REQUIRE(nlohmann::json(ccf::IdentityType::ECDSA) == "ECDSA");
   REQUIRE(nlohmann::json(ccf::IdentityType::MLDSA) == "MLDSA");
 
   std::set<std::string> names;
@@ -85,7 +85,7 @@ TEST_CASE("Identity round-trips through JSON")
 TEST_CASE("Identities round-trips through JSON")
 {
   const ccf::Identities identities{
-    {ccf::IdentityType::ES,
+    {ccf::IdentityType::ECDSA,
      {ccf::IdentityKind::X509_CERT_DER, std::vector<uint8_t>{1, 2}}},
     {ccf::IdentityType::MLDSA,
      {ccf::IdentityKind::X509_SPKI_DER, std::vector<uint8_t>{3, 4}}}};

--- a/src/node/test/identity_types.cpp
+++ b/src/node/test/identity_types.cpp
@@ -19,19 +19,19 @@ using IdentityTypeSerialiser =
   ccf::kv::serialisers::BlitSerialiser<ccf::IdentityType>;
 
 static constexpr std::array<ccf::IdentityType, 2> IDENTITY_TYPES = {
-  ccf::IdentityType::ES384, ccf::IdentityType::MLDSA65};
+  ccf::IdentityType::ES, ccf::IdentityType::MLDSA};
 
-TEST_CASE("ES384 shares the serialised key of a single-Value table")
+TEST_CASE("ES shares the serialised key of a single-Value table")
 {
   // ServiceValue is a Map with a single entry, whose key is 8 null bytes. A
   // table keyed by IdentityType is therefore serialised identically to a
-  // ServiceValue for as long as ES384 is its only entry.
+  // ServiceValue for as long as ES is its only entry.
   REQUIRE(
-    IdentityTypeSerialiser::to_serialised(ccf::IdentityType::ES384) ==
+    IdentityTypeSerialiser::to_serialised(ccf::IdentityType::ES) ==
     ccf::kv::serialisers::ZeroBlitUnitCreator::get());
 
   REQUIRE(
-    IdentityTypeSerialiser::to_serialised(ccf::IdentityType::MLDSA65) !=
+    IdentityTypeSerialiser::to_serialised(ccf::IdentityType::MLDSA) !=
     ccf::kv::serialisers::ZeroBlitUnitCreator::get());
 }
 
@@ -59,8 +59,8 @@ TEST_CASE("Unknown identity types are rejected")
 TEST_CASE("IdentityType names are distinct and stable")
 {
   // These names will appear in the ledger, so they must not change.
-  REQUIRE(nlohmann::json(ccf::IdentityType::ES384) == "ES384");
-  REQUIRE(nlohmann::json(ccf::IdentityType::MLDSA65) == "MLDSA65");
+  REQUIRE(nlohmann::json(ccf::IdentityType::ES) == "ES");
+  REQUIRE(nlohmann::json(ccf::IdentityType::MLDSA) == "MLDSA");
 
   std::set<std::string> names;
   for (const auto identity_type : IDENTITY_TYPES)
@@ -74,10 +74,10 @@ TEST_CASE("IdentityType names are distinct and stable")
 TEST_CASE("Identity round-trips through JSON")
 {
   const ccf::Identity identity{
-    ccf::IdentityKind::RawX509Key, std::vector<uint8_t>{1, 2, 3, 4}};
+    ccf::IdentityKind::X509_SPKI_DER, std::vector<uint8_t>{1, 2, 3, 4}};
 
   const nlohmann::json j = identity;
-  REQUIRE(j["kind"] == "RawX509Key");
+  REQUIRE(j["kind"] == "X509_SPKI_DER");
 
   REQUIRE(j.get<ccf::Identity>() == identity);
 }
@@ -85,10 +85,10 @@ TEST_CASE("Identity round-trips through JSON")
 TEST_CASE("Identities round-trips through JSON")
 {
   const ccf::Identities identities{
-    {ccf::IdentityType::ES384,
-     {ccf::IdentityKind::RawX509Cert, std::vector<uint8_t>{1, 2}}},
-    {ccf::IdentityType::MLDSA65,
-     {ccf::IdentityKind::RawX509Key, std::vector<uint8_t>{3, 4}}}};
+    {ccf::IdentityType::ES,
+     {ccf::IdentityKind::X509_CERT_DER, std::vector<uint8_t>{1, 2}}},
+    {ccf::IdentityType::MLDSA,
+     {ccf::IdentityKind::X509_SPKI_DER, std::vector<uint8_t>{3, 4}}}};
 
   const nlohmann::json j = identities;
   REQUIRE(j.get<ccf::Identities>() == identities);

--- a/src/service/tables/identity_types.h
+++ b/src/service/tables/identity_types.h
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "ccf/ds/json.h"
+#include "ccf/kv/serialisers/blit_serialiser.h"
+
+#include <cstdint>
+#include <map>
+#include <stdexcept>
+#include <vector>
+
+namespace ccf
+{
+  enum class IdentityType : uint64_t
+  {
+    EC384 = 0,
+    MLDSA65 = 1,
+  };
+
+  DECLARE_JSON_ENUM(
+    IdentityType,
+    {{IdentityType::EC384, "EC384"}, {IdentityType::MLDSA65, "MLDSA65"}});
+
+  enum class IdentityKind : uint8_t
+  {
+    RawX509Cert = 0,
+    RawX509Key = 1,
+    // COSE key and JWK representations may be added here in the future.
+  };
+
+  DECLARE_JSON_ENUM(
+    IdentityKind,
+    {{IdentityKind::RawX509Cert, "RawX509Cert"},
+     {IdentityKind::RawX509Key, "RawX509Key"}});
+
+  using IdentityValue = std::vector<uint8_t>;
+
+  struct Identity
+  {
+    IdentityKind kind;
+    IdentityValue value;
+
+    bool operator==(const Identity&) const = default;
+  };
+
+  DECLARE_JSON_TYPE(Identity);
+  DECLARE_JSON_REQUIRED_FIELDS(Identity, kind, value);
+
+  using Identities = std::map<IdentityType, Identity>;
+}
+
+namespace ccf::kv::serialisers
+{
+  // IdentityType is used as a KV key by tables which were previously a single
+  // Value. EC384 is 0, so it serialises to the same bytes as the unit key of
+  // those tables, keeping their serialised form unchanged.
+  template <>
+  struct BlitSerialiser<ccf::IdentityType>
+  {
+    static SerialisedEntry to_serialised(const ccf::IdentityType& identity_type)
+    {
+      return BlitSerialiser<uint64_t>::to_serialised(
+        static_cast<uint64_t>(identity_type));
+    }
+
+    static ccf::IdentityType from_serialised(const SerialisedEntry& data)
+    {
+      const auto value = BlitSerialiser<uint64_t>::from_serialised(data);
+      switch (value)
+      {
+        case static_cast<uint64_t>(ccf::IdentityType::EC384):
+          return ccf::IdentityType::EC384;
+        case static_cast<uint64_t>(ccf::IdentityType::MLDSA65):
+          return ccf::IdentityType::MLDSA65;
+        default:
+          throw std::logic_error(
+            fmt::format("Unknown identity type: {}", value));
+      }
+    }
+  };
+}

--- a/src/service/tables/identity_types.h
+++ b/src/service/tables/identity_types.h
@@ -14,13 +14,13 @@ namespace ccf
 {
   enum class IdentityType : uint64_t
   {
-    ECDSA = 0,
-    MLDSA = 1,
+    CLASSICAL = 0,
+    PQ = 1,
   };
 
   DECLARE_JSON_ENUM(
     IdentityType,
-    {{IdentityType::ECDSA, "ECDSA"}, {IdentityType::MLDSA, "MLDSA"}});
+    {{IdentityType::CLASSICAL, "CLASSICAL"}, {IdentityType::PQ, "PQ"}});
 
   enum class IdentityKind : uint8_t
   {
@@ -52,8 +52,8 @@ namespace ccf
 namespace ccf::kv::serialisers
 {
   // IdentityType is used as a KV key by tables which were previously a single
-  // Value. ECDSA is 0, so it serialises to the same bytes as the unit key of
-  // those tables, keeping their serialised form unchanged.
+  // Value. CLASSICAL is 0, so it serialises to the same bytes as the unit key
+  // of those tables, keeping their serialised form unchanged.
   template <>
   struct BlitSerialiser<ccf::IdentityType>
   {
@@ -68,10 +68,10 @@ namespace ccf::kv::serialisers
       const auto value = BlitSerialiser<uint64_t>::from_serialised(data);
       switch (value)
       {
-        case static_cast<uint64_t>(ccf::IdentityType::ECDSA):
-          return ccf::IdentityType::ECDSA;
-        case static_cast<uint64_t>(ccf::IdentityType::MLDSA):
-          return ccf::IdentityType::MLDSA;
+        case static_cast<uint64_t>(ccf::IdentityType::CLASSICAL):
+          return ccf::IdentityType::CLASSICAL;
+        case static_cast<uint64_t>(ccf::IdentityType::PQ):
+          return ccf::IdentityType::PQ;
         default:
           throw std::logic_error(
             fmt::format("Unknown identity type: {}", value));

--- a/src/service/tables/identity_types.h
+++ b/src/service/tables/identity_types.h
@@ -14,25 +14,24 @@ namespace ccf
 {
   enum class IdentityType : uint64_t
   {
-    ES384 = 0,
-    MLDSA65 = 1,
+    ES = 0,
+    MLDSA = 1,
   };
 
   DECLARE_JSON_ENUM(
-    IdentityType,
-    {{IdentityType::ES384, "ES384"}, {IdentityType::MLDSA65, "MLDSA65"}});
+    IdentityType, {{IdentityType::ES, "ES"}, {IdentityType::MLDSA, "MLDSA"}});
 
   enum class IdentityKind : uint8_t
   {
-    RawX509Cert = 0,
-    RawX509Key = 1,
+    X509_CERT_DER = 0,
+    X509_SPKI_DER = 1,
     // COSE key and JWK representations may be added here in the future.
   };
 
   DECLARE_JSON_ENUM(
     IdentityKind,
-    {{IdentityKind::RawX509Cert, "RawX509Cert"},
-     {IdentityKind::RawX509Key, "RawX509Key"}});
+    {{IdentityKind::X509_CERT_DER, "X509_CERT_DER"},
+     {IdentityKind::X509_SPKI_DER, "X509_SPKI_DER"}});
 
   using IdentityValue = std::vector<uint8_t>;
 
@@ -53,7 +52,7 @@ namespace ccf
 namespace ccf::kv::serialisers
 {
   // IdentityType is used as a KV key by tables which were previously a single
-  // Value. ES384 is 0, so it serialises to the same bytes as the unit key of
+  // Value. ES is 0, so it serialises to the same bytes as the unit key of
   // those tables, keeping their serialised form unchanged.
   template <>
   struct BlitSerialiser<ccf::IdentityType>
@@ -69,10 +68,10 @@ namespace ccf::kv::serialisers
       const auto value = BlitSerialiser<uint64_t>::from_serialised(data);
       switch (value)
       {
-        case static_cast<uint64_t>(ccf::IdentityType::ES384):
-          return ccf::IdentityType::ES384;
-        case static_cast<uint64_t>(ccf::IdentityType::MLDSA65):
-          return ccf::IdentityType::MLDSA65;
+        case static_cast<uint64_t>(ccf::IdentityType::ES):
+          return ccf::IdentityType::ES;
+        case static_cast<uint64_t>(ccf::IdentityType::MLDSA):
+          return ccf::IdentityType::MLDSA;
         default:
           throw std::logic_error(
             fmt::format("Unknown identity type: {}", value));

--- a/src/service/tables/identity_types.h
+++ b/src/service/tables/identity_types.h
@@ -14,12 +14,13 @@ namespace ccf
 {
   enum class IdentityType : uint64_t
   {
-    ES = 0,
+    ECDSA = 0,
     MLDSA = 1,
   };
 
   DECLARE_JSON_ENUM(
-    IdentityType, {{IdentityType::ES, "ES"}, {IdentityType::MLDSA, "MLDSA"}});
+    IdentityType,
+    {{IdentityType::ECDSA, "ECDSA"}, {IdentityType::MLDSA, "MLDSA"}});
 
   enum class IdentityKind : uint8_t
   {
@@ -51,7 +52,7 @@ namespace ccf
 namespace ccf::kv::serialisers
 {
   // IdentityType is used as a KV key by tables which were previously a single
-  // Value. ES is 0, so it serialises to the same bytes as the unit key of
+  // Value. ECDSA is 0, so it serialises to the same bytes as the unit key of
   // those tables, keeping their serialised form unchanged.
   template <>
   struct BlitSerialiser<ccf::IdentityType>
@@ -67,8 +68,8 @@ namespace ccf::kv::serialisers
       const auto value = BlitSerialiser<uint64_t>::from_serialised(data);
       switch (value)
       {
-        case static_cast<uint64_t>(ccf::IdentityType::ES):
-          return ccf::IdentityType::ES;
+        case static_cast<uint64_t>(ccf::IdentityType::ECDSA):
+          return ccf::IdentityType::ECDSA;
         case static_cast<uint64_t>(ccf::IdentityType::MLDSA):
           return ccf::IdentityType::MLDSA;
         default:

--- a/src/service/tables/identity_types.h
+++ b/src/service/tables/identity_types.h
@@ -14,13 +14,13 @@ namespace ccf
 {
   enum class IdentityType : uint64_t
   {
-    EC384 = 0,
+    ES384 = 0,
     MLDSA65 = 1,
   };
 
   DECLARE_JSON_ENUM(
     IdentityType,
-    {{IdentityType::EC384, "EC384"}, {IdentityType::MLDSA65, "MLDSA65"}});
+    {{IdentityType::ES384, "ES384"}, {IdentityType::MLDSA65, "MLDSA65"}});
 
   enum class IdentityKind : uint8_t
   {
@@ -53,7 +53,7 @@ namespace ccf
 namespace ccf::kv::serialisers
 {
   // IdentityType is used as a KV key by tables which were previously a single
-  // Value. EC384 is 0, so it serialises to the same bytes as the unit key of
+  // Value. ES384 is 0, so it serialises to the same bytes as the unit key of
   // those tables, keeping their serialised form unchanged.
   template <>
   struct BlitSerialiser<ccf::IdentityType>
@@ -69,8 +69,8 @@ namespace ccf::kv::serialisers
       const auto value = BlitSerialiser<uint64_t>::from_serialised(data);
       switch (value)
       {
-        case static_cast<uint64_t>(ccf::IdentityType::EC384):
-          return ccf::IdentityType::EC384;
+        case static_cast<uint64_t>(ccf::IdentityType::ES384):
+          return ccf::IdentityType::ES384;
         case static_cast<uint64_t>(ccf::IdentityType::MLDSA65):
           return ccf::IdentityType::MLDSA65;
         default:

--- a/src/service/tables/identity_types.h
+++ b/src/service/tables/identity_types.h
@@ -25,7 +25,6 @@ namespace ccf
   {
     X509_CERT_DER = 0,
     X509_SPKI_DER = 1,
-    // COSE key and JWK representations may be added here in the future.
   };
 
   DECLARE_JSON_ENUM(


### PR DESCRIPTION
Opening #7848. This PR is part 1 of unknown.

_Disclaimer. The new headers aren't exposed under public interface for now on purpose. It will be a job for the closing PR(s) to advertise this to the users, add the necessary changelog entries and documentation._

Adds (currently unused) `IdentityType`, `IdentityKind`, and `Identity=IdentityKind+bytes`.