### PR TITLE
Explore ccache for CI Debug builds

### DIFF
--- a/.github/actions/save-ccache/action.yml
+++ b/.github/actions/save-ccache/action.yml
@@ -1,0 +1,26 @@
+name: Save compiler cache
+description: Report ccache statistics for the build that just ran and save the cache for later runs
+
+runs:
+  using: composite
+  steps:
+    - name: Report ccache statistics
+      if: env.CCACHE_CACHE_KEY != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "::group::ccache statistics"
+        ccache --show-stats --verbose
+        echo "::endgroup::"
+        # Drop entries that no longer fit under CCACHE_MAXSIZE before the
+        # directory is archived, so the saved entry stays bounded.
+        ccache --cleanup > /dev/null
+        echo "Saving cache size: $(du -sh "$CCACHE_DIR" | cut -f 1)"
+
+    - name: Save compiler cache
+      if: env.CCACHE_CACHE_KEY != ''
+      continue-on-error: true
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ env.CCACHE_DIR }}
+        key: ${{ env.CCACHE_CACHE_KEY }}

--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -1,0 +1,105 @@
+name: Set up compiler cache
+description: Install and configure ccache, then restore the newest cache for this build configuration
+
+inputs:
+  key:
+    description: Identifies the build configuration; jobs sharing a key restore each other's caches
+    required: true
+  max-size:
+    description: Upper bound on the local ccache directory, in ccache size syntax
+    required: false
+    default: 500M
+
+outputs:
+  enabled:
+    description: Whether ccache is installed and configured for subsequent build steps
+    value: ${{ steps.configure.outputs.enabled }}
+
+runs:
+  using: composite
+  steps:
+    - name: Configure ccache
+      id: configure
+      shell: bash
+      env:
+        CACHE_KEY_INPUT: ${{ inputs.key }}
+        MAX_SIZE_INPUT: ${{ inputs.max-size }}
+      run: |
+        set -euo pipefail
+
+        if ! command -v ccache > /dev/null; then
+          package_manager=""
+          for candidate in tdnf dnf; do
+            if command -v "$candidate" > /dev/null; then
+              package_manager=$candidate
+              break
+            fi
+          done
+
+          installed=false
+          if [[ -n $package_manager ]]; then
+            for attempt in 1 2 3; do
+              if "$package_manager" -y install ccache; then
+                installed=true
+                break
+              fi
+              if (( attempt == 1 )); then
+                sleep 5
+              elif (( attempt == 2 )); then
+                sleep 30
+              fi
+            done
+          fi
+
+          if [[ $installed != true ]]; then
+            echo "::warning::ccache is not available on this runner, building without a compiler cache"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+        fi
+
+        ccache_dir="$RUNNER_TEMP/ccache"
+        mkdir -p "$ccache_dir"
+
+        # Every run saves a new immutable entry, so the key must be unique per
+        # job and attempt. Restore matches on the configuration prefix, which
+        # picks the most recently saved cache for that configuration.
+        restore_prefix="ccache-${CACHE_KEY_INPUT}-${RUNNER_ARCH}-"
+        cache_key="${restore_prefix}${GITHUB_JOB}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+        {
+          echo "CCACHE_DIR=$ccache_dir"
+          echo "CCACHE_MAXSIZE=$MAX_SIZE_INPUT"
+          # Hash the compiler by version rather than by mtime, so a cache
+          # populated on one runner image is reusable on another with the same
+          # toolchain.
+          echo "CCACHE_COMPILERCHECK=%compiler% --version"
+          echo "CCACHE_CACHE_KEY=$cache_key"
+          echo "CCACHE_RESTORE_PREFIX=$restore_prefix"
+          # CMake reads these as the initial values of the matching cache
+          # variables, so build steps need no changes to opt in.
+          echo "CMAKE_C_COMPILER_LAUNCHER=ccache"
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache"
+        } >> "$GITHUB_ENV"
+
+        echo "enabled=true" >> "$GITHUB_OUTPUT"
+        ccache --version | head -n 1
+
+    - name: Restore compiler cache
+      if: steps.configure.outputs.enabled == 'true'
+      continue-on-error: true
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ env.CCACHE_DIR }}
+        key: ${{ env.CCACHE_CACHE_KEY }}
+        restore-keys: ${{ env.CCACHE_RESTORE_PREFIX }}
+
+    - name: Reset ccache statistics
+      if: steps.configure.outputs.enabled == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Zero the counters so the statistics reported after the build only
+        # cover this job's compilations.
+        ccache --zero-stats > /dev/null
+        echo "Restored cache size: $(du -sh "$CCACHE_DIR" | cut -f 1)"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,6 +10,10 @@ At a weekly rollover, restore keys first reuse the latest cache for the same dep
 
 The action also assigns uv a writable cache directory outside `/github/home/.cache`, because some tests clear that directory. A weekly cache persists uv's content-addressed package cache, keyed on the pinned uv installer, `python/pyproject.toml`, and the `python-requirements` input, which each workflow sets to the requirements files it installs so unrelated jobs do not invalidate each other's cache; jobs that do not install Python packages disable this cache entirely with `cache-python-packages: false`. CI dependency setup uses `uv pip` so cached packages remain reusable, with workflows configuring the package index through `UV_INDEX_URL`. Pip is not used for package installation because the PyPI proxy redirects artifacts to short-lived URLs that pip cannot reuse across jobs.
 
+## Compiler cache
+
+The local composite actions in `.github/actions/setup-ccache/action.yml` and `.github/actions/save-ccache/action.yml` wrap a `ccache` compiler cache around the CMake build steps. `setup-ccache` installs `ccache` when the runner image lacks it, points CMake at it through the `CMAKE_C_COMPILER_LAUNCHER` and `CMAKE_CXX_COMPILER_LAUNCHER` environment variables, and restores the newest cache saved for the `key` input, which names a build configuration. Jobs that compile the same sources with the same flags on the same runner image share a key, so a cache populated by one job warms the others. `save-ccache` runs immediately after the build, reports hit statistics, and saves a new immutable entry named after the job and run, so the build result is kept even when a later test step fails. The compiler is identified by its version output rather than its modification time, and the cache directory is bounded by the `max-size` input.
+
 # Maintained
 
 ## Bencher

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
           set -ex
           ./scripts/setup-dev.sh
 
+      - name: "Set up ccache"
+        uses: ./.github/actions/setup-ccache
+        with:
+          key: virtual-debug
+
       - name: "Run Checks and Build Debug with clang-tidy"
         run: |
           set -ex
@@ -68,6 +73,10 @@ jobs:
           cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DCLANG_TIDY=ON ..
           ninja
         shell: bash
+
+      - name: "Save ccache"
+        uses: ./.github/actions/save-ccache
+        if: success() || failure()
 
       - name: "Run tests for Python package"
         run: |
@@ -153,6 +162,11 @@ jobs:
           python3 tests/infra/platform_detection.py virtual
         shell: bash
 
+      - name: "Set up ccache"
+        uses: ./.github/actions/setup-ccache
+        with:
+          key: virtual-debug
+
       - name: "Build Debug"
         run: |
           set -ex
@@ -162,6 +176,10 @@ jobs:
           cmake -GNinja -DCMAKE_BUILD_TYPE=Debug ..
           ninja
         shell: bash
+
+      - name: "Save ccache"
+        uses: ./.github/actions/save-ccache
+        if: success() || failure()
 
       - name: "Test virtual"
         run: |
@@ -215,6 +233,11 @@ jobs:
       - name: "Install dependencies"
         uses: ./.github/actions/install-ci-dependencies
 
+      - name: "Set up ccache"
+        uses: ./.github/actions/setup-ccache
+        with:
+          key: virtual-debug
+
       - name: "Build Debug"
         run: |
           set -ex
@@ -224,6 +247,10 @@ jobs:
           cmake -GNinja -DCMAKE_BUILD_TYPE=Debug ..
           ninja
         shell: bash
+
+      - name: "Save ccache"
+        uses: ./.github/actions/save-ccache
+        if: success() || failure()
 
       - name: "Test virtual"
         run: |
@@ -292,6 +319,11 @@ jobs:
           python3 tests/infra/platform_detection.py snp milan
         shell: bash
 
+      - name: "Set up ccache"
+        uses: ./.github/actions/setup-ccache
+        with:
+          key: aci-debug
+
       - name: "Build Debug"
         run: |
           set -ex
@@ -301,6 +333,10 @@ jobs:
           cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DWORKER_THREADS=1 ..
           ninja
         shell: bash
+
+      - name: "Save ccache"
+        uses: ./.github/actions/save-ccache
+        if: success() || failure()
 
       - name: "Tests"
         run: |
@@ -378,6 +414,11 @@ jobs:
           python3 tests/infra/platform_detection.py snp genoa
         shell: bash
 
+      - name: "Set up ccache"
+        uses: ./.github/actions/setup-ccache
+        with:
+          key: aci-debug
+
       - name: "Build Debug"
         run: |
           set -ex
@@ -387,6 +428,10 @@ jobs:
           cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DWORKER_THREADS=1 ..
           ninja
         shell: bash
+
+      - name: "Save ccache"
+        uses: ./.github/actions/save-ccache
+        if: success() || failure()
 
       - name: "Tests"
         run: |

--- a/scripts/setup-ci.sh
+++ b/scripts/setup-ci.sh
@@ -69,7 +69,8 @@ install_build_dependencies() {
         doxygen  \
         clang-tools-extra-devel  \
         rust  \
-        libbacktrace-static
+        libbacktrace-static  \
+        ccache
 }
 
 install_test_dependencies() {


### PR DESCRIPTION
Draft to measure what a compiler cache buys `ci.yml`. Not intended to merge as-is until the numbers are in.

## Why

Analysis of the last 8 green `main` runs of `ci.yml`: every job compiles all 324 targets from scratch, with no compiler caching anywhere.

| Job | avg wall | Build step |
|---|---|---|
| VMSS Virtual A | 13.9 min | 8.1 min (Debug + clang-tidy) |
| VMSS Virtual B | 15.7 min | 3.1 min |
| VMSS Virtual C | 15.9 min | 3.1 min |
| ACI SNP Milan | 13.2 min | 6.8 min |
| ACI SNP Genoa | 11.2 min | 5.0 min |

`WORKER_THREADS` is only a test argument and `CLANG_TIDY` only sets a target property, so all five builds compile identical objects.

## What

- `.github/actions/setup-ccache`: installs `ccache` if the runner image lacks it (ACI), sets `CMAKE_{C,CXX}_COMPILER_LAUNCHER` via `GITHUB_ENV` so build steps are unchanged, restores the newest cache for the given `key`.
- `.github/actions/save-ccache`: prints `ccache --show-stats --verbose` and saves a new entry keyed by job + run, immediately after the build (so a later test failure does not lose it).
- Virtual A/B/C share key `virtual-debug`; Milan/Genoa share `aci-debug`. `CCACHE_COMPILERCHECK=%compiler% --version` so the hash does not depend on the compiler binary's mtime on each image.
- `ccache` added to `scripts/setup-ci.sh`.

## Local measurement (20-core AL4, clang 21, Debug, `-GNinja`)

| | wall | compiler CPU | hits |
|---|---|---|---|
| Cold (empty cache) | 362 s | 4123 s | 11/226 (4.9%) |
| Warm (`ninja clean`, populated) | **21 s** | 131 s | 226/226 |

Full-build cache footprint: **189 MB** (ccache zstd), so five entries per run are well inside the 10 GB repo cap (currently 9.99 GB used, mostly per-PR uv caches that are already churning). `max-size` defaults to 500M.

## How to read the results

- **Run 1 on this PR is cold**: no `main` cache exists yet. It measures ccache's overhead on a miss (expect ~1-3% on the build step) and populates the caches.
- **Run 2** (any push, or re-run) restores run 1's cache: the "Build Debug" step time and the `ccache statistics` group in the "Save ccache" step give the warm numbers per job.
- Virtual A's tidy step will only shrink by the compile portion; clang-tidy itself reruns on every TU and is out of scope here.
- If `tdnf install ccache` is not possible on the ACI image, the action emits a warning and the build proceeds uncached; that outcome is itself useful to know.

Expected, extrapolating from local: VMSS build 3 min -> ~20-30 s; ACI build 5-7 min -> ~40-60 s; Virtual A tidy step 8 min -> ~5 min.