### PR TITLE
Bind the Locust master to IPv4 loopback

### DIFF
--- a/tests/infra/locust_benchmark.py
+++ b/tests/infra/locust_benchmark.py
@@ -140,7 +140,8 @@ def run_locust(
     cmd += ["--processes", str(args.locust_processes)]
 
     # Avoid colliding with another Locust master on its default port.
-    master_host = "localhost"
+    # Match the IPv4 port probe and workers, without resolving localhost to IPv6.
+    master_host = "127.0.0.1"
     master_port = infra.net.probably_free_local_port(master_host)
     cmd += [
         "--master-bind-host",


### PR DESCRIPTION
## Summary

Follow-up to #8301, fixing the [Benchmark Virtual failure](https://github.com/microsoft/CCF/actions/runs/34154982103/job/101844825099) on its merge commit, `28d40d248`.

`localhost` can resolve to both IPv4 and IPv6. Locust 2.46.5 then enables IPv6 for its ZeroMQ listener, while the port probe and forked workers use IPv4. If `::1` is unavailable, the master fails with:

```text
Socket bind failure: Cannot assign requested address (addr='tcp://localhost:43749')
```

This affected all five Locust benchmarks; their workers subsequently spent about five minutes retrying connections.

Use `127.0.0.1` explicitly for the port probe and master binding. This preserves #8301's loopback-only binding and port-collision protection without depending on hostname resolution or IPv6 availability.

## Validation

- Reproduced the exact failure with Locust 2.46.5 in an isolated Linux network/mount namespace where `localhost` resolves to both address families but IPv6 loopback is unavailable.
- Confirmed that explicit IPv4 binding succeeds and a worker/master RPC round trip completes in the same environment.
- `scripts/ci-checks.sh -f` passed under WSL.