### PR TITLE
Fix ACK handler to use find() for stateDigest validation

### DIFF
--- a/src/node/gov/handlers/acks.h
+++ b/src/node/gov/handlers/acks.h
@@ -232,8 +232,21 @@ namespace ccf::gov::endpoints
           // Check signed digest matches expected digest in KV
           const auto expected_digest = ack->state_digest;
           const auto signed_body = ccf::parse_json_safe(cose_ident.content);
+          const auto state_digest_it = signed_body.find("stateDigest");
+          if (
+            state_digest_it == signed_body.end() ||
+            !state_digest_it.value().is_string())
+          {
+            detail::set_gov_error(
+              ctx.rpc_ctx,
+              HTTP_STATUS_BAD_REQUEST,
+              ccf::errors::InvalidInput,
+              "Signed request body is not a JSON object containing required "
+              "string field \"stateDigest\"");
+            return;
+          }
           const auto actual_digest =
-            signed_body["stateDigest"].template get<std::string>();
+            state_digest_it.value().template get<std::string>();
           if (expected_digest != actual_digest)
           {
             detail::set_gov_error(

--- a/tests/governance.py
+++ b/tests/governance.py
@@ -321,6 +321,17 @@ def test_ack_state_digest_update(network, args):
             r = c.get(f"/gov/members/state-digests/{member.service_id}")
             assert r.status_code == http.HTTPStatus.OK, r
             assert r.body.json() == updated_digest
+
+        for invalid_body in ({}, {"stateDigest": 42}):
+            with node.api_versioned_client(
+                *member.auth(write=True), api_version=args.gov_api_version
+            ) as c:
+                r = c.post(
+                    f"/gov/members/state-digests/{member.service_id}:ack",
+                    body=invalid_body,
+                )
+                assert r.status_code == http.HTTPStatus.BAD_REQUEST, r
+                assert r.body.json()["error"]["code"] == "InvalidInput", r
     return network
 
 


### PR DESCRIPTION
This pull request addresses a correctness issue in the ACK handler by replacing the use of `const` nlohmann `operator[]` with a safer approach using `find()` and `is_string()`. This change prevents potential crashes due to missing or non-string `stateDigest` fields.

### Changes made:
- Updated `acks.h` to use `find()` and `is_string()` for validating `stateDigest`, returning a `400 InvalidInput` response for invalid inputs.
- Simplified the test cases in `governance.py` to focus solely on invalid bodies, specifically testing an empty object and a non-string digest.

This fix enhances the robustness of the ACK handler while maintaining minimal changes to the existing codebase. All relevant tests have been verified to ensure functionality.