### PR TITLE
Fix bounds check in handle_ledger_entries and add unit tests

### DIFF
--- a/src/node/historical_queries.h
+++ b/src/node/historical_queries.h
@@ -1426,6 +1426,16 @@ namespace ccf::historical
           serialized::peek<ccf::kv::SerialisedEntryHeader>(data, size);
         const auto whole_size =
           header.size + ccf::kv::serialised_entry_header_size;
+        if (whole_size > size)
+        {
+          LOG_FAIL_FMT(
+            "Corrupt ledger entry received at {} - claims to be {} bytes but "
+            "only {} bytes remain",
+            seqno,
+            whole_size,
+            size);
+          return false;
+        }
         all_accepted &= handle_ledger_entry(seqno, data, whole_size);
         data += whole_size;
         size -= whole_size;

--- a/src/node/test/historical_queries.cpp
+++ b/src/node/test/historical_queries.cpp
@@ -887,6 +887,55 @@ TEST_CASE("StateCache range queries")
   }
 }
 
+TEST_CASE("Ledger entry bounds")
+{
+  auto state = create_and_init_state();
+  auto& kv_store = *state.kv_store;
+  const auto begin_seqno = kv_store.current_version() + 1;
+  const auto end_seqno = write_transactions_and_signature(kv_store, 2);
+  const auto ledger = construct_host_ledger(kv_store.get_consensus());
+  ccf::historical::StateCache cache(
+    kv_store, state.ledger_secrets, std::make_shared<StubWriter>());
+
+  constexpr auto handle = 0;
+  REQUIRE(cache.get_store_range(handle, begin_seqno, end_seqno).empty());
+
+  std::vector<uint8_t> combined;
+  auto invalid_seqno = begin_seqno;
+  SUBCASE("Invalid first entry") {}
+  SUBCASE("Invalid entry after a valid entry")
+  {
+    // Check against the remaining bytes, not the original batch size.
+    combined = ledger.at(begin_seqno);
+    ++invalid_seqno;
+  }
+
+  // Claim a one-byte body, but supply only the header.
+  ccf::kv::SerialisedEntryHeader header;
+  header.set_size(1);
+  const auto offset = combined.size();
+  combined.resize(offset + ccf::kv::serialised_entry_header_size);
+  auto* data = combined.data() + offset;
+  auto size = ccf::kv::serialised_entry_header_size;
+  serialized::write(data, size, header);
+
+  REQUIRE_FALSE(
+    cache.handle_ledger_entries(begin_seqno, invalid_seqno, combined));
+  REQUIRE(cache.get_store_range(handle, begin_seqno, end_seqno).empty());
+
+  // Retry from the rejected entry. Any valid prefix must remain cached.
+  combined.clear();
+  for (auto seqno = invalid_seqno; seqno <= end_seqno; ++seqno)
+  {
+    const auto& entry = ledger.at(seqno);
+    combined.insert(combined.end(), entry.begin(), entry.end());
+  }
+  REQUIRE(cache.handle_ledger_entries(invalid_seqno, end_seqno, combined));
+  REQUIRE(
+    cache.get_store_range(handle, begin_seqno, end_seqno).size() ==
+    end_seqno - begin_seqno + 1);
+}
+
 TEST_CASE("Incremental progress")
 {
   const auto seed = time(NULL);


### PR DESCRIPTION
This pull request addresses a bug in the `handle_ledger_entries` function by implementing a bounds check for `whole_size` against `size`. The changes include:

- Added a check to ensure that `whole_size` does not exceed the remaining buffer size before deserializing or advancing the pointer.
- Introduced unit tests that construct invalid entry headers to validate the rejection of oversized entries, both at the start of a batch and after valid entries.
- Renamed the test case to `Ledger entry bounds` for better filtering and clarity.
- Included comments in the test case to explain the logic behind the remaining-buffer check, malformed header construction, and retry mechanisms.

All tests in the historical-query suite have passed successfully, and formatting checks were also verified.