### PR TITLE
Fix OpenAPI schema: primary_id must allow null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Transactions with pending writes now correctly validate `foreach`, `size`, and `clear` observations of an existing empty KV table made at revision zero. Previously, these observations could be mistaken for no whole-map read dependency (#8320).
+- The OpenAPI schema for `GET /node/consensus` and `GET /node/network` now correctly marks `details.primary_id` and `primary_id` as nullable, matching their `null` value while no primary is known (e.g. between elections). Previously the schema required a non-null string, causing spurious response validation failures.
 
 ## [7.0.14]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Transactions with pending writes now correctly validate `foreach`, `size`, and `clear` observations of an existing empty KV table made at revision zero. Previously, these observations could be mistaken for no whole-map read dependency (#8320).
-- The OpenAPI schema for `GET /node/consensus` and `GET /node/network` now correctly marks `details.primary_id` and `primary_id` as nullable, matching their `null` value while no primary is known (e.g. between elections). Previously the schema required a non-null string, causing spurious response validation failures.
+- The OpenAPI schema for `GET /node/consensus` and `GET /node/network` now correctly marks `details.primary_id` and `primary_id` as nullable, matching their `null` value while no primary is known (e.g. between elections). Previously the schema required a non-null string, causing spurious response validation failures (#8344).
 
 ## [7.0.14]
 

--- a/doc/schemas/app_openapi.json
+++ b/doc/schemas/app_openapi.json
@@ -67,7 +67,18 @@
       "LoggingGetCoseEndorsements__Out": {
         "properties": {
           "endorsements": {
-            "$ref": "#/components/schemas/base64string_array"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/base64string_array"
+              },
+              {
+                "enum": [
+                  null
+                ],
+                "nullable": true,
+                "type": "object"
+              }
+            ]
           }
         },
         "required": [
@@ -261,7 +272,7 @@
   "info": {
     "description": "This CCF sample app implements a simple logging application, securely recording messages at client-specified IDs. It demonstrates most of the features available to CCF apps.",
     "title": "CCF Sample Logging App",
-    "version": "2.8.4"
+    "version": "2.8.5"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -147,7 +147,12 @@
             "$ref": "#/components/schemas/MembershipState"
           },
           "primary_id": {
-            "$ref": "#/components/schemas/NodeId"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NodeId"
+              }
+            ],
+            "nullable": true
           },
           "reconfiguration_type": {
             "$ref": "#/components/schemas/ReconfigurationType"
@@ -262,7 +267,12 @@
             "$ref": "#/components/schemas/uint64"
           },
           "primary_id": {
-            "$ref": "#/components/schemas/NodeId"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NodeId"
+              }
+            ],
+            "nullable": true
           },
           "recovery_count": {
             "$ref": "#/components/schemas/uint64"
@@ -919,7 +929,7 @@
   "info": {
     "description": "This API provides public, uncredentialed access to service and node state.",
     "title": "CCF Public Node API",
-    "version": "5.0.6"
+    "version": "5.0.7"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -147,12 +147,18 @@
             "$ref": "#/components/schemas/MembershipState"
           },
           "primary_id": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/NodeId"
+              },
+              {
+                "enum": [
+                  null
+                ],
+                "nullable": true,
+                "type": "object"
               }
-            ],
-            "nullable": true
+            ]
           },
           "reconfiguration_type": {
             "$ref": "#/components/schemas/ReconfigurationType"
@@ -267,12 +273,18 @@
             "$ref": "#/components/schemas/uint64"
           },
           "primary_id": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/NodeId"
+              },
+              {
+                "enum": [
+                  null
+                ],
+                "nullable": true,
+                "type": "object"
               }
-            ],
-            "nullable": true
+            ]
           },
           "recovery_count": {
             "$ref": "#/components/schemas/uint64"

--- a/doc/schemas/node_openapi.json
+++ b/doc/schemas/node_openapi.json
@@ -267,10 +267,32 @@
       "GetNetworkInfo__Out": {
         "properties": {
           "current_service_create_txid": {
-            "$ref": "#/components/schemas/TransactionId"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TransactionId"
+              },
+              {
+                "enum": [
+                  null
+                ],
+                "nullable": true,
+                "type": "object"
+              }
+            ]
           },
           "current_view": {
-            "$ref": "#/components/schemas/uint64"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/uint64"
+              },
+              {
+                "enum": [
+                  null
+                ],
+                "nullable": true,
+                "type": "object"
+              }
+            ]
           },
           "primary_id": {
             "anyOf": [

--- a/include/ccf/ds/json.h
+++ b/include/ccf/ds/json.h
@@ -496,7 +496,7 @@ namespace std
 #define FILL_SCHEMA_REQUIRED_WITH_RENAMES_FOR_JSON_NEXT( \
   TYPE, C_FIELD, JSON_FIELD) \
   j["properties"][JSON_FIELD] = \
-    ccf::ds::json::schema_element<decltype(TYPE::C_FIELD)>(); \
+    ccf::ds::json::required_schema_element<decltype(TYPE::C_FIELD)>(); \
   j["required"].push_back(JSON_FIELD);
 #define FILL_SCHEMA_REQUIRED_WITH_RENAMES_FOR_JSON_FINAL( \
   TYPE, C_FIELD, JSON_FIELD) \
@@ -523,7 +523,7 @@ namespace std
 #define ADD_SCHEMA_COMPONENTS_REQUIRED_WITH_RENAMES_FOR_JSON_NEXT( \
   TYPE, C_FIELD, JSON_FIELD) \
   j["properties"][JSON_FIELD] = \
-    doc.template add_schema_component<decltype(TYPE::C_FIELD)>(); \
+    doc.template add_required_schema_component<decltype(TYPE::C_FIELD)>(); \
   j["required"].push_back(JSON_FIELD);
 #define ADD_SCHEMA_COMPONENTS_REQUIRED_WITH_RENAMES_FOR_JSON_FINAL( \
   TYPE, C_FIELD, JSON_FIELD) \

--- a/include/ccf/ds/json_schema.h
+++ b/include/ccf/ds/json_schema.h
@@ -64,6 +64,28 @@ namespace ccf::ds::json
     return element;
   }
 
+  /** Produces the schema for a field which is marked as required (ie -
+   * always present in the JSON object), but whose C++ type is
+   * std::optional<T>. Such fields are always serialised, but may hold a JSON
+   * null when the C++ value is std::nullopt (for instance, a consensus's
+   * primary_id while no primary is currently known). The produced schema
+   * therefore describes the inner type T, additionally marked as nullable.
+   */
+  template <typename T>
+  inline nlohmann::json required_schema_element()
+  {
+    if constexpr (ccf::nonstd::is_specialization<T, std::optional>::value)
+    {
+      auto element = schema_element<typename T::value_type>();
+      element["nullable"] = true;
+      return element;
+    }
+    else
+    {
+      return schema_element<T>();
+    }
+  }
+
   namespace adl
   {
 #pragma clang diagnostic push

--- a/include/ccf/ds/json_schema.h
+++ b/include/ccf/ds/json_schema.h
@@ -4,6 +4,7 @@
 
 #include "ccf/ds/nonstd.h"
 
+#include <algorithm>
 #include <optional>
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
@@ -78,6 +79,13 @@ namespace ccf::ds::json
     {
       auto element = schema_element<typename T::value_type>();
       element["nullable"] = true;
+      const auto enum_it = element.find("enum");
+      if (
+        enum_it != element.end() &&
+        std::find(enum_it->begin(), enum_it->end(), nullptr) == enum_it->end())
+      {
+        enum_it->push_back(nullptr);
+      }
       return element;
     }
     else

--- a/include/ccf/ds/openapi.h
+++ b/include/ccf/ds/openapi.h
@@ -456,7 +456,7 @@ namespace ccf::ds::openapi
       {
         auto inner = add_schema_component<typename T::value_type>();
         auto schema = nlohmann::json::object();
-        schema["allOf"] = {inner};
+        schema["allOf"] = nlohmann::json::array({inner});
         schema["nullable"] = true;
         return schema;
       }

--- a/include/ccf/ds/openapi.h
+++ b/include/ccf/ds/openapi.h
@@ -435,6 +435,36 @@ namespace ccf::ds::openapi
         return components_ref_object(name);
       }
     }
+
+    /** Produces the schema for a field which is marked as required (ie -
+     * always present in the JSON object), but whose C++ type is
+     * std::optional<T>. Such fields are always serialised, but may hold a
+     * JSON null when the C++ value is std::nullopt (for instance, a
+     * consensus's primary_id while no primary is currently known). The
+     * produced schema therefore describes the inner type T, additionally
+     * allowing a null value.
+     *
+     * OpenAPI 3.0 does not support "type": "null", and a bare $ref cannot
+     * carry a sibling "nullable" key, so the inner schema is wrapped in an
+     * "allOf" and "nullable" is set alongside it. This is the standard
+     * OpenAPI 3.0 idiom for a nullable reference.
+     */
+    template <typename T>
+    nlohmann::json add_required_schema_component()
+    {
+      if constexpr (ccf::nonstd::is_specialization<T, std::optional>::value)
+      {
+        auto inner = add_schema_component<typename T::value_type>();
+        auto schema = nlohmann::json::object();
+        schema["allOf"] = {inner};
+        schema["nullable"] = true;
+        return schema;
+      }
+      else
+      {
+        return add_schema_component<T>();
+      }
+    }
   };
 
   template <typename T>

--- a/include/ccf/ds/openapi.h
+++ b/include/ccf/ds/openapi.h
@@ -444,10 +444,10 @@ namespace ccf::ds::openapi
      * produced schema therefore describes the inner type T, additionally
      * allowing a null value.
      *
-     * OpenAPI 3.0 does not support "type": "null", and a bare $ref cannot
-     * carry a sibling "nullable" key, so the inner schema is wrapped in an
-     * "allOf" and "nullable" is set alongside it. This is the standard
-     * OpenAPI 3.0 idiom for a nullable reference.
+     * OpenAPI 3.0 does not support "type": "null", and "nullable" only
+     * affects a "type" defined in the same schema object. The second "anyOf"
+     * branch therefore describes only null, while the first retains all
+     * constraints from the inner schema.
      */
     template <typename T>
     nlohmann::json add_required_schema_component()
@@ -456,8 +456,12 @@ namespace ccf::ds::openapi
       {
         auto inner = add_schema_component<typename T::value_type>();
         auto schema = nlohmann::json::object();
-        schema["allOf"] = nlohmann::json::array({inner});
-        schema["nullable"] = true;
+        schema["anyOf"] = nlohmann::json::array(
+          {inner,
+           nlohmann::json{
+             {"type", "object"},
+             {"nullable", true},
+             {"enum", nlohmann::json::array({nullptr})}}});
         return schema;
       }
       else

--- a/samples/apps/logging/logging.cpp
+++ b/samples/apps/logging/logging.cpp
@@ -586,7 +586,7 @@ namespace loggingapp
         "recording messages at client-specified IDs. It demonstrates most of "
         "the features available to CCF apps.";
 
-      openapi_info.document_version = "2.8.4";
+      openapi_info.document_version = "2.8.5";
     };
 
     // NOLINTNEXTLINE(readability-function-cognitive-complexity)

--- a/src/ds/test/json_schema.cpp
+++ b/src/ds/test/json_schema.cpp
@@ -433,6 +433,13 @@ DECLARE_JSON_ENUM(
 DECLARE_JSON_TYPE(EnumStruct);
 DECLARE_JSON_REQUIRED_FIELDS(EnumStruct, se);
 
+struct RequiredOptionalEnum
+{
+  std::optional<EnumStruct::SampleEnum> maybe_enum = std::nullopt;
+};
+DECLARE_JSON_TYPE(RequiredOptionalEnum);
+DECLARE_JSON_REQUIRED_FIELDS(RequiredOptionalEnum, maybe_enum);
+
 TEST_CASE("enum")
 {
   {
@@ -448,6 +455,17 @@ TEST_CASE("enum")
 
     const nlohmann::json expected{"one", "two", "three"};
     REQUIRE(schema["properties"]["se"]["enum"] == expected);
+  }
+
+  {
+    INFO("Required optional enum schema generation");
+    const auto schema =
+      ccf::ds::json::build_schema<RequiredOptionalEnum>("RequiredOptionalEnum");
+    const auto& property = schema["properties"]["maybe_enum"];
+
+    REQUIRE(property["nullable"] == true);
+    const nlohmann::json expected{"one", "two", "three", nullptr};
+    REQUIRE(property["enum"] == expected);
   }
 
   {

--- a/src/ds/test/json_schema.cpp
+++ b/src/ds/test/json_schema.cpp
@@ -173,6 +173,49 @@ TEST_CASE("schema generation")
   }
 }
 
+// Some struct fields are always present in the serialised JSON (ie - they
+// are required), but are std::optional<T> in C++, and may be serialised as a
+// JSON null. For instance, a node's consensus does not always know its
+// current primary. This must be reflected in the produced schema, which
+// should mark such fields as nullable rather than simply describing the
+// inner (non-optional) type.
+struct RequiredOptional
+{
+  std::optional<size_t> maybe_present = std::nullopt;
+};
+DECLARE_JSON_TYPE(RequiredOptional);
+DECLARE_JSON_REQUIRED_FIELDS(RequiredOptional, maybe_present);
+
+TEST_CASE("schema generation for required optional field")
+{
+  const auto schema =
+    ccf::ds::json::build_schema<RequiredOptional>("RequiredOptional");
+
+  const auto required_it = schema.find("required");
+  REQUIRE(required_it != schema.end());
+  REQUIRE(required_it->size() == 1);
+  REQUIRE((*required_it)[0] == "maybe_present");
+
+  const auto& property = schema.at("properties").at("maybe_present");
+  REQUIRE(property.at("type") == "integer");
+  REQUIRE(property.at("nullable") == true);
+
+  // A JSON null is accepted for this required-but-nullable field
+  auto j = nlohmann::json::object();
+  j["maybe_present"] = nullptr;
+  const RequiredOptional parsed = j;
+  REQUIRE(!parsed.maybe_present.has_value());
+
+  // As is a concrete value
+  j["maybe_present"] = 7;
+  const RequiredOptional parsed_value = j;
+  REQUIRE(parsed_value.maybe_present == 7);
+
+  // But the field must still be present
+  auto j_missing = nlohmann::json::object();
+  REQUIRE_THROWS_AS(j_missing.get<RequiredOptional>(), ccf::JsonParseError);
+}
+
 TEST_CASE_TEMPLATE("schema types, integer", T, size_t, ssize_t)
 {
   std::map<T, std::string> m;

--- a/src/ds/test/openapi.cpp
+++ b/src/ds/test/openapi.cpp
@@ -272,6 +272,65 @@ TEST_CASE("Manual function definitions")
   }
 }
 
+struct WithRequiredOptionalField
+{
+  std::optional<Foo> maybe_foo;
+};
+DECLARE_JSON_TYPE(WithRequiredOptionalField);
+DECLARE_JSON_REQUIRED_FIELDS(WithRequiredOptionalField, maybe_foo);
+
+TEST_CASE(
+  "Required optional field produces nullable component schema, not "
+  "generated output")
+{
+  // Regression test: a std::optional<T> field which is JSON-required (always
+  // present, but may hold a null value - e.g.
+  // ccf::kv::ConsensusDetails::primary_id while no primary is known) must
+  // produce a schema that permits null, in addition to the ref/inline schema
+  // for T. See https://github.com/microsoft/CCF/issues/8323.
+  auto doc = openapi::create_document(
+    "Test generated API",
+    "Some longer description enhanced with **Markdown**",
+    "0.1.42");
+
+  openapi::server(doc, server_url);
+
+  openapi::add_response_schema<WithRequiredOptionalField>(
+    doc, "/app/required_optional", HTTP_GET, HTTP_STATUS_OK);
+
+  const auto& components_schemas = doc["components"]["schemas"];
+  const auto it = components_schemas.find("WithRequiredOptionalField");
+  REQUIRE(it != components_schemas.end());
+
+  const auto& schema = *it;
+  REQUIRE(schema.contains("required"));
+  const auto& required = schema["required"];
+  bool found_required = false;
+  for (const auto& field : required)
+  {
+    if (field == "maybe_foo")
+    {
+      found_required = true;
+    }
+  }
+  REQUIRE(found_required);
+
+  const auto& properties = schema["properties"];
+  const auto prop_it = properties.find("maybe_foo");
+  REQUIRE(prop_it != properties.end());
+  const auto& maybe_foo_schema = *prop_it;
+
+  // OpenAPI 3.0 does not support "type": "null", nor a $ref with sibling
+  // keys, so a nullable $ref'd field is expressed as "allOf": [{"$ref": ...}]
+  // alongside "nullable": true.
+  REQUIRE(maybe_foo_schema.contains("nullable"));
+  CHECK(maybe_foo_schema["nullable"] == true);
+  REQUIRE(maybe_foo_schema.contains("allOf"));
+  const auto& all_of = maybe_foo_schema["allOf"];
+  REQUIRE(all_of.size() == 1);
+  CHECK(all_of[0]["$ref"] == "#/components/schemas/Foo");
+}
+
 TEST_CASE("sanitise_components_key")
 {
   using namespace ccf::ds::openapi;

--- a/src/ds/test/openapi.cpp
+++ b/src/ds/test/openapi.cpp
@@ -321,15 +321,19 @@ TEST_CASE(
   const auto& maybe_foo_schema = *prop_it;
 
   // OpenAPI 3.0 does not support "type": "null", nor a $ref with sibling
-  // keys, so a nullable $ref'd field is expressed as "allOf": [{"$ref": ...}]
-  // alongside "nullable": true.
-  REQUIRE(maybe_foo_schema.contains("nullable"));
-  CHECK(maybe_foo_schema["nullable"] == true);
-  REQUIRE(maybe_foo_schema.contains("allOf"));
-  const auto& all_of = maybe_foo_schema["allOf"];
-  REQUIRE(all_of.is_array());
-  REQUIRE(all_of.size() == 1);
-  CHECK(all_of[0]["$ref"] == "#/components/schemas/Foo");
+  // keys. Express this as the referenced type or a branch constrained to
+  // null. The enum is necessary so this branch does not accept arbitrary
+  // values as well as null.
+  REQUIRE(maybe_foo_schema.contains("anyOf"));
+  const auto& any_of = maybe_foo_schema["anyOf"];
+  REQUIRE(any_of.is_array());
+  REQUIRE(any_of.size() == 2);
+  CHECK(any_of[0]["$ref"] == "#/components/schemas/Foo");
+  CHECK(any_of[1]["type"] == "object");
+  CHECK(any_of[1]["nullable"] == true);
+  REQUIRE(any_of[1]["enum"].is_array());
+  REQUIRE(any_of[1]["enum"].size() == 1);
+  CHECK(any_of[1]["enum"][0].is_null());
 }
 
 TEST_CASE("sanitise_components_key")

--- a/src/ds/test/openapi.cpp
+++ b/src/ds/test/openapi.cpp
@@ -327,6 +327,7 @@ TEST_CASE(
   CHECK(maybe_foo_schema["nullable"] == true);
   REQUIRE(maybe_foo_schema.contains("allOf"));
   const auto& all_of = maybe_foo_schema["allOf"];
+  REQUIRE(all_of.is_array());
   REQUIRE(all_of.size() == 1);
   CHECK(all_of[0]["$ref"] == "#/components/schemas/Foo");
 }

--- a/src/node/rpc/node_frontend.h
+++ b/src/node/rpc/node_frontend.h
@@ -449,7 +449,7 @@ namespace ccf
       openapi_info.description =
         "This API provides public, uncredentialed access to service and node "
         "state.";
-      openapi_info.document_version = "5.0.6";
+      openapi_info.document_version = "5.0.7";
     }
 
     // NOLINTNEXTLINE(readability-function-cognitive-complexity)

--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -145,7 +145,9 @@ def test_isolate_primary_from_one_backup(network, args):
     timeout = time.time() + 2 * network.args.election_timeout_ms / 1000
     while True:
         with p.client() as c:
-            r = c.get("/node/consensus", log_capture=[]).body.json()["details"]
+            r = c.get(
+                "/node/consensus", log_capture=[], validate_openapi=False
+            ).body.json()["details"]
             ack = r["acks"][b_0.node_id]["last_received_ms"]
             has_stepped_down = r["leadership_state"] in {"Follower", "PreVoteCandidate"}
             if not has_stepped_down:
@@ -154,7 +156,9 @@ def test_isolate_primary_from_one_backup(network, args):
                 ), f"Nodes {p.local_node_id} and {b_0.local_node_id} are no longer partitioned"
                 last_ack = ack
         with b_0.client() as c:
-            r = c.get("/node/consensus", log_capture=[]).body.json()["details"]
+            r = c.get(
+                "/node/consensus", log_capture=[], validate_openapi=False
+            ).body.json()["details"]
             if r["leadership_state"] == "Leader":
                 LOG.info(
                     f"Backup {b_0.local_node_id} has become primary in new view {r['current_view']}"
@@ -168,11 +172,32 @@ def test_isolate_primary_from_one_backup(network, args):
 
         time.sleep(0.1)
 
-    p.wait_for_leadership_state(
-        initial_txid.view,
-        ["Follower", "PreVoteCandidate"],
-        timeout=4 * network.args.election_timeout_ms / 1000,
-    )
+    timeout = time.time() + 4 * network.args.election_timeout_ms / 1000
+    while True:
+        with p.client() as c:
+            r = c.get(
+                "/node/consensus", log_capture=[], validate_openapi=False
+            ).body.json()["details"]
+        if (
+            r["current_view"] > initial_txid.view
+            and r["leadership_state"] in {"Follower", "PreVoteCandidate"}
+            and r["primary_id"] is None
+        ):
+            break
+        if time.time() > timeout:
+            raise RuntimeError(
+                f"Former primary {p.local_node_id} did not enter a "
+                f"no-known-primary state within timeout: {r}"
+            )
+        time.sleep(0.1)
+
+    # Keep the polling above out of OpenAPI validation so this is the first
+    # validated /node/consensus response. This exercises the exact runtime
+    # validation path that previously rejected the legitimate null primary_id.
+    with p.client() as c:
+        response = c.get("/node/consensus", log_capture=[])
+        assert response.status_code == http.HTTPStatus.OK, response
+        assert response.body.json()["details"]["primary_id"] is None
 
     # Verify that b_0 is stably the primary, and that p is a Follower/PreVoteCandidate
     timeout = time.time() + 2 * network.args.election_timeout_ms / 1000

--- a/tests/partitions_test.py
+++ b/tests/partitions_test.py
@@ -145,9 +145,7 @@ def test_isolate_primary_from_one_backup(network, args):
     timeout = time.time() + 2 * network.args.election_timeout_ms / 1000
     while True:
         with p.client() as c:
-            r = c.get(
-                "/node/consensus", log_capture=[], validate_openapi=False
-            ).body.json()["details"]
+            r = c.get("/node/consensus", log_capture=[]).body.json()["details"]
             ack = r["acks"][b_0.node_id]["last_received_ms"]
             has_stepped_down = r["leadership_state"] in {"Follower", "PreVoteCandidate"}
             if not has_stepped_down:
@@ -156,9 +154,7 @@ def test_isolate_primary_from_one_backup(network, args):
                 ), f"Nodes {p.local_node_id} and {b_0.local_node_id} are no longer partitioned"
                 last_ack = ack
         with b_0.client() as c:
-            r = c.get(
-                "/node/consensus", log_capture=[], validate_openapi=False
-            ).body.json()["details"]
+            r = c.get("/node/consensus", log_capture=[]).body.json()["details"]
             if r["leadership_state"] == "Leader":
                 LOG.info(
                     f"Backup {b_0.local_node_id} has become primary in new view {r['current_view']}"
@@ -172,32 +168,11 @@ def test_isolate_primary_from_one_backup(network, args):
 
         time.sleep(0.1)
 
-    timeout = time.time() + 4 * network.args.election_timeout_ms / 1000
-    while True:
-        with p.client() as c:
-            r = c.get(
-                "/node/consensus", log_capture=[], validate_openapi=False
-            ).body.json()["details"]
-        if (
-            r["current_view"] > initial_txid.view
-            and r["leadership_state"] in {"Follower", "PreVoteCandidate"}
-            and r["primary_id"] is None
-        ):
-            break
-        if time.time() > timeout:
-            raise RuntimeError(
-                f"Former primary {p.local_node_id} did not enter a "
-                f"no-known-primary state within timeout: {r}"
-            )
-        time.sleep(0.1)
-
-    # Keep the polling above out of OpenAPI validation so this is the first
-    # validated /node/consensus response. This exercises the exact runtime
-    # validation path that previously rejected the legitimate null primary_id.
-    with p.client() as c:
-        response = c.get("/node/consensus", log_capture=[])
-        assert response.status_code == http.HTTPStatus.OK, response
-        assert response.body.json()["details"]["primary_id"] is None
+    p.wait_for_leadership_state(
+        initial_txid.view,
+        ["Follower", "PreVoteCandidate"],
+        timeout=4 * network.args.election_timeout_ms / 1000,
+    )
 
     # Verify that b_0 is stably the primary, and that p is a Follower/PreVoteCandidate
     timeout = time.time() + 2 * network.args.election_timeout_ms / 1000

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -9,13 +9,17 @@ import e2e_tutorial
 import infra.checker
 import infra.e2e_args
 import infra.network
+import infra.openapi
 import infra.proc
 import nobuiltins
 import openapi_spec_validator
 import packaging.version
 from infra.runner import ConcurrentRunner
 from loguru import logger as LOG
+from openapi_core import OpenAPI
+from openapi_core.datatypes import RequestParameters
 from packaging import version
+from werkzeug.datastructures import Headers, ImmutableMultiDict
 
 
 def is_newer_openapi_version(fetched_version, file_version):
@@ -26,6 +30,41 @@ def is_newer_openapi_version(fetched_version, file_version):
         return version.parse(fetched_version) > version.parse(file_version)
     except packaging.version.InvalidVersion:
         return fetched_version > file_version
+
+
+def validate_nullable_consensus_primary(schema):
+    api = OpenAPI.from_dict(schema)
+    request = infra.openapi._Request(
+        host_url="https://localhost",
+        path="/node/consensus",
+        method="get",
+        parameters=RequestParameters(
+            query=ImmutableMultiDict(),
+            header=Headers(),
+            cookie=ImmutableMultiDict(),
+            path={},
+        ),
+        body=None,
+        content_type="",
+    )
+    body = {
+        "details": {
+            "configs": [],
+            "acks": {},
+            "membership_state": "Active",
+            "primary_id": None,
+            "current_view": 0,
+            "ticking": False,
+        }
+    }
+    response = infra.openapi._Response(
+        status_code=http.HTTPStatus.OK,
+        headers=Headers({"content-type": "application/json"}),
+        data=json.dumps(body).encode(),
+        content_type="application/json",
+    )
+
+    api.validate_response(request, response)
 
 
 def run(args):
@@ -99,6 +138,8 @@ def run(args):
 
         try:
             openapi_spec_validator.validate_spec(response_body)
+            if target_file_path == "node_openapi.json":
+                validate_nullable_consensus_primary(response_body)
         except Exception as e:
             LOG.error(f"Validation of {prefix} schema failed")
             LOG.error(e)

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -18,6 +18,7 @@ from infra.runner import ConcurrentRunner
 from loguru import logger as LOG
 from openapi_core import OpenAPI
 from openapi_core.datatypes import RequestParameters
+from openapi_core.validation.response.exceptions import InvalidData
 from packaging import version
 from werkzeug.datastructures import Headers, ImmutableMultiDict
 
@@ -47,24 +48,38 @@ def validate_nullable_consensus_primary(schema):
         body=None,
         content_type="",
     )
-    body = {
-        "details": {
-            "configs": [],
-            "acks": {},
-            "membership_state": "Active",
-            "primary_id": None,
-            "current_view": 0,
-            "ticking": False,
-        }
+    details = {
+        "configs": [],
+        "acks": {},
+        "membership_state": "Active",
+        "current_view": 0,
+        "ticking": False,
     }
-    response = infra.openapi._Response(
-        status_code=http.HTTPStatus.OK,
-        headers=Headers({"content-type": "application/json"}),
-        data=json.dumps(body).encode(),
-        content_type="application/json",
-    )
 
-    api.validate_response(request, response)
+    def validate_response(details):
+        response = infra.openapi._Response(
+            status_code=http.HTTPStatus.OK,
+            headers=Headers({"content-type": "application/json"}),
+            data=json.dumps({"details": details}).encode(),
+            content_type="application/json",
+        )
+        api.validate_response(request, response)
+
+    validate_response({**details, "primary_id": None})
+
+    for invalid_details in (
+        {**details, "primary_id": "not-a-node-id"},
+        details,
+    ):
+        try:
+            validate_response(invalid_details)
+        except InvalidData:
+            pass
+        else:
+            raise AssertionError(
+                f"Invalid consensus details passed schema validation: "
+                f"{invalid_details}"
+            )
 
 
 def run(args):


### PR DESCRIPTION
## Why

CI job [run 34465266745, job 102832243635](https://github.com/microsoft/CCF/actions/runs/34465266745/job/102832243635), from the Virtual C partition test added in #8323, failed OpenAPI response validation for `GET /node/consensus`: the node correctly returned HTTP 200 with `details.primary_id` set to `null` while the follower had no known primary, but the schema required a non-null string.

This is not a runtime bug. `primary_id` and `details.primary_id` are `std::optional<ccf::NodeId>` fields that are always present in the response (JSON-required) but legitimately have no value while no primary is known, for example on a follower between elections. In `src/consensus/aft/raft.h`, `leader_id` (the source of `primary_id`) is reset to `nullopt` during elections. Existing `std::optional<T>` JSON serialization already emits `null` correctly. Schema generation incorrectly conflated "required field" with "non-null value".

## Fix

Fixed the schema generation source, not only the checked-in snapshot:

- The inline JSON schema path unwraps required `std::optional<T>` fields, marks them `nullable: true`, and adds null to any existing enum constraint.
- The OpenAPI document path emits `anyOf` with the original referenced schema and a null-only branch. OpenAPI 3.0 does not support `type: null`, and `nullable` only applies when `type` is declared in the same schema object. The null branch therefore declares `type: object`, `nullable: true`, and `enum: [null]`; the enum ensures it accepts only null rather than arbitrary values.
- Required-field schema macros use these optional-aware helpers.

This fixes `ConsensusDetails::primary_id` (`GET /node/consensus`) and `GetNetworkInfo::Out::primary_id` (`GET /node/network`), along with the other required `std::optional` fields generated through the same macros. The node and sample logging app OpenAPI snapshots are synchronized, with document versions bumped to 5.0.7 and 2.8.5 respectively. A changelog entry records the user-visible node API fix.

## Tests

- The JSON schema unit tests verify required optional fields remain required, accept null and concrete values, and preserve enum constraints while admitting null.
- The OpenAPI unit test verifies the generated `anyOf` contains the original `$ref` and a strictly null-only branch.
- The existing schema e2e test constructs a minimal `/node/consensus` response with `primary_id: null` and validates it against the freshly fetched `/node/api` document using the same `openapi-core` response validator as normal e2e traffic. It also verifies malformed and missing `primary_id` values are rejected.