### PR TITLE
Enforce dependencies for acyclic source components

### DIFF
--- a/scripts/source-dependencies.json
+++ b/scripts/source-dependencies.json
@@ -22,8 +22,16 @@
     "src/node/gov/api_schema.h"
   ],
   "allowed_internal_dependencies": {
+    "apps": ["ccf-api", "js"],
+    "cose": [],
     "crypto": ["cose", "ds"],
     "ds": [],
-    "pal": ["crypto", "ds"]
+    "msgpack": [],
+    "pal": ["crypto", "ds"],
+    "tasks": ["ds"],
+    "tcp": ["ds"],
+    "threading": [],
+    "tls": ["crypto", "ds"],
+    "udp": ["ds"]
   }
 }


### PR DESCRIPTION
CCF's source dependency checker currently protects only `crypto`, `ds`, and `pal`, leaving the other components outside the cyclic core free to gain new outgoing dependencies unnoticed.

Extend the exact dependency allowlist to every currently acyclic source component. This covers `apps`, `cose`, `msgpack`, `tasks`, `tcp`, `threading`, `tls`, and `udp`. `apps` is allowed to depend on both the synthetic `ccf-api` component and `js`, matching its includes of `ccf/app_interface.h` and `ccf/js/samples/governance_driven_registry.h`. No checker behavior changes are required.

## Testing

- `scripts/ci-checks.sh -f`

Towards #3517