### PR TITLE
Align patched quickjs.c build path with sanitizer suppressions

### DIFF
--- a/cmake/quickjs.cmake
+++ b/cmake/quickjs.cmake
@@ -17,11 +17,15 @@ set(
   QUICKJS_HEAP_LIMIT_PATCH
   ${QUICKJS_PATCH_DIR}/0002-enforce-lowered-heap-limit.patch
 )
-set(QUICKJS_PATCHED_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/quickjs/quickjs.c)
+# Mirror the source prefix (3rdparty/exported/quickjs) under the build
+# directory so that the generated, patched quickjs.c still matches the
+# path-based sanitizer suppressions in src/san_common.suppressions.
+set(QUICKJS_PATCHED_DIR ${CMAKE_CURRENT_BINARY_DIR}/3rdparty/exported/quickjs)
+set(QUICKJS_PATCHED_SOURCE ${QUICKJS_PATCHED_DIR}/quickjs.c)
 add_custom_command(
   OUTPUT ${QUICKJS_PATCHED_SOURCE}
   BYPRODUCTS ${QUICKJS_PATCHED_SOURCE}.backtrace
-  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/quickjs
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${QUICKJS_PATCHED_DIR}
   COMMAND
     ${PATCH_EXECUTABLE} --batch --forward --fuzz=0 --output
     ${QUICKJS_PATCHED_SOURCE}.backtrace ${QUICKJS_PREFIX}/quickjs.c


### PR DESCRIPTION
## Symptom

The ASAN/UBSan CI job fails on every PR, e.g. https://github.com/microsoft/CCF/actions/runs/34486211149/job/102901038963:

```
/__w/CCF/CCF/build/quickjs/quickjs.c:35440:67: runtime error: left shift of 168 by 24 places cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /__w/CCF/CCF/build/quickjs/quickjs.c:35440:67
```

CCF's e2e infra treats node stderr output as a test failure, so this fails the job.

## Root cause

The UB is pre-existing, upstream QuickJS: the `M4(op1, op2, op3, op4)` macro does a signed `<< 24` shift that's technically UB. It has always been suppressed via the clang ignorelist at `src/san_common.suppressions`, which matches `*/3rdparty/exported/quickjs/quickjs.c`.

#8340 ("Update QuickJS to 2026-06-04") changed `cmake/quickjs.cmake` to copy `quickjs.c` and apply local patches to it before compiling, writing the patched copy to `${CMAKE_CURRENT_BINARY_DIR}/quickjs/quickjs.c` (e.g. `build/quickjs/quickjs.c`) instead of compiling the source-tree file directly. Since the ignorelist match is against the actual path passed to the compiler, this new build-dir path no longer matched the existing glob and the previously-suppressed UB started being reported.

## Fix

Rather than widen the sanitizer suppressions glob, keep it as-is and instead have CMake generate the patched file under a path that mirrors the source prefix, so it lands where the suppression already expects it:

```diff
-set(QUICKJS_PATCHED_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/quickjs/quickjs.c)
+set(QUICKJS_PATCHED_DIR ${CMAKE_CURRENT_BINARY_DIR}/3rdparty/exported/quickjs)
+set(QUICKJS_PATCHED_SOURCE ${QUICKJS_PATCHED_DIR}/quickjs.c)
```

The patched file now ends up at `build/3rdparty/exported/quickjs/quickjs.c`, matching `src:*/3rdparty/exported/quickjs/quickjs.c` in `src/san_common.suppressions` unchanged.

## Validation

- Verified locally: a fresh CMake configure + `ninja quickjs` build succeeds, and the patched source is generated at `build/3rdparty/exported/quickjs/quickjs.c` as expected.
- `scripts/cmake-format-checks.sh`, `scripts/ascii-checks.sh`, and `scripts/copyright-checks.sh` all pass.
- A full ASAN build was not attempted locally (not feasible in this environment); CI's ASAN job is the real verification for the suppression behavior.

No user-facing API or behaviour change, so no CHANGELOG entry.
