### PR TITLE
[DO NOT MERGE] ci: diagnose partition reconnect failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   vmss-virtual-a:
+    if: false # DEBUG ONLY: do not merge this branch.
     name: "VMSS Virtual A" # CI Checks, Clang Tidy, Python package tests, Doc build, Unit tests, e2e (bucket_a)
     runs-on:
       [
@@ -116,6 +117,7 @@ jobs:
         if: success() || failure()
 
   vmss-virtual-b:
+    if: false # DEBUG ONLY: do not merge this branch.
     name: "VMSS Virtual B" # End-to-end tests (bucket_b)
     runs-on:
       [
@@ -188,7 +190,8 @@ jobs:
         if: success() || failure()
 
   vmss-virtual-c:
-    name: "VMSS Virtual C" # End-to-end tests (bucket_c)
+    name: "DEBUG ONLY - partitions until first failure (DO NOT MERGE)"
+    timeout-minutes: 360
     runs-on:
       [
         self-hosted,
@@ -222,30 +225,26 @@ jobs:
           mkdir build
           cd build
           cmake -GNinja -DCMAKE_BUILD_TYPE=Debug ..
-          ninja
+          ninja logging
         shell: bash
 
-      - name: "Test virtual"
-        run: |
-          set -ex
-          cd build
-          rm -rf /github/home/.cache
-          mkdir -p /github/home/.cache
-
-          ./tests.sh --timeout 360 --output-on-failure -L bucket_c
+      - name: "DEBUG ONLY - repeat partitions, stop at first failure"
+        timeout-minutes: 330
         shell: bash
-
-      - name: "Run partitions tests"
         run: |
-          set -ex
-          cd build
-          ./tests.sh --timeout 360 --output-on-failure -L partitions -C partitions
+          ./scripts/debug-partitions-loop.sh
 
-      - name: "Upload logs for virtual C"
+      - name: "Upload final partition iteration only"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: logs-azurelinux-virtual-c
+          retention-days: 3
+          compression-level: 9
           path: |
+            build/partitions-current.log
+            build/partitions-iterations.tsv
+            build/Testing/Temporary/LastTest.log
+            build/Testing/Temporary/LastTestsFailed.log
             build/workspace/*/*.config.json
             build/workspace/*/out
             build/workspace/*/err
@@ -253,9 +252,10 @@ jobs:
             build/workspace/*/stack_trace
             build/workspace/**/openapi_coverage.json
           if-no-files-found: ignore
-        if: success() || failure()
+        if: always()
 
   aci_snp_milan:
+    if: false # DEBUG ONLY: do not merge this branch.
     name: "ACI SNP Milan"
     runs-on:
       [
@@ -342,6 +342,7 @@ jobs:
         if: success() || failure()
 
   aci_snp_genoa:
+    if: false # DEBUG ONLY: do not merge this branch.
     name: "ACI SNP Genoa"
     runs-on:
       [

--- a/scripts/debug-partitions-loop.sh
+++ b/scripts/debug-partitions-loop.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+# Temporary CI diagnostic, not a test-suite change. Run from the repository root.
+set -euo pipefail
+
+cd build
+unset CR_FILTER
+./tests.sh -N -R '^partitions$' -C partitions
+source env/bin/activate
+export VENV_DIR="$PWD/env"
+export BETTER_EXCEPTIONS=1
+
+printf 'iteration\tstarted_utc\telapsed_seconds\texit_status\n' > partitions-iterations.tsv
+for iteration in $(seq 1 100); do
+  started=$(date -u +%FT%TZ)
+  start_seconds=$SECONDS
+  echo "Partitions iteration $iteration/100 ($started)"
+  status=0
+  ctest --timeout 360 --verbose --output-on-failure \
+    -R '^partitions$' -C partitions --no-tests=error \
+    > partitions-current.log 2>&1 || status=$?
+  elapsed=$((SECONDS - start_seconds))
+  printf '%s\t%s\t%s\t%s\n' "$iteration" "$started" "$elapsed" "$status" >> partitions-iterations.tsv
+  echo "Partitions iteration $iteration: exit=$status, elapsed=${elapsed}s"
+  if [ "$status" -ne 0 ]; then
+    echo "Stopping at first failure; preserving this iteration's logs and node artifacts."
+    tail -n 80 partitions-current.log
+    exit "$status"
+  fi
+  if [ "$iteration" -lt 100 ]; then
+    # Networks have stopped. Do not accumulate successful node logs or ledgers.
+    rm -rf -- workspace
+  fi
+done
+echo "All 100 iterations passed; preserving only the final iteration."

--- a/src/host/node_connections.h
+++ b/src/host/node_connections.h
@@ -192,7 +192,11 @@ namespace asynchost
 
       void on_disconnect() override
       {
-        LOG_INFO_FMT("Disconnecting incoming connection {}", id);
+        LOG_INFO_FMT(
+          "Disconnecting incoming connection {}, behaviour={}, node={}",
+          id,
+          fmt::ptr(this),
+          node_id.value_or(UnassociatedNode));
         parent.unassociated_incoming.erase(id);
 
         if (node_id.has_value())
@@ -242,11 +246,27 @@ namespace asynchost
           return false;
         }
 
+        if (existing != parent.connections.end())
+        {
+          LOG_INFO_FMT(
+            "Replacing connection to {} with incoming {}, outgoing={}, "
+            "age_ms={}",
+            n,
+            id,
+            existing->second.outgoing,
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::steady_clock::now() - existing->second.created)
+              .count());
+        }
         node_id = n;
         parent.connections[n] = {unassociated->second, false};
         parent.unassociated_incoming.erase(unassociated);
 
-        LOG_INFO_FMT("Node incoming connection ({}) associated with {}", id, n);
+        LOG_INFO_FMT(
+          "Node incoming connection ({}) associated with {}, behaviour={}",
+          id,
+          n,
+          fmt::ptr(this));
         return true;
       }
     };
@@ -292,8 +312,10 @@ namespace asynchost
       void on_disconnect() override
       {
         LOG_INFO_FMT(
-          "Disconnecting outgoing connection with {}: disconnected",
-          *node); // NOLINT(bugprone-unchecked-optional-access)
+          "Disconnecting outgoing connection with {}: disconnected, "
+          "behaviour={}",
+          *node, // NOLINT(bugprone-unchecked-optional-access)
+          fmt::ptr(this));
         parent.remove_connection(
           *node); // NOLINT(bugprone-unchecked-optional-access)
       }
@@ -400,6 +422,7 @@ namespace asynchost
           auto [node_id] =
             ringbuffer::read_message<ccf::close_node_outbound>(data, size);
 
+          LOG_INFO_FMT("Enclave requested connection closure with {}", node_id);
           remove_connection(node_id);
         });
 
@@ -588,6 +611,17 @@ namespace asynchost
     // Remove the connection with this peer, if any.
     bool remove_connection(ccf::NodeId node)
     {
+      const auto existing = connections.find(node);
+      if (existing != connections.end())
+      {
+        LOG_INFO_FMT(
+          "Removing connection with {}, outgoing={}, age_ms={}",
+          node,
+          existing->second.outgoing,
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - existing->second.created)
+            .count());
+      }
       if (connections.erase(node) < 1)
       {
         LOG_DEBUG_FMT("Cannot remove node connection {}: does not exist", node);

--- a/src/host/tcp.h
+++ b/src/host/tcp.h
@@ -915,14 +915,24 @@ namespace asynchost
     {
       if (uv_is_closing(reinterpret_cast<uv_handle_t*>(&uv_handle)) != 0)
       {
-        LOG_DEBUG_FMT("on_connect: closing");
+        LOG_INFO_FMT(
+          "TCP on_connect: closing socket={}, behaviour={}, peer={}",
+          fmt::ptr(this),
+          fmt::ptr(behaviour.get()),
+          get_address_name());
         return;
       }
 
       if (rc < 0)
       {
         // Try again on the next address.
-        LOG_DEBUG_FMT("uv_tcp_connect async retry: {}", uv_strerror(rc));
+        LOG_INFO_FMT(
+          "TCP connect retry: socket={}, behaviour={}, peer={}, error={} ({})",
+          fmt::ptr(this),
+          fmt::ptr(behaviour.get()),
+          get_address_name(),
+          rc,
+          uv_strerror(rc));
         addr_current = addr_current->ai_next;
         assert_status(CONNECTING, CONNECTING_RESOLVING);
         connect_resolved();
@@ -1029,7 +1039,13 @@ namespace asynchost
         on_free(buf);
         uv_read_stop(reinterpret_cast<uv_stream_t*>(&uv_handle));
 
-        LOG_DEBUG_FMT("TCP on_read: {}", uv_strerror(static_cast<int>(sz)));
+        LOG_INFO_FMT(
+          "TCP read closed: socket={}, behaviour={}, peer={}, error={} ({})",
+          fmt::ptr(this),
+          fmt::ptr(behaviour.get()),
+          get_address_name(),
+          sz,
+          uv_strerror(static_cast<int>(sz)));
         behaviour->on_disconnect();
         return;
       }
@@ -1044,6 +1060,11 @@ namespace asynchost
 
       if (!read_good)
       {
+        LOG_INFO_FMT(
+          "TCP read rejected by behaviour: socket={}, behaviour={}, peer={}",
+          fmt::ptr(this),
+          fmt::ptr(behaviour.get()),
+          get_address_name());
         behaviour->on_disconnect();
         return;
       }

--- a/src/node/node_to_node_channel_manager.h
+++ b/src/node/node_to_node_channel_manager.h
@@ -165,7 +165,7 @@ namespace ccf
           }
           else
           {
-            LOG_DEBUG_FMT(
+            LOG_INFO_FMT(
               "Closing idle channel to node {}. Was idle for {}, threshold for "
               "closure is {}",
               it->first,


### PR DESCRIPTION
## DEBUGGING ONLY — DO NOT MERGE

This is a temporary diagnostic experiment, **not a proposed fix**. It intentionally disables other jobs in the CI workflow. Close rather than merge when the evidence has been collected.

### Experiment

- Keep the existing Virtual C runner pool, Azure Linux container, Debug build, and NET_ADMIN/NET_RAW/SYS_PTRACE capabilities.
- Build only `logging`; skip bucket C and the other four CI jobs. Other repository workflows may still run normally.
- Run the **unchanged full `partitions_test.py` suite**, preserving all eight sub-tests, their ordering within each group, and concurrency of two. No join retries, routing changes, sleeps, or experimental fixes from the investigation branch are included.
- Repeat at most **100 times**, **stop on the first failing CTest invocation** and preserve its failure exit status. Keep the normal 360-second per-test timeout; bound the loop step to 330 minutes and the job to 360 minutes.

### Diagnostics and storage

Keep the normal Info log level. Add targeted socket read/connect error codes and descriptions, socket/behaviour identifiers to correlate callbacks with peers, incoming-connection replacement and connection-removal ages, enclave-requested closure, and idle encrypted-channel closure. Existing channel establishment/reset logs remain available. No message/key payload dumps or per-message tracing are added.

Prepare Python once. Each iteration overwrites `build/partitions-current.log`; successful node workspaces are removed before the next iteration. Retain only the failure (or iteration 100 if all pass), plus `partitions-iterations.tsv`, final CTest logs, and the existing node config/out/err/ledger/stack-trace artifacts. Artifact retention is **3 days**. The Actions console gets a small iteration summary and only the final 80 lines on failure.

The loop expects this job's fresh, dedicated build directory; do not run it in a shared build/workspace containing evidence you want to retain.

### Motivation

Recent failures show successful post-partition commit checks followed by clustered node-to-node TCP disconnects and a late election during pending joins. Depending on registration rollback, this surfaces as a join timeout or `No such node` during trust. Related discussion: #8323 and historical workaround #7601 / #7570. This PR does not resolve those issues.

Representative failures:
- https://github.com/microsoft/CCF/actions/runs/34246953556/job/102131270678
- https://github.com/microsoft/CCF/actions/runs/34260509899/job/102176982076
- https://github.com/microsoft/CCF/actions/runs/34281082842/job/102245729951

### Local validation

- Debug build: `logging` and `node_connections_test` succeeded.
- Existing `node_connections_test` passed.
- One full unchanged partition run passed: **166.94 seconds**, eight sub-tests, concurrency two.
- Shell fixtures verified failure at iteration 3 stops with exit 8 and keeps only iteration 3; 100 passes retain only iteration 100; setup failure runs no tests and preserves the workspace.
- All 15 `scripts/ci-checks.sh` groups passed without auto-fix.
- Independent code review completed with no significant issues.

The repeated CI experiment is intentionally left to the CI-sized runner; one local pass is not evidence that the flake is fixed.