### PR TITLE
Add LTS compatibility regression test for coverage hole

### DIFF
--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -3,6 +3,7 @@
 import datetime
 import json
 import os
+import re
 import shutil
 
 import ccf.ledger
@@ -33,11 +34,52 @@ ENV_VAR_LATEST_LTS_BRANCH_NAME = (
 )
 
 LOCAL_CHECKOUT_DIRECTORY = "."
+FINAL_RELEASE_TAG = re.compile(r"^ccf-(\d+)\.0\.(\d+)$")
 
 # When a 2.x node joins a 1.x service, the node has to self-endorse
 # its certificate, using a default value for the validity period
 # hardcoded in CCF.
 DEFAULT_NODE_CERTIFICATE_VALIDITY_DAYS = 365
+
+
+def validate_compatibility_report(report):
+    current_tag = report["version"]
+    current_match = FINAL_RELEASE_TAG.fullmatch(current_tag)
+    if current_match is None:
+        return
+
+    current_major, current_patch = map(int, current_match.groups())
+    live_compatibility = report["live compatibility"]
+
+    previous_lts = live_compatibility["with previous LTS"]
+    previous_lts_match = FINAL_RELEASE_TAG.fullmatch(previous_lts or "")
+    assert (
+        previous_lts_match is not None
+        and int(previous_lts_match.group(1)) == current_major - 1
+    ), f"Expected previous LTS from major {current_major - 1}, got {previous_lts}"
+
+    same_lts = live_compatibility["with same LTS"]
+    expected_same_lts = (
+        None if current_patch == 0 else f"ccf-{current_major}.0.{current_patch - 1}"
+    )
+    assert (
+        same_lts == expected_same_lts
+    ), f"Expected same LTS {expected_same_lts}, got {same_lts}"
+
+    data_compatibility = report.get("data compatibility")
+    if data_compatibility is not None:
+        ledger_versions = data_compatibility["with previous ledger"]
+        snapshot_versions = data_compatibility["with previous snapshots"]
+        assert (
+            ledger_versions == snapshot_versions
+        ), "Ledger and snapshot compatibility covered different releases"
+        expected_versions = {previous_lts}
+        if same_lts is not None:
+            expected_versions.add(same_lts)
+        missing_versions = expected_versions.difference(ledger_versions)
+        assert (
+            not missing_versions
+        ), f"Data compatibility did not cover releases {missing_versions}"
 
 
 def disable_openapi_validation(network):
@@ -892,5 +934,10 @@ if __name__ == "__main__":
             LOG.info(
                 f"Compatibility report written to {args.compatibility_report_file}"
             )
+        if not args.release_install_path:
+            with open(
+                args.compatibility_report_file, encoding="utf-8"
+            ) as compatibility_report_file:
+                validate_compatibility_report(json.load(compatibility_report_file))
 
     LOG.success(f"Compatibility report:\n {json.dumps(compatibility_report, indent=2)}")

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -48,7 +48,7 @@ def validate_compatibility_report(report):
     if current_match is None:
         return
 
-    current_major, current_patch = map(int, current_match.groups())
+    current_major, current_patch = (int(group) for group in current_match.groups())
     live_compatibility = report["live compatibility"]
 
     previous_lts = live_compatibility["with previous LTS"]

--- a/tests/lts_compatibility.py
+++ b/tests/lts_compatibility.py
@@ -52,11 +52,14 @@ def validate_compatibility_report(report):
     live_compatibility = report["live compatibility"]
 
     previous_lts = live_compatibility["with previous LTS"]
-    previous_lts_match = FINAL_RELEASE_TAG.fullmatch(previous_lts or "")
-    assert (
-        previous_lts_match is not None
-        and int(previous_lts_match.group(1)) == current_major - 1
-    ), f"Expected previous LTS from major {current_major - 1}, got {previous_lts}"
+    if current_major == 1:
+        assert previous_lts is None, f"Expected no previous LTS, got {previous_lts}"
+    else:
+        previous_lts_match = FINAL_RELEASE_TAG.fullmatch(previous_lts or "")
+        assert (
+            previous_lts_match is not None
+            and int(previous_lts_match.group(1)) == current_major - 1
+        ), f"Expected previous LTS from major {current_major - 1}, got {previous_lts}"
 
     same_lts = live_compatibility["with same LTS"]
     expected_same_lts = (
@@ -73,7 +76,9 @@ def validate_compatibility_report(report):
         assert (
             ledger_versions == snapshot_versions
         ), "Ledger and snapshot compatibility covered different releases"
-        expected_versions = {previous_lts}
+        expected_versions = set()
+        if previous_lts is not None:
+            expected_versions.add(previous_lts)
         if same_lts is not None:
             expected_versions.add(same_lts)
         missing_versions = expected_versions.difference(ledger_versions)
@@ -934,6 +939,8 @@ if __name__ == "__main__":
             LOG.info(
                 f"Compatibility report written to {args.compatibility_report_file}"
             )
+        # An explicit release path emits "with release (<path>)" rather than
+        # exercising the automatic previous- and same-LTS discovery checked here.
         if not args.release_install_path:
             with open(
                 args.compatibility_report_file, encoding="utf-8"


### PR DESCRIPTION
This pull request introduces a regression test to address the coverage gap identified in issue #8314 regarding LTS compatibility checks. The changes include:

- A new sanity-check function in `lts_compatibility.py` that validates the structure and content of the `compatibility_report.json` file after it is generated.
- The function asserts that:
  - For a final report `ccf-X.0.N`, the previous LTS must be from major `X-1`.
  - For `X.0.0`, the same LTS must be null.
  - For `N > 0`, the same LTS must be exactly `ccf-X.0.(N-1)`.
  - If ledger and snapshot lists are present, they must match and include the exact live compatibility releases.
- Removed the standalone `_report.py` module and its associated tests to simplify the implementation.

Validation has been performed, and all checks have passed, ensuring that the new test effectively prevents regressions related to LTS compatibility.