### PR TITLE
Narrow recovery protocol dependencies to reduce compilation

### DIFF
--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -46,6 +46,7 @@
 #include "node/node_to_node_channel_manager.h"
 #include "node/recovery_decision_protocol.h"
 #include "node/recovery_snapshot_ledger.h"
+#include "node/rpc/gov_effects.h"
 #include "node/signature_cache_subsystem.h"
 #include "node/snapshotter.h"
 #include "node_to_node.h"
@@ -140,8 +141,6 @@ namespace ccf
 
   class NodeState : public AbstractNodeState
   {
-    friend class RecoveryDecisionProtocolSubsystem;
-
     struct FetchSnapshot : public ccf::tasks::BaseTask
     {
       const ccf::StartupConfig::Join join_config;
@@ -779,6 +778,67 @@ namespace ccf
       start_public_ledger_recovery_unsafe();
     }
 
+    struct RecoveryDecisionProtocolNode
+      : public AbstractRecoveryDecisionProtocolNode
+    {
+      NodeState& owner;
+
+      RecoveryDecisionProtocolNode(NodeState& owner_) : owner(owner_) {}
+
+      NodeId get_node_id() const override
+      {
+        return owner.get_node_id();
+      }
+
+      void cache_node_info(
+        std::optional<recovery_decision_protocol::RequestNodeInfo>& cache,
+        const QuoteInfo& quote_info_) override
+      {
+        std::lock_guard<ds::Mutex> guard(owner.lock);
+        if (!owner.config.sealing_recovery.has_value())
+        {
+          throw std::logic_error("Sealing recovery not configured");
+        }
+        cache = recovery_decision_protocol::RequestNodeInfo{
+          .quote_info = quote_info_,
+          .location = owner.config.sealing_recovery->location,
+          .service_cert_der =
+            ccf::crypto::cert_pem_to_der(owner.network.identity->cert),
+        };
+      }
+
+      crypto::Pem get_self_signed_certificate() override
+      {
+        return owner.get_self_signed_certificate();
+      }
+
+      crypto::Pem get_private_key() override
+      {
+        return owner.node_sign_kp->private_key_pem();
+      }
+
+      TxID get_last_recovered_signed_txid() override
+      {
+        auto recovery_seqno = owner.last_recovered_signed_idx;
+        auto recovery_view = owner.consensus->get_view(recovery_seqno);
+        // get_view returns VIEW_UNKNOWN if the seqno is outside view history.
+        if (recovery_view == ccf::VIEW_UNKNOWN)
+        {
+          throw std::logic_error(fmt::format(
+            "Could not find view for last recovered signed seqno {}",
+            recovery_seqno));
+        }
+        return {recovery_view, recovery_seqno};
+      }
+
+      void restart() override
+      {
+        RINGBUFFER_WRITE_MESSAGE(AdminMessage::restart, owner.to_host);
+      }
+    };
+
+    GovernanceEffects recovery_governance;
+    RecoveryDecisionProtocolNode recovery_node;
     RecoveryDecisionProtocolSubsystem recovery_decision_protocol;
 
   public:
@@ -797,7 +857,13 @@ namespace ccf
       network(network),
       rpcsessions(std::move(rpcsessions)),
       share_manager(network.ledger_secrets),
-      recovery_decision_protocol(this)
+      recovery_governance(*this),
+      recovery_node(*this),
+      recovery_decision_protocol(
+        config.sealing_recovery,
+        network.tables,
+        recovery_governance,
+        recovery_node)
     {
       network.tables->set_readiness(ccf::kv::StoreReadiness::Unavailable);
     }

--- a/src/node/node_state.h
+++ b/src/node/node_state.h
@@ -785,7 +785,7 @@ namespace ccf
 
       RecoveryDecisionProtocolNode(NodeState& owner_) : owner(owner_) {}
 
-      NodeId get_node_id() const override
+      [[nodiscard]] NodeId get_node_id() const override
       {
         return owner.get_node_id();
       }

--- a/src/node/recovery_decision_protocol.cpp
+++ b/src/node/recovery_decision_protocol.cpp
@@ -7,10 +7,14 @@
 #include "ccf/ds/locking.h"
 #include "ccf/service/tables/nodes.h"
 #include "ccf/service/tables/self_healing_open.h"
+#include "ccf/service/tables/service.h"
 #include "ccf/tx.h"
 #include "ccf/tx_id.h"
+#include "ds/actors.h"
 #include "http_client/curl.h"
-#include "node_state.h"
+#include "kv/store.h"
+#include "node/rpc/gov_effects_interface.h"
+#include "service/tables/previous_service_identity.h"
 #include "tasks/basic_task.h"
 #include "tasks/task_system.h"
 
@@ -21,8 +25,14 @@ namespace ccf
 {
 
   RecoveryDecisionProtocolSubsystem::RecoveryDecisionProtocolSubsystem(
-    NodeState* node_state_) :
-    node_state(node_state_)
+    const std::optional<SealingRecoveryConfig>& sealing_recovery_,
+    const std::shared_ptr<kv::Store>& tables_,
+    AbstractGovernanceEffects& governance_,
+    AbstractRecoveryDecisionProtocolNode& node_) :
+    sealing_recovery(sealing_recovery_),
+    tables(tables_),
+    governance(governance_),
+    node(node_)
   {}
 
   void RecoveryDecisionProtocolSubsystem::reset_state(ccf::kv::Tx& tx)
@@ -54,13 +64,12 @@ namespace ccf
   void RecoveryDecisionProtocolSubsystem::try_start(
     ccf::kv::Tx& tx, bool recovering)
   {
-    if (!node_state->config.sealing_recovery.has_value())
+    if (!sealing_recovery.has_value())
     {
       LOG_INFO_FMT("Recovery-decision-protocol not configured, skipping");
       return;
     }
-    auto& config =
-      node_state->config.sealing_recovery->recovery_decision_protocol;
+    auto& config = sealing_recovery->recovery_decision_protocol;
     if (!recovering || !config.has_value())
     {
       LOG_INFO_FMT("Skipping recovery-decision-protocol");
@@ -77,7 +86,7 @@ namespace ccf
       ->put(recovery_decision_protocol::StateMachine::GOSSIPING);
 
     // Delay start of message retry and failover timers until after commit
-    node_state->network.tables->set_global_hook(
+    tables->set_global_hook(
       Tables::RECOVERY_DECISION_PROTOCOL_SM_STATE,
       recovery_decision_protocol::SMState::wrap_commit_hook(
         [this](
@@ -211,7 +220,7 @@ namespace ccf
           sm_state_handle->put(
             recovery_decision_protocol::StateMachine::OPENING);
 
-          node_state->transition_service_to_open(tx, identities);
+          governance.transition_service_to_open(tx, identities);
         }
         break;
       }
@@ -246,7 +255,7 @@ namespace ccf
           ccf::crypto::cert_der_to_pem(node_config->service_cert_der);
         LOG_INFO_FMT("{}", service_cert.str());
 
-        RINGBUFFER_WRITE_MESSAGE(AdminMessage::restart, node_state->to_host);
+        node.restart();
       }
       case recovery_decision_protocol::StateMachine::OPENING:
       {
@@ -299,20 +308,19 @@ namespace ccf
 
     retry_task = ccf::tasks::make_basic_task(
       [this]() {
-        if (!node_state->config.sealing_recovery.has_value())
+        if (!sealing_recovery.has_value())
         {
           LOG_INFO_FMT(
             "Recovery-decision-protocol not configured, skipping retry timers");
           return;
         }
-        auto& config =
-          node_state->config.sealing_recovery->recovery_decision_protocol;
+        auto& config = sealing_recovery->recovery_decision_protocol;
         if (!config.has_value())
         {
           throw std::logic_error("Recovery-decision-protocol not configured");
         }
 
-        auto tx = node_state->network.tables->create_read_only_tx();
+        auto tx = tables->create_read_only_tx();
         auto* sm_state_handle = tx.ro<recovery_decision_protocol::SMState>(
           Tables::RECOVERY_DECISION_PROTOCOL_SM_STATE);
 
@@ -409,7 +417,7 @@ namespace ccf
 
         // Stop the timer if the node has completed its
         // recovery-decision-protocol
-        auto tx = node_state->network.tables->create_read_only_tx();
+        auto tx = tables->create_read_only_tx();
         auto* sm_state_handle = tx.ro<recovery_decision_protocol::SMState>(
           Tables::RECOVERY_DECISION_PROTOCOL_SM_STATE);
         if (!sm_state_handle->get().has_value())
@@ -429,8 +437,8 @@ namespace ccf
         // Send a timeout to the internal handlers
         http_client::UniqueCURL curl_handle;
 
-        const auto cert = node_state->get_self_signed_certificate();
-        const auto privkey_pem = node_state->node_sign_kp->private_key_pem();
+        const auto cert = node.get_self_signed_certificate();
+        const auto privkey_pem = node.get_private_key();
 
         curl_handle.set_opt(CURLOPT_SSL_VERIFYHOST, 0L);
         curl_handle.set_opt(CURLOPT_SSL_VERIFYPEER, 0L);
@@ -563,21 +571,13 @@ namespace ccf
     }
 
     auto* nodes_handle = tx.ro<Nodes>(Tables::NODES);
-    auto node_info_opt = nodes_handle->get(node_state->get_node_id());
+    auto node_info_opt = nodes_handle->get(node.get_node_id());
     if (!node_info_opt.has_value())
     {
-      throw std::logic_error(fmt::format(
-        "Node {} not found in nodes table", node_state->get_node_id()));
+      throw std::logic_error(
+        fmt::format("Node {} not found in nodes table", node.get_node_id()));
     }
-    {
-      std::lock_guard<ds::Mutex> ns_guard(node_state->lock);
-      node_info_cache = recovery_decision_protocol::RequestNodeInfo{
-        .quote_info = node_info_opt->quote_info,
-        .location = get_location(),
-        .service_cert_der =
-          ccf::crypto::cert_pem_to_der(node_state->network.identity->cert),
-      };
-    }
+    node.cache_node_info(node_info_cache, node_info_opt->quote_info);
     return node_info_cache.value();
   }
 
@@ -589,11 +589,10 @@ namespace ccf
 
     recovery_decision_protocol::GossipRequest request;
     request.info = get_node_info(tx);
-    request.txid = get_last_recovered_signed_txid();
+    request.txid = node.get_last_recovered_signed_txid();
     nlohmann::json request_json = request;
-    const auto self_signed_node_cert =
-      node_state->get_self_signed_certificate();
-    const auto node_private_key = node_state->node_sign_kp->private_key_pem();
+    const auto self_signed_node_cert = node.get_self_signed_certificate();
+    const auto node_private_key = node.get_private_key();
 
     for (auto& target : config.expected_locations)
     {
@@ -618,15 +617,14 @@ namespace ccf
     recovery_decision_protocol::TaggedWithNodeInfo request{
       .info = get_node_info(tx)};
     nlohmann::json request_json = request;
-    const auto self_signed_node_cert =
-      node_state->get_self_signed_certificate();
+    const auto self_signed_node_cert = node.get_self_signed_certificate();
 
     dispatch_authenticated_message(
       request_json,
       node_info.location.address,
       "vote",
       self_signed_node_cert,
-      node_state->node_sign_kp->private_key_pem());
+      node.get_private_key());
   }
 
   recovery_decision_protocol::IAmOpenRequest&
@@ -641,7 +639,7 @@ namespace ccf
     }
 
     auto previous_service_cert =
-      tx.ro(node_state->network.previous_service_identity)->get();
+      tx.ro<PreviousServiceIdentity>(Tables::PREVIOUS_SERVICE_IDENTITY)->get();
     if (!previous_service_cert.has_value())
     {
       throw std::logic_error(
@@ -660,7 +658,7 @@ namespace ccf
       iamopen_request_cache->info = node_info;
       iamopen_request_cache->prev_service_fingerprint =
         previous_service_identity_fingerprint;
-      iamopen_request_cache->txid = get_last_recovered_signed_txid();
+      iamopen_request_cache->txid = node.get_last_recovered_signed_txid();
     }
 
     return iamopen_request_cache.value();
@@ -675,9 +673,8 @@ namespace ccf
     LOG_TRACE_FMT("Sending recovery-decision-protocol iamopen");
 
     nlohmann::json request_json = get_iamopen_request(tx);
-    const auto self_signed_node_cert =
-      node_state->get_self_signed_certificate();
-    const auto node_private_key = node_state->node_sign_kp->private_key_pem();
+    const auto self_signed_node_cert = node.get_self_signed_certificate();
+    const auto node_private_key = node.get_private_key();
 
     for (auto& target : config.expected_locations)
     {
@@ -695,15 +692,14 @@ namespace ccf
     }
   }
 
-  RecoveryDecisionProtocolConfig& RecoveryDecisionProtocolSubsystem::
+  const RecoveryDecisionProtocolConfig& RecoveryDecisionProtocolSubsystem::
     get_config()
   {
-    if (!node_state->config.sealing_recovery.has_value())
+    if (!sealing_recovery.has_value())
     {
       throw std::logic_error("Sealing recovery not configured");
     }
-    auto& config =
-      node_state->config.sealing_recovery->recovery_decision_protocol;
+    auto& config = sealing_recovery->recovery_decision_protocol;
     if (!config.has_value())
     {
       throw std::logic_error("Recovery-decision-protocol not configured");
@@ -711,27 +707,13 @@ namespace ccf
     return config.value();
   }
 
-  sealing_recovery::Location& RecoveryDecisionProtocolSubsystem::get_location()
+  const sealing_recovery::Location& RecoveryDecisionProtocolSubsystem::
+    get_location()
   {
-    if (!node_state->config.sealing_recovery.has_value())
+    if (!sealing_recovery.has_value())
     {
       throw std::logic_error("Sealing recovery not configured");
     }
-    return node_state->config.sealing_recovery->location;
-  }
-
-  ccf::TxID RecoveryDecisionProtocolSubsystem::get_last_recovered_signed_txid()
-  {
-    auto recovery_seqno = node_state->last_recovered_signed_idx;
-    auto recovery_view = node_state->consensus->get_view(recovery_seqno);
-    // get_view returns VIEW_UNKNOWN=InvalidView if the view is not in the view
-    // history (too old or too new)
-    if (recovery_view == ccf::VIEW_UNKNOWN)
-    {
-      throw std::logic_error(fmt::format(
-        "Could not find view for last recovered signed seqno {}",
-        recovery_seqno));
-    }
-    return ccf::TxID{recovery_view, recovery_seqno};
+    return sealing_recovery->location;
   }
 }

--- a/src/node/recovery_decision_protocol.cpp
+++ b/src/node/recovery_decision_protocol.cpp
@@ -69,7 +69,7 @@ namespace ccf
       LOG_INFO_FMT("Recovery-decision-protocol not configured, skipping");
       return;
     }
-    auto& config = sealing_recovery->recovery_decision_protocol;
+    const auto& config = sealing_recovery->recovery_decision_protocol;
     if (!recovering || !config.has_value())
     {
       LOG_INFO_FMT("Skipping recovery-decision-protocol");
@@ -104,7 +104,7 @@ namespace ccf
 
   void RecoveryDecisionProtocolSubsystem::advance(ccf::kv::Tx& tx, bool timeout)
   {
-    auto& config = get_config();
+    const auto& config = get_config();
 
     auto* sm_state_handle = tx.rw<recovery_decision_protocol::SMState>(
       Tables::RECOVERY_DECISION_PROTOCOL_SM_STATE);
@@ -304,7 +304,7 @@ namespace ccf
   {
     LOG_TRACE_FMT("Recovery-decision-protocol: Setting up retry timers");
 
-    auto& config = get_config();
+    const auto& config = get_config();
 
     retry_task = ccf::tasks::make_basic_task(
       [this]() {
@@ -314,7 +314,7 @@ namespace ccf
             "Recovery-decision-protocol not configured, skipping retry timers");
           return;
         }
-        auto& config = sealing_recovery->recovery_decision_protocol;
+        const auto& config = sealing_recovery->recovery_decision_protocol;
         if (!config.has_value())
         {
           throw std::logic_error("Recovery-decision-protocol not configured");
@@ -395,7 +395,7 @@ namespace ccf
 
   void RecoveryDecisionProtocolSubsystem::start_failover_timers()
   {
-    auto& config = get_config();
+    const auto& config = get_config();
 
     if (config.failover_timeout.count_ms() == 0)
     {
@@ -409,7 +409,7 @@ namespace ccf
 
     failover_task = ccf::tasks::make_basic_task(
       [this]() {
-        auto& location = get_location();
+        const auto& location = get_location();
 
         LOG_TRACE_FMT(
           "Recovery-decision-protocol timeout, sending timeout to internal "
@@ -578,12 +578,16 @@ namespace ccf
         fmt::format("Node {} not found in nodes table", node.get_node_id()));
     }
     node.cache_node_info(node_info_cache, node_info_opt->quote_info);
+    if (!node_info_cache.has_value())
+    {
+      throw std::bad_optional_access();
+    }
     return node_info_cache.value();
   }
 
   void RecoveryDecisionProtocolSubsystem::send_gossip_unsafe(kv::ReadOnlyTx& tx)
   {
-    auto& config = get_config();
+    const auto& config = get_config();
 
     LOG_TRACE_FMT("Broadcasting recovery-decision-protocol gossip");
 
@@ -594,7 +598,7 @@ namespace ccf
     const auto self_signed_node_cert = node.get_self_signed_certificate();
     const auto node_private_key = node.get_private_key();
 
-    for (auto& target : config.expected_locations)
+    for (const auto& target : config.expected_locations)
     {
       auto target_address = target.address;
       dispatch_authenticated_message(
@@ -667,8 +671,8 @@ namespace ccf
   void RecoveryDecisionProtocolSubsystem::send_iamopen_unsafe(
     ccf::kv::ReadOnlyTx& tx)
   {
-    auto& config = get_config();
-    auto& location = get_location();
+    const auto& config = get_config();
+    const auto& location = get_location();
 
     LOG_TRACE_FMT("Sending recovery-decision-protocol iamopen");
 
@@ -676,7 +680,7 @@ namespace ccf
     const auto self_signed_node_cert = node.get_self_signed_certificate();
     const auto node_private_key = node.get_private_key();
 
-    for (auto& target : config.expected_locations)
+    for (const auto& target : config.expected_locations)
     {
       if (target.name == location.name)
       {
@@ -699,7 +703,7 @@ namespace ccf
     {
       throw std::logic_error("Sealing recovery not configured");
     }
-    auto& config = sealing_recovery->recovery_decision_protocol;
+    const auto& config = sealing_recovery->recovery_decision_protocol;
     if (!config.has_value())
     {
       throw std::logic_error("Recovery-decision-protocol not configured");

--- a/src/node/recovery_decision_protocol.h
+++ b/src/node/recovery_decision_protocol.h
@@ -50,7 +50,7 @@ namespace ccf
   {
   public:
     virtual ~AbstractRecoveryDecisionProtocolNode() = default;
-    virtual NodeId get_node_id() const = 0;
+    [[nodiscard]] virtual NodeId get_node_id() const = 0;
     virtual void cache_node_info(
       std::optional<recovery_decision_protocol::RequestNodeInfo>& cache,
       const QuoteInfo& quote_info) = 0;

--- a/src/node/recovery_decision_protocol.h
+++ b/src/node/recovery_decision_protocol.h
@@ -39,13 +39,37 @@ namespace ccf::recovery_decision_protocol
 
 namespace ccf
 {
-  class NodeState;
+  namespace kv
+  {
+    class Store;
+  }
+
+  class AbstractGovernanceEffects;
+
+  class AbstractRecoveryDecisionProtocolNode
+  {
+  public:
+    virtual ~AbstractRecoveryDecisionProtocolNode() = default;
+    virtual NodeId get_node_id() const = 0;
+    virtual void cache_node_info(
+      std::optional<recovery_decision_protocol::RequestNodeInfo>& cache,
+      const QuoteInfo& quote_info) = 0;
+    virtual crypto::Pem get_self_signed_certificate() = 0;
+    virtual crypto::Pem get_private_key() = 0;
+    virtual TxID get_last_recovered_signed_txid() = 0;
+    virtual void restart() = 0;
+  };
+
   class RecoveryDecisionProtocolSubsystem
   {
   private:
-    // RecoveryDecisionProtocolSubsystem is solely owned by NodeState, and all
-    // tasks should finish before NodeState is destroyed
-    NodeState* node_state;
+    // The owner must keep these dependencies alive and finish all tasks before
+    // destroying the subsystem. Retain references to configuration and store
+    // slots, which are populated after NodeState construction.
+    const std::optional<SealingRecoveryConfig>& sealing_recovery;
+    const std::shared_ptr<kv::Store>& tables;
+    AbstractGovernanceEffects& governance;
+    AbstractRecoveryDecisionProtocolNode& node;
 
     // Periodic task handles - kept to allow cancellation
     ccf::tasks::Task retry_task;
@@ -57,7 +81,11 @@ namespace ccf
       iamopen_request_cache;
 
   public:
-    RecoveryDecisionProtocolSubsystem(NodeState* node_state);
+    RecoveryDecisionProtocolSubsystem(
+      const std::optional<SealingRecoveryConfig>& sealing_recovery,
+      const std::shared_ptr<kv::Store>& tables,
+      AbstractGovernanceEffects& governance,
+      AbstractRecoveryDecisionProtocolNode& node);
     void reset_state(ccf::kv::Tx& tx);
     void try_start(ccf::kv::Tx& tx, bool recovering);
     void advance(ccf::kv::Tx& tx, bool timeout);
@@ -82,8 +110,7 @@ namespace ccf
       const recovery_decision_protocol::NodeInfo& node_info);
     void send_iamopen_unsafe(kv::ReadOnlyTx& tx);
 
-    RecoveryDecisionProtocolConfig& get_config();
-    sealing_recovery::Location& get_location();
-    ccf::TxID get_last_recovered_signed_txid();
+    const RecoveryDecisionProtocolConfig& get_config();
+    const sealing_recovery::Location& get_location();
   };
 }

--- a/src/node/rpc/gov_effects.h
+++ b/src/node/rpc/gov_effects.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache 2.0 License.
 #pragma once
 
-#include "node/node_state.h"
 #include "node/rpc/gov_effects_interface.h"
+#include "node/rpc/node_interface.h"
 
 namespace ccf
 {

--- a/src/node/rpc/test/frontend_test.cpp
+++ b/src/node/rpc/test/frontend_test.cpp
@@ -20,6 +20,7 @@
 #include "node/rpc/node_frontend.h"
 #include "node/test/channel_stub.h"
 #include "node_stub.h"
+#include "recovery_decision_protocol_test.h"
 #include "service/internal_tables_access.h"
 
 #include <doctest/doctest.h>

--- a/src/node/rpc/test/node_frontend_test.cpp
+++ b/src/node/rpc/test/node_frontend_test.cpp
@@ -10,6 +10,7 @@
 #include "nlohmann/json.hpp"
 #include "node/rpc/node_frontend.h"
 #include "node_stub.h"
+#include "recovery_decision_protocol_test.h"
 #include "service/internal_tables_access.h"
 
 #include <latch>

--- a/src/node/rpc/test/recovery_decision_protocol_test.h
+++ b/src/node/rpc/test/recovery_decision_protocol_test.h
@@ -34,8 +34,9 @@ namespace ccf::recovery_decision_protocol::test
     TxID recovered_txid = {2, 42};
     size_t cache_calls = 0;
     size_t restarts = 0;
+    bool populate_cache = true;
 
-    NodeId get_node_id() const override
+    [[nodiscard]] NodeId get_node_id() const override
     {
       return NodeId{"test-node"};
     }
@@ -45,8 +46,11 @@ namespace ccf::recovery_decision_protocol::test
       const QuoteInfo& quote_info) override
     {
       ++cache_calls;
-      cache = info;
-      cache->quote_info = quote_info;
+      if (populate_cache)
+      {
+        cache = info;
+        cache->quote_info = quote_info;
+      }
     }
 
     crypto::Pem get_self_signed_certificate() override
@@ -297,6 +301,24 @@ namespace ccf::recovery_decision_protocol::test
     ccf::NodeInfo node_info;
     node_info.encryption_pub_key = dummy_enc_pubk;
     tx.rw<Nodes>(Tables::NODES)->put(f.node.get_node_id(), node_info);
+    SUBCASE("Adapter leaves cache empty")
+    {
+      f.node.populate_cache = false;
+      bool caught = false;
+      try
+      {
+        f.protocol.get_iamopen_request(tx);
+      }
+      catch (const std::bad_optional_access& e)
+      {
+        caught = true;
+        CHECK(std::string(e.what()) == std::bad_optional_access().what());
+      }
+      CHECK(caught);
+      CHECK(f.node.cache_calls == 1);
+      f.node.cache_calls = 0;
+      f.node.populate_cache = true;
+    }
     auto first = f.protocol.get_iamopen_request(tx);
     CHECK(first.txid == f.node.recovered_txid);
     CHECK(first.info.location == f.config->location);

--- a/src/node/rpc/test/recovery_decision_protocol_test.h
+++ b/src/node/rpc/test/recovery_decision_protocol_test.h
@@ -1,0 +1,342 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+#pragma once
+
+#include "frontend_test_infra.h"
+#include "kv/test/null_encryptor.h"
+#include "node/recovery_decision_protocol.h"
+#include "node_stub.h"
+#include "service/tables/previous_service_identity.h"
+#include "tasks/task_system.h"
+
+namespace ccf::recovery_decision_protocol::test
+{
+  // The frontend harness disables doctest's exception assertions.
+  template <typename F>
+  void check_logic_error(F&& operation, const std::string& expected)
+  {
+    bool caught = false;
+    try
+    {
+      operation();
+    }
+    catch (const std::logic_error& e)
+    {
+      caught = true;
+      CHECK(std::string(e.what()) == expected);
+    }
+    CHECK(caught);
+  }
+
+  struct Node : public AbstractRecoveryDecisionProtocolNode
+  {
+    RequestNodeInfo info;
+    TxID recovered_txid = {2, 42};
+    size_t cache_calls = 0;
+    size_t restarts = 0;
+
+    NodeId get_node_id() const override
+    {
+      return NodeId{"test-node"};
+    }
+
+    void cache_node_info(
+      std::optional<RequestNodeInfo>& cache,
+      const QuoteInfo& quote_info) override
+    {
+      ++cache_calls;
+      cache = info;
+      cache->quote_info = quote_info;
+    }
+
+    crypto::Pem get_self_signed_certificate() override
+    {
+      throw std::logic_error("Unexpected network request");
+    }
+
+    crypto::Pem get_private_key() override
+    {
+      throw std::logic_error("Unexpected network request");
+    }
+
+    TxID get_last_recovered_signed_txid() override
+    {
+      return recovered_txid;
+    }
+
+    void restart() override
+    {
+      ++restarts;
+    }
+  };
+
+  struct Governance : public StubGovernanceEffects
+  {
+    size_t opens = 0;
+    kv::Tx* expected_tx = nullptr;
+    bool fail = false;
+
+    void transition_service_to_open(
+      kv::Tx& tx, ServiceIdentities identities) override
+    {
+      ++opens;
+      CHECK(&tx == expected_tx);
+      CHECK(
+        tx.ro<SMState>(Tables::RECOVERY_DECISION_PROTOCOL_SM_STATE)->get() ==
+        StateMachine::OPENING);
+      auto* service = tx.rw<Service>(Tables::SERVICE);
+      auto info = service->get().value();
+      CHECK(identities.next == info.cert);
+      CHECK(
+        identities.previous ==
+        tx.ro<PreviousServiceIdentity>(Tables::PREVIOUS_SERVICE_IDENTITY)
+          ->get());
+      info.status = ServiceStatus::OPEN;
+      service->put(info);
+      if (fail)
+      {
+        throw std::logic_error("Rejected recovery transition");
+      }
+    }
+  };
+
+  struct Fixture
+  {
+    std::optional<SealingRecoveryConfig> config;
+    std::shared_ptr<kv::Store> tables;
+    Governance governance;
+    Node node;
+    RecoveryDecisionProtocolSubsystem protocol{
+      config, tables, governance, node};
+
+    Fixture()
+    {
+      tables = std::make_shared<kv::Store>();
+      tables->set_encryptor(std::make_shared<kv::NullTxEncryptor>());
+      config = SealingRecoveryConfig{
+        .location = {"a", "localhost:1234"},
+        .recovery_decision_protocol = RecoveryDecisionProtocolConfig{
+          .expected_locations =
+            {{"a", "localhost:1234"},
+             {"b", "localhost:1235"},
+             {"c", "localhost:1236"}},
+          .failover_timeout = {"0ms"}}};
+    }
+
+    void set_state(kv::Tx& tx, StateMachine state)
+    {
+      tx.rw<SMState>(Tables::RECOVERY_DECISION_PROTOCOL_SM_STATE)->put(state);
+      tx.rw<TimeoutSMState>(Tables::RECOVERY_DECISION_PROTOCOL_TIMEOUT_SM_STATE)
+        ->put(state);
+    }
+  };
+
+  TEST_CASE(
+    "Recovery protocol start gates and global commit" *
+    doctest::test_suite("recovery_decision_protocol"))
+  {
+    Fixture f;
+    auto& board = tasks::get_main_job_board();
+    REQUIRE(board.get_summary().pending_tasks == 0);
+
+    {
+      auto tx = f.tables->create_tx();
+      f.protocol.try_start(tx, false);
+      CHECK_FALSE(tx.ro<SMState>(Tables::RECOVERY_DECISION_PROTOCOL_SM_STATE)
+                    ->get()
+                    .has_value());
+      f.config.reset();
+      f.protocol.try_start(tx, true);
+      CHECK_FALSE(tx.ro<SMState>(Tables::RECOVERY_DECISION_PROTOCOL_SM_STATE)
+                    ->get()
+                    .has_value());
+      f.config.emplace();
+      f.protocol.try_start(tx, true);
+      CHECK_FALSE(tx.ro<SMState>(Tables::RECOVERY_DECISION_PROTOCOL_SM_STATE)
+                    ->get()
+                    .has_value());
+      f.config->recovery_decision_protocol.emplace();
+      f.config->recovery_decision_protocol->failover_timeout = {"0ms"};
+      f.protocol.try_start(tx, true);
+      tasks::tick(std::chrono::milliseconds(0));
+      CHECK(board.get_summary().pending_tasks == 0);
+      REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+    }
+    tasks::tick(std::chrono::milliseconds(0));
+    CHECK(board.get_summary().pending_tasks == 0);
+    f.tables->rollback({0, 0}, 1);
+    f.tables->compact(0);
+    tasks::tick(std::chrono::milliseconds(0));
+    CHECK(board.get_summary().pending_tasks == 0);
+
+    {
+      auto tx = f.tables->create_tx();
+      f.protocol.try_start(tx, true);
+      REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+    }
+    f.tables->compact(f.tables->current_version());
+    tasks::tick(std::chrono::milliseconds(0));
+    auto retry = board.get_task();
+    REQUIRE(retry != nullptr);
+    struct CancelTask
+    {
+      tasks::Task task;
+      ~CancelTask()
+      {
+        task->cancel_task();
+      }
+    } cancel{retry};
+    CHECK(retry->get_name() == "RecoveryDecisionProtocolRetry");
+    CHECK(board.get_summary().pending_tasks == 0);
+
+    // Callback-time reads must use the live store slot, not a constructor copy.
+    f.tables = std::make_shared<kv::Store>();
+    f.tables->set_encryptor(std::make_shared<kv::NullTxEncryptor>());
+    {
+      auto tx = f.tables->create_tx();
+      f.set_state(tx, StateMachine::OPEN);
+      REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+    }
+    retry->do_task();
+    CHECK(retry->is_cancelled());
+    tasks::tick(std::chrono::milliseconds(100));
+    CHECK(board.get_summary().pending_tasks == 0);
+  }
+
+  TEST_CASE(
+    "Recovery protocol governance uses the caller transaction" *
+    doctest::test_suite("recovery_decision_protocol"))
+  {
+    Fixture f;
+    auto identity = make_test_network_ident();
+    bool timeout = false;
+    size_t votes = 2;
+    SUBCASE("Quorum") {}
+    SUBCASE("Failover")
+    {
+      timeout = true;
+      votes = 1;
+    }
+    SUBCASE("No votes")
+    {
+      timeout = true;
+      votes = 0;
+    }
+    SUBCASE("Governance failure")
+    {
+      f.governance.fail = true;
+    }
+    {
+      auto tx = f.tables->create_tx();
+      f.set_state(tx, StateMachine::VOTING);
+      tx.rw<Service>(Tables::SERVICE)
+        ->put(ServiceInfo{identity->cert, ServiceStatus::RECOVERING});
+      tx.rw<PreviousServiceIdentity>(Tables::PREVIOUS_SERVICE_IDENTITY)
+        ->put(identity->cert);
+      for (size_t i = 0; i < votes; ++i)
+      {
+        tx.rw<Votes>(Tables::RECOVERY_DECISION_PROTOCOL_VOTES)
+          ->insert(std::to_string(i));
+      }
+      REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+    }
+    {
+      auto tx = f.tables->create_tx();
+      f.governance.expected_tx = &tx;
+      if (f.governance.fail)
+      {
+        check_logic_error(
+          [&]() { f.protocol.advance(tx, timeout); },
+          "Rejected recovery transition");
+      }
+      else
+      {
+        f.protocol.advance(tx, timeout);
+        REQUIRE(tx.commit() == kv::CommitResult::SUCCESS);
+      }
+    }
+    auto tx = f.tables->create_read_only_tx();
+    const auto opened = votes > 0 && !f.governance.fail;
+    CHECK(f.governance.opens == (votes > 0 ? 1 : 0));
+    CHECK(
+      tx.ro<SMState>(Tables::RECOVERY_DECISION_PROTOCOL_SM_STATE)->get() ==
+      (opened ? StateMachine::OPENING : StateMachine::VOTING));
+    CHECK(
+      tx.ro<Service>(Tables::SERVICE)->get()->status ==
+      (opened ? ServiceStatus::OPEN : ServiceStatus::RECOVERING));
+    auto kind =
+      tx.ro<OpenKind>(Tables::RECOVERY_DECISION_PROTOCOL_OPEN_KIND)->get();
+    if (opened)
+    {
+      CHECK(kind == (timeout ? OpenKinds::FAILOVER : OpenKinds::QUORUM));
+    }
+    else
+    {
+      CHECK_FALSE(kind.has_value());
+    }
+  }
+
+  TEST_CASE(
+    "Recovery protocol node info cache and missing state" *
+    doctest::test_suite("recovery_decision_protocol"))
+  {
+    Fixture f;
+    auto identity = make_test_network_ident();
+    f.node.info.location = f.config->location;
+    f.node.info.service_cert_der = crypto::cert_pem_to_der(identity->cert);
+    auto tx = f.tables->create_tx();
+    check_logic_error(
+      [&]() { f.protocol.get_iamopen_request(tx); },
+      "Previous service identity not found in table but expected as "
+      "recovering");
+    tx.rw<PreviousServiceIdentity>(Tables::PREVIOUS_SERVICE_IDENTITY)
+      ->put(identity->cert);
+    check_logic_error(
+      [&]() { f.protocol.get_iamopen_request(tx); },
+      "Node n[test-node] not found in nodes table");
+    ccf::NodeInfo node_info;
+    node_info.encryption_pub_key = dummy_enc_pubk;
+    tx.rw<Nodes>(Tables::NODES)->put(f.node.get_node_id(), node_info);
+    auto first = f.protocol.get_iamopen_request(tx);
+    CHECK(first.txid == f.node.recovered_txid);
+    CHECK(first.info.location == f.config->location);
+    CHECK(first.info.service_cert_der == f.node.info.service_cert_der);
+    CHECK(
+      first.prev_service_fingerprint ==
+      service_fingerprint_from_pem(identity->cert));
+    f.node.recovered_txid = {3, 50};
+    auto second = f.protocol.get_iamopen_request(tx);
+    CHECK(second.txid == first.txid);
+    CHECK(f.node.cache_calls == 1);
+  }
+
+  TEST_CASE(
+    "Recovery protocol restart requires a chosen node" *
+    doctest::test_suite("recovery_decision_protocol"))
+  {
+    Fixture f;
+    auto tx = f.tables->create_tx();
+    f.set_state(tx, StateMachine::JOINING);
+    check_logic_error(
+      [&]() { f.protocol.advance(tx, false); },
+      "Recovery-decision-protocol chosen node not set, cannot join");
+    tx.rw<ChosenNode>(Tables::RECOVERY_DECISION_PROTOCOL_CHOSEN_NODE)->put("b");
+    check_logic_error(
+      [&]() { f.protocol.advance(tx, false); },
+      "Recovery-decision-protocol chosen node b not found");
+    CHECK(f.node.restarts == 0);
+    auto identity = make_test_network_ident();
+    NodeInfo chosen{
+      {.quote_info = {},
+       .location = {"b", "localhost:1235"},
+       .service_cert_der = crypto::cert_pem_to_der(identity->cert)},
+      {}};
+    tx.rw<NodeInfoMap>(Tables::RECOVERY_DECISION_PROTOCOL_NODES)
+      ->put("b", chosen);
+    f.protocol.advance(tx, false);
+    CHECK(f.node.restarts == 1);
+    CHECK(
+      tx.ro<SMState>(Tables::RECOVERY_DECISION_PROTOCOL_SM_STATE)->get() ==
+      StateMachine::JOINING);
+  }
+}


### PR DESCRIPTION
## Purpose and scope

Depends on #8362. Independent A3 experiment, not stacked on A1. Historical measured base: `ce863391d239544ee936068de356719bf8c8338c`; historical measured variant: `1928cb234f5a7ae9952fa01c7b59ed1fd4c61dc5`. The PR targets `achamayou-ci-build-performance`; that branch has since advanced through a changelog-only merge, without changing the measurement baseline. Current head `23d3be1366f5b64bde7d115e00684a1f010ccb9f` adds the CI follow-up described below and **has not been cold-benchmarked**.

Remove the concrete `NodeState` header dependency from `recovery_decision_protocol.cpp` using references to live sealing-recovery configuration and store slots, existing `AbstractGovernanceEffects`, and a small private NodeState-owned adapter. Actual Ninja dependency lists confirm removal from all three recovery-protocol object configurations (`ccf`, `frontend_test`, `node_frontend_test`).

Preserve nested cache-lock scope through cache assignment, certificate locking, live reads, recovered-index/view access, restart, same-transaction governance identities, owner/adapter lifetimes, global-commit timer registration, cancellation, rollback, and error propagation. No DTO moves, object deduplication, broad NodeState outlining, configuration flattening, or intended recovery behaviour change. The measured delta was seven files, +493/-74, including a 342-line regression header shared by both existing frontend suites. No source changes were made just to publish the initial draft. With the CI follow-up, the PR remains seven files, +526/-81.

## Qualification gate

**REAL SNP SELF-HEALING RECOVERY IS UNQUALIFIED LOCALLY.** WSL has neither `/dev/sev-guest` nor `/dev/sev`. The three SNP recovery-decision-protocol e2e paths need hardware CI before this is ready. Virtual and unit results do not establish those hardware attestation, authorization or unsealing paths. Original CI job-level SNP success alone is not evidence that those specific paths executed.

## CI follow-up, not remeasured

Commit `23d3be1366f5b64bde7d115e00684a1f010ccb9f` fixes the Virtual A clang-tidy failures in initial CI run [34719144911](https://github.com/microsoft/CCF/actions/runs/34719144911). That run finished with only Virtual A failing; its other four jobs succeeded.

The follow-up adds consistent `[[nodiscard]]` attributes to the node-ID interface and overrides, explicitly qualifies the existing const references, and checks cache population after the adapter call. The guard throws the same `std::bad_optional_access` that an empty `optional::value()` previously threw, while retaining the same mutex scope. No fallback, rule disabling, new suppression, early unlock, or recovery-semantic change. An explicit try/catch regression asserts exception type/message and successful retry when a test adapter leaves the cache empty; it does not rely on disabled doctest exception macros. Follow-up delta: four files, +43/-17.

Exact-source native validation used an LF-normalized, disk-backed WSL archive, verified against all 2000 blobs of tree `2117df5d5f99aec6d389a7f180739607ad26d3b2`, with the original fixed source-version metadata:

- Native clang-tidy 18.1.8 reproduced the original RDP diagnostics, then passed the unchanged full repository policy on fixed `recovery_decision_protocol.cpp` in all three compile-database configurations, `src/enclave/main.cpp`, and `historical_queries_utils.cpp`. No emitted diagnostics remained; existing non-user-code/NOLINT suppression totals were inspected and no suppressions were added.
- Clang 21.1.8, Debug, LLD, `ninja -j2 ccf frontend_test node_frontend_test`: all 111 edges completed. Both frontend suites passed: 25/7 cases and 1767/137 assertions, no failures or skips, including the empty-cache/retry regression.
- Native clang-format 18.1.8 passed all four changed files. Repository include, copyright, ASCII and comment-policy checks passed.

The installed tidy version matches CI, but the local compiler is Clang 21.1.8 rather than CI's Clang 18.1.8; no compiler/tooling was installed for this follow-up. Exact-CI-toolchain confirmation remains with automatically triggered qualification run [34722457121](https://github.com/microsoft/CCF/actions/runs/34722457121), queued at publication. No new cold timings, broad sanitizer reruns, or full-suite claim accompany this follow-up. Original measurement sources and logs are preserved unchanged.

## Local full-cold measurements

These measurements and the historical correctness evidence below apply to **`1928cb234f5a7ae9952fa01c7b59ed1fd4c61dc5`**, not the CI-follow-up head.

Interleaved order B1, V1, B2, V2; full default builds, not warm-build or isolated-TU extrapolations.

| Sample | Baseline full Ninja | Variant full Ninja | Baseline configure | Variant configure |
|---|---:|---:|---:|---:|
| 1 | 1116.43s | 992.23s | 7.86s | 8.01s |
| 2 | 1145.42s | 1097.31s | 11.10s | 10.45s |
| Mean | 1130.925s | 1044.770s | 9.48s | 9.23s |

Mean full-build change: **-86.155s (-7.618%)**. Paired changes: **-11.12% / -4.20%**. Baseline sample SD: 20.499s; variant sample SD: 74.303s. Only two samples per revision and substantial variance: this supports CI evaluation, **not an Azure CI prediction or an additive saving to combine with other experiments**.

Each run completed the same 314 Ninja edges, including added regression compilation, in a previously nonexistent build directory with all generated C++ and Rust/Cargo outputs empty. No compiler-cache or retained-library reuse; no global page-cache/swap flushing. Normal cached source dependencies were retained. Normalized `git archive` snapshots were checked against every intended blob, including the new test header, with identical fixed source-version metadata.

Environment: native disk-backed WSL2 ext4, 12 CPUs / approximately 15.5 GiB RAM, Clang 21.1.8, CMake 4.2.3, Ninja 1.13.2, LLD 21.1.8, Rust/Cargo 1.93.1. Other experiment builds/tests were paused.

```sh
cmake -S <source> -B <fresh-build> -GNinja \
  -DCMAKE_BUILD_TYPE=Debug \
  -DCMAKE_C_COMPILER=/usr/bin/clang \
  -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
  -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld \
  -DCLANG_TIDY=OFF
ninja -C <fresh-build> -j4
```

Clang resolved LLD to `/usr/lib/llvm-21/bin/ld.lld`. Configure and Ninja were timed separately. GNU time maximum child RSS was approximately 2,577,000 KiB in every run; aggregate concurrent peak memory was not measured. TU timings are diagnostic, not summed wall-clock savings.

## Correctness evidence on the historical measured variant

- Production and both frontend targets build. Ordinary `frontend_test` / `node_frontend_test`: 25 / 7 cases, 1764 / 134 assertions, no skips.
- Shared new cases cover startup gates and late configuration, global commit versus speculative rollback, live callback store reads/cancellation, same-transaction quorum/failover opening, zero-vote refusal, governance-error transaction discard, identity-cache prerequisites, and restart prerequisites. The harness disables doctest exception macros, so failure actions execute in explicit `try`/`catch(const std::logic_error&)` with type/message assertions. Fixtures are generated through existing CCF crypto helpers.
- Virtual `recovery_test`: all 20 sub-tests passed (246.14s). Full virtual `e2e_logging` passed (136.26s).
- Separate `TSAN=ON`, `USE_SNMALLOC=OFF` diagnostic build: both frontend suites passed. `frontend_test` retains `detect_deadlocks=1:halt_on_error=1:second_deadlock_stack=1` without suppressions; `node_frontend_test` retains its original repository suppressions. Policies were not flattened.
- Full TSAN `e2e_logging` passed (174.94s), retaining deadlock detection and original narrow `tsan_e2e_logging_suppressions`. Final node stderr had no ThreadSanitizer warning/summary/fatal reports. No suppressions or coverage were weakened.
- All 15 report-only `scripts/ci-checks.sh` checks passed, including formatting of all modified/new files, includes, ASCII, copyright, and test buckets.

Preflight fixture/type/message issues were fixed before freezing sources. Initial infrastructure failures were resolved by providing the wrapper's expected sibling-layout `../cddl` path, selecting native Python/formatter tools command-locally, setting `MPLBACKEND=Agg`, disabling snmalloc only in the supported TSAN configuration, and building the missing instrumented `programmability` target. Full unchanged tests then passed. Failed/incremental diagnostics were excluded from measurements.

## Remaining evidence

Hardware SNP self-healing recovery path qualification and successful CI on the follow-up head remain required. No full-clean tidy timing pair, llvm-cov coverage run, or entire CTest suite is claimed. Local results do not imply CI is green. No intended user-facing API/behaviour change or release-note claim for this experimental local speedup.