### PR TITLE
Fix node connection removal lifetime

### DIFF
--- a/src/host/node_connections.h
+++ b/src/host/node_connections.h
@@ -586,7 +586,7 @@ namespace asynchost
     }
 
     // Remove the connection with this peer, if any.
-    bool remove_connection(const ccf::NodeId& node)
+    bool remove_connection(ccf::NodeId node)
     {
       if (connections.erase(node) < 1)
       {


### PR DESCRIPTION
## Summary

Take ownership of the node ID passed to `NodeConnectionsImpl::remove_connection()` before erasing the corresponding connection.

Disconnect callbacks pass a node ID stored in their socket behaviour. Erasing the connection destroys that behaviour, so the previous post-erase INFO log formatted a dangling reference and failed both ASAN and TSAN in the scheduled Long Test run.

Closes #8275

## Testing

- ASAN `node_connections_test`: 2 test cases and 10 assertions passed
- C++ formatting, include dependency, and ASCII checks passed