### PR TITLE
Build only required targets in each CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
           mkdir build
           cd build
           cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DCLANG_TIDY=ON ..
-          # Keep the full graph here to preserve clang-tidy coverage.
           ninja
         shell: bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
           mkdir build
           cd build
           cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DCLANG_TIDY=ON ..
+          # Keep the full graph here to preserve clang-tidy coverage.
           ninja
         shell: bash
 
@@ -160,7 +161,8 @@ jobs:
           mkdir build
           cd build
           cmake -GNinja -DCMAKE_BUILD_TYPE=Debug ..
-          ninja
+          # Recovery and schema dynamically select all three logging variants.
+          ninja js_generic logging logging_cose_only logging_cose_only_allow_join_dual programmability nobuiltins
         shell: bash
 
       - name: "Test virtual"
@@ -222,7 +224,8 @@ jobs:
           mkdir build
           cd build
           cmake -GNinja -DCMAKE_BUILD_TYPE=Debug ..
-          ninja
+          # bucket_c and partitions, including the Python-driven Raft scenarios.
+          ninja js_generic logging logging_cose_only programmability raft_driver
         shell: bash
 
       - name: "Test virtual"
@@ -299,7 +302,8 @@ jobs:
           mkdir build
           cd build
           cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DWORKER_THREADS=1 ..
-          ninja
+          # SNP unit/e2e tests, code_update, and the explicitly run ledger bench.
+          ninja logging programmability snp_ioctl_test snp_attestation_test ledger_bench
         shell: bash
 
       - name: "Tests"
@@ -385,7 +389,8 @@ jobs:
           mkdir build
           cd build
           cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DWORKER_THREADS=1 ..
-          ninja
+          # SNP unit/e2e tests, code_update, and the explicitly run ledger bench.
+          ninja logging programmability snp_ioctl_test snp_attestation_test ledger_bench
         shell: bash
 
       - name: "Tests"


### PR DESCRIPTION
Build only the targets consumed by each CI job, preserving all test selections and existing clang-tidy coverage. This PR targets `main` independently of #8362.

### CI time savings

| Job | Build before -> after | Build reduction | Whole job before -> after | Job reduction |
| --- | ---: | ---: | ---: | ---: |
| Virtual A | 7m56s -> 7m54s | 0.4% | 13m35s -> 13m32s | 0.4% |
| Virtual B | 3m05s -> 1m43s | 44.3% | 14m12s -> 12m45s | 10.2% |
| Virtual C | 3m04s -> 1m42s | 44.6% | 14m05s -> 12m33s | 10.9% |
| SNP Milan | 6m57s -> 3m19s | 52.3% | 13m44s -> 10m00s | 27.2% |
| SNP Genoa | 4m58s -> 2m30s | 49.7% | 11m31s -> 8m42s | 24.5% |

**Across the four changed jobs: 49% less summed build time and 18% less summed job time.** All five jobs passed, including partitions and both SNP platforms. Virtual A is unchanged; its small timing difference is run-to-run variation.

Build timings include configure; Virtual A's step also includes checks and clang-tidy. Whole-job timings include setup, tests and cleanup, but exclude queueing. Jobs run in parallel, so summed savings are not pipeline elapsed-time savings.

Single [baseline](https://github.com/microsoft/CCF/actions/runs/34719016396)/[candidate](https://github.com/microsoft/CCF/actions/runs/34719204907) comparison, measured with #8362's optimizations before this PR was rebased onto `main`.