### PR TITLE
Update merklecpp from 1.1.1 to 1.1.5

### DIFF
--- a/3rdparty/internal/merklecpp/merklecpp.h
+++ b/3rdparty/internal/merklecpp/merklecpp.h
@@ -3,26 +3,28 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <format>
 #include <functional>
+#include <iterator>
+#include <limits>
 #include <list>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <stack>
+#include <stdexcept>
+#include <utility>
 #include <vector>
 
 #ifdef HAVE_OPENSSL
 #  include <openssl/evp.h>
-#  include <openssl/sha.h>
-#endif
-
-#ifdef HAVE_MBEDTLS
-#  include <mbedtls/sha256.h>
 #endif
 
 #ifdef MERKLECPP_TRACE_ENABLED
@@ -42,9 +44,9 @@
 #  define MERKLECPP_TRACE(X)
 #endif
 
-#define MERKLECPP_VERSION_MAJOR 1
-#define MERKLECPP_VERSION_MINOR 0
-#define MERKLECPP_VERSION_PATCH 0
+static constexpr std::uint8_t MERKLECPP_VERSION_MAJOR = 1;
+static constexpr std::uint8_t MERKLECPP_VERSION_MINOR = 0;
+static constexpr std::uint8_t MERKLECPP_VERSION_PATCH = 0;
 
 namespace merkle
 {
@@ -71,20 +73,60 @@ namespace merkle
 
   static inline void serialise_uint64_t(uint64_t n, std::vector<uint8_t>& bytes)
   {
-    size_t sz = sizeof(uint64_t);
+    size_t const sz = sizeof(uint64_t);
     bytes.reserve(bytes.size() + sz);
     for (uint64_t i = 0; i < sz; i++)
+    {
       bytes.push_back((n >> (8 * (sz - i - 1))) & 0xFF);
+    }
   }
 
   static inline uint64_t deserialise_uint64_t(
     const std::vector<uint8_t>& bytes, size_t& index)
   {
     uint64_t r = 0;
-    uint64_t sz = sizeof(uint64_t);
+    uint64_t const sz = sizeof(uint64_t);
     for (uint64_t i = 0; i < sz; i++)
+    {
       r |= static_cast<uint64_t>(bytes.at(index++)) << (8 * (sz - i - 1));
+    }
     return r;
+  }
+
+  static inline size_t deserialise_size_t(
+    const std::vector<uint8_t>& bytes, size_t& index)
+  {
+    const auto value = deserialise_uint64_t(bytes, index);
+    if constexpr (
+      std::numeric_limits<size_t>::digits < // NOLINT(misc-redundant-expression)
+      std::numeric_limits<uint64_t>::digits)
+    {
+      if (value > std::numeric_limits<size_t>::max())
+      {
+        throw std::runtime_error("serialised value exceeds platform limits");
+      }
+    }
+    return static_cast<size_t>(value);
+  }
+
+  static inline bool decode_hex_digit(char c, uint8_t& value)
+  {
+    if ('0' <= c && c <= '9')
+    {
+      value = static_cast<uint8_t>(c - '0');
+      return true;
+    }
+    if ('a' <= c && c <= 'f')
+    {
+      value = static_cast<uint8_t>(c - 'a' + 10);
+      return true;
+    }
+    if ('A' <= c && c <= 'F')
+    {
+      value = static_cast<uint8_t>(c - 'A' + 10);
+      return true;
+    }
+    return false;
   }
 
   /// @brief Template for fixed-size hashes
@@ -92,66 +134,81 @@ namespace merkle
   template <size_t SIZE>
   struct HashT
   {
+    /// Size of the hash in bytes.
+    static constexpr size_t size_bytes = SIZE;
+
     /// Holds the hash bytes
     uint8_t bytes[SIZE];
 
     /// @brief Constructs a Hash with all bytes set to zero
-    HashT<SIZE>()
+    HashT()
     {
       std::fill(bytes, bytes + SIZE, 0);
     }
 
     /// @brief Constructs a Hash from a byte buffer
     /// @param bytes Buffer with hash value
-    HashT<SIZE>(const uint8_t* bytes)
+    HashT(const uint8_t* bytes)
     {
       std::copy(bytes, bytes + SIZE, this->bytes);
     }
 
     /// @brief Constructs a Hash from a string
     /// @param s String to read the hash value from
-    HashT<SIZE>(const std::string& s)
+    HashT(const std::string& s)
     {
       if (s.length() != 2 * SIZE)
+      {
         throw std::runtime_error("invalid hash string");
+      }
       for (size_t i = 0; i < SIZE; i++)
       {
-        int tmp;
-        sscanf(s.c_str() + 2 * i, "%02x", &tmp);
-        bytes[i] = tmp;
+        uint8_t high = 0;
+        uint8_t low = 0;
+        if (
+          !decode_hex_digit(s[2 * i], high) ||
+          !decode_hex_digit(s[2 * i + 1], low))
+        {
+          throw std::runtime_error("invalid hash string");
+        }
+        bytes[i] = static_cast<uint8_t>((high << 4) | low);
       }
     }
 
     /// @brief Deserialises a Hash from a vector of bytes
     /// @param bytes Vector to read the hash value from
-    HashT<SIZE>(const std::vector<uint8_t>& bytes)
+    HashT(const std::vector<uint8_t>& bytes)
     {
       if (bytes.size() < SIZE)
+      {
         throw std::runtime_error("not enough bytes");
+      }
       deserialise(bytes);
     }
 
     /// @brief Deserialises a Hash from a vector of bytes
     /// @param bytes Vector to read the hash value from
     /// @param position Position of the first byte in @p bytes
-    HashT<SIZE>(const std::vector<uint8_t>& bytes, size_t& position)
+    HashT(const std::vector<uint8_t>& bytes, size_t& position)
     {
-      if (bytes.size() - position < SIZE)
+      if (position > bytes.size() || bytes.size() - position < SIZE)
+      {
         throw std::runtime_error("not enough bytes");
+      }
       deserialise(bytes, position);
     }
 
     /// @brief Deserialises a Hash from an array of bytes
     /// @param bytes Array to read the hash value from
-    HashT<SIZE>(const std::array<uint8_t, SIZE>& bytes)
+    HashT(const std::array<uint8_t, SIZE>& bytes)
     {
       std::copy(bytes.data(), bytes.data() + SIZE, this->bytes);
     }
 
     /// @brief The size of the hash (in number of bytes)
-    size_t size() const
+    [[nodiscard]] size_t size() const
     {
-      return SIZE;
+      return size_bytes;
     }
 
     /// @brief zeros out all bytes in the hash
@@ -161,24 +218,38 @@ namespace merkle
     }
 
     /// @brief The size of the serialisation of the hash (in number of bytes)
-    size_t serialised_size() const
+    [[nodiscard]] size_t serialised_size() const
     {
-      return SIZE;
+      return size_bytes;
     }
 
     /// @brief Convert a hash to a hex-encoded string
-    /// @param num_bytes The maximum number of bytes to convert
+    /// @param num_bytes The number of bytes to convert
     /// @param lower_case Enables lower-case hex characters
-    std::string to_string(size_t num_bytes = SIZE, bool lower_case = true) const
+    /// @throws std::out_of_range if @p num_bytes exceeds the hash size
+    [[nodiscard]] std::string to_string(
+      size_t num_bytes = size_bytes, bool lower_case = true) const
     {
-      size_t num_chars = 2 * num_bytes;
-      std::string r(num_chars, '_');
+      if (num_bytes > size_bytes)
+      {
+        throw std::out_of_range("hash string byte count exceeds hash size");
+      }
+      size_t const num_chars = 2 * num_bytes;
+      std::string r;
+      r.reserve(num_chars);
       for (size_t i = 0; i < num_bytes; i++)
-        snprintf(
-          const_cast<char*>(r.data() + 2 * i),
-          num_chars + 1 - 2 * i,
-          lower_case ? "%02x" : "%02X",
-          bytes[i]);
+      {
+        if (lower_case)
+        {
+          std::format_to(
+            std::back_inserter(r), "{:02x}", static_cast<unsigned>(bytes[i]));
+        }
+        else
+        {
+          std::format_to(
+            std::back_inserter(r), "{:02X}", static_cast<unsigned>(bytes[i]));
+        }
+      }
       return r;
     }
 
@@ -207,7 +278,9 @@ namespace merkle
     {
       MERKLECPP_TRACE(MERKLECPP_TOUT << "> HashT::serialise " << std::endl);
       for (auto& b : bytes)
+      {
         buffer.push_back(b);
+      }
     }
 
     /// @brief Deserialises a hash
@@ -216,10 +289,14 @@ namespace merkle
     void deserialise(const std::vector<uint8_t>& buffer, size_t& position)
     {
       MERKLECPP_TRACE(MERKLECPP_TOUT << "> HashT::deserialise " << std::endl);
-      if (buffer.size() - position < SIZE)
+      if (position > buffer.size() || buffer.size() - position < SIZE)
+      {
         throw std::runtime_error("not enough bytes");
+      }
       for (size_t i = 0; i < sizeof(bytes); i++)
+      {
         bytes[i] = buffer[position++];
+      }
     }
 
     /// @brief Deserialises a hash
@@ -252,14 +329,10 @@ namespace merkle
   {
   public:
     /// @brief Path direction
-    typedef enum
-    {
-      PATH_LEFT,
-      PATH_RIGHT
-    } Direction;
+    using Direction = enum { PATH_LEFT, PATH_RIGHT };
 
     /// @brief Path element
-    typedef struct
+    using Element = struct
     {
       /// @brief The hash of the path element
       HashT<HASH_SIZE> hash;
@@ -268,7 +341,7 @@ namespace merkle
       /// @note If @p direction == PATH_LEFT, @p hash joins at the left, i.e.
       /// if t is the current hash, e.g. a leaf, then t' = Hash( @p hash, t );
       Direction direction;
-    } Element;
+    };
 
     /// @brief Path constructor
     /// @param leaf
@@ -283,24 +356,16 @@ namespace merkle
       _leaf(leaf),
       _leaf_index(leaf_index),
       _max_index(max_index),
-      elements(elements)
+      elements(std::move(elements))
     {}
 
     /// @brief Path copy constructor
     /// @param other Path to copy
-    PathT(const PathT& other)
-    {
-      _leaf = other._leaf;
-      elements = other.elements;
-    }
+    PathT(const PathT& other) = default;
 
     /// @brief Path move constructor
     /// @param other Path to move
-    PathT(PathT&& other)
-    {
-      _leaf = std::move(other._leaf);
-      elements = std::move(other.elements);
-    }
+    PathT(PathT&& other) noexcept = default;
 
     /// @brief Deserialises a path
     /// @param bytes Vector to deserialise from
@@ -384,9 +449,9 @@ namespace merkle
       MERKLECPP_TRACE(MERKLECPP_TOUT << "> PathT::deserialise " << std::endl);
       elements.clear();
       _leaf.deserialise(bytes, position);
-      _leaf_index = deserialise_uint64_t(bytes, position);
-      _max_index = deserialise_uint64_t(bytes, position);
-      size_t num_elements = deserialise_uint64_t(bytes, position);
+      _leaf_index = deserialise_size_t(bytes, position);
+      _max_index = deserialise_size_t(bytes, position);
+      size_t const num_elements = deserialise_size_t(bytes, position);
       for (size_t i = 0; i < num_elements; i++)
       {
         HashT<HASH_SIZE> hash(bytes, position);
@@ -416,32 +481,31 @@ namespace merkle
     }
 
     /// @brief The number of elements on the path
-    size_t size() const
+    [[nodiscard]] size_t size() const
     {
       return elements.size();
     }
 
     /// @brief The size of the serialised path in number of bytes
-    size_t serialised_size() const
+    [[nodiscard]] size_t serialised_size() const
     {
-      return sizeof(_leaf) +
-      sizeof(uint64_t) + // leaf index
-      sizeof(uint64_t) + // max index
-      sizeof(uint64_t) + // number of elements
-      elements.size() * (
-        sizeof(Element::hash) + // hash
-        sizeof(uint8_t) // direction
-      );
+      return sizeof(_leaf) + sizeof(uint64_t) + // leaf index
+        sizeof(uint64_t) + // max index
+        sizeof(uint64_t) + // number of elements
+        elements.size() *
+        (sizeof(Element::hash) + // hash
+         sizeof(uint8_t) // direction
+        );
     }
 
     /// @brief Index of the leaf of the path
-    size_t leaf_index() const
+    [[nodiscard]] size_t leaf_index() const
     {
       return _leaf_index;
     }
 
     /// @brief Maximum index of the tree at the time the path was extracted
-    size_t max_index() const
+    [[nodiscard]] size_t max_index() const
     {
       return _max_index;
     }
@@ -454,7 +518,7 @@ namespace merkle
     }
 
     /// @brief Iterator for path elements
-    typedef typename std::list<Element>::const_iterator const_iterator;
+    using const_iterator = typename std::list<Element>::const_iterator;
 
     /// @brief Start iterator for path elements
     const_iterator begin() const
@@ -471,14 +535,16 @@ namespace merkle
     /// @brief Convert a path to a string
     /// @param num_bytes The maximum number of bytes to convert
     /// @param lower_case Enables lower-case hex characters
-    std::string to_string(
+    [[nodiscard]] std::string to_string(
       size_t num_bytes = HASH_SIZE, bool lower_case = true) const
     {
       std::stringstream stream;
       stream << _leaf.to_string(num_bytes);
       for (auto& e : elements)
+      {
         stream << " " << e.hash.to_string(num_bytes, lower_case)
                << (e.direction == PATH_LEFT ? "(L)" : "(R)");
+      }
       return stream.str();
     }
 
@@ -491,14 +557,21 @@ namespace merkle
     /// @brief Equality operator for paths
     bool operator==(const PathT<HASH_SIZE, HASH_FUNCTION>& other) const
     {
-      if (_leaf != other._leaf || elements.size() != other.elements.size())
+      if (
+        _leaf != other._leaf || _leaf_index != other._leaf_index ||
+        _max_index != other._max_index ||
+        elements.size() != other.elements.size())
+      {
         return false;
+      }
       auto it = elements.begin();
       auto other_it = other.elements.begin();
       while (it != elements.end() && other_it != other.elements.end())
       {
         if (it->hash != other_it->hash || it->direction != other_it->direction)
+        {
           return false;
+        }
         it++;
         other_it++;
       }
@@ -506,7 +579,7 @@ namespace merkle
     }
 
     /// @brief Inequality operator for paths
-    bool operator!=(const PathT<HASH_SIZE, HASH_FUNCTION>& other)
+    bool operator!=(const PathT<HASH_SIZE, HASH_FUNCTION>& other) const
     {
       return !this->operator==(other);
     }
@@ -554,6 +627,19 @@ namespace merkle
       }
 
       /// @brief Constructs a new tree node
+      /// @param hash The hash to move into the node
+      static Node* make(HashT<HASH_SIZE>&& hash)
+      {
+        auto r = new Node();
+        r->left = r->right = nullptr;
+        r->hash = std::move(hash);
+        r->dirty = false;
+        r->update_sizes();
+        assert(r->invariant());
+        return r;
+      }
+
+      /// @brief Constructs a new tree node
       /// @param left The left child of the new node
       /// @param right The right child of the new node
       static Node* make(Node* left, Node* right)
@@ -584,7 +670,9 @@ namespace merkle
         size_t indent = 0)
       {
         if (from == nullptr)
+        {
           return nullptr;
+        }
 
         Node* r = make(from->hash);
         r->size = from->size;
@@ -607,9 +695,13 @@ namespace merkle
         if (leaf_nodes && r->size == 1 && !r->left && !r->right)
         {
           if (*num_flushed == 0)
+          {
             leaf_nodes->push_back(r);
+          }
           else
+          {
             *num_flushed = *num_flushed - 1;
+          }
         }
         return r;
       }
@@ -624,7 +716,7 @@ namespace merkle
         bool cl = !left || left->invariant();
         bool cr = !right || right->invariant();
         bool ch = height <= sizeof(size) * 8;
-        bool r = c1 && c2 && cl && cr && ch;
+        bool const r = c1 && c2 && cl && cr && ch;
         return r;
       }
 
@@ -640,11 +732,24 @@ namespace merkle
       /// @brief Indicates whether a subtree is full
       /// @note A subtree is full if the number of nodes under a tree is
       /// 2**height-1.
-      bool is_full() const
+      [[nodiscard]] bool is_full() const
       {
-        size_t max_size = (1 << height) - 1;
+        constexpr size_t size_digits = std::numeric_limits<size_t>::digits;
+        if (height > size_digits)
+        {
+          return false;
+        }
+        const size_t max_size = full_size(height);
         assert(size <= max_size);
         return size == max_size;
+      }
+
+      static size_t full_size(uint8_t height)
+      {
+        constexpr size_t size_digits = std::numeric_limits<size_t>::digits;
+        assert(height <= size_digits);
+        return height == size_digits ? std::numeric_limits<size_t>::max() :
+                                       (size_t{1} << height) - 1;
       }
 
       /// @brief Updates the tree size and height of the subtree under a node
@@ -656,7 +761,9 @@ namespace merkle
           height = std::max(left->height, right->height) + 1;
         }
         else
+        {
           size = height = 1;
+        }
       }
 
       /// @brief The Hash of the node
@@ -681,17 +788,20 @@ namespace merkle
     };
 
   public:
+    /// @brief Hash function used to combine tree nodes.
+    static constexpr auto hash_function = HASH_FUNCTION;
+
     /// @brief The type of hashes in the tree
-    typedef HashT<HASH_SIZE> Hash;
+    using Hash = HashT<HASH_SIZE>;
 
     /// @brief The type of paths in the tree
-    typedef PathT<HASH_SIZE, HASH_FUNCTION> Path;
+    using Path = PathT<HASH_SIZE, HASH_FUNCTION>;
 
     /// @brief The type of the tree
-    typedef TreeT<HASH_SIZE, HASH_FUNCTION> Tree;
+    using Tree = TreeT<HASH_SIZE, HASH_FUNCTION>;
 
     /// @brief Constructs an empty tree
-    TreeT() {}
+    TreeT() = default;
 
     /// @brief Copies a tree
     TreeT(const TreeT& other)
@@ -701,15 +811,10 @@ namespace merkle
 
     /// @brief Moves a tree
     /// @param other Tree to move
-    TreeT(TreeT&& other) :
-      leaf_nodes(std::move(other.leaf_nodes)),
-      uninserted_leaf_nodes(std::move(other.uninserted_leaf_nodes)),
-      _root(std::move(other._root)),
-      num_flushed(other.num_flushed),
-      insertion_stack(std::move(other.insertion_stack)),
-      hashing_stack(std::move(other.hashing_stack)),
-      walk_stack(std::move(other.walk_stack))
-    {}
+    TreeT(TreeT&& other) noexcept
+    {
+      move_from(other);
+    }
 
     /// @brief Deserialises a tree
     /// @param bytes Byte buffer containing a serialised tree
@@ -736,9 +841,7 @@ namespace merkle
     /// @brief Deconstructor
     ~TreeT()
     {
-      delete (_root);
-      for (auto n : uninserted_leaf_nodes)
-        delete (n);
+      clear();
     }
 
     /// @brief Invariant of the tree
@@ -758,9 +861,9 @@ namespace merkle
     /// @param hash Hash to insert
     void insert(const Hash& hash)
     {
-      MERKLECPP_TRACE(MERKLECPP_TOUT << "> insert "
-                                     << hash.to_string(TRACE_HASH_SIZE)
-                                     << std::endl;);
+      MERKLECPP_TRACE(
+        MERKLECPP_TOUT << "> insert " << hash.to_string(TRACE_HASH_SIZE)
+                       << std::endl;);
       uninserted_leaf_nodes.push_back(Node::make(hash));
       statistics.num_insert++;
     }
@@ -770,7 +873,9 @@ namespace merkle
     void insert(const std::vector<Hash>& hashes)
     {
       for (auto hash : hashes)
+      {
         insert(hash);
+      }
     }
 
     /// @brief Inserts multiple hashes into the tree
@@ -778,7 +883,9 @@ namespace merkle
     void insert(const std::list<Hash>& hashes)
     {
       for (auto hash : hashes)
+      {
         insert(hash);
+      }
     }
 
     /// @brief Flush the tree to some leaf
@@ -791,17 +898,21 @@ namespace merkle
       statistics.num_flush++;
 
       if (index <= min_index())
+      {
         return;
+      }
 
       walk_to(index, false, [this](Node*& n, bool go_right) {
         if (go_right && n->left)
         {
-          MERKLECPP_TRACE(MERKLECPP_TOUT
-                            << " - conflate "
-                            << n->left->hash.to_string(TRACE_HASH_SIZE)
-                            << std::endl;);
+          MERKLECPP_TRACE(
+            MERKLECPP_TOUT << " - conflate "
+                           << n->left->hash.to_string(TRACE_HASH_SIZE)
+                           << std::endl;);
           if (n->left && n->left->dirty)
+          {
             hash(n->left);
+          }
           delete (n->left->left);
           n->left->left = nullptr;
           delete (n->left->right);
@@ -826,10 +937,14 @@ namespace merkle
       statistics.num_retract++;
 
       if (max_index() < index)
+      {
         return;
+      }
 
       if (index < min_index())
+      {
         throw std::runtime_error("leaf index out of bounds");
+      }
 
       if (index >= num_flushed + leaf_nodes.size())
       {
@@ -848,10 +963,10 @@ namespace merkle
           n->dirty = true;
           if (go_left && n->right)
           {
-            MERKLECPP_TRACE(MERKLECPP_TOUT
-                              << " - eliminate "
-                              << n->right->hash.to_string(TRACE_HASH_SIZE)
-                              << std::endl;);
+            MERKLECPP_TRACE(
+              MERKLECPP_TOUT << " - eliminate "
+                             << n->right->hash.to_string(TRACE_HASH_SIZE)
+                             << std::endl;);
             bool is_root = n == _root;
 
             Node* old_left = n->left;
@@ -865,26 +980,27 @@ namespace merkle
             old_left = nullptr;
 
             if (n->left && n->right)
+            {
               n->dirty = true;
+            }
 
             if (is_root)
             {
-              MERKLECPP_TRACE(MERKLECPP_TOUT
-                                << " - new root: "
-                                << n->hash.to_string(TRACE_HASH_SIZE)
-                                << std::endl;);
+              MERKLECPP_TRACE(
+                MERKLECPP_TOUT
+                  << " - new root: " << n->hash.to_string(TRACE_HASH_SIZE)
+                  << std::endl;);
               assert(_root == n);
             }
 
             assert(n->invariant());
 
-            MERKLECPP_TRACE(MERKLECPP_TOUT
-                              << " - after elimination: " << std::endl
-                              << to_string(TRACE_HASH_SIZE) << std::endl;);
+            MERKLECPP_TRACE(
+              MERKLECPP_TOUT << " - after elimination: " << std::endl
+                             << to_string(TRACE_HASH_SIZE) << std::endl;);
             return false;
           }
-          else
-            return true;
+          return true;
         });
 
       // The leaf is now elsewhere, save the pointer.
@@ -892,9 +1008,13 @@ namespace merkle
 
       size_t num_retracted = num_leaves() - index - 1;
       if (num_retracted < leaf_nodes.size())
+      {
         leaf_nodes.resize(leaf_nodes.size() - num_retracted);
+      }
       else
+      {
         leaf_nodes.clear();
+      }
 
       assert(num_leaves() == index + 1);
     }
@@ -904,13 +1024,11 @@ namespace merkle
     /// @return The tree
     Tree& operator=(const Tree& other)
     {
-      leaf_nodes.clear();
-      for (auto n : uninserted_leaf_nodes)
-        delete (n);
-      uninserted_leaf_nodes.clear();
-      insertion_stack.clear();
-      hashing_stack.clear();
-      walk_stack.clear();
+      if (this == &other)
+      {
+        return *this;
+      }
+      clear();
 
       size_t to_skip = (other.num_flushed % 2 == 0) ? 0 : 1;
       _root = Node::copy_node(
@@ -920,10 +1038,27 @@ namespace merkle
         other.min_index(),
         other.max_index());
       for (auto n : other.uninserted_leaf_nodes)
+      {
         uninserted_leaf_nodes.push_back(Node::copy_node(n));
+      }
       num_flushed = other.num_flushed;
       assert(min_index() == other.min_index());
       assert(max_index() == other.max_index());
+      return *this;
+    }
+
+    /// @brief Assigns a tree by move
+    /// @param other The tree to assign
+    /// @return The tree
+    Tree& operator=(Tree&& other) noexcept
+    {
+      if (this == &other)
+      {
+        return *this;
+      }
+
+      clear();
+      move_from(other);
       return *this;
     }
 
@@ -935,9 +1070,9 @@ namespace merkle
       statistics.num_root++;
       compute_root();
       assert(_root && !_root->dirty);
-      MERKLECPP_TRACE(MERKLECPP_TOUT
-                        << " - root: " << _root->hash.to_string(TRACE_HASH_SIZE)
-                        << std::endl;);
+      MERKLECPP_TRACE(
+        MERKLECPP_TOUT << " - root: " << _root->hash.to_string(TRACE_HASH_SIZE)
+                       << std::endl;);
       return _root->hash;
     }
 
@@ -961,9 +1096,13 @@ namespace merkle
         MERKLECPP_TOUT << " - " << result->to_string(TRACE_HASH_SIZE)
                        << std::endl;);
 
-      for (auto e : *p)
+      for (const auto& e : *p)
+      {
         if (e.direction == Path::Direction::PATH_LEFT)
+        {
           HASH_FUNCTION(e.hash, *result, *result);
+        }
+      }
 
       return result;
     }
@@ -975,11 +1114,13 @@ namespace merkle
     /// @param f Function to call for each node on the path; the Boolean
     /// indicates whether the current step is a right or left turn.
     /// @return The final leaf node in the walk
-    inline Node* walk_to(
+    Node* walk_to(
       size_t index, bool update, const std::function<bool(Node*&, bool)>&& f)
     {
       if (index < min_index() || max_index() < index)
+      {
         throw std::runtime_error("invalid leaf index");
+      }
 
       compute_root();
 
@@ -988,25 +1129,31 @@ namespace merkle
       Node* cur = _root;
       size_t it = 0;
       if (_root->height > 1)
+      {
         it = index << (sizeof(index) * 8 - _root->height + 1);
+      }
       assert(walk_stack.empty());
 
       for (uint8_t height = _root->height; height > 1;)
       {
         assert(cur->invariant());
-        bool go_right = (it >> (8 * sizeof(it) - 1)) & 0x01;
+        bool go_right = ((it >> (8 * sizeof(it) - 1)) & 0x01) != 0U;
         if (update)
+        {
           walk_stack.push_back(cur);
-        MERKLECPP_TRACE(MERKLECPP_TOUT
-                          << " - at " << cur->hash.to_string(TRACE_HASH_SIZE)
-                          << " (" << cur->size << "/" << (unsigned)cur->height
-                          << ")"
-                          << " (" << (go_right ? "R" : "L") << ")"
-                          << std::endl;);
+        }
+        MERKLECPP_TRACE(
+          MERKLECPP_TOUT << " - at " << cur->hash.to_string(TRACE_HASH_SIZE)
+                         << " (" << cur->size << "/" << (unsigned)cur->height
+                         << ")"
+                         << " (" << (go_right ? "R" : "L") << ")"
+                         << std::endl;);
         if (cur->height == height)
         {
           if (!f(cur, go_right))
+          {
             continue;
+          }
           cur = (go_right ? cur->right : cur->left);
         }
         it <<= 1;
@@ -1014,11 +1161,13 @@ namespace merkle
       }
 
       if (update)
+      {
         while (!walk_stack.empty())
         {
           walk_stack.back()->update_sizes();
           walk_stack.pop_back();
         }
+      }
 
       return cur;
     }
@@ -1053,14 +1202,17 @@ namespace merkle
     /// tree to @p as_of and then extracting the path of @p index.
     std::shared_ptr<Path> past_path(size_t index, size_t as_of)
     {
-      MERKLECPP_TRACE(MERKLECPP_TOUT << "> past_path from " << index
-                                     << " as of " << as_of << std::endl;);
+      MERKLECPP_TRACE(
+        MERKLECPP_TOUT << "> past_path from " << index << " as of " << as_of
+                       << std::endl;);
       statistics.num_past_paths++;
 
       if (
         (index < min_index() || max_index() < index) ||
         (as_of < min_index() || max_index() < as_of) || index > as_of)
+      {
         throw std::runtime_error("invalid leaf indices");
+      }
 
       compute_root();
 
@@ -1070,12 +1222,15 @@ namespace merkle
       // the node at which they fork (recorded in `root_to_fork`), then
       // separately to `index` and `as_of`, recording their paths
       // in `fork_to_index` and `fork_to_as_of`.
-      std::list<typename Path::Element> root_to_fork, fork_to_index,
-        fork_to_as_of;
+      std::list<typename Path::Element> root_to_fork;
+      std::list<typename Path::Element> fork_to_index;
+      std::list<typename Path::Element> fork_to_as_of;
       Node* fork_node = nullptr;
 
-      Node *cur_i = _root, *cur_a = _root;
-      size_t it_i = 0, it_a = 0;
+      Node* cur_i = _root;
+      Node* cur_a = _root;
+      size_t it_i = 0;
+      size_t it_a = 0;
       if (_root->height > 1)
       {
         it_i = index << (sizeof(index) * 8 - _root->height + 1);
@@ -1085,27 +1240,27 @@ namespace merkle
       for (uint8_t height = _root->height; height > 1;)
       {
         assert(cur_i->invariant() && cur_a->invariant());
-        bool go_right_i = (it_i >> (8 * sizeof(it_i) - 1)) & 0x01;
-        bool go_right_a = (it_a >> (8 * sizeof(it_a) - 1)) & 0x01;
+        bool const go_right_i = ((it_i >> (8 * sizeof(it_i) - 1)) & 0x01) != 0U;
+        bool const go_right_a = ((it_a >> (8 * sizeof(it_a) - 1)) & 0x01) != 0U;
 
-        MERKLECPP_TRACE(MERKLECPP_TOUT
-                          << " - at " << (unsigned)height << ": "
-                          << cur_i->hash.to_string(TRACE_HASH_SIZE) << " ("
-                          << cur_i->size << "/" << (unsigned)cur_i->height
-                          << "/" << (go_right_i ? "R" : "L") << ")"
-                          << " / " << cur_a->hash.to_string(TRACE_HASH_SIZE)
-                          << " (" << cur_a->size << "/"
-                          << (unsigned)cur_a->height << "/"
-                          << (go_right_a ? "R" : "L") << ")" << std::endl;);
+        MERKLECPP_TRACE(
+          MERKLECPP_TOUT << " - at " << (unsigned)height << ": "
+                         << cur_i->hash.to_string(TRACE_HASH_SIZE) << " ("
+                         << cur_i->size << "/" << (unsigned)cur_i->height << "/"
+                         << (go_right_i ? "R" : "L") << ")"
+                         << " / " << cur_a->hash.to_string(TRACE_HASH_SIZE)
+                         << " (" << cur_a->size << "/"
+                         << (unsigned)cur_a->height << "/"
+                         << (go_right_a ? "R" : "L") << ")" << std::endl;);
 
         if (!fork_node && go_right_i != go_right_a)
         {
           assert(cur_i == cur_a);
           assert(!go_right_i && go_right_a);
-          MERKLECPP_TRACE(MERKLECPP_TOUT
-                            << " - split at "
-                            << cur_i->hash.to_string(TRACE_HASH_SIZE)
-                            << std::endl;);
+          MERKLECPP_TRACE(
+            MERKLECPP_TOUT << " - split at "
+                           << cur_i->hash.to_string(TRACE_HASH_SIZE)
+                           << std::endl;);
           fork_node = cur_i;
         }
 
@@ -1180,9 +1335,13 @@ namespace merkle
 
       // The hashes along the path from the fork to `index` remain unchanged.
       if (!fork_to_index.empty())
+      {
         fork_to_index.pop_front();
+      }
       for (auto it = fork_to_index.rbegin(); it != fork_to_index.rend(); it++)
+      {
         path.push_back(std::move(*it));
+      }
 
       if (fork_node)
       {
@@ -1191,9 +1350,13 @@ namespace merkle
         // `as_of`.
         Hash as_of_hash = cur_a->hash;
         if (!fork_to_as_of.empty())
+        {
           fork_to_as_of.pop_front();
+        }
         for (auto it = fork_to_as_of.rbegin(); it != fork_to_as_of.rend(); it++)
+        {
           HASH_FUNCTION(it->hash, as_of_hash, as_of_hash);
+        }
 
         MERKLECPP_TRACE({
           MERKLECPP_TOUT << " - as_of hash: "
@@ -1209,10 +1372,86 @@ namespace merkle
       // The hashes along the path from the fork (now with new fork hash) to the
       // (past) root remains unchanged.
       for (auto it = root_to_fork.rbegin(); it != root_to_fork.rend(); it++)
+      {
         path.push_back(std::move(*it));
+      }
 
       return std::make_shared<Path>(
         leaf_node(index)->hash, index, std::move(path), as_of);
+    }
+
+    /// @brief Extracts the root hash of a complete subtree resident in memory
+    /// @param level The height of the subtree (it spans 2**level leaves)
+    /// @param index The index of the subtree at that height
+    /// @return The subtree root hash if the subtree is complete (balanced) and
+    /// fully resident in memory; otherwise, std::nullopt
+    /// @note Like root() and path(), it may
+    /// materialize pending nodes and compute dirty hashes, but does not change
+    /// logical leaf contents or hashing semantics. It returns std::nullopt if
+    /// any leaf of the subtree has been flushed, if the subtree extends past
+    /// the last leaf, or if the node at that position is not a full subtree.
+    /// The subtree spans leaf indices
+    /// [index << level, (index + 1) << level).
+    std::optional<Hash> subtree_root(uint8_t level, size_t index)
+    {
+      const size_t leaves = num_leaves();
+      if (leaves == 0 || level >= std::numeric_limits<size_t>::digits)
+      {
+        return std::nullopt;
+      }
+      if (index > (std::numeric_limits<size_t>::max() >> level))
+      {
+        return std::nullopt;
+      }
+
+      const size_t lo = index << level;
+      const size_t count = (size_t)1 << level;
+
+      if (lo < min_index() || count > leaves || lo > leaves - count)
+      {
+        return std::nullopt;
+      }
+
+      if (level == 0)
+      {
+        return leaf(lo);
+      }
+
+      compute_root();
+
+      const uint8_t target_height = level + 1;
+      if (!_root || _root->height < target_height)
+      {
+        return std::nullopt;
+      }
+
+      Node* cur = _root;
+      size_t it = lo << (sizeof(lo) * 8 - _root->height + 1);
+      for (uint8_t height = _root->height; height > target_height;)
+      {
+        const bool go_right = ((it >> (8 * sizeof(it) - 1)) & 0x01) != 0U;
+        if (cur->height == height)
+        {
+          Node* next = go_right ? cur->right : cur->left;
+          if (!next)
+          {
+            return std::nullopt; // conflated/flushed: not resident
+          }
+          cur = next;
+        }
+        it <<= 1;
+        height--;
+      }
+
+      if (cur->height != target_height || !cur->is_full())
+      {
+        return std::nullopt;
+      }
+      if (cur->dirty)
+      {
+        hash(cur);
+      }
+      return cur->hash;
     }
 
     /// @brief Serialises the tree
@@ -1225,9 +1464,13 @@ namespace merkle
         leaf_nodes.size() + uninserted_leaf_nodes.size(), bytes);
       serialise_uint64_t(num_flushed, bytes);
       for (auto& n : leaf_nodes)
+      {
         n->hash.serialise(bytes);
+      }
       for (auto& n : uninserted_leaf_nodes)
+      {
         n->hash.serialise(bytes);
+      }
 
       if (!empty())
       {
@@ -1235,18 +1478,22 @@ namespace merkle
 
         compute_root();
 
-        MERKLECPP_TRACE(MERKLECPP_TOUT << to_string(TRACE_HASH_SIZE)
-                                       << std::endl;);
+        MERKLECPP_TRACE(
+          MERKLECPP_TOUT << to_string(TRACE_HASH_SIZE) << std::endl;);
 
         std::vector<Node*> extras;
         walk_to(min_index(), false, [&extras](Node*& n, bool go_right) {
           if (go_right)
+          {
             extras.push_back(n->left);
+          }
           return true;
         });
 
         for (size_t i = extras.size() - 1; i != SIZE_MAX; i--)
+        {
           extras.at(i)->hash.serialise(bytes);
+        }
       }
     }
 
@@ -1256,18 +1503,18 @@ namespace merkle
     /// @param bytes The vector of bytes to serialise to
     void serialise(size_t from, size_t to, std::vector<uint8_t>& bytes)
     {
-      MERKLECPP_TRACE(MERKLECPP_TOUT << "> serialise from " << from << " to "
-                                     << to << std::endl;);
+      MERKLECPP_TRACE(
+        MERKLECPP_TOUT << "> serialise from " << from << " to " << to
+                       << std::endl;);
 
-      if (
-        (from < min_index() || max_index() < from) ||
-        (to < min_index() || max_index() < to) || from > to)
-        throw std::runtime_error("invalid leaf indices");
+      validate_partial_range(from, to);
 
       serialise_uint64_t(to - from + 1, bytes);
       serialise_uint64_t(from, bytes);
       for (size_t i = from; i <= to; i++)
+      {
         leaf(i).serialise(bytes);
+      }
 
       if (!empty())
       {
@@ -1275,18 +1522,22 @@ namespace merkle
 
         compute_root();
 
-        MERKLECPP_TRACE(MERKLECPP_TOUT << to_string(TRACE_HASH_SIZE)
-                                       << std::endl;);
+        MERKLECPP_TRACE(
+          MERKLECPP_TOUT << to_string(TRACE_HASH_SIZE) << std::endl;);
 
         std::vector<Node*> extras;
         walk_to(from, false, [&extras](Node*& n, bool go_right) {
           if (go_right)
+          {
             extras.push_back(n->left);
+          }
           return true;
         });
 
         for (size_t i = extras.size() - 1; i != SIZE_MAX; i--)
+        {
           extras.at(i)->hash.serialise(bytes);
+        }
       }
     }
 
@@ -1305,56 +1556,87 @@ namespace merkle
     {
       MERKLECPP_TRACE(MERKLECPP_TOUT << "> deserialise " << std::endl;);
 
-      delete (_root);
-      leaf_nodes.clear();
-      for (auto n : uninserted_leaf_nodes)
-        delete (n);
-      uninserted_leaf_nodes.clear();
-      insertion_stack.clear();
-      hashing_stack.clear();
-      walk_stack.clear();
-      _root = nullptr;
+      clear();
 
-      size_t num_leaf_nodes = deserialise_uint64_t(bytes, position);
-      num_flushed = deserialise_uint64_t(bytes, position);
+      const size_t num_leaf_nodes = deserialise_size_t(bytes, position);
+      const size_t deserialised_num_flushed =
+        deserialise_size_t(bytes, position);
 
-      leaf_nodes.reserve(num_leaf_nodes);
-      for (size_t i = 0; i < num_leaf_nodes; i++)
+      if (num_leaf_nodes == 0 && deserialised_num_flushed != 0)
       {
-        Node* n = Node::make(bytes.data() + position);
-        position += HASH_SIZE;
-        leaf_nodes.push_back(n);
+        throw std::runtime_error("serialised tree has no retained leaves");
       }
 
-      std::vector<Node*> level = leaf_nodes, next_level;
-      size_t it = num_flushed;
+      // A binary tree has 2 * leaves - 1 nodes, which must fit in Node::size.
+      constexpr size_t max_num_leaves =
+        std::numeric_limits<size_t>::max() / 2 + 1;
+      if (
+        deserialised_num_flushed > max_num_leaves ||
+        num_leaf_nodes > max_num_leaves - deserialised_num_flushed)
+      {
+        throw std::runtime_error("serialised tree exceeds platform limits");
+      }
+
+      size_t num_hashes = num_leaf_nodes;
+      for (size_t it = deserialised_num_flushed; it != 0; it >>= 1)
+      {
+        num_hashes += it & 0x01;
+      }
+      if (
+        position > bytes.size() ||
+        num_hashes > (bytes.size() - position) / HASH_SIZE)
+      {
+        throw std::runtime_error("not enough bytes");
+      }
+
+      std::vector<Node*> deserialised_leaf_nodes;
+      deserialised_leaf_nodes.reserve(num_leaf_nodes);
+      std::vector<std::unique_ptr<Node>> level;
+      level.reserve(num_leaf_nodes);
+      for (size_t i = 0; i < num_leaf_nodes; i++)
+      {
+        auto n = std::unique_ptr<Node>(Node::make(Hash(bytes, position)));
+        deserialised_leaf_nodes.push_back(n.get());
+        level.push_back(std::move(n));
+      }
+
+      std::vector<std::unique_ptr<Node>> next_level;
+      size_t it = deserialised_num_flushed;
       uint8_t level_no = 0;
       while (it != 0 || level.size() > 1)
       {
         // Restore extra hashes on the left edge of the tree
-        if (it & 0x01)
+        if ((it & 0x01) != 0U)
         {
           Hash h(bytes, position);
           MERKLECPP_TRACE(MERKLECPP_TOUT << "+";);
-          auto n = Node::make(h);
+          auto n = std::unique_ptr<Node>(Node::make(std::move(h)));
           n->height = level_no + 1;
-          n->size = (1 << n->height) - 1;
+          n->size = Node::full_size(n->height);
           assert(n->invariant());
-          level.insert(level.begin(), n);
+          level.insert(level.begin(), std::move(n));
         }
 
-        MERKLECPP_TRACE(for (auto& n
-                             : level) MERKLECPP_TOUT
-                          << " " << n->hash.to_string(TRACE_HASH_SIZE);
-                        MERKLECPP_TOUT << std::endl;);
+        MERKLECPP_TRACE(
+          for (auto& n : level) MERKLECPP_TOUT
+            << " " << n->hash.to_string(TRACE_HASH_SIZE);
+          MERKLECPP_TOUT << std::endl;);
 
         // Rebuild the level
         for (size_t i = 0; i < level.size(); i += 2)
         {
           if (i + 1 >= level.size())
-            next_level.push_back(level.at(i));
+          {
+            next_level.push_back(std::move(level.at(i)));
+          }
           else
-            next_level.push_back(Node::make(level.at(i), level.at(i + 1)));
+          {
+            auto parent = std::unique_ptr<Node>(
+              Node::make(level.at(i).get(), level.at(i + 1).get()));
+            level.at(i).release();
+            level.at(i + 1).release();
+            next_level.push_back(std::move(parent));
+          }
         }
 
         level.swap(next_level);
@@ -1364,13 +1646,15 @@ namespace merkle
         level_no++;
       }
 
-      assert(level.size() == 0 || level.size() == 1);
+      assert(level.empty() || level.size() == 1);
 
       if (level.size() == 1)
       {
-        _root = level.at(0);
+        _root = level.at(0).release();
         assert(_root->invariant());
       }
+      leaf_nodes = std::move(deserialised_leaf_nodes);
+      num_flushed = deserialised_num_flushed;
     }
 
     /// @brief Operator to serialise the tree
@@ -1396,13 +1680,16 @@ namespace merkle
     {
       MERKLECPP_TRACE(MERKLECPP_TOUT << "> leaf " << index << std::endl;);
       if (index >= num_leaves())
+      {
         throw std::runtime_error("leaf index out of bounds");
+      }
       if (index - num_flushed >= leaf_nodes.size())
+      {
         return uninserted_leaf_nodes
           .at(index - num_flushed - leaf_nodes.size())
           ->hash;
-      else
-        return leaf_nodes.at(index - num_flushed)->hash;
+      }
+      return leaf_nodes.at(index - num_flushed)->hash;
     }
 
     /// @brief Number of leaves in the tree
@@ -1447,7 +1734,9 @@ namespace merkle
     size_t size()
     {
       if (!uninserted_leaf_nodes.empty())
+      {
         insert_leaves();
+      }
       return _root ? _root->size : 0;
     }
 
@@ -1462,7 +1751,9 @@ namespace merkle
       {
         walk_to(min_index(), false, [&num_extras](Node*&, bool go_right) {
           if (go_right)
+          {
             num_extras++;
+          }
           return true;
         });
       }
@@ -1477,10 +1768,14 @@ namespace merkle
     /// @return The number of bytes required to serialise the tree segment
     size_t serialised_size(size_t from, size_t to)
     {
+      validate_partial_range(from, to);
+
       size_t num_extras = 0;
       walk_to(from, false, [&num_extras](Node*&, bool go_right) {
         if (go_right)
+        {
           num_extras++;
+        }
         return true;
       });
 
@@ -1517,7 +1812,7 @@ namespace merkle
       size_t num_past_paths = 0;
 
       /// @brief String representation of the statistics
-      std::string to_string() const
+      [[nodiscard]] std::string to_string() const
       {
         std::stringstream stream;
         stream << "num_insert=" << num_insert << " num_hash=" << num_hash
@@ -1537,17 +1832,18 @@ namespace merkle
     {
       static const std::string dirty_hash(2 * num_bytes, '?');
       std::stringstream stream;
-      std::vector<Node*> level, next_level;
+      std::vector<Node*> level;
+      std::vector<Node*> next_level;
 
       if (num_leaves() == 0)
       {
-        stream << "<EMPTY>" << std::endl;
+        stream << "<EMPTY>" << '\n';
         return stream.str();
       }
 
       if (!_root)
       {
-        stream << "No root." << std::endl;
+        stream << "No root." << '\n';
       }
       else
       {
@@ -1561,12 +1857,16 @@ namespace merkle
             stream << (n->dirty ? dirty_hash : n->hash.to_string(num_bytes));
             stream << "(" << n->size << "," << (unsigned)n->height << ")";
             if (n->left)
+            {
               next_level.push_back(n->left);
+            }
             if (n->right)
+            {
               next_level.push_back(n->right);
+            }
             stream << " ";
           }
-          stream << std::endl << std::flush;
+          stream << '\n' << std::flush;
           std::swap(level, next_level);
           next_level.clear();
         }
@@ -1582,6 +1882,41 @@ namespace merkle
     }
 
   protected:
+    void validate_partial_range(size_t from, size_t to) const
+    {
+      if (empty() || !(min_index() <= from && from <= to && to <= max_index()))
+      {
+        throw std::runtime_error("invalid leaf indices");
+      }
+    }
+
+    void clear()
+    {
+      leaf_nodes.clear();
+      for (auto n : uninserted_leaf_nodes)
+      {
+        delete (n);
+      }
+      uninserted_leaf_nodes.clear();
+      insertion_stack.clear();
+      hashing_stack.clear();
+      walk_stack.clear();
+      delete (_root);
+      _root = nullptr;
+      num_flushed = 0;
+    }
+
+    void move_from(TreeT& other) noexcept
+    {
+      leaf_nodes = std::exchange(other.leaf_nodes, {});
+      uninserted_leaf_nodes = std::exchange(other.uninserted_leaf_nodes, {});
+      _root = std::exchange(other._root, nullptr);
+      num_flushed = std::exchange(other.num_flushed, 0);
+      insertion_stack = std::exchange(other.insertion_stack, {});
+      hashing_stack = std::exchange(other.hashing_stack, {});
+      walk_stack = std::exchange(other.walk_stack, {});
+    }
+
     /// @brief Vector of leaf nodes current in the tree
     std::vector<Node*> leaf_nodes;
 
@@ -1598,14 +1933,14 @@ namespace merkle
 
   private:
     /// @brief The structure of elements on the insertion stack
-    typedef struct
+    using InsertionStackElement = struct
     {
       /// @brief The tree node to insert
       Node* n;
       /// @brief Flag to indicate whether @p n should be inserted into the
       ///  left or the right subtree of the current position in the tree.
       bool left;
-    } InsertionStackElement;
+    };
 
     /// @brief The insertion stack
     /// @note To avoid actual recursion, this holds the stack/continuation for
@@ -1629,12 +1964,15 @@ namespace merkle
     {
       MERKLECPP_TRACE(MERKLECPP_TOUT << "> leaf_node " << index << std::endl;);
       if (index >= num_leaves())
+      {
         throw std::runtime_error("leaf index out of bounds");
+      }
       if (index - num_flushed >= leaf_nodes.size())
+      {
         return uninserted_leaf_nodes.at(
           index - num_flushed - leaf_nodes.size());
-      else
-        return leaf_nodes.at(index - num_flushed);
+      }
+      return leaf_nodes.at(index - num_flushed);
     }
 
     /// @brief Computes the hash of a tree node
@@ -1658,12 +1996,20 @@ namespace merkle
         assert((n->left && n->right) || (!n->left && !n->right));
 
         if (n->left && n->left->dirty)
+        {
           hashing_stack.push_back(n->left);
+        }
         else if (n->right && n->right->dirty)
+        {
           hashing_stack.push_back(n->right);
+        }
         else
         {
           assert(n->left && n->right);
+          if (!n->left || !n->right)
+          {
+            throw std::runtime_error("unexpected null child node");
+          }
           HASH_FUNCTION(n->left->hash, n->right->hash, n->hash);
           statistics.num_hash++;
           MERKLECPP_TRACE(
@@ -1684,7 +2030,9 @@ namespace merkle
     {
       insert_leaves(true);
       if (num_leaves() == 0)
+      {
         throw std::runtime_error("empty tree does not have a root");
+      }
       assert(_root);
       assert(_root->invariant());
       if (_root->dirty)
@@ -1703,9 +2051,9 @@ namespace merkle
     {
       while (true)
       {
-        MERKLECPP_TRACE(MERKLECPP_TOUT << "  @ "
-                                       << n->hash.to_string(TRACE_HASH_SIZE)
-                                       << std::endl;);
+        MERKLECPP_TRACE(
+          MERKLECPP_TOUT << "  @ " << n->hash.to_string(TRACE_HASH_SIZE)
+                         << std::endl;);
         assert(n->invariant());
 
         if (n->is_full())
@@ -1715,23 +2063,21 @@ namespace merkle
           insertion_stack.back().n = result;
           return;
         }
+
+        assert(n->left && n->right);
+        insertion_stack.push_back(InsertionStackElement());
+        InsertionStackElement& se = insertion_stack.back();
+        se.n = n;
+        n->dirty = true;
+        if (!n->left->is_full())
+        {
+          se.left = true;
+          n = n->left;
+        }
         else
         {
-          assert(n->left && n->right);
-          insertion_stack.push_back(InsertionStackElement());
-          InsertionStackElement& se = insertion_stack.back();
-          se.n = n;
-          n->dirty = true;
-          if (!n->left->is_full())
-          {
-            se.left = true;
-            n = n->left;
-          }
-          else
-          {
-            se.left = false;
-            n = n->right;
-          }
+          se.left = false;
+          n = n->right;
         }
       }
     }
@@ -1744,8 +2090,10 @@ namespace merkle
       MERKLECPP_TRACE({
         std::string nodes;
         for (size_t i = 0; i < insertion_stack.size(); i++)
-          nodes +=
-            " " + insertion_stack.at(i).n->hash.to_string(TRACE_HASH_SIZE);
+          std::format_to(
+            std::back_inserter(nodes),
+            " {}",
+            insertion_stack.at(i).n->hash.to_string(TRACE_HASH_SIZE));
         MERKLECPP_TOUT << "  X " << (complete ? "complete" : "continue") << ":"
                        << nodes << std::endl;
       });
@@ -1764,9 +2112,13 @@ namespace merkle
         insertion_stack.pop_back();
 
         if (left)
+        {
           n->left = result;
+        }
         else
+        {
           n->right = result;
+        }
         n->dirty = true;
         n->update_sizes();
 
@@ -1774,10 +2126,10 @@ namespace merkle
 
         if (!complete && !result->is_full())
         {
-          MERKLECPP_TRACE(MERKLECPP_TOUT
-                            << "  X save "
-                            << result->hash.to_string(TRACE_HASH_SIZE)
-                            << std::endl;);
+          MERKLECPP_TRACE(
+            MERKLECPP_TOUT << "  X save "
+                           << result->hash.to_string(TRACE_HASH_SIZE)
+                           << std::endl;);
           return result;
         }
       }
@@ -1792,12 +2144,14 @@ namespace merkle
     /// @param n New leaf node to insert
     void insert_leaf(Node*& root, Node* n)
     {
-      MERKLECPP_TRACE(MERKLECPP_TOUT << " - insert_leaf "
-                                     << n->hash.to_string(TRACE_HASH_SIZE)
-                                     << std::endl;);
+      MERKLECPP_TRACE(
+        MERKLECPP_TOUT << " - insert_leaf "
+                       << n->hash.to_string(TRACE_HASH_SIZE) << std::endl;);
       leaf_nodes.push_back(n);
       if (insertion_stack.empty() && !root)
+      {
         root = n;
+      }
       else
       {
         continue_insertion_stack(root, n);
@@ -1812,92 +2166,149 @@ namespace merkle
     {
       if (!uninserted_leaf_nodes.empty())
       {
-        MERKLECPP_TRACE(MERKLECPP_TOUT
-                          << "* insert_leaves " << leaf_nodes.size() << " +"
-                          << uninserted_leaf_nodes.size() << std::endl;);
+        MERKLECPP_TRACE(
+          MERKLECPP_TOUT << "* insert_leaves " << leaf_nodes.size() << " +"
+                         << uninserted_leaf_nodes.size() << std::endl;);
         // Potential future improvement: make this go fast when there are many
         // leaves to insert.
         for (auto& n : uninserted_leaf_nodes)
+        {
           insert_leaf(_root, n);
+        }
         uninserted_leaf_nodes.clear();
       }
       if (complete && !insertion_stack.empty())
+      {
         _root = process_insertion_stack();
+      }
     }
   };
 
-  // clang-format off
-  /// @brief SHA256 compression function for tree node hashes
+  namespace detail
+  {
+    static inline std::array<uint32_t, 8> sha256_initial_state()
+    {
+      return {
+        0x6a09e667,
+        0xbb67ae85,
+        0x3c6ef372,
+        0xa54ff53a,
+        0x510e527f,
+        0x9b05688c,
+        0x1f83d9ab,
+        0x5be0cd19};
+    }
+
+    static inline void sha256_transform(
+      const uint8_t block[64], std::array<uint32_t, 8>& state)
+    {
+      static constexpr std::array<uint32_t, 64> constants = {
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+        0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+        0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+        0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+        0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+        0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+        0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+        0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+      std::array<uint32_t, 64> schedule = {};
+      for (size_t i = 0; i < 16; ++i)
+      {
+        const size_t offset = i * 4;
+        schedule[i] = (static_cast<uint32_t>(block[offset]) << 24) |
+          (static_cast<uint32_t>(block[offset + 1]) << 16) |
+          (static_cast<uint32_t>(block[offset + 2]) << 8) |
+          static_cast<uint32_t>(block[offset + 3]);
+      }
+
+      for (size_t i = 16; i < 64; ++i)
+      {
+        const uint32_t word15 = schedule[i - 15];
+        const uint32_t word2 = schedule[i - 2];
+        const uint32_t sigma0 = (word15 >> 7 | word15 << 25) ^
+          (word15 >> 18 | word15 << 14) ^ (word15 >> 3);
+        const uint32_t sigma1 = (word2 >> 17 | word2 << 15) ^
+          (word2 >> 19 | word2 << 13) ^ (word2 >> 10);
+        schedule[i] = schedule[i - 16] + sigma0 + schedule[i - 7] + sigma1;
+      }
+
+      auto working = state;
+      for (size_t i = 0; i < 64; ++i)
+      {
+        const uint32_t choice =
+          (working[4] & working[5]) ^ (~working[4] & working[6]);
+        const uint32_t majority = (working[0] & working[1]) ^
+          (working[0] & working[2]) ^ (working[1] & working[2]);
+        const uint32_t sigma0 = (working[0] >> 2 | working[0] << 30) ^
+          (working[0] >> 13 | working[0] << 19) ^
+          (working[0] >> 22 | working[0] << 10);
+        const uint32_t sigma1 = (working[4] >> 6 | working[4] << 26) ^
+          (working[4] >> 11 | working[4] << 21) ^
+          (working[4] >> 25 | working[4] << 7);
+        const uint32_t temporary1 =
+          working[7] + sigma1 + choice + constants[i] + schedule[i];
+        const uint32_t temporary2 = sigma0 + majority;
+
+        working[7] = working[6];
+        working[6] = working[5];
+        working[5] = working[4];
+        working[4] = working[3] + temporary1;
+        working[3] = working[2];
+        working[2] = working[1];
+        working[1] = working[0];
+        working[0] = temporary1 + temporary2;
+      }
+
+      for (size_t i = 0; i < state.size(); ++i)
+      {
+        state[i] += working[i];
+      }
+    }
+
+    static inline void sha256_write_digest(
+      const std::array<uint32_t, 8>& state, HashT<32>& out)
+    {
+      for (size_t i = 0; i < state.size(); ++i)
+      {
+        out.bytes[i * 4] = static_cast<uint8_t>(state[i] >> 24);
+        out.bytes[i * 4 + 1] = static_cast<uint8_t>(state[i] >> 16);
+        out.bytes[i * 4 + 2] = static_cast<uint8_t>(state[i] >> 8);
+        out.bytes[i * 4 + 3] = static_cast<uint8_t>(state[i]);
+      }
+    }
+  }
+
+  /// @brief Built-in SHA256 function for tree node hashes
   /// @param l Left node hash
   /// @param r Right node hash
   /// @param out Output node hash
-  /// @details This function is the compression function of SHA256, which, for
-  /// the special case of hashing two hashes, is more efficient than a full
-  /// SHA256 while providing similar guarantees.
-  static inline void sha256_compress(const HashT<32> &l, const HashT<32> &r, HashT<32> &out) {
-    static const uint32_t constants[] = {
-      0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
-      0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
-      0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-      0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
-      0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
-      0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-      0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-      0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
-    };
-
+  /// @details Computes SHA256 over the 64-byte concatenation of @p l and @p r,
+  /// including standard SHA256 message padding.
+  static inline void sha256(
+    const HashT<32>& l, const HashT<32>& r, HashT<32>& out)
+  {
     uint8_t block[32 * 2];
     memcpy(&block[0], l.bytes, 32);
     memcpy(&block[32], r.bytes, 32);
 
-    static const uint32_t s[8] = { 0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
-                                   0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19 };
+    auto state = detail::sha256_initial_state();
+    detail::sha256_transform(block, state);
 
-    uint32_t cws[64] = {0};
-
-    for (int i=0; i < 16; i++)
-      cws[i] = convert_endianness(((int32_t *)block)[i]);
-
-    for (int i = 16; i < 64; i++) {
-      uint32_t t16 = cws[i - 16];
-      uint32_t t15 = cws[i - 15];
-      uint32_t t7 = cws[i - 7];
-      uint32_t t2 = cws[i - 2];
-      uint32_t s1 = (t2 >> 17 | t2 << 15) ^ ((t2 >> 19 | t2 << 13) ^ t2 >> 10);
-      uint32_t s0 = (t15 >> 7 | t15 << 25) ^ ((t15 >> 18 | t15 << 14) ^ t15 >> 3);
-      cws[i] = (s1 + t7 + s0 + t16);
-    }
-
-    uint32_t h[8];
-    for (int i=0; i < 8; i++)
-      h[i] = s[i];
-
-    for (int i=0; i < 64; i++) {
-      uint32_t a0 = h[0], b0 = h[1], c0 = h[2], d0 = h[3], e0 = h[4], f0 = h[5], g0 = h[6], h03 = h[7];
-      uint32_t w = cws[i];
-      uint32_t t1 = h03 + ((e0 >> 6 | e0 << 26) ^ ((e0 >> 11 | e0 << 21) ^ (e0 >> 25 | e0 << 7))) + ((e0 & f0) ^ (~e0 & g0)) + constants[i] + w;
-      uint32_t t2 = ((a0 >> 2 | a0 << 30) ^ ((a0 >> 13 | a0 << 19) ^ (a0 >> 22 | a0 << 10))) + ((a0 & b0) ^ ((a0 & c0) ^ (b0 & c0)));
-      h[0] = t1 + t2;
-      h[1] = a0;
-      h[2] = b0;
-      h[3] = c0;
-      h[4] = d0 + t1;
-      h[5] = e0;
-      h[6] = f0;
-      h[7] = g0;
-    }
-
-    for (int i=0; i < 8; i++)
-      ((uint32_t*)out.bytes)[i] = convert_endianness(s[i] + h[i]);
+    uint8_t padding[64] = {0x80};
+    padding[62] = 0x02;
+    detail::sha256_transform(padding, state);
+    detail::sha256_write_digest(state, out);
   }
-  // clang-format on
 
 #ifdef HAVE_OPENSSL
   /// @brief OpenSSL SHA256
   /// @param l Left node hash
   /// @param r Right node hash
   /// @param out Output node hash
-  /// @note Some versions of OpenSSL may not provide SHA256_Transform.
   static inline void sha256_openssl(
     const merkle::HashT<32>& l,
     const merkle::HashT<32>& r,
@@ -1908,60 +2319,83 @@ namespace merkle
     memcpy(&block[32], r.bytes, 32);
 
     const EVP_MD* md = EVP_sha256();
-    int rc =
+    const int rc =
       EVP_Digest(&block[0], sizeof(block), out.bytes, nullptr, md, nullptr);
     if (rc != 1)
     {
-      throw std::runtime_error("EVP_Digest failed: " + std::to_string(rc));
+      throw std::runtime_error(std::format("EVP_Digest failed: {}", rc));
     }
   }
-#endif
 
-#ifdef HAVE_MBEDTLS
-  /// @brief mbedTLS SHA256 compression function
+  /// @brief OpenSSL SHA384
   /// @param l Left node hash
   /// @param r Right node hash
   /// @param out Output node hash
-  /// @note Technically, mbedtls_internal_sha256_process is marked for internal
-  /// use only.
-  static inline void sha256_compress_mbedtls(
-    const HashT<32>& l, const HashT<32>& r, HashT<32>& out)
+  static inline void sha384_openssl(
+    const merkle::HashT<48>& l,
+    const merkle::HashT<48>& r,
+    merkle::HashT<48>& out)
   {
-    unsigned char block[32 * 2];
-    memcpy(&block[0], l.bytes, 32);
-    memcpy(&block[32], r.bytes, 32);
+    uint8_t block[48 * 2];
+    memcpy(&block[0], l.bytes, 48);
+    memcpy(&block[48], r.bytes, 48);
 
-    mbedtls_sha256_context ctx;
-    mbedtls_sha256_init(&ctx);
-    mbedtls_sha256_starts_ret(&ctx, false);
-    mbedtls_internal_sha256_process(&ctx, &block[0]);
-
-    for (int i = 0; i < 8; i++)
-      ((uint32_t*)out.bytes)[i] = htobe32(ctx.state[i]);
+    const EVP_MD* md = EVP_sha384();
+    const int rc =
+      EVP_Digest(&block[0], sizeof(block), out.bytes, nullptr, md, nullptr);
+    if (rc != 1)
+    {
+      throw std::runtime_error(std::format("EVP_Digest failed: {}", rc));
+    }
   }
 
-  /// @brief mbedTLS SHA256
+  /// @brief OpenSSL SHA512
   /// @param l Left node hash
   /// @param r Right node hash
   /// @param out Output node hash
-  static inline void sha256_mbedtls(
-    const merkle::HashT<32>& l,
-    const merkle::HashT<32>& r,
-    merkle::HashT<32>& out)
+  static inline void sha512_openssl(
+    const merkle::HashT<64>& l,
+    const merkle::HashT<64>& r,
+    merkle::HashT<64>& out)
   {
-    uint8_t block[32 * 2];
-    memcpy(&block[0], l.bytes, 32);
-    memcpy(&block[32], r.bytes, 32);
-    mbedtls_sha256_ret(block, sizeof(block), out.bytes, false);
+    uint8_t block[64 * 2];
+    memcpy(&block[0], l.bytes, 64);
+    memcpy(&block[64], r.bytes, 64);
+
+    const EVP_MD* md = EVP_sha512();
+    const int rc =
+      EVP_Digest(&block[0], sizeof(block), out.bytes, nullptr, md, nullptr);
+    if (rc != 1)
+    {
+      throw std::runtime_error(std::format("EVP_Digest failed: {}", rc));
+    }
   }
+
+  /// @brief Type of paths in the SHA384 tree type
+  using Path384 = PathT<48, sha384_openssl>;
+
+  /// @brief SHA384 tree with OpenSSL hash function
+  using Tree384 = TreeT<48, sha384_openssl>;
+
+  /// @brief Type of paths in the SHA512 tree type
+  using Path512 = PathT<64, sha512_openssl>;
+
+  /// @brief SHA512 tree with OpenSSL hash function
+  using Tree512 = TreeT<64, sha512_openssl>;
 #endif
+
+  /// @brief Type of SHA384-sized hashes
+  using Hash384 = HashT<48>;
+
+  /// @brief Type of SHA512-sized hashes
+  using Hash512 = HashT<64>;
 
   /// @brief Type of hashes in the default tree type
-  typedef HashT<32> Hash;
+  using Hash = HashT<32>;
 
   /// @brief Type of paths in the default tree type
-  typedef PathT<32, sha256_compress> Path;
+  using Path = PathT<32, sha256>;
 
   /// @brief Default tree with default hash size and function
-  typedef TreeT<32, sha256_compress> Tree;
+  using Tree = TreeT<32, sha256>;
 };

--- a/3rdparty/internal/merklecpp/merklecpp_pal.h
+++ b/3rdparty/internal/merklecpp/merklecpp_pal.h
@@ -1,0 +1,307 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <algorithm>
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <format>
+#include <iterator>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#ifdef _WIN32
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#    define MERKLECPP_UNDEF_NOMINMAX
+#  endif
+#  include <windows.h>
+#  ifdef MERKLECPP_UNDEF_NOMINMAX
+#    undef MERKLECPP_UNDEF_NOMINMAX
+#    undef NOMINMAX
+#  endif
+#else
+#  include <fcntl.h>
+#  include <unistd.h>
+#endif
+
+// Internal platform abstraction for durable file operations.
+
+namespace merkle // NOLINT(modernize-concat-nested-namespaces)
+{
+  namespace pal
+  {
+#ifdef _WIN32
+    using SystemError = DWORD;
+#else
+    using SystemError = int;
+#endif
+
+    static inline SystemError last_system_error()
+    {
+#ifdef _WIN32
+      return GetLastError();
+#else
+      return errno;
+#endif
+    }
+
+    template <typename... Args>
+    std::string system_error_message(
+      SystemError error,
+      std::format_string<Args...> format_string,
+      Args&&... args)
+    {
+      std::string message;
+      std::format_to(
+        std::back_inserter(message),
+        format_string,
+        std::forward<Args>(args)...);
+#ifdef _WIN32
+      std::format_to(std::back_inserter(message), ": error {}", error);
+#else
+      std::format_to(std::back_inserter(message), ": {}", std::strerror(error));
+#endif
+      return message;
+    }
+
+    static inline uint64_t process_id()
+    {
+#ifdef _WIN32
+      return static_cast<uint64_t>(GetCurrentProcessId());
+#else
+      return static_cast<uint64_t>(::getpid());
+#endif
+    }
+
+#ifndef _WIN32
+    namespace detail
+    {
+      template <typename Operation>
+      static inline int retry_on_eintr(const Operation& operation)
+      {
+        int result = 0;
+        do
+        {
+          result = operation();
+        } while (result == -1 && errno == EINTR);
+        return result;
+      }
+
+    }
+#endif
+
+    static inline void require_write_progress(
+      size_t written, const std::filesystem::path& path)
+    {
+      if (written == 0)
+      {
+        throw std::runtime_error(std::format("short write: {}", path.string()));
+      }
+    }
+
+    static inline void remove_owned_file(
+      const std::filesystem::path& path) noexcept
+    {
+      std::error_code ec;
+      std::filesystem::remove(path, ec);
+    }
+
+    /// Writes and syncs a new file, failing if @p path already exists.
+    /// A file created by this call is removed if a later operation fails.
+    static inline void write_and_sync_file(
+      const std::filesystem::path& path, const std::vector<uint8_t>& bytes)
+    {
+#ifdef _WIN32
+      HANDLE handle = CreateFileW(
+        path.wstring().c_str(),
+        GENERIC_WRITE,
+        0,
+        nullptr,
+        CREATE_NEW,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr);
+      if (handle == INVALID_HANDLE_VALUE)
+      {
+        const auto error = last_system_error();
+        throw std::runtime_error(
+          system_error_message(error, "cannot open file {}", path.string()));
+      }
+      bool close_handle = true;
+      try
+      {
+        constexpr auto max_write_size =
+          static_cast<size_t>(std::numeric_limits<DWORD>::max());
+        size_t written = 0;
+        while (written < bytes.size())
+        {
+          const auto remaining = bytes.size() - written;
+          const auto chunk =
+            static_cast<DWORD>(std::min(remaining, max_write_size));
+          DWORD done = 0;
+          if (!WriteFile(handle, bytes.data() + written, chunk, &done, nullptr))
+          {
+            const auto error = last_system_error();
+            throw std::runtime_error(system_error_message(
+              error, "error writing file {}", path.string()));
+          }
+          require_write_progress(static_cast<size_t>(done), path);
+          written += done;
+        }
+        if (!FlushFileBuffers(handle))
+        {
+          const auto error = last_system_error();
+          throw std::runtime_error(system_error_message(
+            error, "error syncing file {}", path.string()));
+        }
+        if (!CloseHandle(handle))
+        {
+          const auto error = last_system_error();
+          throw std::runtime_error(system_error_message(
+            error, "error closing file {}", path.string()));
+        }
+        close_handle = false;
+      }
+      catch (...)
+      {
+        if (close_handle)
+        {
+          CloseHandle(handle);
+        }
+        remove_owned_file(path);
+        throw;
+      }
+#else
+      int flags = O_WRONLY | O_CREAT | O_EXCL;
+#  ifdef O_CLOEXEC
+      flags |= O_CLOEXEC;
+#  endif
+      int fd = ::open(path.c_str(), flags, 0666);
+      if (fd < 0)
+      {
+        const auto error = last_system_error();
+        throw std::runtime_error(
+          system_error_message(error, "cannot open file {}", path.string()));
+      }
+      try
+      {
+        size_t written = 0;
+        while (written < bytes.size())
+        {
+          const ssize_t done =
+            ::write(fd, bytes.data() + written, bytes.size() - written);
+          if (done < 0)
+          {
+            if (errno == EINTR)
+            {
+              continue;
+            }
+            const auto error = last_system_error();
+            throw std::runtime_error(system_error_message(
+              error, "error writing file {}", path.string()));
+          }
+          require_write_progress(static_cast<size_t>(done), path);
+          written += static_cast<size_t>(done);
+        }
+        if (detail::retry_on_eintr([fd]() { return ::fsync(fd); }) != 0)
+        {
+          const auto error = last_system_error();
+          throw std::runtime_error(system_error_message(
+            error, "error syncing file {}", path.string()));
+        }
+        if (::close(fd) != 0)
+        {
+          const auto error = last_system_error();
+          fd = -1;
+          throw std::runtime_error(system_error_message(
+            error, "error closing file {}", path.string()));
+        }
+        fd = -1;
+      }
+      catch (...)
+      {
+        if (fd >= 0)
+        {
+          ::close(fd);
+        }
+        remove_owned_file(path);
+        throw;
+      }
+#endif
+    }
+
+    static inline void replace_file(
+      const std::filesystem::path& tmp, const std::filesystem::path& path)
+    {
+#ifdef _WIN32
+      if (!MoveFileExW(
+            tmp.wstring().c_str(),
+            path.wstring().c_str(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
+      {
+        const auto error = last_system_error();
+        throw std::runtime_error(system_error_message(
+          error,
+          "cannot rename temp file {} to {}",
+          tmp.string(),
+          path.string()));
+      }
+#else
+      std::error_code ec;
+      std::filesystem::rename(tmp, path, ec);
+      if (ec)
+      {
+        throw std::runtime_error(std::format(
+          "cannot rename temp file {} to {}: {}",
+          tmp.string(),
+          path.string(),
+          ec.message()));
+      }
+#endif
+    }
+
+    static inline void sync_directory_on_disk(const std::filesystem::path& path)
+    {
+#ifndef _WIN32
+      int flags = O_RDONLY;
+#  ifdef O_DIRECTORY
+      flags |= O_DIRECTORY;
+#  endif
+#  ifdef O_CLOEXEC
+      flags |= O_CLOEXEC;
+#  endif
+      const int fd = ::open(path.c_str(), flags);
+      if (fd < 0)
+      {
+        const auto error = last_system_error();
+        throw std::runtime_error(system_error_message(
+          error, "cannot open directory {}", path.string()));
+      }
+      if (detail::retry_on_eintr([fd]() { return ::fsync(fd); }) != 0)
+      {
+        const auto error = last_system_error();
+        const std::string message = system_error_message(
+          error, "error syncing directory {}", path.string());
+        ::close(fd);
+        throw std::runtime_error(message);
+      }
+      if (::close(fd) != 0)
+      {
+        const auto error = last_system_error();
+        throw std::runtime_error(system_error_message(
+          error, "error closing directory {}", path.string()));
+      }
+#else
+      (void)path;
+#endif
+    }
+  }
+}

--- a/3rdparty/internal/merklecpp/merklecpp_tiles.h
+++ b/3rdparty/internal/merklecpp/merklecpp_tiles.h
@@ -1,0 +1,2578 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "merklecpp.h"
+#include "merklecpp_pal.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <functional>
+#include <iterator>
+#include <limits>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+// Tiled storage for merklecpp trees, following the full-tile geometry, payload,
+// and path encoding of the C2SP tlog-tiles layout
+// (https://c2sp.org/tlog-tiles). C2SP defines SHA-256 and 256-hash tiles.
+// merklecpp uses that geometry by default, supports compile-time power-of-two
+// tile widths as an extension, and separates each format under an
+// algorithm-and-width-qualified directory such as sha256-256w or sha384-16w.
+// Only complete, immutable tiles are stored. Their hash values are produced by
+// the tree's existing HASH_FUNCTION, so tile-derived proofs are byte-identical
+// to those produced by merkle::TreeT.
+//
+// Thread safety: types in this header do not synchronize access internally.
+// Callers must serialize access to each shared object, including const proof
+// operations that update the tile cache, and all writers sharing a store
+// prefix. Independent store objects may read while the serialized writer
+// publishes tiles atomically.
+
+namespace merkle // NOLINT(modernize-concat-nested-namespaces)
+{
+  namespace tiles
+  {
+    /// @brief Default number of tree levels spanned by a single tile.
+    static constexpr uint16_t DEFAULT_TILE_HEIGHT = 8;
+
+    /// @brief Default number of hashes in a full tile.
+    static constexpr uint16_t DEFAULT_TILE_WIDTH =
+      uint16_t{1U << DEFAULT_TILE_HEIGHT};
+
+    /// @brief Highest tile level permitted by the tlog-tiles layout.
+    static constexpr uint8_t MAX_TILE_LEVEL = 63;
+
+    // Leaf indices and counts follow two deliberate conventions. The storage
+    // and proof layers below (TileRef, TileStoreT, TileWriterT, hash sources,
+    // ProofEngineT, EntryBundleWriterT) index the on-disk log as uint64_t,
+    // matching the tlog-tiles layout. TreeT and its TiledTreeT wrapper use
+    // size_t, because those leaves are resident in memory. Conversions are
+    // confined to the boundary between the two: widening size_t to uint64_t
+    // must be lossless, while the reverse direction is range-checked before
+    // narrowing (see ProofEngineT::inclusion_proof and
+    // MemoryHashSourceT::subtree_root).
+    static_assert(
+      sizeof(size_t) <= sizeof(uint64_t),
+      "tiled storage indexes leaves as uint64_t; a size_t wider than 64 bits "
+      "would truncate when tree-level values cross into the tile layer");
+
+    namespace detail
+    {
+      static constexpr std::string_view SHA256_ALGORITHM_SHORT_NAME = "sha256";
+      static constexpr std::string_view SHA384_ALGORITHM_SHORT_NAME = "sha384";
+      static constexpr std::string_view SHA512_ALGORITHM_SHORT_NAME = "sha512";
+      static constexpr size_t ENTRY_LENGTH_PREFIX_SIZE = 2;
+      static constexpr size_t MAX_ENTRY_SIZE = 0xFFFF;
+
+      template <uint8_t TILE_HEIGHT_VALUE>
+      struct TileGeometry
+      {
+        static_assert(
+          TILE_HEIGHT_VALUE > 0,
+          "tile height must be greater than zero");
+        static_assert(
+          TILE_HEIGHT_VALUE < std::numeric_limits<size_t>::digits,
+          "tile width must fit in size_t");
+
+        static constexpr uint8_t HEIGHT = TILE_HEIGHT_VALUE;
+        static constexpr size_t WIDTH = size_t{1} << HEIGHT;
+        static constexpr size_t MAX_ENCODED_ENTRY_SIZE =
+          ENTRY_LENGTH_PREFIX_SIZE + MAX_ENTRY_SIZE;
+
+        static_assert(
+          WIDTH <=
+            std::numeric_limits<size_t>::max() / MAX_ENCODED_ENTRY_SIZE,
+          "maximum entry bundle size must fit in size_t");
+
+        static constexpr size_t MAX_ENTRY_BUNDLE_SIZE =
+          WIDTH * MAX_ENCODED_ENTRY_SIZE;
+      };
+
+      template <typename Present>
+      uint64_t contiguous_prefix_length(uint64_t limit, const Present& present)
+      {
+        uint64_t length = 0;
+        while (length < limit && present(length))
+        {
+          length++;
+        }
+        return length;
+      }
+    }
+
+    /// @brief Encodes a tile index as tlog-tiles path elements.
+    /// @param n The tile index
+    /// @return The index as zero-padded, '/'-separated 3-digit groups, where
+    /// all but the last group are prefixed with 'x'. For example, 1234067 is
+    /// encoded as "x001/x234/067" and 5 as "005".
+    static inline std::string encode_tile_index(uint64_t n)
+    {
+      std::vector<uint16_t> parts;
+      do
+      {
+        parts.emplace_back(static_cast<uint16_t>(n % 1000));
+        n /= 1000;
+      } while (n > 0);
+
+      std::string r;
+      r.reserve(parts.size() * 5);
+      for (size_t i = 0; i < parts.size(); i++)
+      {
+        const auto part = parts[parts.size() - 1 - i];
+        std::format_to(
+          std::back_inserter(r),
+          "{}{}{:03}",
+          i == 0 ? "" : "/",
+          i + 1 < parts.size() ? "x" : "",
+          part);
+      }
+      return r;
+    }
+
+    /// @brief Identifies a single (full) tile within a tiled log.
+    /// @note Only full tiles of the associated store's width are produced and
+    /// consumed; the incomplete frontier is never tiled.
+    struct TileRef
+    {
+      /// @brief The level of the tile (0 == leaf hashes, maximum 63).
+      uint8_t level = 0;
+
+      /// @brief The index of the tile within its level.
+      uint64_t index = 0;
+    };
+
+    template <
+      size_t HASH_SIZE,
+      void HASH_FUNCTION(
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&),
+      uint8_t TILE_HEIGHT_VALUE = DEFAULT_TILE_HEIGHT>
+    class TileWriterT;
+
+    template <
+      size_t HASH_SIZE,
+      void HASH_FUNCTION(
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&),
+      uint8_t TILE_HEIGHT_VALUE = DEFAULT_TILE_HEIGHT>
+    class EntryBundleWriterT;
+
+    template <
+      size_t HASH_SIZE,
+      void HASH_FUNCTION(
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&),
+      uint8_t TILE_HEIGHT_VALUE>
+    class TiledTreeT;
+
+    /// @brief Reads and writes tlog-tiles tile files on a local filesystem.
+    /// @tparam HASH_SIZE Size of each hash in bytes
+    /// @tparam HASH_FUNCTION The tree's node hash function (carried for use by
+    /// later components; tile I/O itself does not hash).
+    /// @tparam TILE_HEIGHT_VALUE Number of tree levels represented by a tile;
+    /// the tile width is 2**TILE_HEIGHT_VALUE. The default value 8 is the C2SP
+    /// tlog-tiles geometry; other values are merklecpp extensions.
+    /// @warning No internal synchronization is provided. Callers must serialize
+    /// access to each store object and all writers sharing its prefix.
+    /// Independent store objects may read while the serialized writer publishes
+    /// tiles atomically.
+    template <
+      size_t HASH_SIZE,
+      void HASH_FUNCTION(
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&),
+      uint8_t TILE_HEIGHT_VALUE = DEFAULT_TILE_HEIGHT>
+    class TileStoreT
+    {
+      friend class TileWriterT<
+        HASH_SIZE,
+        HASH_FUNCTION,
+        TILE_HEIGHT_VALUE>;
+      friend class EntryBundleWriterT<
+        HASH_SIZE,
+        HASH_FUNCTION,
+        TILE_HEIGHT_VALUE>;
+      friend class TiledTreeT<
+        HASH_SIZE,
+        HASH_FUNCTION,
+        TILE_HEIGHT_VALUE>;
+
+    public:
+      /// @brief The type of hashes stored in tiles.
+      using Hash = HashT<HASH_SIZE>;
+
+      /// @brief The compile-time tile geometry.
+      using Geometry = detail::TileGeometry<TILE_HEIGHT_VALUE>;
+
+      /// @brief Number of tree levels represented by one tile.
+      static constexpr uint8_t TILE_HEIGHT = Geometry::HEIGHT;
+
+      /// @brief Number of hashes in one full tile.
+      static constexpr size_t TILE_WIDTH = Geometry::WIDTH;
+
+      static_assert(
+        HASH_SIZE > 0 &&
+          TILE_WIDTH <= std::numeric_limits<size_t>::max() / HASH_SIZE,
+        "tile byte size must fit in size_t");
+
+      /// @brief Constructs a tile store below an algorithm-qualified directory
+      /// under @p prefix.
+      /// @param prefix The directory under which the format directory lives
+      /// @note Built-in SHA functions select sha256, sha384, or sha512.
+      explicit TileStoreT(std::filesystem::path prefix) :
+        TileStoreT(std::move(prefix), default_hash_algorithm_short_name())
+      {}
+
+      /// @brief Constructs a tile store for an explicitly named hash algorithm.
+      /// @param prefix The directory under which the format directory lives
+      /// @param hash_algorithm_short_name Lowercase algorithm short name
+      TileStoreT(
+        std::filesystem::path prefix,
+        const std::string& hash_algorithm_short_name) :
+        prefix(storage_root(std::move(prefix), hash_algorithm_short_name))
+      {}
+
+      /// @brief The algorithm-qualified root directory of the store.
+      [[nodiscard]] const std::filesystem::path& root() const
+      {
+        return prefix;
+      }
+
+      /// @brief The format directory for @p hash_algorithm_short_name.
+      /// @note The default geometry produces names such as sha256-256w.
+      static std::string storage_directory_name(
+        const std::string& hash_algorithm_short_name)
+      {
+        validate_hash_algorithm_short_name(hash_algorithm_short_name);
+        return std::format("{}-{}w", hash_algorithm_short_name, TILE_WIDTH);
+      }
+
+      /// @brief Encodes a tile index (see encode_tile_index).
+      static std::string encode_index(uint64_t n)
+      {
+        return encode_tile_index(n);
+      }
+
+      /// @brief The filesystem path of a tile.
+      /// @throws std::runtime_error if the tile level exceeds 63
+      [[nodiscard]] std::filesystem::path tile_path(const TileRef& ref) const
+      {
+        if (ref.level > MAX_TILE_LEVEL)
+        {
+          throw std::runtime_error("tile level out of range");
+        }
+        const auto relative_path = std::format(
+          "tile/{}/{}",
+          static_cast<unsigned>(ref.level),
+          encode_tile_index(ref.index));
+        return prefix / relative_path;
+      }
+
+      /// @brief The filesystem path of an entry bundle.
+      [[nodiscard]] std::filesystem::path entries_path(uint64_t index) const
+      {
+        const auto relative_path =
+          std::format("tile/entries/{}", encode_tile_index(index));
+        return prefix / relative_path;
+      }
+
+      /// @brief Whether a full tile exists on disk.
+      [[nodiscard]] bool has_full_tile(uint8_t level, uint64_t index) const
+      {
+        if (level > MAX_TILE_LEVEL)
+        {
+          return false;
+        }
+        std::error_code ec;
+        const auto path = tile_path(TileRef{level, index});
+        if (!std::filesystem::is_regular_file(path, ec) || ec)
+        {
+          return false;
+        }
+        return std::filesystem::file_size(path, ec) ==
+          (uintmax_t)TILE_WIDTH * HASH_SIZE &&
+          !ec;
+      }
+
+      /// @brief Writes a tile to disk atomically.
+      /// @param ref The tile to write
+      /// @param hashes The tile's hashes (exactly TILE_WIDTH of them)
+      void write_tile(const TileRef& ref, const std::vector<Hash>& hashes)
+      {
+        if (hashes.size() != TILE_WIDTH)
+        {
+          throw std::runtime_error("tile width mismatch");
+        }
+
+        std::vector<uint8_t> bytes;
+        bytes.reserve(hashes.size() * HASH_SIZE);
+        for (const auto& h : hashes)
+        {
+          h.serialise(bytes);
+        }
+
+        write_file_atomically(tile_path(ref), bytes);
+      }
+
+      /// @brief Reads a tile from disk.
+      /// @param ref The tile to read
+      /// @return The tile's hashes (TILE_WIDTH of them)
+      [[nodiscard]] std::vector<Hash> read_tile(const TileRef& ref) const
+      {
+        const size_t expected = (size_t)TILE_WIDTH * HASH_SIZE;
+        const auto path = tile_path(ref);
+        std::vector<uint8_t> bytes = read_file(path, expected);
+        if (bytes.size() != expected)
+        {
+          throw std::runtime_error(
+            std::format(
+              "unexpected tile size for {}: expected {} bytes, got {}",
+              path.string(),
+              expected,
+              bytes.size()));
+        }
+
+        std::vector<Hash> hashes;
+        hashes.reserve(TILE_WIDTH);
+        size_t position = 0;
+        for (size_t i = 0; i < TILE_WIDTH; i++)
+        {
+          hashes.emplace_back(bytes, position);
+        }
+        return hashes;
+      }
+
+      /// @brief Whether a full entry bundle exists on disk.
+      [[nodiscard]] bool has_entry_bundle(uint64_t index) const
+      {
+        std::error_code ec;
+        const auto path = entries_path(index);
+        if (!std::filesystem::is_regular_file(path, ec) || ec)
+        {
+          return false;
+        }
+        try
+        {
+          (void)decode_entries(
+            read_file(path, Geometry::MAX_ENTRY_BUNDLE_SIZE), TILE_WIDTH);
+          return true;
+        }
+        catch (const std::runtime_error&)
+        {
+          return false;
+        }
+      }
+
+      /// @brief Writes a full entry bundle to disk atomically.
+      /// @param index The bundle index
+      /// @param entries The raw log entries (exactly TILE_WIDTH of them)
+      /// @note Entries are stored in the tlog-tiles entry-bundle format: a
+      /// sequence of big-endian uint16 length-prefixed byte strings.
+      void write_entry_bundle(
+        uint64_t index, const std::vector<std::vector<uint8_t>>& entries)
+      {
+        if (entries.size() != TILE_WIDTH)
+        {
+          throw std::runtime_error("entry bundle width mismatch");
+        }
+        write_file_atomically(entries_path(index), encode_entries(entries));
+      }
+
+      /// @brief Reads a full entry bundle from disk.
+      /// @param index The bundle index
+      /// @return The raw log entries (TILE_WIDTH of them)
+      [[nodiscard]] std::vector<std::vector<uint8_t>> read_entry_bundle(
+        uint64_t index) const
+      {
+        const auto path = entries_path(index);
+        const auto bytes = read_file(path, Geometry::MAX_ENTRY_BUNDLE_SIZE);
+        try
+        {
+          return decode_entries(bytes, TILE_WIDTH);
+        }
+        catch (const std::runtime_error& error)
+        {
+          throw std::runtime_error(
+            std::format(
+              "invalid entry bundle {}: {}", path.string(), error.what()));
+        }
+      }
+
+      /// @brief Encodes log entries into the tlog-tiles entry-bundle format.
+      static std::vector<uint8_t> encode_entries(
+        const std::vector<std::vector<uint8_t>>& entries)
+      {
+        size_t encoded_size = 0;
+        for (const auto& e : entries)
+        {
+          if (e.size() > detail::MAX_ENTRY_SIZE)
+          {
+            throw std::runtime_error(
+              "entry too large for uint16 length prefix");
+          }
+          encoded_size += detail::ENTRY_LENGTH_PREFIX_SIZE + e.size();
+        }
+
+        std::vector<uint8_t> bytes;
+        bytes.reserve(encoded_size);
+        for (const auto& e : entries)
+        {
+          bytes.push_back((uint8_t)((e.size() >> 8) & 0xFF));
+          bytes.push_back((uint8_t)(e.size() & 0xFF));
+          bytes.insert(bytes.end(), e.begin(), e.end());
+        }
+        return bytes;
+      }
+
+      /// @brief Decodes @p count entries from the entry-bundle format.
+      static std::vector<std::vector<uint8_t>> decode_entries(
+        const std::vector<uint8_t>& bytes, size_t count)
+      {
+        if (count > bytes.size() / detail::ENTRY_LENGTH_PREFIX_SIZE)
+        {
+          throw std::runtime_error("truncated entry bundle");
+        }
+        std::vector<std::vector<uint8_t>> out;
+        out.reserve(count);
+        size_t pos = 0;
+        for (size_t i = 0; i < count; i++)
+        {
+          if (bytes.size() - pos < 2)
+          {
+            throw std::runtime_error("truncated entry bundle");
+          }
+          const auto len =
+            (uint16_t)(((uint16_t)bytes[pos] << 8) | bytes[pos + 1]);
+          pos += 2;
+          if (len > bytes.size() - pos)
+          {
+            throw std::runtime_error("truncated entry bundle");
+          }
+          out.emplace_back(
+            bytes.begin() + static_cast<std::ptrdiff_t>(pos),
+            bytes.begin() + static_cast<std::ptrdiff_t>(pos + len));
+          pos += len;
+        }
+        if (pos != bytes.size())
+        {
+          throw std::runtime_error("trailing bytes in entry bundle");
+        }
+        return out;
+      }
+
+      /// @cond INTERNAL
+    protected:
+      using DirectorySync = std::function<void(const std::filesystem::path&)>;
+
+      TileStoreT(std::filesystem::path prefix, DirectorySync directory_sync) :
+        TileStoreT(
+          std::move(prefix),
+          default_hash_algorithm_short_name(),
+          std::move(directory_sync))
+      {}
+
+      TileStoreT(
+        std::filesystem::path prefix,
+        const std::string& hash_algorithm_short_name,
+        DirectorySync directory_sync) :
+        prefix(storage_root(std::move(prefix), hash_algorithm_short_name)),
+        directory_sync(std::move(directory_sync))
+      {}
+
+      /// @brief The algorithm-qualified root directory of the store.
+      std::filesystem::path prefix;
+
+      DirectorySync directory_sync;
+      std::set<std::filesystem::path> durable_directory_entries;
+      std::set<std::filesystem::path> durable_directory_contents;
+
+      static std::string default_hash_algorithm_short_name()
+      {
+        if constexpr (HASH_SIZE == merkle::Tree::Hash::size_bytes)
+        {
+          if constexpr (HASH_FUNCTION == merkle::Tree::hash_function)
+          {
+            return std::string(detail::SHA256_ALGORITHM_SHORT_NAME);
+          }
+#ifdef HAVE_OPENSSL
+          if constexpr (HASH_FUNCTION == sha256_openssl)
+          {
+            return std::string(detail::SHA256_ALGORITHM_SHORT_NAME);
+          }
+#endif
+        }
+#ifdef HAVE_OPENSSL
+        else if constexpr (HASH_SIZE == merkle::Tree384::Hash::size_bytes)
+        {
+          if constexpr (HASH_FUNCTION == merkle::Tree384::hash_function)
+          {
+            return std::string(detail::SHA384_ALGORITHM_SHORT_NAME);
+          }
+        }
+        else if constexpr (HASH_SIZE == merkle::Tree512::Hash::size_bytes)
+        {
+          if constexpr (HASH_FUNCTION == merkle::Tree512::hash_function)
+          {
+            return std::string(detail::SHA512_ALGORITHM_SHORT_NAME);
+          }
+        }
+#endif
+        throw std::runtime_error(
+          "TileStoreT requires a hash algorithm short name");
+      }
+
+      static void validate_hash_algorithm_short_name(
+        const std::string& hash_algorithm_short_name)
+      {
+        if (
+          hash_algorithm_short_name.empty() ||
+          hash_algorithm_short_name.front() == '-' ||
+          hash_algorithm_short_name.back() == '-')
+        {
+          throw std::runtime_error("invalid hash algorithm short name");
+        }
+        for (const char c : hash_algorithm_short_name)
+        {
+          if ((c < 'a' || c > 'z') && (c < '0' || c > '9') && c != '-')
+          {
+            throw std::runtime_error("invalid hash algorithm short name");
+          }
+        }
+      }
+
+      static std::filesystem::path storage_root(
+        std::filesystem::path prefix,
+        const std::string& hash_algorithm_short_name)
+      {
+        if (
+          (hash_algorithm_short_name == detail::SHA256_ALGORITHM_SHORT_NAME &&
+           HASH_SIZE != merkle::Hash::size_bytes) ||
+          (hash_algorithm_short_name == detail::SHA384_ALGORITHM_SHORT_NAME &&
+           HASH_SIZE != merkle::Hash384::size_bytes) ||
+          (hash_algorithm_short_name == detail::SHA512_ALGORITHM_SHORT_NAME &&
+           HASH_SIZE != merkle::Hash512::size_bytes))
+        {
+          throw std::runtime_error(
+            "hash algorithm short name does not match hash size");
+        }
+        prefix = std::filesystem::absolute(prefix);
+        prefix /= storage_directory_name(hash_algorithm_short_name);
+        return prefix;
+      }
+
+      [[nodiscard]] bool confirm_full_tile(uint8_t level, uint64_t index)
+      {
+        const auto path = tile_path(TileRef{level, index});
+        if (!has_full_tile(level, index))
+        {
+          return false;
+        }
+        confirm_file_durable(path);
+        return true;
+      }
+
+      [[nodiscard]] bool confirm_entry_bundle(uint64_t index)
+      {
+        const auto path = entries_path(index);
+        if (!has_entry_bundle(index))
+        {
+          return false;
+        }
+        confirm_file_durable(path);
+        return true;
+      }
+
+      void begin_write_attempt()
+      {
+        durable_directory_contents.clear();
+      }
+
+      /// @brief Reads an entire file into a byte vector.
+      static std::vector<uint8_t> read_file(
+        const std::filesystem::path& path, size_t max_size)
+      {
+        std::ifstream f(path, std::ios::binary);
+        if (!f.good())
+        {
+          throw std::runtime_error(
+            std::format("cannot open file: {}", path.string()));
+        }
+
+        std::vector<uint8_t> bytes;
+        std::array<uint8_t, 4096> buffer{};
+        while (f)
+        {
+          const size_t remaining = max_size - bytes.size();
+          const size_t request =
+            remaining < buffer.size() ? remaining + 1 : buffer.size();
+          f.read(
+            reinterpret_cast<char*>(buffer.data()),
+            static_cast<std::streamsize>(request));
+          const auto count = static_cast<size_t>(f.gcount());
+          if (count == 0)
+          {
+            break;
+          }
+          if (count > remaining)
+          {
+            throw std::runtime_error(
+              std::format("file exceeds maximum size: {}", path.string()));
+          }
+          bytes.insert(bytes.end(), buffer.begin(), buffer.begin() + count);
+        }
+        if (f.bad())
+        {
+          throw std::runtime_error(
+            std::format("error reading file: {}", path.string()));
+        }
+        return bytes;
+      }
+
+      /// @brief Writes a file atomically via a synced temporary file.
+      /// @note Uses unique temp names, cleans them up on errors, and syncs the
+      /// file before publishing it with an atomic replace. POSIX builds also
+      /// confirm each directory entry in the path and sync the destination
+      /// directory after rename. Existing files are only reused after these
+      /// syncs are re-confirmed by the current write attempt.
+      void write_file_atomically(
+        const std::filesystem::path& path, const std::vector<uint8_t>& bytes)
+      {
+        create_directories_durably(path.parent_path());
+
+        const std::filesystem::path tmp = temp_path(path);
+        TempFileGuard guard(tmp);
+        merkle::pal::write_and_sync_file(tmp, bytes);
+        guard.arm();
+        const auto parent = directory_or_dot(path.parent_path());
+        durable_directory_contents.erase(parent);
+        merkle::pal::replace_file(tmp, path);
+        sync_directory_contents(parent);
+        guard.dismiss();
+      }
+
+      static std::filesystem::path directory_or_dot(
+        const std::filesystem::path& directory)
+      {
+        return directory.empty() ? std::filesystem::path(".") : directory;
+      }
+
+      void create_directories_durably(
+        const std::filesystem::path& requested_directory)
+      {
+        const auto directory = directory_or_dot(requested_directory);
+        if (durable_directory_entries.contains(directory))
+        {
+          return;
+        }
+
+        auto parent = directory_or_dot(directory.parent_path());
+        if (parent != directory)
+        {
+          create_directories_durably(parent);
+        }
+
+        std::error_code ec;
+        const bool exists = std::filesystem::exists(directory, ec);
+        if (ec)
+        {
+          throw std::runtime_error(
+            std::format(
+              "cannot inspect directory {}: {}",
+              directory.string(),
+              ec.message()));
+        }
+        if (exists)
+        {
+          const bool is_directory =
+            std::filesystem::is_directory(directory, ec);
+          if (ec)
+          {
+            throw std::runtime_error(
+              std::format(
+                "cannot inspect directory {}: {}",
+                directory.string(),
+                ec.message()));
+          }
+          if (!is_directory)
+          {
+            throw std::runtime_error(
+              std::format(
+                "cannot create directory {}: path exists and is not a "
+                "directory",
+                directory.string()));
+          }
+        }
+        else
+        {
+          const bool created = std::filesystem::create_directory(directory, ec);
+          if (ec)
+          {
+            throw std::runtime_error(
+              std::format(
+                "cannot create directory {}: {}",
+                directory.string(),
+                ec.message()));
+          }
+          if (!created && !std::filesystem::is_directory(directory, ec))
+          {
+            throw std::runtime_error(
+              ec ?
+                std::format(
+                  "cannot create directory {}: {}",
+                  directory.string(),
+                  ec.message()) :
+                std::format("cannot create directory {}", directory.string()));
+          }
+        }
+
+        if (parent != directory)
+        {
+          sync_directory_for_durability(parent);
+          durable_directory_contents.insert(parent);
+        }
+        durable_directory_entries.insert(directory);
+      }
+
+      void confirm_file_durable(const std::filesystem::path& path)
+      {
+        const auto parent = directory_or_dot(path.parent_path());
+        create_directories_durably(parent);
+        sync_directory_contents(parent);
+      }
+
+      void sync_directory_contents(const std::filesystem::path& directory)
+      {
+        const auto path = directory_or_dot(directory);
+        if (durable_directory_contents.contains(path))
+        {
+          return;
+        }
+        sync_directory_for_durability(path);
+        durable_directory_contents.insert(path);
+      }
+
+      class TempFileGuard
+      {
+      public:
+        explicit TempFileGuard(std::filesystem::path path) :
+          path(std::move(path))
+        {}
+
+        ~TempFileGuard()
+        {
+          if (active)
+          {
+            std::error_code ec;
+            std::filesystem::remove(path, ec);
+          }
+        }
+
+        void arm()
+        {
+          active = true;
+        }
+
+        void dismiss()
+        {
+          active = false;
+        }
+
+      private:
+        std::filesystem::path path;
+        bool active = false;
+      };
+
+      static std::filesystem::path temp_path(const std::filesystem::path& path)
+      {
+        static std::atomic<uint64_t> counter{0};
+        const auto stamp =
+          std::chrono::steady_clock::now().time_since_epoch().count();
+        std::filesystem::path tmp = path;
+        tmp += std::format(
+          ".tmp.{}.{}.{}",
+          merkle::pal::process_id(),
+          (uint64_t)stamp,
+          counter.fetch_add(1, std::memory_order_relaxed));
+        return tmp;
+      }
+
+      void sync_directory_for_durability(const std::filesystem::path& path)
+      {
+        if (directory_sync)
+        {
+          directory_sync(path);
+          return;
+        }
+        merkle::pal::sync_directory_on_disk(path);
+      }
+      /// @endcond
+    };
+
+    namespace detail
+    {
+      template <
+        size_t HASH_SIZE,
+        void HASH_FUNCTION(
+          const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&)>
+      HashT<HASH_SIZE> perfect_root_range(
+        const std::vector<HashT<HASH_SIZE>>& hashes,
+        size_t offset,
+        size_t count)
+      {
+        if (count == 1)
+        {
+          return hashes[offset];
+        }
+        const size_t half = count / 2;
+        const auto left =
+          perfect_root_range<HASH_SIZE, HASH_FUNCTION>(hashes, offset, half);
+        const auto right = perfect_root_range<HASH_SIZE, HASH_FUNCTION>(
+          hashes, offset + half, half);
+        HashT<HASH_SIZE> out;
+        HASH_FUNCTION(left, right, out);
+        return out;
+      }
+    }
+
+    /// @brief Computes the Merkle Tree Hash of a perfect (balanced) subtree.
+    /// @param leaves The subtree's leaves; the count MUST be a power of two.
+    /// @return The subtree root, computed with the tree's HASH_FUNCTION.
+    /// @note This is exactly a merkle::TreeT full-node hash, which is why tile
+    /// entries (such roots) are immutable: an unbalanced subtree would still
+    /// change as leaves are added and must therefore never be tiled.
+    template <
+      size_t HASH_SIZE,
+      void HASH_FUNCTION(
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&)>
+    inline HashT<HASH_SIZE> perfect_root(
+      const std::vector<HashT<HASH_SIZE>>& leaves)
+    {
+      if (leaves.empty())
+      {
+        throw std::runtime_error("perfect_root requires at least one leaf");
+      }
+      if ((leaves.size() & (leaves.size() - 1)) != 0)
+      {
+        throw std::runtime_error(
+          "perfect_root requires a power-of-two number of leaves");
+      }
+
+      return detail::perfect_root_range<HASH_SIZE, HASH_FUNCTION>(
+        leaves, 0, leaves.size());
+    }
+
+    /// @brief Computes and persists tlog-tiles tiles for a growing tree.
+    /// @tparam HASH_SIZE Size of each hash in bytes
+    /// @tparam HASH_FUNCTION The tree's node hash function
+    /// @tparam TILE_HEIGHT_VALUE Number of tree levels represented by a tile
+    /// @note Only balanced subtrees are tiled: a level-L entry is the root of a
+    /// complete 2**(TILE_HEIGHT_VALUE*L)-leaf subtree. Only full tiles are
+    /// written. Tiles in a caller-validated prefix are immutable; repair() may
+    /// replace files beyond that prefix. Entries beyond the last full-tile
+    /// boundary remain in memory until a later flush completes the next tile.
+    /// @warning No internal synchronization is provided. Callers must serialize
+    /// access to a writer and its store.
+    /// @warning An ordinary writer trusts existing full tiles as output from the
+    /// same tree and hash function. repair() trusts only its explicit prefix and
+    /// replaces later tiles. Callers must establish prefix ownership and restore
+    /// the matching tree state.
+    template <
+      size_t HASH_SIZE,
+      void HASH_FUNCTION(
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&),
+      uint8_t TILE_HEIGHT_VALUE>
+    class TileWriterT
+    {
+      friend class TiledTreeT<HASH_SIZE, HASH_FUNCTION, TILE_HEIGHT_VALUE>;
+
+    public:
+      /// @brief The type of hashes stored in tiles.
+      using Hash = HashT<HASH_SIZE>;
+
+      /// @brief The associated tile store type.
+      using Store =
+        TileStoreT<HASH_SIZE, HASH_FUNCTION, TILE_HEIGHT_VALUE>;
+
+      /// @brief The compile-time tile geometry.
+      using Geometry = typename Store::Geometry;
+
+      /// @brief Number of tree levels represented by one tile.
+      static constexpr uint8_t TILE_HEIGHT = Geometry::HEIGHT;
+
+      /// @brief Number of hashes in one full tile.
+      static constexpr size_t TILE_WIDTH = Geometry::WIDTH;
+
+      /// @brief Supplies the level-0 leaf hash for a given leaf index.
+      using LeafFn = std::function<const Hash&(uint64_t)>;
+
+      /// @brief Counts of work performed by a write_up_to call.
+      struct Stats
+      {
+        /// @brief Number of full tiles written.
+        uint64_t full_written = 0;
+      };
+
+      /// @brief Constructs a writer over @p store.
+      explicit TileWriterT(Store& store) : store(store) {}
+
+      /// @brief Constructs a writer that repairs a store after a trusted prefix.
+      /// @param store The store to populate or repair
+      /// @param trusted_size Caller-validated, tile-aligned leaf count below
+      /// which every required full tile is already durable and correct
+      /// @return A writer that preserves the trusted prefix and replaces every
+      /// existing full tile beyond it as write_up_to() reaches that tile
+      /// @note The returned writer owns no store. It may be used independently
+      /// of a TiledTree, including on a background thread, while the caller
+      /// serializes all writers sharing the namespace.
+      [[nodiscard]] static TileWriterT repair(
+        Store& store, uint64_t trusted_size)
+      {
+        return TileWriterT(store, trusted_size);
+      }
+
+      /// @brief Writes all newly-complete full tiles for a tree of @p size
+      /// leaves.
+      /// @param size The current tree size
+      /// @param leaf_at Returns the level-0 leaf hash for a leaf index in
+      /// [0, size); only ever queried for leaves of complete subtrees.
+      /// @return Counts of tiles written
+      /// @note Incremental: an ordinary writer reuses full tiles already on disk
+      /// once validated and confirmed durable. A repair writer preserves only
+      /// its trusted prefix and replaces later tiles. Malformed files are
+      /// replaced. Entries that do not complete a tile are not written.
+      /// Tiles are always rolled up through MAX_TILE_LEVEL, so the on-disk set
+      /// always contains the higher-level roll-ups that proof generation relies
+      /// on.
+      Stats write_up_to(uint64_t size, const LeafFn& leaf_at)
+      {
+        Stats stats;
+        store.begin_write_attempt();
+
+        // The loop stops early once a level has no complete entries (see the
+        // entries == 0 break below).
+        for (uint8_t level = 0; level <= MAX_TILE_LEVEL; level++)
+        {
+          // Number of complete (balanced) level-L entries available; this
+          // deliberately excludes the incomplete frontier subtree.
+          const uint64_t entries = entries_at_level(size, level);
+          if (entries == 0)
+          {
+            break;
+          }
+          ensure_level(level);
+
+          const uint64_t full_tiles = entries / TILE_WIDTH;
+
+          if (cursor_inited[level] == 0)
+          {
+            next_full[level] =
+              trust_existing_tiles ? full_prefix_length(level, full_tiles) : 0;
+            cursor_inited[level] = 1;
+          }
+
+          for (uint64_t n = next_full[level]; n < full_tiles; n++)
+          {
+            if (trust_existing_tiles && store.confirm_full_tile(level, n))
+            {
+              next_full[level] = n + 1;
+              continue;
+            }
+            store.write_tile(
+              TileRef{level, n},
+              collect(level, n * TILE_WIDTH, TILE_WIDTH, leaf_at));
+            stats.full_written++;
+            next_full[level] = n + 1;
+          }
+        }
+
+        return stats;
+      }
+
+    protected:
+      /// @brief The tile store written to.
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+      Store& store;
+
+      /// @brief Per-level index of the next full tile to write.
+      std::vector<uint64_t> next_full;
+
+      /// @brief Per-level flag indicating next_full has been initialised.
+      std::vector<uint8_t> cursor_inited;
+
+      /// @brief Whether correctly-sized files at and beyond next_full may be
+      /// adopted rather than replaced.
+      bool trust_existing_tiles = true;
+
+      /// @brief Constructs a writer after a caller-validated tile prefix.
+      /// Files beyond @p trusted_size are replaced before they become readable.
+      TileWriterT(Store& store, uint64_t trusted_size) : store(store)
+      {
+        reset_trusted_size(trusted_size);
+      }
+
+      /// @brief Resets this writer after a caller-validated tile prefix.
+      void reset_trusted_size(uint64_t trusted_size)
+      {
+        if (trusted_size % TILE_WIDTH != 0)
+        {
+          throw std::runtime_error(
+            "TileWriter::repair: trusted size is not tile-aligned");
+        }
+
+        std::vector<uint64_t> restored_next_full;
+        std::vector<uint8_t> restored_cursor_inited;
+        for (uint8_t level = 0; level <= MAX_TILE_LEVEL; level++)
+        {
+          const uint64_t entries = entries_at_level(trusted_size, level);
+          if (entries == 0)
+          {
+            break;
+          }
+          const size_t needed = (size_t)level + 1;
+          restored_next_full.resize(needed, 0);
+          restored_cursor_inited.resize(needed, 0);
+          restored_next_full[level] = entries / TILE_WIDTH;
+          restored_cursor_inited[level] = 1;
+        }
+        next_full = std::move(restored_next_full);
+        cursor_inited = std::move(restored_cursor_inited);
+        trust_existing_tiles = false;
+      }
+
+      /// @brief Rebinds a moved writer to its destination store.
+      // members are moved individually so the store reference can be rebound.
+      // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+      TileWriterT(Store& store, TileWriterT&& other) noexcept :
+        store(store),
+        next_full(std::move(other.next_full)),
+        cursor_inited(std::move(other.cursor_inited)),
+        trust_existing_tiles(other.trust_existing_tiles)
+      {
+        if (trust_existing_tiles)
+        {
+          next_full.clear();
+          cursor_inited.clear();
+        }
+      }
+
+      /// @brief Number of complete level-@p level entries for a tree of @p
+      /// size.
+      static uint64_t entries_at_level(uint64_t size, uint8_t level)
+      {
+        const unsigned shift =
+          static_cast<unsigned>(TILE_HEIGHT) * static_cast<unsigned>(level);
+        return shift >= 64 ? 0 : (size >> shift);
+      }
+
+      /// @brief Ensures per-level bookkeeping vectors cover @p level.
+      void ensure_level(uint8_t level)
+      {
+        const size_t needed = (size_t)level + 1;
+        if (next_full.size() < needed)
+        {
+          next_full.resize(needed, 0);
+          cursor_inited.resize(needed, 0);
+        }
+      }
+
+      /// @brief Length of the confirmed contiguous prefix, bounded by @p limit.
+      [[nodiscard]] uint64_t full_prefix_length(uint8_t level, uint64_t limit)
+      {
+        return detail::contiguous_prefix_length(limit, [&](uint64_t index) {
+          return store.confirm_full_tile(level, index);
+        });
+      }
+
+      /// @brief Collects @p count consecutive level-@p level entries, each the
+      /// root of a complete (balanced) subtree.
+      std::vector<Hash> collect(
+        uint8_t level,
+        uint64_t first_entry,
+        uint64_t count,
+        const LeafFn& leaf_at)
+      {
+        std::vector<Hash> out;
+        out.reserve(count);
+        for (uint64_t i = 0; i < count; i++)
+        {
+          const uint64_t g = first_entry + i;
+          if (level == 0)
+          {
+            out.push_back(leaf_at(g));
+          }
+          else
+          {
+            // Roll up the complete child full tile.
+            out.push_back(
+              perfect_root<HASH_SIZE, HASH_FUNCTION>(
+                store.read_tile(TileRef{(uint8_t)(level - 1), g})));
+          }
+        }
+        return out;
+      }
+    };
+
+    /// @brief Abstract source of Merkle subtree roots for proof generation.
+    /// @note Implementations resolve the root of a complete (balanced) subtree
+    /// from tiles, from an in-memory tree, or from a combination of the two.
+    template <
+      size_t HASH_SIZE,
+      void HASH_FUNCTION(
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&)>
+    struct HashSourceT
+    {
+      /// @brief The type of hashes resolved.
+      using Hash = HashT<HASH_SIZE>;
+
+      virtual ~HashSourceT() = default;
+
+      /// @brief Resolves MTH(D[index << level : (index + 1) << level]).
+      /// @param level The subtree height (the subtree spans 2**level leaves)
+      /// @param index The subtree index at that height
+      /// @param out Set to the subtree root on success
+      /// @return Whether the complete, balanced subtree could be resolved
+      virtual bool subtree_root(
+        uint8_t level, uint64_t index, Hash& out) const = 0;
+
+      /// @brief Resolves the level-0 leaf hash at @p index.
+      virtual bool leaf(uint64_t index, Hash& out) const
+      {
+        return subtree_root(0, index, out);
+      }
+    };
+
+    /// @brief Resolves subtree roots from tlog-tiles tile files.
+    /// @tparam HASH_SIZE Size of each hash in bytes
+    /// @tparam HASH_FUNCTION The tree's node hash function
+    /// @tparam TILE_HEIGHT_VALUE Number of tree levels represented by a tile
+    /// @note @p available_size is rounded down to a whole number of full tiles:
+    /// only complete, durably-written full tiles are read. A complete subtree
+    /// within that full-tile prefix is resolvable; anything reaching into the
+    /// incomplete frontier yields false so that a proof builder can fall back
+    /// to another source (e.g. an in-memory tree).
+    /// @warning No internal synchronization is provided. Even const operations
+    /// update the internal LRU cache, so callers must serialize all access to a
+    /// shared source.
+    template <
+      size_t HASH_SIZE,
+      void HASH_FUNCTION(
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&),
+      uint8_t TILE_HEIGHT_VALUE = DEFAULT_TILE_HEIGHT>
+    class TileHashSourceT : public HashSourceT<HASH_SIZE, HASH_FUNCTION>
+    {
+    public:
+      using Hash = HashT<HASH_SIZE>;
+      using Store =
+        TileStoreT<HASH_SIZE, HASH_FUNCTION, TILE_HEIGHT_VALUE>;
+
+      /// @brief The compile-time tile geometry.
+      using Geometry = typename Store::Geometry;
+
+      /// @brief Number of tree levels represented by one tile.
+      static constexpr uint8_t TILE_HEIGHT = Geometry::HEIGHT;
+
+      /// @brief Number of hashes in one full tile.
+      static constexpr size_t TILE_WIDTH = Geometry::WIDTH;
+
+      /// @brief Constructs a source over @p store for trees up to
+      /// @p available_size leaves. @p available_size is rounded down to a whole
+      /// number of full tiles, since only full tiles are durable.
+      TileHashSourceT(const Store& store, uint64_t available_size) :
+        store(store), available_size((available_size / TILE_WIDTH) * TILE_WIDTH)
+      {
+        tile_cache.reserve(TILE_CACHE_SIZE);
+      }
+
+      bool subtree_root(uint8_t level, uint64_t index, Hash& out) const override
+      {
+        // The subtree covers leaves [index << level, (index + 1) << level). It
+        // is resolvable only when it lies entirely within the full-tile-covered
+        // prefix; the incomplete frontier is served from another source.
+        if (level >= 64 || index >= (available_size >> level))
+        {
+          return false;
+        }
+        resolve(level, index, out);
+        return true;
+      }
+
+    protected:
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+      const Store& store;
+      uint64_t available_size; // full-tile prefix length (a multiple of WIDTH)
+
+      /// @brief Combines the @p span entries at @p off of @p tile into a root.
+      static Hash roll_up(
+        const std::vector<Hash>& tile, uint64_t off, uint64_t span)
+      {
+        if (
+          span == 0 || span > TILE_WIDTH || (span & (span - 1)) != 0 ||
+          off > tile.size() || span > tile.size() - off)
+        {
+          throw std::runtime_error("invalid tile roll-up range");
+        }
+        return detail::perfect_root_range<HASH_SIZE, HASH_FUNCTION>(
+          tile, static_cast<size_t>(off), static_cast<size_t>(span));
+      }
+
+      /// @brief Resolves a complete subtree known to lie within the full-tile
+      /// prefix, reading the highest-level full tile that holds it (and rolling
+      /// up); descends to lower full tiles when a higher-level full tile has
+      /// not completed. Terminates because full level-0 tiles always cover the
+      /// prefix.
+      void resolve(uint8_t level, uint64_t index, Hash& out) const
+      {
+        if (level <= TILE_HEIGHT)
+        {
+          // Spans 2**level <= TILE_WIDTH leaves: held by one level-0 tile.
+          const uint64_t span = (uint64_t)1 << level;
+          const uint64_t start = index << level;
+          const std::vector<Hash>& tile =
+            read_tile(TileRef{0, start / TILE_WIDTH});
+          out = roll_up(tile, start % TILE_WIDTH, span);
+          return;
+        }
+
+        const uint8_t L = level / TILE_HEIGHT;
+        const uint8_t r = level % TILE_HEIGHT;
+        const uint64_t first = index << r; // first level-L entry
+        const uint64_t n = first / TILE_WIDTH; // level-L tile index
+        const unsigned full_shift =
+          static_cast<unsigned>(TILE_HEIGHT) * (static_cast<unsigned>(L) + 1U);
+        const uint64_t full_tiles =
+          full_shift >= 64 ? 0 : (available_size >> full_shift);
+
+        if (n < full_tiles)
+        {
+          // One full level-L tile holds all 2**r entries of this subtree.
+          const std::vector<Hash>& tile = read_tile(TileRef{L, n});
+          out = roll_up(tile, first % TILE_WIDTH, (uint64_t)1 << r);
+          return;
+        }
+
+        // No full level-L tile here: split into two level-(level-1) subtrees.
+        Hash lo;
+        Hash hi;
+        resolve((uint8_t)(level - 1), index * 2, lo);
+        resolve((uint8_t)(level - 1), index * 2 + 1, hi);
+        HASH_FUNCTION(lo, hi, out);
+      }
+
+      struct TileCacheEntry
+      {
+        TileRef ref;
+        std::vector<Hash> hashes;
+      };
+
+      static constexpr size_t DEFAULT_TILE_CACHE_SIZE = 64;
+      static constexpr size_t TILE_CACHE_HASH_BUDGET =
+        DEFAULT_TILE_CACHE_SIZE * DEFAULT_TILE_WIDTH;
+      static constexpr size_t TILE_CACHE_SIZE = std::clamp(
+        TILE_CACHE_HASH_BUDGET / TILE_WIDTH,
+        size_t{1},
+        DEFAULT_TILE_CACHE_SIZE);
+      mutable std::vector<TileCacheEntry> tile_cache;
+
+      const std::vector<Hash>& read_tile(const TileRef& ref) const
+      {
+        for (auto it = tile_cache.begin(); it != tile_cache.end(); it++)
+        {
+          if (it->ref.level == ref.level && it->ref.index == ref.index)
+          {
+            TileCacheEntry entry = std::move(*it);
+            tile_cache.erase(it);
+            tile_cache.push_back(std::move(entry));
+            return tile_cache.back().hashes;
+          }
+        }
+
+        if (tile_cache.size() >= TILE_CACHE_SIZE)
+        {
+          tile_cache.erase(tile_cache.begin());
+        }
+        tile_cache.push_back(TileCacheEntry{ref, store.read_tile(ref)});
+        return tile_cache.back().hashes;
+      }
+    };
+
+    /// @brief Builds and verifies inclusion and consistency proofs.
+    /// @note Proofs are assembled from a HashSourceT using the tree's
+    /// HASH_FUNCTION, so an inclusion proof is byte-identical to the one
+    /// produced by merkle::TreeT::path()/past_path() and verifies with
+    /// PathT::verify().
+    /// @warning Thread safety is inherited from the supplied HashSourceT.
+    /// Callers must serialize operations when the source is shared.
+    template <
+      size_t HASH_SIZE,
+      void HASH_FUNCTION(
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&)>
+    class ProofEngineT
+    {
+    public:
+      using Hash = HashT<HASH_SIZE>;
+      using Path = PathT<HASH_SIZE, HASH_FUNCTION>;
+      using Source = HashSourceT<HASH_SIZE, HASH_FUNCTION>;
+
+      explicit ProofEngineT(const Source& source) : source(source) {}
+
+      /// @brief The Merkle root of a tree of @p size leaves.
+      Hash root(uint64_t size) const
+      {
+        if (size == 0)
+        {
+          throw std::runtime_error("empty tree has no root");
+        }
+        Hash out;
+        if (!mth_range(0, size, out))
+        {
+          throw std::runtime_error("unresolved subtree while computing root");
+        }
+        return out;
+      }
+
+      /// @brief Inclusion proof for leaf @p index in a tree of @p size leaves.
+      /// @note Equivalent to TreeT::path(index) when size == num_leaves(), and
+      /// to TreeT::past_path(index, size - 1) otherwise.
+      std::shared_ptr<Path> inclusion_proof(uint64_t index, uint64_t size) const
+      {
+        if (index >= size)
+        {
+          throw std::runtime_error("leaf index out of bounds");
+        }
+        if (
+          index > std::numeric_limits<size_t>::max() ||
+          size - 1 > std::numeric_limits<size_t>::max())
+        {
+          throw std::runtime_error("inclusion proof exceeds PathT index range");
+        }
+
+        std::list<typename Path::Element> elements; // leaf -> root order
+        uint64_t lo = 0;
+        uint64_t hi = size;
+        while (hi - lo > 1)
+        {
+          const uint64_t k = largest_pow2_lt(hi - lo);
+          typename Path::Element e;
+          if (index - lo < k)
+          {
+            if (!mth_range(lo + k, hi, e.hash))
+            {
+              throw std::runtime_error("unresolved subtree in inclusion proof");
+            }
+            e.direction = Path::PATH_RIGHT;
+            hi = lo + k;
+          }
+          else
+          {
+            if (!mth_range(lo, lo + k, e.hash))
+            {
+              throw std::runtime_error("unresolved subtree in inclusion proof");
+            }
+            e.direction = Path::PATH_LEFT;
+            lo = lo + k;
+          }
+          elements.push_front(std::move(e));
+        }
+
+        Hash leaf;
+        if (!source.leaf(index, leaf))
+        {
+          throw std::runtime_error("unresolved leaf in inclusion proof");
+        }
+        return std::make_shared<Path>(
+          leaf,
+          static_cast<size_t>(index),
+          std::move(elements),
+          static_cast<size_t>(size - 1));
+      }
+
+      /// @brief Consistency proof that a tree of @p m leaves is a prefix of a
+      /// tree of @p n leaves (RFC 6962).
+      std::vector<Hash> consistency_proof(uint64_t m, uint64_t n) const
+      {
+        if (m == 0 || m > n)
+        {
+          throw std::runtime_error("invalid consistency proof sizes");
+        }
+        std::vector<Hash> proof;
+        if (m == n)
+        {
+          return proof;
+        }
+        subproof(m, 0, n, true, proof);
+        return proof;
+      }
+
+      /// @brief Consistency proof between the trees whose last leaves are at
+      /// indices @p first_index and @p second_index (first_index <=
+      /// second_index).
+      /// @note Equivalent to consistency_proof(first_index + 1,
+      /// second_index + 1): it proves the tree of the first first_index + 1
+      /// leaves is a prefix of the tree of the first second_index + 1 leaves.
+      std::vector<Hash> consistency_proof_from_indices(
+        uint64_t first_index, uint64_t second_index) const
+      {
+        if (
+          first_index == std::numeric_limits<uint64_t>::max() ||
+          second_index == std::numeric_limits<uint64_t>::max())
+        {
+          throw std::runtime_error("consistency proof index out of bounds");
+        }
+        return consistency_proof(first_index + 1, second_index + 1);
+      }
+
+      /// @brief Verifies an RFC 6962 consistency proof reconciling the roots of
+      /// trees of @p m and @p n leaves.
+      static bool verify_consistency(
+        uint64_t m,
+        uint64_t n,
+        const Hash& first_hash,
+        const Hash& second_hash,
+        const std::vector<Hash>& proof)
+      {
+        if (m > n)
+        {
+          return false;
+        }
+        if (m == n)
+        {
+          return proof.empty() && first_hash == second_hash;
+        }
+        if (m == 0)
+        {
+          return proof.empty();
+        }
+
+        size_t proof_index = 0;
+        Hash fr = first_hash;
+        Hash sr = first_hash;
+        if (!is_pow2(m))
+        {
+          if (proof.empty())
+          {
+            return false;
+          }
+          fr = proof[0];
+          sr = proof[0];
+          proof_index = 1;
+        }
+
+        uint64_t fn = m - 1;
+        uint64_t sn = n - 1;
+        while ((fn & 1) != 0)
+        {
+          fn >>= 1;
+          sn >>= 1;
+        }
+
+        for (size_t i = proof_index; i < proof.size(); i++)
+        {
+          if (sn == 0)
+          {
+            return false;
+          }
+          const Hash& c = proof[i];
+          if ((fn & 1) != 0 || fn == sn)
+          {
+            HASH_FUNCTION(c, fr, fr);
+            HASH_FUNCTION(c, sr, sr);
+            if ((fn & 1) == 0)
+            {
+              while ((fn & 1) == 0 && fn != 0)
+              {
+                fn >>= 1;
+                sn >>= 1;
+              }
+            }
+          }
+          else
+          {
+            HASH_FUNCTION(sr, c, sr);
+          }
+          fn >>= 1;
+          sn >>= 1;
+        }
+
+        return fr == first_hash && sr == second_hash && sn == 0;
+      }
+
+    protected:
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+      const Source& source;
+
+      static bool is_pow2(uint64_t n)
+      {
+        return n != 0 && (n & (n - 1)) == 0;
+      }
+
+      static uint64_t largest_pow2_lt(uint64_t n)
+      {
+        uint64_t k = 1;
+        while (k <= (n - 1) / 2)
+        {
+          k <<= 1;
+        }
+        return k;
+      }
+
+      static uint8_t log2_exact(uint64_t n)
+      {
+        uint8_t r = 0;
+        while (n > 1)
+        {
+          n >>= 1;
+          r++;
+        }
+        return r;
+      }
+
+      /// @brief MTH(D[a:b]) via the source; falls back to splitting when a
+      /// perfect subtree cannot be resolved directly.
+      bool mth_range(uint64_t a, uint64_t b, Hash& out) const
+      {
+        const uint64_t w = b - a;
+        if (w == 0)
+        {
+          return false;
+        }
+        if (w == 1)
+        {
+          return source.leaf(a, out);
+        }
+        if (is_pow2(w) && (a % w == 0))
+        {
+          if (source.subtree_root(log2_exact(w), a / w, out))
+          {
+            return true;
+          }
+        }
+        const uint64_t k = largest_pow2_lt(w);
+        Hash left;
+        Hash right;
+        if (!mth_range(a, a + k, left) || !mth_range(a + k, b, right))
+        {
+          return false;
+        }
+        HASH_FUNCTION(left, right, out);
+        return true;
+      }
+
+      void subproof(
+        uint64_t m,
+        uint64_t lo,
+        uint64_t hi,
+        bool complete,
+        std::vector<Hash>& proof) const
+      {
+        if (m == hi - lo)
+        {
+          if (!complete)
+          {
+            Hash h;
+            if (!mth_range(lo, hi, h))
+            {
+              throw std::runtime_error(
+                "unresolved subtree in consistency proof");
+            }
+            proof.push_back(h);
+          }
+          return;
+        }
+        const uint64_t k = largest_pow2_lt(hi - lo);
+        Hash h;
+        if (m <= k)
+        {
+          subproof(m, lo, lo + k, complete, proof);
+          if (!mth_range(lo + k, hi, h))
+          {
+            throw std::runtime_error("unresolved subtree in consistency proof");
+          }
+        }
+        else
+        {
+          subproof(m - k, lo + k, hi, false, proof);
+          if (!mth_range(lo, lo + k, h))
+          {
+            throw std::runtime_error("unresolved subtree in consistency proof");
+          }
+        }
+        proof.push_back(h);
+      }
+    };
+
+    /// @brief Resolves subtree roots from an in-memory merkle::TreeT.
+    /// @note Resolves only complete subtrees that are fully resident (not
+    /// flushed), returning false otherwise so that a builder can fall back to
+    /// another source. It may materialize pending nodes and compute dirty
+    /// hashes but does not change logical contents or hashing semantics.
+    template <
+      size_t HASH_SIZE,
+      void HASH_FUNCTION(
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&)>
+    class MemoryHashSourceT : public HashSourceT<HASH_SIZE, HASH_FUNCTION>
+    {
+    public:
+      using Hash = HashT<HASH_SIZE>;
+      using Tree = TreeT<HASH_SIZE, HASH_FUNCTION>;
+
+      explicit MemoryHashSourceT(Tree& tree) : tree(tree) {}
+
+      bool subtree_root(uint8_t level, uint64_t index, Hash& out) const override
+      {
+        if (index > std::numeric_limits<size_t>::max())
+        {
+          return false;
+        }
+        const auto root = tree.subtree_root(level, static_cast<size_t>(index));
+        if (!root)
+        {
+          return false;
+        }
+        out = *root;
+        return true;
+      }
+
+    protected:
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+      Tree& tree;
+    };
+
+    /// @brief Resolves subtree roots from a primary source, falling back to a
+    /// secondary source.
+    /// @note Used to combine an in-memory tree (primary: no I/O, serves the
+    /// resident frontier) with tile files (secondary: serve the flushed past).
+    template <
+      size_t HASH_SIZE,
+      void HASH_FUNCTION(
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&)>
+    class CombinedHashSourceT : public HashSourceT<HASH_SIZE, HASH_FUNCTION>
+    {
+    public:
+      using Hash = HashT<HASH_SIZE>;
+      using Source = HashSourceT<HASH_SIZE, HASH_FUNCTION>;
+
+      CombinedHashSourceT(const Source& primary, const Source& secondary) :
+        primary(primary), secondary(secondary)
+      {}
+
+      bool subtree_root(uint8_t level, uint64_t index, Hash& out) const override
+      {
+        return primary.subtree_root(level, index, out) ||
+          secondary.subtree_root(level, index, out);
+      }
+
+    protected:
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+      const Source& primary;
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+      const Source& secondary;
+    };
+
+    /// @brief A merkle tree backed by tlog-tiles storage.
+    /// @tparam HASH_SIZE Size of each hash in bytes
+    /// @tparam HASH_FUNCTION The tree's node hash function
+    /// @tparam TILE_HEIGHT_VALUE Number of tree levels represented by a tile
+    /// @note Appends grow an in-memory tree; flush() durably writes only full
+    /// (balanced) tiles, so the incomplete frontier is never tiled and stays
+    /// resident in memory. Compaction (dropping from memory the leaves already
+    /// covered by a full tile) is optional: enable it per flush with
+    /// Config::compact_on_flush, or call compact() explicitly; it never drops
+    /// the un-tiled frontier. Proofs are served from the combination of the
+    /// resident tree (frontier) and the full tiles (compacted past).
+    /// @note TiledTree constructors create a new tiled tree and atomically claim
+    /// a previously absent tile namespace. from_frontier() restores logical tree
+    /// state while trusting no tiles, so a separate writer can populate or
+    /// repair the namespace before adopt_tile_prefix(). resume() combines those
+    /// steps when a validated tile prefix already exists.
+    /// @warning No internal synchronization is provided. Callers must serialize
+    /// all access to a shared tree, including proof operations.
+    template <
+      size_t HASH_SIZE,
+      void HASH_FUNCTION(
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&),
+      uint8_t TILE_HEIGHT_VALUE = DEFAULT_TILE_HEIGHT>
+    class TiledTreeT
+    {
+    public:
+      using Hash = HashT<HASH_SIZE>;
+      using Tree = TreeT<HASH_SIZE, HASH_FUNCTION>;
+      using Path = PathT<HASH_SIZE, HASH_FUNCTION>;
+      using Store =
+        TileStoreT<HASH_SIZE, HASH_FUNCTION, TILE_HEIGHT_VALUE>;
+      using Writer =
+        TileWriterT<HASH_SIZE, HASH_FUNCTION, TILE_HEIGHT_VALUE>;
+      using Stats = typename Writer::Stats;
+      using Geometry = typename Store::Geometry;
+
+      /// @brief Number of tree levels represented by one tile.
+      static constexpr uint8_t TILE_HEIGHT = Geometry::HEIGHT;
+
+      /// @brief Number of hashes in one full tile.
+      static constexpr size_t TILE_WIDTH = Geometry::WIDTH;
+
+      // This wrapper mirrors the core tree's index type on its own public
+      // surface, so leaf counts and indices pass through untouched and cross
+      // conventions only when they reach the tile layer.
+      static_assert(
+        std::is_same_v<decltype(Tree().num_leaves()), size_t>,
+        "TiledTreeT exposes TreeT's leaf counts and indices as size_t; adjust "
+        "its public surface if TreeT changes index type");
+
+      /// @brief Configuration for a tiled tree.
+      struct Config
+      {
+        /// @brief Root directory for the tiled tree.
+        /// @note Fresh construction requires the algorithm-qualified tile
+        /// subdirectory to be absent; resume() requires it to exist.
+        /// from_frontier() does not inspect or create it.
+        std::filesystem::path prefix;
+
+        /// @brief Number of most-recent leaves to keep resident when
+        /// compacting (i.e. a minimum never dropped from memory).
+        /// @note Tile alignment may retain up to TILE_WIDTH - 1 additional
+        /// tiled leaves. A zero margin retains one tiled boundary leaf so
+        /// rollback to exactly immutable_size() remains possible.
+        size_t retention_margin = 0;
+
+        /// @brief If set, flush() compacts after writing tiles, dropping
+        /// from memory the leaves already covered by a full tile. Off by
+        /// default: tiles are written but the tree keeps every leaf resident.
+        bool compact_on_flush = false;
+      };
+
+      /// @brief Restores logical tree state without trusting any tile files.
+      /// @param config Runtime configuration, including the tile prefix
+      /// @param hash_algorithm_short_name Lowercase hash algorithm namespace
+      /// @param serialised_tree Serialized merkle::TreeT state
+      /// @return A tree with flushed_size() and immutable_size() equal to zero
+      /// @note This does not inspect, create, or claim the tile namespace.
+      /// Existing files remain untrusted. Root computation and appends are
+      /// available immediately, but tile-dependent proofs and flushes of
+      /// non-resident history throw until a complete prefix is adopted.
+      /// @warning The caller must establish exclusive ownership of the
+      /// configured namespace.
+      [[nodiscard]] static TiledTreeT from_frontier(
+        Config config,
+        const std::string& hash_algorithm_short_name,
+        const std::vector<uint8_t>& serialised_tree)
+      {
+        return TiledTreeT(
+          FrontierTag{},
+          std::move(config),
+          hash_algorithm_short_name,
+          serialised_tree);
+      }
+
+      /// @brief Resumes a tiled tree from serialized tree state and an existing
+      /// tile namespace.
+      /// @param config Runtime configuration, including the tile prefix
+      /// @param hash_algorithm_short_name Lowercase hash algorithm namespace
+      /// @param serialised_tree Serialized merkle::TreeT state
+      /// @param full_tile_boundary Number of leaves covered by a complete,
+      /// durable tile prefix
+      /// @return A tiled tree whose tile reads are capped at
+      /// @p full_tile_boundary
+      /// @note The serialized tree is deserialized by this call. At every tile
+      /// level, all full tiles below @p full_tile_boundary must already exist,
+      /// be durable, and belong to the same tree. Existing files beyond that
+      /// boundary are not trusted and are replaced when a later flush reaches
+      /// them.
+      [[nodiscard]] static TiledTreeT resume(
+        Config config,
+        const std::string& hash_algorithm_short_name,
+        const std::vector<uint8_t>& serialised_tree,
+        size_t full_tile_boundary)
+      {
+        return resume(
+          std::move(config),
+          hash_algorithm_short_name,
+          serialised_tree,
+          full_tile_boundary,
+          full_tile_boundary);
+      }
+
+      /// @brief Resumes a tiled tree after an interrupted flush.
+      /// @param config Runtime configuration, including the tile prefix
+      /// @param hash_algorithm_short_name Lowercase hash algorithm namespace
+      /// @param serialised_tree Serialized merkle::TreeT state
+      /// @param flushed_tile_boundary Number of leaves covered by the last
+      /// complete, durable tile prefix
+      /// @param immutable_boundary Rollback seal for tiles that may have been
+      /// published by an interrupted flush
+      /// @return A tiled tree whose proof reads are capped at
+      /// @p flushed_tile_boundary and whose rollback seal is
+      /// @p immutable_boundary
+      /// @note The complete prefix is verified against the serialized frontier.
+      /// Tiles between the two boundaries remain untrusted and are replaced by
+      /// the next flush.
+      [[nodiscard]] static TiledTreeT resume(
+        Config config,
+        const std::string& hash_algorithm_short_name,
+        const std::vector<uint8_t>& serialised_tree,
+        size_t flushed_tile_boundary,
+        size_t immutable_boundary)
+      {
+        return TiledTreeT(
+          ResumeTag{},
+          std::move(config),
+          hash_algorithm_short_name,
+          serialised_tree,
+          flushed_tile_boundary,
+          immutable_boundary);
+      }
+
+      explicit TiledTreeT(Config config) :
+        config(std::move(config)), store(this->config.prefix), writer(store)
+      {
+        claim_tile_namespace();
+      }
+
+      /// @brief Constructs a tiled tree with an explicit storage namespace.
+      /// @note Required for custom hash functions whose algorithm name cannot
+      /// be inferred by TileStoreT.
+      TiledTreeT(Config config, const std::string& hash_algorithm_short_name) :
+        config(std::move(config)),
+        store(this->config.prefix, hash_algorithm_short_name),
+        writer(store)
+      {
+        claim_tile_namespace();
+      }
+
+      TiledTreeT(const TiledTreeT&) = delete;
+      TiledTreeT& operator=(const TiledTreeT&) = delete;
+
+      /// @brief Moves a tiled tree, rebinding its writer to the moved store.
+      TiledTreeT(TiledTreeT&& other) noexcept :
+        config(std::move(other.config)),
+        store(std::move(other.store)),
+        writer(store, std::move(other.writer)),
+        tree(std::move(other.tree)),
+        tiles_size(std::exchange(other.tiles_size, 0)),
+        sealed_size(std::exchange(other.sealed_size, 0))
+      {}
+
+      TiledTreeT& operator=(TiledTreeT&&) = delete;
+
+      /// @brief Appends a leaf hash.
+      void append(const Hash& leaf_hash)
+      {
+        tree.insert(leaf_hash);
+      }
+
+      /// @brief The number of leaves (including flushed ones).
+      [[nodiscard]] size_t size() const
+      {
+        return tree.num_leaves();
+      }
+
+      /// @brief The current Merkle root.
+      Hash root()
+      {
+        return tree.root();
+      }
+
+      /// @brief The number of leaves covered by the last fully successful
+      /// flush.
+      /// @note This is always a multiple of TILE_WIDTH. It advances only after
+      /// every required tile level has been written successfully, and controls
+      /// proof reads and compaction.
+      [[nodiscard]] size_t flushed_size() const
+      {
+        return tiles_size;
+      }
+
+      /// @brief The rollback seal for ranges a flush may have published.
+      /// @note A flush seals its full-tile boundary before writing. If the
+      /// write fails, this may exceed flushed_size(); keep the same tree
+      /// contents and retry the flush.
+      [[nodiscard]] size_t immutable_size() const
+      {
+        return sealed_size;
+      }
+
+      /// @brief Access to the underlying tree.
+      /// @warning Mutating the tree directly bypasses tiled-tree bookkeeping.
+      /// In particular, direct retraction can make flushed_size() and
+      /// immutable_size() exceed size() and can make flushed_size() regress.
+      /// Use TiledTreeT operations whenever they are available.
+      Tree& tree_ref()
+      {
+        return tree;
+      }
+
+      /// @brief Access to the underlying tile store.
+      /// @warning Files changed within flushed_size() are used by proofs without
+      /// checking that their hashes match this tree. Mismatched files can
+      /// silently invalidate proofs after compaction.
+      Store& store_ref()
+      {
+        return store;
+      }
+
+      /// @brief Adopts a complete, durable tile prefix produced independently.
+      /// @param full_tile_boundary Tile-aligned number of covered leaves
+      /// @note The caller must quiesce every writer for this namespace before
+      /// calling. Every required full tile below the boundary is verified
+      /// against the serialized frontier. Adoption is monotonic, does not
+      /// compact, and keeps files beyond the new boundary untrusted so later
+      /// flushes replace them.
+      void adopt_tile_prefix(size_t full_tile_boundary)
+      {
+        if (full_tile_boundary < sealed_size)
+        {
+          throw std::runtime_error(
+            "TiledTree::adopt_tile_prefix: boundary precedes immutable tiles");
+        }
+        validate_tile_prefix(full_tile_boundary);
+        writer.reset_trusted_size(
+          static_cast<uint64_t>(full_tile_boundary));
+        tiles_size = full_tile_boundary;
+        sealed_size = full_tile_boundary;
+      }
+
+      /// @brief Writes newly-complete full tiles to disk; compacts only if
+      /// Config::compact_on_flush is set.
+      /// @return Counts of the full tiles written by this flush
+      /// @note The full-tile boundary is made immutable before any tile write.
+      /// Only after every required tile level succeeds does flushed_size()
+      /// advance to that boundary. On failure, immutable_size() may advance
+      /// while flushed_size() does not; the tree remains resident and the flush
+      /// can be retried without rewriting finalized tiles.
+      Stats flush()
+      {
+        return flush_up_to(tree.num_leaves());
+      }
+
+      /// @brief Writes newly-complete full tiles within a committed prefix.
+      /// @param leaf_count Number of leaves in the prefix that may be made
+      /// immutable
+      /// @return Counts of the full tiles written by this flush
+      /// @note This never writes or seals a complete tile beyond
+      /// @p leaf_count, even when the logical tree contains more leaves.
+      /// Requests below flushed_size() are monotonic no-ops. Compaction, when
+      /// configured, only drops leaves covered by the resulting flushed_size().
+      Stats flush_up_to(size_t leaf_count)
+      {
+        Stats stats;
+        const size_t n = tree.num_leaves();
+        if (leaf_count > n)
+        {
+          throw std::runtime_error(
+            "TiledTree::flush_up_to: leaf count exceeds tree size");
+        }
+
+        const size_t covered = (leaf_count / TILE_WIDTH) * TILE_WIDTH;
+        if (covered < tiles_size)
+        {
+          return stats;
+        }
+        if (!has_complete_history())
+        {
+          throw std::runtime_error(
+            "TiledTree::flush_up_to: tile prefix does not overlap the "
+            "resident tree");
+        }
+        if (covered > sealed_size)
+        {
+          sealed_size = covered;
+        }
+
+        stats =
+          writer.write_up_to(leaf_count, [this](uint64_t i) -> const Hash& {
+            if (i < tree.min_index())
+            {
+              throw std::runtime_error(std::format(
+                "TiledTree::flush_up_to: cannot regenerate a missing or "
+                "malformed tile from non-resident leaf {}",
+                i));
+            }
+            return tree.leaf((size_t)i);
+          });
+        tiles_size = covered;
+
+        if (config.compact_on_flush)
+        {
+          compact();
+        }
+        return stats;
+      }
+
+      /// @brief Drops old leaves covered by durably-written full tiles, keeping
+      /// at least retention_margin recent leaves and a tiled boundary leaf.
+      /// @return The new minimum (smallest still-resident) leaf index
+      /// @note Only leaves covered by a full tile are dropped, so the un-tiled
+      /// frontier is always retained in memory and inclusion/consistency proofs
+      /// remain available (the past from tiles, the frontier from memory). The
+      /// leaf at flushed_size() - 1 also remains resident so retract_to() can
+      /// represent a tree whose size is exactly immutable_size(). Has no effect
+      /// until tiling has produced full tiles.
+      size_t compact()
+      {
+        const size_t covered = (tiles_size / TILE_WIDTH) * TILE_WIDTH;
+        const size_t target = compaction_target(covered);
+        if (target > tree.min_index())
+        {
+          tree.flush_to(target);
+        }
+        return tree.min_index();
+      }
+
+      /// @brief Rolls the tree back so that @p index becomes the last leaf,
+      /// removing all leaves after it (same semantics as TreeT::retract_to).
+      /// @note Only full tiles are immutable: this throws if the resulting size
+      /// would be smaller than immutable_size(). A failed flush may advance
+      /// immutable_size() without advancing flushed_size().
+      void retract_to(size_t index)
+      {
+        if (sealed_size > 0 && index < sealed_size - 1)
+        {
+          throw std::runtime_error(
+            "TiledTree::retract_to: cannot roll back entries sealed for "
+            "immutable tiles (resulting size < immutable size)");
+        }
+        tree.retract_to(index);
+      }
+
+      /// @brief Inclusion proof for @p index in a tree of @p proof_size leaves.
+      /// @note Served from tiles (flushed past) combined with the resident tree
+      /// (recent frontier); @p proof_size may exceed flushed_size().
+      std::shared_ptr<Path> inclusion_proof(size_t index, size_t proof_size)
+      {
+        if (proof_size > size())
+        {
+          throw std::runtime_error(
+            "inclusion proof size exceeds current tree size");
+        }
+        return with_engine([&](const auto& engine) {
+          return engine.inclusion_proof(index, proof_size);
+        });
+      }
+
+      /// @brief Consistency proof between tree sizes @p m and @p n.
+      std::vector<Hash> consistency_proof(size_t m, size_t n)
+      {
+        if (n > size())
+        {
+          throw std::runtime_error(
+            "consistency proof size exceeds current tree size");
+        }
+        return with_engine(
+          [&](const auto& engine) { return engine.consistency_proof(m, n); });
+      }
+
+      /// @brief Consistency proof between the trees whose last leaves are at
+      /// indices @p first_index and @p second_index (first_index <=
+      /// second_index).
+      /// @note Equivalent to consistency_proof(first_index + 1,
+      /// second_index + 1).
+      std::vector<Hash> consistency_proof_from_indices(
+        size_t first_index, size_t second_index)
+      {
+        if (first_index >= size() || second_index >= size())
+        {
+          throw std::runtime_error(
+            "consistency proof index exceeds current tree size");
+        }
+        if (first_index > second_index)
+        {
+          throw std::runtime_error(
+            "first consistency proof index exceeds second index");
+        }
+        return with_engine([&](const auto& engine) {
+          return engine.consistency_proof_from_indices(
+            first_index, second_index);
+        });
+      }
+
+    protected:
+      struct FrontierTag
+      {};
+
+      struct ResumeTag
+      {};
+
+      Config config;
+      Store store;
+      Writer writer;
+      Tree tree;
+      size_t tiles_size = 0;
+      size_t sealed_size = 0;
+
+      TiledTreeT(
+        [[maybe_unused]] FrontierTag tag,
+        Config config,
+        const std::string& hash_algorithm_short_name,
+        const std::vector<uint8_t>& serialised_tree) :
+        config(std::move(config)),
+        store(this->config.prefix, hash_algorithm_short_name),
+        writer(store, 0),
+        tree(deserialise_tree(serialised_tree))
+      {
+        validate_frontier();
+      }
+
+      TiledTreeT(
+        [[maybe_unused]] ResumeTag tag,
+        Config config,
+        const std::string& hash_algorithm_short_name,
+        const std::vector<uint8_t>& serialised_tree,
+        size_t flushed_tile_boundary,
+        size_t immutable_boundary) :
+        TiledTreeT(
+          FrontierTag{},
+          std::move(config),
+          hash_algorithm_short_name,
+          serialised_tree)
+      {
+        restore_tile_boundaries(flushed_tile_boundary, immutable_boundary);
+      }
+
+      static Tree deserialise_tree(const std::vector<uint8_t>& serialised_tree)
+      {
+        size_t position = 0;
+        Tree restored(serialised_tree, position);
+        if (position != serialised_tree.size())
+        {
+          throw std::runtime_error(
+            "TiledTree: trailing bytes in serialized tree");
+        }
+        return restored;
+      }
+
+      void validate_frontier()
+      {
+        if (!tree.invariant())
+        {
+          throw std::runtime_error(
+            "TiledTree: deserialized tree invariant failed");
+        }
+      }
+
+      void validate_tile_prefix(size_t full_tile_boundary)
+      {
+        validate_frontier();
+        const auto tile_root = store.root() / "tile";
+        std::error_code ec;
+        if (!std::filesystem::is_directory(tile_root, ec) || ec)
+        {
+          throw std::runtime_error(std::format(
+            "TiledTree: tile namespace does not exist: {}",
+            tile_root.string()));
+        }
+        if (full_tile_boundary % TILE_WIDTH != 0)
+        {
+          throw std::runtime_error(
+            "TiledTree: tile boundary is not aligned");
+        }
+        if (full_tile_boundary > tree.num_leaves())
+        {
+          throw std::runtime_error(
+            "TiledTree: tile boundary exceeds tree size");
+        }
+        if (full_tile_boundary == 0)
+        {
+          if (tree.min_index() != 0)
+          {
+            throw std::runtime_error(
+              "TiledTree: compacted tree has no tile "
+              "coverage");
+          }
+          return;
+        }
+        const size_t required_resident_leaves =
+          std::min(config.retention_margin, full_tile_boundary);
+        const size_t latest_resident_start =
+          full_tile_boundary -
+          std::max(required_resident_leaves, size_t{1});
+        if (tree.min_index() > latest_resident_start)
+        {
+          throw std::runtime_error(
+            "TiledTree: tree does not satisfy the configured "
+            "retention margin");
+        }
+
+        store.begin_write_attempt();
+        for (uint8_t level = 0; level <= MAX_TILE_LEVEL; level++)
+        {
+          const uint64_t entries = Writer::entries_at_level(
+            static_cast<uint64_t>(full_tile_boundary), level);
+          if (entries == 0)
+          {
+            break;
+          }
+
+          const uint64_t full_tiles = entries / TILE_WIDTH;
+          for (uint64_t tile_index = 0; tile_index < full_tiles; tile_index++)
+          {
+            const auto hashes = read_required_tile(level, tile_index);
+            if (level == 0)
+            {
+              continue;
+            }
+
+            const uint64_t first_child = tile_index * TILE_WIDTH;
+            for (uint64_t offset = 0; offset < TILE_WIDTH; offset++)
+            {
+              const auto child =
+                read_required_tile((uint8_t)(level - 1), first_child + offset);
+              const auto expected =
+                perfect_root<HASH_SIZE, HASH_FUNCTION>(child);
+              if (hashes[(size_t)offset] != expected)
+              {
+                throw std::runtime_error(std::format(
+                  "TiledTree: tile roll-up mismatch at "
+                  "level {}, index {}, entry {}",
+                  static_cast<unsigned>(level),
+                  tile_index,
+                  offset));
+              }
+            }
+          }
+        }
+
+        TileHashSourceT<HASH_SIZE, HASH_FUNCTION, TILE_HEIGHT_VALUE> tile_source(
+          store, static_cast<uint64_t>(full_tile_boundary));
+        ProofEngineT<HASH_SIZE, HASH_FUNCTION> engine(tile_source);
+        const Hash tile_root_hash =
+          engine.root(static_cast<uint64_t>(full_tile_boundary));
+        const Hash frontier_root_hash =
+          *tree.past_root(full_tile_boundary - 1);
+        if (tile_root_hash != frontier_root_hash)
+        {
+          throw std::runtime_error(
+            "TiledTree: tile prefix root does not match "
+            "the serialized frontier");
+        }
+      }
+
+      [[nodiscard]] std::vector<Hash> read_required_tile(
+        uint8_t level, uint64_t index)
+      {
+        if (!store.confirm_full_tile(level, index))
+        {
+          throw std::runtime_error(std::format(
+            "TiledTree: missing or malformed tile at "
+            "level {}, index {}",
+            static_cast<unsigned>(level),
+            index));
+        }
+        return store.read_tile(TileRef{level, index});
+      }
+
+      void restore_tile_boundaries(
+        size_t flushed_tile_boundary, size_t immutable_boundary)
+      {
+        if (immutable_boundary % TILE_WIDTH != 0)
+        {
+          throw std::runtime_error(
+            "TiledTree::resume: immutable boundary is not tile-aligned");
+        }
+        if (immutable_boundary < flushed_tile_boundary)
+        {
+          throw std::runtime_error(
+            "TiledTree::resume: immutable boundary precedes flushed tiles");
+        }
+        const size_t covered =
+          (tree.num_leaves() / TILE_WIDTH) * TILE_WIDTH;
+        if (immutable_boundary > covered)
+        {
+          throw std::runtime_error(
+            "TiledTree::resume: immutable boundary exceeds tree size");
+        }
+
+        validate_tile_prefix(flushed_tile_boundary);
+        writer.reset_trusted_size(
+          static_cast<uint64_t>(flushed_tile_boundary));
+        tiles_size = flushed_tile_boundary;
+        sealed_size = immutable_boundary;
+      }
+
+      [[nodiscard]] bool has_complete_history() const
+      {
+        return tree.min_index() == 0 || tiles_size > tree.min_index();
+      }
+
+      [[nodiscard]] size_t compaction_target(size_t covered) const
+      {
+        size_t target = covered > config.retention_margin ?
+          covered - config.retention_margin :
+          0;
+        target = (target / TILE_WIDTH) * TILE_WIDTH;
+        // TreeT cannot retract below min_index(). Keep the final tiled leaf
+        // resident so rollback to a size of exactly immutable_size() remains
+        // representable after compaction.
+        if (covered > 0 && target == covered)
+        {
+          target--;
+        }
+        return target;
+      }
+
+      void claim_tile_namespace() const
+      {
+        const auto tile_root = store.root() / "tile";
+        std::error_code ec;
+        std::filesystem::create_directories(tile_root.parent_path(), ec);
+        if (ec)
+        {
+          throw std::runtime_error(std::format(
+            "TiledTree: cannot create tile namespace parent {}: {}",
+            tile_root.parent_path().string(),
+            ec.message()));
+        }
+        const bool claimed = std::filesystem::create_directory(tile_root, ec);
+        if (ec)
+        {
+          throw std::runtime_error(std::format(
+            "TiledTree: cannot claim tile namespace {}: {}",
+            tile_root.string(),
+            ec.message()));
+        }
+        if (!claimed)
+        {
+          throw std::runtime_error(
+            "TiledTree: tile namespace already exists; reopening or sharing "
+            "a tiled tree is not supported");
+        }
+      }
+
+      /// @brief Builds a proof engine over the combined resident-tree
+      /// (frontier) and full-tile (flushed past) source, and invokes @p fn with
+      /// it.
+      /// @note The sources and engine are stack-local; @p fn must consume the
+      /// engine before returning (proofs are returned by value, holding hash
+      /// copies, so the result outlives the engine).
+      template <typename Fn>
+      auto with_engine(Fn fn)
+      {
+        if (!has_complete_history())
+        {
+          throw std::runtime_error(
+            "TiledTree: tile prefix does not overlap the resident tree");
+        }
+        MemoryHashSourceT<HASH_SIZE, HASH_FUNCTION> mem(tree);
+        TileHashSourceT<HASH_SIZE, HASH_FUNCTION, TILE_HEIGHT_VALUE> tile_src(
+          store, tiles_size);
+        CombinedHashSourceT<HASH_SIZE, HASH_FUNCTION> combined(mem, tile_src);
+        ProofEngineT<HASH_SIZE, HASH_FUNCTION> engine(combined);
+        return fn(engine);
+      }
+    };
+
+    /// @brief Writes tlog-tiles entry bundles (raw log entries) for a growing
+    /// log.
+    /// @tparam HASH_SIZE Size of each hash in bytes
+    /// @tparam HASH_FUNCTION The tree's node hash function
+    /// @tparam TILE_HEIGHT_VALUE Number of tree levels represented by a bundle
+    /// @note Entry bundles are level-0 only and application-owned: merklecpp
+    /// stores leaf hashes, while the raw entries (and the leaf-hash derivation
+    /// linking each entry to its level-0 tile hash) are the application's
+    /// responsibility. Only full bundles (TILE_WIDTH entries) are written; they
+    /// are immutable and written exactly once. The incomplete tail stays with
+    /// the application until it grows into a full bundle, mirroring the
+    /// un-tiled Merkle frontier.
+    /// @warning No internal synchronization is provided. Callers must serialize
+    /// access to a writer and its store.
+    template <
+      size_t HASH_SIZE,
+      void HASH_FUNCTION(
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&),
+      uint8_t TILE_HEIGHT_VALUE>
+    class EntryBundleWriterT
+    {
+    public:
+      using Store =
+        TileStoreT<HASH_SIZE, HASH_FUNCTION, TILE_HEIGHT_VALUE>;
+      using Geometry = typename Store::Geometry;
+
+      /// @brief Number of tree levels represented by one bundle.
+      static constexpr uint8_t TILE_HEIGHT = Geometry::HEIGHT;
+
+      /// @brief Number of entries in one full bundle.
+      static constexpr size_t TILE_WIDTH = Geometry::WIDTH;
+
+      /// @brief Supplies the raw bytes of the log entry at a given index.
+      using EntryFn = std::function<std::vector<uint8_t>(uint64_t)>;
+
+      /// @brief Counts of work performed by a write_up_to call.
+      struct Stats
+      {
+        /// @brief Number of full bundles written.
+        uint64_t full_written = 0;
+      };
+
+      explicit EntryBundleWriterT(Store& store) : store(store) {}
+
+      /// @brief Writes all newly-complete full bundles for a log of @p size
+      /// entries.
+      /// @param size The current number of entries
+      /// @param entry_at Returns the raw bytes of the entry at an index in
+      /// [0, size); only ever queried for entries of complete bundles.
+      /// @return Counts of bundles written
+      /// @note Incremental: full bundles already on disk are immutable and are
+      /// never rewritten once validated and confirmed durable. Malformed files
+      /// are replaced. The incomplete tail is never bundled.
+      Stats write_up_to(uint64_t size, const EntryFn& entry_at)
+      {
+        Stats stats;
+        store.begin_write_attempt();
+        const uint64_t full = size / TILE_WIDTH;
+
+        if (!cursor_inited)
+        {
+          next_full = full_prefix_length(full);
+          cursor_inited = true;
+        }
+
+        for (uint64_t n = next_full; n < full; n++)
+        {
+          if (store.confirm_entry_bundle(n))
+          {
+            continue; // immutable: never rewrite an existing full bundle
+          }
+          store.write_entry_bundle(
+            n, collect(n * TILE_WIDTH, TILE_WIDTH, entry_at));
+          stats.full_written++;
+        }
+        if (full > next_full)
+        {
+          next_full = full;
+        }
+        return stats;
+      }
+
+    protected:
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+      Store& store;
+      uint64_t next_full = 0;
+      bool cursor_inited = false;
+
+      std::vector<std::vector<uint8_t>> collect(
+        uint64_t first, uint64_t count, const EntryFn& entry_at)
+      {
+        std::vector<std::vector<uint8_t>> out;
+        out.reserve(count);
+        for (uint64_t i = 0; i < count; i++)
+        {
+          out.push_back(entry_at(first + i));
+        }
+        return out;
+      }
+
+      [[nodiscard]] uint64_t full_prefix_length(uint64_t limit)
+      {
+        return detail::contiguous_prefix_length(limit, [&](uint64_t index) {
+          return store.confirm_entry_bundle(index);
+        });
+      }
+    };
+
+    /// @brief Default tile store (SHA256, default hash function).
+    using TileStore =
+      TileStoreT<
+        merkle::Tree::Hash::size_bytes,
+        merkle::Tree::hash_function,
+        DEFAULT_TILE_HEIGHT>;
+
+    /// @brief Default tile writer (SHA256, default hash function).
+    using TileWriter =
+      TileWriterT<
+        merkle::Tree::Hash::size_bytes,
+        merkle::Tree::hash_function,
+        DEFAULT_TILE_HEIGHT>;
+
+    /// @brief Default abstract hash source (SHA256, default hash function).
+    using HashSource =
+      HashSourceT<merkle::Tree::Hash::size_bytes, merkle::Tree::hash_function>;
+
+    /// @brief Default tile-backed hash source (SHA256, default hash function).
+    using TileHashSource = TileHashSourceT<
+      merkle::Tree::Hash::size_bytes,
+      merkle::Tree::hash_function,
+      DEFAULT_TILE_HEIGHT>;
+
+    /// @brief Default proof engine (SHA256, default hash function).
+    using ProofEngine =
+      ProofEngineT<merkle::Tree::Hash::size_bytes, merkle::Tree::hash_function>;
+
+    /// @brief Default in-memory hash source (SHA256, default hash function).
+    using MemoryHashSource = MemoryHashSourceT<
+      merkle::Tree::Hash::size_bytes,
+      merkle::Tree::hash_function>;
+
+    /// @brief Default combined hash source (SHA256, default hash function).
+    using CombinedHashSource = CombinedHashSourceT<
+      merkle::Tree::Hash::size_bytes,
+      merkle::Tree::hash_function>;
+
+    /// @brief Default tiled tree (SHA256, default hash function).
+    using TiledTree =
+      TiledTreeT<
+        merkle::Tree::Hash::size_bytes,
+        merkle::Tree::hash_function,
+        DEFAULT_TILE_HEIGHT>;
+
+    /// @brief Default entry-bundle writer (SHA256, default hash function).
+    using EntryBundleWriter = EntryBundleWriterT<
+      merkle::Tree::Hash::size_bytes,
+      merkle::Tree::hash_function,
+      DEFAULT_TILE_HEIGHT>;
+
+#ifdef HAVE_OPENSSL
+    /// @brief SHA384 tile store.
+    using TileStore384 =
+      TileStoreT<48, sha384_openssl, DEFAULT_TILE_HEIGHT>;
+
+    /// @brief SHA512 tile store.
+    using TileStore512 =
+      TileStoreT<64, sha512_openssl, DEFAULT_TILE_HEIGHT>;
+
+    /// @brief SHA384 tile writer.
+    using TileWriter384 =
+      TileWriterT<48, sha384_openssl, DEFAULT_TILE_HEIGHT>;
+
+    /// @brief SHA512 tile writer.
+    using TileWriter512 =
+      TileWriterT<64, sha512_openssl, DEFAULT_TILE_HEIGHT>;
+
+    /// @brief SHA384 hash source, tile-backed source and proof engine.
+    using HashSource384 = HashSourceT<48, sha384_openssl>;
+    using TileHashSource384 =
+      TileHashSourceT<48, sha384_openssl, DEFAULT_TILE_HEIGHT>;
+    using ProofEngine384 = ProofEngineT<48, sha384_openssl>;
+
+    /// @brief SHA512 hash source, tile-backed source and proof engine.
+    using HashSource512 = HashSourceT<64, sha512_openssl>;
+    using TileHashSource512 =
+      TileHashSourceT<64, sha512_openssl, DEFAULT_TILE_HEIGHT>;
+    using ProofEngine512 = ProofEngineT<64, sha512_openssl>;
+
+    /// @brief SHA384 memory/combined sources and tiled tree.
+    using MemoryHashSource384 = MemoryHashSourceT<48, sha384_openssl>;
+    using CombinedHashSource384 = CombinedHashSourceT<48, sha384_openssl>;
+    using TiledTree384 =
+      TiledTreeT<48, sha384_openssl, DEFAULT_TILE_HEIGHT>;
+
+    /// @brief SHA512 memory/combined sources and tiled tree.
+    using MemoryHashSource512 = MemoryHashSourceT<64, sha512_openssl>;
+    using CombinedHashSource512 = CombinedHashSourceT<64, sha512_openssl>;
+    using TiledTree512 =
+      TiledTreeT<64, sha512_openssl, DEFAULT_TILE_HEIGHT>;
+
+    /// @brief SHA384/512 entry-bundle writers.
+    using EntryBundleWriter384 =
+      EntryBundleWriterT<48, sha384_openssl, DEFAULT_TILE_HEIGHT>;
+    using EntryBundleWriter512 =
+      EntryBundleWriterT<64, sha512_openssl, DEFAULT_TILE_HEIGHT>;
+#endif
+  }
+}

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -95,8 +95,8 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/microsoft/merklecpp",
-          "commitHash": "30d1dc7dc3b46b7da71124fb8df385a8b67ef59b",
-          "tag": "v1.1.1"
+          "commitHash": "8be8cf393ebec13c8939af21c08a6a52abb5069c",
+          "tag": "v1.1.5"
         }
       }
     },


### PR DESCRIPTION
Update merklecpp from v1.1.1 to [v1.1.5](https://github.com/microsoft/merklecpp/releases/tag/v1.1.5), bringing upstream deserialisation bounds and exception-safety improvements, tree/path correctness fixes, and tiled-storage APIs.

Vendor all three upstream library headers (`merklecpp.h`, `merklecpp_pal.h`, and `merklecpp_tiles.h`) from commit `8be8cf393ebec13c8939af21c08a6a52abb5069c` without local modifications, and update the matching commit and tag in `cgmanifest.json`.

The tiled-storage and platform headers are included for use by CCF. This does not switch CCF's existing history implementation to tiled storage: it retains its explicit SHA-256 callback, so the upstream change to the default tree hash does not affect CCF's hashing.

Upstream changes: https://github.com/microsoft/merklecpp/compare/v1.1.1...v1.1.5