### PR TITLE
Fix null certificate crash on unsecured TLS server interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Reaching the soft session cap on an unsecured RPC interface no longer terminates the node by attempting a TLS handshake without a certificate.
 - Transactions from an earlier view are now rejected before entering the replication queue even after the node has stepped down. This prevents rolled-back writes from being replicated after a later election and blocking subsequent replication (#8293, #8295).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Reaching the soft session cap on an unsecured RPC interface no longer terminates the node by attempting a TLS handshake without a certificate.
+- Reaching the soft session cap on an unsecured RPC interface no longer terminates the node by attempting a TLS handshake without a certificate. (#8331)
 - Transactions from an earlier view are now rejected before entering the replication queue even after the node has stepped down. This prevents rolled-back writes from being replicated after a later election and blocking subsequent replication (#8293, #8295).
 
 ### Changed

--- a/src/enclave/rpc_sessions.h
+++ b/src/enclave/rpc_sessions.h
@@ -314,10 +314,11 @@ namespace ccf
       }
 
       auto& per_listen_interface = it->second;
+      const auto unsecured =
+        per_listen_interface.endorsement.authority == Authority::UNSECURED;
+      const auto cert_it = certs.find(listen_interface_id);
 
-      if (
-        per_listen_interface.endorsement.authority != Authority::UNSECURED &&
-        certs.find(listen_interface_id) == certs.end())
+      if (!unsecured && cert_it == certs.end())
       {
         LOG_DEBUG_FMT(
           "Refusing TLS session {} inside the enclave - interface {} "
@@ -355,7 +356,17 @@ namespace ccf
           listen_interface_id,
           per_listen_interface.max_open_sessions_soft);
 
-        auto ctx = std::make_unique<::tls::Server>(certs[listen_interface_id]);
+        std::unique_ptr<tls::Context> ctx;
+        if (unsecured)
+        {
+          ctx = std::make_unique<nontls::PlaintextServer>();
+        }
+        else
+        {
+          ctx = std::make_unique<::tls::Server>(
+            cert_it->second, per_listen_interface.app_protocol == "HTTP2");
+        }
+
         std::shared_ptr<Session> capped_session;
         if (per_listen_interface.app_protocol == "HTTP2")
         {
@@ -419,16 +430,14 @@ namespace ccf
         else
         {
           std::unique_ptr<tls::Context> ctx;
-          if (
-            per_listen_interface.endorsement.authority == Authority::UNSECURED)
+          if (unsecured)
           {
             ctx = std::make_unique<nontls::PlaintextServer>();
           }
           else
           {
             ctx = std::make_unique<::tls::Server>(
-              certs[listen_interface_id],
-              per_listen_interface.app_protocol == "HTTP2");
+              cert_it->second, per_listen_interface.app_protocol == "HTTP2");
           }
 
           auto session = make_server_session(

--- a/src/enclave/rpc_sessions.h
+++ b/src/enclave/rpc_sessions.h
@@ -316,6 +316,8 @@ namespace ccf
       auto& per_listen_interface = it->second;
       const auto unsecured =
         per_listen_interface.endorsement.authority == Authority::UNSECURED;
+      const auto is_http2_interface =
+        per_listen_interface.app_protocol == "HTTP2";
       const auto cert_it = certs.find(listen_interface_id);
 
       if (!unsecured && cert_it == certs.end())
@@ -364,11 +366,11 @@ namespace ccf
         else
         {
           ctx = std::make_unique<::tls::Server>(
-            cert_it->second, per_listen_interface.app_protocol == "HTTP2");
+            cert_it->second, is_http2_interface);
         }
 
         std::shared_ptr<Session> capped_session;
-        if (per_listen_interface.app_protocol == "HTTP2")
+        if (is_http2_interface)
         {
           capped_session =
             std::make_shared<NoMoreSessionsImpl<::http::HTTP2ServerSession>>(
@@ -437,7 +439,7 @@ namespace ccf
           else
           {
             ctx = std::make_unique<::tls::Server>(
-              cert_it->second, per_listen_interface.app_protocol == "HTTP2");
+              cert_it->second, is_http2_interface);
           }
 
           auto session = make_server_session(

--- a/tests/connections.py
+++ b/tests/connections.py
@@ -57,6 +57,72 @@ def interface_caps(i):
     }
 
 
+def run_unsecured_connection_cap_test(args):
+    interface_name = "unsecured_interface"
+    soft_cap = 3
+    for i, node_spec in enumerate(args.nodes):
+        node_spec.rpc_interfaces[interface_name] = infra.interfaces.RPCInterface(
+            host=f"127.{i}.0.1",
+            max_open_sessions_soft=soft_cap,
+            endorsement=infra.interfaces.Endorsement(
+                infra.interfaces.EndorsementAuthority.Unsecured
+            ),
+            accepted_endpoints=["/node/version"],
+        )
+
+    with infra.network.network(
+        args.nodes, args.binary_dir, args.debug_nodes, pdb=args.pdb
+    ) as network:
+        network.start_and_open(args)
+        primary, _ = network.find_nodes()
+        rpc_interface = primary.host.rpc_interfaces[interface_name]
+
+        with contextlib.ExitStack() as es:
+            for _ in range(soft_cap):
+                connection = socket.create_connection(
+                    (rpc_interface.public_host, rpc_interface.public_port),
+                    timeout=1,
+                )
+                es.callback(connection.close)
+
+            end_time = time.time() + 3
+            while time.time() < end_time:
+                metrics = get_session_metrics(primary)
+                interface_metrics = metrics["interfaces"][interface_name]
+                if interface_metrics["active"] == soft_cap:
+                    break
+                time.sleep(0.1)
+            assert interface_metrics["active"] == soft_cap, interface_metrics
+
+            with contextlib.closing(
+                http.client.HTTPConnection(
+                    rpc_interface.public_host,
+                    rpc_interface.public_port,
+                    timeout=1,
+                )
+            ) as capped_connection:
+                capped_connection.request(
+                    "GET", "/node/version", headers={"Content-Length": "0"}
+                )
+                try:
+                    response = capped_connection.getresponse()
+                except http.client.RemoteDisconnected:
+                    pass
+                else:
+                    assert (
+                        response.status == http.HTTPStatus.SERVICE_UNAVAILABLE
+                    ), response.status
+                    response.read()
+
+            with primary.client() as client:
+                response = client.get("/node/commit")
+                assert response.status_code == http.HTTPStatus.OK, response
+
+            metrics = get_session_metrics(primary)
+            interface_metrics = metrics["interfaces"][interface_name]
+            assert interface_metrics["peak"] == soft_cap + 1, interface_metrics
+
+
 def run_connection_caps_tests(args):
     # Listen on additional RPC interfaces with even lower session caps
     for i, node_spec in enumerate(args.nodes):
@@ -462,6 +528,13 @@ if __name__ == "__main__":
     cr.add(
         "idletimeout",
         run_idle_timeout_tests,
+        package="samples/apps/logging/logging",
+        nodes=infra.e2e_args.nodes(cr.args, 1),
+    )
+
+    cr.add(
+        "unsecured_caps",
+        run_unsecured_connection_cap_test,
         package="samples/apps/logging/logging",
         nodes=infra.e2e_args.nodes(cr.args, 1),
     )

--- a/tests/connections.py
+++ b/tests/connections.py
@@ -3,6 +3,7 @@
 import contextlib
 import functools
 import http
+import http.client
 import os
 import random
 import resource


### PR DESCRIPTION
This pull request addresses a critical issue where a TLS server with a null certificate could lead to a null dereference in the enclave when handling unsecured interfaces. The changes made include:

- Updated the `RPCSessions::accept` method to ensure that capped unsecured sessions use `PlaintextServer`, while secured sessions are refused if no certificate is found.
- Implemented a regression test in `tests/connections.py` that verifies the behavior of the unsecured interface when reaching its soft session cap, ensuring the node remains responsive and the peak connections are correctly tracked.
- Added a release note in the `CHANGELOG.md` to document this fix.

Validation has been completed successfully, including builds and tests, confirming that the crash is resolved without introducing new issues.